### PR TITLE
Remove GUID on hover from PayeeCell

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -296,7 +296,14 @@ function getPayeePretty(transaction, payee, transferAcct) {
         }}
       >
         <Icon width={10} height={8} style={{ marginRight: 5, flexShrink: 0 }} />
-        <div>{transferAcct.name}</div>
+        <div
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }}
+        >
+          {transferAcct.name}
+        </div>
       </View>
     );
   } else if (payee && !payee.transfer_acct) {
@@ -409,7 +416,6 @@ function PayeeCell({
       valueStyle={[valueStyle, inherited && { color: colors.n8 }]}
       formatter={value => getPayeePretty(transaction, payee, transferAcct)}
       exposed={focused}
-      title={importedPayee || payeeId}
       onExpose={!isPreview && (name => onEdit(id, name))}
       onUpdate={async value => {
         onUpdate('payee', value);


### PR DESCRIPTION
Resolves #567 by removing the title attribute on PayeeCell and add `text-overflow` styling for Transfer Accounts in that cell too.

![CleanShot 2023-01-25 at 12 20 16@2x](https://user-images.githubusercontent.com/3413011/214681445-d2562550-5d6b-4338-9dde-33ed9a38b62b.png)
