### PR TITLE
Implement localization for schedule descriptions

### DIFF
--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -328,7 +328,7 @@ class Budget extends React.PureComponent {
       pathname: '/accounts',
       state: {
         goBack: true,
-        filterName: `${categoryName} (${monthUtils.format(
+        filterName: `${categoryName} (${monthUtils.nonLocalizedFormat(
           month,
           'MMMM yyyy'
         )})`,

--- a/packages/desktop-client/src/components/modals/EditRule.js
+++ b/packages/desktop-client/src/components/modals/EditRule.js
@@ -256,7 +256,7 @@ function ScheduleDescription({ id }) {
         </Text>
         <Text style={{ margin: '0 5px' }}> — </Text>
         <Text style={{ flexShrink: 0 }}>
-          Next: {monthUtils.format(schedule.next_date, dateFormat)}
+          Next: {monthUtils.nonLocalizedFormat(schedule.next_date, dateFormat)}
         </Text>
       </View>
       <StatusBadge status={status} />

--- a/packages/desktop-client/src/components/modals/ManageRules.js
+++ b/packages/desktop-client/src/components/modals/ManageRules.js
@@ -40,6 +40,7 @@ import {
   getRecurringDescription
 } from 'loot-core/src/shared/schedules';
 import { getPayeesById } from 'loot-core/src/client/reducers/queries';
+import { useTranslation } from 'react-i18next';
 
 let SchedulesQuery = liveQueryContext(q('schedules').select('*'));
 
@@ -50,6 +51,7 @@ export function Value({
   data: dataProp,
   describe = x => x.name
 }) {
+  const { i18n } = useTranslation();
   let { data, dateFormat } = useSelector(state => {
     let data;
     if (dataProp) {
@@ -93,7 +95,7 @@ export function Value({
       } else if (field === 'date') {
         if (value) {
           if (value.frequency) {
-            return getRecurringDescription(value);
+            return getRecurringDescription(value, i18n);
           }
           return formatDate(parseISO(value), dateFormat);
         }

--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -51,7 +51,7 @@ function CashFlow() {
         .rangeInclusive(earliestMonth, monthUtils.currentMonth())
         .map(month => ({
           name: month,
-          pretty: monthUtils.format(month, 'MMMM, yyyy')
+          pretty: monthUtils.nonLocalizedFormat(month, 'MMMM, yyyy')
         }))
         .reverse();
 

--- a/packages/desktop-client/src/components/reports/NetWorth.js
+++ b/packages/desktop-client/src/components/reports/NetWorth.js
@@ -49,7 +49,7 @@ function NetWorth({ accounts }) {
         .rangeInclusive(earliestMonth, monthUtils.currentMonth())
         .map(month => ({
           name: month,
-          pretty: monthUtils.format(month, 'MMMM, yyyy')
+          pretty: monthUtils.nonLocalizedFormat(month, 'MMMM, yyyy')
         }))
         .reverse();
 

--- a/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
+++ b/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
@@ -27,17 +27,19 @@ import useSelected, {
 import { Page } from '../Page';
 import DisplayId from '../util/DisplayId';
 import { ScheduleAmountCell } from './SchedulesTable';
+import { useTranslation } from 'react-i18next';
 
 let ROW_HEIGHT = 43;
 
 function DiscoverSchedulesTable({ schedules, loading }) {
   let selectedItems = useSelectedItems();
   let dispatchSelected = useSelectedDispatch();
+  let { i18n } = useTranslation();
 
   function renderItem({ item }) {
     let selected = selectedItems.has(item.id);
     let amountOp = item._conditions.find(c => c.field === 'amount').op;
-    let recurDescription = getRecurringDescription(item.date);
+    let recurDescription = getRecurringDescription(item.date, i18n);
 
     return (
       <Row

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -548,7 +548,9 @@ export default function ScheduleDetails() {
                 style={{ marginTop: 10, color: colors.n4 }}
               >
                 {state.upcomingDates.map(date => (
-                  <View>{monthUtils.format(date, `${dateFormat} EEEE`)}</View>
+                  <View>
+                    {monthUtils.nonLocalizedFormat(date, `${dateFormat} EEEE`)}
+                  </View>
                 ))}
               </Stack>
             </View>

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -179,7 +179,7 @@ export function SchedulesTable({
         </Field>
         <Field width={110}>
           {item.next_date
-            ? monthUtils.format(item.next_date, dateFormat)
+            ? monthUtils.nonLocalizedFormat(item.next_date, dateFormat)
             : null}
         </Field>
         <Field width={120} style={{ alignItems: 'flex-start' }}>

--- a/packages/desktop-client/src/components/tutorial/Overspending.js
+++ b/packages/desktop-client/src/components/tutorial/Overspending.js
@@ -13,7 +13,7 @@ import { Standalone, Title, useMinimized } from './common';
 function Overspending({ navigationProps, stepTwo }) {
   let currentMonth = monthUtils.currentMonth();
   let sheetName = monthUtils.sheetForMonth(currentMonth);
-  let month = monthUtils.format(currentMonth, 'MMM');
+  let month = monthUtils.nonLocalizedFormat(currentMonth, 'MMM');
   let [minimized, toggle] = useMinimized();
 
   return (

--- a/packages/desktop-client/src/locales/en-GB.json
+++ b/packages/desktop-client/src/locales/en-GB.json
@@ -29,7 +29,11 @@
     "save": "Save",
     "schedule": "Schedule",
     "schedule_other": "Schedules",
-    "status": "Status"
+    "status": "Status",
+    "ordinal_one": "{{count}}st",
+    "ordinal_two": "{{count}}nd",
+    "ordinal_few": "{{count}}rd",
+    "ordinal_other": "{{count}}th"
   },
   "schedules": {
     "addNewSchedule": "Add new schedule",
@@ -53,7 +57,24 @@
     "theseTransactionsMatchThisSchedule": "These transactions match this schedule:",
     "thisScheduleHasCustomConditionsAndActions": "This schedule has custom conditions and actions",
     "unlinkFromSchedule": "Unlink from schedule",
-    "upcomingDates": "Upcoming dates"
+    "upcomingDates": "Upcoming dates",
+    "recurring": {
+      "weekly_one": "Every week on {{day}}",
+      "weekly_other": "Every {{count}} weeks on {{day}}",
+      "monthly_one": "Every month on the {{day}}",
+      "monthly_other": "Every {{count}} months on the {{day}}",
+      "monthlyPattern_one": "Every month on the {{pattern}}",
+      "monthlyPattern_other": "Every {{count}} months on the {{pattern}}",
+      "yearly_one": "Every year on {{day}}",
+      "yearly_other": "Every {{count}} years on {{day}}",
+      "pattern": {
+        "lastDay": "last day",
+        "weekAndDay": "{{week}} {{dayName}}",
+        "weekAndDay_sameDay": "{{week}}",
+        "lastWeekday": "last {{dayName}}",
+        "lastWeekday_sameDay": "last"
+      }
+    }
   },
   "status": {
     "completed": "completed",

--- a/packages/loot-core/src/shared/months.js
+++ b/packages/loot-core/src/shared/months.js
@@ -210,6 +210,10 @@ export function sheetForMonth(month) {
   return 'budget' + month.replace('-', '');
 }
 
+export function format(month, opts, locale) {
+  return Intl.DateTimeFormat(locale, opts).format(_parse(month));
+}
+
 export function nonLocalizedFormat(month, str) {
   return d.format(_parse(month), str);
 }

--- a/packages/loot-core/src/shared/months.js
+++ b/packages/loot-core/src/shared/months.js
@@ -210,11 +210,7 @@ export function sheetForMonth(month) {
   return 'budget' + month.replace('-', '');
 }
 
-export function nameForMonth(month) {
-  return d.format(_parse(month), "MMMM 'yy");
-}
-
-export function format(month, str) {
+export function nonLocalizedFormat(month, str) {
   return d.format(_parse(month), str);
 }
 

--- a/packages/loot-core/src/shared/schedules.js
+++ b/packages/loot-core/src/shared/schedules.js
@@ -45,7 +45,7 @@ export function getHasTransactionsQuery(schedules) {
 function makeNumberSuffix(num) {
   // Slight abuse of date-fns to turn a number like "1" into the full
   // form "1st" but formatting a date with that number
-  return monthUtils.format(new Date(2020, 0, num, 12), 'do');
+  return monthUtils.nonLocalizedFormat(new Date(2020, 0, num, 12), 'do');
 }
 
 function prettyDayName(day) {
@@ -68,7 +68,7 @@ export function getRecurringDescription(config) {
     case 'weekly': {
       let desc = 'Every ';
       desc += interval !== 1 ? `${interval} weeks` : 'week';
-      desc += ' on ' + monthUtils.format(config.start, 'EEEE');
+      desc += ' on ' + monthUtils.nonLocalizedFormat(config.start, 'EEEE');
       return desc;
     }
     case 'monthly': {
@@ -135,7 +135,7 @@ export function getRecurringDescription(config) {
           desc += ' ' + prettyDayName(patterns[0].type);
         }
       } else {
-        desc += ' on the ' + monthUtils.format(config.start, 'do');
+        desc += ' on the ' + monthUtils.nonLocalizedFormat(config.start, 'do');
       }
 
       return desc;
@@ -143,7 +143,7 @@ export function getRecurringDescription(config) {
     case 'yearly': {
       let desc = 'Every ';
       desc += interval !== 1 ? `${interval} years` : 'year';
-      desc += ' on ' + monthUtils.format(config.start, 'LLL do');
+      desc += ' on ' + monthUtils.nonLocalizedFormat(config.start, 'LLL do');
       return desc;
     }
     default:

--- a/packages/loot-core/src/shared/schedules.test.js
+++ b/packages/loot-core/src/shared/schedules.test.js
@@ -1,5 +1,8 @@
 import { getRecurringDescription } from './schedules';
 import MockDate from 'mockdate';
+import i18n from '../../../desktop-client/src/locales';
+
+i18n.changeLanguage('en');
 
 describe('recurring date description', () => {
   beforeEach(() => {
@@ -8,149 +11,197 @@ describe('recurring date description', () => {
 
   it('describes weekly interval', () => {
     expect(
-      getRecurringDescription({ start: '2021-05-17', frequency: 'weekly' })
+      getRecurringDescription(
+        { start: '2021-05-17', frequency: 'weekly' },
+        i18n
+      )
     ).toBe('Every week on Monday');
 
     expect(
-      getRecurringDescription({
-        start: '2021-05-17',
-        frequency: 'weekly',
-        interval: 2
-      })
+      getRecurringDescription(
+        {
+          start: '2021-05-17',
+          frequency: 'weekly',
+          interval: 2
+        },
+        i18n
+      )
     ).toBe('Every 2 weeks on Monday');
   });
 
   it('describes monthly interval', () => {
     expect(
-      getRecurringDescription({ start: '2021-04-25', frequency: 'monthly' })
+      getRecurringDescription(
+        { start: '2021-04-25', frequency: 'monthly' },
+        i18n
+      )
     ).toBe('Every month on the 25th');
 
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        interval: 2
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          interval: 2
+        },
+        i18n
+      )
     ).toBe('Every 2 months on the 25th');
 
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [{ type: 'day', value: 25 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [{ type: 'day', value: 25 }]
+        },
+        i18n
+      )
     ).toBe('Every month on the 25th');
 
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        interval: 2,
-        patterns: [{ type: 'day', value: 25 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          interval: 2,
+          patterns: [{ type: 'day', value: 25 }]
+        },
+        i18n
+      )
     ).toBe('Every 2 months on the 25th');
 
     // Last day should work
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [{ type: 'day', value: 31 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [{ type: 'day', value: 31 }]
+        },
+        i18n
+      )
     ).toBe('Every month on the 31st');
 
     // -1 should work, representing the last day
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [{ type: 'day', value: -1 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [{ type: 'day', value: -1 }]
+        },
+        i18n
+      )
     ).toBe('Every month on the last day');
 
     // Day names should work
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [{ type: 'FR', value: 2 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [{ type: 'FR', value: 2 }]
+        },
+        i18n
+      )
     ).toBe('Every month on the 2nd Friday');
 
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [{ type: 'FR', value: -1 }]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [{ type: 'FR', value: -1 }]
+        },
+        i18n
+      )
     ).toBe('Every month on the last Friday');
   });
 
   it('describes monthly interval with multiple days', () => {
     // Note how order doesn't matter - the day should be sorted
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [
-          { type: 'day', value: 15 },
-          { type: 'day', value: 3 },
-          { type: 'day', value: 20 }
-        ]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [
+            { type: 'day', value: 15 },
+            { type: 'day', value: 3 },
+            { type: 'day', value: 20 }
+          ]
+        },
+        i18n
+      )
     ).toBe('Every month on the 3rd, 15th, and 20th');
 
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [
-          { type: 'day', value: 3 },
-          { type: 'day', value: -1 },
-          { type: 'day', value: 20 }
-        ]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [
+            { type: 'day', value: 3 },
+            { type: 'day', value: -1 },
+            { type: 'day', value: 20 }
+          ]
+        },
+        i18n
+      )
     ).toBe('Every month on the 3rd, 20th, and last day');
 
     // Mix days and day names
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [
-          { type: 'day', value: 3 },
-          { type: 'day', value: -1 },
-          { type: 'FR', value: 2 }
-        ]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [
+            { type: 'day', value: 3 },
+            { type: 'day', value: -1 },
+            { type: 'FR', value: 2 }
+          ]
+        },
+        i18n
+      )
     ).toBe('Every month on the 2nd Friday, 3rd, and last day');
 
     // When there is a mixture of types, day names should always come first
     expect(
-      getRecurringDescription({
-        start: '2021-04-25',
-        frequency: 'monthly',
-        patterns: [
-          { type: 'SA', value: 1 },
-          { type: 'day', value: 2 },
-          { type: 'FR', value: 3 },
-          { type: 'day', value: 10 }
-        ]
-      })
+      getRecurringDescription(
+        {
+          start: '2021-04-25',
+          frequency: 'monthly',
+          patterns: [
+            { type: 'SA', value: 1 },
+            { type: 'day', value: 2 },
+            { type: 'FR', value: 3 },
+            { type: 'day', value: 10 }
+          ]
+        },
+        i18n
+      )
     ).toBe('Every month on the 1st Saturday, 3rd Friday, 2nd, and 10th');
   });
 
   it('describes yearly interval', () => {
     expect(
-      getRecurringDescription({ start: '2021-05-17', frequency: 'yearly' })
+      getRecurringDescription(
+        { start: '2021-05-17', frequency: 'yearly' },
+        i18n
+      )
     ).toBe('Every year on May 17th');
 
     expect(
-      getRecurringDescription({
-        start: '2021-05-17',
-        frequency: 'yearly',
-        interval: 2
-      })
+      getRecurringDescription(
+        {
+          start: '2021-05-17',
+          frequency: 'yearly',
+          interval: 2
+        },
+        i18n
+      )
     ).toBe('Every 2 years on May 17th');
   });
 });

--- a/packages/loot-design/src/components/RecurringSchedulePicker.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.js
@@ -17,8 +17,7 @@ import { colors } from 'loot-design/src/style';
 import { useTooltip } from 'loot-design/src/components/tooltips';
 import SubtractIcon from 'loot-design/src/svg/Subtract';
 import AddIcon from 'loot-design/src/svg/Add';
-
-const DATE_FORMAT = 'yyyy-MM-dd';
+import { useTranslation } from 'react-i18next';
 
 // ex: There is no 6th Friday of the Month
 const MAX_DAY_OF_WEEK_INTERVAL = 5;
@@ -376,6 +375,7 @@ export default function RecurringSchedulePicker({
   onChange
 }) {
   let { isOpen, close, getOpenEvents } = useTooltip();
+  let { i18n } = useTranslation();
 
   function onSave(config) {
     onChange(config);
@@ -385,7 +385,7 @@ export default function RecurringSchedulePicker({
   return (
     <View>
       <Button {...getOpenEvents()} style={[{ textAlign: 'left' }, buttonStyle]}>
-        {value ? getRecurringDescription(value) : 'No recurring date'}
+        {value ? getRecurringDescription(value, i18n) : 'No recurring date'}
       </Button>
       {isOpen && (
         <RecurringScheduleTooltip

--- a/packages/loot-design/src/components/RecurringSchedulePicker.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.js
@@ -68,7 +68,7 @@ function unparseConfig(parsed) {
 
 function createMonthlyRecurrence(startDate) {
   return {
-    value: parseInt(monthUtils.format(startDate, 'd')),
+    value: parseInt(monthUtils.nonLocalizedFormat(startDate, 'd')),
     type: 'day'
   };
 }
@@ -158,8 +158,8 @@ function SchedulePreview({ previewDates }) {
         <Stack direction="row" spacing={4} style={{ marginTop: 10 }}>
           {previewDates.map(d => (
             <View>
-              <Text>{monthUtils.format(d, dateFormat)}</Text>
-              <Text>{monthUtils.format(d, 'EEEE')}</Text>
+              <Text>{monthUtils.nonLocalizedFormat(d, dateFormat)}</Text>
+              <Text>{monthUtils.nonLocalizedFormat(d, 'EEEE')}</Text>
             </View>
           ))}
         </Stack>

--- a/packages/loot-design/src/components/budget/index.js
+++ b/packages/loot-design/src/components/budget/index.js
@@ -1255,7 +1255,7 @@ export const MonthPicker = scope(lively => {
 
   function getCurrentMonthName(startMonth, currentMonth) {
     return monthUtils.getYear(startMonth) === monthUtils.getYear(currentMonth)
-      ? monthUtils.format(currentMonth, 'MMM')
+      ? monthUtils.nonLocalizedFormat(currentMonth, 'MMM')
       : null;
   }
 
@@ -1263,7 +1263,7 @@ export const MonthPicker = scope(lively => {
     const currentMonth = monthUtils.currentMonth();
     const range = getRangeForYear(currentMonth);
     const monthNames = range.map(month => {
-      return monthUtils.format(month, 'MMM');
+      return monthUtils.nonLocalizedFormat(month, 'MMM');
     });
 
     return {
@@ -1313,7 +1313,7 @@ export const MonthPicker = scope(lively => {
             flex: '0 0 40px'
           }}
         >
-          {monthUtils.format(year, 'yyyy')}
+          {monthUtils.nonLocalizedFormat(year, 'yyyy')}
         </View>
         <ElementQuery
           sizes={[

--- a/packages/loot-design/src/components/budget/report/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/report/BudgetSummary.js
@@ -318,7 +318,7 @@ export default React.memo(function BudgetSummary({ month }) {
               currentMonth === month && { textDecoration: 'underline' }
             ])}
           >
-            {monthUtils.format(month, 'MMMM')}
+            {monthUtils.nonLocalizedFormat(month, 'MMMM')}
           </div>
 
           <View

--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -270,7 +270,10 @@ export default React.memo(function BudgetSummary({ month }) {
     setMenuOpen(false);
   }
 
-  let prevMonthName = monthUtils.format(monthUtils.prevMonth(month), 'MMM');
+  let prevMonthName = monthUtils.nonLocalizedFormat(
+    monthUtils.prevMonth(month),
+    'MMM'
+  );
 
   let ExpandOrCollapseIcon = collapsed ? ArrowButtonDown1 : ArrowButtonUp1;
 
@@ -336,7 +339,7 @@ export default React.memo(function BudgetSummary({ month }) {
               currentMonth === month && { textDecoration: 'underline' }
             ])}
           >
-            {monthUtils.format(month, 'MMMM')}
+            {monthUtils.nonLocalizedFormat(month, 'MMMM')}
           </div>
 
           <View

--- a/packages/loot-design/src/components/mobile/budget.js
+++ b/packages/loot-design/src/components/mobile/budget.js
@@ -123,7 +123,7 @@ export class BudgetCell extends React.PureComponent {
 
     return (
       <SheetValue binding={binding}>
-        {(node) => {
+        {node => {
           return (
             <View style={style}>
               <AmountInput
@@ -140,7 +140,7 @@ export class BudgetCell extends React.PureComponent {
                 scrollIntoView={Platform.OS === 'android'}
                 textStyle={[styles.smallText, textStyle]}
                 animationColor="white"
-                onBlur={(value) => {
+                onBlur={value => {
                   onBudgetAction(month, 'budget-amount', {
                     category: categoryId,
                     amount: amountToInteger(value)
@@ -288,7 +288,7 @@ export class BudgetCategory extends React.PureComponent {
 
     let content = (
       <ListItem
-        ref={(el) => (this.container = el)}
+        ref={el => (this.container = el)}
         style={[
           {
             backgroundColor: editing ? colors.p11 : 'transparent',
@@ -323,7 +323,7 @@ export class BudgetCategory extends React.PureComponent {
             name="balance"
             binding={balance}
             style={[styles.smallText, { width: 90, textAlign: 'right' }]}
-            getStyle={(value) => value < 0 && { color: colors.r4 }}
+            getStyle={value => value < 0 && { color: colors.r4 }}
             type="financial"
           />
         </Animated.View>
@@ -487,8 +487,14 @@ export class TotalsRow extends React.PureComponent {
 
 export class IncomeCategory extends React.PureComponent {
   render() {
-    const { name, budget, balance, style, nameTextStyle, amountTextStyle } =
-      this.props;
+    const {
+      name,
+      budget,
+      balance,
+      style,
+      nameTextStyle,
+      amountTextStyle
+    } = this.props;
     return (
       <ListItem
         style={[
@@ -717,10 +723,10 @@ export class IncomeBudgetGroup extends React.Component {
 }
 
 export class BudgetGroups extends React.Component {
-  getGroups = memoizeOne((groups) => {
+  getGroups = memoizeOne(groups => {
     return {
-      incomeGroup: groups.find((group) => group.is_income),
-      expenseGroups: groups.filter((group) => !group.is_income)
+      incomeGroup: groups.find(group => group.is_income),
+      expenseGroups: groups.filter(group => !group.is_income)
     };
   });
 
@@ -742,7 +748,7 @@ export class BudgetGroups extends React.Component {
 
     return (
       <View style={{ marginBottom: 15 }}>
-        {expenseGroups.map((group) => {
+        {expenseGroups.map(group => {
           return (
             <BudgetGroup
               key={group.id}
@@ -800,7 +806,7 @@ export class BudgetTable extends React.Component {
       }
     });
 
-    const keyboardWillHide = (e) => {
+    const keyboardWillHide = e => {
       if (ACTScrollViewManager) {
         ACTScrollViewManager.setFocused(-1);
       }
@@ -831,7 +837,7 @@ export class BudgetTable extends React.Component {
     this.cleanup();
   }
 
-  onEditCategory = (id) => {
+  onEditCategory = id => {
     this.setState({ editingCategory: id });
   };
 
@@ -849,11 +855,9 @@ export class BudgetTable extends React.Component {
   onMoveUp = () => {
     const { categories } = this.props;
     const { editingCategory } = this.state;
-    const expenseCategories = categories.filter((cat) => !cat.is_income);
+    const expenseCategories = categories.filter(cat => !cat.is_income);
 
-    const idx = expenseCategories.findIndex(
-      (cat) => editingCategory === cat.id
-    );
+    const idx = expenseCategories.findIndex(cat => editingCategory === cat.id);
     if (idx - 1 >= 0) {
       this.onEditCategory(expenseCategories[idx - 1].id);
     }
@@ -862,11 +866,9 @@ export class BudgetTable extends React.Component {
   onMoveDown = () => {
     const { categories } = this.props;
     const { editingCategory } = this.state;
-    const expenseCategories = categories.filter((cat) => !cat.is_income);
+    const expenseCategories = categories.filter(cat => !cat.is_income);
 
-    const idx = expenseCategories.findIndex(
-      (cat) => editingCategory === cat.id
-    );
+    const idx = expenseCategories.findIndex(cat => editingCategory === cat.id);
     if (idx + 1 < expenseCategories.length) {
       this.onEditCategory(expenseCategories[idx + 1].id);
     }
@@ -937,7 +939,7 @@ export class BudgetTable extends React.Component {
                   styles.smallText,
                   { color: colors.n1, textAlign: 'right', fontWeight: '500' }
                 ]}
-                formatter={(value) => {
+                formatter={value => {
                   return format(-parseFloat(value || '0'), 'financial');
                 }}
               />
@@ -958,7 +960,7 @@ export class BudgetTable extends React.Component {
           <AndroidKeyboardAvoidingView includeStatusBar={true}>
             {!editMode ? (
               <ScrollView
-                ref={(el) => (this.list = el)}
+                ref={el => (this.list = el)}
                 keyboardShouldPersistTaps="always"
                 refreshControl={refreshControl}
                 style={{ backgroundColor: colors.n10 }}
@@ -993,7 +995,7 @@ export class BudgetTable extends React.Component {
                     ref={this.gestures.scroll}
                   >
                     <Animated.ScrollView
-                      ref={(el) => {
+                      ref={el => {
                         scrollRef.current = el;
                         this.list = el;
                       }}

--- a/packages/loot-design/src/components/mobile/budget.js
+++ b/packages/loot-design/src/components/mobile/budget.js
@@ -1088,7 +1088,7 @@ export function BudgetHeader({
           }
         ]}
       >
-        {monthUtils.format(currentMonth, "MMMM ''yy")}
+        {monthUtils.nonLocalizedFormat(currentMonth, "MMMM ''yy")}
       </Text>
       {editMode ? (
         <Button

--- a/packages/loot-design/src/components/mobile/transaction.js
+++ b/packages/loot-design/src/components/mobile/transaction.js
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  View,
-  Text,
-  SectionList,
-  ScrollView,
-  Animated
-} from 'react-native';
+import { View, Text, SectionList, ScrollView, Animated } from 'react-native';
 import memoizeOne from 'memoize-one';
 import {
   format as formatDate,
@@ -772,8 +766,8 @@ export class Transaction extends React.PureComponent {
     let prettyCategory = transferAcct
       ? 'Transfer'
       : is_parent
-        ? 'Split'
-        : categoryName;
+      ? 'Split'
+      : categoryName;
 
     let isPreview = isPreviewId(id);
     let textStyle = isPreview && {
@@ -787,8 +781,8 @@ export class Transaction extends React.PureComponent {
           notes === 'missed'
             ? colors.r6
             : notes === 'due'
-              ? colors.y4
-              : colors.n5
+            ? colors.y4
+            : colors.n5
       }
     ];
 

--- a/packages/loot-design/src/components/mobile/transaction.js
+++ b/packages/loot-design/src/components/mobile/transaction.js
@@ -696,7 +696,7 @@ export function DateHeader({ date }) {
       }}
     >
       <Text style={[styles.text, { fontSize: 13, color: colors.n4 }]}>
-        {monthUtils.format(date, 'MMMM dd, yyyy')}
+        {monthUtils.nonLocalizedFormat(date, 'MMMM dd, yyyy')}
       </Text>
     </ListItem>
   );

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import * as d from 'date-fns';
 import * as actions from 'loot-core/src/client/actions';
-import { format as formatDate_ } from 'loot-core/src/shared/months';
+import { nonLocalizedFormat as formatDate_ } from 'loot-core/src/shared/months';
 import {
   amountToCurrency,
   amountToInteger,

--- a/packages/mobile/src/components/budget/index.js
+++ b/packages/mobile/src/components/budget/index.js
@@ -28,7 +28,10 @@ import {
 } from 'loot-core/src/shared/categories.js';
 
 function BudgetSummary({ month, onClose }) {
-  const prevMonthName = monthUtils.format(monthUtils.prevMonth(month), 'MMM');
+  const prevMonthName = monthUtils.nonLocalizedFormat(
+    monthUtils.prevMonth(month),
+    'MMM'
+  );
 
   return (
     <NamespaceContext.Provider value={monthUtils.sheetForMonth(month)}>


### PR DESCRIPTION
cc @manuelcanepa — let me know if all of this makes sense for Spanish too :)

One thing I’m not super confident about is `general.ordinal`, but I’m not sure what the best approach for that is. (The `Intl` API doesn’t offer ordinal formatting for some reason)