### PR TITLE
Silence warning for missing moment.js install

### DIFF
--- a/packages/desktop-client/config/webpack.config.js
+++ b/packages/desktop-client/config/webpack.config.js
@@ -526,6 +526,10 @@ module.exports = function(webpackEnv) {
       // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
       // You can remove this if you don't use Moment.js:
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      // Pikaday throws a warning if Moment.js is not installed however it doesn't
+      // actually require it to be installed. As we don't use Moment.js ourselves
+      // then we can just silence this warning.
+      new webpack.IgnorePlugin(/moment$/, /pikaday$/),
       !(isEnvDevelopment || process.env.PERF_BUILD) &&
         new webpack.IgnorePlugin(/perf-deets\/frontend/),
       // Generate a service worker script that will precache, and keep up to date,


### PR DESCRIPTION
This removes the bogus warning for us not having moment.js installed which pikaday throws if it can't find it.

https://github.com/Pikaday/Pikaday/issues/815