### PR TITLE
test: re-enable skipped unit tests

### DIFF
--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -69,7 +69,7 @@
     "prettier": "^1.19.1",
     "sanitize-filename": "^1.6.1",
     "search-query-parser": "^1.3.0",
-    "snapshot-diff": "^0.2.2",
+    "snapshot-diff": "^0.10.0",
     "source-map": "^0.7.3",
     "throttleit": "^1.0.0",
     "ts-jest": "^28.0.1",

--- a/packages/loot-core/src/mocks/setup.js
+++ b/packages/loot-core/src/mocks/setup.js
@@ -6,6 +6,7 @@ import {
   enableGlobalMutations,
   disableGlobalMutations
 } from '../server/mutators';
+import { setServer } from '../server/server-config';
 import * as sheet from '../server/sheet';
 import { setSyncingMode } from '../server/sync';
 import * as tracking from '../server/tracking/events';
@@ -21,6 +22,9 @@ const nativeFs = require('fs');
 
 // By default, syncing is disabled
 setSyncingMode('disabled');
+
+// Set a mock url for the testing server
+setServer('https://test.env');
 
 process.on('unhandledRejection', reason => {
   console.log('REJECTION', reason);

--- a/packages/loot-core/src/server/accounts/__snapshots__/sync.test.js.snap
+++ b/packages/loot-core/src/server/accounts/__snapshots__/sync.test.js.snap
@@ -444,8 +444,8 @@ exports[`Account sync import never matches existing with financial ids 3`] = `
       \\"account\\": \\"one\\",
 -     \\"amount\\": -1462,
 +     \\"amount\\": -2947,
-      \\"category\\": null,
-      \\"cleared\\": 1,
++     \\"category\\": null,
++     \\"cleared\\": 1,
 +     \\"date\\": 20171017,
 +     \\"error\\": null,
 +     \\"id\\": \\"two\\",
@@ -488,8 +488,8 @@ exports[`Account sync import never matches existing with financial ids 3`] = `
 +   Object {
 +     \\"account\\": \\"one\\",
 +     \\"amount\\": 8105,
-+     \\"category\\": null,
-+     \\"cleared\\": 1,
+      \\"category\\": null,
+      \\"cleared\\": 1,
       \\"date\\": 20171015,
       \\"error\\": null,
 -     \\"id\\": \\"id20\\",
@@ -920,12 +920,15 @@ exports[`Account sync import updates transfers when matched 2`] = `
       \\"category\\": null,
       \\"cleared\\": 1,
       \\"date\\": 20171015,
-@@ -65,10 +87,32 @@
+@@ -62,10 +84,32 @@
+      \\"schedule\\": null,
+      \\"sort_order\\": 123456789,
+      \\"starting_balance_flag\\": 0,
       \\"tombstone\\": 0,
       \\"transfer_id\\": null,
-    },
-    Object {
-      \\"account\\": \\"one\\",
++   },
++   Object {
++     \\"account\\": \\"one\\",
 +     \\"amount\\": -2948,
 +     \\"category\\": null,
 +     \\"cleared\\": 0,
@@ -945,14 +948,11 @@ exports[`Account sync import updates transfers when matched 2`] = `
 +     \\"starting_balance_flag\\": 0,
 +     \\"tombstone\\": 0,
 +     \\"transfer_id\\": \\"one\\",
-+   },
-+   Object {
-+     \\"account\\": \\"one\\",
+    },
+    Object {
+      \\"account\\": \\"one\\",
       \\"amount\\": -4207,
-      \\"category\\": null,
-      \\"cleared\\": 1,
-      \\"date\\": 20171015,
-      \\"error\\": null,"
+      \\"category\\": null,"
 `;
 
 exports[`Account sync import updates transfers when matched 3`] = `

--- a/packages/loot-core/src/server/accounts/__snapshots__/transfer.test.js.snap
+++ b/packages/loot-core/src/server/accounts/__snapshots__/transfer.test.js.snap
@@ -51,7 +51,7 @@ exports[`Transfer transfers are properly de-categorized 2`] = `
       \\"tombstone\\": 0,
 -     \\"transfer_id\\": null,
 +     \\"transfer_id\\": \\"id7\\",
-    },
++   },
 +   Object {
 +     \\"account\\": \\"three\\",
 +     \\"amount\\": -5000,
@@ -73,7 +73,7 @@ exports[`Transfer transfers are properly de-categorized 2`] = `
 +     \\"starting_balance_flag\\": 0,
 +     \\"tombstone\\": 0,
 +     \\"transfer_id\\": \\"id6\\",
-+   },
+    },
   ]"
 `;
 
@@ -334,7 +334,7 @@ exports[`Transfer transfers are properly inserted/updated/deleted 5`] = `
 - First value
 + Second value
 
-@@ -11,41 +11,19 @@
+@@ -11,39 +11,17 @@
       \\"imported_payee\\": null,
       \\"is_child\\": 0,
       \\"is_parent\\": 0,
