### PR TITLE
Bumped up Electron version to fix GPU process isn't usable error

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@sentry/cli": "^1.68.0",
     "@sentry/wizard": "1.2.11",
-    "electron": "12.2.1",
+    "electron": "13.6.9",
     "electron-builder": "22.10.5",
     "electron-download": "4.1.1",
     "electron-notarize": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6457,10 +6457,10 @@ electron-updater@4.3.8:
     lodash.isequal "^4.5.0"
     semver "^7.3.4"
 
-electron@12.2.1:
-  version "12.2.1"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.2.1.tgz#ef138fde11efd01743934c3e0df717cc53ee362b"
-  integrity sha512-Gp+rO81qoaRDP7PTVtBOvnSgDgGlwUuAEWXxi621uOJMIlYFas9ChXe8pjdL0R0vyUpiHVzp6Vrjx41VZqEpsw==
+electron@13.6.9:
+  version "13.6.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.9.tgz#7bd83cc1662ceaaa09dcd132a7b507cec888b028"
+  integrity sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
This is my fix for this issue: https://github.com/actualbudget/actual/issues/44

Keeping it super simple to get us Linux users unblocked from running the Electron app.

You may also have to do the following to get the app running depending on your node version:

rm patches/react-modal+3.4.4.patch
yarn rebuild-node
yarn rebuild-electron

