### PR TITLE
Allow `enter` to create new transaction when focused on `cleared` column

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -1649,7 +1649,8 @@ export let TransactionTable = React.forwardRef((props, ref) => {
             onAddSplit(lastTransaction.id);
           } else if (
             (newNavigator.focusedField === 'debit' ||
-              newNavigator.focusedField === 'credit') &&
+              newNavigator.focusedField === 'credit' ||
+              newNavigator.focusedField === 'cleared') &&
             newNavigator.editingId === lastTransaction.id &&
             (!isSplit || !lastTransaction.error)
           ) {


### PR DESCRIPTION
This addresses #226

Currently only the `credit`/`debit` columns can be focused to press enter and add a transaction, but if you tab past them to the `cleared` column it stands to reason you'd want to add it at that point too.