### PR TITLE
Remove patch-package dependency from loot-design

### DIFF
--- a/packages/loot-design/package.json
+++ b/packages/loot-design/package.json
@@ -36,9 +36,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.1.2",
     "hotkeys-js": "3.8.2",
-    "patch-package": "^6.1.2",
     "pikaday": "1.8.0",
-    "postinstall-postinstall": "^2.0.0",
     "react-dnd": "^10.0.2",
     "react-merge-refs": "^1.1.0",
     "react-modal": "3.4.4",
@@ -48,7 +46,6 @@
   "scripts": {
     "start": "react-scripts start",
     "start:mobile": "IS_REACT_NATIVE=1 react-scripts start",
-    "postinstall": "patch-package",
     "test": "npm-run-all -cp 'test:*'",
     "test:web": "jest -c jest.config.js",
     "test:react-native": "jest -c jest.rn.config.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14606,10 +14606,8 @@ jest-snapshot@test:
     memoizee: ^0.4.12
     node-noop: 1.0.0
     npm-run-all: ^4.1.3
-    patch-package: ^6.1.2
     pikaday: 1.8.0
     polished: ^1.8.1
-    postinstall-postinstall: ^2.0.0
     prettier: ^1.14.2
     prop-types: 15.6.0
     react: 16.13.1
@@ -18202,13 +18200,6 @@ jest-snapshot@test:
     picocolors: ^0.2.1
     source-map: ^0.6.1
   checksum: 4ac793f506c23259189064bdc921260d869a115a82b5e713973c5af8e94fbb5721a5cc3e1e26840500d7e1f1fa42a209747c5b1a151918a9bc11f0d7ed9048e3
-  languageName: node
-  linkType: hard
-
-"postinstall-postinstall@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "postinstall-postinstall@npm:2.1.0"
-  checksum: e1d34252cf8d2c5641c7d2db7426ec96e3d7a975f01c174c68f09ef5b8327bc8d5a9aa2001a45e693db2cdbf69577094d3fe6597b564ad2d2202b65fba76134b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We no longer have any patches in loot-design so we don't need to call it in the package's context