### PR TITLE
Add a CI workflow to perform builds of api, web and electron packages

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup
+
+runs:
+  using: composite
+  steps:
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 16
+    - name: Cache
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: '**/node_modules'
+        key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+    - name: Install
+      run: yarn --immutable
+      shell: bash
+      if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
       id: cache
       with:
         path: '**/node_modules'
-        key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+        key: yarn-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
     - name: Install
       run: yarn --immutable
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,29 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
       - name: Build Web
         run: ./bin/package-browser
+
+  electron:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: '**/node_modules'
+          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn --immutable
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Build Electron
+        run: ./bin/package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
 
+defaults:
+  run:
+    shell: bash
+
 env:
   CI: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         id: cache
         with:
           path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+          key: yarn-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: yarn --immutable
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,8 @@ jobs:
         run: ./bin/package-browser
 
   electron:
+    # As electron builds take longer, we only run them in master.
+    if: github.event_name != 'pull_request'
     strategy:
       matrix:
         os:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+env:
+  CI: true
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: '*'
+
+jobs:
+  api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: '**/node_modules'
+          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn --immutable
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Build API
+        run: cd packages/loot-core && yarn build:api
+
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+      - name: Cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: '**/node_modules'
+          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn --immutable
+        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Build Web
+        run: ./bin/package-browser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,19 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Build API
         run: cd packages/loot-core && yarn build:api
 
@@ -39,19 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Build Web
         run: ./bin/package-browser
 
@@ -67,18 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Build Electron
         run: ./bin/package

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,18 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 16
-      - name: Cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: '**/node_modules'
-          key: yarn-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install
-        run: yarn --immutable
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Set up environment
+        uses: ./.github/actions/setup
       - name: Lint
         run: yarn lint

--- a/bin/package
+++ b/bin/package
@@ -65,10 +65,11 @@ if [ -n "$RELEASE" ]; then
 fi
 
 if [ "$OSTYPE" == "msys" ]; then
-    if [ -z "$CIRCLE_TAG" ]; then
+    if [ $CI != true ]; then
         read -s -p "Windows certificate password: " -r CSC_KEY_PASSWORD
         export CSC_KEY_PASSWORD
-    else
+    elif [ -n "$CIRCLE_TAG" ]; then
+        # We only want to run this on CircleCI as Github doesn't have the CSC_KEY_PASSWORD secret set.
         certutil -f -p ${CSC_KEY_PASSWORD} -importPfx ~/windows-shift-reset-llc.p12
     fi
 fi

--- a/bin/package
+++ b/bin/package
@@ -6,6 +6,7 @@ VERSION=""
 BETA=""
 RELEASE=""
 RELEASE_NOTES=""
+CI=${CI:-false}
 
 cd "$ROOT/.."
 
@@ -74,7 +75,7 @@ fi
 
 # We only need to run linting once (and this doesn't seem to work on
 # Windows for some reason)
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ $CI != true && "$OSTYPE" == "darwin"* ]]; then
     yarn lint
 fi
 

--- a/bin/package-browser
+++ b/bin/package-browser
@@ -3,6 +3,7 @@
 ROOT=`dirname $0`
 VERSION=""
 RELEASE=""
+CI=${CI:-false}
 
 cd "$ROOT/.."
 
@@ -50,7 +51,10 @@ if [ -n "$RELEASE" ]; then
     fi
 fi
 
-yarn lint
+# There's no need to check linting in CI as it'll be done in a different step.
+if [ $CI != true ]; then
+    yarn lint
+fi
 
 (
   cd packages/loot-design;

--- a/packages/desktop-electron/afterSignHook.js
+++ b/packages/desktop-electron/afterSignHook.js
@@ -2,6 +2,12 @@ const fs = require('fs');
 const path = require('path');
 var electron_notarize = require('electron-notarize');
 
+// This is expected to be run by `electron-builder` after it signs the build.
+// It's disabled for now as we currently don't sign builds after Actual being open sourced.
+// To start signing builds again:
+// - add the property `"afterSign": "./afterSignHook.js"` to the `build` object in package.json.
+// - add the property `"certificateSubjectName": "Shift Reset LLC"` (or similar) to the `win` object in package.json.
+
 module.exports = async function(params) {
   // Only notarize the app on Mac OS only.
   if (process.platform !== 'darwin' || process.env['SKIP_NOTARIZATION']) {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -12,7 +12,6 @@
   "main": "index.js",
   "build": {
     "appId": "com.shiftreset.actual",
-    "afterSign": "./afterSignHook.js",
     "files": [
       "!node_modules/loot-core/src{,/**/*}",
       "!node_modules/loot-core/lib-dist/{browser,bundle.mobile*}",
@@ -40,8 +39,7 @@
     },
     "win": {
       "target": "nsis",
-      "icon": "icons/icon.ico",
-      "certificateSubjectName": "Shift Reset LLC"
+      "icon": "icons/icon.ico"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Builds on top of #53, #55 and #72 as they all fix issues which causes the CI build to blow up.

This PR adds a github workflow which checks that running the steps in [releasing.md](https://github.com/actualbudget/actual/blob/master/docs/releasing.md) succeeds and that we can build the electron app on linux/mac/windows platforms.

This also includes some small changes to `bin/package` and `bin/package-browser` to avoid performing linting in CI but it shouldn't affect usage from the CLI.