### PR TITLE
Update patches

### DIFF
--- a/patches/eslint-config-react-app+3.0.8.patch
+++ b/patches/eslint-config-react-app+3.0.8.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/eslint-config-react-app/index.js b/node_modules/eslint-config-react-app/index.js
-index ca232b8..2d88066 100644
+index f83ed06..b0857ce 100644
 --- a/node_modules/eslint-config-react-app/index.js
 +++ b/node_modules/eslint-config-react-app/index.js
-@@ -126,13 +126,6 @@ module.exports = {
+@@ -132,13 +132,6 @@ module.exports = {
        },
      ],
      'no-unused-labels': 'warn',

--- a/patches/hotkeys-js+3.8.7.patch
+++ b/patches/hotkeys-js+3.8.7.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/hotkeys-js/dist/hotkeys.common.js b/node_modules/hotkeys-js/dist/hotkeys.common.js
-index bc18534..34c0d7d 100644
+index ed95889..faab803 100644
 --- a/node_modules/hotkeys-js/dist/hotkeys.common.js
 +++ b/node_modules/hotkeys-js/dist/hotkeys.common.js
 @@ -22,7 +22,6 @@ function addEvent(object, event, method) {
@@ -19,7 +19,7 @@ index bc18534..34c0d7d 100644
    if (typeof key !== 'string') key = '';
    key = key.replace(/\s/g, ''); // 匹配任何空白字符,包括空格、制表符、换页符等等
 diff --git a/node_modules/hotkeys-js/dist/hotkeys.esm.js b/node_modules/hotkeys-js/dist/hotkeys.esm.js
-index 90295a5..f998483 100644
+index 69833cf..fb8024e 100644
 --- a/node_modules/hotkeys-js/dist/hotkeys.esm.js
 +++ b/node_modules/hotkeys-js/dist/hotkeys.esm.js
 @@ -9,6 +9,8 @@
@@ -54,7 +54,7 @@ index 90295a5..f998483 100644
    }
  
    return mods;
-@@ -145,6 +155,9 @@ var elementHasBindEvent = []; // 已绑定事件的节点记录
+@@ -161,6 +171,9 @@ var elementHasBindEvent = []; // 已绑定事件的节点记录
  // 返回键码
  
  var code = function code(x) {
@@ -64,7 +64,7 @@ index 90295a5..f998483 100644
    return _keyMap[x.toLowerCase()] || _modifier[x.toLowerCase()] || x.toUpperCase().charCodeAt(0);
  }; // 设置获取当前范围（默认为'所有'）
  
-@@ -319,7 +332,6 @@ function eventHandler(event, handler, scope) {
+@@ -335,7 +348,6 @@ function eventHandler(event, handler, scope) {
        }
      } // 调用处理程序，如果是修饰键不做处理
  
@@ -73,7 +73,7 @@ index 90295a5..f998483 100644
        if (handler.method(event, handler) === false) {
          if (event.preventDefault) event.preventDefault();else event.returnValue = false;
 diff --git a/node_modules/hotkeys-js/dist/hotkeys.js b/node_modules/hotkeys-js/dist/hotkeys.js
-index 15480e8..d203a42 100644
+index d3d974c..cdb4046 100644
 --- a/node_modules/hotkeys-js/dist/hotkeys.js
 +++ b/node_modules/hotkeys-js/dist/hotkeys.js
 @@ -26,7 +26,6 @@

--- a/patches/pikaday+1.8.2.patch
+++ b/patches/pikaday+1.8.2.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/pikaday/pikaday.js b/node_modules/pikaday/pikaday.js
-index 8dae838..13ecfbe 100755
+index 6164245..8b0be6e 100755
 --- a/node_modules/pikaday/pikaday.js
 +++ b/node_modules/pikaday/pikaday.js
 @@ -12,8 +12,8 @@

--- a/patches/react-modal+3.14.4.patch
+++ b/patches/react-modal+3.14.4.patch
@@ -1,13 +1,13 @@
 diff --git a/node_modules/react-modal/lib/components/ModalPortal.js b/node_modules/react-modal/lib/components/ModalPortal.js
-index 1dcab7d..0fa19dc 100644
+index d77a0ad..aa4070c 100644
 --- a/node_modules/react-modal/lib/components/ModalPortal.js
 +++ b/node_modules/react-modal/lib/components/ModalPortal.js
-@@ -286,7 +286,7 @@ var ModalPortal = function (_Component) {
-   }, {
+@@ -302,7 +302,7 @@ var ModalPortal = function (_Component) {
      key: "componentWillUnmount",
      value: function componentWillUnmount() {
--      this.afterClose();
-+      setTimeout(() => { this.afterClose() }, 0)
+       if (this.state.isOpen) {
+-        this.afterClose();
++        setTimeout(() => { this.afterClose() }, 0);
+       }
        clearTimeout(this.closeTimer);
-     }
-   }, {
+       cancelAnimationFrame(this.openAnimationFrame);


### PR DESCRIPTION
To reduce warnings on `yarn install`. 

All patch version bumps except `react-modal`. 
☝🏻 **This one could use review.** 

In intervening minor bumps, the lib guarded the `afterClose` close call with a check for the modal being open. Presumably, that's what one would want. 
However, it's not clear to me what purpose the non-blocking `afterClose` patch is serving within Actual (I find no uses of this function), so I couldn't say for sure this is still how we want to patch it. Or if it even needs patching anymore.


❌  BEFORE
```
patch-package 6.4.7
Applying patches...
@reach/listbox@0.11.2 ✔
@sentry/browser@6.12.0 ✔
absurd-sql@0.0.53 ✔
eslint-config-react-app@3.0.5 ✔
hotkeys-js@3.8.2 ✔
pikaday@1.8.0 ✔
react-dnd-html5-backend@10.0.2 ✔
...
<warnings warnings warnings>

**ERROR** Failed to apply patch for package react-modal at path
  
    node_modules/react-modal

<details details>

  Info:
    Patch file: patches/react-modal+3.4.4.patch
    Patch was made for version: 3.4.4
    Installed version: 3.14.4
patch-package finished with 3 warning(s), 1 error(s).
```

✅  AFTER

![after](https://user-images.githubusercontent.com/5862724/173730731-c3a9b135-5853-493e-8151-f2765584b488.png)
