### PR TITLE
Add a help button to the menu

### DIFF
--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -398,7 +398,7 @@ const MenuButton = withRouter(function MenuButton({ history }) {
         history.push('/settings');
         break;
       case 'help':
-        window.open("https://actualbudget.github.io/docs","_blank");
+        window.open('https://actualbudget.github.io/docs', '_blank');
         break;
       case 'close':
         dispatch(closeBudget());
@@ -414,7 +414,7 @@ const MenuButton = withRouter(function MenuButton({ history }) {
     { name: 'repair-splits', text: 'Repair split transactions' },
     Menu.line,
     { name: 'settings', text: 'Settings' },
-    { name: 'help', text: 'Help'},
+    { name: 'help', text: 'Help' },
     { name: 'close', text: 'Close File' }
   ];
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -398,7 +398,7 @@ const MenuButton = withRouter(function MenuButton({ history }) {
         history.push('/settings');
         break;
       case 'help':
-        window.open("https://actualbudget.github.io/docs","_self");
+        window.open("https://actualbudget.github.io/docs","_blank");
         break;
       case 'close':
         dispatch(closeBudget());

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -397,6 +397,9 @@ const MenuButton = withRouter(function MenuButton({ history }) {
       case 'settings':
         history.push('/settings');
         break;
+      case 'help':
+        window.open("https://actualbudget.github.io/docs","_self");
+        break;
       case 'close':
         dispatch(closeBudget());
         break;
@@ -411,6 +414,7 @@ const MenuButton = withRouter(function MenuButton({ history }) {
     { name: 'repair-splits', text: 'Repair split transactions' },
     Menu.line,
     { name: 'settings', text: 'Settings' },
+    { name: 'help', text: 'Help'},
     { name: 'close', text: 'Close File' }
   ];
 


### PR DESCRIPTION
This PR adds a help button to the menu and directs the user to the community documentation at https://actualbudget.github.io/docs

The URL is opened in a new tab in the browser.
![shot01](https://user-images.githubusercontent.com/20625555/201447539-22663d0c-71d6-49c0-a0d8-862490c05287.png)
![shot02](https://user-images.githubusercontent.com/20625555/201447548-2ba73cac-ce4f-42ab-839d-2fb2efa48b6c.png)
