### PR TITLE
feat: creating test budget on the config page

### DIFF
--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -84,8 +84,9 @@ export default function ConfigServer() {
   }
 
   async function onCreateTestFile() {
+    await send('set-server-url', { url: null });
     await dispatch(createBudget({ testMode: true }));
-    await onSkip();
+    window.__history.push('/');
   }
 
   return (

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import { createBudget } from 'loot-core/src/client/actions/budgets';
 import { signOut, loggedIn } from 'loot-core/src/client/actions/user';
 import { send } from 'loot-core/src/platform/client/fetch';
 import {
@@ -11,6 +12,10 @@ import {
   ButtonWithLoading
 } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
+import {
+  isDevelopmentEnvironment,
+  isPreviewEnvironment
+} from 'loot-design/src/util/environment';
 
 import { useServerURL } from '../../hooks/useServerURL';
 import { Title, Input } from './subscribe/common';
@@ -76,6 +81,11 @@ export default function ConfigServer() {
     await send('set-server-url', { url: null });
     await dispatch(loggedIn());
     history.push('/');
+  }
+
+  async function onCreateTestFile() {
+    await dispatch(createBudget({ testMode: true }));
+    await onSkip();
   }
 
   return (
@@ -169,6 +179,16 @@ export default function ConfigServer() {
               <Button bare style={{ color: colors.n4 }} onClick={onSkip}>
                 Don't use a server
               </Button>
+
+              {(isDevelopmentEnvironment() || isPreviewEnvironment()) && (
+                <Button
+                  primary
+                  style={{ marginLeft: 15 }}
+                  onClick={onCreateTestFile}
+                >
+                  Create test file
+                </Button>
+              )}
             </>
           )}
         </View>


### PR DESCRIPTION
Adding a test-budget creation button on the very first screen to simplify things in the preview and dev environment.

The button is not visible for prod builds.

<img width="694" alt="Screenshot 2023-01-02 at 11 38 42" src="https://user-images.githubusercontent.com/886567/210226402-e97a6339-7183-4680-8093-94db1845d22c.png">
