### PR TITLE
Update stale workflow

### DIFF
--- a/.github/workflows/opened-pr-triage.yml
+++ b/.github/workflows/opened-pr-triage.yml
@@ -1,0 +1,14 @@
+name: Mark new pull request as waiting review
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: awaiting-review

--- a/.github/workflows/opened-pr-triage.yml
+++ b/.github/workflows/opened-pr-triage.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: awaiting-review
+          labels: waiting-review

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,8 +1,7 @@
-name: Close inactive issues
+name: Mark PR As Stale
 on:
   schedule:
     - cron: "30 1 * * *"
-
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -12,9 +11,9 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
-          days-before-issue-stale: 90
-          days-before-issue-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "🚧🚨 This issue is being marked as stale due to 90 days of inactivity. 🚧🚨"
-          only-labels: 'needs triage'
+          stale-pr-label: "stale"
+          stale-pr-message: "🚧🚨 This Pull Request is being marked as stale due to 30 days of inactivity. 🚧🚨"
+          days-before-pr-stale: 30
+          days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
           days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-pr-label: "stale"
-          stale-pr-message: "🚧🚨 This Pull Request is being marked as stale due to 90 days of inactivity. 🚧🚨"
+          stale-pr-message: "🚧🚨 This Pull Request is being marked as stale due to 30 days of inactivity. 🚧🚨"
           stale-issue-message: "🚧🚨 This issue is being marked as stale due to 90 days of inactivity. 🚧🚨"
           days-before-pr-stale: 30
           days-before-pr-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,13 +10,15 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v7
         with:
           days-before-issue-stale: 90
           days-before-issue-close: -1
           stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          stale-pr-message: "🚧🚨 This Pull Request is being marked as stale due to 90 days of inactivity. 🚧🚨"
           stale-issue-message: "🚧🚨 This issue is being marked as stale due to 90 days of inactivity. 🚧🚨"
-          days-before-pr-stale: -1
+          days-before-pr-stale: 30
           days-before-pr-close: -1
-          only-labels: 'needs triage'
+          only-labels: 'needs triage, waiting-review'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added the ability to mark PR as stale after 30 days for PR's that are waiting review and added the label when new PR's are created