### PR TITLE
docs: add netlify as sponsors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Want to say thanks? Click the ⭐ at the top of the page.
 
 ## Key Links
 
-* Actual [discord](https://discord.gg/pRYNYr4W5A) community.
-* Actual [Community Documentation](https://actualbudget.github.io/docs)
+- Actual [discord](https://discord.gg/pRYNYr4W5A) community.
+- Actual [Community Documentation](https://actualbudget.github.io/docs)
 
 ## Installation
 
@@ -31,9 +31,15 @@ We have a wide range of documentation on how to use Actual, this is all availabl
 
 The Actual app is split up into a few packages:
 
-* loot-core - The core application that runs on any platform
-* loot-design - The generic design components that make up the UI
-* desktop-client - The desktop UI
-* desktop-electron - The desktop app
+- loot-core - The core application that runs on any platform
+- loot-design - The generic design components that make up the UI
+- desktop-client - The desktop UI
+- desktop-electron - The desktop app
 
 More information on the project structure is available in our [community documentation](https://actualbudget.github.io/docs/Developers/project-layout).
+
+## Sponsors
+
+Thanks to our wonderful sponsors who make Actual budget possible!
+
+<a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Deploys by Netlify" /> </a>


### PR DESCRIPTION
Adding Netlify badge to our README.

Netlify have provided us with an open-source license for preview deployments. They have been instrumental so far to get through the backlog of PRs.