### PR TITLE
:lock:  removing CSP headers

### DIFF
--- a/packages/desktop-client/public/_headers
+++ b/packages/desktop-client/public/_headers
@@ -1,10 +1,6 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
-  Content-Security-Policy: default-src 'self' https://sentry.io blob:; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.actualbudget.com https://api.mixpanel.com https://sentry.io;
-
-/kcab/*
-  Content-Security-Policy: default-src 'self' https://sentry.io blob:; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://*.actualbudget.com https://api.mixpanel.com https://sentry.io;
 
 /*.wasm
   Content-Type: application/wasm


### PR DESCRIPTION
[WIP]

CSP was first designed to reduce the attack surface of Cross Site Scripting (XSS) attacks, later versions of the spec also protect against other forms of attack such as Click Jacking: [read more](https://content-security-policy.com/).

**Why remove them?**

With the headers present it is not possible to host the actual-server under domain X and actual-web under domain Y. This also means we cannot use our own actual-server to test Netlify preview deployments.

**Why keep them?**

Increased security for real deployments of Actual.

**What's the purpose of this PR?**

