### PR TITLE
Schedule Editor: Keep payee list open while toggling transfer payees focus

### DIFF
--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useState } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useHistory } from 'react-router-dom';
 
@@ -340,10 +340,6 @@ export default function ScheduleDetails() {
 
   let selectedInst = useSelected('transactions', state.transactions, []);
 
-  // helps emulate the <TransactionsTable> behavior where <PayeeAutocomplete>
-  // remains open as long as we're interacting with it
-  const [payeeFieldFocused, setPayeeFieldFocused] = useState(false);
-
   async function onSave() {
     dispatch({ type: 'form-error', error: null });
 
@@ -434,15 +430,10 @@ export default function ScheduleDetails() {
           <FormLabel title="Payee" />
           <PayeeAutocomplete
             value={state.fields.payee}
-            inputProps={{
-              onBlur: () => setPayeeFieldFocused(false),
-              onFocus: () => setPayeeFieldFocused(true),
-              placeholder: '(none)'
-            }}
+            inputProps={{ placeholder: '(none)' }}
             onSelect={id =>
               dispatch({ type: 'set-field', field: 'payee', value: id })
             }
-            focused={payeeFieldFocused}
           />
         </FormField>
 

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useHistory } from 'react-router-dom';
 
@@ -340,6 +340,10 @@ export default function ScheduleDetails() {
 
   let selectedInst = useSelected('transactions', state.transactions, []);
 
+  // helps emulate the <TransactionsTable> behavior where <PayeeAutocomplete>
+  // remains open as long as we're interacting with it
+  const [payeeFieldFocused, setPayeeFieldFocused] = useState(false);
+
   async function onSave() {
     dispatch({ type: 'form-error', error: null });
 
@@ -430,10 +434,15 @@ export default function ScheduleDetails() {
           <FormLabel title="Payee" />
           <PayeeAutocomplete
             value={state.fields.payee}
-            inputProps={{ placeholder: '(none)' }}
+            inputProps={{
+              onBlur: () => setPayeeFieldFocused(false),
+              onFocus: () => setPayeeFieldFocused(true),
+              placeholder: '(none)'
+            }}
             onSelect={id =>
               dispatch({ type: 'set-field', field: 'payee', value: id })
             }
+            focused={payeeFieldFocused}
           />
         </FormField>
 

--- a/packages/loot-design/src/components/PayeeAutocomplete.js
+++ b/packages/loot-design/src/components/PayeeAutocomplete.js
@@ -217,6 +217,8 @@ export default function PayeeAutocomplete({
     }
   }
 
+  const [payeeFieldFocused, setPayeeFieldFocused] = useState(false);
+
   return (
     <Autocomplete
       key={focusTransferPayees ? 'transfers' : 'all'}
@@ -233,8 +235,11 @@ export default function PayeeAutocomplete({
         }
         return item.name;
       }}
+      focused={payeeFieldFocused}
       inputProps={{
         ...inputProps,
+        onBlur: () => setPayeeFieldFocused(false),
+        onFocus: () => setPayeeFieldFocused(true),
         onChange: text => (rawPayee.current = text)
       }}
       onUpdate={value => onUpdate && onUpdate(makeNew(value, rawPayee))}


### PR DESCRIPTION
This makes the schedule editor match the behavior of the PayeeAutocomplete in TransactionsTable

Fixes #300 


## Show 'n' Tell

**BEFORE**
![bug_300_before](https://user-images.githubusercontent.com/5862724/196809810-689581f6-65ca-4a7d-bfb6-2f617acd57f3.gif)


**AFTER**
![bug_300_after](https://user-images.githubusercontent.com/5862724/196809971-b8ce6cf8-c7da-4c60-93ea-f4a5963441ef.gif)
