### PR TITLE
Add ability to import categories from CSV

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1212,6 +1212,7 @@ class AccountInternal extends React.PureComponent {
   onImport = async () => {
     const accountId = this.props.accountId;
     const account = this.props.accounts.find(acct => acct.id === accountId);
+    const categories = await this.props.getCategories();
 
     if (account) {
       const res = await window.Actual.openFileDialog({
@@ -1223,6 +1224,7 @@ class AccountInternal extends React.PureComponent {
       if (res) {
         this.props.pushModal('import-transactions', {
           accountId,
+          categories,
           filename: res[0],
           onImported: didChange => {
             if (didChange) {

--- a/packages/loot-design/src/components/budget/index.js
+++ b/packages/loot-design/src/components/budget/index.js
@@ -35,6 +35,10 @@ function getScrollbarWidth() {
   return Math.max(styles.scrollbarWidth - 2, 0);
 }
 
+function copyToClipboard(text) {
+  navigator.clipboard.writeText(text);
+};
+
 export class BudgetTable extends React.Component {
   constructor(props) {
     super(props);
@@ -344,15 +348,22 @@ export function SidebarCategory({
           >
             <Menu
               onMenuSelect={type => {
-                if (type === 'rename') {
-                  onEditName(category.id);
-                } else {
-                  onDelete(category.id);
+                switch(type) {
+                  case 'rename':
+                    onEditName(category.id);
+                    break;
+                  case 'copy-id':
+                    copyToClipboard(category.id);
+                    break;
+                  case 'delete':
+                    onDelete(category.id);
+                    break;
                 }
                 setMenuOpen(false);
               }}
               items={[
                 { name: 'rename', text: 'Rename' },
+                { name: 'copy-id', text: `Copy ID to clipboard` },
                 { name: 'delete', text: 'Delete' }
               ]}
             />

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -148,29 +148,39 @@ function getInitialMappings(transactions) {
   }
 
   let dateField = key(
-    fields.find(([name, value]) => name.toLowerCase().includes('date')) ||
-      fields.find(([name, value]) => value.match(/^\d+[-/]\d+[-/]\d+$/))
+    fields.find(([name, _value]) => name.toLowerCase().includes('date')) ||
+      fields.find(([_name, value]) => value.match(/^\d+[-/]\d+[-/]\d+$/))
   );
 
   let amountField = key(
-    fields.find(([name, value]) => name.toLowerCase().includes('amount')) ||
-      fields.find(([name, value]) => value.match(/^-?[.,\d]+$/))
+    fields.find(([name, _value]) => name.toLowerCase().includes('amount')) ||
+      fields.find(([_name, value]) => value.match(/^-?[.,\d]+$/))
   );
 
+  let takenNames = [dateField, amountField];
+
   let payeeField = key(
-    fields.find(([name, value]) => name !== dateField && name !== amountField)
+    fields.find(([name, _value]) => !takenNames.includes(name))
   );
+
+  takenNames.push(payeeField);
+
+  let categoryField = key(
+    fields.find(([name, _value]) => !takenNames.includes(name))
+  );
+
+  takenNames.push(categoryField);
 
   let notesField = key(
     fields.find(
-      ([name, value]) =>
-        name !== dateField && name !== amountField && name !== payeeField
+      ([name, _value]) =>! takenNames.includes(name)
     )
   );
 
   return {
     date: dateField,
     amount: amountField,
+    category: categoryField,
     payee: payeeField,
     notes: notesField
   };
@@ -444,6 +454,16 @@ function FieldMappings({ transactions, mappings, onChange, splitMode }) {
           />
         </View>
         <View style={{ flex: 1 }}>
+          <SubLabel title="Category" />
+          <SelectField
+            width="flex"
+            options={options}
+            value={mappings.category || ''}
+            style={{ marginRight: 5 }}
+            onChange={name => onChange('category', name)}
+          />
+        </View>
+        <View style={{ flex: 1 }}>
           <SubLabel title="Notes" />
           <SelectField
             width="flex"
@@ -508,7 +528,7 @@ export function ImportTransactions({
   let [fieldMappings, setFieldMappings] = useState(null);
   let [splitMode, setSplitMode] = useState(false);
   let [flipAmount, setFlipAmount] = useState(false);
-  let { accountId, onImported } = options;
+  let { accountId, categories, onImported } = options;
 
   // This cannot be set after parsing the file, because changing it
   // requires re-parsing the file. This is different from the other
@@ -698,6 +718,7 @@ export function ImportTransactions({
   let headers = [
     { name: 'Date', width: 200 },
     { name: 'Payee', width: 'flex' },
+    { name: 'Category', width: 'flex' },
     { name: 'Notes', width: 'flex' }
   ];
 


### PR DESCRIPTION
## Summary 

- Added category parsing to CSV imports to detect category IDs
- Added menu option to copy a category ID

## Evidence

![2-actual_PR_5-31-2022-1](https://user-images.githubusercontent.com/17950836/171308200-4c71363d-052d-45f0-ac54-eb3befcd6b46.gif)

## Notes

- It is currently possible to enable this functionality with rules, however, one would need to be made for each category and another field would need to be used to hold category identifiers, such as `Notes`
- Currently category IDs are not explicitly stated in the UI as far as I'm aware
- A checkbox could be added to the `Import Options` section to toggle this functionality on and off, though this is functionality only works with category IDs and all other values are ignored; this could be easily changed to create unrecognized categories, like the `Payee`field
- The copy to clipboard implementation is simplistic but [won't work in older browsers](https://caniuse.com/?search=clipboard.writeText); this is a [known problem space](https://stackoverflow.com/a/30810322/5988852) and it may be worth pulling in a dependency like [`react-copy-to-clipboard`](https://www.npmjs.com/package/react-copy-to-clipboard) for a more comprehensive approach
- An alternative to adding "Copy ID to clipboard" to the menu toolbar would be to add an icon that shows on hover like the `Notes` icon

  <img width="210" alt="image" src="https://user-images.githubusercontent.com/17950836/171310617-e8e20eae-4d2c-4511-bd07-453a5d38e6cb.png">
