### PR TITLE
Fix bug where rules page may not load due to link-schedule payee dependency

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -234,7 +234,7 @@ function ScheduleValue({ value }) {
       data={schedules}
       describe={s => {
         let payeeId = s._payee;
-        return payeeId
+        return byId[payeeId]
           ? `${byId[payeeId].name} (${s.next_date})`
           : `Next: ${s.next_date}`;
       }}
@@ -529,9 +529,9 @@ export default function ManageRules({
       let loadedRules = await loadRules();
       setRules(loadedRules.slice(0, 100));
       setLoading(false);
-    }
 
-    dispatch(initiallyLoadPayees());
+      await dispatch(initiallyLoadPayees());
+    }
 
     undo.setUndoState('openModal', 'manage-rules');
 

--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -529,9 +529,9 @@ export default function ManageRules({
       let loadedRules = await loadRules();
       setRules(loadedRules.slice(0, 100));
       setLoading(false);
-
-      await dispatch(initiallyLoadPayees());
     }
+
+    dispatch(initiallyLoadPayees());
 
     undo.setUndoState('openModal', 'manage-rules');
 


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/450

Rules page fails to load when link-schedule rules > 0 and payees not already in state


Not sure if this is the best way to achieve this, but it fixes the issue