### PR TITLE
Fix timestamp test suite

### DIFF
--- a/packages/loot-core/src/server/timestamp.js
+++ b/packages/loot-core/src/server/timestamp.js
@@ -75,6 +75,9 @@ var config = {
   maxDrift: 5 * 60 * 1000
 };
 
+const MAX_COUNTER = parseInt('0xFFFF');
+const MAX_NODE_LENGTH = 16;
+
 /**
  * timestamp instance class
  */
@@ -191,7 +194,7 @@ Timestamp.send = function() {
   if (lNew - phys > config.maxDrift) {
     throw new Timestamp.ClockDriftError(lNew, phys, config.maxDrift);
   }
-  if (cNew > 65535) {
+  if (cNew > MAX_COUNTER) {
     throw new Timestamp.OverflowError();
   }
 
@@ -253,7 +256,7 @@ Timestamp.recv = function(msg) {
   if (lNew - phys > config.maxDrift) {
     throw new Timestamp.ClockDriftError();
   }
-  if (cNew > 65535) {
+  if (cNew > MAX_COUNTER) {
     throw new Timestamp.OverflowError();
   }
 
@@ -279,8 +282,16 @@ Timestamp.parse = function(timestamp) {
       var millis = Date.parse(parts.slice(0, 3).join('-')).valueOf();
       var counter = parseInt(parts[3], 16);
       var node = parts[4];
-      if (!isNaN(millis) && !isNaN(counter))
+      if (
+        !isNaN(millis) &&
+        millis >= 0 &&
+        !isNaN(counter) &&
+        counter <= MAX_COUNTER &&
+        typeof node === 'string' &&
+        node.length <= MAX_NODE_LENGTH
+      ) {
         return new Timestamp(millis, counter, node);
+      }
     }
   }
   return null;

--- a/packages/loot-core/src/server/timestamp.test.js
+++ b/packages/loot-core/src/server/timestamp.test.js
@@ -24,7 +24,7 @@ describe('Timestamp', function() {
 
   describe('parsing', function() {
     it('should not parse', function() {
-      var invalid = [
+      const invalidInputs = [
         null,
         undefined,
         {},
@@ -40,26 +40,26 @@ describe('Timestamp', function() {
         '9999-12-31T23:59:59.999Z-10000-FFFFFFFFFFFFFFFF',
         '9999-12-31T23:59:59.999Z-FFFF-10000000000000000'
       ];
-      for (var i = 0; i < invalid.length; i++) {
-        expect(Timestamp.parse(invalid)).toBe(null);
+      for (const invalidInput of invalidInputs) {
+        expect(Timestamp.parse(invalidInput)).toBe(null);
       }
     });
 
     it('should parse', function() {
-      var valid = [
+      var validInputs = [
         '1970-01-01T00:00:00.000Z-0000-0000000000000000',
         '2015-04-24T22:23:42.123Z-1000-0123456789ABCDEF',
         '9999-12-31T23:59:59.999Z-FFFF-FFFFFFFFFFFFFFFF'
       ];
-      for (var i = 0; i < valid.length; i++) {
-        var parsed = Timestamp.parse(valid[i]);
+      for (const validInput of validInputs) {
+        var parsed = Timestamp.parse(validInput);
         expect(typeof parsed).toBe('object');
         expect(parsed.millis() >= 0).toBeTruthy();
         expect(parsed.millis() < 253402300800000).toBeTruthy();
         expect(parsed.counter() >= 0).toBeTruthy();
         expect(parsed.counter() < 65536).toBeTruthy();
         expect(typeof parsed.node()).toBe('string');
-        expect(parsed.toString()).toBe(valid[i]);
+        expect(parsed.toString()).toBe(validInput);
       }
     });
   });


### PR DESCRIPTION
I noticed an issue in the timestamp test suite where we're passing the full array of invalid inputs into `Timestamp.parse` rather than one by one. Fixing this shows that we're accepting a number of invalid timestamp formats so I've added additional checks on this.