### PR TITLE
Add truthy condition to ambiguousDuplication check

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -485,7 +485,7 @@ function SelectedTransactionsButton({
   let ambiguousDuplication = useMemo(() => {
     let transactions = [...selectedItems].map(id => getTransaction(id));
 
-    return transactions.some(t => t.is_child);
+    return transactions.some(t => t && t.is_child);
   }, [selectedItems]);
 
   let linked = useMemo(() => {


### PR DESCRIPTION
@shall0pass reported a bug where the accounts page would crash if you selected a scheduled transaction, this is because getTransaction will return `undefined` for a preview ID. We'll check that all transactions is defined before attempting to access `is_child` on the transaction now. 

This was bug was introduced with #582!