### PR TITLE
Update git attributes for better End of Line handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+# *.c text
+# *.h text
+
+# Declare files that will always have LF line endings on checkout.
+*.js text eol=lf
 yarn.lock text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Proposing this change to support windows development better, i ran into an issue with `yarn start:browser` where lint would throw not allowing local start. 

https://cdn.discordapp.com/attachments/1027831756545609789/1051764870065967164/image.png