### PR TITLE
mobile: disable edit on tap of category balance

### DIFF
--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -334,17 +334,6 @@ export class BudgetCategory extends React.PureComponent {
       </ListItem>
     );
 
-    if (!editMode) {
-      return (
-        // <TouchableOpacity
-        //   onClick={() => onEdit(category.id)}
-        //   activeOpacity={0.7}
-        // >
-        <div onClick={() => onEdit(category.id)}>{content}</div>
-        // </TouchableOpacity>
-      );
-    }
-
     return <div>{() => content}</div>;
     // <Draggable
     //   id={category.id}
@@ -500,8 +489,14 @@ export class TotalsRow extends React.PureComponent {
 
 export class IncomeCategory extends React.PureComponent {
   render() {
-    const { name, budget, balance, style, nameTextStyle, amountTextStyle } =
-      this.props;
+    const {
+      name,
+      budget,
+      balance,
+      style,
+      nameTextStyle,
+      amountTextStyle
+    } = this.props;
     return (
       <ListItem
         style={[

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -489,14 +489,8 @@ export class TotalsRow extends React.PureComponent {
 
 export class IncomeCategory extends React.PureComponent {
   render() {
-    const {
-      name,
-      budget,
-      balance,
-      style,
-      nameTextStyle,
-      amountTextStyle
-    } = this.props;
+    const { name, budget, balance, style, nameTextStyle, amountTextStyle } =
+      this.props;
     return (
       <ListItem
         style={[


### PR DESCRIPTION
Fixes #470 
See ☝🏻 this issue for details of the bug.
In short: an `onEdit` click handler was bringing up the keyboard for mobile users

Let's get rid of this block entirely. 

