### PR TITLE
Sort import in alphabetical order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,10 @@ module.exports = {
     'import/order': [
       'error',
       {
+        alphabetize: {
+          caseInsensitive: true,
+          order: 'asc'
+        },
         groups: [
           'builtin', // Built-in types are first
           'external',

--- a/packages/desktop-client/src/components/App.js
+++ b/packages/desktop-client/src/components/App.js
@@ -11,12 +11,12 @@ import {
 import { styles, hasHiddenScrollbars } from 'loot-design/src/style';
 
 import installPolyfills from '../polyfills';
-import FatalError from './FatalError';
-import ManagementApp from './manager/ManagementApp';
-import FinancesApp from './FinancesApp';
 import AppBackground from './AppBackground';
-import UpdateNotification from './UpdateNotification';
+import FatalError from './FatalError';
+import FinancesApp from './FinancesApp';
+import ManagementApp from './manager/ManagementApp';
 import MobileWebMessage from './MobileWebMessage';
+import UpdateNotification from './UpdateNotification';
 
 class App extends React.Component {
   state = {

--- a/packages/desktop-client/src/components/AppBackground.js
+++ b/packages/desktop-client/src/components/AppBackground.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { css } from 'glamor';
 
 import { View, Block } from 'loot-design/src/components/common';
-import AnimatedLoading from 'loot-design/src/svg/v1/AnimatedLoading';
 import { colors } from 'loot-design/src/style';
+import AnimatedLoading from 'loot-design/src/svg/v1/AnimatedLoading';
 
 import Background from './Background';
 

--- a/packages/desktop-client/src/components/Debugger.js
+++ b/packages/desktop-client/src/components/Debugger.js
@@ -2,11 +2,11 @@ import React from 'react';
 
 import CodeMirror from 'codemirror';
 
+import * as spreadsheet from 'loot-core/src/client/sheetql/spreadsheet';
 import {
   send,
   init as initConnection
 } from 'loot-core/src/platform/client/fetch';
-import * as spreadsheet from 'loot-core/src/client/sheetql/spreadsheet';
 import {
   View,
   Button,

--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -1,42 +1,42 @@
 import React, { useMemo } from 'react';
-import { Router, Route, Redirect, Switch, useLocation } from 'react-router-dom';
-import { connect } from 'react-redux';
 import { DndProvider } from 'react-dnd';
 import Backend from 'react-dnd-html5-backend';
+import { connect } from 'react-redux';
+import { Router, Route, Redirect, Switch, useLocation } from 'react-router-dom';
 
 import { createBrowserHistory } from 'history';
 import hotkeys from 'hotkeys-js';
 
 import * as actions from 'loot-core/src/client/actions';
+import { AccountsProvider } from 'loot-core/src/client/data-hooks/accounts';
+import { PayeesProvider } from 'loot-core/src/client/data-hooks/payees';
 import { SpreadsheetProvider } from 'loot-core/src/client/SpreadsheetProvider';
 import checkForUpgradeNotifications from 'loot-core/src/client/upgrade-notifications';
-import { colors } from 'loot-design/src/style';
-import { View } from 'loot-design/src/components/common';
-import { BudgetMonthCountProvider } from 'loot-design/src/components/budget/BudgetMonthCountContext';
 import * as undo from 'loot-core/src/platform/client/undo';
-import { PayeesProvider } from 'loot-core/src/client/data-hooks/payees';
-import { AccountsProvider } from 'loot-core/src/client/data-hooks/accounts';
+import { BudgetMonthCountProvider } from 'loot-design/src/components/budget/BudgetMonthCountContext';
+import { View } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 
 import { getLocationState } from '../util/location-state';
 import { makeLocationState } from '../util/location-state';
-import { PageTypeProvider } from './Page';
+import Account from './accounts/Account';
 import { ActiveLocationProvider } from './ActiveLocation';
 import BankSyncStatus from './BankSyncStatus';
-import Titlebar, { TitlebarProvider } from './Titlebar';
-import FloatableSidebar, { SidebarProvider } from './FloatableSidebar';
-import Account from './accounts/Account';
 import Budget from './budget';
-import Reports from './reports';
-import Schedules from './schedules';
-import EditSchedule from './schedules/EditSchedule';
-import LinkSchedule from './schedules/LinkSchedule';
-import DiscoverSchedules from './schedules/DiscoverSchedules';
-import PostsOfflineNotification from './schedules/PostsOfflineNotification';
-import FixSplitsTool from './tools/FixSplitsTool';
-import Settings from './Settings';
+import FloatableSidebar, { SidebarProvider } from './FloatableSidebar';
+import GlobalKeys from './GlobalKeys';
 import Modals from './Modals';
 import Notifications from './Notifications';
-import GlobalKeys from './GlobalKeys';
+import { PageTypeProvider } from './Page';
+import Reports from './reports';
+import Schedules from './schedules';
+import DiscoverSchedules from './schedules/DiscoverSchedules';
+import EditSchedule from './schedules/EditSchedule';
+import LinkSchedule from './schedules/LinkSchedule';
+import PostsOfflineNotification from './schedules/PostsOfflineNotification';
+import Settings from './Settings';
+import Titlebar, { TitlebarProvider } from './Titlebar';
+import FixSplitsTool from './tools/FixSplitsTool';
 // import Debugger from './Debugger';
 
 function URLBar() {

--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -17,8 +17,7 @@ import { BudgetMonthCountProvider } from 'loot-design/src/components/budget/Budg
 import { View } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import { getLocationState } from '../util/location-state';
-import { makeLocationState } from '../util/location-state';
+import { getLocationState, makeLocationState } from '../util/location-state';
 import Account from './accounts/Account';
 import { ActiveLocationProvider } from './ActiveLocation';
 import BankSyncStatus from './BankSyncStatus';

--- a/packages/desktop-client/src/components/Modals.js
+++ b/packages/desktop-client/src/components/Modals.js
@@ -2,30 +2,30 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 
-import { bindActionCreators } from 'redux';
-import { createLocation } from 'history';
 import Component from '@reactions/component';
+import { createLocation } from 'history';
+import { bindActionCreators } from 'redux';
 
 import * as actions from 'loot-core/src/client/actions';
 import { send, listen, unlisten } from 'loot-core/src/platform/client/fetch';
-import CreateLocalAccount from 'loot-design/src/components/modals/CreateLocalAccount';
 import CloseAccount from 'loot-design/src/components/modals/CloseAccount';
-import SelectLinkedAccounts from 'loot-design/src/components/modals/SelectLinkedAccounts';
 import ConfigureLinkedAccounts from 'loot-design/src/components/modals/ConfigureLinkedAccounts';
+import CreateLocalAccount from 'loot-design/src/components/modals/CreateLocalAccount';
+import EditField from 'loot-design/src/components/modals/EditField';
+import ImportTransactions from 'loot-design/src/components/modals/ImportTransactions';
 import LoadBackup from 'loot-design/src/components/modals/LoadBackup';
 import PlaidExternalMsg from 'loot-design/src/components/modals/PlaidExternalMsg';
-import ImportTransactions from 'loot-design/src/components/modals/ImportTransactions';
-import EditField from 'loot-design/src/components/modals/EditField';
+import SelectLinkedAccounts from 'loot-design/src/components/modals/SelectLinkedAccounts';
 
-import CreateAccount from './modals/CreateAccount';
-import ManagePayeesWithData from './payees/ManagePayeesWithData';
-import ManageRules from './modals/ManageRules';
-import EditRule from './modals/EditRule';
-import MergeUnusedPayees from './modals/MergeUnusedPayees';
 import ConfirmCategoryDelete from './modals/ConfirmCategoryDelete';
-import WelcomeScreen from './modals/WelcomeScreen';
+import CreateAccount from './modals/CreateAccount';
 import CreateEncryptionKey from './modals/CreateEncryptionKey';
+import EditRule from './modals/EditRule';
 import FixEncryptionKey from './modals/FixEncryptionKey';
+import ManageRules from './modals/ManageRules';
+import MergeUnusedPayees from './modals/MergeUnusedPayees';
+import WelcomeScreen from './modals/WelcomeScreen';
+import ManagePayeesWithData from './payees/ManagePayeesWithData';
 
 function Modals({
   history,

--- a/packages/desktop-client/src/components/Notifications.js
+++ b/packages/desktop-client/src/components/Notifications.js
@@ -12,9 +12,9 @@ import {
   Stack,
   ExternalLink
 } from 'loot-design/src/components/common';
+import { styles, colors } from 'loot-design/src/style';
 import Delete from 'loot-design/src/svg/Delete';
 import Loading from 'loot-design/src/svg/v1/AnimatedLoading';
-import { styles, colors } from 'loot-design/src/style';
 
 function compileMessage(message, actions, setLoading, onRemove) {
   return (

--- a/packages/desktop-client/src/components/Settings.js
+++ b/packages/desktop-client/src/components/Settings.js
@@ -5,6 +5,10 @@ import { Route, Switch, Redirect } from 'react-router-dom';
 import { css } from 'glamor';
 
 import * as actions from 'loot-core/src/client/actions';
+import Platform from 'loot-core/src/client/platform';
+import { send, listen } from 'loot-core/src/platform/client/fetch';
+import { numberFormats } from 'loot-core/src/shared/util';
+import { Information } from 'loot-design/src/components/alerts';
 import {
   View,
   Text,
@@ -12,12 +16,8 @@ import {
   ButtonWithLoading,
   AnchorLink
 } from 'loot-design/src/components/common';
-import { send, listen } from 'loot-core/src/platform/client/fetch';
-import { numberFormats } from 'loot-core/src/shared/util';
 import { styles, colors } from 'loot-design/src/style';
-import { Information } from 'loot-design/src/components/alerts';
 import ExpandArrow from 'loot-design/src/svg/ExpandArrow';
-import Platform from 'loot-core/src/client/platform';
 
 import useServerVersion from '../hooks/useServerVersion';
 

--- a/packages/desktop-client/src/components/SidebarWithData.js
+++ b/packages/desktop-client/src/components/SidebarWithData.js
@@ -4,8 +4,9 @@ import { withRouter } from 'react-router-dom';
 
 import { bindActionCreators } from 'redux';
 
+import * as actions from 'loot-core/src/client/actions';
+import * as queries from 'loot-core/src/client/queries';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { styles, colors } from 'loot-design/src/style';
 import {
   Button,
   Input,
@@ -13,8 +14,7 @@ import {
   Text
 } from 'loot-design/src/components/common';
 import { Sidebar } from 'loot-design/src/components/sidebar';
-import * as actions from 'loot-core/src/client/actions';
-import * as queries from 'loot-core/src/client/queries';
+import { styles, colors } from 'loot-design/src/style';
 
 function EditableBudgetName({ prefs, savePrefs }) {
   const [editing, setEditing] = useState(false);

--- a/packages/desktop-client/src/components/SpreadsheetInterface.js
+++ b/packages/desktop-client/src/components/SpreadsheetInterface.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import Cell from 'loot-design/src/components/spreadsheet/Cell';
 import { View } from 'loot-design/src/components/common';
+import Cell from 'loot-design/src/components/spreadsheet/Cell';
 
 function SpreadsheetInterface() {
   return (

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -1,12 +1,11 @@
 import React, { useState, useEffect, useRef, useContext } from 'react';
-import { Switch, Route, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { Switch, Route, withRouter } from 'react-router-dom';
 
 import * as actions from 'loot-core/src/client/actions';
+import Platform from 'loot-core/src/client/platform';
 import * as queries from 'loot-core/src/client/queries';
 import { listen } from 'loot-core/src/platform/client/fetch';
-import Platform from 'loot-core/src/client/platform';
-import { colors } from 'loot-design/src/style';
 import {
   View,
   Text,
@@ -17,16 +16,17 @@ import {
   P
 } from 'loot-design/src/components/common';
 import SheetValue from 'loot-design/src/components/spreadsheet/SheetValue';
-import ArrowButtonRight1 from 'loot-design/src/svg/v2/ArrowButtonRight1';
-import NavigationMenu from 'loot-design/src/svg/v2/NavigationMenu';
+import { colors } from 'loot-design/src/style';
 import ArrowLeft from 'loot-design/src/svg/v1/ArrowLeft';
 import AlertTriangle from 'loot-design/src/svg/v2/AlertTriangle';
+import ArrowButtonRight1 from 'loot-design/src/svg/v2/ArrowButtonRight1';
+import NavigationMenu from 'loot-design/src/svg/v2/NavigationMenu';
 
-import { MonthCountSelector } from './budget/MonthCountSelector';
 import AccountSyncCheck from './accounts/AccountSyncCheck';
-import LoggedInUser from './LoggedInUser';
 import AnimatedRefresh from './AnimatedRefresh';
+import { MonthCountSelector } from './budget/MonthCountSelector';
 import { useSidebar } from './FloatableSidebar';
+import LoggedInUser from './LoggedInUser';
 
 export let TitlebarContext = React.createContext();
 

--- a/packages/desktop-client/src/components/Tutorial.js
+++ b/packages/desktop-client/src/components/Tutorial.js
@@ -7,17 +7,17 @@ import { bindActionCreators } from 'redux';
 
 import * as actions from 'loot-core/src/client/actions';
 
-import Intro from './tutorial/Intro';
-import BudgetSummary from './tutorial/BudgetSummary';
 import BudgetCategories from './tutorial/BudgetCategories';
 import BudgetInitial from './tutorial/BudgetInitial';
+import BudgetNewIncome from './tutorial/BudgetNewIncome';
+import BudgetNextMonth from './tutorial/BudgetNextMonth';
+import BudgetSummary from './tutorial/BudgetSummary';
+import CategoryBalance from './tutorial/CategoryBalance';
+import Final from './tutorial/Final';
+import Intro from './tutorial/Intro';
+import Overspending from './tutorial/Overspending';
 import TransactionAdd from './tutorial/TransactionAdd';
 import TransactionEnter from './tutorial/TransactionEnter';
-import BudgetNewIncome from './tutorial/BudgetNewIncome';
-import CategoryBalance from './tutorial/CategoryBalance';
-import Overspending from './tutorial/Overspending';
-import BudgetNextMonth from './tutorial/BudgetNextMonth';
-import Final from './tutorial/Final';
 
 function generatePath(innerRect, outerRect) {
   const i = innerRect;

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import * as actions from 'loot-core/src/client/actions';
 import { View, Button, Tooltip } from 'loot-design/src/components/common';
-import ExclamationOutline from 'loot-design/src/svg/v1/ExclamationOutline';
 import { colors } from 'loot-design/src/style';
+import ExclamationOutline from 'loot-design/src/svg/v1/ExclamationOutline';
 
 import { reauthorizeBank } from '../../plaid';
 

--- a/packages/desktop-client/src/components/accounts/Filters.js
+++ b/packages/desktop-client/src/components/accounts/Filters.js
@@ -1,25 +1,15 @@
 import React, { useState, useRef, useEffect, useReducer } from 'react';
 import { useSelector } from 'react-redux';
 
-import scopeTab from 'react-modal/lib/helpers/scopeTab';
 import {
   parse as parseDate,
   format as formatDate,
   isValid as isDateValid
 } from 'date-fns';
+import scopeTab from 'react-modal/lib/helpers/scopeTab';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
-import { titleFirst } from 'loot-core/src/shared/util';
-import {
-  View,
-  Text,
-  Tooltip,
-  Stack,
-  Button,
-  Menu,
-  CustomSelect
-} from 'loot-design/src/components/common';
 import {
   mapField,
   friendlyOp,
@@ -30,12 +20,22 @@ import {
   FIELD_TYPES,
   TYPE_INFO
 } from 'loot-core/src/shared/rules';
+import { titleFirst } from 'loot-core/src/shared/util';
+import {
+  View,
+  Text,
+  Tooltip,
+  Stack,
+  Button,
+  Menu,
+  CustomSelect
+} from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 import DeleteIcon from 'loot-design/src/svg/Delete';
 import SettingsSliderAlternate from 'loot-design/src/svg/v2/SettingsSliderAlternate';
-import { colors } from 'loot-design/src/style';
 
-import GenericInput from '../util/GenericInput';
 import { Value } from '../modals/ManageRules';
+import GenericInput from '../util/GenericInput';
 
 let filterFields = [
   'date',

--- a/packages/desktop-client/src/components/accounts/SimpleTransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/SimpleTransactionsTable.js
@@ -8,6 +8,11 @@ import {
 } from 'date-fns';
 
 import {
+  getAccountsById,
+  getCategoriesById
+} from 'loot-core/src/client/reducers/queries';
+import { integerToCurrency } from 'loot-core/src/shared/util';
+import {
   Table,
   Row,
   Field,
@@ -18,13 +23,8 @@ import {
   useSelectedItems,
   useSelectedDispatch
 } from 'loot-design/src/components/useSelected';
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import {
-  getAccountsById,
-  getCategoriesById
-} from 'loot-core/src/client/reducers/queries';
-import ArrowsSynchronize from 'loot-design/src/svg/v2/ArrowsSynchronize';
 import { styles } from 'loot-design/src/style';
+import ArrowsSynchronize from 'loot-design/src/svg/v2/ArrowsSynchronize';
 
 import DisplayId from '../util/DisplayId';
 

--- a/packages/desktop-client/src/components/accounts/TransactionList.js
+++ b/packages/desktop-client/src/components/accounts/TransactionList.js
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useCallback, useLayoutEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
+import { send } from 'loot-core/src/platform/client/fetch';
 import {
   splitTransaction,
   updateTransaction,
@@ -8,7 +9,6 @@ import {
   realizeTempTransactions,
   applyTransactionDiff
 } from 'loot-core/src/shared/transactions';
-import { send } from 'loot-core/src/platform/client/fetch';
 import { getChangedValues, applyChanges } from 'loot-core/src/shared/util';
 
 import { TransactionTable } from './TransactionsTable';

--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -16,36 +16,31 @@ import {
   isValid as isDateValid
 } from 'date-fns';
 
-import { View, Text, Tooltip, Button } from 'loot-design/src/components/common';
-import CategoryAutocomplete from 'loot-design/src/components/CategorySelect';
-import PayeeAutocomplete from 'loot-design/src/components/PayeeAutocomplete';
-import AccountAutocomplete from 'loot-design/src/components/AccountAutocomplete';
-import DateSelect from 'loot-design/src/components/DateSelect';
-import RightArrow2 from 'loot-design/src/svg/RightArrow2';
-import LeftArrow2 from 'loot-design/src/svg/LeftArrow2';
-import Hyperlink2 from 'loot-design/src/svg/v2/Hyperlink2';
-import CheveronDown from 'loot-design/src/svg/v1/CheveronDown';
-import CalendarIcon from 'loot-design/src/svg/v2/Calendar';
-import ArrowsSynchronize from 'loot-design/src/svg/v2/ArrowsSynchronize';
-import {
-  integerToCurrency,
-  amountToInteger,
-  titleFirst
-} from 'loot-core/src/shared/util';
-import evalArithmetic from 'loot-core/src/shared/arithmetic';
+import { useCachedSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import {
   getAccountsById,
   getPayeesById,
   getCategoriesById
 } from 'loot-core/src/client/reducers/queries';
+import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { currentDay } from 'loot-core/src/shared/months';
+import { getScheduledAmount } from 'loot-core/src/shared/schedules';
 import {
   splitTransaction,
   updateTransaction,
   deleteTransaction,
   addSplitTransaction
 } from 'loot-core/src/shared/transactions';
-import { styles, colors } from 'loot-design/src/style';
+import {
+  integerToCurrency,
+  amountToInteger,
+  titleFirst
+} from 'loot-core/src/shared/util';
+import AccountAutocomplete from 'loot-design/src/components/AccountAutocomplete';
+import CategoryAutocomplete from 'loot-design/src/components/CategorySelect';
+import { View, Text, Tooltip, Button } from 'loot-design/src/components/common';
+import DateSelect from 'loot-design/src/components/DateSelect';
+import PayeeAutocomplete from 'loot-design/src/components/PayeeAutocomplete';
 import {
   Cell,
   Field,
@@ -58,13 +53,18 @@ import {
   useTableNavigator,
   Table
 } from 'loot-design/src/components/table';
+import { useMergedRefs } from 'loot-design/src/components/useMergedRefs';
 import {
   useSelectedDispatch,
   useSelectedItems
 } from 'loot-design/src/components/useSelected';
-import { useMergedRefs } from 'loot-design/src/components/useMergedRefs';
-import { useCachedSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { getScheduledAmount } from 'loot-core/src/shared/schedules';
+import { styles, colors } from 'loot-design/src/style';
+import LeftArrow2 from 'loot-design/src/svg/LeftArrow2';
+import RightArrow2 from 'loot-design/src/svg/RightArrow2';
+import CheveronDown from 'loot-design/src/svg/v1/CheveronDown';
+import ArrowsSynchronize from 'loot-design/src/svg/v2/ArrowsSynchronize';
+import CalendarIcon from 'loot-design/src/svg/v2/Calendar';
+import Hyperlink2 from 'loot-design/src/svg/v2/Hyperlink2';
 
 import { getStatusProps } from '../schedules/StatusBadge';
 

--- a/packages/desktop-client/src/components/accounts/TransactionsTable.test.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.test.js
@@ -1,23 +1,23 @@
 import React from 'react';
 
-import { act } from 'react-dom/test-utils';
 import { render, fireEvent } from '@testing-library/react';
 import { format as formatDate, parse as parseDate } from 'date-fns';
+import { act } from 'react-dom/test-utils';
 
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { initServer } from 'loot-core/src/platform/client/fetch';
 import {
   generateTransaction,
   generateAccount,
   generateCategoryGroups,
   TestProvider
 } from 'loot-core/src/mocks';
+import { initServer } from 'loot-core/src/platform/client/fetch';
 import {
   addSplitTransaction,
   realizeTempTransactions,
   splitTransaction,
   updateTransaction
 } from 'loot-core/src/shared';
+import { integerToCurrency } from 'loot-core/src/shared/util';
 import { SelectedProviderWithItems } from 'loot-design/src/components';
 
 import { SplitsExpandedProvider, TransactionTable } from './TransactionsTable';

--- a/packages/desktop-client/src/components/budget/MonthCountSelector.js
+++ b/packages/desktop-client/src/components/budget/MonthCountSelector.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { colors } from 'loot-design/src/style';
-import { View } from 'loot-design/src/components/common';
 import { useBudgetMonthCount } from 'loot-design/src/components/budget/BudgetMonthCountContext';
+import { View } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 import CalendarIcon from 'loot-design/src/svg/v2/Calendar';
 
 function Calendar({ color, onClick }) {

--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -3,16 +3,6 @@ import { connect } from 'react-redux';
 
 import * as actions from 'loot-core/src/client/actions';
 import { send, listen } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { getValidMonthBounds } from 'loot-design/src/components/budget/MonthsContext';
-import * as rollover from 'loot-design/src/components/budget/rollover/rollover-components';
-import { RolloverContext } from 'loot-design/src/components/budget/rollover/RolloverContext';
-import * as report from 'loot-design/src/components/budget/report/components';
-import { ReportProvider } from 'loot-design/src/components/budget/report/ReportContext';
-import DynamicBudgetTable from 'loot-design/src/components/budget/DynamicBudgetTable';
-import SpreadsheetContext from 'loot-design/src/components/spreadsheet/SpreadsheetContext';
-import { View } from 'loot-design/src/components/common';
-import { styles } from 'loot-design/src/style';
 import {
   addCategory,
   updateCategory,
@@ -23,6 +13,16 @@ import {
   updateGroup,
   deleteGroup
 } from 'loot-core/src/shared/categories.js';
+import * as monthUtils from 'loot-core/src/shared/months';
+import DynamicBudgetTable from 'loot-design/src/components/budget/DynamicBudgetTable';
+import { getValidMonthBounds } from 'loot-design/src/components/budget/MonthsContext';
+import * as report from 'loot-design/src/components/budget/report/components';
+import { ReportProvider } from 'loot-design/src/components/budget/report/ReportContext';
+import * as rollover from 'loot-design/src/components/budget/rollover/rollover-components';
+import { RolloverContext } from 'loot-design/src/components/budget/rollover/RolloverContext';
+import { View } from 'loot-design/src/components/common';
+import SpreadsheetContext from 'loot-design/src/components/spreadsheet/SpreadsheetContext';
+import { styles } from 'loot-design/src/style';
 
 import { TitlebarContext } from '../Titlebar';
 

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { signOut, loggedIn } from 'loot-core/src/client/actions/user';
+import { send } from 'loot-core/src/platform/client/fetch';
 import {
   View,
   Text,
@@ -9,8 +11,6 @@ import {
   ButtonWithLoading
 } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
-import { signOut, loggedIn } from 'loot-core/src/client/actions/user';
-import { send } from 'loot-core/src/platform/client/fetch';
 
 import { Title, Input } from './subscribe/common';
 

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -8,16 +8,16 @@ import * as actions from 'loot-core/src/client/actions';
 import { View, Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
+import useServerVersion from '../../hooks/useServerVersion';
 import LoggedInUser from '../LoggedInUser';
 import Notifications from '../Notifications';
-import useServerVersion from '../../hooks/useServerVersion';
-import ServerURL from './ServerURL';
-import Modals from './Modals';
-import Login from './subscribe/Login';
-import Bootstrap from './subscribe/Bootstrap';
-import Error from './subscribe/Error';
-import ChangePassword from './subscribe/ChangePassword';
 import ConfigServer from './ConfigServer';
+import Modals from './Modals';
+import ServerURL from './ServerURL';
+import Bootstrap from './subscribe/Bootstrap';
+import ChangePassword from './subscribe/ChangePassword';
+import Error from './subscribe/Error';
+import Login from './subscribe/Login';
 
 function Version() {
   const version = useServerVersion();

--- a/packages/desktop-client/src/components/manager/Modals.js
+++ b/packages/desktop-client/src/components/manager/Modals.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { bindActionCreators } from 'redux';
 import Component from '@reactions/component';
+import { bindActionCreators } from 'redux';
 
-import { send } from 'loot-core/src/platform/client/fetch';
 import * as actions from 'loot-core/src/client/actions';
+import { send } from 'loot-core/src/platform/client/fetch';
 import { View } from 'loot-design/src/components/common';
 import BudgetList from 'loot-design/src/components/manager/BudgetList';
-import LoadBackup from 'loot-design/src/components/modals/LoadBackup';
+import DeleteFile from 'loot-design/src/components/manager/DeleteFile';
 import Import from 'loot-design/src/components/manager/Import';
+import ImportActual from 'loot-design/src/components/manager/ImportActual';
 import ImportYNAB4 from 'loot-design/src/components/manager/ImportYNAB4';
 import ImportYNAB5 from 'loot-design/src/components/manager/ImportYNAB5';
-import ImportActual from 'loot-design/src/components/manager/ImportActual';
-import DeleteFile from 'loot-design/src/components/manager/DeleteFile';
+import LoadBackup from 'loot-design/src/components/modals/LoadBackup';
 
 import CreateEncryptionKey from '../modals/CreateEncryptionKey';
 import FixEncryptionKey from '../modals/FixEncryptionKey';

--- a/packages/desktop-client/src/components/manager/ServerURL.js
+++ b/packages/desktop-client/src/components/manager/ServerURL.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
-import { View, Text, AnchorLink } from 'loot-design/src/components/common';
 import { send } from 'loot-core/src/platform/client/fetch';
+import { View, Text, AnchorLink } from 'loot-design/src/components/common';
 
 export default function ServerURL() {
   let [url, setUrl] = useState(null);

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.js
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.js
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { createBudget } from 'loot-core/src/client/actions/budgets';
+import { loggedIn } from 'loot-core/src/client/actions/user';
+import { send } from 'loot-core/src/platform/client/fetch';
 import { View, Text, Button } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
-import { loggedIn } from 'loot-core/src/client/actions/user';
-import { createBudget } from 'loot-core/src/client/actions/budgets';
-import { send } from 'loot-core/src/platform/client/fetch';
 
-import { ConfirmPasswordForm } from './ConfirmPasswordForm';
 import { useBootstrapped, Title } from './common';
+import { ConfirmPasswordForm } from './ConfirmPasswordForm';
 
 export default function Bootstrap() {
   let dispatch = useDispatch();

--- a/packages/desktop-client/src/components/manager/subscribe/ChangePassword.js
+++ b/packages/desktop-client/src/components/manager/subscribe/ChangePassword.js
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { send } from 'loot-core/src/platform/client/fetch';
 import { View, Text, Button } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
-import { send } from 'loot-core/src/platform/client/fetch';
 
-import { ConfirmPasswordForm } from './ConfirmPasswordForm';
 import { Title } from './common';
+import { ConfirmPasswordForm } from './ConfirmPasswordForm';
 
 export default function ChangePassword() {
   let dispatch = useDispatch();

--- a/packages/desktop-client/src/components/manager/subscribe/Login.js
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.js
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { createBudget } from 'loot-core/src/client/actions/budgets';
+import { loggedIn } from 'loot-core/src/client/actions/user';
+import { send } from 'loot-core/src/platform/client/fetch';
 import {
   View,
   Text,
@@ -9,9 +12,6 @@ import {
   ButtonWithLoading
 } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
-import { loggedIn } from 'loot-core/src/client/actions/user';
-import { createBudget } from 'loot-core/src/client/actions/budgets';
-import { send } from 'loot-core/src/platform/client/fetch';
 
 import { useBootstrapped, Title, Input } from './common';
 

--- a/packages/desktop-client/src/components/manager/subscribe/common.js
+++ b/packages/desktop-client/src/components/manager/subscribe/common.js
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import { send } from 'loot-core/src/platform/client/fetch';
 import {
   Text,
   Button,
   Input as BaseInput
 } from 'loot-design/src/components/common';
 import { colors, styles } from 'loot-design/src/style';
-import { send } from 'loot-core/src/platform/client/fetch';
 
 // There are two URLs that dance with each other: `/login` and
 // `/bootstrap`. Both of these URLs check the state of the the server

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDelete.js
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDelete.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { NativeCategorySelect } from 'loot-design/src/components/CategorySelect';
 import {
   View,
   Text,
@@ -8,7 +9,6 @@ import {
   Button
 } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
-import { NativeCategorySelect } from 'loot-design/src/components/CategorySelect';
 
 class ConfirmCategoryDelete extends React.Component {
   state = { transferCategory: null, error: null };

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKey.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 
 import { css } from 'glamor';
 
+import { send } from 'loot-core/src/platform/client/fetch';
+import { getCreateKeyError } from 'loot-core/src/shared/errors';
 import {
   View,
   Text,
@@ -13,9 +15,7 @@ import {
   Input,
   InitialFocus
 } from 'loot-design/src/components/common';
-import { send } from 'loot-core/src/platform/client/fetch';
 import { colors } from 'loot-design/src/style';
-import { getCreateKeyError } from 'loot-core/src/shared/errors';
 
 export default function CreateEncryptionKey({
   modalProps,

--- a/packages/desktop-client/src/components/modals/EditRule.js
+++ b/packages/desktop-client/src/components/modals/EditRule.js
@@ -5,21 +5,10 @@ import {
   initiallyLoadPayees,
   setUndoEnabled
 } from 'loot-core/src/client/actions/queries';
+import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import q, { runQuery } from 'loot-core/src/client/query-helpers';
-import {
-  View,
-  Text,
-  Modal,
-  Button,
-  Stack,
-  CustomSelect,
-  Tooltip
-} from 'loot-design/src/components/common';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { colors } from 'loot-design/src/style';
-import SubtractIcon from 'loot-design/src/svg/Subtract';
-import AddIcon from 'loot-design/src/svg/Add';
-import InformationOutline from 'loot-design/src/svg/v1/InformationOutline';
+import * as monthUtils from 'loot-core/src/shared/months';
 import {
   mapField,
   friendlyOp,
@@ -30,22 +19,33 @@ import {
   FIELD_TYPES,
   TYPE_INFO
 } from 'loot-core/src/shared/rules';
-import useSelected, {
-  SelectedProvider
-} from 'loot-design/src/components/useSelected';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import {
   integerToCurrency,
   integerToAmount,
   amountToInteger
 } from 'loot-core/src/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
+import {
+  View,
+  Text,
+  Modal,
+  Button,
+  Stack,
+  CustomSelect,
+  Tooltip
+} from 'loot-design/src/components/common';
+import useSelected, {
+  SelectedProvider
+} from 'loot-design/src/components/useSelected';
+import { colors } from 'loot-design/src/style';
+import AddIcon from 'loot-design/src/svg/Add';
+import SubtractIcon from 'loot-design/src/svg/Subtract';
+import InformationOutline from 'loot-design/src/svg/v1/InformationOutline';
 
 import SimpleTransactionsTable from '../accounts/SimpleTransactionsTable';
 import { StatusBadge } from '../schedules/StatusBadge';
+import { BetweenAmountInput } from '../util/AmountInput';
 import DisplayId from '../util/DisplayId';
 import GenericInput from '../util/GenericInput';
-import { BetweenAmountInput } from '../util/AmountInput';
 
 function updateValue(array, value, update) {
   return array.map(v => (v === value ? update() : v));

--- a/packages/desktop-client/src/components/modals/FixEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKey.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { send } from 'loot-core/src/platform/client/fetch';
+import { getTestKeyError } from 'loot-core/src/shared/errors';
 import {
   View,
   Text,
@@ -12,9 +14,7 @@ import {
   InitialFocus,
   ExternalLink
 } from 'loot-design/src/components/common';
-import { send } from 'loot-core/src/platform/client/fetch';
 import { colors } from 'loot-design/src/style';
-import { getTestKeyError } from 'loot-core/src/shared/errors';
 
 export default function FixEncryptionKey({
   modalProps,

--- a/packages/desktop-client/src/components/modals/ManageRules.js
+++ b/packages/desktop-client/src/components/modals/ManageRules.js
@@ -1,13 +1,23 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { css } from 'glamor';
 import { format as formatDate, parseISO } from 'date-fns';
+import { css } from 'glamor';
 
-import * as undo from 'loot-core/src/platform/client/undo';
+import { pushModal } from 'loot-core/src/client/actions/modals';
 import { initiallyLoadPayees } from 'loot-core/src/client/actions/queries';
 import q from 'loot-core/src/client/query-helpers';
 import { liveQueryContext } from 'loot-core/src/client/query-hooks';
+import { getPayeesById } from 'loot-core/src/client/reducers/queries';
+import { send } from 'loot-core/src/platform/client/fetch';
+import * as undo from 'loot-core/src/platform/client/undo';
+import { getMonthYearFormat } from 'loot-core/src/shared/months';
+import { mapField, friendlyOp } from 'loot-core/src/shared/rules';
+import {
+  extractScheduleConds,
+  getRecurringDescription
+} from 'loot-core/src/shared/schedules';
+import { integerToCurrency } from 'loot-core/src/shared/util';
 import {
   View,
   Text,
@@ -30,18 +40,8 @@ import useSelected, {
   useSelectedItems,
   SelectedProvider
 } from 'loot-design/src/components/useSelected';
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { mapField, friendlyOp } from 'loot-core/src/shared/rules';
-import ArrowRight from 'loot-design/src/svg/RightArrow2';
 import { colors } from 'loot-design/src/style';
-import { getMonthYearFormat } from 'loot-core/src/shared/months';
-import {
-  extractScheduleConds,
-  getRecurringDescription
-} from 'loot-core/src/shared/schedules';
-import { getPayeesById } from 'loot-core/src/client/reducers/queries';
+import ArrowRight from 'loot-design/src/svg/RightArrow2';
 
 let SchedulesQuery = liveQueryContext(q('schedules').select('*'));
 

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayees.js
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayees.js
@@ -1,6 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { replaceModal } from 'loot-core/src/client/actions/modals';
+import { send } from 'loot-core/src/platform/client/fetch';
+import { Information } from 'loot-design/src/components/alerts';
 import {
   View,
   Text,
@@ -9,10 +12,7 @@ import {
   Button,
   P
 } from 'loot-design/src/components/common';
-import { Information } from 'loot-design/src/components/alerts';
 import { colors } from 'loot-design/src/style';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { replaceModal } from 'loot-core/src/client/actions/modals';
 
 let highlightStyle = { color: colors.p5 };
 

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.js
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.js
@@ -2,10 +2,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 
 import * as actions from 'loot-core/src/client/actions';
-import * as undo from 'loot-core/src/platform/client/undo';
 import { send, listen } from 'loot-core/src/platform/client/fetch';
-import { ManagePayees } from 'loot-design/src/components/payees';
+import * as undo from 'loot-core/src/platform/client/undo';
 import { applyChanges } from 'loot-core/src/shared/util';
+import { ManagePayees } from 'loot-design/src/components/payees';
 
 function ManagePayeesWithData({
   history,

--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -12,8 +12,7 @@ import {
   P,
   AlignedText
 } from 'loot-design/src/components/common';
-import { styles } from 'loot-design/src/style';
-import { colors } from 'loot-design/src/style';
+import { colors, styles } from 'loot-design/src/style';
 
 import Change from './Change';
 import { cashFlowByDate } from './graphs/cash-flow-spreadsheet';

--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -2,6 +2,9 @@ import React, { useState, useEffect } from 'react';
 
 import * as d from 'date-fns';
 
+import { send } from 'loot-core/src/platform/client/fetch';
+import * as monthUtils from 'loot-core/src/shared/months';
+import { integerToCurrency } from 'loot-core/src/shared/util';
 import {
   View,
   Text,
@@ -10,15 +13,12 @@ import {
   AlignedText
 } from 'loot-design/src/components/common';
 import { styles } from 'loot-design/src/style';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency } from 'loot-core/src/shared/util';
 import { colors } from 'loot-design/src/style';
 
-import Header from './Header';
 import Change from './Change';
-import CashFlowGraph from './graphs/CashFlowGraph';
 import { cashFlowByDate } from './graphs/cash-flow-spreadsheet';
+import CashFlowGraph from './graphs/CashFlowGraph';
+import Header from './Header';
 import useReport from './useReport';
 import { useArgsMemo } from './util';
 

--- a/packages/desktop-client/src/components/reports/Change.js
+++ b/packages/desktop-client/src/components/reports/Change.js
@@ -2,8 +2,7 @@ import React from 'react';
 
 import { integerToCurrency } from 'loot-core/src/shared/util';
 import { Block } from 'loot-design/src/components/common';
-import { styles } from 'loot-design/src/style';
-import { colors } from 'loot-design/src/style';
+import { colors, styles } from 'loot-design/src/style';
 
 function Change({ amount, style }) {
   return (

--- a/packages/desktop-client/src/components/reports/Change.js
+++ b/packages/desktop-client/src/components/reports/Change.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { styles } from 'loot-design/src/style';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 import { Block } from 'loot-design/src/components/common';
+import { styles } from 'loot-design/src/style';
 import { colors } from 'loot-design/src/style';
 
 function Change({ amount, style }) {

--- a/packages/desktop-client/src/components/reports/DateRange.js
+++ b/packages/desktop-client/src/components/reports/DateRange.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import * as d from 'date-fns';
 
-import { colors } from 'loot-design/src/style';
 import { Block } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 
 function DateRange({ start, end }) {
   start = d.parseISO(start);

--- a/packages/desktop-client/src/components/reports/Header.js
+++ b/packages/desktop-client/src/components/reports/Header.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { styles } from 'loot-design/src/style';
+import * as monthUtils from 'loot-core/src/shared/months';
 import {
   View,
   Select,
   Button,
   ButtonLink
 } from 'loot-design/src/components/common';
-import * as monthUtils from 'loot-core/src/shared/months';
+import { styles } from 'loot-design/src/style';
 import ArrowLeft from 'loot-design/src/svg/v1/ArrowLeft';
 
 function validateStart(allMonths, start, end) {

--- a/packages/desktop-client/src/components/reports/NetWorth.js
+++ b/packages/desktop-client/src/components/reports/NetWorth.js
@@ -1,22 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 
-import { bindActionCreators } from 'redux';
 import * as d from 'date-fns';
+import { bindActionCreators } from 'redux';
 
 import * as actions from 'loot-core/src/client/actions';
-import { View, P } from 'loot-design/src/components/common';
-import { styles } from 'loot-design/src/style';
+import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { View, P } from 'loot-design/src/components/common';
+import { styles } from 'loot-design/src/style';
 
-import Header from './Header';
-import { fromDateRepr } from './util';
-import useReport from './useReport';
+import Change from './Change';
 import netWorthSpreadsheet from './graphs/net-worth-spreadsheet';
 import NetWorthGraph from './graphs/NetWorthGraph';
-import Change from './Change';
+import Header from './Header';
+import useReport from './useReport';
+import { fromDateRepr } from './util';
 import { useArgsMemo } from './util';
 
 function NetWorth({ accounts }) {

--- a/packages/desktop-client/src/components/reports/NetWorth.js
+++ b/packages/desktop-client/src/components/reports/NetWorth.js
@@ -16,8 +16,7 @@ import netWorthSpreadsheet from './graphs/net-worth-spreadsheet';
 import NetWorthGraph from './graphs/NetWorthGraph';
 import Header from './Header';
 import useReport from './useReport';
-import { fromDateRepr } from './util';
-import { useArgsMemo } from './util';
+import { fromDateRepr, useArgsMemo } from './util';
 
 function NetWorth({ accounts }) {
   const [earliestMonth, setEarliestMonth] = useState(null);

--- a/packages/desktop-client/src/components/reports/Overview.js
+++ b/packages/desktop-client/src/components/reports/Overview.js
@@ -5,21 +5,21 @@ import { bindActionCreators } from 'redux';
 import { VictoryBar, VictoryGroup, VictoryVoronoiContainer } from 'victory';
 
 import * as actions from 'loot-core/src/client/actions';
-import { View, Block, AnchorLink } from 'loot-design/src/components/common';
-import { colors, styles } from 'loot-design/src/style';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
+import { View, Block, AnchorLink } from 'loot-design/src/components/common';
+import { colors, styles } from 'loot-design/src/style';
 
-import { useArgsMemo } from './util';
+import Change from './Change';
 import theme from './chart-theme';
 import Container from './Container';
+import DateRange from './DateRange';
+import { simpleCashFlow } from './graphs/cash-flow-spreadsheet';
+import netWorthSpreadsheet from './graphs/net-worth-spreadsheet';
+import NetWorthGraph from './graphs/NetWorthGraph';
 import Tooltip from './Tooltip';
 import useReport from './useReport';
-import netWorthSpreadsheet from './graphs/net-worth-spreadsheet';
-import { simpleCashFlow } from './graphs/cash-flow-spreadsheet';
-import NetWorthGraph from './graphs/NetWorthGraph';
-import Change from './Change';
-import DateRange from './DateRange';
+import { useArgsMemo } from './util';
 
 function Card({ flex, to, style, children }) {
   const containerProps = { flex, margin: 15 };

--- a/packages/desktop-client/src/components/reports/Tooltip.js
+++ b/packages/desktop-client/src/components/reports/Tooltip.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { VictoryTooltip } from 'victory';
 import { css, before } from 'glamor';
+import { VictoryTooltip } from 'victory';
 
 import { colors } from 'loot-design/src/style';
 

--- a/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.js
+++ b/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import * as d from 'date-fns';
 import {
   VictoryChart,
   VictoryBar,
@@ -8,13 +9,12 @@ import {
   VictoryVoronoiContainer,
   VictoryGroup
 } from 'victory';
-import * as d from 'date-fns';
 
 import { colors } from 'loot-design/src/style';
 
+import theme from '../chart-theme';
 import Container from '../Container';
 import Tooltip from '../Tooltip';
-import theme from '../chart-theme';
 
 function CashFlowGraph({ style, start, end, graphData, isConcise, compact }) {
   return (

--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.js
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import * as d from 'date-fns';
 import {
   VictoryChart,
   VictoryBar,
@@ -8,11 +9,10 @@ import {
   VictoryVoronoiContainer,
   VictoryGroup
 } from 'victory';
-import * as d from 'date-fns';
 
+import theme from '../chart-theme';
 import Container from '../Container';
 import Tooltip from '../Tooltip';
-import theme from '../chart-theme';
 
 function Area({ start, end, data, style, scale, range }) {
   const zero = scale.y(0);

--- a/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
@@ -2,10 +2,10 @@ import React from 'react';
 
 import * as d from 'date-fns';
 
-import * as monthUtils from 'loot-core/src/shared/months';
-import { AlignedText } from 'loot-design/src/components/common';
-import { integerToCurrency, integerToAmount } from 'loot-core/src/shared/util';
 import q from 'loot-core/src/client/query-helpers';
+import * as monthUtils from 'loot-core/src/shared/months';
+import { integerToCurrency, integerToAmount } from 'loot-core/src/shared/util';
+import { AlignedText } from 'loot-design/src/components/common';
 
 import { fromDateRepr, fromDateReprToDay, runAll, index } from '../util';
 

--- a/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
@@ -2,14 +2,14 @@ import React from 'react';
 
 import * as d from 'date-fns';
 
-import * as monthUtils from 'loot-core/src/shared/months';
-import { AlignedText } from 'loot-design/src/components/common';
 import q, { runQuery } from 'loot-core/src/client/query-helpers';
+import * as monthUtils from 'loot-core/src/shared/months';
 import {
   integerToCurrency,
   integerToAmount,
   amountToInteger
 } from 'loot-core/src/shared/util';
+import { AlignedText } from 'loot-design/src/components/common';
 
 import { index } from '../util';
 

--- a/packages/desktop-client/src/components/reports/index.js
+++ b/packages/desktop-client/src/components/reports/index.js
@@ -3,9 +3,9 @@ import { Route } from 'react-router-dom';
 
 import { View } from 'loot-design/src/components/common';
 
-import Overview from './Overview';
-import NetWorth from './NetWorth';
 import CashFlow from './CashFlow';
+import NetWorth from './NetWorth';
+import Overview from './Overview';
 
 class Reports extends React.Component {
   render() {

--- a/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
+++ b/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
-import q, { runQuery } from 'loot-core/src/client/query-helpers';
 import Platform from 'loot-core/src/client/platform';
+import q, { runQuery } from 'loot-core/src/client/query-helpers';
 import { send } from 'loot-core/src/platform/client/fetch';
+import { getRecurringDescription } from 'loot-core/src/shared/schedules';
 import {
   View,
   Stack,
@@ -18,13 +19,12 @@ import {
   Field,
   SelectCell
 } from 'loot-design/src/components/table';
-import { getRecurringDescription } from 'loot-core/src/shared/schedules';
-import { colors } from 'loot-design/src/style';
 import useSelected, {
   useSelectedDispatch,
   useSelectedItems,
   SelectedProvider
 } from 'loot-design/src/components/useSelected';
+import { colors } from 'loot-design/src/style';
 
 import { Page } from '../Page';
 import DisplayId from '../util/DisplayId';

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -1,33 +1,33 @@
 import React, { useEffect, useReducer } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { useParams, useHistory } from 'react-router-dom';
 
 import { pushModal } from 'loot-core/src/client/actions/modals';
-import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
-import q, { runQuery, liveQuery } from 'loot-core/src/client/query-helpers';
-import { extractScheduleConds } from 'loot-core/src/shared/schedules';
-import * as monthUtils from 'loot-core/src/shared/months';
 import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
+import q, { runQuery, liveQuery } from 'loot-core/src/client/query-helpers';
+import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
+import * as monthUtils from 'loot-core/src/shared/months';
+import { extractScheduleConds } from 'loot-core/src/shared/schedules';
+import AccountAutocomplete from 'loot-design/src/components/AccountAutocomplete';
+import { Stack, View, Text, Button } from 'loot-design/src/components/common';
+import DateSelect from 'loot-design/src/components/DateSelect';
 import {
   FormField,
   FormLabel,
   Checkbox
 } from 'loot-design/src/components/forms';
-import { colors } from 'loot-design/src/style';
 import PayeeAutocomplete from 'loot-design/src/components/PayeeAutocomplete';
-import AccountAutocomplete from 'loot-design/src/components/AccountAutocomplete';
-import { Stack, View, Text, Button } from 'loot-design/src/components/common';
-import DateSelect from 'loot-design/src/components/DateSelect';
+import RecurringSchedulePicker from 'loot-design/src/components/RecurringSchedulePicker';
 import { SelectedItemsButton } from 'loot-design/src/components/table';
 import useSelected, {
   SelectedProvider
 } from 'loot-design/src/components/useSelected';
-import RecurringSchedulePicker from 'loot-design/src/components/RecurringSchedulePicker';
+import { colors } from 'loot-design/src/style';
 
 import SimpleTransactionsTable from '../accounts/SimpleTransactionsTable';
+import { OpSelect } from '../modals/EditRule';
 import { usePageType } from '../Page';
 import { Page } from '../Page';
-import { OpSelect } from '../modals/EditRule';
 import { AmountInput, BetweenAmountInput } from '../util/AmountInput';
 
 function mergeFields(defaults, initial) {

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -26,8 +26,7 @@ import { colors } from 'loot-design/src/style';
 
 import SimpleTransactionsTable from '../accounts/SimpleTransactionsTable';
 import { OpSelect } from '../modals/EditRule';
-import { usePageType } from '../Page';
-import { Page } from '../Page';
+import { Page, usePageType } from '../Page';
 import { AmountInput, BetweenAmountInput } from '../util/AmountInput';
 
 function mergeFields(defaults, initial) {

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -1,8 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
+import * as monthUtils from 'loot-core/src/shared/months';
+import { getScheduledAmount } from 'loot-core/src/shared/schedules';
 import { integerToCurrency } from 'loot-core/src/shared/util';
-import { colors } from 'loot-design/src/style';
 import {
   View,
   Text,
@@ -17,8 +18,7 @@ import {
   Field,
   Cell
 } from 'loot-design/src/components/table';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { getScheduledAmount } from 'loot-core/src/shared/schedules';
+import { colors } from 'loot-design/src/style';
 import DotsHorizontalTriple from 'loot-design/src/svg/v1/DotsHorizontalTriple';
 import Check from 'loot-design/src/svg/v2/Check';
 

--- a/packages/desktop-client/src/components/schedules/StatusBadge.js
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.js
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import { colors } from 'loot-design/src/style';
-import { View, Text } from 'loot-design/src/components/common';
 import { titleFirst } from 'loot-core/src/shared/util';
-import EditSkull1 from 'loot-design/src/svg/v2/EditSkull1';
+import { View, Text } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 import AlertTriangle from 'loot-design/src/svg/v2/AlertTriangle';
 import CalendarIcon from 'loot-design/src/svg/v2/Calendar';
-import ValidationCheck from 'loot-design/src/svg/v2/ValidationCheck';
-import FavoriteStar from 'loot-design/src/svg/v2/FavoriteStar';
 import CheckCircle1 from 'loot-design/src/svg/v2/CheckCircle1';
+import EditSkull1 from 'loot-design/src/svg/v2/EditSkull1';
+import FavoriteStar from 'loot-design/src/svg/v2/FavoriteStar';
+import ValidationCheck from 'loot-design/src/svg/v2/ValidationCheck';
 
 export function getStatusProps(status) {
   let color, backgroundColor, Icon;

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { View, Button } from 'loot-design/src/components/common';
-import { send } from 'loot-core/src/platform/client/fetch';
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
+import { send } from 'loot-core/src/platform/client/fetch';
+import { View, Button } from 'loot-design/src/components/common';
 
 import { Page } from '../Page';
 import { SchedulesTable, ROW_HEIGHT } from './SchedulesTable';

--- a/packages/desktop-client/src/components/tools/FixSplitsTool.js
+++ b/packages/desktop-client/src/components/tools/FixSplitsTool.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 
 import { send } from 'loot-core/src/platform/client/fetch';
-import { colors } from 'loot-design/src/style';
 import { View, P, ButtonWithLoading } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 
 import { Page } from '../Page';
 

--- a/packages/desktop-client/src/components/tutorial/BudgetCategories.js
+++ b/packages/desktop-client/src/components/tutorial/BudgetCategories.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Tooltip, Pointer, P } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import Navigation from './Navigation';
 import { Title } from './common';
+import Navigation from './Navigation';
 
 function BudgetInitial({ targetRect, navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/tutorial/BudgetNewIncome.js
+++ b/packages/desktop-client/src/components/tutorial/BudgetNewIncome.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Tooltip, Pointer, P } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import Navigation from './Navigation';
 import { Title } from './common';
+import Navigation from './Navigation';
 
 function BudgetSummary({ targetRect, navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/tutorial/BudgetNextMonth.js
+++ b/packages/desktop-client/src/components/tutorial/BudgetNextMonth.js
@@ -6,8 +6,8 @@ import { bindActionCreators } from 'redux';
 import * as actions from 'loot-core/src/client/actions';
 import { View, P, Button } from 'loot-design/src/components/common';
 
-import Navigation from './Navigation';
 import { Standalone, Title, useMinimized } from './common';
+import Navigation from './Navigation';
 
 function BudgetNextMonth({ stepTwo, navigationProps }) {
   let [minimized, toggle] = useMinimized();

--- a/packages/desktop-client/src/components/tutorial/BudgetSummary.js
+++ b/packages/desktop-client/src/components/tutorial/BudgetSummary.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Tooltip, Pointer, P } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import Navigation from './Navigation';
 import { Title } from './common';
+import Navigation from './Navigation';
 
 function BudgetSummary({ fromYNAB, targetRect, navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/tutorial/CategoryBalance.js
+++ b/packages/desktop-client/src/components/tutorial/CategoryBalance.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { P, Button } from 'loot-design/src/components/common';
 
-import Navigation from './Navigation';
 import { Standalone, Title, useMinimized } from './common';
+import Navigation from './Navigation';
 
 function CategoryBalance({ targetRect, navigationProps }) {
   let [minimized, toggle] = useMinimized();

--- a/packages/desktop-client/src/components/tutorial/DeleteTransactions.js
+++ b/packages/desktop-client/src/components/tutorial/DeleteTransactions.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { P } from 'loot-design/src/components/common';
 
-import Navigation from './Navigation';
 import { Standalone, Title } from './common';
+import Navigation from './Navigation';
 
 function DeleteTransactions({ targetRect, navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/tutorial/Overspending.js
+++ b/packages/desktop-client/src/components/tutorial/Overspending.js
@@ -4,14 +4,14 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import * as actions from 'loot-core/src/client/actions';
-import SheetValue from 'loot-design/src/components/spreadsheet/SheetValue';
-import NamespaceContext from 'loot-design/src/components/spreadsheet/NamespaceContext';
-import { P, View, Text, Button } from 'loot-design/src/components/common';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
+import { P, View, Text, Button } from 'loot-design/src/components/common';
+import NamespaceContext from 'loot-design/src/components/spreadsheet/NamespaceContext';
+import SheetValue from 'loot-design/src/components/spreadsheet/SheetValue';
 
-import Navigation from './Navigation';
 import { Standalone, Title, useMinimized } from './common';
+import Navigation from './Navigation';
 
 function Overspending({ navigationProps, stepTwo }) {
   let currentMonth = monthUtils.currentMonth();

--- a/packages/desktop-client/src/components/tutorial/TransactionAdd.js
+++ b/packages/desktop-client/src/components/tutorial/TransactionAdd.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Tooltip, Pointer, P } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import Navigation from './Navigation';
 import { Title } from './common';
+import Navigation from './Navigation';
 
 function TransactionAdd({ targetRect, navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/tutorial/TransactionEnter.js
+++ b/packages/desktop-client/src/components/tutorial/TransactionEnter.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { P } from 'loot-design/src/components/common';
 import * as monthUtils from 'loot-core/src/shared/months';
+import { P } from 'loot-design/src/components/common';
 
-import Navigation from './Navigation';
 import { Standalone, Title } from './common';
+import Navigation from './Navigation';
 
 function TransactionEnter({ fromYNAB, navigationProps }) {
   const currentDay = monthUtils.currentDay();

--- a/packages/desktop-client/src/components/tutorial/TransactionFinalize.js
+++ b/packages/desktop-client/src/components/tutorial/TransactionFinalize.js
@@ -4,8 +4,8 @@ import { css } from 'glamor';
 
 import { P } from 'loot-design/src/components/common';
 
-import Navigation from './Navigation';
 import { Standalone } from './common';
+import Navigation from './Navigation';
 
 function TransactionFinalize({ navigationProps }) {
   return (

--- a/packages/desktop-client/src/components/util/DisplayId.js
+++ b/packages/desktop-client/src/components/util/DisplayId.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { CachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { CachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
+import { CachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 

--- a/packages/desktop-client/src/components/util/GenericInput.js
+++ b/packages/desktop-client/src/components/util/GenericInput.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
-import { View, Input } from 'loot-design/src/components/common';
-import PayeeAutocomplete from 'loot-design/src/components/PayeeAutocomplete';
 import AccountAutocomplete from 'loot-design/src/components/AccountAutocomplete';
 import Autocomplete from 'loot-design/src/components/Autocomplete';
 import CategoryAutocomplete from 'loot-design/src/components/CategorySelect';
+import { View, Input } from 'loot-design/src/components/common';
 import DateSelect from 'loot-design/src/components/DateSelect';
+import PayeeAutocomplete from 'loot-design/src/components/PayeeAutocomplete';
 import RecurringSchedulePicker from 'loot-design/src/components/RecurringSchedulePicker';
 
 export default function GenericInput({

--- a/packages/desktop-client/src/global-events.js
+++ b/packages/desktop-client/src/global-events.js
@@ -1,6 +1,6 @@
+import * as sharedListeners from 'loot-core/src/client/shared-listeners';
 import { send, listen } from 'loot-core/src/platform/client/fetch';
 import * as undo from 'loot-core/src/platform/client/undo';
-import * as sharedListeners from 'loot-core/src/client/shared-listeners';
 
 export function handleGlobalEvents(actions, store) {
   global.Actual.onEventFromMain('update-downloaded', (event, info) => {

--- a/packages/desktop-client/src/index.js
+++ b/packages/desktop-client/src/index.js
@@ -17,15 +17,15 @@ import {
 } from 'redux';
 import thunk from 'redux-thunk';
 
-import constants from 'loot-core/src/client/constants';
-import reducers from 'loot-core/src/client/reducers';
-import { send } from 'loot-core/src/platform/client/fetch';
-import q, { runQuery } from 'loot-core/src/client/query-helpers';
 import * as actions from 'loot-core/src/client/actions';
+import constants from 'loot-core/src/client/constants';
+import q, { runQuery } from 'loot-core/src/client/query-helpers';
+import reducers from 'loot-core/src/client/reducers';
 import { initialState as initialAppState } from 'loot-core/src/client/reducers/app';
+import { send } from 'loot-core/src/platform/client/fetch';
 
-import { handleGlobalEvents } from './global-events';
 import App from './components/App';
+import { handleGlobalEvents } from './global-events';
 
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.

--- a/packages/loot-core/src/client/SpreadsheetProvider.js
+++ b/packages/loot-core/src/client/SpreadsheetProvider.js
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import LRU from 'lru-cache';
 

--- a/packages/loot-core/src/client/actions/account.js
+++ b/packages/loot-core/src/client/actions/account.js
@@ -1,7 +1,7 @@
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
-import { getPayees, getAccounts } from './queries';
 import { addNotification } from './notifications';
+import { getPayees, getAccounts } from './queries';
 
 export function setAccountsSyncing(name) {
   return {

--- a/packages/loot-core/src/client/actions/budgets.js
+++ b/packages/loot-core/src/client/actions/budgets.js
@@ -1,10 +1,10 @@
+import { send } from '../../platform/client/fetch';
+import { getDownloadError } from '../../shared/errors';
 import constants from '../constants';
+import { setAppState } from './app';
 import { closeModal, pushModal } from './modals';
 import { loadPrefs, loadGlobalPrefs } from './prefs';
-import { send } from '../../platform/client/fetch';
-import { setAppState } from './app';
 import { startTutorialFirstTime } from './tutorial';
-import { getDownloadError } from '../../shared/errors';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/client/actions/prefs.js
+++ b/packages/loot-core/src/client/actions/prefs.js
@@ -1,6 +1,6 @@
+import { send } from '../../platform/client/fetch';
 import constants from '../constants';
 import { closeModal } from './modals';
-import { send } from '../../platform/client/fetch';
 
 export function loadPrefs() {
   return async (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/queries.js
+++ b/packages/loot-core/src/client/actions/queries.js
@@ -2,8 +2,8 @@ import throttle from 'throttleit';
 
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
-import { addNotification, addGenericErrorNotification } from './notifications';
 import { pushModal } from './modals';
+import { addNotification, addGenericErrorNotification } from './notifications';
 
 export function applyBudgetAction(month, type, args) {
   return async function() {

--- a/packages/loot-core/src/client/actions/sync.js
+++ b/packages/loot-core/src/client/actions/sync.js
@@ -1,9 +1,9 @@
 import { send } from '../../platform/client/fetch';
+import { getUploadError } from '../../shared/errors';
 import constants from '../constants';
-import { loadPrefs } from './prefs';
 import { syncAccounts } from './account';
 import { pushModal } from './modals';
-import { getUploadError } from '../../shared/errors';
+import { loadPrefs } from './prefs';
 
 export function unregister() {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/user.js
+++ b/packages/loot-core/src/client/actions/user.js
@@ -1,7 +1,7 @@
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
-import { loadGlobalPrefs } from './prefs';
 import { loadAllFiles, closeBudget } from './budgets';
+import { loadGlobalPrefs } from './prefs';
 
 export function getUserData() {
   return async dispatch => {

--- a/packages/loot-core/src/client/data-hooks/schedules.js
+++ b/packages/loot-core/src/client/data-hooks/schedules.js
@@ -1,10 +1,10 @@
 import React, { useEffect, useState, useContext } from 'react';
 
+import q, { liveQuery } from 'loot-core/src/client/query-helpers';
 import {
   getStatus,
   getHasTransactionsQuery
 } from 'loot-core/src/shared/schedules';
-import q, { liveQuery } from 'loot-core/src/client/query-helpers';
 
 function loadStatuses(schedules, onData) {
   return liveQuery(getHasTransactionsQuery(schedules), onData, {

--- a/packages/loot-core/src/client/queries.js
+++ b/packages/loot-core/src/client/queries.js
@@ -1,6 +1,5 @@
 import { parse as parseDate, isValid as isDateValid } from 'date-fns';
 
-import { currencyToAmount, amountToInteger } from '../shared/util';
 import {
   dayFromDate,
   getDayMonthRegex,
@@ -9,6 +8,7 @@ import {
   getShortYearFormat
 } from '../shared/months';
 import q from '../shared/query';
+import { currencyToAmount, amountToInteger } from '../shared/util';
 
 function isInteger(num) {
   return (num | 0) === num;

--- a/packages/loot-core/src/client/query-helpers.test.js
+++ b/packages/loot-core/src/client/query-helpers.test.js
@@ -1,8 +1,8 @@
 import { initServer, serverPush } from '../platform/client/fetch';
-import q from '../shared/query';
-import { runQuery, liveQuery, pagedQuery } from './query-helpers';
-import { tracer } from '../shared/test-helpers';
 import { subDays } from '../shared/months';
+import q from '../shared/query';
+import { tracer } from '../shared/test-helpers';
+import { runQuery, liveQuery, pagedQuery } from './query-helpers';
 
 function wait(n) {
   return new Promise(resolve => setTimeout(() => resolve(`wait(${n})`), n));

--- a/packages/loot-core/src/client/reducers/index.js
+++ b/packages/loot-core/src/client/reducers/index.js
@@ -1,12 +1,12 @@
-import app from './app';
-import queries from './queries';
 import account from './account';
+import app from './app';
+import budgets from './budgets';
 import debug from './debug';
-import profile from './profile';
-import prefs from './prefs';
 import modals from './modals';
 import notifications from './notifications';
-import budgets from './budgets';
+import prefs from './prefs';
+import profile from './profile';
+import queries from './queries';
 import tutorial from './tutorial';
 import user from './user';
 

--- a/packages/loot-core/src/client/reducers/prefs.js
+++ b/packages/loot-core/src/client/reducers/prefs.js
@@ -1,5 +1,5 @@
-import constants from '../constants';
 import { setNumberFormat } from '../../shared/util.js';
+import constants from '../constants';
 
 const initialState = {
   local: null,

--- a/packages/loot-core/src/client/reducers/queries.js
+++ b/packages/loot-core/src/client/reducers/queries.js
@@ -1,7 +1,7 @@
 import memoizeOne from 'memoize-one';
 
-import constants from '../constants';
 import { groupById } from '../../shared/util';
+import constants from '../constants';
 
 const initialState = {
   newTransactions: [],

--- a/packages/loot-core/src/mocks/budget.js
+++ b/packages/loot-core/src/mocks/budget.js
@@ -1,13 +1,13 @@
-import * as monthUtils from '../shared/months';
-import * as sheet from '../server/sheet';
+import { addTransactions } from '../server/accounts/sync';
+import { runQuery as aqlQuery } from '../server/aql';
+import * as budgetActions from '../server/budget/actions';
 import * as budget from '../server/budget/base';
 import * as db from '../server/db';
-import * as prefs from '../server/prefs';
-import * as budgetActions from '../server/budget/actions';
-import { runQuery as aqlQuery } from '../server/aql';
-import { batchMessages, setSyncingMode } from '../server/sync';
 import { runHandler, runMutator } from '../server/mutators';
-import { addTransactions } from '../server/accounts/sync';
+import * as prefs from '../server/prefs';
+import * as sheet from '../server/sheet';
+import { batchMessages, setSyncingMode } from '../server/sync';
+import * as monthUtils from '../shared/months';
 import q from '../shared/query';
 
 function pickRandom(list) {

--- a/packages/loot-core/src/mocks/redux.js
+++ b/packages/loot-core/src/mocks/redux.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import thunk from 'redux-thunk';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 
 import reducers from '../client/reducers';
 

--- a/packages/loot-core/src/mocks/setup.js
+++ b/packages/loot-core/src/mocks/setup.js
@@ -1,16 +1,16 @@
-import * as sqlite from '../platform/server/sqlite';
 import * as fetchClient from '../platform/client/fetch';
-import * as db from '../server/db';
-import * as sheet from '../server/sheet';
+import * as sqlite from '../platform/server/sqlite';
 import * as rules from '../server/accounts/transaction-rules';
-import * as tracking from '../server/tracking/events';
-import { setSyncingMode } from '../server/sync';
-import { updateVersion } from '../server/update';
-import { resetTracer, tracer } from '../shared/test-helpers';
+import * as db from '../server/db';
 import {
   enableGlobalMutations,
   disableGlobalMutations
 } from '../server/mutators';
+import * as sheet from '../server/sheet';
+import { setSyncingMode } from '../server/sync';
+import * as tracking from '../server/tracking/events';
+import { updateVersion } from '../server/update';
+import { resetTracer, tracer } from '../shared/test-helpers';
 
 jest.mock('../server/post');
 

--- a/packages/loot-core/src/platform/client/fetch/index.browser.js
+++ b/packages/loot-core/src/platform/client/fetch/index.browser.js
@@ -1,6 +1,6 @@
-const undo = require('../undo');
 const { captureException, captureBreadcrumb } = require('../../exceptions');
 const uuid = require('../../uuid');
+const undo = require('../undo');
 let replyHandlers = new Map();
 let listeners = new Map();
 let messageQueue = [];

--- a/packages/loot-core/src/platform/client/fetch/index.web.js
+++ b/packages/loot-core/src/platform/client/fetch/index.web.js
@@ -1,5 +1,5 @@
-const undo = require('../undo');
 const uuid = require('../../uuid');
+const undo = require('../undo');
 let replyHandlers = new Map();
 let listeners = new Map();
 let messageQueue = [];

--- a/packages/loot-core/src/platform/client/undo/index.web.js
+++ b/packages/loot-core/src/platform/client/undo/index.web.js
@@ -1,5 +1,5 @@
-const uuid = require('../../uuid');
 const { getChangedValues } = require('../../../shared/util');
+const uuid = require('../../uuid');
 
 // List of recently used states. We don't use a true MRU structure
 // because our needs are simple and we also do some custom reordering.

--- a/packages/loot-core/src/platform/server/fs/index.web.js
+++ b/packages/loot-core/src/platform/server/fs/index.web.js
@@ -2,8 +2,8 @@ let { SQLiteFS } = require('absurd-sql');
 let IndexedDBBackend = require('absurd-sql/dist/indexeddb-backend').default;
 
 let connection = require('../connection');
-let { _getModule } = require('../sqlite');
 let idb = require('../indexeddb');
+let { _getModule } = require('../sqlite');
 let baseAPI = require('./index.electron.js');
 let join = require('./path-join');
 

--- a/packages/loot-core/src/server/accounts/export-to-csv.js
+++ b/packages/loot-core/src/server/accounts/export-to-csv.js
@@ -1,7 +1,7 @@
 import csvStringify from 'csv-stringify/lib/sync';
 
-import { runQuery as aqlQuery } from '../aql';
 import { integerToAmount } from '../../shared/util';
+import { runQuery as aqlQuery } from '../aql';
 
 export async function exportToCSV(
   transactions,

--- a/packages/loot-core/src/server/accounts/link.js
+++ b/packages/loot-core/src/server/accounts/link.js
@@ -1,11 +1,11 @@
 import asyncStorage from '../../platform/server/asyncStorage';
-import * as db from '../db';
-import { getServer } from '../server-config';
-import * as bankSync from './sync';
 import { fromPlaidAccountType } from '../../shared/accounts';
 import { amountToInteger } from '../../shared/util';
-import { post } from '../post';
+import * as db from '../db';
 import { runMutator } from '../mutators';
+import { post } from '../post';
+import { getServer } from '../server-config';
+import * as bankSync from './sync';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/accounts/parse-file.js
+++ b/packages/loot-core/src/server/accounts/parse-file.js
@@ -1,9 +1,9 @@
 import csv2json from 'csv-parse/lib/sync';
 
 import fs from '../../platform/server/fs';
-import qif2json from './qif2json';
 import { dayFromDate } from '../../shared/months';
 import { looselyParseAmount } from '../../shared/util';
+import qif2json from './qif2json';
 
 export function parseFile(filepath, options) {
   let errors = [];

--- a/packages/loot-core/src/server/accounts/parse-file.test.js
+++ b/packages/loot-core/src/server/accounts/parse-file.test.js
@@ -1,10 +1,10 @@
 import * as d from 'date-fns';
 
+import { amountToInteger } from '../../shared/util';
+import * as db from '../db';
+import * as prefs from '../prefs';
 import { parseFile } from './parse-file';
 import { reconcileTransactions } from './sync';
-import * as prefs from '../prefs';
-import * as db from '../db';
-import { amountToInteger } from '../../shared/util';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/accounts/rules.js
+++ b/packages/loot-core/src/server/accounts/rules.js
@@ -1,6 +1,5 @@
 import * as dateFns from 'date-fns';
 
-import { RuleError } from '../errors';
 import {
   monthFromDate,
   yearFromDate,
@@ -10,9 +9,10 @@ import {
   subDays,
   parseDate
 } from '../../shared/months';
-import { fastSetMerge } from '../../shared/util';
 import { sortNumbers, getApproxNumberThreshold } from '../../shared/rules';
 import { recurConfigToRSchedule } from '../../shared/schedules';
+import { fastSetMerge } from '../../shared/util';
+import { RuleError } from '../errors';
 import { Schedule as RSchedule } from '../util/rschedule';
 
 function safeNumber(n) {

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -1,23 +1,23 @@
-import title from './title';
-import * as db from '../db';
-import { hasFieldsChanged, amountToInteger } from '../../shared/util';
+import * as monthUtils from '../../shared/months';
 import {
   makeChild as makeChildTransaction,
   recalculateSplit
 } from '../../shared/transactions';
-import * as monthUtils from '../../shared/months';
+import { hasFieldsChanged, amountToInteger } from '../../shared/util';
+import * as db from '../db';
+import { runMutator } from '../mutators';
 import { getServer } from '../server-config';
 import { batchMessages } from '../sync';
-import { runMutator } from '../mutators';
 import { getStartingBalancePayee } from './payees';
+import title from './title';
 import { runRules } from './transaction-rules';
 import { batchUpdateTransactions } from './transactions';
 
-const dateFns = require('date-fns');
 const levenshtein = require('damerau-levenshtein');
+const dateFns = require('date-fns');
 
-const { post } = require('../post');
 const uuid = require('../../platform/uuid');
+const { post } = require('../post');
 
 // Plaid article about API options:
 // https://support.plaid.com/customer/en/portal/articles/2612155-transactions-returned-per-request

--- a/packages/loot-core/src/server/accounts/sync.test.js
+++ b/packages/loot-core/src/server/accounts/sync.test.js
@@ -1,3 +1,4 @@
+import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 import { loadMappings } from '../db/mappings';
 import { getServer } from '../server-config';
@@ -7,9 +8,8 @@ import {
   addTransactions,
   fromPlaid
 } from './sync';
-import * as monthUtils from '../../shared/months';
-import * as transfer from './transfer';
 import { loadRules, insertRule } from './transaction-rules';
+import * as transfer from './transfer';
 
 const snapshotDiff = require('snapshot-diff');
 

--- a/packages/loot-core/src/server/accounts/transaction-rules.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.js
@@ -1,4 +1,18 @@
+import { addDays, subDays, parseDate, dayFromDate } from '../../shared/months';
+import { currentDay } from '../../shared/months';
+import {
+  FIELD_TYPES,
+  sortNumbers,
+  getApproxNumberThreshold
+} from '../../shared/rules';
+import { partitionByField, fastSetMerge } from '../../shared/util';
+import { schemaConfig } from '../aql';
 import * as db from '../db';
+import { getMappings } from '../db/mappings';
+import { RuleError } from '../errors';
+import { requiredFields, toDateRepr } from '../models';
+import { setSyncingMode, batchMessages } from '../sync';
+import { addSyncListener } from '../sync/index';
 import {
   Condition,
   Action,
@@ -8,20 +22,6 @@ import {
   migrateIds,
   iterateIds
 } from './rules';
-import { getMappings } from '../db/mappings';
-import { addDays, subDays, parseDate, dayFromDate } from '../../shared/months';
-import { addSyncListener } from '../sync/index';
-import { RuleError } from '../errors';
-import {
-  FIELD_TYPES,
-  sortNumbers,
-  getApproxNumberThreshold
-} from '../../shared/rules';
-import { requiredFields, toDateRepr } from '../models';
-import { currentDay } from '../../shared/months';
-import { partitionByField, fastSetMerge } from '../../shared/util';
-import { setSyncingMode, batchMessages } from '../sync';
-import { schemaConfig } from '../aql';
 
 // TODO: Detect if it looks like the user is creating a rename rule
 // and prompt to create it in the pre phase instead

--- a/packages/loot-core/src/server/accounts/transaction-rules.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.js
@@ -1,4 +1,10 @@
-import { currentDay, addDays, subDays, parseDate, dayFromDate } from '../../shared/months';
+import {
+  currentDay,
+  addDays,
+  subDays,
+  parseDate,
+  dayFromDate
+} from '../../shared/months';
 import {
   FIELD_TYPES,
   sortNumbers,

--- a/packages/loot-core/src/server/accounts/transaction-rules.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.js
@@ -1,5 +1,4 @@
-import { addDays, subDays, parseDate, dayFromDate } from '../../shared/months';
-import { currentDay } from '../../shared/months';
+import { currentDay, addDays, subDays, parseDate, dayFromDate } from '../../shared/months';
 import {
   FIELD_TYPES,
   sortNumbers,

--- a/packages/loot-core/src/server/accounts/transaction-rules.test.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.test.js
@@ -1,4 +1,7 @@
+import q from '../../shared/query';
+import { runQuery } from '../aql';
 import * as db from '../db';
+import { loadMappings } from '../db/mappings';
 import {
   getRules,
   loadRules,
@@ -13,9 +16,6 @@ import {
   updateCategoryRules,
   migrateOldRules
 } from './transaction-rules';
-import { loadMappings } from '../db/mappings';
-import { runQuery } from '../aql';
-import q from '../../shared/query';
 
 // TODO: write tests to make sure payee renaming is "pre" and category
 // setting is "null" stage

--- a/packages/loot-core/src/server/accounts/transactions.js
+++ b/packages/loot-core/src/server/accounts/transactions.js
@@ -1,8 +1,8 @@
-import { batchMessages } from '../sync';
 import * as db from '../db';
 import { incrFetch, whereIn } from '../db/util';
-import * as transfer from './transfer';
+import { batchMessages } from '../sync';
 import * as rules from './transaction-rules';
+import * as transfer from './transfer';
 
 const connection = require('../../platform/server/connection');
 

--- a/packages/loot-core/src/server/accounts/transfer.test.js
+++ b/packages/loot-core/src/server/accounts/transfer.test.js
@@ -1,6 +1,6 @@
+import { expectSnapshotWithDiffer } from '../../mocks/util';
 import * as db from '../db';
 import * as transfer from './transfer';
-import { expectSnapshotWithDiffer } from '../../mocks/util';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/api.js
+++ b/packages/loot-core/src/server/api.js
@@ -1,3 +1,11 @@
+import * as monthUtils from '../shared/months';
+import q from '../shared/query';
+import {
+  ungroupTransactions,
+  updateTransaction,
+  deleteTransaction
+} from '../shared/transactions';
+import { integerToAmount } from '../shared/util';
 import { addTransactions } from './accounts/sync';
 import {
   accountModel,
@@ -6,22 +14,14 @@ import {
   payeeModel,
   payeeRuleModel
 } from './api-models';
-import {
-  ungroupTransactions,
-  updateTransaction,
-  deleteTransaction
-} from '../shared/transactions';
-import * as db from './db';
-import * as sheet from './sheet';
-import * as prefs from './prefs';
-import * as monthUtils from '../shared/months';
-import * as cloudStorage from './cloud-storage';
-import { setSyncingMode, batchMessages } from './sync';
-import { getClock } from './crdt';
-import { runMutator } from './mutators';
-import { integerToAmount } from '../shared/util';
 import { runQuery as aqlQuery } from './aql';
-import q from '../shared/query';
+import * as cloudStorage from './cloud-storage';
+import { getClock } from './crdt';
+import * as db from './db';
+import { runMutator } from './mutators';
+import * as prefs from './prefs';
+import * as sheet from './sheet';
+import { setSyncingMode, batchMessages } from './sync';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-core/src/server/aql/exec.test.js
+++ b/packages/loot-core/src/server/aql/exec.test.js
@@ -1,6 +1,6 @@
-import * as db from '../db';
 import query from '../../shared/query';
 import { makeChild } from '../../shared/transactions';
+import * as db from '../db';
 import * as aql from './exec';
 import { schema, schemaConfig } from './schema';
 

--- a/packages/loot-core/src/server/aql/schema-helpers.js
+++ b/packages/loot-core/src/server/aql/schema-helpers.js
@@ -1,5 +1,5 @@
-import { toDateRepr, fromDateRepr } from '../models';
 import { dayFromDate } from '../../shared/months';
+import { toDateRepr, fromDateRepr } from '../models';
 
 function isRequired(name, fieldDesc) {
   return fieldDesc.required || name === 'id';

--- a/packages/loot-core/src/server/aql/schema/executors.js
+++ b/packages/loot-core/src/server/aql/schema/executors.js
@@ -1,8 +1,8 @@
 import * as db from '../../db';
 import { whereIn } from '../../db/util';
 import { isAggregateQuery } from '../compiler';
-import { convertOutputType } from '../schema-helpers';
 import { execQuery } from '../exec';
+import { convertOutputType } from '../schema-helpers';
 
 // Transactions executor
 

--- a/packages/loot-core/src/server/aql/schema/executors.test.js
+++ b/packages/loot-core/src/server/aql/schema/executors.test.js
@@ -1,13 +1,13 @@
 import fc from 'fast-check';
 
-import * as db from '../../db';
-import query from '../../../shared/query';
-import { batchMessages, setSyncingMode } from '../../sync/index';
-import { setClock } from '../../crdt';
-import { groupById } from '../../../shared/util';
 import arbs from '../../../mocks/arbitrary-schema';
-import { runQuery } from './run-query';
+import query from '../../../shared/query';
+import { groupById } from '../../../shared/util';
+import { setClock } from '../../crdt';
+import * as db from '../../db';
+import { batchMessages, setSyncingMode } from '../../sync/index';
 import { isHappyPathQuery } from './executors';
+import { runQuery } from './run-query';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/aql/schema/run-query.js
+++ b/packages/loot-core/src/server/aql/schema/run-query.js
@@ -1,9 +1,9 @@
-import schemaExecutors from './executors';
+import { Query } from '../../../shared/query';
 import {
   runQuery as _runQuery,
   runCompiledQuery as _runCompiledQuery
 } from '../exec';
-import { Query } from '../../../shared/query';
+import schemaExecutors from './executors';
 
 import { schema, schemaConfig } from './index';
 

--- a/packages/loot-core/src/server/backups.js
+++ b/packages/loot-core/src/server/backups.js
@@ -1,8 +1,8 @@
 import fs from '../platform/server/fs';
-import * as monthUtils from '../shared/months';
 import * as sqlite from '../platform/server/sqlite';
-import * as prefs from './prefs';
+import * as monthUtils from '../shared/months';
 import * as cloudStorage from './cloud-storage';
+import * as prefs from './prefs';
 
 const dateFns = require('date-fns');
 

--- a/packages/loot-core/src/server/budget/actions.js
+++ b/packages/loot-core/src/server/budget/actions.js
@@ -1,8 +1,8 @@
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
-import { batchMessages } from '../sync';
 import * as prefs from '../prefs';
 import * as sheet from '../sheet';
+import { batchMessages } from '../sync';
 
 async function getSheetValue(sheetName, cell) {
   const node = await sheet.getCell(sheetName, cell);

--- a/packages/loot-core/src/server/budget/base.js
+++ b/packages/loot-core/src/server/budget/base.js
@@ -1,12 +1,12 @@
-import * as sheet from '../sheet';
-import * as db from '../db';
 import * as monthUtils from '../../shared/months';
 import { getChangedValues } from '../../shared/util';
+import * as db from '../db';
+import * as sheet from '../sheet';
 import { resolveName } from '../spreadsheet/util';
+import * as budgetActions from './actions';
 import * as report from './report';
 import * as rollover from './rollover';
 import { sumAmounts } from './util';
-import * as budgetActions from './actions';
 
 function mergeUpdates(updates) {
   const merged = {};

--- a/packages/loot-core/src/server/budget/base.test.js
+++ b/packages/loot-core/src/server/budget/base.test.js
@@ -1,6 +1,6 @@
-import * as sheet from '../sheet';
-import * as db from '../db';
 import * as monthUtils from '../../shared/months';
+import * as db from '../db';
+import * as sheet from '../sheet';
 import { createAllBudgets } from './base';
 
 beforeEach(() => {

--- a/packages/loot-core/src/server/budget/rollover.js
+++ b/packages/loot-core/src/server/budget/rollover.js
@@ -1,5 +1,5 @@
-import * as sheet from '../sheet';
 import * as monthUtils from '../../shared/months';
+import * as sheet from '../sheet';
 import { number, sumAmounts, flatten2, unflatten2 } from './util';
 
 const { resolveName } = require('../spreadsheet/util');

--- a/packages/loot-core/src/server/cloud-storage.js
+++ b/packages/loot-core/src/server/cloud-storage.js
@@ -1,19 +1,19 @@
-import fs from '../platform/server/fs';
 import asyncStorage from '../platform/server/asyncStorage';
 import { fetch } from '../platform/server/fetch';
-import * as monthUtils from '../shared/months';
+import fs from '../platform/server/fs';
 import * as sqlite from '../platform/server/sqlite';
-import * as prefs from './prefs';
-import { getServer } from './server-config';
-import { runMutator } from './mutators';
+import * as monthUtils from '../shared/months';
+import encryption from './encryption';
 import {
   HTTPError,
   PostError,
   FileDownloadError,
   FileUploadError
 } from './errors';
-import encryption from './encryption';
+import { runMutator } from './mutators';
 import { post } from './post';
+import * as prefs from './prefs';
+import { getServer } from './server-config';
 
 let AdmZip = require('adm-zip');
 

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -3,8 +3,7 @@ import LRU from 'lru-cache';
 import fs from '../../platform/server/fs';
 import * as sqlite from '../../platform/server/sqlite';
 import { groupById } from '../../shared/util';
-import { schema, schemaConfig } from '../aql';
-import { convertForInsert, convertForUpdate, convertFromSelect } from '../aql';
+import { schema, schemaConfig, convertForInsert, convertForUpdate, convertFromSelect } from '../aql';
 import {
   makeClock,
   setClock,

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -3,7 +3,13 @@ import LRU from 'lru-cache';
 import fs from '../../platform/server/fs';
 import * as sqlite from '../../platform/server/sqlite';
 import { groupById } from '../../shared/util';
-import { schema, schemaConfig, convertForInsert, convertForUpdate, convertFromSelect } from '../aql';
+import {
+  schema,
+  schemaConfig,
+  convertForInsert,
+  convertForUpdate,
+  convertFromSelect
+} from '../aql';
 import {
   makeClock,
   setClock,

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -1,17 +1,10 @@
 import LRU from 'lru-cache';
 
-import * as sqlite from '../../platform/server/sqlite';
 import fs from '../../platform/server/fs';
-import { sendMessages, batchMessages } from '../sync';
-import { schema, schemaConfig } from '../aql';
-import {
-  accountModel,
-  categoryModel,
-  categoryGroupModel,
-  payeeModel,
-  payeeRuleModel
-} from '../models';
+import * as sqlite from '../../platform/server/sqlite';
 import { groupById } from '../../shared/util';
+import { schema, schemaConfig } from '../aql';
+import { convertForInsert, convertForUpdate, convertFromSelect } from '../aql';
 import {
   makeClock,
   setClock,
@@ -20,7 +13,14 @@ import {
   makeClientId,
   Timestamp
 } from '../crdt';
-import { convertForInsert, convertForUpdate, convertFromSelect } from '../aql';
+import {
+  accountModel,
+  categoryModel,
+  categoryGroupModel,
+  payeeModel,
+  payeeRuleModel
+} from '../models';
+import { sendMessages, batchMessages } from '../sync';
 import { shoveSortOrders, SORT_INCREMENT } from './sort';
 
 export { toDateRepr, fromDateRepr } from '../models';

--- a/packages/loot-core/src/server/main.test.js
+++ b/packages/loot-core/src/server/main.test.js
@@ -1,24 +1,24 @@
 import { expectSnapshotWithDiffer } from '../mocks/util';
-import * as prefs from './prefs';
-import * as db from './db';
-import * as budget from './budget/base';
 import * as monthUtils from '../shared/months';
+import * as budgetActions from './budget/actions';
+import * as budget from './budget/base';
 import { getClock, deserializeClock } from './crdt';
+import * as db from './db';
 import {
   runHandler,
   runMutator,
   disableGlobalMutations,
   enableGlobalMutations
 } from './mutators';
-import * as budgetActions from './budget/actions';
+import * as prefs from './prefs';
 
 jest.mock('./post');
+const connection = require('../platform/server/connection');
+const fs = require('../platform/server/fs');
 const backend = require('./main');
 const { post } = require('./post');
 const handlers = backend.handlers;
 const sheet = require('./sheet');
-const fs = require('../platform/server/fs');
-const connection = require('../platform/server/connection');
 
 beforeEach(async () => {
   await global.emptyDatabase()();

--- a/packages/loot-core/src/server/migrate/migrations.test.js
+++ b/packages/loot-core/src/server/migrate/migrations.test.js
@@ -1,3 +1,4 @@
+import * as db from '../db';
 import {
   migrate,
   withMigrationsDir,
@@ -5,7 +6,6 @@ import {
   getMigrationList,
   getPending
 } from './migrations';
-import * as db from '../db';
 
 beforeEach(global.emptyDatabase(true));
 

--- a/packages/loot-core/src/server/mutators.js
+++ b/packages/loot-core/src/server/mutators.js
@@ -1,5 +1,5 @@
-import { sequential } from '../shared/async';
 import { captureException, captureBreadcrumb } from '../platform/exceptions';
+import { sequential } from '../shared/async';
 
 let runningMethods = new Set();
 

--- a/packages/loot-core/src/server/post.js
+++ b/packages/loot-core/src/server/post.js
@@ -1,7 +1,7 @@
 import Platform from './platform';
 
-const { PostError } = require('./errors');
 const { fetch } = require('../platform/server/fetch');
+const { PostError } = require('./errors');
 
 function throwIfNot200(res, text) {
   if (res.status !== 200) {

--- a/packages/loot-core/src/server/prefs.js
+++ b/packages/loot-core/src/server/prefs.js
@@ -1,5 +1,5 @@
-import { sendMessages } from './sync';
 import { Timestamp } from './crdt';
+import { sendMessages } from './sync';
 
 const fs = require('../platform/server/fs');
 

--- a/packages/loot-core/src/server/schedules/app.js
+++ b/packages/loot-core/src/server/schedules/app.js
@@ -1,20 +1,9 @@
-import deepEqual from 'deep-equal';
 import * as d from 'date-fns';
+import deepEqual from 'deep-equal';
 
-import { createApp } from '../app';
-import * as db from '../db';
-import * as prefs from '../prefs';
-import { toDateRepr } from '../models';
-import { runQuery as aqlQuery } from '../aql';
+import { captureBreadcrumb } from '../../platform/exceptions';
 import { dayFromDate, currentDay, parseDate } from '../../shared/months';
 import q from '../../shared/query';
-import {
-  insertRule,
-  updateRule,
-  getRules,
-  ruleModel
-} from '../accounts/transaction-rules';
-import { Rule, Condition } from '../accounts/rules';
 import {
   extractScheduleConds,
   recurConfigToRSchedule,
@@ -22,12 +11,23 @@ import {
   getStatus,
   getScheduledAmount
 } from '../../shared/schedules';
+import { Rule, Condition } from '../accounts/rules';
+import { addTransactions } from '../accounts/sync';
+import {
+  insertRule,
+  updateRule,
+  getRules,
+  ruleModel
+} from '../accounts/transaction-rules';
+import { createApp } from '../app';
+import { runQuery as aqlQuery } from '../aql';
+import * as db from '../db';
+import { toDateRepr } from '../models';
 import { mutator, runMutator } from '../mutators';
+import * as prefs from '../prefs';
+import { addSyncListener, batchMessages } from '../sync';
 import { undoable } from '../undo';
 import { Schedule as RSchedule } from '../util/rschedule';
-import { addSyncListener, batchMessages } from '../sync';
-import { captureBreadcrumb } from '../../platform/exceptions';
-import { addTransactions } from '../accounts/sync';
 import { findSchedules } from './find-schedules';
 
 const connection = require('../../platform/server/connection');

--- a/packages/loot-core/src/server/schedules/app.test.js
+++ b/packages/loot-core/src/server/schedules/app.test.js
@@ -1,8 +1,8 @@
 import MockDate from 'mockdate';
 
-import { runQuery as aqlQuery } from '../aql';
 import q from '../../shared/query';
 import { loadRules, updateRule } from '../accounts/transaction-rules';
+import { runQuery as aqlQuery } from '../aql';
 import { loadMappings } from '../db/mappings';
 import {
   updateConditions,

--- a/packages/loot-core/src/server/schedules/find-schedules.js
+++ b/packages/loot-core/src/server/schedules/find-schedules.js
@@ -1,15 +1,15 @@
 import * as d from 'date-fns';
 
-import * as db from '../db';
-import { Schedule as RSchedule } from '../util/rschedule';
-import { groupBy } from '../../shared/util';
-import { fromDateRepr } from '../models';
-import { runQuery as aqlQuery } from '../aql';
+import { dayFromDate, parseDate } from '../../shared/months';
 import q from '../../shared/query';
 import { getApproxNumberThreshold } from '../../shared/rules';
 import { recurConfigToRSchedule } from '../../shared/schedules';
-import { dayFromDate, parseDate } from '../../shared/months';
+import { groupBy } from '../../shared/util';
 import { conditionsToAQL } from '../accounts/transaction-rules';
+import { runQuery as aqlQuery } from '../aql';
+import * as db from '../db';
+import { fromDateRepr } from '../models';
+import { Schedule as RSchedule } from '../util/rschedule';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/sheet.js
+++ b/packages/loot-core/src/server/sheet.js
@@ -1,9 +1,9 @@
-import Spreadsheet from './spreadsheet/spreadsheet';
-import * as prefs from './prefs';
 import { captureBreadcrumb } from '../platform/exceptions';
 import * as sqlite from '../platform/server/sqlite';
 import { sheetForMonth } from '../shared/months';
 import Platform from './platform';
+import * as prefs from './prefs';
+import Spreadsheet from './spreadsheet/spreadsheet';
 
 const { resolveName } = require('./spreadsheet/util');
 

--- a/packages/loot-core/src/server/sheet.test.js
+++ b/packages/loot-core/src/server/sheet.test.js
@@ -1,6 +1,6 @@
+import { generateTransaction } from '../mocks';
 import * as db from './db';
 import * as sheet from './sheet';
-import { generateTransaction } from '../mocks';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/spreadsheet/new/compiler.js
+++ b/packages/loot-core/src/server/spreadsheet/new/compiler.js
@@ -1,6 +1,5 @@
-import parse from './parser';
+import getSqlFields from './get-sql-fields';
 import * as nodes from './nodes';
-import generateSql from './sqlgen';
 import {
   MOV,
   CALL,
@@ -14,7 +13,8 @@ import {
   JUMPT,
   LABEL
 } from './ops';
-import getSqlFields from './get-sql-fields';
+import parse from './parser';
+import generateSql from './sqlgen';
 
 class Compiler {
   constructor() {

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
@@ -1,6 +1,6 @@
-import Spreadsheet from './spreadsheet';
-import * as db from '../db';
 import { generateTransaction } from '../../mocks';
+import * as db from '../db';
+import Spreadsheet from './spreadsheet';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/spreadsheet/usage.js
+++ b/packages/loot-core/src/server/spreadsheet/usage.js
@@ -1,8 +1,8 @@
-const sqlite = require('sqlite3');
 const escodegen = require('escodegen');
+const sqlite = require('sqlite3');
 
-const sqlgen = require('./sqlgen');
 const Spreadsheet = require('./spreadsheet');
+const sqlgen = require('./sqlgen');
 
 // Example usage:
 

--- a/packages/loot-core/src/server/sync/index.js
+++ b/packages/loot-core/src/server/sync/index.js
@@ -1,16 +1,9 @@
-import { sequential, once } from '../../shared/async';
-import * as prefs from '../prefs';
-import app from '../main-app';
-import asyncStorage from '../../platform/server/asyncStorage';
 import { captureException } from '../../platform/exceptions';
+import asyncStorage from '../../platform/server/asyncStorage';
 import logger from '../../platform/server/log';
-import { postBinary } from '../post';
-import * as db from '../db';
-import * as sheet from '../sheet';
-import { triggerBudgetChanges, setType as setBudgetType } from '../budget/base';
-import * as undo from '../undo';
-import { runMutator } from '../mutators';
+import { sequential, once } from '../../shared/async';
 import { setIn, getIn } from '../../shared/util';
+import { triggerBudgetChanges, setType as setBudgetType } from '../budget/base';
 import {
   serializeClock,
   deserializeClock,
@@ -18,12 +11,19 @@ import {
   Timestamp,
   merkle
 } from '../crdt';
-import * as encoder from './encoder';
+import * as db from '../db';
+import app from '../main-app';
+import { runMutator } from '../mutators';
+import { postBinary } from '../post';
+import * as prefs from '../prefs';
 import { getServer } from '../server-config';
+import * as sheet from '../sheet';
+import * as undo from '../undo';
+import * as encoder from './encoder';
 import { rebuildMerkleHash } from './repair';
 
-const { PostError, SyncError } = require('../errors');
 const connection = require('../../platform/server/connection');
+const { PostError, SyncError } = require('../errors');
 
 export { default as makeTestMessage } from './make-test-message';
 export { default as resetSync } from './reset';

--- a/packages/loot-core/src/server/sync/migrate.test.js
+++ b/packages/loot-core/src/server/sync/migrate.test.js
@@ -1,10 +1,10 @@
 import fc from 'fast-check';
 
-import * as db from '../db';
-import { listen, unlisten } from './migrate';
+import arbs from '../../mocks/arbitrary-schema';
 import { execTracer } from '../../shared/test-helpers';
 import { convertInputType, schema, schemaConfig } from '../aql';
-import arbs from '../../mocks/arbitrary-schema';
+import * as db from '../db';
+import { listen, unlisten } from './migrate';
 
 import { addSyncListener, sendMessages } from './index';
 

--- a/packages/loot-core/src/server/sync/repair.js
+++ b/packages/loot-core/src/server/sync/repair.js
@@ -1,5 +1,5 @@
-import * as db from '../db';
 import { serializeClock, getClock, Timestamp, merkle } from '../crdt';
+import * as db from '../db';
 
 export function rebuildMerkleHash() {
   let rows = db.runQuery('SELECT timestamp FROM messages_crdt', [], true);

--- a/packages/loot-core/src/server/sync/reset.js
+++ b/packages/loot-core/src/server/sync/reset.js
@@ -1,9 +1,9 @@
+import { captureException } from '../../platform/exceptions';
+import asyncStorage from '../../platform/server/asyncStorage';
 import * as cloudStorage from '../cloud-storage';
 import * as db from '../db';
-import * as prefs from '../prefs';
-import asyncStorage from '../../platform/server/asyncStorage';
-import { captureException } from '../../platform/exceptions';
 import { runMutator } from '../mutators';
+import * as prefs from '../prefs';
 
 const connection = require('../../platform/server/connection');
 

--- a/packages/loot-core/src/server/sync/sync.property.test.js
+++ b/packages/loot-core/src/server/sync/sync.property.test.js
@@ -1,7 +1,7 @@
-import * as prefs from '../prefs';
-import * as db from '../db';
-import * as sheet from '../sheet';
 import { merkle, getClock, Timestamp } from '../crdt';
+import * as db from '../db';
+import * as prefs from '../prefs';
+import * as sheet from '../sheet';
 import * as encoder from './encoder';
 
 import * as sync from './index';

--- a/packages/loot-core/src/server/sync/sync.test.js
+++ b/packages/loot-core/src/server/sync/sync.test.js
@@ -1,7 +1,7 @@
-import * as prefs from '../prefs';
-import * as db from '../db';
-import * as sheet from '../sheet';
 import { getClock, Timestamp } from '../crdt';
+import * as db from '../db';
+import * as prefs from '../prefs';
+import * as sheet from '../sheet';
 import { resolveName } from '../spreadsheet/util';
 import * as encoder from './encoder';
 

--- a/packages/loot-core/src/server/tests/mockSyncServer.js
+++ b/packages/loot-core/src/server/tests/mockSyncServer.js
@@ -2,8 +2,8 @@ import dateFns from 'date-fns';
 
 import { makeClock, Timestamp, merkle } from '../crdt';
 
-const defaultMockData = require('./mockData').basic;
 const SyncPb = require('../sync/proto/sync_pb');
+const defaultMockData = require('./mockData').basic;
 
 const handlers = {};
 let currentMockData = defaultMockData;

--- a/packages/loot-core/src/server/tools/app.js
+++ b/packages/loot-core/src/server/tools/app.js
@@ -1,7 +1,7 @@
-import { runMutator } from '../mutators';
+import { batchUpdateTransactions } from '../accounts/transactions';
 import { createApp } from '../app';
 import * as db from '../db';
-import { batchUpdateTransactions } from '../accounts/transactions';
+import { runMutator } from '../mutators';
 
 let app = createApp();
 

--- a/packages/loot-core/src/server/undo.js
+++ b/packages/loot-core/src/server/undo.js
@@ -1,7 +1,7 @@
-import { sendMessages } from './sync';
 import { getIn } from '../shared/util';
 import { Timestamp } from './crdt';
 import { withMutatorContext, getMutatorContext } from './mutators';
+import { sendMessages } from './sync';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-core/src/server/update.js
+++ b/packages/loot-core/src/server/update.js
@@ -1,8 +1,8 @@
 import md5 from 'md5';
 
-import * as migrations from './migrate/migrations';
-import * as db from './db';
 import { schema, schemaConfig, makeViews } from './aql';
+import * as db from './db';
+import * as migrations from './migrate/migrations';
 
 // Managing the init/update process
 

--- a/packages/loot-design/src/components/AccountAutocomplete.js
+++ b/packages/loot-design/src/components/AccountAutocomplete.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 
+import { colors } from '../style';
 import Autocomplete from './Autocomplete';
 import { View } from './common';
-import { colors } from '../style';
 
 export function AccountList({
   items,

--- a/packages/loot-design/src/components/Autocomplete.usage.js
+++ b/packages/loot-design/src/components/Autocomplete.usage.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import Autocomplete, { MultiAutocomplete } from './Autocomplete';
 import { Section } from '../guide/components';
+import Autocomplete, { MultiAutocomplete } from './Autocomplete';
 
 let items = [
   { id: 'one', name: 'James' },

--- a/packages/loot-design/src/components/CategorySelect.js
+++ b/packages/loot-design/src/components/CategorySelect.js
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react';
 
-import { View, Text, Select } from './common';
-import Autocomplete, { defaultFilterSuggestion } from './Autocomplete';
 import { colors } from '../style';
 import Split from '../svg/split';
+import Autocomplete, { defaultFilterSuggestion } from './Autocomplete';
+import { View, Text, Select } from './common';
 
 export const NativeCategorySelect = React.forwardRef(
   ({ categoryGroups, emptyLabel, ...nativeProps }, ref) => {

--- a/packages/loot-design/src/components/DateSelect.usage.js
+++ b/packages/loot-design/src/components/DateSelect.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import DateSelect from './DateSelect';
 import { Section } from '../guide/components';
+import DateSelect from './DateSelect';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/FixedSizeList.js
+++ b/packages/loot-design/src/components/FixedSizeList.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import memoizeOne from 'memoize-one';
 
-import useResizeObserver from './useResizeObserver';
 import { View } from './common';
+import useResizeObserver from './useResizeObserver';
 
 const IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 

--- a/packages/loot-design/src/components/NotesButton.js
+++ b/packages/loot-design/src/components/NotesButton.js
@@ -2,13 +2,13 @@ import React, { useState, useEffect, useMemo } from 'react';
 
 import { css } from 'glamor';
 
-import { send } from 'loot-core/src/platform/client/fetch';
-import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import q from 'loot-core/src/client/query-helpers';
+import { useLiveQuery } from 'loot-core/src/client/query-hooks';
+import { send } from 'loot-core/src/platform/client/fetch';
 
-import { View, Button, Tooltip, useTooltip } from './common';
-import CustomNotesPaper from '../svg/v2/CustomNotesPaper';
 import { colors } from '../style';
+import CustomNotesPaper from '../svg/v2/CustomNotesPaper';
+import { View, Button, Tooltip, useTooltip } from './common';
 
 export function NotesTooltip({
   defaultNotes,

--- a/packages/loot-design/src/components/PayeeAutocomplete.js
+++ b/packages/loot-design/src/components/PayeeAutocomplete.js
@@ -1,19 +1,19 @@
 import React, { useState, useMemo, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { getActivePayees } from 'loot-core/src/client/reducers/queries';
 import { createPayee } from 'loot-core/src/client/actions/queries';
-import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
+import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
+import { getActivePayees } from 'loot-core/src/client/reducers/queries';
 
-import { View } from './common';
+import { colors } from '../style';
 import Add from '../svg/v1/Add';
 import Autocomplete, {
   defaultFilterSuggestion,
   AutocompleteFooter,
   AutocompleteFooterButton
 } from './Autocomplete';
-import { colors } from '../style';
+import { View } from './common';
 
 function getPayeeSuggestions(payees, focusTransferPayees, accounts) {
   let activePayees = accounts ? getActivePayees(payees, accounts) : payees;

--- a/packages/loot-design/src/components/RecurringSchedulePicker.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.js
@@ -4,10 +4,10 @@ import { useSelector } from 'react-redux';
 import { sendCatch } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { getRecurringDescription } from 'loot-core/src/shared/schedules';
-import { colors } from 'loot-design/src/style';
 import { useTooltip } from 'loot-design/src/components/tooltips';
-import SubtractIcon from 'loot-design/src/svg/Subtract';
+import { colors } from 'loot-design/src/style';
 import AddIcon from 'loot-design/src/svg/Add';
+import SubtractIcon from 'loot-design/src/svg/Subtract';
 
 import { Button, Select, Input, Tooltip, View, Text, Stack } from './common';
 import DateSelect from './DateSelect';

--- a/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import RecurringSchedulePicker from './RecurringSchedulePicker';
 import { Section } from '../guide/components';
 import { Button, View } from './common';
+import RecurringSchedulePicker from './RecurringSchedulePicker';
 import { useTooltip } from './tooltips';
 
 export default () => {

--- a/packages/loot-design/src/components/Stack.js
+++ b/packages/loot-design/src/components/Stack.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import View from './View';
 import Text from './Text';
+import View from './View';
 
 function getChildren(key, children) {
   return React.Children.toArray(children).reduce((list, child) => {

--- a/packages/loot-design/src/components/alerts.js
+++ b/packages/loot-design/src/components/alerts.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { View, Text } from './common';
 import { styles, colors } from '../style';
-import InformationOutline from '../svg/v1/InformationOutline';
 import ExclamationOutline from '../svg/v1/ExclamationOutline';
+import InformationOutline from '../svg/v1/InformationOutline';
+import { View, Text } from './common';
 
 export function Alert({ icon: Icon, color, backgroundColor, style, children }) {
   return (

--- a/packages/loot-design/src/components/budget/BalanceWithCarryover.js
+++ b/packages/loot-design/src/components/budget/BalanceWithCarryover.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
+import ArrowThinRight from '../../svg/v1/ArrowThinRight';
+import { View } from '../common';
+import CellValue from '../spreadsheet/CellValue';
 import useSheetValue from '../spreadsheet/useSheetValue';
 import { makeAmountStyle } from './util';
-import { View } from '../common';
-import ArrowThinRight from '../../svg/v1/ArrowThinRight';
-import CellValue from '../spreadsheet/CellValue';
 
 export default function BalanceWithCarryover({
   carryover,

--- a/packages/loot-design/src/components/budget/BudgetSummaries.js
+++ b/packages/loot-design/src/components/budget/BudgetSummaries.js
@@ -6,14 +6,14 @@ import React, {
   useLayoutEffect
 } from 'react';
 
-import { Spring } from 'wobble';
 import { css } from 'glamor';
+import { Spring } from 'wobble';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { MonthsContext } from './MonthsContext';
 import { View } from '../common';
 import useResizeObserver from '../useResizeObserver';
+import { MonthsContext } from './MonthsContext';
 
 export default function BudgetSummaries({ SummaryComponent }) {
   let { months } = useContext(MonthsContext);

--- a/packages/loot-design/src/components/budget/DynamicBudgetTable.js
+++ b/packages/loot-design/src/components/budget/DynamicBudgetTable.js
@@ -2,8 +2,8 @@ import React, { useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { View } from '../common';
-import { CategoryGroupsContext } from './util';
 import { useBudgetMonthCount } from './BudgetMonthCountContext';
+import { CategoryGroupsContext } from './util';
 
 import { BudgetPageHeader, BudgetTable } from './index';
 

--- a/packages/loot-design/src/components/budget/index.js
+++ b/packages/loot-design/src/components/budget/index.js
@@ -4,7 +4,11 @@ import { scope } from '@jlongster/lively';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import ElementQuery from '../ElementQuery';
+import { styles, colors } from '../../style';
+import ExpandArrow from '../../svg/ExpandArrow';
+import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
+import ArrowThinRight from '../../svg/v1/ArrowThinRight';
+import CheveronDown from '../../svg/v1/CheveronDown';
 import {
   View,
   Text,
@@ -13,7 +17,8 @@ import {
   Menu,
   IntersectionBoundary
 } from '../common';
-import { Row, InputCell, ROW_HEIGHT } from '../table';
+import ElementQuery from '../ElementQuery';
+import NotesButton from '../NotesButton';
 import {
   useDraggable,
   useDroppable,
@@ -21,16 +26,11 @@ import {
   DropHighlightPosContext
 } from '../sort.js';
 import NamespaceContext from '../spreadsheet/NamespaceContext';
-import { styles, colors } from '../../style';
-import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
-import ArrowThinRight from '../../svg/v1/ArrowThinRight';
-import ExpandArrow from '../../svg/ExpandArrow';
-import CheveronDown from '../../svg/v1/CheveronDown';
-import { separateGroups, findSortDown, findSortUp } from './util';
-import { MonthsProvider, MonthsContext } from './MonthsContext';
-import NotesButton from '../NotesButton';
+import { Row, InputCell, ROW_HEIGHT } from '../table';
 import BudgetSummaries from './BudgetSummaries';
 import { INCOME_HEADER_HEIGHT, MONTH_BOX_SHADOW } from './constants';
+import { MonthsProvider, MonthsContext } from './MonthsContext';
+import { separateGroups, findSortDown, findSortUp } from './util';
 
 function getScrollbarWidth() {
   return Math.max(styles.scrollbarWidth - 2, 0);

--- a/packages/loot-design/src/components/budget/index.usage.js
+++ b/packages/loot-design/src/components/budget/index.usage.js
@@ -2,18 +2,18 @@ import React from 'react';
 import { DndProvider } from 'react-dnd';
 import Backend from 'react-dnd-html5-backend';
 
-import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import { generateCategoryGroups } from 'loot-core/src/mocks';
+import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import * as monthUtils from 'loot-core/src/shared/months';
 
 import { Section } from '../../guide/components';
+import { colors } from '../../style';
 import { View } from '../common';
 import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
-import DynamicBudgetTable from './DynamicBudgetTable';
 import { BudgetMonthCountContext } from './BudgetMonthCountContext';
+import DynamicBudgetTable from './DynamicBudgetTable';
 import * as rollover from './rollover/rollover-components';
 import { RolloverContext } from './rollover/RolloverContext';
-import { colors } from '../../style';
 
 const categoryGroups = generateCategoryGroups([
   {

--- a/packages/loot-design/src/components/budget/report/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/report/BudgetSummary.js
@@ -2,13 +2,13 @@ import React, { useState } from 'react';
 
 import { css } from 'glamor';
 
-import * as monthUtils from 'loot-core/src/shared/months';
 import { reportBudget } from 'loot-core/src/client/queries';
+import * as monthUtils from 'loot-core/src/shared/months';
 
-import NamespaceContext from '../../spreadsheet/NamespaceContext';
-import CellValue from '../../spreadsheet/CellValue';
-import useSheetValue from '../../spreadsheet/useSheetValue';
-import format from '../../spreadsheet/format';
+import { colors, styles } from '../../../style';
+import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
+import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
+import ArrowButtonUp1 from '../../../svg/v2/ArrowButtonUp1';
 import {
   View,
   Text,
@@ -19,14 +19,14 @@ import {
   HoverTarget,
   AlignedText
 } from '../../common';
+import NotesButton from '../../NotesButton';
+import CellValue from '../../spreadsheet/CellValue';
+import format from '../../spreadsheet/format';
+import NamespaceContext from '../../spreadsheet/NamespaceContext';
+import useSheetValue from '../../spreadsheet/useSheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
 import { makeAmountFullStyle } from '../util';
-import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
-import ArrowButtonUp1 from '../../../svg/v2/ArrowButtonUp1';
-import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
 import { useReport } from './ReportContext';
-import NotesButton from '../../NotesButton';
-import { colors, styles } from '../../../style';
 
 function PieProgress({ style, progress, color, backgroundColor }) {
   let radius = 4;

--- a/packages/loot-design/src/components/budget/report/components.js
+++ b/packages/loot-design/src/components/budget/report/components.js
@@ -1,18 +1,18 @@
 import React from 'react';
 
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
-import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { reportBudget } from 'loot-core/src/client/queries';
+import evalArithmetic from 'loot-core/src/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
 import { styles, colors } from '../../../style';
 import { View, Text, Tooltip, Menu, useTooltip } from '../../common';
-import { Field, SheetCell } from '../../table';
-import useSheetValue from '../../spreadsheet/useSheetValue';
-import { makeAmountGrey } from '../util';
-import { MONTH_RIGHT_PADDING } from '../constants';
-import format from '../../spreadsheet/format';
 import CellValue from '../../spreadsheet/CellValue';
+import format from '../../spreadsheet/format';
+import useSheetValue from '../../spreadsheet/useSheetValue';
+import { Field, SheetCell } from '../../table';
 import BalanceWithCarryover from '../BalanceWithCarryover';
+import { MONTH_RIGHT_PADDING } from '../constants';
+import { makeAmountGrey } from '../util';
 
 export BudgetSummary from './BudgetSummary';
 

--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -1,15 +1,15 @@
 import React, { useState } from 'react';
 
-import { css } from 'glamor';
 import Component from '@reactions/component';
+import { css } from 'glamor';
 
-import * as monthUtils from 'loot-core/src/shared/months';
 import { rolloverBudget } from 'loot-core/src/client/queries';
+import * as monthUtils from 'loot-core/src/shared/months';
 
-import NamespaceContext from '../../spreadsheet/NamespaceContext';
-import format from '../../spreadsheet/format';
-import SheetValue from '../../spreadsheet/SheetValue';
-import CellValue from '../../spreadsheet/CellValue';
+import { colors, styles } from '../../../style';
+import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
+import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
+import ArrowButtonUp1 from '../../../svg/v2/ArrowButtonUp1';
 import {
   View,
   Block,
@@ -19,15 +19,15 @@ import {
   HoverTarget,
   AlignedText
 } from '../../common';
+import NotesButton from '../../NotesButton';
+import CellValue from '../../spreadsheet/CellValue';
+import format from '../../spreadsheet/format';
+import NamespaceContext from '../../spreadsheet/NamespaceContext';
+import SheetValue from '../../spreadsheet/SheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
-import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
-import ArrowButtonUp1 from '../../../svg/v2/ArrowButtonUp1';
-import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
-import { colors, styles } from '../../../style';
+import HoldTooltip from './HoldTooltip';
 import { useRollover } from './RolloverContext';
 import TransferTooltip from './TransferTooltip';
-import HoldTooltip from './HoldTooltip';
-import NotesButton from '../../NotesButton';
 
 function TotalsList({ prevMonthName, collapsed }) {
   return (

--- a/packages/loot-design/src/components/budget/rollover/HoldTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/HoldTooltip.js
@@ -1,11 +1,11 @@
 import React, { useState, useContext, useEffect } from 'react';
 
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
 import { View, Button, Tooltip, InitialFocus, Input } from '../../common';
-import SpreadsheetContext from '../../spreadsheet/SpreadsheetContext';
 import NamespaceContext from '../../spreadsheet/NamespaceContext';
+import SpreadsheetContext from '../../spreadsheet/SpreadsheetContext';
 
 export default function HoldTooltip({ onSubmit, onClose }) {
   const spreadsheet = useContext(SpreadsheetContext);

--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -7,8 +7,7 @@ import CategoryAutocomplete from '../../CategorySelect';
 import { View, Button, Tooltip, InitialFocus, Input } from '../../common';
 import NamespaceContext from '../../spreadsheet/NamespaceContext';
 import SpreadsheetContext from '../../spreadsheet/SpreadsheetContext';
-import { addToBeBudgetedGroup } from '../util';
-import { CategoryGroupsContext } from '../util';
+import { addToBeBudgetedGroup, CategoryGroupsContext } from '../util';
 
 export default function TransferTooltip({
   initialAmount,

--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -1,13 +1,13 @@
 import React, { useState, useContext, useEffect } from 'react';
 
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
-import { View, Button, Tooltip, InitialFocus, Input } from '../../common';
-import SpreadsheetContext from '../../spreadsheet/SpreadsheetContext';
-import NamespaceContext from '../../spreadsheet/NamespaceContext';
-import { addToBeBudgetedGroup } from '../util';
 import CategoryAutocomplete from '../../CategorySelect';
+import { View, Button, Tooltip, InitialFocus, Input } from '../../common';
+import NamespaceContext from '../../spreadsheet/NamespaceContext';
+import SpreadsheetContext from '../../spreadsheet/SpreadsheetContext';
+import { addToBeBudgetedGroup } from '../util';
 import { CategoryGroupsContext } from '../util';
 
 export default function TransferTooltip({

--- a/packages/loot-design/src/components/budget/rollover/rollover-components.js
+++ b/packages/loot-design/src/components/budget/rollover/rollover-components.js
@@ -1,10 +1,11 @@
 import React, { useContext, useState } from 'react';
 
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
-import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { rolloverBudget } from 'loot-core/src/client/queries';
+import evalArithmetic from 'loot-core/src/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
 import { styles, colors } from '../../../style';
+import CategoryAutocomplete from '../../CategorySelect';
 import {
   View,
   Text,
@@ -14,19 +15,18 @@ import {
   Button,
   Menu
 } from '../../common';
+import CellValue from '../../spreadsheet/CellValue';
+import format from '../../spreadsheet/format';
+import useSheetValue from '../../spreadsheet/useSheetValue';
 import { Row, Field, SheetCell } from '../../table';
+import BalanceWithCarryover from '../BalanceWithCarryover';
+import { MONTH_RIGHT_PADDING } from '../constants';
 import {
   makeAmountGrey,
   addToBeBudgetedGroup,
   CategoryGroupsContext
 } from '../util';
-import { MONTH_RIGHT_PADDING } from '../constants';
-import useSheetValue from '../../spreadsheet/useSheetValue';
-import format from '../../spreadsheet/format';
-import CellValue from '../../spreadsheet/CellValue';
-import CategoryAutocomplete from '../../CategorySelect';
 import TransferTooltip from './TransferTooltip';
-import BalanceWithCarryover from '../BalanceWithCarryover';
 
 export BudgetSummary from './BudgetSummary';
 

--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -15,8 +15,6 @@ import {
   useRouteMatch
 } from 'react-router-dom';
 
-import { css } from 'glamor';
-import hotkeys from 'hotkeys-js';
 import {
   ListboxInput,
   ListboxButton,
@@ -24,6 +22,8 @@ import {
   ListboxList,
   ListboxOption
 } from '@reach/listbox';
+import { css } from 'glamor';
+import hotkeys from 'hotkeys-js';
 
 import { integerToCurrency } from 'loot-core/src/shared/util';
 import ExpandArrow from 'loot-design/src/svg/ExpandArrow';
@@ -31,9 +31,9 @@ import ExpandArrow from 'loot-design/src/svg/ExpandArrow';
 import { styles, colors } from '../style';
 import Delete from '../svg/Delete';
 import Loading from '../svg/v1/AnimatedLoading';
-import View from './View';
 import Text from './Text';
 import { useProperFocus } from './useProperFocus';
+import View from './View';
 
 export { default as View } from './View';
 export { default as Text } from './Text';

--- a/packages/loot-design/src/components/forms.js
+++ b/packages/loot-design/src/components/forms.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { css } from 'glamor';
 
-import { View, Text } from './common';
 import { colors } from '../style';
+import { View, Text } from './common';
 
 export function SectionLabel({ title, style }) {
   return (

--- a/packages/loot-design/src/components/manager/BudgetList.js
+++ b/packages/loot-design/src/components/manager/BudgetList.js
@@ -1,16 +1,16 @@
 import React, { useState, useRef } from 'react';
 
+import Loading from 'loot-design/src/svg/v1/AnimatedLoading';
 import Key from 'loot-design/src/svg/v2/Key';
 import RefreshArrow from 'loot-design/src/svg/v2/RefreshArrow';
-import Loading from 'loot-design/src/svg/v1/AnimatedLoading';
 
-import { View, Text, Modal, Button, Tooltip, Menu } from '../common';
 import { styles, colors } from '../../style';
 import CloudCheck from '../../svg/v1/CloudCheck';
 import CloudDownload from '../../svg/v1/CloudDownload';
-import CloudUnknown from '../../svg/v2/CloudUnknown';
-import FileDouble from '../../svg/v1/FileDouble';
 import DotsHorizontalTriple from '../../svg/v1/DotsHorizontalTriple';
+import FileDouble from '../../svg/v1/FileDouble';
+import CloudUnknown from '../../svg/v2/CloudUnknown';
+import { View, Text, Modal, Button, Tooltip, Menu } from '../common';
 
 function getFileDescription(file) {
   if (file.state === 'unknown') {

--- a/packages/loot-design/src/components/manager/DeleteFile.js
+++ b/packages/loot-design/src/components/manager/DeleteFile.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { View, Text, Modal, ButtonWithLoading } from '../common';
 import { colors } from '../../style';
+import { View, Text, Modal, ButtonWithLoading } from '../common';
 
 export default function DeleteMenu({ modalProps, actions, file }) {
   let [loadingState, setLoadingState] = useState(null);

--- a/packages/loot-design/src/components/manager/Import.js
+++ b/packages/loot-design/src/components/manager/Import.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { View, Block, Modal, Button } from '../common';
 import { styles, colors } from '../../style';
+import { View, Block, Modal, Button } from '../common';
 
 function getErrorMessage(error) {
   switch (error) {

--- a/packages/loot-design/src/components/manager/ImportActual.js
+++ b/packages/loot-design/src/components/manager/ImportActual.js
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { importBudget } from 'loot-core/src/client/actions/budgets';
 
+import { styles, colors } from '../../style';
 import {
   View,
   Block,
@@ -13,7 +14,6 @@ import {
   P,
   ExternalLink
 } from '../common';
-import { styles, colors } from '../../style';
 
 function getErrorMessage(error) {
   switch (error) {

--- a/packages/loot-design/src/components/manager/ImportYNAB4.js
+++ b/packages/loot-design/src/components/manager/ImportYNAB4.js
@@ -3,8 +3,8 @@ import { useDispatch } from 'react-redux';
 
 import { importBudget } from 'loot-core/src/client/actions/budgets';
 
-import { View, Block, Modal, Button, ButtonWithLoading, P } from '../common';
 import { styles, colors } from '../../style';
+import { View, Block, Modal, Button, ButtonWithLoading, P } from '../common';
 
 function getErrorMessage(error) {
   switch (error) {

--- a/packages/loot-design/src/components/manager/ImportYNAB5.js
+++ b/packages/loot-design/src/components/manager/ImportYNAB5.js
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import { importBudget } from 'loot-core/src/client/actions/budgets';
 
+import { styles, colors } from '../../style';
 import {
   View,
   Block,
@@ -12,7 +13,6 @@ import {
   P,
   ExternalLink
 } from '../common';
-import { styles, colors } from '../../style';
 
 function getErrorMessage(error) {
   switch (error) {

--- a/packages/loot-design/src/components/mobile/AmountInput.js
+++ b/packages/loot-design/src/components/mobile/AmountInput.js
@@ -11,20 +11,20 @@ import { RectButton } from 'react-native-gesture-handler';
 
 import mitt from 'mitt';
 
+import Platform from 'loot-core/src/client/platform';
 import {
   toRelaxedNumber,
   amountToCurrency,
   getNumberFormat
 } from 'loot-core/src/shared/util';
-import Platform from 'loot-core/src/client/platform';
 
 import { colors } from '../../style';
-import { KeyboardButton } from './common';
-import TextInputWithAccessory from './TextInputWithAccessory';
 import MathIcon from '../../svg/Math';
 import Add from '../../svg/v1/Add';
-import Subtract from '../../svg/v1/Subtract';
 import Equals from '../../svg/v1/Equals';
+import Subtract from '../../svg/v1/Subtract';
+import { KeyboardButton } from './common';
+import TextInputWithAccessory from './TextInputWithAccessory';
 
 function getValue(state) {
   const { value, isNegative } = state;

--- a/packages/loot-design/src/components/mobile/account.js
+++ b/packages/loot-design/src/components/mobile/account.js
@@ -1,11 +1,11 @@
 import React, { useMemo } from 'react';
 import { View, TextInput } from 'react-native';
 
-import CellValue from '../spreadsheet/CellValue';
-import { TransactionList } from './transaction';
-import Search from '../../svg/v1/Search';
-import { Label } from './common';
 import { colors } from '../../style';
+import Search from '../../svg/v1/Search';
+import CellValue from '../spreadsheet/CellValue';
+import { Label } from './common';
+import { TransactionList } from './transaction';
 
 class TransactionSearchInput extends React.Component {
   state = { text: '' };

--- a/packages/loot-design/src/components/mobile/account.usage.js
+++ b/packages/loot-design/src/components/mobile/account.usage.js
@@ -2,10 +2,10 @@ import React from 'react';
 
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
-import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 import { MobileSection, WithHeader } from '../../guide/components';
-import { accounts, categories, transactions } from './accounts.usage';
+import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 import { AccountDetails } from './account';
+import { accounts, categories, transactions } from './accounts.usage';
 
 export default () => (
   <SpreadsheetContext.Provider value={makeSpreadsheet()}>

--- a/packages/loot-design/src/components/mobile/accounts.js
+++ b/packages/loot-design/src/components/mobile/accounts.js
@@ -4,11 +4,11 @@ import { RectButton } from 'react-native-gesture-handler';
 
 import { prettyAccountType } from 'loot-core/src/shared/accounts';
 
+import { colors, mobileStyles as styles } from '../../style';
+import Wallet from '../../svg/v1/Wallet';
+import CellValue from '../spreadsheet/CellValue';
 import { Button, TextOneLine } from './common';
 import { TransactionList } from './transaction';
-import CellValue from '../spreadsheet/CellValue';
-import Wallet from '../../svg/v1/Wallet';
-import { colors, mobileStyles as styles } from '../../style';
 
 export function AccountHeader({ name, amount }) {
   return (

--- a/packages/loot-design/src/components/mobile/accounts.usage.js
+++ b/packages/loot-design/src/components/mobile/accounts.usage.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import {
   generateAccount,
   generateCategory,
   generateTransaction
 } from 'loot-core/src/mocks';
+import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
 import { MobileSection } from '../../guide/components';
 import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';

--- a/packages/loot-design/src/components/mobile/alerts.js
+++ b/packages/loot-design/src/components/mobile/alerts.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 
-import InformationSolid from 'loot-design/src/svg/v1/InformationOutline';
 import { styles, colors } from 'loot-design/src/style';
+import InformationSolid from 'loot-design/src/svg/v1/InformationOutline';
 
 export function Information({ style, children }) {
   return (

--- a/packages/loot-design/src/components/mobile/budget.js
+++ b/packages/loot-design/src/components/mobile/budget.js
@@ -17,31 +17,31 @@ import Animated, { Easing } from 'react-native-reanimated';
 
 import memoizeOne from 'memoize-one';
 
-import { amountToInteger, integerToAmount } from 'loot-core/src/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
 import Platform from 'loot-core/src/client/platform';
 import { rolloverBudget, reportBudget } from 'loot-core/src/client/queries';
+import * as monthUtils from 'loot-core/src/shared/months';
+import { amountToInteger, integerToAmount } from 'loot-core/src/shared/util';
 
-import AndroidKeyboardAvoidingView from './AndroidKeyboardAvoidingView';
+import { colors, mobileStyles as styles } from '../../style';
+import Add from '../../svg/v1/Add';
+import ArrowThinDown from '../../svg/v1/ArrowThinDown';
+import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
+import ArrowThinRight from '../../svg/v1/ArrowThinRight';
+import ArrowThinUp from '../../svg/v1/ArrowThinUp';
+import DotsHorizontalTriple from '../../svg/v1/DotsHorizontalTriple';
 import CellValue from '../spreadsheet/CellValue';
+import format from '../spreadsheet/format';
+import NamespaceContext from '../spreadsheet/NamespaceContext';
 import SheetValue from '../spreadsheet/SheetValue';
 import useSheetValue from '../spreadsheet/useSheetValue';
-import { colors, mobileStyles as styles } from '../../style';
-import format from '../spreadsheet/format';
-import { Button, KeyboardButton, Card, Label } from './common';
-import { ListItem, ROW_HEIGHT } from './table';
-import NamespaceContext from '../spreadsheet/NamespaceContext';
 import AmountInput, {
   MathOperations,
   AmountAccessoryContext
 } from './AmountInput';
+import AndroidKeyboardAvoidingView from './AndroidKeyboardAvoidingView';
+import { Button, KeyboardButton, Card, Label } from './common';
 import { DragDrop, Draggable, Droppable, DragDropHighlight } from './dragdrop';
-import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
-import ArrowThinRight from '../../svg/v1/ArrowThinRight';
-import ArrowThinUp from '../../svg/v1/ArrowThinUp';
-import ArrowThinDown from '../../svg/v1/ArrowThinDown';
-import DotsHorizontalTriple from '../../svg/v1/DotsHorizontalTriple';
-import Add from '../../svg/v1/Add';
+import { ListItem, ROW_HEIGHT } from './table';
 
 const ACTScrollViewManager =
   NativeModules && NativeModules.ACTScrollViewManager;

--- a/packages/loot-design/src/components/mobile/budget.test.js
+++ b/packages/loot-design/src/components/mobile/budget.test.js
@@ -2,14 +2,14 @@ import React from 'react';
 
 import { render, fireEvent } from '@testing-library/react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
+import * as monthUtils from 'loot-core/src/shared/months';
 
 import { MobileScreen } from '../../guide/components';
-import { categories, categoryGroups } from './budget.usage';
-import { BudgetTable, BudgetAccessoryView } from './budget';
-import InputAccessoryView from './InputAccessoryView';
 import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
+import { BudgetTable, BudgetAccessoryView } from './budget';
+import { categories, categoryGroups } from './budget.usage';
+import InputAccessoryView from './InputAccessoryView';
 
 function makeLoadedSpreadsheet() {
   let spreadsheet = makeSpreadsheet();

--- a/packages/loot-design/src/components/mobile/budget.usage.js
+++ b/packages/loot-design/src/components/mobile/budget.usage.js
@@ -5,9 +5,9 @@ import { generateCategoryGroups } from 'loot-core/src/mocks';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
 import { MobileSection } from '../../guide/components';
+import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 import { BudgetTable, BudgetAccessoryView } from './budget';
 import InputAccessoryView from './InputAccessoryView';
-import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 
 export const categoryGroups = generateCategoryGroups([
   {

--- a/packages/loot-design/src/components/mobile/transaction.js
+++ b/packages/loot-design/src/components/mobile/transaction.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { View, Text, SectionList, ScrollView, Animated } from 'react-native';
 import { Swipeable, RectButton } from 'react-native-gesture-handler';
 
-import memoizeOne from 'memoize-one';
 import {
   format as formatDate,
   parse as parseDate,
   parseISO,
   isValid as isValidDate
 } from 'date-fns';
+import memoizeOne from 'memoize-one';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import {
@@ -27,14 +27,15 @@ import {
 } from 'loot-core/src/shared/util';
 import ArrowsSynchronize from 'loot-design/src/svg/v2/ArrowsSynchronize';
 
-import KeyboardAvoidingView from './KeyboardAvoidingView';
-import { ListItem } from './table';
-import { Button, TextOneLine } from './common';
 import { colors, mobileStyles as styles } from '../../style';
 import Add from '../../svg/v1/Add';
 import Trash from '../../svg/v1/Trash';
+import AlertTriangle from '../../svg/v2/AlertTriangle';
+import CheckCircle1 from '../../svg/v2/CheckCircle1';
+import EditSkull1 from '../../svg/v2/EditSkull1';
 import PencilWriteAlternate from '../../svg/v2/PencilWriteAlternate';
 import { FocusableAmountInput } from './AmountInput';
+import { Button, TextOneLine } from './common';
 import ExitTransition from './ExitTransition';
 import {
   FieldLabel,
@@ -43,9 +44,8 @@ import {
   BooleanField,
   EDITING_PADDING
 } from './forms';
-import EditSkull1 from '../../svg/v2/EditSkull1';
-import AlertTriangle from '../../svg/v2/AlertTriangle';
-import CheckCircle1 from '../../svg/v2/CheckCircle1';
+import KeyboardAvoidingView from './KeyboardAvoidingView';
+import { ListItem } from './table';
 
 let getPayeesById = memoizeOne(payees => groupById(payees));
 let getAccountsById = memoizeOne(accounts => groupById(accounts));

--- a/packages/loot-design/src/components/mobile/transaction.usage.js
+++ b/packages/loot-design/src/components/mobile/transaction.usage.js
@@ -1,15 +1,15 @@
 import React from 'react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
 import {
   generateAccount,
   generateCategory,
   generateTransaction
 } from 'loot-core/src/mocks';
+import * as monthUtils from 'loot-core/src/shared/months';
 
 import { Section, MobileSection } from '../../guide/components';
-import { TransactionList, TransactionEdit } from './transaction';
 import { colors } from '../../style';
+import { TransactionList, TransactionEdit } from './transaction';
 
 export const accounts = [generateAccount('Checking')];
 

--- a/packages/loot-design/src/components/modals/CloseAccount.js
+++ b/packages/loot-design/src/components/modals/CloseAccount.js
@@ -4,8 +4,8 @@ import { Formik } from 'formik';
 
 import { integerToCurrency } from 'loot-core/src/shared/util';
 
-import { View, Text, Modal, Button, P, Select, FormError } from '../common';
 import { colors } from '../../style';
+import { View, Text, Modal, Button, P, Select, FormError } from '../common';
 
 function needsCategory(account, currentTransfer, accounts) {
   const acct = accounts.find(a => a.id === currentTransfer);

--- a/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.js
+++ b/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.js
@@ -7,8 +7,8 @@ import {
 } from 'loot-core/src/shared/accounts';
 import Checkmark from 'loot-design/src/svg/v1/Checkmark';
 
-import { View, Text, Modal, Button } from '../common';
 import { styles, colors } from '../../style';
+import { View, Text, Modal, Button } from '../common';
 
 function EmptyMessage() {
   return null;

--- a/packages/loot-design/src/components/modals/CreateLocalAccount.js
+++ b/packages/loot-design/src/components/modals/CreateLocalAccount.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { Formik } from 'formik';
 
-import { toRelaxedNumber } from 'loot-core/src/shared/util';
 import { determineOffBudget } from 'loot-core/src/shared/accounts';
+import { toRelaxedNumber } from 'loot-core/src/shared/util';
 
 import {
   View,

--- a/packages/loot-design/src/components/modals/EditField.js
+++ b/packages/loot-design/src/components/modals/EditField.js
@@ -4,16 +4,16 @@ import { connect } from 'react-redux';
 import { parseISO, format as formatDate, parse as parseDate } from 'date-fns';
 
 import * as actions from 'loot-core/src/client/actions';
-import { amountToInteger } from 'loot-core/src/shared/util';
 import { currentDay, dayFromDate } from 'loot-core/src/shared/months';
+import { amountToInteger } from 'loot-core/src/shared/util';
 
+import { colors } from '../../style';
+import AccountAutocomplete from '../AccountAutocomplete';
+import CategoryAutocomplete from '../CategorySelect';
 import { View, Modal, Input } from '../common';
 import DateSelect from '../DateSelect';
-import CategoryAutocomplete from '../CategorySelect';
-import AccountAutocomplete from '../AccountAutocomplete';
-import PayeeAutocomplete from '../PayeeAutocomplete';
 import { SectionLabel } from '../forms';
-import { colors } from '../../style';
+import PayeeAutocomplete from '../PayeeAutocomplete';
 // import { colors } from '../../style';
 
 function EditField({

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -21,8 +21,7 @@ import {
   Button,
   ButtonWithLoading
 } from '../common';
-import { Checkbox } from '../forms';
-import { SectionLabel } from '../forms';
+import { Checkbox, SectionLabel } from '../forms';
 import { TableHeader, TableWithNavigator, Row, Field } from '../table';
 
 let dateFormats = [

--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -11,6 +11,7 @@ import {
   looselyParseAmount
 } from 'loot-core/src/shared/util';
 
+import { colors, styles } from '../../style';
 import {
   View,
   Text,
@@ -21,9 +22,8 @@ import {
   ButtonWithLoading
 } from '../common';
 import { Checkbox } from '../forms';
-import { TableHeader, TableWithNavigator, Row, Field } from '../table';
 import { SectionLabel } from '../forms';
-import { colors, styles } from '../../style';
+import { TableHeader, TableWithNavigator, Row, Field } from '../table';
 
 let dateFormats = [
   { format: 'yyyy mm dd', label: 'YYYY MM DD' },

--- a/packages/loot-design/src/components/modals/ImportTransactions.usage.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { TestProvider } from 'loot-core/src/mocks/redux';
 import { generateTransactions } from 'loot-core/src/mocks';
+import { TestProvider } from 'loot-core/src/mocks/redux';
 
 import { Section, TestModal } from '../../guide/components';
 import { ImportTransactions } from './ImportTransactions';

--- a/packages/loot-design/src/components/modals/LoadBackup.js
+++ b/packages/loot-design/src/components/modals/LoadBackup.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import { colors } from '../../style';
 import { View, Text, Block, Modal, Button } from '../common';
 import { Row, Cell } from '../table';
-import { colors } from '../../style';
 
 class BackupTable extends React.Component {
   state = { hoveredBackup: null };

--- a/packages/loot-design/src/components/modals/PlaidExternalMsg.js
+++ b/packages/loot-design/src/components/modals/PlaidExternalMsg.js
@@ -1,9 +1,9 @@
 import React, { useState, useRef } from 'react';
 
-import { View, Text, Modal, Button, P, ModalButtons } from '../common';
-import { Error } from '../alerts';
 import { colors } from '../../style';
 import AnimatedLoading from '../../svg/v1/AnimatedLoading';
+import { Error } from '../alerts';
+import { View, Text, Modal, Button, P, ModalButtons } from '../common';
 
 function renderError(error) {
   return (

--- a/packages/loot-design/src/components/payees.js
+++ b/packages/loot-design/src/components/payees.js
@@ -8,11 +8,16 @@ import React, {
   useImperativeHandle
 } from 'react';
 
-import memoizeOne from 'memoize-one';
 import Component from '@reactions/component';
+import memoizeOne from 'memoize-one';
 
 import { groupById } from 'loot-core/src/shared/util';
 
+import { colors } from '../style';
+import Delete from '../svg/Delete';
+import ExpandArrow from '../svg/ExpandArrow';
+import Merge from '../svg/merge';
+import ArrowThinRight from '../svg/v1/ArrowThinRight';
 import {
   useStableCallback,
   View,
@@ -23,7 +28,6 @@ import {
   Tooltip,
   Menu
 } from './common';
-import { colors } from '../style';
 import {
   Table,
   Row,
@@ -38,10 +42,6 @@ import useSelected, {
   useSelectedItems,
   useSelectedDispatch
 } from './useSelected';
-import Delete from '../svg/Delete';
-import Merge from '../svg/merge';
-import ExpandArrow from '../svg/ExpandArrow';
-import ArrowThinRight from '../svg/v1/ArrowThinRight';
 
 let getPayeesById = memoizeOne(payees => groupById(payees));
 

--- a/packages/loot-design/src/components/payees.usage.js
+++ b/packages/loot-design/src/components/payees.usage.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import { applyChanges } from 'loot-core/src/shared/util';
 import { TestProvider } from 'loot-core/src/mocks/redux';
+import { applyChanges } from 'loot-core/src/shared/util';
 
 import { Section, TestModal } from '../guide/components';
 import { ManagePayees } from './payees';

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -4,11 +4,19 @@ import { withRouter } from 'react-router-dom';
 
 import { css } from 'glamor';
 
-import { pushModal } from 'loot-core/src/client/actions/modals';
 import { closeBudget } from 'loot-core/src/client/actions/budgets';
+import { pushModal } from 'loot-core/src/client/actions/modals';
 import Platform from 'loot-core/src/client/platform';
 import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 
+import { styles, colors } from '../style';
+import Add from '../svg/v1/Add';
+import Cog from '../svg/v1/Cog';
+import DotsHorizontalTriple from '../svg/v1/DotsHorizontalTriple';
+import Reports from '../svg/v1/Reports';
+import Wallet from '../svg/v1/Wallet';
+import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
+import CalendarIcon from '../svg/v2/Calendar';
 import {
   View,
   Block,
@@ -19,16 +27,8 @@ import {
   Menu,
   Tooltip
 } from './common';
-import CellValue from './spreadsheet/CellValue';
-import Add from '../svg/v1/Add';
-import CalendarIcon from '../svg/v2/Calendar';
-import { styles, colors } from '../style';
-import Wallet from '../svg/v1/Wallet';
-import Reports from '../svg/v1/Reports';
-import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
-import Cog from '../svg/v1/Cog';
-import DotsHorizontalTriple from '../svg/v1/DotsHorizontalTriple';
 import { useDraggable, useDroppable, DropHighlight } from './sort.js';
+import CellValue from './spreadsheet/CellValue';
 
 export const SIDEBAR_WIDTH = 240;
 

--- a/packages/loot-design/src/components/sidebar.usage.js
+++ b/packages/loot-design/src/components/sidebar.usage.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import { MemoryRouter as Router } from 'react-router-dom';
 import { DndProvider } from 'react-dnd';
 import Backend from 'react-dnd-html5-backend';
+import { MemoryRouter as Router } from 'react-router-dom';
 
 import lively from '@jlongster/lively';
 
-import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import { generateAccount } from 'loot-core/src/mocks';
+import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
-import SpreadsheetContext from './spreadsheet/SpreadsheetContext';
 import { Section } from '../guide/components';
 import { Sidebar } from './sidebar';
+import SpreadsheetContext from './spreadsheet/SpreadsheetContext';
 
 function withState(state, render) {
   const Component = lively(render, { getInitialState: () => state });

--- a/packages/loot-design/src/components/spreadsheet/CellValue.js
+++ b/packages/loot-design/src/components/spreadsheet/CellValue.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { styles } from '../../style';
+import Text from '../Text';
 import format from './format';
 import SheetValue from './SheetValue';
-import Text from '../Text';
-import { styles } from '../../style';
 
 function CellValue({ binding, type, formatter, style, getStyle, debug }) {
   return (

--- a/packages/loot-design/src/components/table.js
+++ b/packages/loot-design/src/components/table.js
@@ -13,12 +13,12 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { scope } from '@jlongster/lively';
 
-import { FixedSizeList } from './FixedSizeList';
 import { styles, colors } from '../style';
 import DeleteIcon from '../svg/Delete';
-import Checkmark from '../svg/v1/Checkmark';
 import ExpandArrow from '../svg/ExpandArrow';
 import AnimatedLoading from '../svg/v1/AnimatedLoading';
+import Checkmark from '../svg/v1/Checkmark';
+import { keys } from '../util/keys';
 import {
   View,
   Text,
@@ -28,11 +28,11 @@ import {
   IntersectionBoundary,
   Menu
 } from './common';
-import { KeyHandlers } from './KeyHandlers';
-import SheetValue from './spreadsheet/SheetValue';
 import DateSelect from './DateSelect';
+import { FixedSizeList } from './FixedSizeList';
+import { KeyHandlers } from './KeyHandlers';
 import format from './spreadsheet/format';
-import { keys } from '../util/keys';
+import SheetValue from './spreadsheet/SheetValue';
 import { AvoidRefocusScrollProvider, useProperFocus } from './useProperFocus';
 import { useSelectedItems } from './useSelected';
 

--- a/packages/loot-design/src/components/useSelected.js
+++ b/packages/loot-design/src/components/useSelected.js
@@ -7,8 +7,8 @@ import React, {
 } from 'react';
 import { useSelector } from 'react-redux';
 
-import * as undo from 'loot-core/src/platform/client/undo';
 import { listen } from 'loot-core/src/platform/client/fetch';
+import * as undo from 'loot-core/src/platform/client/undo';
 
 import { hasModifierKey } from '../util/keys';
 

--- a/packages/mobile/src/components/manager/TransitionView.js
+++ b/packages/mobile/src/components/manager/TransitionView.js
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Animated } from 'react-native';
 import { useIsFocused } from '@react-navigation/native';
 

--- a/packages/mobile/src/components/modals/GenericSearchableSelect.js
+++ b/packages/mobile/src/components/modals/GenericSearchableSelect.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { View, Text, FlatList, TextInput, NativeModules } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
 import q from 'loot-core/src/client/query-helpers';


### PR DESCRIPTION
This PR re-adds the `alphabetize` rule from #221. The benefits I see from this are:

- `loot-core` imports are always placed before `loot-design` which creates a nice division between importing implementation vs display
- Sorting according the the path results in commonly used imports which sit at the top of the directory structure sitting above more specialised imports which sit close to where they are used.
- A number of cases where we have multiple separate imports from the same file were found as these imports were sorted to be next to each other.