### PR TITLE
Remove dollar sign from close account modal

### DIFF
--- a/packages/loot-design/src/components/modals/CloseAccount.js
+++ b/packages/loot-design/src/components/modals/CloseAccount.js
@@ -116,7 +116,7 @@ function CloseAccount({
                   <View>
                     <P>
                       This account has a balance of{' '}
-                      <strong>${integerToCurrency(balance)}</strong>. To close
+                      <strong>{integerToCurrency(balance)}</strong>. To close
                       this account, select a different account to transfer this
                       balance to:
                     </P>


### PR DESCRIPTION
Actual generally omits currency symbols so that it's currency agnostic, however we display a $ when closing an account.

This PR removes this $ symbol for consistency.