### PR TITLE
Add missing comma in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "actual",
   "version": "0.0.1",
   "private": true,
-  "description": "A local-first personal finance system"
+  "description": "A local-first personal finance system",
   "homepage": "https://github.com/actualbudget/actual/",
   "bugs": {
     "url": "https://github.com/actualbudget/actual/issues/"


### PR DESCRIPTION
Noticed some fields were added to package.json in #1 and added a missing comma that was causing `yarn install` to fail. 

Cool that this project is open source :)