### PR TITLE
Fix some errors caused by using `bash` syntax with `sh` shebang

### DIFF
--- a/bin/package-browser
+++ b/bin/package-browser
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ROOT=`dirname $0`
 VERSION=""

--- a/packages/loot-core/bin/build-browser
+++ b/packages/loot-core/bin/build-browser
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 cd `dirname "$0"`
 ROOT=`pwd -P`

--- a/packages/loot-core/bin/build-mobile
+++ b/packages/loot-core/bin/build-mobile
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ROOT=`dirname $0`
 


### PR DESCRIPTION
Running `package-browser` on Linux gets me the error:

```
bin/package-browser: 9: Syntax error: "(" unexpected
```

This appears to be due to the fact that [the shebang specifies `sh`](https://unix.stackexchange.com/a/253900) whereas the other scripts use bash. Switching the shebang to match the other files fixes this issue.