### PR TITLE
fix(useSheetValue): default value should be null not undefined

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -106,6 +106,7 @@ function EmptyMessage({ onAdd }) {
 function ReconcilingMessage({ balanceQuery, targetBalance, onDone }) {
   let cleared = useSheetValue({
     name: balanceQuery.name + '-cleared',
+    value: 0,
     query: balanceQuery.query.filter({ cleared: true })
   });
   let targetDiff = targetBalance - cleared;

--- a/packages/loot-design/src/components/spreadsheet/useSheetValue.js
+++ b/packages/loot-design/src/components/spreadsheet/useSheetValue.js
@@ -41,7 +41,7 @@ export default function useSheetValue(binding, onChange) {
   let spreadsheet = useContext(SpreadsheetContext);
   let [result, setResult] = useState({
     name: sheetName + '!' + binding.name,
-    value: binding.value,
+    value: binding.value === undefined ? null : binding.value,
     query: binding.query
   });
   let latestOnChange = useRef(onChange);


### PR DESCRIPTION
Fixes #393

---

**Problem:** clicking on "reconcile" causes a fatal page crash.

**Issue:**
by default `useSheetValue` returns `undefined` value.

In the calculations we use `cleared` balance minus `targetBalance` (customer input) to calculate `targetDiff`. If `cleared` is `undefined`, we end up with `targetBalance === NaN`.

`targetBalance` later is used in the `format()` util function. This function expects number values and not a `NaN`.

https://github.com/MatissJanis/actual/blob/4904da500672f11d28bc47ddedfbaaae94b96aeb/packages/desktop-client/src/components/accounts/Account.js#L107-L111

**Fix:**
The simple fix is to return `null` by default in `useSheetValue`. `null` is already used as a default value for `string`-type bindings [here](https://github.com/MatissJanis/actual/blob/master/packages/loot-design/src/components/spreadsheet/useSheetValue.js#L25-L26), so IMO this change is safe to be applied.

```
console.log(100 - null) // 100
console.log(100 - undefined) // NaN
```

