### PR TITLE
Fix handling of -0 in budget summary

### DIFF
--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -113,7 +113,7 @@ function TotalsList({ prevMonthName, collapsed }) {
           binding={rolloverBudget.forNextMonth}
           formatter={value => {
             let n = parseInt(value);
-            n = isNaN(n) ? 0 : -n;
+            n = isNaN(n) || n === 0 ? 0 : -n;
             let v = format(n, 'financial');
 
             return n > 0 ? '+' + v : n === 0 ? '-' + v : v;

--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -112,11 +112,9 @@ function TotalsList({ prevMonthName, collapsed }) {
         <CellValue
           binding={rolloverBudget.forNextMonth}
           formatter={value => {
-            let n = parseInt(value);
-            n = isNaN(n) || n === 0 ? 0 : -n;
-            let v = format(n, 'financial');
-
-            return n > 0 ? '+' + v : n === 0 ? '-' + v : v;
+            let n = parseInt(value) || 0;
+            let v = format(Math.abs(n), 'financial');
+            return n >= 0 ? '-' + v : '+' + v;
           }}
           style={[{ fontWeight: 600 }, styles.tnum]}
         />


### PR DESCRIPTION
Before:

![CleanShot 2022-08-31 at 13 45 25@2x](https://user-images.githubusercontent.com/25517624/187745235-dea75d6b-5e5e-4782-9818-334b5c12fe3c.png)