### PR TITLE
Fix TypeScript warning about too many files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "moduleResolution": "Node",
     "module": "ESNext"
   },
-  "exclude": ["node_modules", "build"]
+  "exclude": ["**/node_modules/*", "**/build/*", "**/lib-dist/*"]
 }


### PR DESCRIPTION
> To enable project-wide JavaScript/TypeScript language features, exclude large folders with source files that you do not work on.

Per https://github.com/Microsoft/vscode/issues/31188, just excluding `node_modules` isn’t enough, we also have to ignore the relevant directories anywhere in the directory hierarchy.