### PR TITLE
Improve handling of “no server” state

### DIFF
--- a/packages/desktop-client/src/components/LoggedInUser.js
+++ b/packages/desktop-client/src/components/LoggedInUser.js
@@ -37,7 +37,7 @@ function LoggedInUser({
 
   async function onChangePassword() {
     await closeBudget();
-    history.push('/change-password');
+    window.__history.push('/change-password');
   }
 
   function onMenuSelect(type) {
@@ -54,11 +54,12 @@ function LoggedInUser({
     }
   }
 
-  function onClick() {
+  async function onClick() {
     if (serverUrl) {
       setMenuOpen(true);
     } else {
-      history.push('/config-server');
+      await closeBudget();
+      window.__history.push('/config-server');
     }
   }
 

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -22,6 +22,7 @@ import AlertTriangle from 'loot-design/src/svg/v2/AlertTriangle';
 import ArrowButtonRight1 from 'loot-design/src/svg/v2/ArrowButtonRight1';
 import NavigationMenu from 'loot-design/src/svg/v2/NavigationMenu';
 
+import { useServerURL } from '../hooks/useServerURL';
 import AccountSyncCheck from './accounts/AccountSyncCheck';
 import AnimatedRefresh from './AnimatedRefresh';
 import { MonthCountSelector } from './budget/MonthCountSelector';
@@ -247,6 +248,7 @@ function Titlebar({
   sync
 }) {
   let sidebar = useSidebar();
+  const serverURL = useServerURL();
 
   return (
     <View
@@ -353,11 +355,13 @@ function Titlebar({
       </Switch>
       <View style={{ flex: 1 }} />
       <UncategorizedButton />
-      <SyncButton
-        style={{ marginLeft: 10 }}
-        localPrefs={localPrefs}
-        onSync={sync}
-      />
+      {serverURL ? (
+        <SyncButton
+          style={{ marginLeft: 10 }}
+          localPrefs={localPrefs}
+          onSync={sync}
+        />
+      ) : null}
       <LoggedInUser style={{ marginLeft: 10 }} />
     </View>
   );


### PR DESCRIPTION
- hide the “🔁 Offline” button
- when clicking on “No server,” close the current budget before attempting to navigate to `/config-server`