### PR TITLE
Revert change to use the importers from inside the monorepo

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -48,7 +48,7 @@
     "electron-is-dev": "2.0.0",
     "electron-log": "4.3.2",
     "electron-updater": "4.3.8",
-    "loot-core": "workspace:*",
+    "loot-core": "*",
     "node-fetch": "^1.6.3",
     "node-ipc": "9.1.4"
   },

--- a/packages/import-ynab4/package.json
+++ b/packages/import-ynab4/package.json
@@ -16,7 +16,7 @@
   "bin": "./index.js",
   "homepage": "https://github.com/actualbudget/actual/tree/master/packages/import-ynab4#readme",
   "dependencies": {
-    "@actual-app/api": "workspace:*",
+    "@actual-app/api": "^1.0.0",
     "adm-zip": "^0.5.9",
     "date-fns": "2.0.0-alpha.27",
     "slash": "3.0.0",

--- a/packages/import-ynab5/package.json
+++ b/packages/import-ynab5/package.json
@@ -16,7 +16,7 @@
   "bin": "./index.js",
   "homepage": "https://github.com/actualbudget/actual/tree/master/packages/import-ynab5#readme",
   "dependencies": {
-    "@actual-app/api": "workspace:*",
+    "@actual-app/api": "^1.0.0",
     "date-fns": "2.0.0-alpha.27",
     "uuid": "3.3.2"
   }

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -35,12 +35,12 @@
     "md5": "^2.3.0",
     "mitt": "^2.1.0",
     "node-fetch": "^1.6.3",
-    "node-libofx": "workspace:*",
+    "node-libofx": "*",
     "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
-    "@actual-app/api": "workspace:*",
-    "@actual-app/import-ynab4": "workspace:*",
+    "@actual-app/api": "*",
+    "@actual-app/import-ynab4": "*",
     "@babel/core": "~7.14.3",
     "@types/jest": "^27.5.0",
     "adm-zip": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,7 +12,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actual-app/api@workspace:*, @actual-app/api@workspace:packages/api":
+"@actual-app/api@*, @actual-app/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@actual-app/api@workspace:packages/api"
   dependencies:
@@ -22,11 +22,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@actual-app/import-ynab4@workspace:*, @actual-app/import-ynab4@workspace:packages/import-ynab4":
+"@actual-app/api@npm:^1.0.0":
+  version: 1.1.3
+  resolution: "@actual-app/api@npm:1.1.3"
+  dependencies:
+    node-ipc: 9.1.1
+    uuid: 3.3.2
+  checksum: e7fccff7583d64ac908eb7a7c93226200fd75af92b9fe9718b6e3fe0d004d92d79d87485e212b0d3d86cb685827e6733c939ece799156eea64db886bf1457a94
+  languageName: node
+  linkType: hard
+
+"@actual-app/import-ynab4@*, @actual-app/import-ynab4@workspace:packages/import-ynab4":
   version: 0.0.0-use.local
   resolution: "@actual-app/import-ynab4@workspace:packages/import-ynab4"
   dependencies:
-    "@actual-app/api": "workspace:*"
+    "@actual-app/api": ^1.0.0
     adm-zip: ^0.5.9
     date-fns: 2.0.0-alpha.27
     slash: 3.0.0
@@ -40,7 +50,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/import-ynab5@workspace:packages/import-ynab5"
   dependencies:
-    "@actual-app/api": "workspace:*"
+    "@actual-app/api": ^1.0.0
     date-fns: 2.0.0-alpha.27
     uuid: 3.3.2
   bin:
@@ -4292,7 +4302,7 @@ __metadata:
     electron-notarize: 1.0.0
     electron-rebuild: 2.3.5
     electron-updater: 4.3.8
-    loot-core: "workspace:*"
+    loot-core: "*"
     node-fetch: ^1.6.3
     node-ipc: 9.1.4
   languageName: unknown
@@ -8809,7 +8819,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"easy-stack@npm:^1.0.1":
+"easy-stack@npm:^1.0.0, easy-stack@npm:^1.0.1":
   version: 1.0.1
   resolution: "easy-stack@npm:1.0.1"
   checksum: 161a99e497b3857b0be4ec9e1ebbe90b241ea9d84702f9881b8e5b3f6822065b8c4e33436996935103e191bffba3607de70712a792f4d406a050def48c6bc381
@@ -13680,10 +13690,26 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
+"js-message@npm:1.0.5":
+  version: 1.0.5
+  resolution: "js-message@npm:1.0.5"
+  checksum: fd2fc8837a88a115aa2fa859bf5c13d9b335fd7eeba8426c44da6eb006b04c52cfe6675b3c27d6b112ffc51dadb8bc51d58340c3a3aa5c555d7da6bdc72ce9c0
+  languageName: node
+  linkType: hard
+
 "js-message@npm:1.0.7":
   version: 1.0.7
   resolution: "js-message@npm:1.0.7"
   checksum: 18dcc4d80356e8b5be978ca7838d96d4e350a1cb8adc5741c229dec6df09f53bfed7c75c1f360171d2d791a14e2f077d6c2b1013ba899ded7a27d7dfcd4f3784
+  languageName: node
+  linkType: hard
+
+"js-queue@npm:2.0.0":
+  version: 2.0.0
+  resolution: "js-queue@npm:2.0.0"
+  dependencies:
+    easy-stack: ^1.0.0
+  checksum: 8f8e589cc20fd3bc3067db73ecaac77b55411c3ac58fdd6882868924ee19ab4203d19e68d3ec680c5c8f5e8282e30dafa377014dbec05c3f2d33be4596f4fb65
   languageName: node
   linkType: hard
 
@@ -14515,12 +14541,12 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"loot-core@*, loot-core@workspace:*, loot-core@workspace:packages/loot-core":
+"loot-core@*, loot-core@workspace:packages/loot-core":
   version: 0.0.0-use.local
   resolution: "loot-core@workspace:packages/loot-core"
   dependencies:
-    "@actual-app/api": "workspace:*"
-    "@actual-app/import-ynab4": "workspace:*"
+    "@actual-app/api": "*"
+    "@actual-app/import-ynab4": "*"
     "@babel/core": ~7.14.3
     "@babel/register": ^7.12.10
     "@jlongster/mixpanel": ^0.13.4
@@ -14561,7 +14587,7 @@ jest-snapshot@test:
     mockdate: ^3.0.5
     murmurhash: ^0.0.2
     node-fetch: ^1.6.3
-    node-libofx: "workspace:*"
+    node-libofx: "*"
     npm-run-all: ^4.1.3
     perf-deets: ^1.0.15
     prettier: ^1.19.1
@@ -16070,6 +16096,17 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
+"node-ipc@npm:9.1.1":
+  version: 9.1.1
+  resolution: "node-ipc@npm:9.1.1"
+  dependencies:
+    event-pubsub: 4.3.0
+    js-message: 1.0.5
+    js-queue: 2.0.0
+  checksum: 2b66099d1976e4328d34ae7fec853d3969ca337b52b5aefb48ae1d19387c37d6716c2b98d4a4934ec24aa79f0441721961d6c1beb858c294ad6a7a97ddf5460d
+  languageName: node
+  linkType: hard
+
 "node-ipc@npm:9.1.4":
   version: 9.1.4
   resolution: "node-ipc@npm:9.1.4"
@@ -16081,7 +16118,7 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"node-libofx@workspace:*, node-libofx@workspace:packages/node-libofx":
+"node-libofx@*, node-libofx@workspace:packages/node-libofx":
   version: 0.0.0-use.local
   resolution: "node-libofx@workspace:packages/node-libofx"
   languageName: unknown


### PR DESCRIPTION
#204 causes `bin/package-browser` to take 30mins or so to complete which is unacceptably long. It's most likely due to the weird circular dependencies we have.

I'm reverting this change while we fix this.