### PR TITLE
Use navigitor.userAgent to determine isMobile

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -202,7 +202,7 @@ function MobileNavTabs() {
 class FinancesApp extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { isMobile: isMobile(window.innerWidth) };
+    this.state = { isMobile: isMobile() };
     this.history = createBrowserHistory();
 
     let oldPush = this.history.push;
@@ -231,7 +231,7 @@ class FinancesApp extends React.Component {
 
   handleWindowResize() {
     this.setState({
-      isMobile: isMobile(window.innerWidth),
+      isMobile: isMobile(),
       windowWidth: window.innerWidth
     });
   }

--- a/packages/desktop-client/src/util.js
+++ b/packages/desktop-client/src/util.js
@@ -1,12 +1,11 @@
-import tokens from 'loot-design/src/tokens';
-
 export function getModalRoute(name) {
   let parts = name.split('/');
   return [parts[0], parts.slice(1).join('/')];
 }
 
-export function isMobile(width) {
-  // Simple detection: if the screen width is too small
-  const containerWidth = width || window.innerWidth;
-  return containerWidth < parseInt(tokens.breakpoint_medium);
+export function isMobile() {
+  let details = navigator.userAgent;
+  let regexp = /Mobi|android|iphone|kindle|ipad/i;
+  let isMobileDevice = regexp.test(details);
+  return isMobileDevice;
 }

--- a/packages/desktop-client/src/util.js
+++ b/packages/desktop-client/src/util.js
@@ -6,6 +6,5 @@ export function getModalRoute(name) {
 export function isMobile() {
   let details = navigator.userAgent;
   let regexp = /Mobi|android|iphone|kindle|ipad/i;
-  let isMobileDevice = regexp.test(details);
-  return isMobileDevice;
+  return regexp.test(details);
 }


### PR DESCRIPTION
This is an alternate method to determine the isMobile status for using the responsive mobile view.  This should respect the "Desktop site" option if used in a mobile browser.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent

Reference: https://www.tutorialspoint.com/javascript-how-to-detect-if-a-website-is-open-on-a-mobile-or-a-desktop