### PR TITLE
[donotmerge] ci: preview deployments to firebase

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "actual-budget"
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,12 +32,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build Web
         run: ./bin/package-browser
-      - name: Deploy a preview
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ACTUAL_BUDGET }}'
-          projectId: actual-budget
 
   electron:
     # As electron builds take longer, we only run them in master.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,12 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build Web
         run: ./bin/package-browser
+      - name: Deploy a preview
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_ACTUAL_BUDGET }}'
+          projectId: actual-budget
 
   electron:
     # As electron builds take longer, we only run them in master.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "packages/desktop-client/build",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Ignore the file changes. Focus on the preview deployment feature.**

Generating a preview deployment for actual on every PR. The preview deploys expire in 7 days.

Why?
They give a quick and easy way to review the frontend changes. See comment on this PR for an example preview deployment.