### PR TITLE
Update downshift patch to match installed version

### DIFF
--- a/packages/loot-design/package.json
+++ b/packages/loot-design/package.json
@@ -11,7 +11,7 @@
     "camelcase": "^5.0.0",
     "chroma-js": "^1.3.3",
     "date-fns": "2.0.0-alpha.27",
-    "downshift": "^1.31.7",
+    "downshift": "1.31.16",
     "fast-glob": "^2.2.2",
     "formik": "^0.11.10",
     "glamor": "^2.20.40",

--- a/packages/loot-design/patches/downshift+1.31.16.patch
+++ b/packages/loot-design/patches/downshift+1.31.16.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/downshift/dist/downshift.esm.js b/node_modules/downshift/dist/downshift.esm.js
-index b89f7d6..4020b47 100644
+index f39a298..da7b6f5 100644
 --- a/node_modules/downshift/dist/downshift.esm.js
 +++ b/node_modules/downshift/dist/downshift.esm.js
-@@ -1198,10 +1198,15 @@ var _initialiseProps = function () {
+@@ -1200,10 +1200,15 @@ var _initialiseProps = function () {
        // onMouseMove is used over onMouseEnter here. onMouseMove
        // is only triggered on actual mouse movement while onMouseEnter
        // can fire on DOM changes, interrupting keyboard navigation

--- a/yarn.lock
+++ b/yarn.lock
@@ -6304,7 +6304,7 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
-downshift@^1.31.7:
+downshift@1.31.16:
   version "1.31.16"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.31.16.tgz#acd81631539502d4112d01bd573654419fd9f640"
   integrity sha512-RskXmiGSoz0EHAyBrmTBGSLHg6+NYDGuLu2W3GpmuOe6hmZEWhCiQrq5g6DWzhnUaJD41xHbbfC6j1Fe86YqgA==


### PR DESCRIPTION
There seems to be patched dependency which was missed out from #55 and is currently causing #50 to fail in CI.

I've updated the patch for this package to match the version which is referenced in the lock file.