### PR TITLE
[Feature] List of categories in transfer money dialog

### DIFF
--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -79,7 +79,7 @@ export default function TransferTooltip({
       <CategoryAutocomplete
         categoryGroups={categoryGroups}
         value={null}
-        openOnFocus={false}
+        openOnFocus={true}
         onUpdate={id => {}}
         onSelect={id => setCategory(id)}
         inputProps={{


### PR DESCRIPTION
Fixes #566

This change allows the category list to pop up upon clicking into the text box without waiting for text input first. As issue #566 stated, this is consistent with the accounts transaction page where you simply click on the category box and the list of categories appears without any keyboard input.

![image](https://user-images.githubusercontent.com/20625555/214061891-42fab740-bf39-40f4-9c73-dbd18143cd65.png)
