### PR TITLE
Cover Overspending dropdown menu, open on click

### DIFF
--- a/packages/loot-design/src/components/budget/rollover/rollover-components.js
+++ b/packages/loot-design/src/components/budget/rollover/rollover-components.js
@@ -66,7 +66,7 @@ function CoverTooltip({
           <CategoryAutocomplete
             categoryGroups={categoryGroups}
             value={null}
-            openOnFocus={false}
+            openOnFocus={true}
             onUpdate={id => {}}
             onSelect={id => setCategory(id)}
             inputProps={{


### PR DESCRIPTION
This automatically opens the category drop down menu when the field is selected to cover over spending from another category.  This will match the behavior of the earlier PRs.