### PR TITLE
Render a schedule rule with the mapped payee id; fixes crash

### DIFF
--- a/packages/desktop-client/src/components/modals/ManageRules.js
+++ b/packages/desktop-client/src/components/modals/ManageRules.js
@@ -238,9 +238,9 @@ function ScheduleValue({ value }) {
       field="rule"
       data={schedules}
       describe={s => {
-        let { payee } = extractScheduleConds(s._conditions);
-        return payee
-          ? `${byId[payee.value].name} (${s.next_date})`
+        let payeeId = s._payee;
+        return payeeId
+          ? `${byId[payeeId].name} (${s.next_date})`
           : `Next: ${s.next_date}`;
       }}
     />


### PR DESCRIPTION
This bug has been around for a while and I finally tracked it down. The fix is small, but requires understanding several important things:

* When an item is deleted, several other items may be pointing to it. In several cases, we allow changing this pointer. One case is when you merge payees; we delete all but 1 payee, and change the pointers of all of the deleted ones to the final one. Everything else in the system that uses payees will automatically be linked to the final payee (if any of the merged payees was used)
* To do this, we have "mappings" tables with two columns: one id of the real item, and a second id of the item it "points" to. When querying for items, we _always_ need to join through this table. This is only needed for categories and payees (I think?), and it's automatically handled internally for most queries.
* We can't always do this mapping easily in SQL though. One case is rules; the actions and conditions are stored as JSON blobs. This JSON can contain ids that need mapping; unfortunately, we have to resort to doing the mapping for rule actions and conditions in JS. That means the JSON blob always stores unmapped ids
* Schedules do have special fields, however. When the query system returns them, they contain `_payee`, `_account`, `_amount`, and `_date`. These are all still constructed in a single SQL statement; it uses `json_extract` to pull these conditions out because we need them so much for working with schedules. Most importantly: it maps the ids for these fields! This removes most of the burden

(These fields have underscores to mark that they aren't real fields, and if an object is submitted as a mutation it'll automatically strip those fields away)

When reading values like `payee` from a schedule, you shouldn't touch `_conditions` directly because you can run into problems. Here, we were using the unmapped payee id so when it tries to render it, that payee doesn't exist (since it's been deleted). We need to use the mapped version, which is simple because the query system has already gotten it for us.