@@ -349,9 +349,8 @@ exports[`Transfer transfers are properly inserted/updated/deleted 5`] = `
       \\"starting_balance_flag\\": 0,
       \\"tombstone\\": 0,
 -     \\"transfer_id\\": \\"id8\\",
-+     \\"transfer_id\\": null,
-    },
-    Object {
+-   },
+-   Object {
 -     \\"account\\": \\"three\\",
 -     \\"amount\\": -5000,
 -     \\"category\\": null,
@@ -372,13 +371,12 @@ exports[`Transfer transfers are properly inserted/updated/deleted 5`] = `
 -     \\"starting_balance_flag\\": 0,
 -     \\"tombstone\\": 0,
 -     \\"transfer_id\\": \\"id7\\",
--   },
--   Object {
++     \\"transfer_id\\": null,
+    },
+    Object {
       \\"account\\": \\"one\\",
       \\"amount\\": 5000,
-      \\"category\\": null,
-      \\"cleared\\": 1,
-      \\"date\\": 20170101,"
+      \\"category\\": null,"
 `;
 
 exports[`Transfer transfers are properly inserted/updated/deleted 6`] = `
@@ -386,7 +384,7 @@ exports[`Transfer transfers are properly inserted/updated/deleted 6`] = `
 - First value
 + Second value
 
-@@ -11,19 +11,41 @@
+@@ -11,17 +11,39 @@
       \\"imported_payee\\": null,
       \\"is_child\\": 0,
       \\"is_parent\\": 0,
@@ -402,8 +400,8 @@ exports[`Transfer transfers are properly inserted/updated/deleted 6`] = `
       \\"tombstone\\": 0,
 -     \\"transfer_id\\": null,
 +     \\"transfer_id\\": \\"id10\\",
-    },
-    Object {
++   },
++   Object {
 +     \\"account\\": \\"two\\",
 +     \\"amount\\": -5000,
 +     \\"category\\": null,
@@ -424,13 +422,11 @@ exports[`Transfer transfers are properly inserted/updated/deleted 6`] = `
 +     \\"starting_balance_flag\\": 0,
 +     \\"tombstone\\": 0,
 +     \\"transfer_id\\": \\"id7\\",
-+   },
-+   Object {
+    },
+    Object {
       \\"account\\": \\"one\\",
       \\"amount\\": 5000,
-      \\"category\\": null,
-      \\"cleared\\": 1,
-      \\"date\\": 20170101,"
+      \\"category\\": null,"
 `;
 
 exports[`Transfer transfers are properly inserted/updated/deleted 7`] = `

--- a/packages/loot-core/src/server/accounts/sync.test.js
+++ b/packages/loot-core/src/server/accounts/sync.test.js
@@ -98,7 +98,7 @@ async function getAllPayees() {
   return (await db.getPayees()).filter(p => p.transfer_acct == null);
 }
 
-describe.skip('Account sync', () => {
+describe('Account sync', () => {
   test('reconcile creates payees correctly', async () => {
     monthUtils.currentDay = () => '2017-10-15';
     let mockTransactions = prepMockTransactions();
@@ -468,7 +468,7 @@ describe.skip('Account sync', () => {
   });
 
   let testMapped = version => {
-    test.skip(`reconcile matches unmapped and mapped payees (${version})`, async () => {
+    test(`reconcile matches unmapped and mapped payees (${version})`, async () => {
       const { id: acctId } = await prepareDatabase();
 
       if (version === 'v1') {

--- a/packages/loot-core/src/server/accounts/transfer.test.js
+++ b/packages/loot-core/src/server/accounts/transfer.test.js
@@ -33,7 +33,7 @@ async function prepareDatabase() {
   });
 }
 
-describe.skip('Transfer', () => {
+describe('Transfer', () => {
   test('transfers are properly inserted/updated/deleted', async () => {
     await prepareDatabase();
 

--- a/packages/loot-core/src/server/main.test.js
+++ b/packages/loot-core/src/server/main.test.js
@@ -96,7 +96,7 @@ describe('Budgets', () => {
   });
 });
 
-describe.skip('Accounts', () => {
+describe('Accounts', () => {
   test('create accounts with correct starting balance', async () => {
     prefs.loadPrefs();
     prefs.savePrefs({ clientId: 'client', groupId: 'group' });
@@ -202,7 +202,7 @@ describe.skip('Accounts', () => {
   });
 });
 
-describe.skip('Budget', () => {
+describe('Budget', () => {
   test('new budgets should be created', async () => {
     const spreadsheet = await sheet.loadSpreadsheet(db);
 
@@ -330,7 +330,7 @@ describe.skip('Budget', () => {
 });
 
 describe('Categories', () => {
-  test.skip('can be deleted', async () => {
+  test('can be deleted', async () => {
     let spreadsheet = await sheet.loadSpreadsheet(db);
 
     await runMutator(async () => {

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
@@ -161,7 +161,7 @@ describe('Spreadsheet', () => {
     expect(spreadsheet.getValue('foo!x')).toBe(1);
   });
 
-  test.skip('async cells work2', done => {
+  test('async cells work2', done => {
     const spreadsheet = new Spreadsheet();
 
     spreadsheet.transaction(() => {

--- a/packages/loot-core/src/server/sync/sync.test.js
+++ b/packages/loot-core/src/server/sync/sync.test.js
@@ -20,7 +20,7 @@ afterEach(() => {
   setSyncingMode('disabled');
 });
 
-describe.skip('Sync', () => {
+describe('Sync', () => {
   it('should send messages to the server', async () => {
     prefs.loadPrefs();
     prefs.savePrefs({ groupId: 'group' });
@@ -173,7 +173,7 @@ function expectCellNotToExist(sheetName, name, voided) {
   expect(value).toBe(voided ? 0 : null);
 }
 
-describe.skip('Sync projections', () => {
+describe('Sync projections', () => {
   test('synced categories should have budgets created', async () => {
     let groupId, fooId, barId;
     await asSecondClient(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,6 +890,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-jsx@npm:^7.7.2":
+  version: 7.18.6
+  resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.18.6
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6d37ea972970195f1ffe1a54745ce2ae456e0ac6145fae9aa1480f297248b262ea6ebb93010eddb86ebfacb94f57c05a1fc5d232b9a67325b09060299d515c67
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-logical-assignment-operators@npm:^7.10.4, @babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
   version: 7.10.4
   resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
@@ -1974,21 +1985,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "@jest/expect-utils@npm:28.0.0-alpha.7"
-  dependencies:
-    jest-get-type: ^28.0.0-alpha.3
-  checksum: 32169c15a813fd1a50830a6c40c7d395f6a7173cd2a3e197b893f899b6c6adfd930f3b511a9cf272c4356383d2de3a2564b4fc523682d30ab9b62a565dc9abfc
-  languageName: node
-  linkType: hard
-
 "@jest/expect-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/expect-utils@npm:28.1.3"
   dependencies:
     jest-get-type: ^28.0.2
   checksum: 808ea3a68292a7e0b95490fdd55605c430b4cf209ea76b5b61bfb2a1badcb41bc046810fe4e364bd5fe04663978aa2bd73d8f8465a761dd7c655aeb44cf22987
+  languageName: node
+  linkType: hard
+
+"@jest/expect-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/expect-utils@npm:29.3.1"
+  dependencies:
+    jest-get-type: ^29.2.0
+  checksum: 7f3b853eb1e4299988f66b9aa49c1aacb7b8da1cf5518dca4ccd966e865947eed8f1bde6c8f5207d8400e9af870112a44b57aa83515ad6ea5e4a04a971863adb
   languageName: node
   linkType: hard
 
@@ -2065,21 +2076,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/schemas@npm:^28.0.0-alpha.3":
-  version: 28.0.0-alpha.3
-  resolution: "@jest/schemas@npm:28.0.0-alpha.3"
-  dependencies:
-    "@sinclair/typebox": ^0.23.3
-  checksum: 91de317908893a7c1404ce278c479a4fb2561c7d4fc344f079c3f81befb37834f0ddb364ac94363a1583a196a2c0affb02d2f362a5c5bb1d4cb58c201cbee722
-  languageName: node
-  linkType: hard
-
 "@jest/schemas@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/schemas@npm:28.1.3"
   dependencies:
     "@sinclair/typebox": ^0.24.1
   checksum: 3cf1d4b66c9c4ffda58b246de1ddcba8e6ad085af63dccdf07922511f13b68c0cc480a7bc620cb4f3099a6f134801c747e1df7bfc7a4ef4dceefbdea3e31e1de
+  languageName: node
+  linkType: hard
+
+"@jest/schemas@npm:^29.0.0":
+  version: 29.0.0
+  resolution: "@jest/schemas@npm:29.0.0"
+  dependencies:
+    "@sinclair/typebox": ^0.24.1
+  checksum: 41355c78f09eb1097e57a3c5d0ca11c9099e235e01ea5fa4e3953562a79a6a9296c1d300f1ba50ca75236048829e056b00685cd2f1ff8285e56fd2ce01249acb
   languageName: node
   linkType: hard
 
@@ -2118,29 +2129,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "@jest/transform@npm:28.0.0-alpha.7"
-  dependencies:
-    "@babel/core": ^7.1.0
-    "@jest/types": ^28.0.0-alpha.7
-    babel-plugin-istanbul: ^6.1.1
-    chalk: ^4.0.0
-    convert-source-map: ^1.4.0
-    fast-json-stable-stringify: ^2.0.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^28.0.0-alpha.7
-    jest-regex-util: ^28.0.0-alpha.6
-    jest-util: ^28.0.0-alpha.7
-    micromatch: ^4.0.4
-    pirates: ^4.0.4
-    slash: ^3.0.0
-    source-map: ^0.6.1
-    write-file-atomic: ^4.0.1
-  checksum: 8598056de435d1d9cc1d944e9e92f2015d9000c036caecd4042c123799fce22809e9f965fd8e9a17593d12da45cd2d4dbed0fa5d03dd05dd8ff3019cd05e47a9
-  languageName: node
-  linkType: hard
-
 "@jest/transform@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/transform@npm:28.1.3"
@@ -2161,6 +2149,29 @@ __metadata:
     slash: ^3.0.0
     write-file-atomic: ^4.0.1
   checksum: dadf618936e0aa84342f07f532801d5bed43cdf95d1417b929e4f8782c872cff1adc84096d5a287a796d0039a2691c06d8450cce5a713a8b52fbb9f872a1e760
+  languageName: node
+  linkType: hard
+
+"@jest/transform@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/transform@npm:29.3.1"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/types": ^29.3.1
+    "@jridgewell/trace-mapping": ^0.3.15
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^2.0.0
+    fast-json-stable-stringify: ^2.1.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.3.1
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.3.1
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    write-file-atomic: ^4.0.1
+  checksum: 673df5900ffc95bc811084e09d6e47948034dea6ab6cc4f81f80977e3a52468a6c2284d0ba9796daf25a62ae50d12f7e97fc9a3a0c587f11f2a479ff5493ca53
   languageName: node
   linkType: hard
 
@@ -2213,20 +2224,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "@jest/types@npm:28.0.0-alpha.7"
-  dependencies:
-    "@jest/schemas": ^28.0.0-alpha.3
-    "@types/istanbul-lib-coverage": ^2.0.0
-    "@types/istanbul-reports": ^3.0.0
-    "@types/node": "*"
-    "@types/yargs": ^17.0.8
-    chalk: ^4.0.0
-  checksum: 4f1d102897985e05a0c434daa79c699f7cfa2f01ec3a1771c61ee726ffe46450865f9bfa18cbb40123477bda6d8d6c036f6d05c83d2cd2aa23992c8484f2bc53
-  languageName: node
-  linkType: hard
-
 "@jest/types@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/types@npm:28.1.3"
@@ -2238,6 +2235,20 @@ __metadata:
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
   checksum: 1e258d9c063fcf59ebc91e46d5ea5984674ac7ae6cae3e50aa780d22b4405bf2c925f40350bf30013839eb5d4b5e521d956ddf8f3b7c78debef0e75a07f57350
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/types@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 6f9faf27507b845ff3839c1adc6dbd038d7046d03d37e84c9fc956f60718711a801a5094c7eeee6b39ccf42c0ab61347fdc0fa49ab493ae5a8efd2fd41228ee8
   languageName: node
   linkType: hard
 
@@ -2273,10 +2284,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
+  checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.0.5
   resolution: "@jridgewell/resolve-uri@npm:3.0.5"
   checksum: 1ee652b693da7979ac4007926cc3f0a32b657ffeb913e111f44e5b67153d94a2f28a1d560101cc0cf8087625468293a69a00f634a2914e1a6d0817ba2039a913
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:1.4.14":
+  version: 1.4.14
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
+  checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
   languageName: node
   linkType: hard
 
@@ -2314,6 +2339,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.15":
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
   languageName: node
   linkType: hard
 
@@ -3274,13 +3309,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:^0.23.3":
-  version: 0.23.4
-  resolution: "@sinclair/typebox@npm:0.23.4"
-  checksum: 98af5b70bf23a36061886966038058c22238d68bcd1bb2528b4470506f8a08ec5190f5f4190de17ce5fa54ebcaf7e150efbe96db6acab2696911391e4358ab39
-  languageName: node
-  linkType: hard
-
 "@sinclair/typebox@npm:^0.24.1":
   version: 0.24.28
   resolution: "@sinclair/typebox@npm:0.24.28"
@@ -3486,7 +3514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.4, @types/babel__traverse@npm:^7.0.6":
+"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6":
   version: 7.14.2
   resolution: "@types/babel__traverse@npm:7.14.2"
   dependencies:
@@ -4608,7 +4636,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-regex@npm:^2.0.0, ansi-regex@npm:^2.1.1":
+"ansi-regex@npm:^2.0.0":
   version: 2.1.1
   resolution: "ansi-regex@npm:2.1.1"
   checksum: 190abd03e4ff86794f338a31795d262c1dfe8c91f7e01d04f13f646f1dcb16c5800818f886047876f1272f065570ab86b24b99089f8b68a0e11ff19aed4ca8f1
@@ -4643,7 +4671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.0.0, ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
+"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -7073,6 +7101,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:1.0.6":
   version: 1.0.6
   resolution: "cookie-signature@npm:1.0.6"
@@ -8511,17 +8546,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^28.0.0-alpha.6":
-  version: 28.0.0-alpha.6
-  resolution: "diff-sequences@npm:28.0.0-alpha.6"
-  checksum: 1dc5c63cc74b68624436f4062fadc45985a4584d23871fe1209037e7cdbf7d97ff3f0f51db3a95a0854cc272456060646ac99fc85e383773801379d4c9325e48
-  languageName: node
-  linkType: hard
-
 "diff-sequences@npm:^28.1.1":
   version: 28.1.1
   resolution: "diff-sequences@npm:28.1.1"
   checksum: e2529036505567c7ca5a2dea86b6bcd1ca0e3ae63bf8ebf529b8a99cfa915bbf194b7021dc1c57361a4017a6d95578d4ceb29fabc3232a4f4cb866a2726c7690
+  languageName: node
+  linkType: hard
+
+"diff-sequences@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "diff-sequences@npm:29.3.1"
+  checksum: 8edab8c383355022e470779a099852d595dd856f9f5bd7af24f177e74138a668932268b4c4fd54096eed643861575c3652d4ecbbb1a9d710488286aed3ffa443
   languageName: node
   linkType: hard
 
@@ -9869,18 +9904,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "expect@npm:28.0.0-alpha.7"
-  dependencies:
-    "@jest/expect-utils": ^28.0.0-alpha.7
-    jest-get-type: ^28.0.0-alpha.3
-    jest-matcher-utils: ^28.0.0-alpha.7
-    jest-message-util: ^28.0.0-alpha.7
-  checksum: efd560734285a9712aa8d82a2723995eeaa604b6f5b9f36f761bc3dd8a24339db532bf33b97e34882ec8481fdb8fbafa76ff932ea0f99a297f1011a5aab6484f
-  languageName: node
-  linkType: hard
-
 "expect@npm:^28.1.3":
   version: 28.1.3
   resolution: "expect@npm:28.1.3"
@@ -9891,6 +9914,19 @@ __metadata:
     jest-message-util: ^28.1.3
     jest-util: ^28.1.3
   checksum: 101e0090de300bcafedb7dbfd19223368a2251ce5fe0105bbb6de5720100b89fb6b64290ebfb42febc048324c76d6a4979cdc4b61eb77747857daf7a5de9b03d
+  languageName: node
+  linkType: hard
+
+"expect@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "expect@npm:29.3.1"
+  dependencies:
+    "@jest/expect-utils": ^29.3.1
+    jest-get-type: ^29.2.0
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
+  checksum: e9588c2a430b558b9a3dc72d4ad05f36b047cb477bc6a7bb9cfeef7614fe7e5edbab424c2c0ce82739ee21ecbbbd24596259528209f84cd72500cc612d910d30
   languageName: node
   linkType: hard
 
@@ -10081,7 +10117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -13174,18 +13210,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^28.0.0-alpha.7, jest-diff@test":
-  version: 28.0.0-alpha.7
-  resolution: "jest-diff@npm:28.0.0-alpha.7"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^28.0.0-alpha.6
-    jest-get-type: ^28.0.0-alpha.3
-    pretty-format: ^28.0.0-alpha.7
-  checksum: c1828a631aee046d7c598ac204dee97b462378b93be2ad4c4e7bc211e20142650531e64b17397414893a6419b0ebe9dc7cb12b32b01050b510214e8a0886589b
-  languageName: node
-  linkType: hard
-
 "jest-diff@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-diff@npm:28.1.3"
@@ -13195,6 +13219,18 @@ __metadata:
     jest-get-type: ^28.0.2
     pretty-format: ^28.1.3
   checksum: fa8583e0ccbe775714ce850b009be1b0f6b17a4b6759f33ff47adef27942ebc610dbbcc8a5f7cfb7f12b3b3b05afc9fb41d5f766674616025032ff1e4f9866e0
+  languageName: node
+  linkType: hard
+
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-diff@npm:29.3.1"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^29.3.1
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.3.1
+  checksum: ac5c09745f2b1897e6f53216acaf6ed44fc4faed8e8df053ff4ac3db5d2a1d06a17b876e49faaa15c8a7a26f5671bcbed0a93781dcc2835f781c79a716a591a9
   languageName: node
   linkType: hard
 
@@ -13264,17 +13300,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^28.0.0-alpha.3":
-  version: 28.0.0-alpha.3
-  resolution: "jest-get-type@npm:28.0.0-alpha.3"
-  checksum: 8a1683f6225c3fc1de385a1b76abd5d7930883bc33de51bfab8f0f17ee917256d6b2c4e205ca26b6f4a14a9237bb3afe6dddcf5f34089eea3a2195a5b2f2186e
-  languageName: node
-  linkType: hard
-
 "jest-get-type@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-get-type@npm:28.0.2"
   checksum: 5281d7c89bc8156605f6d15784f45074f4548501195c26e9b188742768f72d40948252d13230ea905b5349038865a1a8eeff0e614cc530ff289dfc41fe843abd
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-get-type@npm:29.2.0"
+  checksum: e396fd880a30d08940ed8a8e43cd4595db1b8ff09649018eb358ca701811137556bae82626af73459e3c0f8c5e972ed1e57fd3b1537b13a260893dac60a90942
   languageName: node
   linkType: hard
 
@@ -13303,29 +13339,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "jest-haste-map@npm:28.0.0-alpha.7"
-  dependencies:
-    "@jest/types": ^28.0.0-alpha.7
-    "@types/graceful-fs": ^4.1.2
-    "@types/node": "*"
-    anymatch: ^3.0.3
-    fb-watchman: ^2.0.0
-    fsevents: ^2.3.2
-    graceful-fs: ^4.2.9
-    jest-regex-util: ^28.0.0-alpha.6
-    jest-util: ^28.0.0-alpha.7
-    jest-worker: ^28.0.0-alpha.7
-    micromatch: ^4.0.4
-    walker: ^1.0.7
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: e64281968b68ce177e98e7661d065cd97b9c6351258e33b339f137dc21ab3bc0d93a4c85e6ee1357eabf4bc3b4b407521749c27eddf05d065ff33e9ece188634
-  languageName: node
-  linkType: hard
-
 "jest-haste-map@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-haste-map@npm:28.1.3"
@@ -13346,6 +13359,29 @@ __metadata:
     fsevents:
       optional: true
   checksum: d05fdc108645fc2b39fcd4001952cc7a8cb550e93494e98c1e9ab1fc542686f6ac67177c132e564cf94fe8f81503f3f8db8b825b9b713dc8c5748aec63ba4688
+  languageName: node
+  linkType: hard
+
+"jest-haste-map@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-haste-map@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.3.1
+    jest-worker: ^29.3.1
+    micromatch: ^4.0.4
+    walker: ^1.0.8
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 97ea26af0c28a2ba568c9c65d06211487bbcd501cb4944f9d55e07fd2b00ad96653ea2cc9033f3d5b7dc1feda33e47ae9cc56b400191ea4533be213c9f82e67c
   languageName: node
   linkType: hard
 
@@ -13371,18 +13407,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "jest-matcher-utils@npm:28.0.0-alpha.7"
-  dependencies:
-    chalk: ^4.0.0
-    jest-diff: ^28.0.0-alpha.7
-    jest-get-type: ^28.0.0-alpha.3
-    pretty-format: ^28.0.0-alpha.7
-  checksum: 0a2f2c6b6a40c1ab11990da7e90fad52d4393eb70c3e4a547f55f97be480032c9b61abd13643e1192e62326c9b814d689e6f42fdca4d5a497fad988ea4052e5f
-  languageName: node
-  linkType: hard
-
 "jest-matcher-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-matcher-utils@npm:28.1.3"
@@ -13395,20 +13419,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "jest-message-util@npm:28.0.0-alpha.7"
+"jest-matcher-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-matcher-utils@npm:29.3.1"
   dependencies:
-    "@babel/code-frame": ^7.12.13
-    "@jest/types": ^28.0.0-alpha.7
-    "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    micromatch: ^4.0.4
-    pretty-format: ^28.0.0-alpha.7
-    slash: ^3.0.0
-    stack-utils: ^2.0.3
-  checksum: 5678f76334d9ee5ffc634f4e0ae24bdd66d32ce72bf53838a66e55fd5cb978d287c297eab8604014d99b8e4f49718c3e5f128d8bb69f33733eca6c09cc409100
+    jest-diff: ^29.3.1
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.3.1
+  checksum: 311e8d9f1e935216afc7dd8c6acf1fbda67a7415e1afb1bf72757213dfb025c1f2dc5e2c185c08064a35cdc1f2d8e40c57616666774ed1b03e57eb311c20ec77
   languageName: node
   linkType: hard
 
@@ -13426,6 +13445,23 @@ __metadata:
     slash: ^3.0.0
     stack-utils: ^2.0.3
   checksum: 1f266854166dcc6900d75a88b54a25225a2f3710d463063ff1c99021569045c35c7d58557b25447a17eb3a65ce763b2f9b25550248b468a9d4657db365f39e96
+  languageName: node
+  linkType: hard
+
+"jest-message-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-message-util@npm:29.3.1"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.3.1
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.3.1
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 15d0a2fca3919eb4570bbf575734780c4b9e22de6aae903c4531b346699f7deba834c6c86fe6e9a83ad17fac0f7935511cf16dce4d71a93a71ebb25f18a6e07b
   languageName: node
   linkType: hard
 
@@ -13458,17 +13494,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^28.0.0-alpha.6":
-  version: 28.0.0-alpha.6
-  resolution: "jest-regex-util@npm:28.0.0-alpha.6"
-  checksum: a0a26d240307b74cc0adc8a982aba35dc6bd3435f47ee905497cce6e48dccc1b57932e502bf1eeb98225ea56282da02bec9ad442219f24a0cab0696774a5b941
-  languageName: node
-  linkType: hard
-
 "jest-regex-util@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-regex-util@npm:28.0.2"
   checksum: 0ea8c5c82ec88bc85e273c0ec82e0c0f35f7a1e2d055070e50f0cc2a2177f848eec55f73e37ae0d045c3db5014c42b2f90ac62c1ab3fdb354d2abd66a9e08add
+  languageName: node
+  linkType: hard
+
+"jest-regex-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-regex-util@npm:29.2.0"
+  checksum: 7c533e51c51230dac20c0d7395b19b8366cb022f7c6e08e6bcf2921626840ff90424af4c9b4689f02f0addfc9b071c4cd5f8f7a989298a4c8e0f9c94418ca1c3
   languageName: node
   linkType: hard
 
@@ -13599,34 +13635,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-jest-snapshot@test:
-  version: 28.0.0-alpha.7
-  resolution: "jest-snapshot@npm:28.0.0-alpha.7"
+"jest-snapshot@npm:^29.0.0":
+  version: 29.3.1
+  resolution: "jest-snapshot@npm:29.3.1"
   dependencies:
-    "@babel/core": ^7.7.2
+    "@babel/core": ^7.11.6
     "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-jsx": ^7.7.2
     "@babel/plugin-syntax-typescript": ^7.7.2
     "@babel/traverse": ^7.7.2
-    "@babel/types": ^7.0.0
-    "@jest/expect-utils": ^28.0.0-alpha.7
-    "@jest/transform": ^28.0.0-alpha.7
-    "@jest/types": ^28.0.0-alpha.7
-    "@types/babel__traverse": ^7.0.4
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/babel__traverse": ^7.0.6
     "@types/prettier": ^2.1.5
     babel-preset-current-node-syntax: ^1.0.0
     chalk: ^4.0.0
-    expect: ^28.0.0-alpha.7
+    expect: ^29.3.1
     graceful-fs: ^4.2.9
-    jest-diff: ^28.0.0-alpha.7
-    jest-get-type: ^28.0.0-alpha.3
-    jest-haste-map: ^28.0.0-alpha.7
-    jest-matcher-utils: ^28.0.0-alpha.7
-    jest-message-util: ^28.0.0-alpha.7
-    jest-util: ^28.0.0-alpha.7
+    jest-diff: ^29.3.1
+    jest-get-type: ^29.2.0
+    jest-haste-map: ^29.3.1
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
     natural-compare: ^1.4.0
-    pretty-format: ^28.0.0-alpha.7
-    semver: ^7.3.2
-  checksum: 67363a0afffe0ff442b735ec633f37efc99c840696be5e8dd478e5a472287b5b0e637543a553e318ec16889ce456dfb704ad70483b0272bf671d0557c96bd622
+    pretty-format: ^29.3.1
+    semver: ^7.3.5
+  checksum: d7d0077935e78c353c828be78ccb092e12ba7622cb0577f21641fadd728ae63a7c1f4a0d8113bfb38db3453a64bfa232fb1cdeefe0e2b48c52ef4065b0ab75ae
   languageName: node
   linkType: hard
 
@@ -13658,17 +13695,17 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"jest-util@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "jest-util@npm:28.0.0-alpha.7"
+"jest-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-util@npm:29.3.1"
   dependencies:
-    "@jest/types": ^28.0.0-alpha.7
+    "@jest/types": ^29.3.1
     "@types/node": "*"
     chalk: ^4.0.0
     ci-info: ^3.2.0
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
-  checksum: ca314bba65a18d2a45c49dc25749799d6db64dd0559fbf5f45fec22f27d694ca2b52af811fbbc018f285d37e8bbbfb4a92cb7c46065e54e5037e3286dbd82198
+  checksum: f67c60f062b94d21cb60e84b3b812d64b7bfa81fe980151de5c17a74eb666042d0134e2e756d099b7606a1fcf1d633824d2e58197d01d76dde1e2dc00dfcd413
   languageName: node
   linkType: hard
 
@@ -13727,17 +13764,6 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "jest-worker@npm:28.0.0-alpha.7"
-  dependencies:
-    "@types/node": "*"
-    merge-stream: ^2.0.0
-    supports-color: ^8.0.0
-  checksum: 9b598801990b6c2c55f19f6f2bb9d1902c62c22148657db123e128935922610bd158f5ce3f17451a31f69a7e5a39b7bead0c0d68ae6a1bc0ce43d5e32a655e36
-  languageName: node
-  linkType: hard
-
 "jest-worker@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-worker@npm:28.1.3"
@@ -13746,6 +13772,18 @@ jest-snapshot@test:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: e921c9a1b8f0909da9ea07dbf3592f95b653aef3a8bb0cbcd20fc7f9a795a1304adecac31eecb308992c167e8d7e75c522061fec38a5928ace0f9571c90169ca
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-worker@npm:29.3.1"
+  dependencies:
+    "@types/node": "*"
+    jest-util: ^29.3.1
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 38687fcbdc2b7ddc70bbb5dfc703ae095b46b3c7f206d62ecdf5f4d16e336178e217302138f3b906125576bb1cfe4cfe8d43681276fa5899d138ed9422099fb3
   languageName: node
   linkType: hard
 
@@ -14692,7 +14730,7 @@ jest-snapshot@test:
     regenerator-runtime: ^0.13.7
     sanitize-filename: ^1.6.1
     search-query-parser: ^1.3.0
-    snapshot-diff: ^0.2.2
+    snapshot-diff: ^0.10.0
     source-map: ^0.7.3
     throttleit: ^1.0.0
     ts-jest: ^28.0.1
@@ -18431,16 +18469,6 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^20.0.3":
-  version: 20.0.3
-  resolution: "pretty-format@npm:20.0.3"
-  dependencies:
-    ansi-regex: ^2.1.1
-    ansi-styles: ^3.0.0
-  checksum: 59b5ecf0bcc47b81df2dac2c4961aa99eabceaac325f049adba7e2d1c914e05c04888104f087f137a8f1ed14ed22416db365ffcf40df2fd3426069f400e0b757
-  languageName: node
-  linkType: hard
-
 "pretty-format@npm:^24.3.0":
   version: 24.9.0
   resolution: "pretty-format@npm:24.9.0"
@@ -18488,18 +18516,6 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0-alpha.7":
-  version: 28.0.0-alpha.7
-  resolution: "pretty-format@npm:28.0.0-alpha.7"
-  dependencies:
-    "@jest/schemas": ^28.0.0-alpha.3
-    ansi-regex: ^5.0.1
-    ansi-styles: ^5.0.0
-    react-is: ^17.0.1
-  checksum: 26eda23b9dc985db206a4477bb7a22f5f1d73b9146bac4eb004dbcf3119ccae955377be6eddae0f792c2fc4bc14a0b303f43ee98542495da8ecf623654bf3054
-  languageName: node
-  linkType: hard
-
 "pretty-format@npm:^28.1.3":
   version: 28.1.3
   resolution: "pretty-format@npm:28.1.3"
@@ -18509,6 +18525,17 @@ jest-snapshot@test:
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
   checksum: e69f857358a3e03d271252d7524bec758c35e44680287f36c1cb905187fbc82da9981a6eb07edfd8a03bc3cbeebfa6f5234c13a3d5b59f2bbdf9b4c4053e0a7f
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "pretty-format@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 9917a0bb859cd7a24a343363f70d5222402c86d10eb45bcc2f77b23a4e67586257390e959061aec22762a782fe6bafb59bf34eb94527bc2e5d211afdb287eb4e
   languageName: node
   linkType: hard
 
@@ -21002,18 +21029,16 @@ jest-snapshot@test:
   languageName: node
   linkType: hard
 
-"snapshot-diff@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "snapshot-diff@npm:0.2.2"
+"snapshot-diff@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "snapshot-diff@npm:0.10.0"
   dependencies:
-    jest-diff: test
-    jest-snapshot: test
-    pretty-format: ^20.0.3
-    strip-ansi: ^4.0.0
+    jest-diff: ^29.0.0
+    jest-snapshot: ^29.0.0
+    pretty-format: ^29.0.0
   peerDependencies:
     jest: ">=16"
-    react-test-renderer: ">=15"
-  checksum: a614643dd881bfec54d0c2e637894c8148353a20e4002e727d13bf6f43496fcc9955c747d098c82afa438ce9676fe7a990c9220fa013becfca78e28e1d921ab1
+  checksum: d13e310faeed3f091265cc141ac8f19f192b2c6837e1aaabf6ea601ed8edc40471324609434ab85cb5220fff4c7103fa48c4f9f63c3a207944c55224c0dbde0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Re-enabling and fixing skipped unit tests.

Before:
```
➤ YN0000: [loot-core]: Test Suites: 4 skipped, 32 passed, 32 of 36 total
➤ YN0000: [loot-core]: Tests:       33 skipped, 210 passed, 243 total
➤ YN0000: [loot-core]: Snapshots:   40 passed, 40 total
➤ YN0000: [loot-core]: Time:        131.646 s
```

After:
```
➤ YN0000: [loot-core]: Test Suites: 1 skipped, 35 passed, 35 of 36 total
➤ YN0000: [loot-core]: Tests:       2 skipped, 241 passed, 243 total
➤ YN0000: [loot-core]: Snapshots:   69 passed, 69 total
➤ YN0000: [loot-core]: Time:        145.029 s
```