### PR TITLE
Fix overlap of version info and server URL

### DIFF
--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -161,9 +161,10 @@ export default function ConfigServer() {
 
         <View
           style={{
-            marginTop: 15,
             flexDirection: 'row',
-            justifyContent: 'center'
+            flexFlow: 'row wrap',
+            justifyContent: 'center',
+            marginTop: 15
           }}
         >
           {currentUrl ? (
@@ -174,12 +175,20 @@ export default function ConfigServer() {
             <>
               <Button
                 bare
-                style={{ color: colors.n4, marginRight: 15 }}
+                style={{
+                  color: colors.n4,
+                  margin: 5,
+                  marginRight: 15
+                }}
                 onClick={onSameDomain}
               >
                 Use {window.location.origin.replace(/https?:\/\//, '')}
               </Button>
-              <Button bare style={{ color: colors.n4 }} onClick={onSkip}>
+              <Button
+                bare
+                style={{ color: colors.n4, margin: 5 }}
+                onClick={onSkip}
+              >
                 Don't use a server
               </Button>
 

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -209,13 +209,19 @@ class ManagementApp extends React.Component {
                       position: 'absolute',
                       top: 0,
                       right: 0,
-                      padding: '15px 17px',
+                      padding: '6px 10px',
                       zIndex: 4000
                     }}
                   >
                     <Switch>
                       <Route exact path="/config-server" component={null} />
-                      <Route exact path="/" component={LoggedInUser} />
+                      <Route
+                        exact
+                        path="/"
+                        render={() => (
+                          <LoggedInUser style={{ padding: '4px 7px' }} />
+                        )}
+                      />
                     </Switch>
                   </View>
                 </>

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -7,6 +7,7 @@ import { createBrowserHistory } from 'history';
 import * as actions from 'loot-core/src/client/actions';
 import { View, Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
+import tokens from 'loot-design/src/tokens';
 
 import useServerVersion from '../../hooks/useServerVersion';
 import LoggedInUser from '../LoggedInUser';
@@ -25,14 +26,18 @@ function Version() {
   return (
     <Text
       style={{
-        position: 'absolute',
-        bottom: 0,
-        right: 0,
         color: colors.n7,
-        margin: 15,
-        marginRight: 17,
         ':hover': { color: colors.n2 },
-        zIndex: 5001
+        margin: 15,
+        marginLeft: 17,
+        [`@media (min-width: ${tokens.breakpoint_medium})`]: {
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          marginLeft: 15,
+          marginRight: 17,
+          zIndex: 5001
+        }
       }}
       href={'https://actualbudget.com/blog/' + window.Actual.ACTUAL_VERSION}
     >
@@ -204,7 +209,7 @@ class ManagementApp extends React.Component {
                       position: 'absolute',
                       top: 0,
                       right: 0,
-                      padding: '6px 10px',
+                      padding: '15px 17px',
                       zIndex: 4000
                     }}
                   >

--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -101,7 +101,7 @@ export function Link({ style, children, ...nativeProps }) {
       {...css(
         {
           textDecoration: 'none',
-          color: styles.text,
+          color: styles.textColor,
           backgroundColor: 'transparent',
           border: 0,
           cursor: 'pointer',
@@ -873,8 +873,8 @@ export function Modal({
             borderRadius: 4,
             backgroundColor: 'white',
             opacity: isHidden ? 0 : 1,
-            [`@media (min-width: ${tokens.breakpoint_medium})`]: {
-              minWidth: 500
+            [`@media (min-width: ${tokens.breakpoint_narrow})`]: {
+              minWidth: tokens.breakpoint_narrow
             }
           },
           styles.shadowLarge,

--- a/packages/loot-design/src/components/manager/BudgetList.js
+++ b/packages/loot-design/src/components/manager/BudgetList.js
@@ -172,7 +172,9 @@ function File({ file, onSelect, onDelete }) {
         <FileState file={file} />
       </View>
 
-      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <View
+        style={{ flex: '0 0 auto', flexDirection: 'row', alignItems: 'center' }}
+      >
         {file.encryptKeyId && (
           <Key
             style={{


### PR DESCRIPTION
Fixes the overlap @MikeBishop [noted here](https://github.com/actualbudget/actual/discussions/433#discussioncomment-4605317): 
![overlap](https://user-images.githubusercontent.com/5862724/211719914-26a7590e-96fc-468c-995e-c7387b018fd6.jpg)

### Proposed Solution
Move the version info from bottom right to top left at narrow widths.

### Demos
#### The Problem
![problem](https://user-images.githubusercontent.com/5862724/211719863-597519f8-00d9-429f-be51-7721d6bdc5d2.gif)

#### A Solution
Here we're widening from a tiny phone (iPhone SE) and landing back at today's desktop layout:
![solution](https://user-images.githubusercontent.com/5862724/211719692-ff0f8991-8caf-4091-9b83-8f11c1d78dd1.gif)

### Alternative Approach
Stack the server URL and version info in the center bottom. But feels a little crowded down there to me.

### Add-on Improvement
Also seen in the problem demo, the account boxes were growing a little too wide at intermediate widths. Now they won't grow awkwardly wide for no reason. (As seen in the solution demo.)