### PR TITLE
Fix: parse dates without a delimiter in CSV import

### DIFF
--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -55,6 +55,8 @@ export function parseDate(str, order) {
   let parts = str.replace(/\s+/g, '').match(re[order]);
   if (!parts) return null;
 
+  // We're only interested in the groups so slice the full matched string off
+  // of the array.
   parts = parts.slice(1);
 
   let year, month, day;

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -351,10 +351,7 @@ function DateFormatSelect({
   // try to figure out what delimiter the date is using, and default
   // to space if we can't figure it out.
   let delimiter = '-';
-  if (
-    transactions.length > 0 &&
-    (fieldMappings && fieldMappings.date != null)
-  ) {
+  if (transactions.length > 0 && fieldMappings && fieldMappings.date != null) {
     let date = transactions[0][fieldMappings.date];
     let m = date && date.match(/[/.,-/\\]/);
     delimiter = m ? m[0] : ' ';

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -31,18 +31,6 @@ let dateFormats = [
   { format: 'dd mm yy', label: 'DD MM YY' }
 ];
 
-const reYearFirst = /^(\d{4})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{2})$/;
-const reYearLast = /^(\d{2})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{4})$/;
-const reTwoDig = /^(\d{2})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{2})$/;
-const re = {
-  'yyyy mm dd': reYearFirst,
-  'mm dd yyyy': reYearLast,
-  'dd mm yyyy': reYearLast,
-  'yy mm dd': reTwoDig,
-  'mm dd yy': reTwoDig,
-  'dd mm yy': reTwoDig
-};
-
 export function parseDate(str, order) {
   if (typeof str !== 'string') {
     return null;
@@ -52,42 +40,48 @@ export function parseDate(str, order) {
     return v && v.length === 1 ? '0' + v : v;
   }
 
-  let parts = str.replace(/\s+/g, '').match(re[order]);
-  if (!parts) return null;
+  const dateGroups = (a, b) => str => {
+    const digits = str.replace(/[^\d]/g, '');
+    return [digits.slice(0, a), digits.slice(a, a + b), digits.slice(a + b)];
+  };
+  const yearFirst = dateGroups(4, 2);
+  const twoDig = dateGroups(2, 2);
 
-  // We're only interested in the groups so slice the full matched string off
-  // of the array.
-  parts = parts.slice(1);
-
-  let year, month, day;
+  let parts, year, month, day;
   switch (order) {
     case 'dd mm yyyy':
+      parts = twoDig(str);
       year = parts[2];
       month = parts[1];
       day = parts[0];
       break;
     case 'dd mm yy':
+      parts = twoDig(str);
       year = `20${parts[2]}`;
       month = parts[1];
       day = parts[0];
       break;
     case 'yyyy mm dd':
+      parts = yearFirst(str);
       year = parts[0];
       month = parts[1];
       day = parts[2];
       break;
     case 'yy mm dd':
+      parts = twoDig(str);
       year = `20${parts[0]}`;
       month = parts[1];
       day = parts[2];
       break;
     case 'mm dd yy':
+      parts = twoDig(str);
       year = `20${parts[2]}`;
       month = parts[0];
       day = parts[1];
       break;
     default:
     case 'mm dd yyyy':
+      parts = twoDig(str);
       year = parts[2];
       month = parts[0];
       day = parts[1];

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -43,7 +43,7 @@ const re = {
   'dd mm yy': reTwoDig
 };
 
-function parseDate(str, order) {
+export function parseDate(str, order) {
   if (typeof str !== 'string') {
     return null;
   }

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -31,6 +31,18 @@ let dateFormats = [
   { format: 'dd mm yy', label: 'DD MM YY' }
 ];
 
+const reYearFirst = /^(\d{4})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{2})$/;
+const reYearLast = /^(\d{2})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{4})$/;
+const reTwoDig = /^(\d{2})(?:[^\d]*)?(\d{2})(?:[^\d]*)?(\d{2})$/;
+const re = {
+  'yyyy mm dd': reYearFirst,
+  'mm dd yyyy': reYearLast,
+  'dd mm yyyy': reYearLast,
+  'yy mm dd': reTwoDig,
+  'mm dd yy': reTwoDig,
+  'dd mm yy': reTwoDig
+};
+
 function parseDate(str, order) {
   if (typeof str !== 'string') {
     return null;
@@ -40,7 +52,10 @@ function parseDate(str, order) {
     return v && v.length === 1 ? '0' + v : v;
   }
 
-  let parts = str.replace(/ /g, '').split(/[^0-9]/);
+  let parts = str.replace(/\s+/g, '').match(re[order]);
+  if (!parts) return null;
+
+  parts = parts.slice(1);
 
   let year, month, day;
   switch (order) {

--- a/packages/loot-design/src/components/modals/ImportTransactions.test.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.test.js
@@ -14,7 +14,17 @@ describe('Import transactions', function() {
         { str: '12 24 20', order: 'mm dd yyyy' },
         { str: '20 12 24', order: 'yyyy mm dd' },
         { str: '2020 12 24', order: 'yy mm dd' },
-        { str: '12 24 2020', order: 'mm dd yy' }
+        { str: '12 24 2020', order: 'mm dd yy' },
+        { str: '12 00 2020', order: 'mm dd yyyy' },
+        { str: '12 32 2020', order: 'mm dd yyyy' },
+        { str: '13 24 2020', order: 'mm dd yyyy' },
+        { str: '00 24 2020', order: 'mm dd yyyy' },
+        { str: '02 30 2020', order: 'mm dd yyyy' },
+        { str: '04 31 2020', order: 'mm dd yyyy' },
+        { str: '04 31 2020', order: 'mm dd yyyy' },
+        { str: '06 31 2020', order: 'mm dd yyyy' },
+        { str: '09 31 2020', order: 'mm dd yyyy' },
+        { str: '11 31 2020', order: 'mm dd yyyy' }
       ];
 
       for (const { str, order } of invalidInputs) {

--- a/packages/loot-design/src/components/modals/ImportTransactions.test.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.test.js
@@ -24,7 +24,10 @@ describe('Import transactions', function() {
         { str: '04 31 2020', order: 'mm dd yyyy' },
         { str: '06 31 2020', order: 'mm dd yyyy' },
         { str: '09 31 2020', order: 'mm dd yyyy' },
-        { str: '11 31 2020', order: 'mm dd yyyy' }
+        { str: '11 31 2020', order: 'mm dd yyyy' },
+        { str: '2046 31 2020', order: 'mm dd yyyy' },
+        { str: '2011 31 2020', order: 'mm dd yy' },
+        { str: '2020', order: 'mm dd yy' }
       ];
 
       for (const { str, order } of invalidInputs) {

--- a/packages/loot-design/src/components/modals/ImportTransactions.test.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.test.js
@@ -1,0 +1,110 @@
+import { parseDate } from './ImportTransactions';
+
+describe('Import transactions', function() {
+  describe('date parsing', function() {
+    it('should not parse', function() {
+      const invalidInputs = [
+        { str: '', order: 'yyyy mm dd' },
+        { str: null, order: 'yyyy mm dd' },
+        { str: 42, order: 'yyyy mm dd' },
+        { str: {}, order: 'yyyy mm dd' },
+        { str: [], order: 'yyyy mm dd' },
+        { str: 'invalid', order: 'yyyy mm dd' },
+        { str: '2020 Dec 24', order: 'yyyy mm dd' },
+        { str: '12 24 20', order: 'mm dd yyyy' },
+        { str: '20 12 24', order: 'yyyy mm dd' },
+        { str: '2020 12 24', order: 'yy mm dd' },
+        { str: '12 24 2020', order: 'mm dd yy' }
+      ];
+
+      for (const { str, order } of invalidInputs) {
+        expect(parseDate(str, order)).toBe(null);
+      }
+    });
+
+    it('should parse', function() {
+      const validInputs = [
+        {
+          order: 'yyyy mm dd',
+          cases: [
+            '20201224',
+            '2020 12 24',
+            '2020-12-24',
+            '2020/12/24',
+            ' 2020 / 12 / 24',
+            '2020/12/24 ',
+            '2020 12-24 '
+          ]
+        },
+        {
+          order: 'yy mm dd',
+          cases: [
+            '201224',
+            '20 12 24',
+            '20-12-24',
+            '20/12/24',
+            '20/12/24',
+            '20/12/24 ',
+            '20 12-24 '
+          ]
+        },
+        {
+          order: 'mm dd yyyy',
+          cases: [
+            '12242020',
+            '12 24 2020 ',
+            '12-24-2020',
+            '12/24/2020',
+            ' 12/24/2020',
+            '12/24/2020',
+            '12 24-2020'
+          ]
+        },
+        {
+          order: 'mm dd yy',
+          cases: [
+            '122420',
+            '12 24 20 ',
+            '12-24-20',
+            '12/24/20',
+            ' 12/24/20',
+            '12/24/20',
+            '12 24-20'
+          ]
+        },
+        {
+          order: 'dd mm yyyy',
+          cases: [
+            '24122020',
+            '24 12 2020 ',
+            '24-12-2020',
+            '24/12/2020',
+            ' 24/12/2020',
+            '24/12/2020 ',
+            '24-12 2020'
+          ]
+        },
+        {
+          order: 'dd mm yy',
+          cases: [
+            '241220',
+            '2412 20 ',
+            '24-12-20',
+            '24/12/20',
+            ' 24/12/20',
+            '24/12/20 ',
+            '24 12-20 '
+          ]
+        }
+      ];
+
+      for (const { order, cases } of validInputs) {
+        for (const str of cases) {
+          const parsed = parseDate(str, order);
+          expect(typeof parsed).toBe('string');
+          expect(parsed).toBe('2020-12-24');
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Addresses issue #116 by adding new regexes to meet the currently available formats. If anyone has additional test cases to suggest that would be swell.

- [x] Prettier applied (including changes to legacy code)
- [x] Tests added
 