### PR TITLE
Further iteration on the sidebar design

### DIFF
--- a/packages/desktop-client/src/components/SidebarWithData.js
+++ b/packages/desktop-client/src/components/SidebarWithData.js
@@ -94,6 +94,7 @@ function SidebarWithData({
       failedAccounts={failedAccounts}
       updatedAccounts={updatedAccounts}
       getBalanceQuery={queries.accountBalance}
+      getAllAccountBalance={queries.allAccountBalance}
       getOnBudgetBalance={queries.budgetedAccountBalance}
       getOffBudgetBalance={queries.offbudgetAccountBalance}
       onFloat={() => saveGlobalPrefs({ floatingSidebar: !floatingSidebar })}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -287,7 +287,7 @@ function Accounts({
     <View>
       {accounts.length > 0 && (
         <Account
-          name="All Accounts"
+          name="All accounts"
           to={allAccountsPath}
           query={getAllAccountBalance()}
           style={{ marginTop: 8, color: colors.n6 }}
@@ -360,7 +360,7 @@ function Accounts({
           ]}
           onClick={onToggleClosedAccounts}
         >
-          {'Closed Accounts' + (showClosedAccounts ? '' : '...')}
+          {'Closed accounts' + (showClosedAccounts ? '' : '...')}
         </View>
       )}
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -535,7 +535,7 @@ function Tools() {
       />
       <SecondaryItem title="Rules" Icon={TuningIcon} to="/rules" indent={15} />
       <SecondaryItem
-        title="Repair splits"
+        title="Repair split transactions"
         Icon={LoadBalancer}
         to="/tools/fix-splits"
         indent={15}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { RectButton } from 'react-native-gesture-handler';
 import { useDispatch } from 'react-redux';
 import { useLocation, useHistory } from 'react-router';
@@ -12,10 +12,14 @@ import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 
 import { styles, colors } from '../style';
 import Add from '../svg/v1/Add';
-import ChevronRight from '../svg/v1/CheveronRight';
+import CheveronDown from '../svg/v1/CheveronDown';
+import CheveronUp from '../svg/v1/CheveronUp';
 import Cog from '../svg/v1/Cog';
 import DotsHorizontalTriple from '../svg/v1/DotsHorizontalTriple';
+import LoadBalancer from '../svg/v1/LoadBalancer';
 import Reports from '../svg/v1/Reports';
+import StoreFrontIcon from '../svg/v1/StoreFront';
+import TuningIcon from '../svg/v1/Tuning';
 import Wallet from '../svg/v1/Wallet';
 import Wrench from '../svg/v1/Wrench';
 import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
@@ -431,64 +435,77 @@ const MenuButton = withRouter(function MenuButton({ history }) {
 
 function Tools() {
   let [isOpen, setOpen] = useState(false);
+  let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
   let location = useLocation();
   let history = useHistory();
   let onToggle = useCallback(() => setOpen(open => !open), []);
 
-  let items = [
-    { name: 'payees', text: 'Payees' },
-    { name: 'rules', text: 'Rules' },
-    { name: 'repair-splits', text: 'Repair split transactions' }
-  ];
-
-  let onMenuSelect = useCallback(
-    type => {
-      switch (type) {
-        case 'payees':
-          history.push('/payees');
-          break;
-        case 'rules':
-          history.push('/rules');
-          break;
-        case 'repair-splits':
-          history.push('/tools/fix-splits', { locationPtr: history.location });
-          break;
-        default:
-      }
-      setOpen(false);
-    },
-    [history]
-  );
+  useEffect(() => {
+    if (
+      ['/payees', '/rules', '/tools'].some(route =>
+        location.pathname.startsWith(route)
+      )
+    ) {
+      setOpen(true);
+    }
+  }, [location.pathname]);
 
   return (
-    <View style={{ flexShrink: 0 }}>
+    <View
+      style={{
+        borderLeft: isOpen ? '4px solid ' + colors.n9 : '',
+        flexShrink: 0
+      }}
+    >
       <Item
-        title="More Tools"
+        title="Tools"
         icon={<Wrench width={15} height={15} style={{ color: 'inherit' }} />}
         exact={true}
         onClick={onToggle}
-        style={{ pointerEvents: isOpen ? 'none' : 'auto' }}
-        forceHover={isOpen}
-        forceActive={['/payees', '/rules', '/tools'].some(route =>
-          location.pathname.startsWith(route)
-        )}
+        indent={isOpen ? -4 : 0}
         button={
-          <ChevronRight
+          <ExpandOrCollapseIcon
             width={12}
             height={12}
-            style={{ color: colors.n6, marginRight: 6 }}
+            style={{ color: colors.n6 }}
           />
         }
       />
       {isOpen && (
-        <Tooltip
-          position="right"
-          offset={-8}
-          style={{ padding: 0 }}
-          onClose={onToggle}
-        >
-          <Menu onMenuSelect={onMenuSelect} items={items} />
-        </Tooltip>
+        <>
+          <Item
+            title="Payees"
+            icon={
+              <StoreFrontIcon
+                width={15}
+                height={15}
+                style={{ color: 'inherit' }}
+              />
+            }
+            to="/payees"
+            indent={12}
+          />
+          <Item
+            title="Rules"
+            icon={
+              <TuningIcon width={15} height={15} style={{ color: 'inherit' }} />
+            }
+            to="/rules"
+            indent={12}
+          />
+          <Item
+            title="Repair splits"
+            icon={
+              <LoadBalancer
+                width={15}
+                height={15}
+                style={{ color: 'inherit' }}
+              />
+            }
+            to="/tools/fix-splits"
+            indent={12}
+          />
+        </>
       )}
     </View>
   );

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -444,7 +444,14 @@ const MenuButton = withRouter(function MenuButton({ history }) {
   );
 });
 
-function ToggleableSection({ title, Icon, children, isOpen, setOpen }) {
+function ToggleableSection({
+  title,
+  Icon,
+  children,
+  isOpen,
+  setOpen,
+  isActive
+}) {
   let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
   let onToggle = useCallback(() => setOpen(open => !open), []);
   return (
@@ -460,6 +467,7 @@ function ToggleableSection({ title, Icon, children, isOpen, setOpen }) {
             style={{ color: colors.n6 }}
           />
         }
+        forceActive={!isOpen && isActive}
       />
       {isOpen && children}
     </View>
@@ -471,12 +479,12 @@ function Tools() {
   let location = useLocation();
   let history = useHistory();
 
+  const isActive = ['/payees', '/rules', '/tools'].some(route =>
+    location.pathname.startsWith(route)
+  );
+
   useEffect(() => {
-    if (
-      ['/payees', '/rules', '/tools'].some(route =>
-        location.pathname.startsWith(route)
-      )
-    ) {
+    if (isActive) {
       setOpen(true);
     }
   }, [location.pathname]);
@@ -487,6 +495,7 @@ function Tools() {
       Icon={Wrench}
       isOpen={isOpen}
       setOpen={setOpen}
+      isActive={isActive}
     >
       <Item title="Payees" Icon={StoreFrontIcon} to="/payees" />
       <Item title="Rules" Icon={TuningIcon} to="/rules" />
@@ -509,6 +518,7 @@ export function AccountsSection({
   onReorder
 }) {
   let [isOpen, setOpen] = useState(true);
+  let location = useLocation();
 
   return (
     <ToggleableSection
@@ -517,6 +527,7 @@ export function AccountsSection({
       isOpen={isOpen}
       setOpen={setOpen}
       style={{ marginTop: 15 }}
+      isActive={location.pathname.startsWith('/accounts')}
     >
       <Accounts
         accounts={accounts}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -359,7 +359,7 @@ function Accounts({
           name="For budget"
           to={budgetedAccountPath}
           query={getOnBudgetBalance()}
-          style={{ fontWeight, marginTop: 10 }}
+          style={{ fontWeight, marginTop: 15 }}
         />
       )}
 
@@ -384,7 +384,7 @@ function Accounts({
           name="Off budget"
           to={offBudgetAccountPath}
           query={getOffBudgetBalance()}
-          style={{ fontWeight, marginTop: 10 }}
+          style={{ fontWeight, marginTop: 15 }}
         />
       )}
 
@@ -406,7 +406,7 @@ function Accounts({
 
       {closedAccounts.length > 0 && (
         <SecondaryItem
-          style={{ marginTop: 10 }}
+          style={{ marginTop: 15 }}
           title={'Closed accounts' + (showClosedAccounts ? '' : '...')}
           onClick={onToggleClosedAccounts}
           bold
@@ -428,7 +428,7 @@ function Accounts({
 
       <SecondaryItem
         style={{
-          marginTop: 10,
+          marginTop: 15,
           marginBottom: 9
         }}
         onClick={onAddAccount}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -41,7 +41,7 @@ export const SIDEBAR_WIDTH = 240;
 
 function Item({
   children,
-  icon,
+  Icon,
   title,
   style,
   indent = 0,
@@ -83,7 +83,7 @@ function Item({
         height: 20
       }}
     >
-      {icon}
+      <Icon width={15} height={15} style={{ color: 'inherit' }} />
       <Block style={{ marginLeft: 8 }}>{title}</Block>
       <View style={{ flex: 1 }} />
       {button}
@@ -233,9 +233,11 @@ function Accounts({
   failedAccounts,
   updatedAccounts,
   getAccountPath,
+  allAccountsPath,
   budgetedAccountPath,
   offBudgetAccountPath,
   getBalanceQuery,
+  getAllAccountBalance,
   getOnBudgetBalance,
   getOffBudgetBalance,
   showClosedAccounts,
@@ -283,6 +285,15 @@ function Accounts({
 
   return (
     <View>
+      {accounts.length > 0 && (
+        <Account
+          name="All Accounts"
+          to={allAccountsPath}
+          query={getAllAccountBalance()}
+          style={{ marginTop: 8, color: colors.n6 }}
+        />
+      )}
+
       {budgetedAccounts.length > 0 && (
         <Account
           name="For budget"
@@ -433,12 +444,32 @@ const MenuButton = withRouter(function MenuButton({ history }) {
   );
 });
 
+function ToggleableSection({ title, Icon, children, isOpen, setOpen }) {
+  let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
+  let onToggle = useCallback(() => setOpen(open => !open), []);
+  return (
+    <View style={{ flexShrink: 0, marginTop: 15 }}>
+      <Item
+        title={title}
+        Icon={Icon}
+        onClick={onToggle}
+        button={
+          <ExpandOrCollapseIcon
+            width={12}
+            height={12}
+            style={{ color: colors.n6 }}
+          />
+        }
+      />
+      {isOpen && children}
+    </View>
+  );
+}
+
 function Tools() {
   let [isOpen, setOpen] = useState(false);
-  let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
   let location = useLocation();
   let history = useHistory();
-  let onToggle = useCallback(() => setOpen(open => !open), []);
 
   useEffect(() => {
     if (
@@ -451,63 +482,60 @@ function Tools() {
   }, [location.pathname]);
 
   return (
-    <View
-      style={{
-        borderLeft: isOpen ? '4px solid ' + colors.n9 : '',
-        flexShrink: 0
-      }}
+    <ToggleableSection
+      title="Tools"
+      Icon={Wrench}
+      isOpen={isOpen}
+      setOpen={setOpen}
     >
-      <Item
-        title="Tools"
-        icon={<Wrench width={15} height={15} style={{ color: 'inherit' }} />}
-        exact={true}
-        onClick={onToggle}
-        indent={isOpen ? -4 : 0}
-        button={
-          <ExpandOrCollapseIcon
-            width={12}
-            height={12}
-            style={{ color: colors.n6 }}
-          />
-        }
+      <Item title="Payees" Icon={StoreFrontIcon} to="/payees" />
+      <Item title="Rules" Icon={TuningIcon} to="/rules" />
+      <Item title="Repair splits" Icon={LoadBalancer} to="/tools/fix-splits" />
+    </ToggleableSection>
+  );
+}
+
+export function AccountsSection({
+  accounts,
+  failedAccounts,
+  updatedAccounts,
+  getBalanceQuery,
+  getAllAccountBalance,
+  getOnBudgetBalance,
+  getOffBudgetBalance,
+  showClosedAccounts,
+  onAddAccount,
+  onToggleClosedAccounts,
+  onReorder
+}) {
+  let [isOpen, setOpen] = useState(true);
+
+  return (
+    <ToggleableSection
+      title="Accounts"
+      Icon={PiggyBank}
+      isOpen={isOpen}
+      setOpen={setOpen}
+      style={{ marginTop: 15 }}
+    >
+      <Accounts
+        accounts={accounts}
+        failedAccounts={failedAccounts}
+        updatedAccounts={updatedAccounts}
+        getAccountPath={account => `/accounts/${account.id}`}
+        allAccountsPath="/accounts"
+        budgetedAccountPath="/accounts/budgeted"
+        offBudgetAccountPath="/accounts/offbudget"
+        getBalanceQuery={getBalanceQuery}
+        getAllAccountBalance={getAllAccountBalance}
+        getOnBudgetBalance={getOnBudgetBalance}
+        getOffBudgetBalance={getOffBudgetBalance}
+        showClosedAccounts={showClosedAccounts}
+        onAddAccount={onAddAccount}
+        onToggleClosedAccounts={onToggleClosedAccounts}
+        onReorder={onReorder}
       />
-      {isOpen && (
-        <>
-          <Item
-            title="Payees"
-            icon={
-              <StoreFrontIcon
-                width={15}
-                height={15}
-                style={{ color: 'inherit' }}
-              />
-            }
-            to="/payees"
-            indent={12}
-          />
-          <Item
-            title="Rules"
-            icon={
-              <TuningIcon width={15} height={15} style={{ color: 'inherit' }} />
-            }
-            to="/rules"
-            indent={12}
-          />
-          <Item
-            title="Repair splits"
-            icon={
-              <LoadBalancer
-                width={15}
-                height={15}
-                style={{ color: 'inherit' }}
-              />
-            }
-            to="/tools/fix-splits"
-            indent={12}
-          />
-        </>
-      )}
-    </View>
+    </ToggleableSection>
   );
 }
 
@@ -518,6 +546,7 @@ export function Sidebar({
   failedAccounts,
   updatedAccounts,
   getBalanceQuery,
+  getAllAccountBalance,
   getOnBudgetBalance,
   getOffBudgetBalance,
   showClosedAccounts,
@@ -606,56 +635,19 @@ export function Sidebar({
       </View>
 
       <View style={{ overflow: 'auto' }}>
-        <Item
-          title="Budget"
-          icon={<Wallet width={15} height={15} style={{ color: 'inherit' }} />}
-          to="/budget"
-        />
-        <Item
-          title="Reports"
-          icon={<Reports width={15} height={15} style={{ color: 'inherit' }} />}
-          to="/reports"
-        />
+        <Item title="Budget" Icon={Wallet} to="/budget" />
+        <Item title="Reports" Icon={Reports} to="/reports" />
 
-        <Item
-          title="Schedules"
-          icon={
-            <CalendarIcon width={15} height={15} style={{ color: 'inherit' }} />
-          }
-          to="/schedules"
-        />
+        <Item title="Schedules" Icon={CalendarIcon} to="/schedules" />
 
         <Tools />
 
-        <Item
-          title="Accounts"
-          to="/accounts"
-          icon={
-            <PiggyBank width={15} height={15} style={{ color: 'inherit' }} />
-          }
-          exact={true}
-          button={
-            <Button
-              bare
-              onClick={e => {
-                e.stopPropagation();
-                e.preventDefault();
-                onAddAccount();
-              }}
-            >
-              <Add width={12} height={12} style={{ color: colors.n6 }} />
-            </Button>
-          }
-        />
-
-        <Accounts
+        <AccountsSection
           accounts={accounts}
           failedAccounts={failedAccounts}
           updatedAccounts={updatedAccounts}
-          getAccountPath={account => `/accounts/${account.id}`}
-          budgetedAccountPath="/accounts/budgeted"
-          offBudgetAccountPath="/accounts/offbudget"
           getBalanceQuery={getBalanceQuery}
+          getAllAccountBalance={getAllAccountBalance}
           getOnBudgetBalance={getOnBudgetBalance}
           getOffBudgetBalance={getOffBudgetBalance}
           showClosedAccounts={showClosedAccounts}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -504,24 +504,9 @@ const MenuButton = withRouter(function MenuButton({ history }) {
   );
 });
 
-function ToggleableSection({ title, children, isOpen, setOpen, isActive }) {
-  let onToggle = useCallback(() => setOpen(open => !open), []);
-  return (
-    <View style={{ flexShrink: 0 }}>
-      <Item
-        title={title}
-        Icon={isOpen ? CheveronDown : CheveronRight}
-        onClick={onToggle}
-        style={{ marginBottom: isOpen ? 8 : 0 }}
-        forceActive={!isOpen && isActive}
-      />
-      {isOpen && children}
-    </View>
-  );
-}
-
 function Tools() {
   let [isOpen, setOpen] = useState(false);
+  let onToggle = useCallback(() => setOpen(open => !open), []);
   let location = useLocation();
 
   const isActive = ['/payees', '/rules', '/tools'].some(route =>
@@ -535,26 +520,37 @@ function Tools() {
   }, [location.pathname]);
 
   return (
-    <ToggleableSection
-      title="More"
-      isOpen={isOpen}
-      setOpen={setOpen}
-      isActive={isActive}
-    >
-      <SecondaryItem
-        title="Payees"
-        Icon={StoreFrontIcon}
-        to="/payees"
-        indent={15}
+    <View style={{ flexShrink: 0 }}>
+      <Item
+        title="More"
+        Icon={isOpen ? CheveronDown : CheveronRight}
+        onClick={onToggle}
+        style={{ marginBottom: isOpen ? 8 : 0 }}
+        forceActive={!isOpen && isActive}
       />
-      <SecondaryItem title="Rules" Icon={TuningIcon} to="/rules" indent={15} />
-      <SecondaryItem
-        title="Repair split transactions"
-        Icon={LoadBalancer}
-        to="/tools/fix-splits"
-        indent={15}
-      />
-    </ToggleableSection>
+      {isOpen && (
+        <>
+          <SecondaryItem
+            title="Payees"
+            Icon={StoreFrontIcon}
+            to="/payees"
+            indent={15}
+          />
+          <SecondaryItem
+            title="Rules"
+            Icon={TuningIcon}
+            to="/rules"
+            indent={15}
+          />
+          <SecondaryItem
+            title="Repair split transactions"
+            Icon={LoadBalancer}
+            to="/tools/fix-splits"
+            indent={15}
+          />
+        </>
+      )}
+    </View>
   );
 }
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -112,6 +112,56 @@ function Item({
   );
 }
 
+function SecondaryItem({ Icon, title, style, to, exact, onClick }) {
+  const hoverStyle = {
+    backgroundColor: colors.n2
+  };
+  const activeStyle = {
+    borderLeft: '4px solid ' + colors.p8,
+    paddingLeft: 14 - 4,
+    color: colors.p8
+  };
+  const linkStyle = [
+    accountNameStyle,
+    { color: colors.n6, paddingLeft: 14 },
+    { ':hover': hoverStyle }
+  ];
+
+  const content = (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        height: 20
+      }}
+    >
+      {Icon && <Icon width={12} height={12} style={{ color: 'inherit' }} />}
+      <Block style={{ marginLeft: Icon ? 8 : 0, color: 'inherit' }}>
+        {title}
+      </Block>
+    </View>
+  );
+
+  return (
+    <View style={[{ flexShrink: 0 }, style]}>
+      {onClick ? (
+        <RectButton onClick={onClick}>
+          <View style={linkStyle}>{content}</View>
+        </RectButton>
+      ) : (
+        <AnchorLink
+          style={linkStyle}
+          to={to}
+          exact={exact}
+          activeStyle={activeStyle}
+        >
+          {content}
+        </AnchorLink>
+      )}
+    </View>
+  );
+}
+
 let accountNameStyle = [
   {
     marginTop: -2,
@@ -292,7 +342,7 @@ function Accounts({
           }
           to={allAccountsPath}
           query={getAllAccountBalance()}
-          style={{ marginTop: 8, color: colors.n6 }}
+          style={{ color: colors.n6 }}
         />
       )}
 
@@ -347,23 +397,11 @@ function Accounts({
       ))}
 
       {closedAccounts.length > 0 && (
-        <View
-          style={[
-            accountNameStyle,
-            {
-              marginTop: 15,
-              color: colors.n6,
-              flexDirection: 'row',
-              userSelect: 'none',
-              alignItems: 'center',
-              flexShrink: 0,
-              cursor: 'pointer'
-            }
-          ]}
+        <SecondaryItem
+          style={{ marginTop: 15 }}
+          title={'Closed accounts' + (showClosedAccounts ? '' : '...')}
           onClick={onToggleClosedAccounts}
-        >
-          {'Closed accounts' + (showClosedAccounts ? '' : '...')}
-        </View>
+        />
       )}
 
       {showClosedAccounts &&
@@ -379,25 +417,15 @@ function Accounts({
           />
         ))}
 
-      <View
-        style={[
-          accountNameStyle,
-          {
-            marginTop: 15,
-            marginBottom: 9,
-            color: colors.n6,
-            flexDirection: 'row',
-            userSelect: 'none',
-            alignItems: 'center',
-            flexShrink: 0,
-            cursor: 'pointer'
-          }
-        ]}
+      <SecondaryItem
+        style={{
+          marginTop: 15,
+          marginBottom: 9
+        }}
         onClick={onAddAccount}
-      >
-        <Add style={{ width: 13, height: 13, color: colors.n6 }} />
-        <View style={{ marginLeft: 5 }}>Add account</View>
-      </View>
+        Icon={Add}
+        title="Add account"
+      />
     </View>
   );
 }
@@ -483,6 +511,7 @@ function ToggleableSection({
         title={title}
         Icon={Icon}
         onClick={onToggle}
+        style={{ marginBottom: isOpen ? 8 : 0 }}
         button={
           <ExpandOrCollapseIcon
             width={12}
@@ -520,9 +549,13 @@ function Tools() {
       setOpen={setOpen}
       isActive={isActive}
     >
-      <Item title="Payees" Icon={StoreFrontIcon} to="/payees" />
-      <Item title="Rules" Icon={TuningIcon} to="/rules" />
-      <Item title="Repair splits" Icon={LoadBalancer} to="/tools/fix-splits" />
+      <SecondaryItem title="Payees" Icon={StoreFrontIcon} to="/payees" />
+      <SecondaryItem title="Rules" Icon={TuningIcon} to="/rules" />
+      <SecondaryItem
+        title="Repair splits"
+        Icon={LoadBalancer}
+        to="/tools/fix-splits"
+      />
     </ToggleableSection>
   );
 }

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -335,7 +335,7 @@ function Accounts({
   return (
     <View>
       <Account
-        name={closedAccounts.length > 0 ? 'All open accounts' : 'All accounts'}
+        name="All accounts"
         to={allAccountsPath}
         query={getAllAccountBalance()}
         style={{ fontWeight, marginTop: 15 }}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -222,7 +222,7 @@ function Account({
               }
             />
           </AnchorLink>
-        </View>{' '}
+        </View>
       </View>
     </View>
   );
@@ -354,7 +354,8 @@ function Accounts({
               flexDirection: 'row',
               userSelect: 'none',
               alignItems: 'center',
-              flexShrink: 0
+              flexShrink: 0,
+              cursor: 'pointer'
             }
           ]}
           onClick={onToggleClosedAccounts}
@@ -375,6 +376,25 @@ function Accounts({
             onDrop={onReorder}
           />
         ))}
+
+      <View
+        style={[
+          accountNameStyle,
+          {
+            marginTop: 15,
+            color: colors.n6,
+            flexDirection: 'row',
+            userSelect: 'none',
+            alignItems: 'center',
+            flexShrink: 0,
+            cursor: 'pointer'
+          }
+        ]}
+        onClick={onAddAccount}
+      >
+        <Add style={{ width: 13, height: 13, color: colors.n6 }} />
+        <View style={{ marginLeft: 5 }}>Add account</View>
+      </View>
     </View>
   );
 }

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -384,6 +384,7 @@ function Accounts({
           accountNameStyle,
           {
             marginTop: 15,
+            marginBottom: 9,
             color: colors.n6,
             flexDirection: 'row',
             userSelect: 'none',

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -357,7 +357,7 @@ function Accounts({
           name="For budget"
           to={budgetedAccountPath}
           query={getOnBudgetBalance()}
-          style={{ fontWeight, marginTop: 15 }}
+          style={{ fontWeight, marginTop: 13 }}
         />
       )}
 
@@ -382,7 +382,7 @@ function Accounts({
           name="Off budget"
           to={offBudgetAccountPath}
           query={getOffBudgetBalance()}
-          style={{ fontWeight, marginTop: 15 }}
+          style={{ fontWeight, marginTop: 13 }}
         />
       )}
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -39,6 +39,8 @@ import CellValue from './spreadsheet/CellValue';
 
 export const SIDEBAR_WIDTH = 240;
 
+const fontWeight = 550;
+
 function Item({
   children,
   Icon,
@@ -119,11 +121,12 @@ function SecondaryItem({ Icon, title, style, to, exact, onClick, indent = 0 }) {
   const activeStyle = {
     borderLeft: '4px solid ' + colors.p8,
     paddingLeft: 14 - 4 + indent,
-    color: colors.p8
+    color: colors.p8,
+    fontWeight
   };
   const linkStyle = [
     accountNameStyle,
-    { color: colors.n6, paddingLeft: 14 + indent },
+    { color: colors.n9, paddingLeft: 14 + indent, fontWeight },
     { ':hover': hoverStyle }
   ];
 
@@ -233,7 +236,7 @@ function Account({
               // has unread transactions. The system does mark is read and
               // unbolds it, but it still "flashes" bold so this just
               // ignores it if it's active
-              fontWeight: 'normal',
+              fontWeight: (style && style.fontWeight) || 'normal',
               '& .dot': {
                 backgroundColor: colors.p8,
                 transform: 'translateX(-4.5px)'
@@ -342,7 +345,7 @@ function Accounts({
           }
           to={allAccountsPath}
           query={getAllAccountBalance()}
-          style={{ color: colors.n6 }}
+          style={{ fontWeight }}
         />
       )}
 
@@ -351,7 +354,7 @@ function Accounts({
           name="For budget"
           to={budgetedAccountPath}
           query={getOnBudgetBalance()}
-          style={{ marginTop: 15, color: colors.n6 }}
+          style={{ fontWeight, marginTop: 15 }}
         />
       )}
 
@@ -376,7 +379,7 @@ function Accounts({
           name="Off budget"
           to={offBudgetAccountPath}
           query={getOffBudgetBalance()}
-          style={{ color: colors.n6 }}
+          style={{ fontWeight }}
         />
       )}
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -39,7 +39,7 @@ import CellValue from './spreadsheet/CellValue';
 
 export const SIDEBAR_WIDTH = 240;
 
-const fontWeight = 550;
+const fontWeight = 600;
 
 function Item({
   children,
@@ -114,7 +114,16 @@ function Item({
   );
 }
 
-function SecondaryItem({ Icon, title, style, to, exact, onClick, indent = 0 }) {
+function SecondaryItem({
+  Icon,
+  title,
+  style,
+  to,
+  exact,
+  onClick,
+  bold,
+  indent = 0
+}) {
   const hoverStyle = {
     backgroundColor: colors.n2
   };
@@ -122,11 +131,15 @@ function SecondaryItem({ Icon, title, style, to, exact, onClick, indent = 0 }) {
     borderLeft: '4px solid ' + colors.p8,
     paddingLeft: 14 - 4 + indent,
     color: colors.p8,
-    fontWeight
+    fontWeight: bold ? fontWeight : null
   };
   const linkStyle = [
     accountNameStyle,
-    { color: colors.n9, paddingLeft: 14 + indent, fontWeight },
+    {
+      color: colors.n9,
+      paddingLeft: 14 + indent,
+      fontWeight: bold ? fontWeight : null
+    },
     { ':hover': hoverStyle }
   ];
 
@@ -396,6 +409,7 @@ function Accounts({
           style={{ marginTop: 10 }}
           title={'Closed accounts' + (showClosedAccounts ? '' : '...')}
           onClick={onToggleClosedAccounts}
+          bold
         />
       )}
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -146,7 +146,7 @@ function SecondaryItem({
       style={{
         flexDirection: 'row',
         alignItems: 'center',
-        height: 20
+        height: 16
       }}
     >
       {Icon && <Icon width={12} height={12} style={{ color: 'inherit' }} />}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -112,18 +112,18 @@ function Item({
   );
 }
 
-function SecondaryItem({ Icon, title, style, to, exact, onClick }) {
+function SecondaryItem({ Icon, title, style, to, exact, onClick, indent = 0 }) {
   const hoverStyle = {
     backgroundColor: colors.n2
   };
   const activeStyle = {
     borderLeft: '4px solid ' + colors.p8,
-    paddingLeft: 14 - 4,
+    paddingLeft: 14 - 4 + indent,
     color: colors.p8
   };
   const linkStyle = [
     accountNameStyle,
-    { color: colors.n6, paddingLeft: 14 },
+    { color: colors.n6, paddingLeft: 14 + indent },
     { ':hover': hoverStyle }
   ];
 
@@ -549,12 +549,18 @@ function Tools() {
       setOpen={setOpen}
       isActive={isActive}
     >
-      <SecondaryItem title="Payees" Icon={StoreFrontIcon} to="/payees" />
-      <SecondaryItem title="Rules" Icon={TuningIcon} to="/rules" />
+      <SecondaryItem
+        title="Payees"
+        Icon={StoreFrontIcon}
+        to="/payees"
+        indent={15}
+      />
+      <SecondaryItem title="Rules" Icon={TuningIcon} to="/rules" indent={15} />
       <SecondaryItem
         title="Repair splits"
         Icon={LoadBalancer}
         to="/tools/fix-splits"
+        indent={15}
       />
     </ToggleableSection>
   );

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -1,20 +1,18 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { RectButton } from 'react-native-gesture-handler';
 import { useDispatch } from 'react-redux';
-import { useLocation, useHistory } from 'react-router';
+import { useLocation } from 'react-router';
 import { withRouter } from 'react-router-dom';
 
 import { css } from 'glamor';
 
 import { closeBudget } from 'loot-core/src/client/actions/budgets';
 import Platform from 'loot-core/src/client/platform';
-import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 
 import { styles, colors } from '../style';
 import Add from '../svg/v1/Add';
 import CheveronDown from '../svg/v1/CheveronDown';
 import CheveronRight from '../svg/v1/CheveronRight';
-import CheveronUp from '../svg/v1/CheveronUp';
 import Cog from '../svg/v1/Cog';
 import DotsHorizontalTriple from '../svg/v1/DotsHorizontalTriple';
 import LoadBalancer from '../svg/v1/LoadBalancer';

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -661,6 +661,15 @@ export function Sidebar({
 
         <Tools />
 
+        <View
+          style={{
+            height: 1,
+            backgroundColor: colors.n3,
+            marginTop: 15,
+            flexShrink: 0
+          }}
+        />
+
         <Accounts
           accounts={accounts}
           failedAccounts={failedAccounts}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -13,6 +13,7 @@ import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 import { styles, colors } from '../style';
 import Add from '../svg/v1/Add';
 import CheveronDown from '../svg/v1/CheveronDown';
+import CheveronRight from '../svg/v1/CheveronRight';
 import CheveronUp from '../svg/v1/CheveronUp';
 import Cog from '../svg/v1/Cog';
 import DotsHorizontalTriple from '../svg/v1/DotsHorizontalTriple';
@@ -21,7 +22,6 @@ import Reports from '../svg/v1/Reports';
 import StoreFrontIcon from '../svg/v1/StoreFront';
 import TuningIcon from '../svg/v1/Tuning';
 import Wallet from '../svg/v1/Wallet';
-import Wrench from '../svg/v1/Wrench';
 import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
 import CalendarIcon from '../svg/v2/Calendar';
 import {
@@ -490,30 +490,15 @@ const MenuButton = withRouter(function MenuButton({ history }) {
   );
 });
 
-function ToggleableSection({
-  title,
-  Icon,
-  children,
-  isOpen,
-  setOpen,
-  isActive
-}) {
-  let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
+function ToggleableSection({ title, children, isOpen, setOpen, isActive }) {
   let onToggle = useCallback(() => setOpen(open => !open), []);
   return (
     <View style={{ flexShrink: 0 }}>
       <Item
         title={title}
-        Icon={Icon}
+        Icon={isOpen ? CheveronDown : CheveronRight}
         onClick={onToggle}
         style={{ marginBottom: isOpen ? 8 : 0 }}
-        button={
-          <ExpandOrCollapseIcon
-            width={12}
-            height={12}
-            style={{ color: colors.n6 }}
-          />
-        }
         forceActive={!isOpen && isActive}
       />
       {isOpen && children}
@@ -537,8 +522,7 @@ function Tools() {
 
   return (
     <ToggleableSection
-      title="Tools"
-      Icon={Wrench}
+      title="More"
       isOpen={isOpen}
       setOpen={setOpen}
       isActive={isActive}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -328,10 +328,6 @@ function Accounts({
         paddingTop: isDragging ? 15 : 0,
         marginTop: isDragging ? -15 : 0
       };
-    } else if (i === length - 1) {
-      return {
-        paddingBottom: 15
-      };
     }
     return null;
   };
@@ -379,7 +375,7 @@ function Accounts({
           name="Off budget"
           to={offBudgetAccountPath}
           query={getOffBudgetBalance()}
-          style={{ fontWeight }}
+          style={{ fontWeight, marginTop: 15 }}
         />
       )}
 
@@ -509,7 +505,7 @@ function ToggleableSection({
   let ExpandOrCollapseIcon = isOpen ? CheveronUp : CheveronDown;
   let onToggle = useCallback(() => setOpen(open => !open), []);
   return (
-    <View style={{ flexShrink: 0, marginTop: 15 }}>
+    <View style={{ flexShrink: 0 }}>
       <Item
         title={title}
         Icon={Icon}
@@ -532,7 +528,6 @@ function ToggleableSection({
 function Tools() {
   let [isOpen, setOpen] = useState(false);
   let location = useLocation();
-  let history = useHistory();
 
   const isActive = ['/payees', '/rules', '/tools'].some(route =>
     location.pathname.startsWith(route)

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -334,16 +334,12 @@ function Accounts({
 
   return (
     <View>
-      {accounts.length > 0 && (
-        <Account
-          name={
-            closedAccounts.length > 0 ? 'All open accounts' : 'All accounts'
-          }
-          to={allAccountsPath}
-          query={getAllAccountBalance()}
-          style={{ fontWeight }}
-        />
-      )}
+      <Account
+        name={closedAccounts.length > 0 ? 'All open accounts' : 'All accounts'}
+        to={allAccountsPath}
+        query={getAllAccountBalance()}
+        style={{ fontWeight, marginTop: 15 }}
+      />
 
       {budgetedAccounts.length > 0 && (
         <Account
@@ -564,52 +560,6 @@ function Tools() {
   );
 }
 
-export function AccountsSection({
-  accounts,
-  failedAccounts,
-  updatedAccounts,
-  getBalanceQuery,
-  getAllAccountBalance,
-  getOnBudgetBalance,
-  getOffBudgetBalance,
-  showClosedAccounts,
-  onAddAccount,
-  onToggleClosedAccounts,
-  onReorder
-}) {
-  let [isOpen, setOpen] = useState(true);
-  let location = useLocation();
-
-  return (
-    <ToggleableSection
-      title="Accounts"
-      Icon={PiggyBank}
-      isOpen={isOpen}
-      setOpen={setOpen}
-      style={{ marginTop: 15 }}
-      isActive={location.pathname.startsWith('/accounts')}
-    >
-      <Accounts
-        accounts={accounts}
-        failedAccounts={failedAccounts}
-        updatedAccounts={updatedAccounts}
-        getAccountPath={account => `/accounts/${account.id}`}
-        allAccountsPath="/accounts"
-        budgetedAccountPath="/accounts/budgeted"
-        offBudgetAccountPath="/accounts/offbudget"
-        getBalanceQuery={getBalanceQuery}
-        getAllAccountBalance={getAllAccountBalance}
-        getOnBudgetBalance={getOnBudgetBalance}
-        getOffBudgetBalance={getOffBudgetBalance}
-        showClosedAccounts={showClosedAccounts}
-        onAddAccount={onAddAccount}
-        onToggleClosedAccounts={onToggleClosedAccounts}
-        onReorder={onReorder}
-      />
-    </ToggleableSection>
-  );
-}
-
 export function Sidebar({
   style,
   budgetName,
@@ -713,10 +663,14 @@ export function Sidebar({
 
         <Tools />
 
-        <AccountsSection
+        <Accounts
           accounts={accounts}
           failedAccounts={failedAccounts}
           updatedAccounts={updatedAccounts}
+          getAccountPath={account => `/accounts/${account.id}`}
+          allAccountsPath="/accounts"
+          budgetedAccountPath="/accounts/budgeted"
+          offBudgetAccountPath="/accounts/offbudget"
           getBalanceQuery={getBalanceQuery}
           getAllAccountBalance={getAllAccountBalance}
           getOnBudgetBalance={getOnBudgetBalance}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -346,7 +346,7 @@ function Accounts({
           name="For budget"
           to={budgetedAccountPath}
           query={getOnBudgetBalance()}
-          style={{ fontWeight, marginTop: 15 }}
+          style={{ fontWeight, marginTop: 10 }}
         />
       )}
 
@@ -371,7 +371,7 @@ function Accounts({
           name="Off budget"
           to={offBudgetAccountPath}
           query={getOffBudgetBalance()}
-          style={{ fontWeight, marginTop: 15 }}
+          style={{ fontWeight, marginTop: 10 }}
         />
       )}
 
@@ -393,7 +393,7 @@ function Accounts({
 
       {closedAccounts.length > 0 && (
         <SecondaryItem
-          style={{ marginTop: 15 }}
+          style={{ marginTop: 10 }}
           title={'Closed accounts' + (showClosedAccounts ? '' : '...')}
           onClick={onToggleClosedAccounts}
         />
@@ -414,7 +414,7 @@ function Accounts({
 
       <SecondaryItem
         style={{
-          marginTop: 15,
+          marginTop: 10,
           marginBottom: 9
         }}
         onClick={onAddAccount}

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -287,7 +287,9 @@ function Accounts({
     <View>
       {accounts.length > 0 && (
         <Account
-          name="All accounts"
+          name={
+            closedAccounts.length > 0 ? 'All open accounts' : 'All accounts'
+          }
           to={allAccountsPath}
           query={getAllAccountBalance()}
           style={{ marginTop: 8, color: colors.n6 }}


### PR DESCRIPTION
<details><summary>Outdated screenshots</summary>

<img width="249" align=left alt="Screenshot_2023-01-10 16 31 58" src="https://user-images.githubusercontent.com/25517624/211666802-90693583-b8e4-4002-b9de-1ae200297a90.png">
<img width="343" align=right alt="Screenshot_2023-01-10 16 02 51" src="https://user-images.githubusercontent.com/25517624/211662042-81fa54ec-90ce-4628-91fc-cbac537caf8f.png">

&larr; The tools are back inline. The section defaults to closed unless you load the page into one of the tools, then it will open itself.

…and the parent item highlights itself when collapsed if any of its children are selected &rarr;

.

.


<img width="256" align=right alt="Screenshot_2023-01-10 16 04 40" src="https://user-images.githubusercontent.com/25517624/211662290-244195fd-c3b1-47ab-b469-dec0237f1722.png">

<br>New look for the Accounts section: &rarr;

- The “Accounts” header now toggles the visibility of the entire section, just like the Tools section (although the Accounts section is always open by default)
- There’s now a new header called “All accounts” (or “All open accounts” if you have closed accounts, would appreciate feedback on this distinction) that shows your net worth, and lets you see transaction history for on and off budget accounts combined (i.e. what “Accounts” used to do)
- The button to add an account is now at the bottom of the accounts list, below “Closed accounts.” While it could theoretically scroll out of view, by the time you make that many accounts you’ll hopefully know where to look, right? (or you’ll end up scrolling to the bottom of the list anyway)

Here’s how it looks with both open: &darr;
<img width="241" alt="Screenshot_2023-01-10 16 33 10" src="https://user-images.githubusercontent.com/25517624/211667033-e66c6bac-8326-496f-9e3e-ca3d8cba863a.png">