### PR TITLE
Fix enter to create accounts

### DIFF
--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -935,10 +935,6 @@ export function ModalButtons({
         style
       ]}
     >
-      {/* Add a dummy button first so that when a user
-          presses "enter" they do a normal submit, instead of
-          activating the back button */}
-      <Button data-hidden={true} style={{ display: 'none' }} />
       {leftContent}
       <View style={{ flex: 1 }} />
       {children}

--- a/packages/loot-design/src/components/modals/CreateLocalAccount.js
+++ b/packages/loot-design/src/components/modals/CreateLocalAccount.js
@@ -143,7 +143,9 @@ function CreateLocalAccount({ modalProps, actions, history }) {
                 )}
 
                 <ModalButtons>
-                  <Button onClick={() => modalProps.onBack()}>Back</Button>
+                  <Button onClick={() => modalProps.onBack()} type="button">
+                    Back
+                  </Button>
                   <Button primary style={{ marginLeft: 10 }}>
                     Create
                   </Button>


### PR DESCRIPTION
This is a small fix.

Right now, it seems like an attempt was made to insert a hidden button. This **does not work** on my computer (Safari 16.1).

The correct fix as I understand it is to mark non-submit buttons as `type="button"`.

I've searched the codebase and only found one form button that needs to be modified.