### PR TITLE
Fix yaml formatting in CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,13 @@ jobs:
 
       - restore_cache:
           keys:
-          - v3-dependencies-{{ checksum "yarn.lock" }}
+            - v3-dependencies-{{ checksum "yarn.lock" }}
 
       - run: yarn install --pure-lockfile
 
       - save_cache:
           <<: *cached_files
-        
+
       - run: yarn test
 
   build_windows:
@@ -94,7 +94,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v3-dependencies-{{ checksum "yarn.lock" }}
+            - v3-dependencies-{{ checksum "yarn.lock" }}
 
       - run: yarn install --pure-lockfile
 


### PR DESCRIPTION
There's a few formatting errors in the circleCI config which vscode automatically fixes on save. This PR performs these changes to avoid noise in diffs which make meaningful changes to this file.