### PR TITLE
Add an issue template for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,14 +7,15 @@ body:
     id: intro-md
     attributes:
       value: |
-        Thanks for taking the time to fill out this bug report! Please ensure you provide as much information as asked to better assist in confirming and identifying a fix for the bug report.
-  - type: dropdown
+        Thanks for taking the time to fill out this bug report! Please ensure you provide as much information as possible to better assist in confirming and identifying a fix for the bug.
+  - type: checkboxes
     id: existing-issue
     attributes:
       label: 'Verified issue does not already exist?'
       description: 'Please search to see if an issue already exists for the issue you encountered.'
       options:
-        - 'I have searched and found no existing issue'
+        - label: 'I have searched and found no existing issue'
+          required: true
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Feature Request?
-    url: https://github.com/actualbudget/actual/discussions/new?category=ideas
-    about: Website is hosted via GitHub Discussions under actualbudget/actual

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Request a missing feature
+title: '[Feature] '
+labels: ['feature', 'needs triage']
+body:
+  - type: markdown
+    id: intro-md
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request! Please ensure you provide as much information as possible so we can better understand what you want us to add and so we can come up with the best solution for everyone.
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: 'Verified feature request does not already exist?'
+      description: 'Please search to see if an issue already exists for the feature you have requested.'
+      options:
+        - label: 'I have searched and found no existing issue'
+          required: true
+    validations:
+      required: true
+  - type: textarea
+    id: pitch
+    attributes:
+      label: 'Pitch: what problem are you trying to solve?'
+      description: Please concisely describe the problem that motivated your feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you’d like.
+      description: Feel free to give multiple different ideas for how the problem could be solved — we’d love to have a discussion to find the best way to solve your problem and related problems others may face! (Or leave this blank if you don’t have a solution in mind yet.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,6 +9,12 @@ body:
       value: |
         Thanks for taking the time to fill out this feature request! Please ensure you provide as much information as possible so we can better understand what you want us to add and so we can come up with the best solution for everyone.
   - type: checkboxes
+    attributes:
+      label: '💻'
+      description: (Optional) Please check this box if you’re willing to open a PR to implement this feature. We’ll help you get started and answer any questions you have along the way :)
+      options:
+        - label: Would you like to implement this feature?
+  - type: checkboxes
     id: existing-issue
     attributes:
       label: 'Verified feature request does not already exist?'

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -38,3 +38,10 @@ body:
       description: Feel free to give multiple different ideas for how the problem could be solved — we’d love to have a discussion to find the best way to solve your problem and related problems others may face! (Or leave this blank if you don’t have a solution in mind yet.)
     validations:
       required: false
+  - type: textarea
+    id: learning
+    attributes:
+      label: Teaching and learning
+      description: How can we make sure future users find and enjoy this feature? (i.e. how do we make it discoverable? what kind of documentation should we write? are there aspects of the feature that could trip up users?)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,34 +7,34 @@ body:
     id: intro-md
     attributes:
       value: |
-        Thanks for taking the time to fill out this feature request! Please ensure you provide as much information as possible so we can better understand what you want us to add and so we can come up with the best solution for everyone.
+        Thanks for taking the time to fill out this feature request! Please ensure you provide as much information as possible so we can better understand what you’re proposing so we can come up with the best solution for everyone.
+  - type: checkboxes
+    id: existing-issue
+    attributes:
+      label: 'Verified feature request does not already exist?'
+      description: 'Please search to see if an issue or PR already exists for the feature you’re requesting.'
+      options:
+        - label: 'I have searched and found no existing issue'
+          required: true
+    validations:
+      required: true
   - type: checkboxes
     attributes:
       label: '💻'
       description: (Optional) Please check this box if you’re willing to open a PR to implement this feature. We’ll help you get started and answer any questions you have along the way :)
       options:
         - label: Would you like to implement this feature?
-  - type: checkboxes
-    id: existing-issue
-    attributes:
-      label: 'Verified feature request does not already exist?'
-      description: 'Please search to see if an issue already exists for the feature you have requested.'
-      options:
-        - label: 'I have searched and found no existing issue'
-          required: true
-    validations:
-      required: true
   - type: textarea
     id: pitch
     attributes:
       label: 'Pitch: what problem are you trying to solve?'
-      description: Please concisely describe the problem that motivated your feature request.
+      description: Please describe, in as much detail as you can, the problem that motivated you to submit this feature request.
     validations:
       required: true
   - type: textarea
     id: solution
     attributes:
-      label: Describe the solution you’d like.
+      label: Describe your ideal solution to this problem
       description: Feel free to give multiple different ideas for how the problem could be solved — we’d love to have a discussion to find the best way to solve your problem and related problems others may face! (Or leave this blank if you don’t have a solution in mind yet.)
     validations:
       required: false


### PR DESCRIPTION
Let me know if you have any feedback on the language in the template. The fields are based on (i.e. shamelessly copied and pasted from) the [Babel](https://github.com/babel/babel/issues/new?assignees=&labels=i%3A+needs+triage%2Ci%3A+enhancement&template=feature_request.yml), [GitHub Desktop](https://github.com/desktop/desktop/issues/new?assignees=&labels=&template=feature_request.yaml), and [Mastodon](https://github.com/mastodon/mastodon/issues/new?assignees=&labels=suggestion&template=2.feature_request.yml) feature request forms.