### PR TITLE
Add ability to import transfers from CSV

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1211,7 +1211,8 @@ class AccountInternal extends React.PureComponent {
 
   onImport = async () => {
     const accountId = this.props.accountId;
-    const account = this.props.accounts.find(acct => acct.id === accountId);
+    const accounts = this.props.accounts;
+    const account = accounts.find(acct => acct.id === accountId);
 
     if (account) {
       const res = await window.Actual.openFileDialog({
@@ -1223,6 +1224,7 @@ class AccountInternal extends React.PureComponent {
       if (res) {
         this.props.pushModal('import-transactions', {
           accountId,
+          accounts,
           filename: res[0],
           onImported: didChange => {
             if (didChange) {

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -508,7 +508,7 @@ export function ImportTransactions({
   let [fieldMappings, setFieldMappings] = useState(null);
   let [splitMode, setSplitMode] = useState(false);
   let [flipAmount, setFlipAmount] = useState(false);
-  let { accountId, onImported } = options;
+  let { accountId, accounts, onImported } = options;
 
   // This cannot be set after parsing the file, because changing it
   // requires re-parsing the file. This is different from the other
@@ -653,9 +653,23 @@ export function ImportTransactions({
         break;
       }
 
+      let payee = null;
+      const accountWithId = accounts.filter((a) => (a.id === trans.payee_name));
+
+      if (accountWithId.length === 1) {
+        const account = accountWithId[0];
+
+        const payees = await getPayees();
+        // Accounts should already have a payee
+        payee = payees.filter((p) => {
+          return p.name === account.name && p.transfer_acct === account.id
+        })[0].id;
+      }
+
       let { inflow, outflow, ...finalTransaction } = trans;
       finalTransactions.push({
         ...finalTransaction,
+        payee,
         date,
         amount: amountToInteger(amount)
       });


### PR DESCRIPTION
## Summary 

- Added account ID parsing to `Payee` field on CSV imports to detect transfers

## Evidence

![actual_PR_5-31-2022-3](https://user-images.githubusercontent.com/17950836/171097082-15769bdd-a4c9-4f08-9122-1af7e3102fc4.gif)

## Notes

- The `Amount` field defines the transfer direction
  - positive amount: `Payee` account → current account 
  - negative amount: current account → `Payee` account 
- It is currently possible to enable this functionality with rules, however, one would need to be made for each account
- Currently account IDs are not explicitly stated in the UI, just present in the URL, as far as I'm aware
- A checkbox could be added to the `Import Options` section to toggle this functionality on and off, though this is specific use case that I don't believe would be mistakenly triggered; putting an account ID in the `Payee` field is a pretty deliberate act/state