### PR TITLE
Feat/delimiter select on error

### DIFF
--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -490,6 +490,30 @@ function FieldMappings({ transactions, mappings, onChange, splitMode }) {
   );
 }
 
+function DelimiterSelect({
+  setCsvDelimiter,
+  parse,
+  filename,
+  csvDelimiter,
+  style = {}
+}) {
+  return (
+    <View style={{ width: 130, ...style }}>
+      <SectionLabel title="CSV DELIMITER" />
+      <Select
+        value={csvDelimiter}
+        onChange={e => {
+          setCsvDelimiter(e.target.value);
+          parse(filename, { delimiter: e.target.value });
+        }}
+      >
+        <option value=",">,</option>
+        <option value=";">;</option>
+      </Select>
+    </View>
+  );
+}
+
 export function ImportTransactions({
   modalProps,
   options,
@@ -828,19 +852,15 @@ export function ImportTransactions({
         )}
 
         {filetype === 'csv' && (
-          <View style={{ marginLeft: 25 }}>
-            <SectionLabel title="CSV DELIMITER" />
-            <Select
-              value={csvDelimiter}
-              onChange={e => {
-                setCsvDelimiter(e.target.value);
-                parse(filename, { delimiter: e.target.value });
-              }}
-            >
-              <option value=",">,</option>
-              <option value=";">;</option>
-            </Select>
-          </View>
+          <DelimiterSelect
+            {...{
+              setCsvDelimiter,
+              parse,
+              filename,
+              csvDelimiter,
+              style: { marginLeft: 25 }
+            }}
+          />
         )}
 
         <View style={{ flex: 1 }} />

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -794,20 +794,33 @@ export function ImportTransactions({
         </View>
       )}
       {error && error.parsed && (
-        <View
-          style={{
-            color: colors.r4,
-            alignItems: 'center',
-            marginTop: 10
-          }}
-        >
-          <Text style={{ maxWidth: 450, marginBottom: 15 }}>
-            <strong>Error:</strong> {error.message}
-          </Text>
-          {error.parsed && (
-            <Button onClick={() => onNewFile()}>Select new file...</Button>
-          )}
-        </View>
+        <>
+          <View
+            style={{
+              color: colors.r4,
+              alignItems: 'center',
+              marginTop: 10
+            }}
+          >
+            <Text style={{ maxWidth: 450, marginBottom: 15 }}>
+              <strong>Error:</strong> {error.message}
+            </Text>
+            {error.parsed && (
+              <Button onClick={() => onNewFile()}>Select new file...</Button>
+            )}
+            {getFileType(options.filename) === 'csv' && (
+              <DelimiterSelect
+                {...{
+                  setCsvDelimiter,
+                  parse,
+                  filename,
+                  csvDelimiter,
+                  style: { marginTop: 10 }
+                }}
+              />
+            )}
+          </View>
+        </>
       )}
 
       {filetype === 'csv' && (

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -336,10 +336,7 @@ function DateFormatSelect({
   // try to figure out what delimiter the date is using, and default
   // to space if we can't figure it out.
   let delimiter = '-';
-  if (
-    transactions.length > 0 &&
-    (fieldMappings && fieldMappings.date != null)
-  ) {
+  if (transactions.length > 0 && fieldMappings && fieldMappings.date != null) {
     let date = transactions[0][fieldMappings.date];
     let m = date && date.match(/[/.,-/\\]/);
     delimiter = m ? m[0] : ' ';


### PR DESCRIPTION
edit: rewritten for easier review

### Problem
As described in #19. The current flow doesn't provide an opportunity to select the appropriate csv delimiter setting until *after* you've successfully parsed. 
> This seems to happen with CSV files that contain semicolon delimiters and strings that are wrapped with double quotation marks. When trying to import such files for the first time to an account, the error pops up.

### Proposed solution
Adding a delimiter selector when csv parsing fails. This change avoids that flow issue (though i'm sure the aesthetics or UX could be even better) by presenting the delimiter select alongside the error.
![image](https://user-images.githubusercontent.com/2792750/177268997-2bacbf07-c458-4793-ad1b-e9da8aa6f831.png)

There's also a prettier driven style change to legacy code. Unrelated to this change other than existing in the same file.