### PR TITLE
:bug:  make build-browser, watch-browser commands use desktop-client vers

### DIFF
--- a/packages/desktop-client/bin/build-browser
+++ b/packages/desktop-client/bin/build-browser
@@ -3,7 +3,7 @@
 ROOT=`dirname $0`
 cd "$ROOT/.."
 
-VERSION=`cat "$ROOT/../../desktop-electron/package.json" | grep version | head -n1 | awk -F "\"" '{print $4}' | tr -d '\r\n'`
+VERSION=`cat "$ROOT/../../desktop-client/package.json" | grep version | head -n1 | awk -F "\"" '{print $4}' | tr -d '\r\n'`
 
 echo "Building version $VERSION for the browser..."
 

--- a/packages/desktop-client/bin/watch-browser
+++ b/packages/desktop-client/bin/watch-browser
@@ -3,7 +3,7 @@
 ROOT=`dirname $0`
 cd "$ROOT/.."
 
-VERSION=`cat "$ROOT/../../desktop-electron/package.json" | grep version | head -n1 | awk -F "\"" '{print $4}' | tr -d '\r\n'`
+VERSION=`cat "$ROOT/../../desktop-client/package.json" | grep version | head -n1 | awk -F "\"" '{print $4}' | tr -d '\r\n'`
 
 export IS_GENERIC_BROWSER=1
 export PORT=3001


### PR DESCRIPTION
Making the `build-browser` and `watch-browser` commands use the `desktop-client` version.

We are currently not cutting new releases for electron app. How we do releases for that is yet to be figured out. Until then - we'll be bumping up only the web version numbers.