### PR TITLE
Schedules editor: exclude closed accounts in Account autocomplete

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -761,6 +761,7 @@ export const Transaction = React.memo(function Transaction(props) {
             <AccountAutocomplete
               value={accountId}
               accounts={accounts}
+              includeClosedAccounts
               shouldSaveFromKey={shouldSaveFromKey}
               tableBehavior={true}
               focused={true}

--- a/packages/desktop-client/src/components/util/GenericInput.js
+++ b/packages/desktop-client/src/components/util/GenericInput.js
@@ -66,6 +66,7 @@ export default function GenericInput({
           content = (
             <AccountAutocomplete
               accounts={accounts}
+              includeClosedAccounts
               value={value}
               multi={multi}
               openOnFocus={false}

--- a/packages/loot-design/src/components/AccountAutocomplete.js
+++ b/packages/loot-design/src/components/AccountAutocomplete.js
@@ -66,7 +66,7 @@ export function AccountList({
   );
 }
 
-export default function AccountAutocomplete({ embedded, ...props }) {
+export default function AccountAutocomplete({ embedded, includeClosedAccounts=false, ...props }) {
   let accounts = useCachedAccounts() || [];
 
   return (
@@ -74,7 +74,7 @@ export default function AccountAutocomplete({ embedded, ...props }) {
       strict={true}
       highlightFirst={true}
       embedded={embedded}
-      suggestions={accounts}
+      suggestions={includeClosedAccounts ? accounts : accounts.filter(a => a.closed === false)}
       renderItems={(items, getItemProps, highlightedIndex) => (
         <AccountList
           items={items}

--- a/packages/loot-design/src/components/modals/EditField.js
+++ b/packages/loot-design/src/components/modals/EditField.js
@@ -72,6 +72,7 @@ function EditField({
         <AccountAutocomplete
           value={null}
           accounts={accounts}
+          includeClosedAccounts
           focused={true}
           embedded={true}
           onSelect={value => {


### PR DESCRIPTION
Closes #307 

Gave `AccountAutocomplete` a prop for including closed accounts and defaulted it to `false`.
To fix the Account dropdown in the Schedule editor, that particular dropdown will use the default.
However, for the lightest touch, every other `AccountAutocomplete` will specify `includeClosedAccounts` for the moment.