### PR TITLE
Fix child transaction selection edits also applying to their unselected siblings.

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1413,7 +1413,15 @@ class AccountInternal extends React.PureComponent {
         value = !!transactions.find(t => !t.cleared);
       }
 
+      let idSet = new Set(ids);
+
       transactions.forEach(trans => {
+        if (!idSet.has(trans.id)) {
+          // Skip transactions which aren't actually selected, since the
+          // query above also retrieves the siblings of any selected splits.
+          return;
+        }
+
         let { diff } = updateTransaction(transactions, {
           ...trans,
           [name]: value

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1413,12 +1413,12 @@ class AccountInternal extends React.PureComponent {
         value = !!transactions.find(t => !t.cleared);
       }
 
-      let idSet = new Set(ids);
+      const idSet = new Set(ids);
 
       transactions.forEach(trans => {
         if (!idSet.has(trans.id)) {
-          // Skip transactions which aren't actually selected, since the
-          // query above also retrieves the siblings of any selected splits.
+          // Skip transactions which aren't actually selected, since the query
+          // above also retrieves the siblings & parent of any selected splits.
           return;
         }
 


### PR DESCRIPTION
## Description

As per issue #371, after selecting one or more of the children of a split transaction and performing a change, any 'EDIT FIELD' operation would also be erroneously applied to the unselected siblings & parent as well. 

This was caused by `options({ splits: 'grouped' })` retrieving *all* the children of any selected split transaction. This appears to be the intended behaviour for this option (as far as I can tell), however it is now accounted for in the calling code.

I'm up for more performant suggestions - although I reckon this here is pretty alright, with a set used to minimise performance degredation with larger selections. Perhaps a new splits option for SQL queries might make sense? The only trouble with that is that the parents will still need to be retrieved for some other logic to work.

## Changes

- When processing the list of transactions returned from the query, we now ignore the ones not found in the `ids` array parameter.

## Before & After

### Before

https://user-images.githubusercontent.com/54133784/199712252-95f52fdf-7b81-421a-878d-ad1475943dcc.mp4

### After

https://user-images.githubusercontent.com/54133784/199712315-883802df-1eb8-441a-8c74-89e392af23cd.mp4