### PR TITLE
fix: move history to a shared variable

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -4,7 +4,6 @@ import Backend from 'react-dnd-html5-backend';
 import { connect } from 'react-redux';
 import { Router, Route, Redirect, Switch, useLocation } from 'react-router-dom';
 
-import { createBrowserHistory } from 'history';
 import hotkeys from 'hotkeys-js';
 
 import * as actions from 'loot-core/src/client/actions';
@@ -17,6 +16,7 @@ import { BudgetMonthCountProvider } from 'loot-design/src/components/budget/Budg
 import { View } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
+import history from '../history';
 import { getLocationState, makeLocationState } from '../util/location-state';
 import Account from './accounts/Account';
 import { ActiveLocationProvider } from './ActiveLocation';
@@ -147,29 +147,23 @@ function StackedRoutes() {
 class FinancesApp extends React.Component {
   constructor(props) {
     super(props);
-    this.history = createBrowserHistory();
 
-    let oldPush = this.history.push;
-    this.history.push = (to, state) => {
-      return oldPush.call(this.history, to, makeLocationState(state));
+    let oldPush = history.push;
+    history.push = (to, state) => {
+      return oldPush.call(history, to, makeLocationState(state));
     };
-
-    // I'm not sure if this is the best approach but we need this to
-    // globally. We could instead move various workflows inside global
-    // React components, but that's for another day.
-    window.__history = this.history;
 
     undo.setUndoState('url', window.location.href);
 
-    this.cleanup = this.history.listen(location => {
+    this.cleanup = history.listen(location => {
       undo.setUndoState('url', window.location.href);
     });
   }
 
   componentDidMount() {
     // TODO: quick hack fix for showing the demo
-    if (this.history.location.pathname === '/subscribe') {
-      this.history.push('/');
+    if (history.location.pathname === '/subscribe') {
+      history.push('/');
     }
 
     // Get the accounts and check if any exist. If there are no
@@ -177,7 +171,7 @@ class FinancesApp extends React.Component {
     // screen which will prompt them to add an account
     this.props.getAccounts().then(accounts => {
       if (accounts.length === 0) {
-        this.history.push('/accounts');
+        history.push('/accounts');
       }
     });
 
@@ -195,7 +189,7 @@ class FinancesApp extends React.Component {
       checkForUpgradeNotifications(
         this.props.addNotification,
         this.props.resetSync,
-        this.history
+        history
       );
     }, 100);
   }
@@ -206,7 +200,7 @@ class FinancesApp extends React.Component {
 
   render() {
     return (
-      <Router history={this.history}>
+      <Router history={history}>
         <View style={{ height: '100%', backgroundColor: colors.n10 }}>
           <GlobalKeys />
 
@@ -248,7 +242,7 @@ class FinancesApp extends React.Component {
                 {/*window.Actual.IS_DEV && <Debugger />*/}
                 {/*window.Actual.IS_DEV && <URLBar />*/}
 
-                <Modals history={this.history} />
+                <Modals history={history} />
               </div>
             </div>
           </View>

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -2,12 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Switch, Redirect, Router, Route } from 'react-router-dom';
 
-import { createBrowserHistory } from 'history';
-
 import * as actions from 'loot-core/src/client/actions';
 import { View, Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
+import history from '../../history';
 import useServerVersion from '../../hooks/useServerVersion';
 import LoggedInUser from '../LoggedInUser';
 import Notifications from '../Notifications';
@@ -45,8 +44,6 @@ class ManagementApp extends React.Component {
   constructor(props) {
     super(props);
     this.mounted = true;
-    this.history = createBrowserHistory();
-    window.__history = this.history;
   }
 
   async componentDidMount() {
@@ -140,7 +137,7 @@ class ManagementApp extends React.Component {
     let isHidden = loadingText != null;
 
     return (
-      <Router history={this.history}>
+      <Router history={history}>
         <View style={{ height: '100%', minHeight: 500 }}>
           <View
             style={{

--- a/packages/desktop-client/src/global-events.js
+++ b/packages/desktop-client/src/global-events.js
@@ -2,6 +2,8 @@ import * as sharedListeners from 'loot-core/src/client/shared-listeners';
 import { send, listen } from 'loot-core/src/platform/client/fetch';
 import * as undo from 'loot-core/src/platform/client/undo';
 
+import history from './history';
+
 export function handleGlobalEvents(actions, store) {
   global.Actual.onEventFromMain('update-downloaded', (event, info) => {
     actions.setAppState({ updateInfo: info });
@@ -36,13 +38,10 @@ export function handleGlobalEvents(actions, store) {
   });
 
   listen('schedules-offline', ({ payees }) => {
-    let history = window.__history;
-    if (history) {
-      history.push(`/schedule/posts-offline-notification`, {
-        locationPtr: history.location,
-        payees
-      });
-    }
+    history.push(`/schedule/posts-offline-notification`, {
+      locationPtr: history.location,
+      payees
+    });
   });
 
   async function onManage() {

--- a/packages/desktop-client/src/history.js
+++ b/packages/desktop-client/src/history.js
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+
+export default createBrowserHistory();


### PR DESCRIPTION
Currently `history` variable is instatiated 2x. Once in `ManagementApp` and once in `FinanceApp`.

When a customer is setting up the app for the first time and when he is redirected from `ManagementApp` to `FinanceApp` - the history context gets recreated. This also means we _sometimes_ lost `history.push("/new-page")` action.

The fix is rather simple - to use a single, consistent `history` variable that is instatiated only one time.