### PR TITLE
Fix “Repair split transactions” button being missing

### DIFF
--- a/packages/desktop-client/src/components/settings/FixSplits.js
+++ b/packages/desktop-client/src/components/settings/FixSplits.js
@@ -62,7 +62,7 @@ export default function FixSplitsTool() {
 
   return (
     <Setting
-      button={
+      primaryAction={
         <View
           style={{
             flexDirection: 'row',


### PR DESCRIPTION
I’m not sure when this happened but it’s probably my fault. Would be nice to have type checking to warn about this in the future :)