### PR TITLE
Add action to mark new issues for triage

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -1,0 +1,14 @@
+name: Mark new issue for triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs triage


### PR DESCRIPTION
This adds an action to mark new issues with a `needs triage` label on creation (We'd need to create this label as well).

Motivation for this being that we'd remove this label once the issue has been assessed so new issues won't fall through the cracks. 