### PR TITLE
fix: hitting enter after setting password redirects to demo page

### DIFF
--- a/packages/desktop-client/src/components/manager/subscribe/ConfirmPasswordForm.js
+++ b/packages/desktop-client/src/components/manager/subscribe/ConfirmPasswordForm.js
@@ -47,6 +47,7 @@ export function ConfirmPasswordForm({ buttons, onSetPassword, onError }) {
         type={showPassword ? 'text' : 'password'}
         value={password1}
         onChange={e => setPassword1(e.target.value)}
+        onEnter={onSubmit}
       />
       <Input
         placeholder="Confirm password"
@@ -54,6 +55,7 @@ export function ConfirmPasswordForm({ buttons, onSetPassword, onError }) {
         value={password2}
         onChange={e => setPassword2(e.target.value)}
         style={{ marginTop: 10 }}
+        onEnter={onSubmit}
       />
 
       <View


### PR DESCRIPTION
Closes #29 

- At the bootstrap page, when the user sets the password and press enter or even when the password field is empty, he is redirected to the demo page.
- I used the "onEnter" prop from the Input component to trigger the "onSubmit" function whenever the user presses enter within both password input fields.

### Before changes: 
- The user is redirected to the demo page after pressing enter.

[old-screen-record](https://user-images.githubusercontent.com/71379045/177626271-5ba29253-4c4b-477c-ba1f-c51b7fc265ca.webm)

- In this screen record i fill the password fields and then i press enter. The page demo is launched.

### After changes: 
- The user is redirected to the files page after pressing enter.

[new-screen-record](https://user-images.githubusercontent.com/71379045/177625445-fda04a4f-271f-4c1c-bf5d-63d203bfacf5.webm)

- In this screen record I fill the password fields and then I press enter. Now the user is redirected to the files page.
- I also tested pressing enter with empty fields and with just one filled.

