### PR TITLE
Add missing comma to jest.config.js

### DIFF
--- a/packages/desktop-client/jest.config.js
+++ b/packages/desktop-client/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  moduleFileExtensions: ['js', 'json', 'testing.js']
+  moduleFileExtensions: ['js', 'json', 'testing.js'],
   setupFiles: [],
 };


### PR DESCRIPTION
We're missing a comma in this file which makes the `module.exports` invalid.