### PR TITLE
Add ability to import Actual files; enable export on desktop

### DIFF
--- a/packages/desktop-client/src/components/Settings.js
+++ b/packages/desktop-client/src/components/Settings.js
@@ -334,7 +334,7 @@ function FileSettings({
 
   async function onExport() {
     let data = await send('export-budget');
-    window.Actual.saveFile(data, 'budget.zip', 'Export budget');
+    window.Actual.saveFile(data, `${prefs.id}.zip`, 'Export budget');
   }
 
   let dateFormat = prefs.dateFormat || 'MM/dd/yyyy';
@@ -431,12 +431,10 @@ function FileSettings({
         </View>
       </View>
 
-      {Platform.isBrowser && (
-        <View style={{ marginTop: 30, alignItems: 'flex-start' }}>
-          <Title name="Export" />
-          <Button onClick={onExport}>Export data</Button>
-        </View>
-      )}
+      <View style={{ marginTop: 30, alignItems: 'flex-start' }}>
+        <Title name="Export" />
+        <Button onClick={onExport}>Export data</Button>
+      </View>
 
       <Advanced
         prefs={prefs}

--- a/packages/desktop-client/src/components/manager/Modals.js
+++ b/packages/desktop-client/src/components/manager/Modals.js
@@ -10,6 +10,7 @@ import LoadBackup from 'loot-design/src/components/modals/LoadBackup';
 import Import from 'loot-design/src/components/manager/Import';
 import ImportYNAB4 from 'loot-design/src/components/manager/ImportYNAB4';
 import ImportYNAB5 from 'loot-design/src/components/manager/ImportYNAB5';
+import ImportActual from 'loot-design/src/components/manager/ImportActual';
 import DeleteFile from 'loot-design/src/components/manager/DeleteFile';
 import CreateEncryptionKey from '../modals/CreateEncryptionKey';
 import FixEncryptionKey from '../modals/FixEncryptionKey';
@@ -71,6 +72,10 @@ function Modals({
       case 'import-ynab5':
         return (
           <ImportYNAB5 key={name} modalProps={modalProps} actions={actions} />
+        );
+      case 'import-actual':
+        return (
+          <ImportActual key={name} modalProps={modalProps} actions={actions} />
         );
       case 'load-backup': {
         return (

--- a/packages/loot-core/src/platform/server/fs/index.web.js
+++ b/packages/loot-core/src/platform/server/fs/index.web.js
@@ -17,11 +17,15 @@ function pathToId(filepath) {
 
 function _exists(filepath) {
   try {
+    FS.readlink(filepath);
+    return true;
+  } catch (e) {}
+
+  try {
     FS.stat(filepath);
-  } catch (e) {
-    return false;
-  }
-  return true;
+    return true;
+  } catch (e) {}
+  return false;
 }
 
 function _mkdirRecursively(dir) {

--- a/packages/loot-core/src/server/main.js
+++ b/packages/loot-core/src/server/main.js
@@ -1835,6 +1835,41 @@ handlers['import-budget'] = async function({ filepath, type }) {
           return { error: 'not-ynab5' };
         }
         break;
+      case 'actual':
+        // We should pull out import/export into its own app so this
+        // can be abstracted out better. Importing Actual files is a
+        // special case because we can directly write down the files,
+        // but because it doesn't go through the API layer we need to
+        // duplicate some of the workflow
+        await handlers['close-budget']();
+
+        let { id } = await cloudStorage.importBuffer(
+          { cloudFileId: null, groupId: null },
+          buffer
+        );
+
+        // We never want to load cached data from imported files, so
+        // delete the cache
+        let sqliteDb = await sqlite.openDatabase(
+          fs.join(fs.getBudgetDir(id), 'db.sqlite')
+        );
+        sqlite.execQuery(
+          sqliteDb,
+          `
+          DELETE FROM kvcache;
+          DELETE FROM kvcache_key;
+        `
+        );
+        sqlite.closeDatabase(sqliteDb);
+
+        // Load the budget, force everything to be computed, and try
+        // to upload it as a cloud file
+        await handlers['load-budget']({ id });
+        await handlers['get-budget-bounds']();
+        await sheet.waitOnSpreadsheet();
+        await cloudStorage.upload().catch(err => {});
+
+        break;
       default:
     }
   } catch (err) {

--- a/packages/loot-design/src/components/manager/Import.js
+++ b/packages/loot-design/src/components/manager/Import.js
@@ -37,6 +37,9 @@ function Import({ modalProps, actions, availableImports }) {
       case 'ynab5':
         actions.pushModal('import-ynab5');
         break;
+      case 'actual':
+        actions.pushModal('import-actual');
+        break;
       default:
     }
   }
@@ -83,14 +86,12 @@ function Import({ modalProps, actions, availableImports }) {
                   <div>The newer web app</div>
                 </View>
               </Button>
-              {false && (
-                <Button style={itemStyle}>
-                  <span style={{ fontWeight: 700 }}>Actual</span>
-                  <View style={{ color: colors.n5 }}>
-                    <div>Import a backup or external file</div>
-                  </View>
-                </Button>
-              )}
+              <Button style={itemStyle} onClick={() => onSelectType('actual')}>
+                <span style={{ fontWeight: 700 }}>Actual</span>
+                <View style={{ color: colors.n5 }}>
+                  <div>Import a file exported from Actual</div>
+                </View>
+              </Button>
             </View>
           </View>
 

--- a/packages/loot-design/src/components/manager/ImportActual.js
+++ b/packages/loot-design/src/components/manager/ImportActual.js
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { importBudget } from 'loot-core/src/client/actions/budgets';
+import {
+  View,
+  Block,
+  Modal,
+  ButtonWithLoading,
+  Button,
+  Link,
+  P,
+  ExternalLink
+} from '../common';
+import { styles, colors } from '../../style';
+
+function getErrorMessage(error) {
+  switch (error) {
+    case 'parse-error':
+      return 'Unable to parse file. Please select a JSON file exported from nYNAB.';
+    case 'not-ynab5':
+      return 'This file is not valid. Please select a JSON file exported from nYNAB.';
+    default:
+      return 'An unknown error occurred while importing. Sorry! We have been notified of this issue.';
+  }
+}
+
+function Import({ modalProps, availableImports }) {
+  const dispatch = useDispatch();
+  const [error, setError] = useState(false);
+  const [importing, setImporting] = useState(false);
+
+  async function onImport() {
+    const res = await window.Actual.openFileDialog({
+      properties: ['openFile'],
+      filters: [{ name: 'actual', extensions: ['zip'] }]
+    });
+    if (res) {
+      setImporting(true);
+      setError(false);
+      try {
+        await dispatch(importBudget(res[0], 'actual'));
+      } catch (err) {
+        setError(err.message);
+      } finally {
+        setImporting(false);
+      }
+    }
+  }
+
+  return (
+    <Modal
+      {...modalProps}
+      showHeader={false}
+      showOverlay={false}
+      noAnimation={true}
+      style={{ width: 400 }}
+    >
+      {() => (
+        <View style={[styles.smallText, { lineHeight: 1.5, marginTop: 20 }]}>
+          {error && (
+            <Block style={{ color: colors.r4, marginBottom: 15 }}>
+              {getErrorMessage(error)}
+            </Block>
+          )}
+
+          <View style={{ '& > div': { lineHeight: '1.7em' } }}>
+            <P>
+              You can import data from another Actual account or instance. First
+              export your data from a different account, and it will give you a
+              compressed file. This file is simple zip file that contains the
+              "db.sqlite" and "metadata.json" files.
+            </P>
+
+            <P>Select one of these compressed files and import it here.</P>
+
+            <View style={{ alignSelf: 'center' }}>
+              <ButtonWithLoading loading={importing} primary onClick={onImport}>
+                Select file...
+              </ButtonWithLoading>
+            </View>
+          </View>
+
+          <View
+            style={{
+              flexDirection: 'row',
+              marginTop: 20,
+              alignItems: 'center'
+            }}
+          >
+            <View style={{ flex: 1 }} />
+            <Button
+              style={{ marginRight: 10 }}
+              onClick={() => modalProps.onBack()}
+            >
+              Back
+            </Button>
+          </View>
+        </View>
+      )}
+    </Modal>
+  );
+}
+
+export default Import;


### PR DESCRIPTION
This PR does a few things, but the two main things it enables are:

* Exporting data as a compressed zip file on the desktop app. This was already available on the web app, but due to limitations of the IPC used by the desktop app it hadn't been enabled yet.
* Allows importing of these compressed zip files that Actual exports. Clicking "import file" will show a list of file types to import that now includes Actual.

These compressed files are just zip files containing two files: a `db.sqlite` and `metadata.json`. If you are using the desktop app, you can see these two files locally by opening up a budget file in your local Actual directory. All it does it zip them up.

As you can see in the PR, there were several annoying bugfixes required for this which is why it took a while to get this working.

In my research, I also discovered the the IPC layer used by the desktop app was double JSON encoding messages. We were manually encoding them, and then the IPC layer was automating doing it as well. We can pass objects directly to the IPC layer without calling `JSON.stringify`/`JSON.parseˆ.

