### PR TITLE
Avoid pulling in the bundled app from API in backend

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,8 +1,7 @@
 let bundle = require('./app/bundle.api.js');
+let injected = require('./injected');
 let methods = require('./methods');
 let utils = require('./utils');
-
-let injected = require('./injected');
 let actualApp;
 
 async function init({ budgetId, config } = {}) {

--- a/packages/import-ynab4/importer.js
+++ b/packages/import-ynab4/importer.js
@@ -1,9 +1,13 @@
+// This is a special usage of the API because this package is embedded
+// into Actual itself. We only want to pull in the methods in that
+// case and ignore everything else; otherwise we'd be pulling in the
+// entire backend bundle from the API
+const actual = require('@actual-app/api/methods');
+const { amountToInteger } = require('@actual-app/api/utils');
+const AdmZip = require('adm-zip');
 const d = require('date-fns');
 const normalizePathSep = require('slash');
 const uuid = require('uuid');
-const AdmZip = require('adm-zip');
-const actual = require('@actual-app/api');
-const amountToInteger = actual.utils.amountToInteger;
 
 // Utils
 

--- a/packages/import-ynab5/importer.js
+++ b/packages/import-ynab5/importer.js
@@ -1,6 +1,10 @@
+// This is a special usage of the API because this package is embedded
+// into Actual itself. We only want to pull in the methods in that
+// case and ignore everything else; otherwise we'd be pulling in the
+// entire backend bundle from the API
+const actual = require('@actual-app/api/methods');
 const d = require('date-fns');
 const uuid = require('uuid');
-const actual = require('@actual-app/api');
 
 function amountFromYnab(amount) {
   // ynabs multiplies amount by 1000 and actual by 100


### PR DESCRIPTION
The backend imports the `import-ynab4` and `import-ynab5` packages, which we pulling in `@actual-app/api` directly. When we switched to the API using a full bundled version of the app, this is a problem. The importer packages are special because they are inlined directly into Actual, so although they invoke the API they are actually just running directly against Actual when in the app.

We can import just the methods from the API instead, which avoids pulling in the whole bundle. This fixes building the backend, and unblocks us to cut a release. Building the backend previously took many minutes (and resulted in a huge bundle) because it was embedding the API build; now it takes ~30 seconds.