### PR TITLE
opens the category/payee/account lists on focus

### DIFF
--- a/packages/desktop-client/src/components/util/GenericInput.js
+++ b/packages/desktop-client/src/components/util/GenericInput.js
@@ -51,7 +51,7 @@ export default function GenericInput({
                 accounts={accounts}
                 multi={multi}
                 showMakeTransfer={false}
-                openOnFocus={false}
+                openOnFocus={true}
                 value={value}
                 onSelect={onChange}
                 inputProps={{
@@ -69,7 +69,7 @@ export default function GenericInput({
               accounts={accounts}
               value={value}
               multi={multi}
-              openOnFocus={false}
+              openOnFocus={true}
               onSelect={onChange}
               inputProps={{
                 inputRef,
@@ -85,7 +85,7 @@ export default function GenericInput({
               categoryGroups={categoryGroups}
               value={value}
               multi={multi}
-              openOnFocus={false}
+              openOnFocus={true}
               onSelect={onChange}
               inputProps={{
                 inputRef,


### PR DESCRIPTION
This change affects both the Rules modal and filters tooltip.  It will drop down a list of available options for the selected field without the need of keyboard input.