### PR TITLE
:arrow_up:  upgrade eslint-plugin-import and fix issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
         groups: [
           'builtin', // Built-in types are first
           'external',
-          ['sibling', 'parent'], // Then sibling and parent types. They can be mingled together
+          'parent',
+          'sibling',
           'index' // Then the index file
         ],
         'newlines-between': 'always',

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -31,7 +31,7 @@
     "eslint-config-react-app": "3.0.5",
     "eslint-loader": "2.1.1",
     "eslint-plugin-flowtype": "2.50.1",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "6.1.2",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "7.11.1",

--- a/packages/desktop-client/src/components/App.js
+++ b/packages/desktop-client/src/components/App.js
@@ -10,13 +10,14 @@ import {
 } from 'loot-core/src/platform/client/fetch';
 import { styles, hasHiddenScrollbars } from 'loot-design/src/style';
 
+import installPolyfills from '../polyfills';
+
 import AppBackground from './AppBackground';
 import FatalError from './FatalError';
 import FinancesApp from './FinancesApp';
 import ManagementApp from './manager/ManagementApp';
 import MobileWebMessage from './MobileWebMessage';
 import UpdateNotification from './UpdateNotification';
-import installPolyfills from '../polyfills';
 
 class App extends React.Component {
   state = {

--- a/packages/desktop-client/src/components/App.js
+++ b/packages/desktop-client/src/components/App.js
@@ -10,13 +10,13 @@ import {
 } from 'loot-core/src/platform/client/fetch';
 import { styles, hasHiddenScrollbars } from 'loot-design/src/style';
 
-import installPolyfills from '../polyfills';
 import AppBackground from './AppBackground';
 import FatalError from './FatalError';
 import FinancesApp from './FinancesApp';
 import ManagementApp from './manager/ManagementApp';
 import MobileWebMessage from './MobileWebMessage';
 import UpdateNotification from './UpdateNotification';
+import installPolyfills from '../polyfills';
 
 class App extends React.Component {
   state = {

--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -28,8 +28,6 @@ import Cog from 'loot-design/src/svg/v1/Cog';
 import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 import Wallet from 'loot-design/src/svg/v1/Wallet';
 
-import { isMobile } from '../util';
-import { getLocationState, makeLocationState } from '../util/location-state';
 import Account from './accounts/Account';
 import { default as MobileAccount } from './accounts/MobileAccount';
 import { default as MobileAccounts } from './accounts/MobileAccounts';
@@ -52,6 +50,8 @@ import LinkSchedule from './schedules/LinkSchedule';
 import PostsOfflineNotification from './schedules/PostsOfflineNotification';
 import Settings from './settings';
 import Titlebar, { TitlebarProvider } from './Titlebar';
+import { isMobile } from '../util';
+import { getLocationState, makeLocationState } from '../util/location-state';
 // import Debugger from './Debugger';
 
 function PageRoute({ path, component: Component }) {

--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -28,6 +28,9 @@ import Cog from 'loot-design/src/svg/v1/Cog';
 import PiggyBank from 'loot-design/src/svg/v1/PiggyBank';
 import Wallet from 'loot-design/src/svg/v1/Wallet';
 
+import { isMobile } from '../util';
+import { getLocationState, makeLocationState } from '../util/location-state';
+
 import Account from './accounts/Account';
 import { default as MobileAccount } from './accounts/MobileAccount';
 import { default as MobileAccounts } from './accounts/MobileAccounts';
@@ -50,8 +53,6 @@ import LinkSchedule from './schedules/LinkSchedule';
 import PostsOfflineNotification from './schedules/PostsOfflineNotification';
 import Settings from './settings';
 import Titlebar, { TitlebarProvider } from './Titlebar';
-import { isMobile } from '../util';
-import { getLocationState, makeLocationState } from '../util/location-state';
 // import Debugger from './Debugger';
 
 function PageRoute({ path, component: Component }) {

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -25,12 +25,12 @@ import ArrowButtonRight1 from 'loot-design/src/svg/v2/ArrowButtonRight1';
 import NavigationMenu from 'loot-design/src/svg/v2/NavigationMenu';
 import tokens from 'loot-design/src/tokens';
 
-import { useServerURL } from '../hooks/useServerURL';
 import AccountSyncCheck from './accounts/AccountSyncCheck';
 import AnimatedRefresh from './AnimatedRefresh';
 import { MonthCountSelector } from './budget/MonthCountSelector';
 import { useSidebar } from './FloatableSidebar';
 import LoggedInUser from './LoggedInUser';
+import { useServerURL } from '../hooks/useServerURL';
 
 export let TitlebarContext = React.createContext();
 

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -25,12 +25,13 @@ import ArrowButtonRight1 from 'loot-design/src/svg/v2/ArrowButtonRight1';
 import NavigationMenu from 'loot-design/src/svg/v2/NavigationMenu';
 import tokens from 'loot-design/src/tokens';
 
+import { useServerURL } from '../hooks/useServerURL';
+
 import AccountSyncCheck from './accounts/AccountSyncCheck';
 import AnimatedRefresh from './AnimatedRefresh';
 import { MonthCountSelector } from './budget/MonthCountSelector';
 import { useSidebar } from './FloatableSidebar';
 import LoggedInUser from './LoggedInUser';
-import { useServerURL } from '../hooks/useServerURL';
 
 export let TitlebarContext = React.createContext();
 

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -58,9 +58,6 @@ import DownloadThickBottom from 'loot-design/src/svg/v2/DownloadThickBottom';
 import Pencil1 from 'loot-design/src/svg/v2/Pencil1';
 import SearchAlternate from 'loot-design/src/svg/v2/SearchAlternate';
 
-import { authorizeBank } from '../../plaid';
-import { useActiveLocation } from '../ActiveLocation';
-import AnimatedRefresh from '../AnimatedRefresh';
 import { FilterButton, AppliedFilters } from './Filters';
 import TransactionList from './TransactionList';
 import {
@@ -68,6 +65,9 @@ import {
   useSplitsExpanded,
   isPreviewId
 } from './TransactionsTable';
+import { authorizeBank } from '../../plaid';
+import { useActiveLocation } from '../ActiveLocation';
+import AnimatedRefresh from '../AnimatedRefresh';
 
 function EmptyMessage({ onAdd }) {
   return (

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -58,6 +58,10 @@ import DownloadThickBottom from 'loot-design/src/svg/v2/DownloadThickBottom';
 import Pencil1 from 'loot-design/src/svg/v2/Pencil1';
 import SearchAlternate from 'loot-design/src/svg/v2/SearchAlternate';
 
+import { authorizeBank } from '../../plaid';
+import { useActiveLocation } from '../ActiveLocation';
+import AnimatedRefresh from '../AnimatedRefresh';
+
 import { FilterButton, AppliedFilters } from './Filters';
 import TransactionList from './TransactionList';
 import {
@@ -65,9 +69,6 @@ import {
   useSplitsExpanded,
   isPreviewId
 } from './TransactionsTable';
-import { authorizeBank } from '../../plaid';
-import { useActiveLocation } from '../ActiveLocation';
-import AnimatedRefresh from '../AnimatedRefresh';
 
 function EmptyMessage({ onAdd }) {
   return (

--- a/packages/desktop-client/src/components/accounts/MobileAccount.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.js
@@ -22,8 +22,8 @@ import {
 import { colors } from 'loot-design/src/style';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
-import SyncRefresh from '../SyncRefresh';
 import { default as AccountDetails } from './MobileAccountDetails';
+import SyncRefresh from '../SyncRefresh';
 
 const getSchedulesTransform = memoizeOne((id, hasSearch) => {
   let filter = queries.getAccountFilter(id, '_account');

--- a/packages/desktop-client/src/components/accounts/MobileAccount.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.js
@@ -22,8 +22,9 @@ import {
 import { colors } from 'loot-design/src/style';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
-import { default as AccountDetails } from './MobileAccountDetails';
 import SyncRefresh from '../SyncRefresh';
+
+import { default as AccountDetails } from './MobileAccountDetails';
 
 const getSchedulesTransform = memoizeOne((id, hasSearch) => {
   let filter = queries.getAccountFilter(id, '_account');

--- a/packages/desktop-client/src/components/budget/MobileBudget.js
+++ b/packages/desktop-client/src/components/budget/MobileBudget.js
@@ -15,8 +15,8 @@ import { colors } from 'loot-design/src/style';
 import AnimatedLoading from 'loot-design/src/svg/AnimatedLoading';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
-import SyncRefresh from '../SyncRefresh';
 import { BudgetTable } from './MobileBudgetTable';
+import SyncRefresh from '../SyncRefresh';
 
 class Budget extends React.Component {
   constructor(props) {

--- a/packages/desktop-client/src/components/budget/MobileBudget.js
+++ b/packages/desktop-client/src/components/budget/MobileBudget.js
@@ -15,8 +15,9 @@ import { colors } from 'loot-design/src/style';
 import AnimatedLoading from 'loot-design/src/svg/AnimatedLoading';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
-import { BudgetTable } from './MobileBudgetTable';
 import SyncRefresh from '../SyncRefresh';
+
+import { BudgetTable } from './MobileBudgetTable';
 
 class Budget extends React.Component {
   constructor(props) {

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -37,9 +37,9 @@ import ArrowThinRight from 'loot-design/src/svg/v1/ArrowThinRight';
 
 // import { DragDrop, Draggable, Droppable, DragDropHighlight } from './dragdrop';
 
+import { ListItem, ROW_HEIGHT } from './MobileTable';
 import { SyncButton } from '../Titlebar';
 import { AmountInput } from '../util/AmountInput';
-import { ListItem, ROW_HEIGHT } from './MobileTable';
 
 export function ToBudget({ toBudget, onClick }) {
   return (

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -37,9 +37,10 @@ import ArrowThinRight from 'loot-design/src/svg/v1/ArrowThinRight';
 
 // import { DragDrop, Draggable, Droppable, DragDropHighlight } from './dragdrop';
 
-import { ListItem, ROW_HEIGHT } from './MobileTable';
 import { SyncButton } from '../Titlebar';
 import { AmountInput } from '../util/AmountInput';
+
+import { ListItem, ROW_HEIGHT } from './MobileTable';
 
 export function ToBudget({ toBudget, onClick }) {
   return (

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -18,8 +18,8 @@ import {
   isPreviewEnvironment
 } from 'loot-design/src/util/environment';
 
-import { useServerURL } from '../../hooks/useServerURL';
 import { Title, Input } from './subscribe/common';
+import { useServerURL } from '../../hooks/useServerURL';
 
 export default function ConfigServer() {
   useSetThemeColor(colors.p5);

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -18,8 +18,9 @@ import {
   isPreviewEnvironment
 } from 'loot-design/src/util/environment';
 
-import { Title, Input } from './subscribe/common';
 import { useServerURL } from '../../hooks/useServerURL';
+
+import { Title, Input } from './subscribe/common';
 
 export default function ConfigServer() {
   useSetThemeColor(colors.p5);

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -9,6 +9,10 @@ import { View, Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 import tokens from 'loot-design/src/tokens';
 
+import useServerVersion from '../../hooks/useServerVersion';
+import LoggedInUser from '../LoggedInUser';
+import Notifications from '../Notifications';
+
 import ConfigServer from './ConfigServer';
 import Modals from './Modals';
 import ServerURL from './ServerURL';
@@ -16,9 +20,6 @@ import Bootstrap from './subscribe/Bootstrap';
 import ChangePassword from './subscribe/ChangePassword';
 import Error from './subscribe/Error';
 import Login from './subscribe/Login';
-import useServerVersion from '../../hooks/useServerVersion';
-import LoggedInUser from '../LoggedInUser';
-import Notifications from '../Notifications';
 
 function Version() {
   const version = useServerVersion();

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -9,9 +9,6 @@ import { View, Text } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 import tokens from 'loot-design/src/tokens';
 
-import useServerVersion from '../../hooks/useServerVersion';
-import LoggedInUser from '../LoggedInUser';
-import Notifications from '../Notifications';
 import ConfigServer from './ConfigServer';
 import Modals from './Modals';
 import ServerURL from './ServerURL';
@@ -19,6 +16,9 @@ import Bootstrap from './subscribe/Bootstrap';
 import ChangePassword from './subscribe/ChangePassword';
 import Error from './subscribe/Error';
 import Login from './subscribe/Login';
+import useServerVersion from '../../hooks/useServerVersion';
+import LoggedInUser from '../LoggedInUser';
+import Notifications from '../Notifications';
 
 function Version() {
   const version = useServerVersion();

--- a/packages/desktop-client/src/components/payees/ManagePayeesPage.js
+++ b/packages/desktop-client/src/components/payees/ManagePayeesPage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router';
 
-import { Page } from '../Page';
 import ManagePayeesWithData from './ManagePayeesWithData';
+import { Page } from '../Page';
 
 export function ManagePayeesPage() {
   let location = useLocation();

--- a/packages/desktop-client/src/components/payees/ManagePayeesPage.js
+++ b/packages/desktop-client/src/components/payees/ManagePayeesPage.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { useLocation } from 'react-router';
 
-import ManagePayeesWithData from './ManagePayeesWithData';
 import { Page } from '../Page';
+
+import ManagePayeesWithData from './ManagePayeesWithData';
 
 export function ManagePayeesPage() {
   let location = useLocation();

--- a/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
+++ b/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
@@ -24,9 +24,10 @@ import useSelected, {
 } from 'loot-design/src/components/useSelected';
 import { colors } from 'loot-design/src/style';
 
-import { ScheduleAmountCell } from './SchedulesTable';
 import { Page, usePageType } from '../Page';
 import DisplayId from '../util/DisplayId';
+
+import { ScheduleAmountCell } from './SchedulesTable';
 
 let ROW_HEIGHT = 43;
 

--- a/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
+++ b/packages/desktop-client/src/components/schedules/DiscoverSchedules.js
@@ -24,9 +24,9 @@ import useSelected, {
 } from 'loot-design/src/components/useSelected';
 import { colors } from 'loot-design/src/style';
 
+import { ScheduleAmountCell } from './SchedulesTable';
 import { Page, usePageType } from '../Page';
 import DisplayId from '../util/DisplayId';
-import { ScheduleAmountCell } from './SchedulesTable';
 
 let ROW_HEIGHT = 43;
 

--- a/packages/desktop-client/src/components/schedules/LinkSchedule.js
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.js
@@ -5,8 +5,8 @@ import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
 import { Text } from 'loot-design/src/components/common';
 
-import { Page } from '../Page';
 import { SchedulesTable } from './SchedulesTable';
+import { Page } from '../Page';
 
 export default function ScheduleLink() {
   let location = useLocation();

--- a/packages/desktop-client/src/components/schedules/LinkSchedule.js
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.js
@@ -5,8 +5,9 @@ import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
 import { Text } from 'loot-design/src/components/common';
 
-import { SchedulesTable } from './SchedulesTable';
 import { Page } from '../Page';
+
+import { SchedulesTable } from './SchedulesTable';
 
 export default function ScheduleLink() {
   let location = useLocation();

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -22,8 +22,8 @@ import { colors } from 'loot-design/src/style';
 import DotsHorizontalTriple from 'loot-design/src/svg/v1/DotsHorizontalTriple';
 import Check from 'loot-design/src/svg/v2/Check';
 
-import DisplayId from '../util/DisplayId';
 import { StatusBadge } from './StatusBadge';
+import DisplayId from '../util/DisplayId';
 
 export let ROW_HEIGHT = 43;
 

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -22,8 +22,9 @@ import { colors } from 'loot-design/src/style';
 import DotsHorizontalTriple from 'loot-design/src/svg/v1/DotsHorizontalTriple';
 import Check from 'loot-design/src/svg/v2/Check';
 
-import { StatusBadge } from './StatusBadge';
 import DisplayId from '../util/DisplayId';
+
+import { StatusBadge } from './StatusBadge';
 
 export let ROW_HEIGHT = 43;
 

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -5,8 +5,8 @@ import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
 import { View, Button } from 'loot-design/src/components/common';
 
-import { Page } from '../Page';
 import { SchedulesTable, ROW_HEIGHT } from './SchedulesTable';
+import { Page } from '../Page';
 
 export default function Schedules() {
   let history = useHistory();

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -5,8 +5,9 @@ import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
 import { View, Button } from 'loot-design/src/components/common';
 
-import { SchedulesTable, ROW_HEIGHT } from './SchedulesTable';
 import { Page } from '../Page';
+
+import { SchedulesTable, ROW_HEIGHT } from './SchedulesTable';
 
 export default function Schedules() {
   let history = useHistory();

--- a/packages/desktop-client/src/components/settings/Encryption.js
+++ b/packages/desktop-client/src/components/settings/Encryption.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { Text, Button } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import { useServerURL } from '../../hooks/useServerURL';
 import { Setting } from './UI';
+import { useServerURL } from '../../hooks/useServerURL';
 
 export default function EncryptionSettings({ prefs, pushModal }) {
   const serverURL = useServerURL();

--- a/packages/desktop-client/src/components/settings/Encryption.js
+++ b/packages/desktop-client/src/components/settings/Encryption.js
@@ -3,8 +3,9 @@ import React from 'react';
 import { Text, Button } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
-import { Setting } from './UI';
 import { useServerURL } from '../../hooks/useServerURL';
+
+import { Setting } from './UI';
 
 export default function EncryptionSettings({ prefs, pushModal }) {
   const serverURL = useServerURL();

--- a/packages/desktop-client/src/components/settings/index.js
+++ b/packages/desktop-client/src/components/settings/index.js
@@ -12,9 +12,6 @@ import { colors } from 'loot-design/src/style';
 import tokens from 'loot-design/src/tokens';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
-import useServerVersion from '../../hooks/useServerVersion';
-import { isMobile } from '../../util';
-import { Page } from '../Page';
 import EncryptionSettings from './Encryption';
 import ExperimentalFeatures from './Experimental';
 import ExportBudget from './Export';
@@ -23,6 +20,9 @@ import FormatSettings from './Format';
 import GlobalSettings from './Global';
 import { ResetCache, ResetSync } from './Reset';
 import { Section, AdvancedToggle } from './UI';
+import useServerVersion from '../../hooks/useServerVersion';
+import { isMobile } from '../../util';
+import { Page } from '../Page';
 
 function About() {
   const version = useServerVersion();

--- a/packages/desktop-client/src/components/settings/index.js
+++ b/packages/desktop-client/src/components/settings/index.js
@@ -12,6 +12,10 @@ import { colors } from 'loot-design/src/style';
 import tokens from 'loot-design/src/tokens';
 import { withThemeColor } from 'loot-design/src/util/withThemeColor';
 
+import useServerVersion from '../../hooks/useServerVersion';
+import { isMobile } from '../../util';
+import { Page } from '../Page';
+
 import EncryptionSettings from './Encryption';
 import ExperimentalFeatures from './Experimental';
 import ExportBudget from './Export';
@@ -20,9 +24,6 @@ import FormatSettings from './Format';
 import GlobalSettings from './Global';
 import { ResetCache, ResetSync } from './Reset';
 import { Section, AdvancedToggle } from './UI';
-import useServerVersion from '../../hooks/useServerVersion';
-import { isMobile } from '../../util';
-import { Page } from '../Page';
 
 function About() {
   const version = useServerVersion();

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -47,7 +47,7 @@
     "cross-env": "^7.0.3",
     "date-fns": "2.0.0-alpha.27",
     "eslint": "5.6.0",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^3.1.4",
     "esm": "^3.0.82",
     "fake-indexeddb": "^3.1.3",

--- a/packages/loot-core/src/client/actions/account.js
+++ b/packages/loot-core/src/client/actions/account.js
@@ -1,7 +1,7 @@
-import { send } from '../../platform/client/fetch';
-import constants from '../constants';
 import { addNotification } from './notifications';
 import { getPayees, getAccounts } from './queries';
+import { send } from '../../platform/client/fetch';
+import constants from '../constants';
 
 export function setAccountsSyncing(name) {
   return {

--- a/packages/loot-core/src/client/actions/account.js
+++ b/packages/loot-core/src/client/actions/account.js
@@ -1,7 +1,8 @@
-import { addNotification } from './notifications';
-import { getPayees, getAccounts } from './queries';
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
+
+import { addNotification } from './notifications';
+import { getPayees, getAccounts } from './queries';
 
 export function setAccountsSyncing(name) {
   return {

--- a/packages/loot-core/src/client/actions/backups.js
+++ b/packages/loot-core/src/client/actions/backups.js
@@ -1,5 +1,6 @@
-import { closeBudget, loadBudget } from './budgets';
 import { send } from '../../platform/client/fetch';
+
+import { closeBudget, loadBudget } from './budgets';
 
 // Take in the budget id so that backups can be loaded when a budget
 // isn't opened

--- a/packages/loot-core/src/client/actions/backups.js
+++ b/packages/loot-core/src/client/actions/backups.js
@@ -1,5 +1,5 @@
-import { send } from '../../platform/client/fetch';
 import { closeBudget, loadBudget } from './budgets';
+import { send } from '../../platform/client/fetch';
 
 // Take in the budget id so that backups can be loaded when a budget
 // isn't opened

--- a/packages/loot-core/src/client/actions/budgets.js
+++ b/packages/loot-core/src/client/actions/budgets.js
@@ -1,10 +1,10 @@
-import { send } from '../../platform/client/fetch';
-import { getDownloadError } from '../../shared/errors';
-import constants from '../constants';
 import { setAppState } from './app';
 import { closeModal, pushModal } from './modals';
 import { loadPrefs, loadGlobalPrefs } from './prefs';
 import { startTutorialFirstTime } from './tutorial';
+import { send } from '../../platform/client/fetch';
+import { getDownloadError } from '../../shared/errors';
+import constants from '../constants';
 
 export function updateStatusText(text) {
   return (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/budgets.js
+++ b/packages/loot-core/src/client/actions/budgets.js
@@ -1,10 +1,11 @@
+import { send } from '../../platform/client/fetch';
+import { getDownloadError } from '../../shared/errors';
+import constants from '../constants';
+
 import { setAppState } from './app';
 import { closeModal, pushModal } from './modals';
 import { loadPrefs, loadGlobalPrefs } from './prefs';
 import { startTutorialFirstTime } from './tutorial';
-import { send } from '../../platform/client/fetch';
-import { getDownloadError } from '../../shared/errors';
-import constants from '../constants';
 
 export function updateStatusText(text) {
   return (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/prefs.js
+++ b/packages/loot-core/src/client/actions/prefs.js
@@ -1,6 +1,6 @@
+import { closeModal } from './modals';
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
-import { closeModal } from './modals';
 
 export function loadPrefs() {
   return async (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/prefs.js
+++ b/packages/loot-core/src/client/actions/prefs.js
@@ -1,6 +1,7 @@
-import { closeModal } from './modals';
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
+
+import { closeModal } from './modals';
 
 export function loadPrefs() {
   return async (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/queries.js
+++ b/packages/loot-core/src/client/actions/queries.js
@@ -1,9 +1,9 @@
 import throttle from 'throttleit';
 
-import { send } from '../../platform/client/fetch';
-import constants from '../constants';
 import { pushModal } from './modals';
 import { addNotification, addGenericErrorNotification } from './notifications';
+import { send } from '../../platform/client/fetch';
+import constants from '../constants';
 
 export function applyBudgetAction(month, type, args) {
   return async function () {

--- a/packages/loot-core/src/client/actions/queries.js
+++ b/packages/loot-core/src/client/actions/queries.js
@@ -1,9 +1,10 @@
 import throttle from 'throttleit';
 
-import { pushModal } from './modals';
-import { addNotification, addGenericErrorNotification } from './notifications';
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
+
+import { pushModal } from './modals';
+import { addNotification, addGenericErrorNotification } from './notifications';
 
 export function applyBudgetAction(month, type, args) {
   return async function () {

--- a/packages/loot-core/src/client/actions/sync.js
+++ b/packages/loot-core/src/client/actions/sync.js
@@ -1,9 +1,9 @@
-import { send } from '../../platform/client/fetch';
-import { getUploadError } from '../../shared/errors';
-import constants from '../constants';
 import { syncAccounts } from './account';
 import { pushModal } from './modals';
 import { loadPrefs } from './prefs';
+import { send } from '../../platform/client/fetch';
+import { getUploadError } from '../../shared/errors';
+import constants from '../constants';
 
 export function unregister() {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/sync.js
+++ b/packages/loot-core/src/client/actions/sync.js
@@ -1,9 +1,10 @@
-import { syncAccounts } from './account';
-import { pushModal } from './modals';
-import { loadPrefs } from './prefs';
 import { send } from '../../platform/client/fetch';
 import { getUploadError } from '../../shared/errors';
 import constants from '../constants';
+
+import { syncAccounts } from './account';
+import { pushModal } from './modals';
+import { loadPrefs } from './prefs';
 
 export function unregister() {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/transactions.js
+++ b/packages/loot-core/src/client/actions/transactions.js
@@ -1,5 +1,6 @@
-import { filterTransactions } from './queries';
 import { send } from '../../platform/client/fetch';
+
+import { filterTransactions } from './queries';
 
 export function categorize(accountId) {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/transactions.js
+++ b/packages/loot-core/src/client/actions/transactions.js
@@ -1,5 +1,5 @@
-import { send } from '../../platform/client/fetch';
 import { filterTransactions } from './queries';
+import { send } from '../../platform/client/fetch';
 
 export function categorize(accountId) {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/tutorial.js
+++ b/packages/loot-core/src/client/actions/tutorial.js
@@ -1,6 +1,7 @@
-import { pushModal } from './modals';
 import { send } from '../../platform/client/fetch';
 import Platform from '../platform';
+
+import { pushModal } from './modals';
 
 export function startTutorialFirstTime() {
   return (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/tutorial.js
+++ b/packages/loot-core/src/client/actions/tutorial.js
@@ -1,6 +1,6 @@
+import { pushModal } from './modals';
 import { send } from '../../platform/client/fetch';
 import Platform from '../platform';
-import { pushModal } from './modals';
 
 export function startTutorialFirstTime() {
   return (dispatch, getState) => {

--- a/packages/loot-core/src/client/actions/user.js
+++ b/packages/loot-core/src/client/actions/user.js
@@ -1,7 +1,7 @@
-import { send } from '../../platform/client/fetch';
-import constants from '../constants';
 import { loadAllFiles, closeBudget } from './budgets';
 import { loadGlobalPrefs } from './prefs';
+import { send } from '../../platform/client/fetch';
+import constants from '../constants';
 
 export function getUserData() {
   return async dispatch => {

--- a/packages/loot-core/src/client/actions/user.js
+++ b/packages/loot-core/src/client/actions/user.js
@@ -1,7 +1,8 @@
-import { loadAllFiles, closeBudget } from './budgets';
-import { loadGlobalPrefs } from './prefs';
 import { send } from '../../platform/client/fetch';
 import constants from '../constants';
+
+import { loadAllFiles, closeBudget } from './budgets';
+import { loadGlobalPrefs } from './prefs';
 
 export function getUserData() {
   return async dispatch => {

--- a/packages/loot-core/src/client/query-helpers.test.js
+++ b/packages/loot-core/src/client/query-helpers.test.js
@@ -1,8 +1,9 @@
-import { runQuery, liveQuery, pagedQuery } from './query-helpers';
 import { initServer, serverPush } from '../platform/client/fetch';
 import { subDays } from '../shared/months';
 import q from '../shared/query';
 import { tracer } from '../shared/test-helpers';
+
+import { runQuery, liveQuery, pagedQuery } from './query-helpers';
 
 function wait(n) {
   return new Promise(resolve => setTimeout(() => resolve(`wait(${n})`), n));

--- a/packages/loot-core/src/client/query-helpers.test.js
+++ b/packages/loot-core/src/client/query-helpers.test.js
@@ -1,8 +1,8 @@
+import { runQuery, liveQuery, pagedQuery } from './query-helpers';
 import { initServer, serverPush } from '../platform/client/fetch';
 import { subDays } from '../shared/months';
 import q from '../shared/query';
 import { tracer } from '../shared/test-helpers';
-import { runQuery, liveQuery, pagedQuery } from './query-helpers';
 
 function wait(n) {
   return new Promise(resolve => setTimeout(() => resolve(`wait(${n})`), n));

--- a/packages/loot-core/src/client/upgrade-notifications.js
+++ b/packages/loot-core/src/client/upgrade-notifications.js
@@ -1,5 +1,6 @@
-import Platform from './platform';
 import { send } from '../platform/client/fetch';
+
+import Platform from './platform';
 
 export default function checkForUpgradeNotifications(
   addNotification,

--- a/packages/loot-core/src/client/upgrade-notifications.js
+++ b/packages/loot-core/src/client/upgrade-notifications.js
@@ -1,5 +1,5 @@
-import { send } from '../platform/client/fetch';
 import Platform from './platform';
+import { send } from '../platform/client/fetch';
 
 export default function checkForUpgradeNotifications(
   addNotification,

--- a/packages/loot-core/src/platform/server/fs/index.web.js
+++ b/packages/loot-core/src/platform/server/fs/index.web.js
@@ -1,11 +1,11 @@
 let { SQLiteFS } = require('absurd-sql');
 let IndexedDBBackend = require('absurd-sql/dist/indexeddb-backend').default;
 
+let baseAPI = require('./index.electron.js');
+let join = require('./path-join');
 let connection = require('../connection');
 let idb = require('../indexeddb');
 let { _getModule } = require('../sqlite');
-let baseAPI = require('./index.electron.js');
-let join = require('./path-join');
 
 let FS = null;
 let BFS = null;

--- a/packages/loot-core/src/platform/server/fs/index.web.js
+++ b/packages/loot-core/src/platform/server/fs/index.web.js
@@ -1,11 +1,12 @@
 let { SQLiteFS } = require('absurd-sql');
 let IndexedDBBackend = require('absurd-sql/dist/indexeddb-backend').default;
 
-let baseAPI = require('./index.electron.js');
-let join = require('./path-join');
 let connection = require('../connection');
 let idb = require('../indexeddb');
 let { _getModule } = require('../sqlite');
+
+let baseAPI = require('./index.electron.js');
+let join = require('./path-join');
 
 let FS = null;
 let BFS = null;

--- a/packages/loot-core/src/server/accounts/link.js
+++ b/packages/loot-core/src/server/accounts/link.js
@@ -1,3 +1,4 @@
+import * as bankSync from './sync';
 import asyncStorage from '../../platform/server/asyncStorage';
 import { fromPlaidAccountType } from '../../shared/accounts';
 import { amountToInteger } from '../../shared/util';
@@ -5,7 +6,6 @@ import * as db from '../db';
 import { runMutator } from '../mutators';
 import { post } from '../post';
 import { getServer } from '../server-config';
-import * as bankSync from './sync';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/accounts/link.js
+++ b/packages/loot-core/src/server/accounts/link.js
@@ -1,4 +1,3 @@
-import * as bankSync from './sync';
 import asyncStorage from '../../platform/server/asyncStorage';
 import { fromPlaidAccountType } from '../../shared/accounts';
 import { amountToInteger } from '../../shared/util';
@@ -6,6 +5,8 @@ import * as db from '../db';
 import { runMutator } from '../mutators';
 import { post } from '../post';
 import { getServer } from '../server-config';
+
+import * as bankSync from './sync';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/accounts/parse-file.js
+++ b/packages/loot-core/src/server/accounts/parse-file.js
@@ -1,9 +1,9 @@
 import csv2json from 'csv-parse/lib/sync';
 
+import qif2json from './qif2json';
 import fs from '../../platform/server/fs';
 import { dayFromDate } from '../../shared/months';
 import { looselyParseAmount } from '../../shared/util';
-import qif2json from './qif2json';
 
 export function parseFile(filepath, options) {
   let errors = [];

--- a/packages/loot-core/src/server/accounts/parse-file.js
+++ b/packages/loot-core/src/server/accounts/parse-file.js
@@ -1,9 +1,10 @@
 import csv2json from 'csv-parse/lib/sync';
 
-import qif2json from './qif2json';
 import fs from '../../platform/server/fs';
 import { dayFromDate } from '../../shared/months';
 import { looselyParseAmount } from '../../shared/util';
+
+import qif2json from './qif2json';
 
 export function parseFile(filepath, options) {
   let errors = [];

--- a/packages/loot-core/src/server/accounts/parse-file.test.js
+++ b/packages/loot-core/src/server/accounts/parse-file.test.js
@@ -1,10 +1,10 @@
 import * as d from 'date-fns';
 
+import { parseFile } from './parse-file';
+import { reconcileTransactions } from './sync';
 import { amountToInteger } from '../../shared/util';
 import * as db from '../db';
 import * as prefs from '../prefs';
-import { parseFile } from './parse-file';
-import { reconcileTransactions } from './sync';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/accounts/parse-file.test.js
+++ b/packages/loot-core/src/server/accounts/parse-file.test.js
@@ -1,10 +1,11 @@
 import * as d from 'date-fns';
 
-import { parseFile } from './parse-file';
-import { reconcileTransactions } from './sync';
 import { amountToInteger } from '../../shared/util';
 import * as db from '../db';
 import * as prefs from '../prefs';
+
+import { parseFile } from './parse-file';
+import { reconcileTransactions } from './sync';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -1,3 +1,7 @@
+import { getStartingBalancePayee } from './payees';
+import title from './title';
+import { runRules } from './transaction-rules';
+import { batchUpdateTransactions } from './transactions';
 import * as monthUtils from '../../shared/months';
 import {
   makeChild as makeChildTransaction,
@@ -8,10 +12,6 @@ import * as db from '../db';
 import { runMutator } from '../mutators';
 import { getServer } from '../server-config';
 import { batchMessages } from '../sync';
-import { getStartingBalancePayee } from './payees';
-import title from './title';
-import { runRules } from './transaction-rules';
-import { batchUpdateTransactions } from './transactions';
 
 const dateFns = require('date-fns');
 

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -1,7 +1,3 @@
-import { getStartingBalancePayee } from './payees';
-import title from './title';
-import { runRules } from './transaction-rules';
-import { batchUpdateTransactions } from './transactions';
 import * as monthUtils from '../../shared/months';
 import {
   makeChild as makeChildTransaction,
@@ -12,6 +8,11 @@ import * as db from '../db';
 import { runMutator } from '../mutators';
 import { getServer } from '../server-config';
 import { batchMessages } from '../sync';
+
+import { getStartingBalancePayee } from './payees';
+import title from './title';
+import { runRules } from './transaction-rules';
+import { batchUpdateTransactions } from './transactions';
 
 const dateFns = require('date-fns');
 

--- a/packages/loot-core/src/server/accounts/sync.test.js
+++ b/packages/loot-core/src/server/accounts/sync.test.js
@@ -1,7 +1,3 @@
-import * as monthUtils from '../../shared/months';
-import * as db from '../db';
-import { loadMappings } from '../db/mappings';
-import { getServer } from '../server-config';
 import {
   syncAccount,
   reconcileTransactions,
@@ -10,6 +6,10 @@ import {
 } from './sync';
 import { loadRules, insertRule } from './transaction-rules';
 import * as transfer from './transfer';
+import * as monthUtils from '../../shared/months';
+import * as db from '../db';
+import { loadMappings } from '../db/mappings';
+import { getServer } from '../server-config';
 
 const snapshotDiff = require('snapshot-diff');
 

--- a/packages/loot-core/src/server/accounts/sync.test.js
+++ b/packages/loot-core/src/server/accounts/sync.test.js
@@ -1,3 +1,8 @@
+import * as monthUtils from '../../shared/months';
+import * as db from '../db';
+import { loadMappings } from '../db/mappings';
+import { getServer } from '../server-config';
+
 import {
   syncAccount,
   reconcileTransactions,
@@ -6,10 +11,6 @@ import {
 } from './sync';
 import { loadRules, insertRule } from './transaction-rules';
 import * as transfer from './transfer';
-import * as monthUtils from '../../shared/months';
-import * as db from '../db';
-import { loadMappings } from '../db/mappings';
-import { getServer } from '../server-config';
 
 const snapshotDiff = require('snapshot-diff');
 

--- a/packages/loot-core/src/server/accounts/transaction-rules.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.js
@@ -1,13 +1,4 @@
 import {
-  Condition,
-  Action,
-  Rule,
-  RuleIndexer,
-  rankRules,
-  migrateIds,
-  iterateIds
-} from './rules';
-import {
   currentDay,
   addDays,
   subDays,
@@ -27,6 +18,16 @@ import { RuleError } from '../errors';
 import { requiredFields, toDateRepr } from '../models';
 import { setSyncingMode, batchMessages } from '../sync';
 import { addSyncListener } from '../sync/index';
+
+import {
+  Condition,
+  Action,
+  Rule,
+  RuleIndexer,
+  rankRules,
+  migrateIds,
+  iterateIds
+} from './rules';
 
 // TODO: Detect if it looks like the user is creating a rename rule
 // and prompt to create it in the pre phase instead

--- a/packages/loot-core/src/server/accounts/transaction-rules.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.js
@@ -1,4 +1,13 @@
 import {
+  Condition,
+  Action,
+  Rule,
+  RuleIndexer,
+  rankRules,
+  migrateIds,
+  iterateIds
+} from './rules';
+import {
   currentDay,
   addDays,
   subDays,
@@ -18,15 +27,6 @@ import { RuleError } from '../errors';
 import { requiredFields, toDateRepr } from '../models';
 import { setSyncingMode, batchMessages } from '../sync';
 import { addSyncListener } from '../sync/index';
-import {
-  Condition,
-  Action,
-  Rule,
-  RuleIndexer,
-  rankRules,
-  migrateIds,
-  iterateIds
-} from './rules';
 
 // TODO: Detect if it looks like the user is creating a rename rule
 // and prompt to create it in the pre phase instead

--- a/packages/loot-core/src/server/accounts/transaction-rules.test.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.test.js
@@ -1,7 +1,3 @@
-import q from '../../shared/query';
-import { runQuery } from '../aql';
-import * as db from '../db';
-import { loadMappings } from '../db/mappings';
 import {
   getRules,
   loadRules,
@@ -16,6 +12,10 @@ import {
   updateCategoryRules,
   migrateOldRules
 } from './transaction-rules';
+import q from '../../shared/query';
+import { runQuery } from '../aql';
+import * as db from '../db';
+import { loadMappings } from '../db/mappings';
 
 // TODO: write tests to make sure payee renaming is "pre" and category
 // setting is "null" stage

--- a/packages/loot-core/src/server/accounts/transaction-rules.test.js
+++ b/packages/loot-core/src/server/accounts/transaction-rules.test.js
@@ -1,3 +1,8 @@
+import q from '../../shared/query';
+import { runQuery } from '../aql';
+import * as db from '../db';
+import { loadMappings } from '../db/mappings';
+
 import {
   getRules,
   loadRules,
@@ -12,10 +17,6 @@ import {
   updateCategoryRules,
   migrateOldRules
 } from './transaction-rules';
-import q from '../../shared/query';
-import { runQuery } from '../aql';
-import * as db from '../db';
-import { loadMappings } from '../db/mappings';
 
 // TODO: write tests to make sure payee renaming is "pre" and category
 // setting is "null" stage

--- a/packages/loot-core/src/server/accounts/transactions.js
+++ b/packages/loot-core/src/server/accounts/transactions.js
@@ -1,8 +1,8 @@
+import * as rules from './transaction-rules';
+import * as transfer from './transfer';
 import * as db from '../db';
 import { incrFetch, whereIn } from '../db/util';
 import { batchMessages } from '../sync';
-import * as rules from './transaction-rules';
-import * as transfer from './transfer';
 
 const connection = require('../../platform/server/connection');
 

--- a/packages/loot-core/src/server/accounts/transactions.js
+++ b/packages/loot-core/src/server/accounts/transactions.js
@@ -1,8 +1,9 @@
-import * as rules from './transaction-rules';
-import * as transfer from './transfer';
 import * as db from '../db';
 import { incrFetch, whereIn } from '../db/util';
 import { batchMessages } from '../sync';
+
+import * as rules from './transaction-rules';
+import * as transfer from './transfer';
 
 const connection = require('../../platform/server/connection');
 

--- a/packages/loot-core/src/server/accounts/transfer.test.js
+++ b/packages/loot-core/src/server/accounts/transfer.test.js
@@ -1,6 +1,7 @@
-import * as transfer from './transfer';
 import { expectSnapshotWithDiffer } from '../../mocks/util';
 import * as db from '../db';
+
+import * as transfer from './transfer';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/accounts/transfer.test.js
+++ b/packages/loot-core/src/server/accounts/transfer.test.js
@@ -1,6 +1,6 @@
+import * as transfer from './transfer';
 import { expectSnapshotWithDiffer } from '../../mocks/util';
 import * as db from '../db';
-import * as transfer from './transfer';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/api.js
+++ b/packages/loot-core/src/server/api.js
@@ -1,11 +1,3 @@
-import * as monthUtils from '../shared/months';
-import q from '../shared/query';
-import {
-  ungroupTransactions,
-  updateTransaction,
-  deleteTransaction
-} from '../shared/transactions';
-import { integerToAmount } from '../shared/util';
 import { addTransactions } from './accounts/sync';
 import {
   accountModel,
@@ -22,6 +14,14 @@ import { runMutator } from './mutators';
 import * as prefs from './prefs';
 import * as sheet from './sheet';
 import { setSyncingMode, batchMessages } from './sync';
+import * as monthUtils from '../shared/months';
+import q from '../shared/query';
+import {
+  ungroupTransactions,
+  updateTransaction,
+  deleteTransaction
+} from '../shared/transactions';
+import { integerToAmount } from '../shared/util';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-core/src/server/api.js
+++ b/packages/loot-core/src/server/api.js
@@ -1,3 +1,12 @@
+import * as monthUtils from '../shared/months';
+import q from '../shared/query';
+import {
+  ungroupTransactions,
+  updateTransaction,
+  deleteTransaction
+} from '../shared/transactions';
+import { integerToAmount } from '../shared/util';
+
 import { addTransactions } from './accounts/sync';
 import {
   accountModel,
@@ -14,14 +23,6 @@ import { runMutator } from './mutators';
 import * as prefs from './prefs';
 import * as sheet from './sheet';
 import { setSyncingMode, batchMessages } from './sync';
-import * as monthUtils from '../shared/months';
-import q from '../shared/query';
-import {
-  ungroupTransactions,
-  updateTransaction,
-  deleteTransaction
-} from '../shared/transactions';
-import { integerToAmount } from '../shared/util';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-core/src/server/aql/compiler.test.js
+++ b/packages/loot-core/src/server/aql/compiler.test.js
@@ -1,5 +1,5 @@
-import query from '../../shared/query';
 import { generateSQLWithState } from './compiler';
+import query from '../../shared/query';
 
 function sqlLines(str) {
   return str

--- a/packages/loot-core/src/server/aql/compiler.test.js
+++ b/packages/loot-core/src/server/aql/compiler.test.js
@@ -1,5 +1,6 @@
-import { generateSQLWithState } from './compiler';
 import query from '../../shared/query';
+
+import { generateSQLWithState } from './compiler';
 
 function sqlLines(str) {
   return str

--- a/packages/loot-core/src/server/aql/exec.js
+++ b/packages/loot-core/src/server/aql/exec.js
@@ -1,6 +1,7 @@
+import * as db from '../db';
+
 import { compileQuery, defaultConstructQuery } from './compiler';
 import { convertInputType, convertOutputType } from './schema-helpers';
-import * as db from '../db';
 
 // TODO (compiler):
 // * Properly safeguard all inputs against SQL injection

--- a/packages/loot-core/src/server/aql/exec.js
+++ b/packages/loot-core/src/server/aql/exec.js
@@ -1,6 +1,6 @@
-import * as db from '../db';
 import { compileQuery, defaultConstructQuery } from './compiler';
 import { convertInputType, convertOutputType } from './schema-helpers';
+import * as db from '../db';
 
 // TODO (compiler):
 // * Properly safeguard all inputs against SQL injection

--- a/packages/loot-core/src/server/aql/exec.test.js
+++ b/packages/loot-core/src/server/aql/exec.test.js
@@ -1,8 +1,9 @@
-import * as aql from './exec';
-import { schema, schemaConfig } from './schema';
 import query from '../../shared/query';
 import { makeChild } from '../../shared/transactions';
 import * as db from '../db';
+
+import * as aql from './exec';
+import { schema, schemaConfig } from './schema';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/aql/exec.test.js
+++ b/packages/loot-core/src/server/aql/exec.test.js
@@ -1,8 +1,8 @@
+import * as aql from './exec';
+import { schema, schemaConfig } from './schema';
 import query from '../../shared/query';
 import { makeChild } from '../../shared/transactions';
 import * as db from '../db';
-import * as aql from './exec';
-import { schema, schemaConfig } from './schema';
 
 const uuid = require('../../platform/uuid');
 

--- a/packages/loot-core/src/server/aql/schema/executors.test.js
+++ b/packages/loot-core/src/server/aql/schema/executors.test.js
@@ -1,13 +1,14 @@
 import fc from 'fast-check';
 
-import { isHappyPathQuery } from './executors';
-import { runQuery } from './run-query';
 import arbs from '../../../mocks/arbitrary-schema';
 import query from '../../../shared/query';
 import { groupById } from '../../../shared/util';
 import { setClock } from '../../crdt';
 import * as db from '../../db';
 import { batchMessages, setSyncingMode } from '../../sync/index';
+
+import { isHappyPathQuery } from './executors';
+import { runQuery } from './run-query';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/aql/schema/executors.test.js
+++ b/packages/loot-core/src/server/aql/schema/executors.test.js
@@ -1,13 +1,13 @@
 import fc from 'fast-check';
 
+import { isHappyPathQuery } from './executors';
+import { runQuery } from './run-query';
 import arbs from '../../../mocks/arbitrary-schema';
 import query from '../../../shared/query';
 import { groupById } from '../../../shared/util';
 import { setClock } from '../../crdt';
 import * as db from '../../db';
 import { batchMessages, setSyncingMode } from '../../sync/index';
-import { isHappyPathQuery } from './executors';
-import { runQuery } from './run-query';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/aql/schema/run-query.js
+++ b/packages/loot-core/src/server/aql/schema/run-query.js
@@ -1,9 +1,10 @@
-import schemaExecutors from './executors';
 import { Query } from '../../../shared/query';
 import {
   runQuery as _runQuery,
   runCompiledQuery as _runCompiledQuery
 } from '../exec';
+
+import schemaExecutors from './executors';
 
 import { schema, schemaConfig } from './index';
 

--- a/packages/loot-core/src/server/aql/schema/run-query.js
+++ b/packages/loot-core/src/server/aql/schema/run-query.js
@@ -1,9 +1,9 @@
+import schemaExecutors from './executors';
 import { Query } from '../../../shared/query';
 import {
   runQuery as _runQuery,
   runCompiledQuery as _runCompiledQuery
 } from '../exec';
-import schemaExecutors from './executors';
 
 import { schema, schemaConfig } from './index';
 

--- a/packages/loot-core/src/server/aql/views.test.js
+++ b/packages/loot-core/src/server/aql/views.test.js
@@ -1,5 +1,6 @@
-import { makeViews } from './views';
 import * as db from '../db';
+
+import { makeViews } from './views';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/aql/views.test.js
+++ b/packages/loot-core/src/server/aql/views.test.js
@@ -1,5 +1,5 @@
-import * as db from '../db';
 import { makeViews } from './views';
+import * as db from '../db';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/backups.js
+++ b/packages/loot-core/src/server/backups.js
@@ -1,8 +1,8 @@
+import * as cloudStorage from './cloud-storage';
+import * as prefs from './prefs';
 import fs from '../platform/server/fs';
 import * as sqlite from '../platform/server/sqlite';
 import * as monthUtils from '../shared/months';
-import * as cloudStorage from './cloud-storage';
-import * as prefs from './prefs';
 
 const dateFns = require('date-fns');
 

--- a/packages/loot-core/src/server/backups.js
+++ b/packages/loot-core/src/server/backups.js
@@ -1,8 +1,9 @@
-import * as cloudStorage from './cloud-storage';
-import * as prefs from './prefs';
 import fs from '../platform/server/fs';
 import * as sqlite from '../platform/server/sqlite';
 import * as monthUtils from '../shared/months';
+
+import * as cloudStorage from './cloud-storage';
+import * as prefs from './prefs';
 
 const dateFns = require('date-fns');
 

--- a/packages/loot-core/src/server/budget/app.js
+++ b/packages/loot-core/src/server/budget/app.js
@@ -1,7 +1,7 @@
+import * as actions from './actions';
 import { createApp } from '../app';
 import { mutator } from '../mutators';
 import { undoable } from '../undo';
-import * as actions from './actions';
 
 let app = createApp();
 

--- a/packages/loot-core/src/server/budget/app.js
+++ b/packages/loot-core/src/server/budget/app.js
@@ -1,7 +1,8 @@
-import * as actions from './actions';
 import { createApp } from '../app';
 import { mutator } from '../mutators';
 import { undoable } from '../undo';
+
+import * as actions from './actions';
 
 let app = createApp();
 

--- a/packages/loot-core/src/server/budget/base.js
+++ b/packages/loot-core/src/server/budget/base.js
@@ -1,12 +1,12 @@
+import * as budgetActions from './actions';
+import * as report from './report';
+import * as rollover from './rollover';
+import { sumAmounts } from './util';
 import * as monthUtils from '../../shared/months';
 import { getChangedValues } from '../../shared/util';
 import * as db from '../db';
 import * as sheet from '../sheet';
 import { resolveName } from '../spreadsheet/util';
-import * as budgetActions from './actions';
-import * as report from './report';
-import * as rollover from './rollover';
-import { sumAmounts } from './util';
 
 export function getBudgetType() {
   let meta = sheet.get().meta();

--- a/packages/loot-core/src/server/budget/base.js
+++ b/packages/loot-core/src/server/budget/base.js
@@ -1,12 +1,13 @@
-import * as budgetActions from './actions';
-import * as report from './report';
-import * as rollover from './rollover';
-import { sumAmounts } from './util';
 import * as monthUtils from '../../shared/months';
 import { getChangedValues } from '../../shared/util';
 import * as db from '../db';
 import * as sheet from '../sheet';
 import { resolveName } from '../spreadsheet/util';
+
+import * as budgetActions from './actions';
+import * as report from './report';
+import * as rollover from './rollover';
+import { sumAmounts } from './util';
 
 export function getBudgetType() {
   let meta = sheet.get().meta();

--- a/packages/loot-core/src/server/budget/base.test.js
+++ b/packages/loot-core/src/server/budget/base.test.js
@@ -1,7 +1,8 @@
-import { createAllBudgets } from './base';
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 import * as sheet from '../sheet';
+
+import { createAllBudgets } from './base';
 
 beforeEach(() => {
   return global.emptyDatabase()();

--- a/packages/loot-core/src/server/budget/base.test.js
+++ b/packages/loot-core/src/server/budget/base.test.js
@@ -1,7 +1,7 @@
+import { createAllBudgets } from './base';
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 import * as sheet from '../sheet';
-import { createAllBudgets } from './base';
 
 beforeEach(() => {
   return global.emptyDatabase()();

--- a/packages/loot-core/src/server/budget/report.js
+++ b/packages/loot-core/src/server/budget/report.js
@@ -1,6 +1,7 @@
-import { number, sumAmounts } from './util';
 import { safeNumber } from '../../shared/util';
 import * as sheet from '../sheet';
+
+import { number, sumAmounts } from './util';
 
 const { resolveName } = require('../spreadsheet/util');
 

--- a/packages/loot-core/src/server/budget/report.js
+++ b/packages/loot-core/src/server/budget/report.js
@@ -1,6 +1,6 @@
+import { number, sumAmounts } from './util';
 import { safeNumber } from '../../shared/util';
 import * as sheet from '../sheet';
-import { number, sumAmounts } from './util';
 
 const { resolveName } = require('../spreadsheet/util');
 

--- a/packages/loot-core/src/server/budget/rollover.js
+++ b/packages/loot-core/src/server/budget/rollover.js
@@ -1,7 +1,8 @@
-import { number, sumAmounts, flatten2, unflatten2 } from './util';
 import * as monthUtils from '../../shared/months';
 import { safeNumber } from '../../shared/util';
 import * as sheet from '../sheet';
+
+import { number, sumAmounts, flatten2, unflatten2 } from './util';
 
 const { resolveName } = require('../spreadsheet/util');
 

--- a/packages/loot-core/src/server/budget/rollover.js
+++ b/packages/loot-core/src/server/budget/rollover.js
@@ -1,7 +1,7 @@
+import { number, sumAmounts, flatten2, unflatten2 } from './util';
 import * as monthUtils from '../../shared/months';
 import { safeNumber } from '../../shared/util';
 import * as sheet from '../sheet';
-import { number, sumAmounts, flatten2, unflatten2 } from './util';
 
 const { resolveName } = require('../spreadsheet/util');
 

--- a/packages/loot-core/src/server/cloud-storage.js
+++ b/packages/loot-core/src/server/cloud-storage.js
@@ -1,3 +1,9 @@
+import asyncStorage from '../platform/server/asyncStorage';
+import { fetch } from '../platform/server/fetch';
+import fs from '../platform/server/fs';
+import * as sqlite from '../platform/server/sqlite';
+import * as monthUtils from '../shared/months';
+
 import encryption from './encryption';
 import {
   HTTPError,
@@ -9,11 +15,6 @@ import { runMutator } from './mutators';
 import { post } from './post';
 import * as prefs from './prefs';
 import { getServer } from './server-config';
-import asyncStorage from '../platform/server/asyncStorage';
-import { fetch } from '../platform/server/fetch';
-import fs from '../platform/server/fs';
-import * as sqlite from '../platform/server/sqlite';
-import * as monthUtils from '../shared/months';
 
 let AdmZip = require('adm-zip');
 

--- a/packages/loot-core/src/server/cloud-storage.js
+++ b/packages/loot-core/src/server/cloud-storage.js
@@ -1,8 +1,3 @@
-import asyncStorage from '../platform/server/asyncStorage';
-import { fetch } from '../platform/server/fetch';
-import fs from '../platform/server/fs';
-import * as sqlite from '../platform/server/sqlite';
-import * as monthUtils from '../shared/months';
 import encryption from './encryption';
 import {
   HTTPError,
@@ -14,6 +9,11 @@ import { runMutator } from './mutators';
 import { post } from './post';
 import * as prefs from './prefs';
 import { getServer } from './server-config';
+import asyncStorage from '../platform/server/asyncStorage';
+import { fetch } from '../platform/server/fetch';
+import fs from '../platform/server/fs';
+import * as sqlite from '../platform/server/sqlite';
+import * as monthUtils from '../shared/months';
 
 let AdmZip = require('adm-zip');
 

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -1,5 +1,6 @@
 import LRU from 'lru-cache';
 
+import { shoveSortOrders, SORT_INCREMENT } from './sort';
 import fs from '../../platform/server/fs';
 import * as sqlite from '../../platform/server/sqlite';
 import { groupById } from '../../shared/util';
@@ -26,7 +27,6 @@ import {
   payeeRuleModel
 } from '../models';
 import { sendMessages, batchMessages } from '../sync';
-import { shoveSortOrders, SORT_INCREMENT } from './sort';
 
 export { toDateRepr, fromDateRepr } from '../models';
 

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -1,6 +1,5 @@
 import LRU from 'lru-cache';
 
-import { shoveSortOrders, SORT_INCREMENT } from './sort';
 import fs from '../../platform/server/fs';
 import * as sqlite from '../../platform/server/sqlite';
 import { groupById } from '../../shared/util';
@@ -27,6 +26,8 @@ import {
   payeeRuleModel
 } from '../models';
 import { sendMessages, batchMessages } from '../sync';
+
+import { shoveSortOrders, SORT_INCREMENT } from './sort';
 
 export { toDateRepr, fromDateRepr } from '../models';
 

--- a/packages/loot-core/src/server/main.js
+++ b/packages/loot-core/src/server/main.js
@@ -1,6 +1,18 @@
 import './polyfills';
 import injectAPI from '@actual-app/api/injected';
 
+import { createTestBudget } from '../mocks/budget';
+import { captureException, captureBreadcrumb } from '../platform/exceptions';
+import asyncStorage from '../platform/server/asyncStorage';
+import fs from '../platform/server/fs';
+import logger from '../platform/server/log';
+import * as sqlite from '../platform/server/sqlite';
+import { fromPlaidAccountType } from '../shared/accounts';
+import * as monthUtils from '../shared/months';
+import q, { Query } from '../shared/query';
+import { FIELD_TYPES as ruleFieldTypes } from '../shared/rules';
+import { amountToInteger, stringToInteger } from '../shared/util';
+
 import { exportToCSV, exportQueryToCSV } from './accounts/export-to-csv';
 import * as link from './accounts/link';
 import { parseFile } from './accounts/parse-file';
@@ -60,25 +72,15 @@ import toolsApp from './tools/app';
 import { withUndo, clearUndo, undo, redo } from './undo';
 import { updateVersion } from './update';
 import { uniqueFileName, idFromFileName } from './util/budget-name';
-import { createTestBudget } from '../mocks/budget';
-import { captureException, captureBreadcrumb } from '../platform/exceptions';
-import asyncStorage from '../platform/server/asyncStorage';
-import fs from '../platform/server/fs';
-import logger from '../platform/server/log';
-import * as sqlite from '../platform/server/sqlite';
-import { fromPlaidAccountType } from '../shared/accounts';
-import * as monthUtils from '../shared/months';
-import q, { Query } from '../shared/query';
-import { FIELD_TYPES as ruleFieldTypes } from '../shared/rules';
-import { amountToInteger, stringToInteger } from '../shared/util';
 
 const YNAB4 = require('@actual-app/import-ynab4/importer');
 const YNAB5 = require('@actual-app/import-ynab5/importer');
 
-const { resolveName, unresolveName } = require('./spreadsheet/util');
-const SyncPb = require('./sync/proto/sync_pb');
 const connection = require('../platform/server/connection');
 const uuid = require('../platform/uuid');
+
+const { resolveName, unresolveName } = require('./spreadsheet/util');
+const SyncPb = require('./sync/proto/sync_pb');
 
 // let indexeddb = require('../platform/server/indexeddb');
 

--- a/packages/loot-core/src/server/main.js
+++ b/packages/loot-core/src/server/main.js
@@ -1,17 +1,6 @@
 import './polyfills';
 import injectAPI from '@actual-app/api/injected';
 
-import { createTestBudget } from '../mocks/budget';
-import { captureException, captureBreadcrumb } from '../platform/exceptions';
-import asyncStorage from '../platform/server/asyncStorage';
-import fs from '../platform/server/fs';
-import logger from '../platform/server/log';
-import * as sqlite from '../platform/server/sqlite';
-import { fromPlaidAccountType } from '../shared/accounts';
-import * as monthUtils from '../shared/months';
-import q, { Query } from '../shared/query';
-import { FIELD_TYPES as ruleFieldTypes } from '../shared/rules';
-import { amountToInteger, stringToInteger } from '../shared/util';
 import { exportToCSV, exportQueryToCSV } from './accounts/export-to-csv';
 import * as link from './accounts/link';
 import { parseFile } from './accounts/parse-file';
@@ -71,14 +60,25 @@ import toolsApp from './tools/app';
 import { withUndo, clearUndo, undo, redo } from './undo';
 import { updateVersion } from './update';
 import { uniqueFileName, idFromFileName } from './util/budget-name';
+import { createTestBudget } from '../mocks/budget';
+import { captureException, captureBreadcrumb } from '../platform/exceptions';
+import asyncStorage from '../platform/server/asyncStorage';
+import fs from '../platform/server/fs';
+import logger from '../platform/server/log';
+import * as sqlite from '../platform/server/sqlite';
+import { fromPlaidAccountType } from '../shared/accounts';
+import * as monthUtils from '../shared/months';
+import q, { Query } from '../shared/query';
+import { FIELD_TYPES as ruleFieldTypes } from '../shared/rules';
+import { amountToInteger, stringToInteger } from '../shared/util';
 
 const YNAB4 = require('@actual-app/import-ynab4/importer');
 const YNAB5 = require('@actual-app/import-ynab5/importer');
 
-const connection = require('../platform/server/connection');
-const uuid = require('../platform/uuid');
 const { resolveName, unresolveName } = require('./spreadsheet/util');
 const SyncPb = require('./sync/proto/sync_pb');
+const connection = require('../platform/server/connection');
+const uuid = require('../platform/uuid');
 
 // let indexeddb = require('../platform/server/indexeddb');
 

--- a/packages/loot-core/src/server/main.test.js
+++ b/packages/loot-core/src/server/main.test.js
@@ -1,3 +1,6 @@
+import { expectSnapshotWithDiffer } from '../mocks/util';
+import * as monthUtils from '../shared/months';
+
 import * as budgetActions from './budget/actions';
 import * as budget from './budget/base';
 import { getClock, deserializeClock } from './crdt';
@@ -9,16 +12,15 @@ import {
   enableGlobalMutations
 } from './mutators';
 import * as prefs from './prefs';
-import { expectSnapshotWithDiffer } from '../mocks/util';
-import * as monthUtils from '../shared/months';
 
 jest.mock('./post');
+const connection = require('../platform/server/connection');
+const fs = require('../platform/server/fs');
+
 const backend = require('./main');
 const { post } = require('./post');
 const handlers = backend.handlers;
 const sheet = require('./sheet');
-const connection = require('../platform/server/connection');
-const fs = require('../platform/server/fs');
 
 beforeEach(async () => {
   await global.emptyDatabase()();

--- a/packages/loot-core/src/server/main.test.js
+++ b/packages/loot-core/src/server/main.test.js
@@ -1,5 +1,3 @@
-import { expectSnapshotWithDiffer } from '../mocks/util';
-import * as monthUtils from '../shared/months';
 import * as budgetActions from './budget/actions';
 import * as budget from './budget/base';
 import { getClock, deserializeClock } from './crdt';
@@ -11,14 +9,16 @@ import {
   enableGlobalMutations
 } from './mutators';
 import * as prefs from './prefs';
+import { expectSnapshotWithDiffer } from '../mocks/util';
+import * as monthUtils from '../shared/months';
 
 jest.mock('./post');
-const connection = require('../platform/server/connection');
-const fs = require('../platform/server/fs');
 const backend = require('./main');
 const { post } = require('./post');
 const handlers = backend.handlers;
 const sheet = require('./sheet');
+const connection = require('../platform/server/connection');
+const fs = require('../platform/server/fs');
 
 beforeEach(async () => {
   await global.emptyDatabase()();

--- a/packages/loot-core/src/server/migrate/cli.js
+++ b/packages/loot-core/src/server/migrate/cli.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node --trace-warnings
+import * as sqlite from '../../platform/server/sqlite';
+
 import {
   getMigrationsDir,
   withMigrationsDir,
@@ -8,7 +10,6 @@ import {
   getPending,
   migrate
 } from './migrations';
-import * as sqlite from '../../platform/server/sqlite';
 
 const fs = require('fs');
 const path = require('path');

--- a/packages/loot-core/src/server/migrate/cli.js
+++ b/packages/loot-core/src/server/migrate/cli.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node --trace-warnings
-import * as sqlite from '../../platform/server/sqlite';
 import {
   getMigrationsDir,
   withMigrationsDir,
@@ -9,6 +8,7 @@ import {
   getPending,
   migrate
 } from './migrations';
+import * as sqlite from '../../platform/server/sqlite';
 
 const fs = require('fs');
 const path = require('path');

--- a/packages/loot-core/src/server/migrate/migrations.test.js
+++ b/packages/loot-core/src/server/migrate/migrations.test.js
@@ -1,4 +1,3 @@
-import * as db from '../db';
 import {
   migrate,
   withMigrationsDir,
@@ -6,6 +5,7 @@ import {
   getMigrationList,
   getPending
 } from './migrations';
+import * as db from '../db';
 
 beforeEach(global.emptyDatabase(true));
 

--- a/packages/loot-core/src/server/migrate/migrations.test.js
+++ b/packages/loot-core/src/server/migrate/migrations.test.js
@@ -1,3 +1,5 @@
+import * as db from '../db';
+
 import {
   migrate,
   withMigrationsDir,
@@ -5,7 +7,6 @@ import {
   getMigrationList,
   getPending
 } from './migrations';
-import * as db from '../db';
 
 beforeEach(global.emptyDatabase(true));
 

--- a/packages/loot-core/src/server/post.js
+++ b/packages/loot-core/src/server/post.js
@@ -1,7 +1,8 @@
 import Platform from './platform';
 
-const { PostError } = require('./errors');
 const { fetch } = require('../platform/server/fetch');
+
+const { PostError } = require('./errors');
 
 function throwIfNot200(res, text) {
   if (res.status !== 200) {

--- a/packages/loot-core/src/server/post.js
+++ b/packages/loot-core/src/server/post.js
@@ -1,7 +1,7 @@
 import Platform from './platform';
 
-const { fetch } = require('../platform/server/fetch');
 const { PostError } = require('./errors');
+const { fetch } = require('../platform/server/fetch');
 
 function throwIfNot200(res, text) {
   if (res.status !== 200) {

--- a/packages/loot-core/src/server/schedules/app.js
+++ b/packages/loot-core/src/server/schedules/app.js
@@ -1,6 +1,7 @@
 import * as d from 'date-fns';
 import deepEqual from 'deep-equal';
 
+import { findSchedules } from './find-schedules';
 import { captureBreadcrumb } from '../../platform/exceptions';
 import { dayFromDate, currentDay, parseDate } from '../../shared/months';
 import q from '../../shared/query';
@@ -28,7 +29,6 @@ import * as prefs from '../prefs';
 import { addSyncListener, batchMessages } from '../sync';
 import { undoable } from '../undo';
 import { Schedule as RSchedule } from '../util/rschedule';
-import { findSchedules } from './find-schedules';
 
 const connection = require('../../platform/server/connection');
 const uuid = require('../../platform/uuid');

--- a/packages/loot-core/src/server/schedules/app.js
+++ b/packages/loot-core/src/server/schedules/app.js
@@ -1,7 +1,6 @@
 import * as d from 'date-fns';
 import deepEqual from 'deep-equal';
 
-import { findSchedules } from './find-schedules';
 import { captureBreadcrumb } from '../../platform/exceptions';
 import { dayFromDate, currentDay, parseDate } from '../../shared/months';
 import q from '../../shared/query';
@@ -29,6 +28,8 @@ import * as prefs from '../prefs';
 import { addSyncListener, batchMessages } from '../sync';
 import { undoable } from '../undo';
 import { Schedule as RSchedule } from '../util/rschedule';
+
+import { findSchedules } from './find-schedules';
 
 const connection = require('../../platform/server/connection');
 const uuid = require('../../platform/uuid');

--- a/packages/loot-core/src/server/schedules/app.test.js
+++ b/packages/loot-core/src/server/schedules/app.test.js
@@ -1,5 +1,10 @@
 import MockDate from 'mockdate';
 
+import q from '../../shared/query';
+import { loadRules, updateRule } from '../accounts/transaction-rules';
+import { runQuery as aqlQuery } from '../aql';
+import { loadMappings } from '../db/mappings';
+
 import {
   updateConditions,
   getNextDate,
@@ -8,10 +13,6 @@ import {
   deleteSchedule,
   setNextDate
 } from './app';
-import q from '../../shared/query';
-import { loadRules, updateRule } from '../accounts/transaction-rules';
-import { runQuery as aqlQuery } from '../aql';
-import { loadMappings } from '../db/mappings';
 
 beforeEach(async () => {
   await global.emptyDatabase()();

--- a/packages/loot-core/src/server/schedules/app.test.js
+++ b/packages/loot-core/src/server/schedules/app.test.js
@@ -1,9 +1,5 @@
 import MockDate from 'mockdate';
 
-import q from '../../shared/query';
-import { loadRules, updateRule } from '../accounts/transaction-rules';
-import { runQuery as aqlQuery } from '../aql';
-import { loadMappings } from '../db/mappings';
 import {
   updateConditions,
   getNextDate,
@@ -12,6 +8,10 @@ import {
   deleteSchedule,
   setNextDate
 } from './app';
+import q from '../../shared/query';
+import { loadRules, updateRule } from '../accounts/transaction-rules';
+import { runQuery as aqlQuery } from '../aql';
+import { loadMappings } from '../db/mappings';
 
 beforeEach(async () => {
   await global.emptyDatabase()();

--- a/packages/loot-core/src/server/sheet.js
+++ b/packages/loot-core/src/server/sheet.js
@@ -1,9 +1,10 @@
-import Platform from './platform';
-import * as prefs from './prefs';
-import Spreadsheet from './spreadsheet/spreadsheet';
 import { captureBreadcrumb } from '../platform/exceptions';
 import * as sqlite from '../platform/server/sqlite';
 import { sheetForMonth } from '../shared/months';
+
+import Platform from './platform';
+import * as prefs from './prefs';
+import Spreadsheet from './spreadsheet/spreadsheet';
 
 const { resolveName } = require('./spreadsheet/util');
 

--- a/packages/loot-core/src/server/sheet.js
+++ b/packages/loot-core/src/server/sheet.js
@@ -1,9 +1,9 @@
-import { captureBreadcrumb } from '../platform/exceptions';
-import * as sqlite from '../platform/server/sqlite';
-import { sheetForMonth } from '../shared/months';
 import Platform from './platform';
 import * as prefs from './prefs';
 import Spreadsheet from './spreadsheet/spreadsheet';
+import { captureBreadcrumb } from '../platform/exceptions';
+import * as sqlite from '../platform/server/sqlite';
+import { sheetForMonth } from '../shared/months';
 
 const { resolveName } = require('./spreadsheet/util');
 

--- a/packages/loot-core/src/server/sheet.test.js
+++ b/packages/loot-core/src/server/sheet.test.js
@@ -1,6 +1,7 @@
+import { generateTransaction } from '../mocks';
+
 import * as db from './db';
 import * as sheet from './sheet';
-import { generateTransaction } from '../mocks';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/sheet.test.js
+++ b/packages/loot-core/src/server/sheet.test.js
@@ -1,6 +1,6 @@
-import { generateTransaction } from '../mocks';
 import * as db from './db';
 import * as sheet from './sheet';
+import { generateTransaction } from '../mocks';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
@@ -1,6 +1,6 @@
+import Spreadsheet from './spreadsheet';
 import { generateTransaction } from '../../mocks';
 import * as db from '../db';
-import Spreadsheet from './spreadsheet';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.test.js
@@ -1,6 +1,7 @@
-import Spreadsheet from './spreadsheet';
 import { generateTransaction } from '../../mocks';
 import * as db from '../db';
+
+import Spreadsheet from './spreadsheet';
 
 beforeEach(global.emptyDatabase());
 

--- a/packages/loot-core/src/server/sync/encoder.js
+++ b/packages/loot-core/src/server/sync/encoder.js
@@ -1,8 +1,8 @@
 import encryption from '../encryption';
 import * as prefs from '../prefs';
 
-let { SyncError } = require('../errors');
 let SyncPb = require('./proto/sync_pb');
+let { SyncError } = require('../errors');
 
 function coerceBuffer(value) {
   // The web encryption APIs give us back raw Uint8Array... but our

--- a/packages/loot-core/src/server/sync/encoder.js
+++ b/packages/loot-core/src/server/sync/encoder.js
@@ -1,8 +1,9 @@
 import encryption from '../encryption';
 import * as prefs from '../prefs';
 
-let SyncPb = require('./proto/sync_pb');
 let { SyncError } = require('../errors');
+
+let SyncPb = require('./proto/sync_pb');
 
 function coerceBuffer(value) {
   // The web encryption APIs give us back raw Uint8Array... but our

--- a/packages/loot-core/src/server/sync/index.js
+++ b/packages/loot-core/src/server/sync/index.js
@@ -1,5 +1,3 @@
-import * as encoder from './encoder';
-import { rebuildMerkleHash } from './repair';
 import { captureException } from '../../platform/exceptions';
 import asyncStorage from '../../platform/server/asyncStorage';
 import logger from '../../platform/server/log';
@@ -21,6 +19,9 @@ import * as prefs from '../prefs';
 import { getServer } from '../server-config';
 import * as sheet from '../sheet';
 import * as undo from '../undo';
+
+import * as encoder from './encoder';
+import { rebuildMerkleHash } from './repair';
 
 const connection = require('../../platform/server/connection');
 const { PostError, SyncError } = require('../errors');

--- a/packages/loot-core/src/server/sync/index.js
+++ b/packages/loot-core/src/server/sync/index.js
@@ -1,3 +1,5 @@
+import * as encoder from './encoder';
+import { rebuildMerkleHash } from './repair';
 import { captureException } from '../../platform/exceptions';
 import asyncStorage from '../../platform/server/asyncStorage';
 import logger from '../../platform/server/log';
@@ -19,8 +21,6 @@ import * as prefs from '../prefs';
 import { getServer } from '../server-config';
 import * as sheet from '../sheet';
 import * as undo from '../undo';
-import * as encoder from './encoder';
-import { rebuildMerkleHash } from './repair';
 
 const connection = require('../../platform/server/connection');
 const { PostError, SyncError } = require('../errors');

--- a/packages/loot-core/src/server/sync/migrate.test.js
+++ b/packages/loot-core/src/server/sync/migrate.test.js
@@ -1,10 +1,10 @@
 import fc from 'fast-check';
 
+import { listen, unlisten } from './migrate';
 import arbs from '../../mocks/arbitrary-schema';
 import { execTracer } from '../../shared/test-helpers';
 import { convertInputType, schema, schemaConfig } from '../aql';
 import * as db from '../db';
-import { listen, unlisten } from './migrate';
 
 import { addSyncListener, sendMessages } from './index';
 

--- a/packages/loot-core/src/server/sync/migrate.test.js
+++ b/packages/loot-core/src/server/sync/migrate.test.js
@@ -1,10 +1,11 @@
 import fc from 'fast-check';
 
-import { listen, unlisten } from './migrate';
 import arbs from '../../mocks/arbitrary-schema';
 import { execTracer } from '../../shared/test-helpers';
 import { convertInputType, schema, schemaConfig } from '../aql';
 import * as db from '../db';
+
+import { listen, unlisten } from './migrate';
 
 import { addSyncListener, sendMessages } from './index';
 

--- a/packages/loot-core/src/server/sync/sync.property.test.js
+++ b/packages/loot-core/src/server/sync/sync.property.test.js
@@ -1,8 +1,9 @@
-import * as encoder from './encoder';
 import { merkle, getClock, Timestamp } from '../crdt';
 import * as db from '../db';
 import * as prefs from '../prefs';
 import * as sheet from '../sheet';
+
+import * as encoder from './encoder';
 
 import * as sync from './index';
 

--- a/packages/loot-core/src/server/sync/sync.property.test.js
+++ b/packages/loot-core/src/server/sync/sync.property.test.js
@@ -1,8 +1,8 @@
+import * as encoder from './encoder';
 import { merkle, getClock, Timestamp } from '../crdt';
 import * as db from '../db';
 import * as prefs from '../prefs';
 import * as sheet from '../sheet';
-import * as encoder from './encoder';
 
 import * as sync from './index';
 

--- a/packages/loot-core/src/server/sync/sync.test.js
+++ b/packages/loot-core/src/server/sync/sync.test.js
@@ -1,8 +1,8 @@
+import * as encoder from './encoder';
 import { getClock, Timestamp } from '../crdt';
 import * as db from '../db';
 import * as prefs from '../prefs';
 import * as sheet from '../sheet';
-import * as encoder from './encoder';
 
 import { setSyncingMode, sendMessages, applyMessages, fullSync } from './index';
 

--- a/packages/loot-core/src/server/sync/sync.test.js
+++ b/packages/loot-core/src/server/sync/sync.test.js
@@ -1,8 +1,9 @@
-import * as encoder from './encoder';
 import { getClock, Timestamp } from '../crdt';
 import * as db from '../db';
 import * as prefs from '../prefs';
 import * as sheet from '../sheet';
+
+import * as encoder from './encoder';
 
 import { setSyncingMode, sendMessages, applyMessages, fullSync } from './index';
 

--- a/packages/loot-core/src/server/tests/mockSyncServer.js
+++ b/packages/loot-core/src/server/tests/mockSyncServer.js
@@ -1,7 +1,8 @@
 import { makeClock, Timestamp, merkle } from '../crdt';
 
-const defaultMockData = require('./mockData').basic;
 const SyncPb = require('../sync/proto/sync_pb');
+
+const defaultMockData = require('./mockData').basic;
 
 const handlers = {};
 let currentMockData = defaultMockData;

--- a/packages/loot-core/src/server/tests/mockSyncServer.js
+++ b/packages/loot-core/src/server/tests/mockSyncServer.js
@@ -1,7 +1,7 @@
 import { makeClock, Timestamp, merkle } from '../crdt';
 
-const SyncPb = require('../sync/proto/sync_pb');
 const defaultMockData = require('./mockData').basic;
+const SyncPb = require('../sync/proto/sync_pb');
 
 const handlers = {};
 let currentMockData = defaultMockData;

--- a/packages/loot-core/src/server/undo.js
+++ b/packages/loot-core/src/server/undo.js
@@ -1,7 +1,7 @@
-import { getIn } from '../shared/util';
 import { Timestamp } from './crdt';
 import { withMutatorContext, getMutatorContext } from './mutators';
 import { sendMessages } from './sync';
+import { getIn } from '../shared/util';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-core/src/server/undo.js
+++ b/packages/loot-core/src/server/undo.js
@@ -1,7 +1,8 @@
+import { getIn } from '../shared/util';
+
 import { Timestamp } from './crdt';
 import { withMutatorContext, getMutatorContext } from './mutators';
 import { sendMessages } from './sync';
-import { getIn } from '../shared/util';
 
 const connection = require('../platform/server/connection');
 

--- a/packages/loot-design/src/components/AccountAutocomplete.js
+++ b/packages/loot-design/src/components/AccountAutocomplete.js
@@ -2,9 +2,10 @@ import React from 'react';
 
 import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 
+import { colors } from '../style';
+
 import Autocomplete from './Autocomplete';
 import { View } from './common';
-import { colors } from '../style';
 
 export function AccountList({
   items,

--- a/packages/loot-design/src/components/AccountAutocomplete.js
+++ b/packages/loot-design/src/components/AccountAutocomplete.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 
-import { colors } from '../style';
 import Autocomplete from './Autocomplete';
 import { View } from './common';
+import { colors } from '../style';
 
 export function AccountList({
   items,

--- a/packages/loot-design/src/components/Autocomplete.js
+++ b/packages/loot-design/src/components/Autocomplete.js
@@ -4,9 +4,9 @@ import lively from '@jlongster/lively';
 import Downshift from 'downshift';
 import { css } from 'glamor';
 
+import { View, Input, Tooltip, Button } from './common';
 import { colors } from '../style';
 import Remove from '../svg/v2/Remove';
-import { View, Input, Tooltip, Button } from './common';
 
 function findItem(strict, suggestions, value) {
   if (strict) {

--- a/packages/loot-design/src/components/Autocomplete.js
+++ b/packages/loot-design/src/components/Autocomplete.js
@@ -4,9 +4,10 @@ import lively from '@jlongster/lively';
 import Downshift from 'downshift';
 import { css } from 'glamor';
 
-import { View, Input, Tooltip, Button } from './common';
 import { colors } from '../style';
 import Remove from '../svg/v2/Remove';
+
+import { View, Input, Tooltip, Button } from './common';
 
 function findItem(strict, suggestions, value) {
   if (strict) {

--- a/packages/loot-design/src/components/Autocomplete.usage.js
+++ b/packages/loot-design/src/components/Autocomplete.usage.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import { Section } from '../guide/components';
 import Autocomplete, { MultiAutocomplete } from './Autocomplete';
+import { Section } from '../guide/components';
 
 let items = [
   { id: 'one', name: 'James' },

--- a/packages/loot-design/src/components/Autocomplete.usage.js
+++ b/packages/loot-design/src/components/Autocomplete.usage.js
@@ -2,8 +2,9 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import Autocomplete, { MultiAutocomplete } from './Autocomplete';
 import { Section } from '../guide/components';
+
+import Autocomplete, { MultiAutocomplete } from './Autocomplete';
 
 let items = [
   { id: 'one', name: 'James' },

--- a/packages/loot-design/src/components/CategorySelect.js
+++ b/packages/loot-design/src/components/CategorySelect.js
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react';
 
-import { colors } from '../style';
-import Split from '../svg/v0/Split';
 import Autocomplete, { defaultFilterSuggestion } from './Autocomplete';
 import { View, Text, Select } from './common';
+import { colors } from '../style';
+import Split from '../svg/v0/Split';
 
 export const NativeCategorySelect = React.forwardRef(
   ({ categoryGroups, emptyLabel, ...nativeProps }, ref) => {

--- a/packages/loot-design/src/components/CategorySelect.js
+++ b/packages/loot-design/src/components/CategorySelect.js
@@ -1,9 +1,10 @@
 import React, { useMemo } from 'react';
 
-import Autocomplete, { defaultFilterSuggestion } from './Autocomplete';
-import { View, Text, Select } from './common';
 import { colors } from '../style';
 import Split from '../svg/v0/Split';
+
+import Autocomplete, { defaultFilterSuggestion } from './Autocomplete';
+import { View, Text, Select } from './common';
 
 export const NativeCategorySelect = React.forwardRef(
   ({ categoryGroups, emptyLabel, ...nativeProps }, ref) => {

--- a/packages/loot-design/src/components/DateSelect.js
+++ b/packages/loot-design/src/components/DateSelect.js
@@ -18,10 +18,11 @@ import {
   getShortYearRegex
 } from 'loot-core/src/shared/months';
 
+import { colors } from '../style';
+
 import { View, Input, Tooltip } from './common';
 import DateSelectLeft from './DateSelect.left.png';
 import DateSelectRight from './DateSelect.right.png';
-import { colors } from '../style';
 
 let pickerStyles = {
   '& .pika-single.actual-date-picker': {

--- a/packages/loot-design/src/components/DateSelect.js
+++ b/packages/loot-design/src/components/DateSelect.js
@@ -18,10 +18,10 @@ import {
   getShortYearRegex
 } from 'loot-core/src/shared/months';
 
-import { colors } from '../style';
 import { View, Input, Tooltip } from './common';
 import DateSelectLeft from './DateSelect.left.png';
 import DateSelectRight from './DateSelect.right.png';
+import { colors } from '../style';
 
 let pickerStyles = {
   '& .pika-single.actual-date-picker': {

--- a/packages/loot-design/src/components/DateSelect.usage.js
+++ b/packages/loot-design/src/components/DateSelect.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Section } from '../guide/components';
 import DateSelect from './DateSelect';
+import { Section } from '../guide/components';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/DateSelect.usage.js
+++ b/packages/loot-design/src/components/DateSelect.usage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import DateSelect from './DateSelect';
 import { Section } from '../guide/components';
+
+import DateSelect from './DateSelect';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/NotesButton.js
+++ b/packages/loot-design/src/components/NotesButton.js
@@ -6,9 +6,10 @@ import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { send } from 'loot-core/src/platform/client/fetch';
 
-import { View, Button, Tooltip, useTooltip } from './common';
 import { colors } from '../style';
 import CustomNotesPaper from '../svg/v2/CustomNotesPaper';
+
+import { View, Button, Tooltip, useTooltip } from './common';
 
 export function NotesTooltip({
   defaultNotes,

--- a/packages/loot-design/src/components/NotesButton.js
+++ b/packages/loot-design/src/components/NotesButton.js
@@ -6,9 +6,9 @@ import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { send } from 'loot-core/src/platform/client/fetch';
 
+import { View, Button, Tooltip, useTooltip } from './common';
 import { colors } from '../style';
 import CustomNotesPaper from '../svg/v2/CustomNotesPaper';
-import { View, Button, Tooltip, useTooltip } from './common';
 
 export function NotesTooltip({
   defaultNotes,

--- a/packages/loot-design/src/components/PayeeAutocomplete.js
+++ b/packages/loot-design/src/components/PayeeAutocomplete.js
@@ -6,14 +6,15 @@ import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { getActivePayees } from 'loot-core/src/client/reducers/queries';
 
+import { colors } from '../style';
+import Add from '../svg/v1/Add';
+
 import Autocomplete, {
   defaultFilterSuggestion,
   AutocompleteFooter,
   AutocompleteFooterButton
 } from './Autocomplete';
 import { View } from './common';
-import { colors } from '../style';
-import Add from '../svg/v1/Add';
 
 function getPayeeSuggestions(payees, focusTransferPayees, accounts) {
   let activePayees = accounts ? getActivePayees(payees, accounts) : payees;

--- a/packages/loot-design/src/components/PayeeAutocomplete.js
+++ b/packages/loot-design/src/components/PayeeAutocomplete.js
@@ -6,14 +6,14 @@ import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { getActivePayees } from 'loot-core/src/client/reducers/queries';
 
-import { colors } from '../style';
-import Add from '../svg/v1/Add';
 import Autocomplete, {
   defaultFilterSuggestion,
   AutocompleteFooter,
   AutocompleteFooterButton
 } from './Autocomplete';
 import { View } from './common';
+import { colors } from '../style';
+import Add from '../svg/v1/Add';
 
 function getPayeeSuggestions(payees, focusTransferPayees, accounts) {
   let activePayees = accounts ? getActivePayees(payees, accounts) : payees;

--- a/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { Section } from '../guide/components';
 import { Button, View } from './common';
 import RecurringSchedulePicker from './RecurringSchedulePicker';
 import { useTooltip } from './tooltips';
+import { Section } from '../guide/components';
 
 export default () => {
   const { isOpen, close, getOpenEvents } = useTooltip();

--- a/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
+++ b/packages/loot-design/src/components/RecurringSchedulePicker.usage.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import { Section } from '../guide/components';
+
 import { Button, View } from './common';
 import RecurringSchedulePicker from './RecurringSchedulePicker';
 import { useTooltip } from './tooltips';
-import { Section } from '../guide/components';
 
 export default () => {
   const { isOpen, close, getOpenEvents } = useTooltip();

--- a/packages/loot-design/src/components/alerts.js
+++ b/packages/loot-design/src/components/alerts.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { View, Text } from './common';
 import { styles, colors } from '../style';
 import ExclamationOutline from '../svg/v1/ExclamationOutline';
 import InformationOutline from '../svg/v1/InformationOutline';
+
+import { View, Text } from './common';
 
 export function Alert({ icon: Icon, color, backgroundColor, style, children }) {
   return (

--- a/packages/loot-design/src/components/alerts.js
+++ b/packages/loot-design/src/components/alerts.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import { View, Text } from './common';
 import { styles, colors } from '../style';
 import ExclamationOutline from '../svg/v1/ExclamationOutline';
 import InformationOutline from '../svg/v1/InformationOutline';
-import { View, Text } from './common';
 
 export function Alert({ icon: Icon, color, backgroundColor, style, children }) {
   return (

--- a/packages/loot-design/src/components/budget/BalanceWithCarryover.js
+++ b/packages/loot-design/src/components/budget/BalanceWithCarryover.js
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { makeAmountStyle } from './util';
 import ArrowThinRight from '../../svg/v1/ArrowThinRight';
 import { View } from '../common';
 import CellValue from '../spreadsheet/CellValue';
 import useSheetValue from '../spreadsheet/useSheetValue';
+
+import { makeAmountStyle } from './util';
 
 export default function BalanceWithCarryover({
   carryover,

--- a/packages/loot-design/src/components/budget/BalanceWithCarryover.js
+++ b/packages/loot-design/src/components/budget/BalanceWithCarryover.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
+import { makeAmountStyle } from './util';
 import ArrowThinRight from '../../svg/v1/ArrowThinRight';
 import { View } from '../common';
 import CellValue from '../spreadsheet/CellValue';
 import useSheetValue from '../spreadsheet/useSheetValue';
-import { makeAmountStyle } from './util';
 
 export default function BalanceWithCarryover({
   carryover,

--- a/packages/loot-design/src/components/budget/BudgetSummaries.js
+++ b/packages/loot-design/src/components/budget/BudgetSummaries.js
@@ -11,9 +11,10 @@ import { Spring } from 'wobble';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { MonthsContext } from './MonthsContext';
 import { View } from '../common';
 import useResizeObserver from '../useResizeObserver';
+
+import { MonthsContext } from './MonthsContext';
 
 export default function BudgetSummaries({ SummaryComponent }) {
   let { months } = useContext(MonthsContext);

--- a/packages/loot-design/src/components/budget/BudgetSummaries.js
+++ b/packages/loot-design/src/components/budget/BudgetSummaries.js
@@ -11,9 +11,9 @@ import { Spring } from 'wobble';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
+import { MonthsContext } from './MonthsContext';
 import { View } from '../common';
 import useResizeObserver from '../useResizeObserver';
-import { MonthsContext } from './MonthsContext';
 
 export default function BudgetSummaries({ SummaryComponent }) {
   let { months } = useContext(MonthsContext);

--- a/packages/loot-design/src/components/budget/DynamicBudgetTable.js
+++ b/packages/loot-design/src/components/budget/DynamicBudgetTable.js
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
+import { View } from '../common';
+
 import { useBudgetMonthCount } from './BudgetMonthCountContext';
 import { CategoryGroupsContext } from './util';
-import { View } from '../common';
 
 import { BudgetPageHeader, BudgetTable } from './index';
 

--- a/packages/loot-design/src/components/budget/DynamicBudgetTable.js
+++ b/packages/loot-design/src/components/budget/DynamicBudgetTable.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import { View } from '../common';
 import { useBudgetMonthCount } from './BudgetMonthCountContext';
 import { CategoryGroupsContext } from './util';
+import { View } from '../common';
 
 import { BudgetPageHeader, BudgetTable } from './index';
 

--- a/packages/loot-design/src/components/budget/index.js
+++ b/packages/loot-design/src/components/budget/index.js
@@ -4,10 +4,6 @@ import { scope } from '@jlongster/lively';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import BudgetSummaries from './BudgetSummaries';
-import { INCOME_HEADER_HEIGHT, MONTH_BOX_SHADOW } from './constants';
-import { MonthsProvider, MonthsContext } from './MonthsContext';
-import { separateGroups, findSortDown, findSortUp } from './util';
 import { styles, colors } from '../../style';
 import ExpandArrow from '../../svg/v0/ExpandArrow';
 import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
@@ -31,6 +27,11 @@ import {
 } from '../sort.js';
 import NamespaceContext from '../spreadsheet/NamespaceContext';
 import { Row, InputCell, ROW_HEIGHT } from '../table';
+
+import BudgetSummaries from './BudgetSummaries';
+import { INCOME_HEADER_HEIGHT, MONTH_BOX_SHADOW } from './constants';
+import { MonthsProvider, MonthsContext } from './MonthsContext';
+import { separateGroups, findSortDown, findSortUp } from './util';
 
 function getScrollbarWidth() {
   return Math.max(styles.scrollbarWidth - 2, 0);

--- a/packages/loot-design/src/components/budget/index.js
+++ b/packages/loot-design/src/components/budget/index.js
@@ -4,6 +4,10 @@ import { scope } from '@jlongster/lively';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
+import BudgetSummaries from './BudgetSummaries';
+import { INCOME_HEADER_HEIGHT, MONTH_BOX_SHADOW } from './constants';
+import { MonthsProvider, MonthsContext } from './MonthsContext';
+import { separateGroups, findSortDown, findSortUp } from './util';
 import { styles, colors } from '../../style';
 import ExpandArrow from '../../svg/v0/ExpandArrow';
 import ArrowThinLeft from '../../svg/v1/ArrowThinLeft';
@@ -27,10 +31,6 @@ import {
 } from '../sort.js';
 import NamespaceContext from '../spreadsheet/NamespaceContext';
 import { Row, InputCell, ROW_HEIGHT } from '../table';
-import BudgetSummaries from './BudgetSummaries';
-import { INCOME_HEADER_HEIGHT, MONTH_BOX_SHADOW } from './constants';
-import { MonthsProvider, MonthsContext } from './MonthsContext';
-import { separateGroups, findSortDown, findSortUp } from './util';
 
 function getScrollbarWidth() {
   return Math.max(styles.scrollbarWidth - 2, 0);

--- a/packages/loot-design/src/components/budget/index.usage.js
+++ b/packages/loot-design/src/components/budget/index.usage.js
@@ -6,14 +6,15 @@ import { generateCategoryGroups } from 'loot-core/src/mocks';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { BudgetMonthCountContext } from './BudgetMonthCountContext';
-import DynamicBudgetTable from './DynamicBudgetTable';
-import * as rollover from './rollover/rollover-components';
-import { RolloverContext } from './rollover/RolloverContext';
 import { Section } from '../../guide/components';
 import { colors } from '../../style';
 import { View } from '../common';
 import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
+
+import { BudgetMonthCountContext } from './BudgetMonthCountContext';
+import DynamicBudgetTable from './DynamicBudgetTable';
+import * as rollover from './rollover/rollover-components';
+import { RolloverContext } from './rollover/RolloverContext';
 
 const categoryGroups = generateCategoryGroups([
   {

--- a/packages/loot-design/src/components/budget/index.usage.js
+++ b/packages/loot-design/src/components/budget/index.usage.js
@@ -6,14 +6,14 @@ import { generateCategoryGroups } from 'loot-core/src/mocks';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { Section } from '../../guide/components';
-import { colors } from '../../style';
-import { View } from '../common';
-import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 import { BudgetMonthCountContext } from './BudgetMonthCountContext';
 import DynamicBudgetTable from './DynamicBudgetTable';
 import * as rollover from './rollover/rollover-components';
 import { RolloverContext } from './rollover/RolloverContext';
+import { Section } from '../../guide/components';
+import { colors } from '../../style';
+import { View } from '../common';
+import SpreadsheetContext from '../spreadsheet/SpreadsheetContext';
 
 const categoryGroups = generateCategoryGroups([
   {

--- a/packages/loot-design/src/components/budget/report/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/report/BudgetSummary.js
@@ -5,6 +5,7 @@ import { css } from 'glamor';
 import { reportBudget } from 'loot-core/src/client/queries';
 import * as monthUtils from 'loot-core/src/shared/months';
 
+import { useReport } from './ReportContext';
 import { colors, styles } from '../../../style';
 import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
 import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
@@ -26,7 +27,6 @@ import NamespaceContext from '../../spreadsheet/NamespaceContext';
 import useSheetValue from '../../spreadsheet/useSheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
 import { makeAmountFullStyle } from '../util';
-import { useReport } from './ReportContext';
 
 function PieProgress({ style, progress, color, backgroundColor }) {
   let radius = 4;

--- a/packages/loot-design/src/components/budget/report/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/report/BudgetSummary.js
@@ -5,7 +5,6 @@ import { css } from 'glamor';
 import { reportBudget } from 'loot-core/src/client/queries';
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { useReport } from './ReportContext';
 import { colors, styles } from '../../../style';
 import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
 import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
@@ -27,6 +26,8 @@ import NamespaceContext from '../../spreadsheet/NamespaceContext';
 import useSheetValue from '../../spreadsheet/useSheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
 import { makeAmountFullStyle } from '../util';
+
+import { useReport } from './ReportContext';
 
 function PieProgress({ style, progress, color, backgroundColor }) {
   let radius = 4;

--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -6,9 +6,6 @@ import { css } from 'glamor';
 import { rolloverBudget } from 'loot-core/src/client/queries';
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import HoldTooltip from './HoldTooltip';
-import { useRollover } from './RolloverContext';
-import TransferTooltip from './TransferTooltip';
 import { colors, styles } from '../../../style';
 import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
 import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
@@ -28,6 +25,10 @@ import format from '../../spreadsheet/format';
 import NamespaceContext from '../../spreadsheet/NamespaceContext';
 import SheetValue from '../../spreadsheet/SheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
+
+import HoldTooltip from './HoldTooltip';
+import { useRollover } from './RolloverContext';
+import TransferTooltip from './TransferTooltip';
 
 function TotalsList({ prevMonthName, collapsed }) {
   return (

--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -6,6 +6,9 @@ import { css } from 'glamor';
 import { rolloverBudget } from 'loot-core/src/client/queries';
 import * as monthUtils from 'loot-core/src/shared/months';
 
+import HoldTooltip from './HoldTooltip';
+import { useRollover } from './RolloverContext';
+import TransferTooltip from './TransferTooltip';
 import { colors, styles } from '../../../style';
 import DotsHorizontalTriple from '../../../svg/v1/DotsHorizontalTriple';
 import ArrowButtonDown1 from '../../../svg/v2/ArrowButtonDown1';
@@ -25,9 +28,6 @@ import format from '../../spreadsheet/format';
 import NamespaceContext from '../../spreadsheet/NamespaceContext';
 import SheetValue from '../../spreadsheet/SheetValue';
 import { MONTH_BOX_SHADOW } from '../constants';
-import HoldTooltip from './HoldTooltip';
-import { useRollover } from './RolloverContext';
-import TransferTooltip from './TransferTooltip';
 
 function TotalsList({ prevMonthName, collapsed }) {
   return (

--- a/packages/loot-design/src/components/budget/rollover/rollover-components.js
+++ b/packages/loot-design/src/components/budget/rollover/rollover-components.js
@@ -4,7 +4,6 @@ import { rolloverBudget } from 'loot-core/src/client/queries';
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
-import TransferTooltip from './TransferTooltip';
 import { styles, colors } from '../../../style';
 import CategoryAutocomplete from '../../CategorySelect';
 import {
@@ -27,6 +26,8 @@ import {
   addToBeBudgetedGroup,
   CategoryGroupsContext
 } from '../util';
+
+import TransferTooltip from './TransferTooltip';
 
 export BudgetSummary from './BudgetSummary';
 

--- a/packages/loot-design/src/components/budget/rollover/rollover-components.js
+++ b/packages/loot-design/src/components/budget/rollover/rollover-components.js
@@ -4,6 +4,7 @@ import { rolloverBudget } from 'loot-core/src/client/queries';
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
 
+import TransferTooltip from './TransferTooltip';
 import { styles, colors } from '../../../style';
 import CategoryAutocomplete from '../../CategorySelect';
 import {
@@ -26,7 +27,6 @@ import {
   addToBeBudgetedGroup,
   CategoryGroupsContext
 } from '../util';
-import TransferTooltip from './TransferTooltip';
 
 export BudgetSummary from './BudgetSummary';
 

--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -22,13 +22,13 @@ import hotkeys from 'hotkeys-js';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 import ExpandArrow from 'loot-design/src/svg/v0/ExpandArrow';
 
+import Text from './Text';
+import { useProperFocus } from './useProperFocus';
+import View from './View';
 import { styles, colors } from '../style';
 import Loading from '../svg/AnimatedLoading';
 import Delete from '../svg/v0/Delete';
 import tokens from '../tokens';
-import Text from './Text';
-import { useProperFocus } from './useProperFocus';
-import View from './View';
 
 export { default as View } from './View';
 export { default as Text } from './Text';

--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -22,13 +22,14 @@ import hotkeys from 'hotkeys-js';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 import ExpandArrow from 'loot-design/src/svg/v0/ExpandArrow';
 
-import Text from './Text';
-import { useProperFocus } from './useProperFocus';
-import View from './View';
 import { styles, colors } from '../style';
 import Loading from '../svg/AnimatedLoading';
 import Delete from '../svg/v0/Delete';
 import tokens from '../tokens';
+
+import Text from './Text';
+import { useProperFocus } from './useProperFocus';
+import View from './View';
 
 export { default as View } from './View';
 export { default as Text } from './Text';

--- a/packages/loot-design/src/components/common.usage.js
+++ b/packages/loot-design/src/components/common.usage.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import { Section, TestModal } from '../guide/components';
 import { Input, Modal, View, Button, Stack } from './common';
+import { Section, TestModal } from '../guide/components';
 
 export default () => {
   return (

--- a/packages/loot-design/src/components/common.usage.js
+++ b/packages/loot-design/src/components/common.usage.js
@@ -2,8 +2,9 @@ import React from 'react';
 
 import Component from '@reactions/component';
 
-import { Input, Modal, View, Button, Stack } from './common';
 import { Section, TestModal } from '../guide/components';
+
+import { Input, Modal, View, Button, Stack } from './common';
 
 export default () => {
   return (

--- a/packages/loot-design/src/components/forms.js
+++ b/packages/loot-design/src/components/forms.js
@@ -2,8 +2,9 @@ import React from 'react';
 
 import { css } from 'glamor';
 
-import { View, Text } from './common';
 import { colors } from '../style';
+
+import { View, Text } from './common';
 
 export function SectionLabel({ title, style }) {
   return (

--- a/packages/loot-design/src/components/forms.js
+++ b/packages/loot-design/src/components/forms.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 import { css } from 'glamor';
 
-import { colors } from '../style';
 import { View, Text } from './common';
+import { colors } from '../style';
 
 export function SectionLabel({ title, style }) {
   return (

--- a/packages/loot-design/src/components/icons.usage.js
+++ b/packages/loot-design/src/components/icons.usage.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { Section } from '../guide/components';
 import { View, Button } from './common';
+import { Section } from '../guide/components';
 
 const context = require.context('../svg/v1', false, /\.js$/);
 const modules = {};

--- a/packages/loot-design/src/components/icons.usage.js
+++ b/packages/loot-design/src/components/icons.usage.js
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 
-import { View, Button } from './common';
 import { Section } from '../guide/components';
+
+import { View, Button } from './common';
 
 const context = require.context('../svg/v1', false, /\.js$/);
 const modules = {};

--- a/packages/loot-design/src/components/manager/BudgetList.usage.js
+++ b/packages/loot-design/src/components/manager/BudgetList.usage.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import BudgetList from './BudgetList';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
+
+import BudgetList from './BudgetList';
 
 const files = [
   { name: 'Finances 2', id: '1', state: 'local' },

--- a/packages/loot-design/src/components/manager/BudgetList.usage.js
+++ b/packages/loot-design/src/components/manager/BudgetList.usage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import BudgetList from './BudgetList';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
-import BudgetList from './BudgetList';
 
 const files = [
   { name: 'Finances 2', id: '1', state: 'local' },

--- a/packages/loot-design/src/components/manager/DeleteFile.usage.js
+++ b/packages/loot-design/src/components/manager/DeleteFile.usage.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import DeleteFile from './DeleteFile';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
+
+import DeleteFile from './DeleteFile';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/manager/DeleteFile.usage.js
+++ b/packages/loot-design/src/components/manager/DeleteFile.usage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import DeleteFile from './DeleteFile';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
-import DeleteFile from './DeleteFile';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/manager/Import.usage.js
+++ b/packages/loot-design/src/components/manager/Import.usage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import Import from './Import';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
-import Import from './Import';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/manager/Import.usage.js
+++ b/packages/loot-design/src/components/manager/Import.usage.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import Import from './Import';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
+
+import Import from './Import';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/CloseAccount.usage.js
+++ b/packages/loot-design/src/components/modals/CloseAccount.usage.js
@@ -3,8 +3,8 @@ import { MemoryRouter as Router } from 'react-router-dom';
 
 import { generateAccount, generateCategoryGroups } from 'loot-core/src/mocks';
 
-import { Section, TestModal } from '../../guide/components';
 import CloseAccount from './CloseAccount';
+import { Section, TestModal } from '../../guide/components';
 
 const accounts = [
   generateAccount('Bank of America', null, null, false),

--- a/packages/loot-design/src/components/modals/CloseAccount.usage.js
+++ b/packages/loot-design/src/components/modals/CloseAccount.usage.js
@@ -3,8 +3,9 @@ import { MemoryRouter as Router } from 'react-router-dom';
 
 import { generateAccount, generateCategoryGroups } from 'loot-core/src/mocks';
 
-import CloseAccount from './CloseAccount';
 import { Section, TestModal } from '../../guide/components';
+
+import CloseAccount from './CloseAccount';
 
 const accounts = [
   generateAccount('Bank of America', null, null, false),

--- a/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.usage.js
+++ b/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.usage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import ConfigureLinkedAccounts from './ConfigureLinkedAccounts';
 import { Section, TestModal } from '../../guide/components';
+
+import ConfigureLinkedAccounts from './ConfigureLinkedAccounts';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.usage.js
+++ b/packages/loot-design/src/components/modals/ConfigureLinkedAccounts.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Section, TestModal } from '../../guide/components';
 import ConfigureLinkedAccounts from './ConfigureLinkedAccounts';
+import { Section, TestModal } from '../../guide/components';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/CreateLocalAccount.usage.js
+++ b/packages/loot-design/src/components/modals/CreateLocalAccount.usage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import CreateLocalAccount from './CreateLocalAccount';
 import { Section, TestModal } from '../../guide/components';
+
+import CreateLocalAccount from './CreateLocalAccount';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/CreateLocalAccount.usage.js
+++ b/packages/loot-design/src/components/modals/CreateLocalAccount.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Section, TestModal } from '../../guide/components';
 import CreateLocalAccount from './CreateLocalAccount';
+import { Section, TestModal } from '../../guide/components';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/ImportTransactions.usage.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.usage.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { generateTransactions } from 'loot-core/src/mocks';
 import { TestProvider } from 'loot-core/src/mocks/redux';
 
-import { Section, TestModal } from '../../guide/components';
 import { ImportTransactions } from './ImportTransactions';
+import { Section, TestModal } from '../../guide/components';
 
 let transactions = generateTransactions(20, 'acct', 'group');
 // The mocks generate "internal" transactions... but we need the

--- a/packages/loot-design/src/components/modals/ImportTransactions.usage.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.usage.js
@@ -3,8 +3,9 @@ import React from 'react';
 import { generateTransactions } from 'loot-core/src/mocks';
 import { TestProvider } from 'loot-core/src/mocks/redux';
 
-import { ImportTransactions } from './ImportTransactions';
 import { Section, TestModal } from '../../guide/components';
+
+import { ImportTransactions } from './ImportTransactions';
 
 let transactions = generateTransactions(20, 'acct', 'group');
 // The mocks generate "internal" transactions... but we need the

--- a/packages/loot-design/src/components/modals/LoadBackup.usage.js
+++ b/packages/loot-design/src/components/modals/LoadBackup.usage.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import LoadBackup from './LoadBackup';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
-import LoadBackup from './LoadBackup';
 
 const backups = [
   { date: 'December 23, 2017 4:08 PM', id: 'sdflkj23' },

--- a/packages/loot-design/src/components/modals/LoadBackup.usage.js
+++ b/packages/loot-design/src/components/modals/LoadBackup.usage.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import LoadBackup from './LoadBackup';
 import { Section, TestModal } from '../../guide/components';
 import { colors } from '../../style';
+
+import LoadBackup from './LoadBackup';
 
 const backups = [
   { date: 'December 23, 2017 4:08 PM', id: 'sdflkj23' },

--- a/packages/loot-design/src/components/modals/PlaidExternalMsg.usage.js
+++ b/packages/loot-design/src/components/modals/PlaidExternalMsg.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Section, TestModal } from '../../guide/components';
 import PlaidExternalMsg from './PlaidExternalMsg';
+import { Section, TestModal } from '../../guide/components';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/PlaidExternalMsg.usage.js
+++ b/packages/loot-design/src/components/modals/PlaidExternalMsg.usage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import PlaidExternalMsg from './PlaidExternalMsg';
 import { Section, TestModal } from '../../guide/components';
+
+import PlaidExternalMsg from './PlaidExternalMsg';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/SelectLinkedAccounts.usage.js
+++ b/packages/loot-design/src/components/modals/SelectLinkedAccounts.usage.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Section, TestModal } from '../../guide/components';
 import SelectLinkedAccounts from './SelectLinkedAccounts';
+import { Section, TestModal } from '../../guide/components';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/modals/SelectLinkedAccounts.usage.js
+++ b/packages/loot-design/src/components/modals/SelectLinkedAccounts.usage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import SelectLinkedAccounts from './SelectLinkedAccounts';
 import { Section, TestModal } from '../../guide/components';
+
+import SelectLinkedAccounts from './SelectLinkedAccounts';
 
 export default () => (
   <Section>

--- a/packages/loot-design/src/components/payees.js
+++ b/packages/loot-design/src/components/payees.js
@@ -13,6 +13,12 @@ import memoizeOne from 'memoize-one';
 
 import { groupById } from 'loot-core/src/shared/util';
 
+import { colors } from '../style';
+import Delete from '../svg/v0/Delete';
+import ExpandArrow from '../svg/v0/ExpandArrow';
+import Merge from '../svg/v0/Merge';
+import ArrowThinRight from '../svg/v1/ArrowThinRight';
+
 import {
   useStableCallback,
   View,
@@ -37,11 +43,6 @@ import useSelected, {
   useSelectedItems,
   useSelectedDispatch
 } from './useSelected';
-import { colors } from '../style';
-import Delete from '../svg/v0/Delete';
-import ExpandArrow from '../svg/v0/ExpandArrow';
-import Merge from '../svg/v0/Merge';
-import ArrowThinRight from '../svg/v1/ArrowThinRight';
 
 let getPayeesById = memoizeOne(payees => groupById(payees));
 

--- a/packages/loot-design/src/components/payees.js
+++ b/packages/loot-design/src/components/payees.js
@@ -13,11 +13,6 @@ import memoizeOne from 'memoize-one';
 
 import { groupById } from 'loot-core/src/shared/util';
 
-import { colors } from '../style';
-import Delete from '../svg/v0/Delete';
-import ExpandArrow from '../svg/v0/ExpandArrow';
-import Merge from '../svg/v0/Merge';
-import ArrowThinRight from '../svg/v1/ArrowThinRight';
 import {
   useStableCallback,
   View,
@@ -42,6 +37,11 @@ import useSelected, {
   useSelectedItems,
   useSelectedDispatch
 } from './useSelected';
+import { colors } from '../style';
+import Delete from '../svg/v0/Delete';
+import ExpandArrow from '../svg/v0/ExpandArrow';
+import Merge from '../svg/v0/Merge';
+import ArrowThinRight from '../svg/v1/ArrowThinRight';
 
 let getPayeesById = memoizeOne(payees => groupById(payees));
 

--- a/packages/loot-design/src/components/payees.usage.js
+++ b/packages/loot-design/src/components/payees.usage.js
@@ -5,8 +5,8 @@ import Component from '@reactions/component';
 import { TestProvider } from 'loot-core/src/mocks/redux';
 import { applyChanges } from 'loot-core/src/shared/util';
 
-import { Section, TestModal } from '../guide/components';
 import { ManagePayees } from './payees';
+import { Section, TestModal } from '../guide/components';
 
 let categoryGroups = [
   {

--- a/packages/loot-design/src/components/payees.usage.js
+++ b/packages/loot-design/src/components/payees.usage.js
@@ -5,8 +5,9 @@ import Component from '@reactions/component';
 import { TestProvider } from 'loot-core/src/mocks/redux';
 import { applyChanges } from 'loot-core/src/shared/util';
 
-import { ManagePayees } from './payees';
 import { Section, TestModal } from '../guide/components';
+
+import { ManagePayees } from './payees';
 
 let categoryGroups = [
   {

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -6,16 +6,6 @@ import { css } from 'glamor';
 
 import Platform from 'loot-core/src/client/platform';
 
-import {
-  View,
-  Block,
-  AlignedText,
-  AnchorLink,
-  ButtonLink,
-  Button
-} from './common';
-import { useDraggable, useDroppable, DropHighlight } from './sort.js';
-import CellValue from './spreadsheet/CellValue';
 import { styles, colors } from '../style';
 import Add from '../svg/v1/Add';
 import CheveronDown from '../svg/v1/CheveronDown';
@@ -27,6 +17,17 @@ import TuningIcon from '../svg/v1/Tuning';
 import Wallet from '../svg/v1/Wallet';
 import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
 import CalendarIcon from '../svg/v2/Calendar';
+
+import {
+  View,
+  Block,
+  AlignedText,
+  AnchorLink,
+  ButtonLink,
+  Button
+} from './common';
+import { useDraggable, useDroppable, DropHighlight } from './sort.js';
+import CellValue from './spreadsheet/CellValue';
 
 export const SIDEBAR_WIDTH = 240;
 

--- a/packages/loot-design/src/components/sidebar.js
+++ b/packages/loot-design/src/components/sidebar.js
@@ -6,6 +6,16 @@ import { css } from 'glamor';
 
 import Platform from 'loot-core/src/client/platform';
 
+import {
+  View,
+  Block,
+  AlignedText,
+  AnchorLink,
+  ButtonLink,
+  Button
+} from './common';
+import { useDraggable, useDroppable, DropHighlight } from './sort.js';
+import CellValue from './spreadsheet/CellValue';
 import { styles, colors } from '../style';
 import Add from '../svg/v1/Add';
 import CheveronDown from '../svg/v1/CheveronDown';
@@ -17,16 +27,6 @@ import TuningIcon from '../svg/v1/Tuning';
 import Wallet from '../svg/v1/Wallet';
 import ArrowButtonLeft1 from '../svg/v2/ArrowButtonLeft1';
 import CalendarIcon from '../svg/v2/Calendar';
-import {
-  View,
-  Block,
-  AlignedText,
-  AnchorLink,
-  ButtonLink,
-  Button
-} from './common';
-import { useDraggable, useDroppable, DropHighlight } from './sort.js';
-import CellValue from './spreadsheet/CellValue';
 
 export const SIDEBAR_WIDTH = 240;
 

--- a/packages/loot-design/src/components/sidebar.usage.js
+++ b/packages/loot-design/src/components/sidebar.usage.js
@@ -8,9 +8,9 @@ import lively from '@jlongster/lively';
 import { generateAccount } from 'loot-core/src/mocks';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
-import { Section } from '../guide/components';
 import { Sidebar } from './sidebar';
 import SpreadsheetContext from './spreadsheet/SpreadsheetContext';
+import { Section } from '../guide/components';
 
 function withState(state, render) {
   const Component = lively(render, { getInitialState: () => state });

--- a/packages/loot-design/src/components/sidebar.usage.js
+++ b/packages/loot-design/src/components/sidebar.usage.js
@@ -8,9 +8,10 @@ import lively from '@jlongster/lively';
 import { generateAccount } from 'loot-core/src/mocks';
 import makeSpreadsheet from 'loot-core/src/mocks/spreadsheet';
 
+import { Section } from '../guide/components';
+
 import { Sidebar } from './sidebar';
 import SpreadsheetContext from './spreadsheet/SpreadsheetContext';
-import { Section } from '../guide/components';
 
 function withState(state, render) {
   const Component = lively(render, { getInitialState: () => state });

--- a/packages/loot-design/src/components/sort.js
+++ b/packages/loot-design/src/components/sort.js
@@ -8,8 +8,9 @@ import React, {
 } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-import { View } from './common';
 import { colors } from '../style';
+
+import { View } from './common';
 
 export function useMergedRefs(ref1, ref2) {
   return useMemo(() => {

--- a/packages/loot-design/src/components/sort.js
+++ b/packages/loot-design/src/components/sort.js
@@ -8,8 +8,8 @@ import React, {
 } from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 
-import { colors } from '../style';
 import { View } from './common';
+import { colors } from '../style';
 
 export function useMergedRefs(ref1, ref2) {
   return useMemo(() => {

--- a/packages/loot-design/src/components/spreadsheet/CellValue.js
+++ b/packages/loot-design/src/components/spreadsheet/CellValue.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { styles } from '../../style';
-import Text from '../Text';
 import format from './format';
 import SheetValue from './SheetValue';
+import { styles } from '../../style';
+import Text from '../Text';
 
 function CellValue({ binding, type, formatter, style, getStyle, debug }) {
   return (

--- a/packages/loot-design/src/components/spreadsheet/CellValue.js
+++ b/packages/loot-design/src/components/spreadsheet/CellValue.js
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import format from './format';
-import SheetValue from './SheetValue';
 import { styles } from '../../style';
 import Text from '../Text';
+
+import format from './format';
+import SheetValue from './SheetValue';
 
 function CellValue({ binding, type, formatter, style, getStyle, debug }) {
   return (

--- a/packages/loot-design/src/components/table.js
+++ b/packages/loot-design/src/components/table.js
@@ -13,12 +13,6 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { scope } from '@jlongster/lively';
 
-import { styles, colors } from '../style';
-import AnimatedLoading from '../svg/AnimatedLoading';
-import DeleteIcon from '../svg/v0/Delete';
-import ExpandArrow from '../svg/v0/ExpandArrow';
-import Checkmark from '../svg/v1/Checkmark';
-import { keys } from '../util/keys';
 import {
   View,
   Text,
@@ -35,6 +29,12 @@ import format from './spreadsheet/format';
 import SheetValue from './spreadsheet/SheetValue';
 import { AvoidRefocusScrollProvider, useProperFocus } from './useProperFocus';
 import { useSelectedItems } from './useSelected';
+import { styles, colors } from '../style';
+import AnimatedLoading from '../svg/AnimatedLoading';
+import DeleteIcon from '../svg/v0/Delete';
+import ExpandArrow from '../svg/v0/ExpandArrow';
+import Checkmark from '../svg/v1/Checkmark';
+import { keys } from '../util/keys';
 
 export const ROW_HEIGHT = 32;
 export const TABLE_BACKGROUND_COLOR = colors.n11;

--- a/packages/loot-design/src/components/table.js
+++ b/packages/loot-design/src/components/table.js
@@ -13,6 +13,13 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { scope } from '@jlongster/lively';
 
+import { styles, colors } from '../style';
+import AnimatedLoading from '../svg/AnimatedLoading';
+import DeleteIcon from '../svg/v0/Delete';
+import ExpandArrow from '../svg/v0/ExpandArrow';
+import Checkmark from '../svg/v1/Checkmark';
+import { keys } from '../util/keys';
+
 import {
   View,
   Text,
@@ -29,12 +36,6 @@ import format from './spreadsheet/format';
 import SheetValue from './spreadsheet/SheetValue';
 import { AvoidRefocusScrollProvider, useProperFocus } from './useProperFocus';
 import { useSelectedItems } from './useSelected';
-import { styles, colors } from '../style';
-import AnimatedLoading from '../svg/AnimatedLoading';
-import DeleteIcon from '../svg/v0/Delete';
-import ExpandArrow from '../svg/v0/ExpandArrow';
-import Checkmark from '../svg/v1/Checkmark';
-import { keys } from '../util/keys';
 
 export const ROW_HEIGHT = 32;
 export const TABLE_BACKGROUND_COLOR = colors.n11;

--- a/packages/loot-design/src/components/table.usage.js
+++ b/packages/loot-design/src/components/table.usage.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import { Section, Component } from '../guide/components';
 import { View, Text } from './common';
 import {
   TableWithNavigator as Table,
@@ -9,6 +8,7 @@ import {
   InputCell,
   useTableNavigator
 } from './table';
+import { Section, Component } from '../guide/components';
 
 let uuid = require('loot-core/src/platform/uuid');
 

--- a/packages/loot-design/src/components/table.usage.js
+++ b/packages/loot-design/src/components/table.usage.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { Section, Component } from '../guide/components';
+
 import { View, Text } from './common';
 import {
   TableWithNavigator as Table,
@@ -8,7 +10,6 @@ import {
   InputCell,
   useTableNavigator
 } from './table';
-import { Section, Component } from '../guide/components';
 
 let uuid = require('loot-core/src/platform/uuid');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,7 +82,7 @@ __metadata:
     eslint-config-react-app: 3.0.5
     eslint-loader: 2.1.1
     eslint-plugin-flowtype: 2.50.1
-    eslint-plugin-import: ^2.26.0
+    eslint-plugin-import: ^2.27.5
     eslint-plugin-jsx-a11y: 6.1.2
     eslint-plugin-prettier: ^3.1.4
     eslint-plugin-react: 7.11.1
@@ -5702,16 +5702,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array-includes@npm:^3.1.4":
-  version: 3.1.5
-  resolution: "array-includes@npm:3.1.5"
+"array-includes@npm:^3.1.6":
+  version: 3.1.6
+  resolution: "array-includes@npm:3.1.6"
   dependencies:
     call-bind: ^1.0.2
     define-properties: ^1.1.4
-    es-abstract: ^1.19.5
-    get-intrinsic: ^1.1.1
+    es-abstract: ^1.20.4
+    get-intrinsic: ^1.1.3
     is-string: ^1.0.7
-  checksum: f6f24d834179604656b7bec3e047251d5cc87e9e87fab7c175c61af48e80e75acd296017abcde21fb52292ab6a2a449ab2ee37213ee48c8709f004d75983f9c5
+  checksum: f22f8cd8ba8a6448d91eebdc69f04e4e55085d09232b5216ee2d476dab3ef59984e8d1889e662c6a0ed939dcb1b57fd05b2c0209c3370942fc41b752c82a2ca5
   languageName: node
   linkType: hard
 
@@ -5745,15 +5745,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.2.5":
-  version: 1.3.0
-  resolution: "array.prototype.flat@npm:1.3.0"
+"array.prototype.flat@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "array.prototype.flat@npm:1.3.1"
   dependencies:
     call-bind: ^1.0.2
-    define-properties: ^1.1.3
-    es-abstract: ^1.19.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
     es-shim-unscopables: ^1.0.0
-  checksum: 2a652b3e8dc0bebb6117e42a5ab5738af0203a14c27341d7bb2431467bdb4b348e2c5dc555dfcda8af0a5e4075c400b85311ded73861c87290a71a17c3e0a257
+  checksum: 5a8415949df79bf6e01afd7e8839bbde5a3581300e8ad5d8449dea52639e9e59b26a467665622783697917b43bf39940a6e621877c7dd9b3d1c1f97484b9b88b
+  languageName: node
+  linkType: hard
+
+"array.prototype.flatmap@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "array.prototype.flatmap@npm:1.3.1"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+    es-shim-unscopables: ^1.0.0
+  checksum: 8c1c43a4995f12cf12523436da28515184c753807b3f0bc2ca6c075f71c470b099e2090cc67dba8e5280958fea401c1d0c59e1db0143272aef6cd1103921a987
   languageName: node
   linkType: hard
 
@@ -10087,7 +10099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.2, es-abstract@npm:^1.19.5":
+"es-abstract@npm:^1.19.0, es-abstract@npm:^1.19.5":
   version: 1.20.1
   resolution: "es-abstract@npm:1.20.1"
   dependencies:
@@ -10118,6 +10130,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-abstract@npm:^1.20.4":
+  version: 1.21.1
+  resolution: "es-abstract@npm:1.21.1"
+  dependencies:
+    available-typed-arrays: ^1.0.5
+    call-bind: ^1.0.2
+    es-set-tostringtag: ^2.0.1
+    es-to-primitive: ^1.2.1
+    function-bind: ^1.1.1
+    function.prototype.name: ^1.1.5
+    get-intrinsic: ^1.1.3
+    get-symbol-description: ^1.0.0
+    globalthis: ^1.0.3
+    gopd: ^1.0.1
+    has: ^1.0.3
+    has-property-descriptors: ^1.0.0
+    has-proto: ^1.0.1
+    has-symbols: ^1.0.3
+    internal-slot: ^1.0.4
+    is-array-buffer: ^3.0.1
+    is-callable: ^1.2.7
+    is-negative-zero: ^2.0.2
+    is-regex: ^1.1.4
+    is-shared-array-buffer: ^1.0.2
+    is-string: ^1.0.7
+    is-typed-array: ^1.1.10
+    is-weakref: ^1.0.2
+    object-inspect: ^1.12.2
+    object-keys: ^1.1.1
+    object.assign: ^4.1.4
+    regexp.prototype.flags: ^1.4.3
+    safe-regex-test: ^1.0.0
+    string.prototype.trimend: ^1.0.6
+    string.prototype.trimstart: ^1.0.6
+    typed-array-length: ^1.0.4
+    unbox-primitive: ^1.0.2
+    which-typed-array: ^1.1.9
+  checksum: 23ff60d42d17a55d150e7bcedbdb065d4077a8b98c436e0e2e1ef4dd532a6d78a56028673de0bd8ed464a43c46ba781c50d9af429b6a17e44dbd14c7d7fb7926
+  languageName: node
+  linkType: hard
+
 "es-get-iterator@npm:^1.1.1":
   version: 1.1.2
   resolution: "es-get-iterator@npm:1.1.2"
@@ -10131,6 +10184,17 @@ __metadata:
     is-string: ^1.0.5
     isarray: ^2.0.5
   checksum: f75e66acb6a45686fa08b3ade9c9421a70d36a0c43ed4363e67f4d7aab2226cb73dd977cb48abbaf75721b946d3cd810682fcf310c7ad0867802fbf929b17dcf
+  languageName: node
+  linkType: hard
+
+"es-set-tostringtag@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "es-set-tostringtag@npm:2.0.1"
+  dependencies:
+    get-intrinsic: ^1.1.3
+    has: ^1.0.3
+    has-tostringtag: ^1.0.0
+  checksum: ec416a12948cefb4b2a5932e62093a7cf36ddc3efd58d6c58ca7ae7064475ace556434b869b0bbeb0c365f1032a8ccd577211101234b69837ad83ad204fff884
   languageName: node
   linkType: hard
 
@@ -10282,13 +10346,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "eslint-import-resolver-node@npm:0.3.6"
+"eslint-import-resolver-node@npm:^0.3.7":
+  version: 0.3.7
+  resolution: "eslint-import-resolver-node@npm:0.3.7"
   dependencies:
     debug: ^3.2.7
-    resolve: ^1.20.0
-  checksum: 6266733af1e112970e855a5bcc2d2058fb5ae16ad2a6d400705a86b29552b36131ffc5581b744c23d550de844206fb55e9193691619ee4dbf225c4bde526b1c8
+    is-core-module: ^2.11.0
+    resolve: ^1.22.1
+  checksum: 3379aacf1d2c6952c1b9666c6fa5982c3023df695430b0d391c0029f6403a7775414873d90f397e98ba6245372b6c8960e16e74d9e4a3b0c0a4582f3bdbe3d6e
   languageName: node
   linkType: hard
 
@@ -10308,7 +10373,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.7.3":
+"eslint-module-utils@npm:^2.7.4":
   version: 2.7.4
   resolution: "eslint-module-utils@npm:2.7.4"
   dependencies:
@@ -10331,26 +10396,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.26.0":
-  version: 2.26.0
-  resolution: "eslint-plugin-import@npm:2.26.0"
+"eslint-plugin-import@npm:^2.27.5":
+  version: 2.27.5
+  resolution: "eslint-plugin-import@npm:2.27.5"
   dependencies:
-    array-includes: ^3.1.4
-    array.prototype.flat: ^1.2.5
-    debug: ^2.6.9
+    array-includes: ^3.1.6
+    array.prototype.flat: ^1.3.1
+    array.prototype.flatmap: ^1.3.1
+    debug: ^3.2.7
     doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.6
-    eslint-module-utils: ^2.7.3
+    eslint-import-resolver-node: ^0.3.7
+    eslint-module-utils: ^2.7.4
     has: ^1.0.3
-    is-core-module: ^2.8.1
+    is-core-module: ^2.11.0
     is-glob: ^4.0.3
     minimatch: ^3.1.2
-    object.values: ^1.1.5
-    resolve: ^1.22.0
+    object.values: ^1.1.6
+    resolve: ^1.22.1
+    semver: ^6.3.0
     tsconfig-paths: ^3.14.1
   peerDependencies:
     eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-  checksum: 0bf77ad80339554481eafa2b1967449e1f816b94c7a6f9614ce33fb4083c4e6c050f10d241dd50b4975d47922880a34de1e42ea9d8e6fd663ebb768baa67e655
+  checksum: f500571a380167e25d72a4d925ef9a7aae8899eada57653e5f3051ec3d3c16d08271fcefe41a30a9a2f4fefc232f066253673ee4ea77b30dba65ae173dade85d
   languageName: node
   linkType: hard
 
@@ -11769,6 +11836,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-intrinsic@npm:^1.1.3":
+  version: 1.2.0
+  resolution: "get-intrinsic@npm:1.2.0"
+  dependencies:
+    function-bind: ^1.1.1
+    has: ^1.0.3
+    has-symbols: ^1.0.3
+  checksum: 78fc0487b783f5c58cf2dccafc3ae656ee8d2d8062a8831ce4a95e7057af4587a1d4882246c033aca0a7b4965276f4802b45cc300338d1b77a73d3e3e3f4877d
+  languageName: node
+  linkType: hard
+
 "get-own-enumerable-property-symbols@npm:^3.0.0":
   version: 3.0.2
   resolution: "get-own-enumerable-property-symbols@npm:3.0.2"
@@ -12029,6 +12107,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globalthis@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "globalthis@npm:1.0.3"
+  dependencies:
+    define-properties: ^1.1.3
+  checksum: fbd7d760dc464c886d0196166d92e5ffb4c84d0730846d6621a39fbbc068aeeb9c8d1421ad330e94b7bca4bb4ea092f5f21f3d36077812af5d098b4dc006c998
+  languageName: node
+  linkType: hard
+
 "globby@npm:^11.0.4":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
@@ -12060,6 +12147,15 @@ __metadata:
   version: 3.19.4
   resolution: "google-protobuf@npm:3.19.4"
   checksum: c0ebc0afbb635271b54db933be74441429e0df095347d0145ae7036377a2cc6fc402ed015855ebc1809c7cedfde3246344ad28a98eac1e6a21800c7b572b2caf
+  languageName: node
+  linkType: hard
+
+"gopd@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "gopd@npm:1.0.1"
+  dependencies:
+    get-intrinsic: ^1.1.3
+  checksum: a5ccfb8806e0917a94e0b3de2af2ea4979c1da920bc381667c260e00e7cafdbe844e2cb9c5bcfef4e5412e8bf73bab837285bc35c7ba73aaaf0134d4583393a6
   languageName: node
   linkType: hard
 
@@ -12260,6 +12356,13 @@ __metadata:
   dependencies:
     get-intrinsic: ^1.1.1
   checksum: a6d3f0a266d0294d972e354782e872e2fe1b6495b321e6ef678c9b7a06a40408a6891817350c62e752adced73a94ac903c54734fee05bf65b1905ee1368194bb
+  languageName: node
+  linkType: hard
+
+"has-proto@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "has-proto@npm:1.0.1"
+  checksum: febc5b5b531de8022806ad7407935e2135f1cc9e64636c3916c6842bd7995994ca3b29871ecd7954bd35f9e2986c17b3b227880484d22259e2f8e6ce63fd383e
   languageName: node
   linkType: hard
 
@@ -13093,6 +13196,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"internal-slot@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "internal-slot@npm:1.0.4"
+  dependencies:
+    get-intrinsic: ^1.1.3
+    has: ^1.0.3
+    side-channel: ^1.0.4
+  checksum: 8974588d06bab4f675573a3b52975370facf6486df51bc0567a982c7024fa29495f10b76c0d4dc742dd951d1b72024fdc1e31bb0bedf1678dc7aacacaf5a4f73
+  languageName: node
+  linkType: hard
+
 "internmap@npm:1 - 2":
   version: 2.0.3
   resolution: "internmap@npm:2.0.3"
@@ -13212,6 +13326,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-array-buffer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "is-array-buffer@npm:3.0.1"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    is-typed-array: ^1.1.10
+  checksum: f26ab87448e698285daf707e52a533920449f7abf63714140ffab9d5571aa5a71ac2fa2677e8b793ad0d5d3e40078d4d2c8a0ab39c957e3cfc6513bb6c9dfdc9
+  languageName: node
+  linkType: hard
+
 "is-arrayish@npm:^0.2.1":
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
@@ -13277,6 +13402,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-callable@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "is-callable@npm:1.2.7"
+  checksum: 61fd57d03b0d984e2ed3720fb1c7a897827ea174bd44402878e059542ea8c4aeedee0ea0985998aa5cc2736b2fa6e271c08587addb5b3959ac52cf665173d1ac
+  languageName: node
+  linkType: hard
+
 "is-ci@npm:^2.0.0":
   version: 2.0.0
   resolution: "is-ci@npm:2.0.0"
@@ -13299,6 +13431,15 @@ __metadata:
     rgb-regex: ^1.0.1
     rgba-regex: ^1.0.0
   checksum: 778dd52a603ab8da827925aa4200fe6733b667b216495a04110f038b925dc5ef58babe759b94ffc4e44fcf439328695770873937f59d6045f676322b97f3f92d
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "is-core-module@npm:2.11.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: f96fd490c6b48eb4f6d10ba815c6ef13f410b0ba6f7eb8577af51697de523e5f2cd9de1c441b51d27251bf0e4aebc936545e33a5d26d5d51f28d25698d4a8bab
   languageName: node
   linkType: hard
 
@@ -13678,6 +13819,19 @@ __metadata:
   dependencies:
     has-symbols: ^1.0.2
   checksum: 92805812ef590738d9de49d677cd17dfd486794773fb6fa0032d16452af46e9b91bb43ffe82c983570f015b37136f4b53b28b8523bfb10b0ece7a66c31a54510
+  languageName: node
+  linkType: hard
+
+"is-typed-array@npm:^1.1.10, is-typed-array@npm:^1.1.9":
+  version: 1.1.10
+  resolution: "is-typed-array@npm:1.1.10"
+  dependencies:
+    available-typed-arrays: ^1.0.5
+    call-bind: ^1.0.2
+    for-each: ^0.3.3
+    gopd: ^1.0.1
+    has-tostringtag: ^1.0.0
+  checksum: aac6ecb59d4c56a1cdeb69b1f129154ef462bbffe434cb8a8235ca89b42f258b7ae94073c41b3cb7bce37f6a1733ad4499f07882d5d5093a7ba84dfc4ebb8017
   languageName: node
   linkType: hard
 
@@ -15459,7 +15613,7 @@ __metadata:
     date-fns: 2.0.0-alpha.27
     deep-equal: ^2.0.5
     eslint: 5.6.0
-    eslint-plugin-import: ^2.26.0
+    eslint-plugin-import: ^2.27.5
     eslint-plugin-prettier: ^3.1.4
     esm: ^3.0.82
     fake-indexeddb: ^3.1.3
@@ -17311,6 +17465,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-inspect@npm:^1.12.2":
+  version: 1.12.3
+  resolution: "object-inspect@npm:1.12.3"
+  checksum: dabfd824d97a5f407e6d5d24810d888859f6be394d8b733a77442b277e0808860555176719c5905e765e3743a7cada6b8b0a3b85e5331c530fd418cc8ae991db
+  languageName: node
+  linkType: hard
+
 "object-is@npm:^1.0.1, object-is@npm:^1.1.4":
   version: 1.1.5
   resolution: "object-is@npm:1.1.5"
@@ -17349,6 +17510,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object.assign@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "object.assign@npm:4.1.4"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    has-symbols: ^1.0.3
+    object-keys: ^1.1.1
+  checksum: 76cab513a5999acbfe0ff355f15a6a125e71805fcf53de4e9d4e082e1989bdb81d1e329291e1e4e0ae7719f0e4ef80e88fb2d367ae60500d79d25a6224ac8864
+  languageName: node
+  linkType: hard
+
 "object.getownpropertydescriptors@npm:^2.0.3, object.getownpropertydescriptors@npm:^2.1.0, object.getownpropertydescriptors@npm:^2.1.1":
   version: 2.1.3
   resolution: "object.getownpropertydescriptors@npm:2.1.3"
@@ -17369,7 +17542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.0, object.values@npm:^1.1.5":
+"object.values@npm:^1.1.0":
   version: 1.1.5
   resolution: "object.values@npm:1.1.5"
   dependencies:
@@ -17377,6 +17550,17 @@ __metadata:
     define-properties: ^1.1.3
     es-abstract: ^1.19.1
   checksum: 0f17e99741ebfbd0fa55ce942f6184743d3070c61bd39221afc929c8422c4907618c8da694c6915bc04a83ab3224260c779ba37fc07bb668bdc5f33b66a902a4
+  languageName: node
+  linkType: hard
+
+"object.values@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "object.values@npm:1.1.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: f6fff9fd817c24cfd8107f50fb33061d81cd11bacc4e3dbb3852e9ff7692fde4dbce823d4333ea27cd9637ef1b6690df5fbb61f1ed314fa2959598dc3ae23d8e
   languageName: node
   linkType: hard
 
@@ -20567,7 +20751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.0":
+"resolve@npm:^1.22.1":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -20602,7 +20786,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -20822,6 +21006,17 @@ __metadata:
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
+  languageName: node
+  linkType: hard
+
+"safe-regex-test@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "safe-regex-test@npm:1.0.0"
+  dependencies:
+    call-bind: ^1.0.2
+    get-intrinsic: ^1.1.3
+    is-regex: ^1.1.4
+  checksum: bc566d8beb8b43c01b94e67de3f070fd2781685e835959bbbaaec91cc53381145ca91f69bd837ce6ec244817afa0a5e974fc4e40a2957f0aca68ac3add1ddd34
   languageName: node
   linkType: hard
 
@@ -21942,6 +22137,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"string.prototype.trimend@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "string.prototype.trimend@npm:1.0.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: 0fdc34645a639bd35179b5a08227a353b88dc089adf438f46be8a7c197fc3f22f8514c1c9be4629b3cd29c281582730a8cbbad6466c60f76b5f99cf2addb132e
+  languageName: node
+  linkType: hard
+
 "string.prototype.trimstart@npm:^1.0.4":
   version: 1.0.4
   resolution: "string.prototype.trimstart@npm:1.0.4"
@@ -21960,6 +22166,17 @@ __metadata:
     define-properties: ^1.1.4
     es-abstract: ^1.19.5
   checksum: a4857c5399ad709d159a77371eeaa8f9cc284469a0b5e1bfe405de16f1fd4166a8ea6f4180e55032f348d1b679b1599fd4301fbc7a8b72bdb3e795e43f7b1048
+  languageName: node
+  linkType: hard
+
+"string.prototype.trimstart@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "string.prototype.trimstart@npm:1.0.6"
+  dependencies:
+    call-bind: ^1.0.2
+    define-properties: ^1.1.4
+    es-abstract: ^1.20.4
+  checksum: 89080feef416621e6ef1279588994305477a7a91648d9436490d56010a1f7adc39167cddac7ce0b9884b8cdbef086987c4dcb2960209f2af8bac0d23ceff4f41
   languageName: node
   linkType: hard
 
@@ -22879,6 +23096,17 @@ __metadata:
   version: 2.6.0
   resolution: "type@npm:2.6.0"
   checksum: 80da01fcc0f6ed5a253dc326530e134000a8f66ea44b6d9687cde2f894f0d0b2486595b0cd040a64f7f79dc3120784236f8c9ef667a8aef03984e049b447cfb4
+  languageName: node
+  linkType: hard
+
+"typed-array-length@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "typed-array-length@npm:1.0.4"
+  dependencies:
+    call-bind: ^1.0.2
+    for-each: ^0.3.3
+    is-typed-array: ^1.1.9
+  checksum: 2228febc93c7feff142b8c96a58d4a0d7623ecde6c7a24b2b98eb3170e99f7c7eff8c114f9b283085cd59dcd2bd43aadf20e25bba4b034a53c5bb292f71f8956
   languageName: node
   linkType: hard
 
@@ -24384,6 +24612,20 @@ __metadata:
     has-tostringtag: ^1.0.0
     is-typed-array: ^1.1.7
   checksum: 147837cf5866e36b6b2e427731709e02f79f1578477cbde68ed773a5307520a6cb6836c73c79c30690a473266ee59010b83b6d9b25d8d677a40ff77fb37a8a84
+  languageName: node
+  linkType: hard
+
+"which-typed-array@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "which-typed-array@npm:1.1.9"
+  dependencies:
+    available-typed-arrays: ^1.0.5
+    call-bind: ^1.0.2
+    for-each: ^0.3.3
+    gopd: ^1.0.1
+    has-tostringtag: ^1.0.0
+    is-typed-array: ^1.1.10
+  checksum: fe0178ca44c57699ca2c0e657b64eaa8d2db2372a4e2851184f568f98c478ae3dc3fdb5f7e46c384487046b0cf9e23241423242b277e03e8ba3dabc7c84c98ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Apologies for the large PR. 

Basically two changes here:

1. upgrade `eslint-plugin-import` to the latest version
2. run auto-fixer to fix all the issues (just re-shuffles some imports without changing any functionality)

**Why the extra space between `parent` and `sibling` group?**

The alternative is to move `parent` below `sibling` imports: [example](https://github.com/actualbudget/actual/pull/492/commits/55b7d60d0e729592e1e5311615c9336745904467). Personally, I don't prefer this approach. So if the choice is between 1) keeping the import order as-is, but having a new line between them and 2) changing so parent imports go below sibling - I would prefer to go with option 1.