### PR TITLE
Building for Windows

### DIFF
--- a/docs/Building-for-Windows.md
+++ b/docs/Building-for-Windows.md
@@ -1,0 +1,18 @@
+# How to build browser for Windows
+Many of the build scripts are bash scripts and not natively invokable in Windows. To solve this, you can build the project using Git Bash.
+1. Install [Git & Git Bash for Windows](https://git-scm.com/downloads)
+2. Install Node v16.x (latest version 17.x does not work due to issue with crypto package)
+3. Clone this repo
+4. From the root of this repo, run `sh` to launch a bash shell
+5. From inside the bash shell, run `yarn install`
+6. From still inside the shell, run `yarn start:browser`
+7. Open your browser to `localhost:3001`
+
+# How to build electron for Windows
+1. Follow steps 1 - 5 above.
+2. Run `yarn start`
+3. If you get an error from electron, run `yarn rebuild-electron` and rerun `yarn start`;
+
+## rsync: command not found
+If you run into this error, you will need to install the rsync binary to Git Bash. Follow the [directions here](https://prasaz.medium.com/add-rsync-to-windows-git-bash-f42736bae1b3). When you get to the final step - installing the libxxhash dll - rename the dll from `msys-xxhash-0.8.0.dll` to `msys-xxhash-0.dll`
+

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -7,8 +7,8 @@
     "build:node": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.desktop.config.js",
     "watch:node": "cross-env NODE_ENV=development webpack --config ./webpack/webpack.desktop.config.js --watch",
     "build:api": "cross-env NODE_ENV=development webpack --config ./webpack/webpack.api.config.js",
-    "build:browser": "NODE_ENV=production ./bin/build-browser",
-    "watch:browser": "NODE_ENV=development ./bin/build-browser",
+    "build:browser": "cross-env NODE_ENV=production ./bin/build-browser",
+    "watch:browser": "cross-env NODE_ENV=development ./bin/build-browser",
     "lint": "eslint src"
   },
   "author": "",


### PR DESCRIPTION
This pull updates patches for the latest version of dependencies, fixes npm scripts to run on windows, fixes a logic error when running `loot-core/bin/build-browser` for the first time in development mode, and creates a doc page for how to get the build to work on Windows with Git Bash.