### PR TITLE
Force react-error-overlay to 6.0.9 to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@babel/preset-env": "^7.15.1",
     "@babel/core": "^7.15.1",
     "@babel/runtime": "^7.15.1",
-    "@babel/helper-plugin-utils": "^7.14.5"
+    "@babel/helper-plugin-utils": "^7.14.5",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14573,10 +14573,10 @@ react-element-query@^3.0.2:
     proptypes "^1.0.0"
     raf "^3.3.0"
 
-react-error-overlay@^6.0.11:
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
-  integrity sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==
+react-error-overlay@6.0.9, react-error-overlay@^6.0.11:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
 react-fast-compare@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR https://github.com/actualbudget/actual/pull/132 replaced `jwl-dev-utils` with `react-dev-utils` and used a much greater major version. This broke the react error overlay feature; when developing and something goes wrong, instead of seeing the error overlay you don't see anything, and the app feels "locked up" but there's really a transparent div covering the whole screen.

There's an error in the console: `process in not defined`. After some research, looks like we need to lock `react-error-overlay` to a specific version. This fixed it for me. I don't love it, but maybe we can move off this whole build stack at some point.

r? @TomAFrench 