### PR TITLE
:construction_worker:  improving playwright install speed

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Setup Playwright
-        run: npx playwright install chrome --with-deps
+        run: npx playwright install chromium --with-deps
       - name: Wait for Pages changed to neutral
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-Netlify

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Playwright
-        run: npx playwright install --with-deps
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Setup Playwright
+        run: npx playwright install chrome --with-deps
       - name: Wait for Pages changed to neutral
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-Netlify


### PR DESCRIPTION
- install only chromium for playwright; this should make it quicker and solve problems such as [this one](https://github.com/actualbudget/actual/actions/runs/3909627256/jobs/6680910274)
- swapped around `yarn install` and playwright install tasks to make things slightly faster