### PR TITLE
Add support for filtering the schedules table

### DIFF
--- a/packages/desktop-client/src/components/schedules/LinkSchedule.js
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.js
@@ -3,8 +3,7 @@ import { useLocation, useHistory } from 'react-router-dom';
 
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { Input, Search, Text, View } from 'loot-design/src/components/common';
-import { colors } from 'loot-design/src/style';
+import { Search, Text, View } from 'loot-design/src/components/common';
 
 import { Page } from '../Page';
 

--- a/packages/desktop-client/src/components/schedules/LinkSchedule.js
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.js
@@ -44,6 +44,7 @@ export default function ScheduleLink() {
         statuses={statuses}
         minimal={true}
         onSelect={onSelect}
+        tableStyle={{ marginInline: -20 }}
       />
     </Page>
   );

--- a/packages/desktop-client/src/components/schedules/LinkSchedule.js
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.js
@@ -1,9 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { Text } from 'loot-design/src/components/common';
+import { Input, Search, Text, View } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 
 import { Page } from '../Page';
 
@@ -15,6 +16,8 @@ export default function ScheduleLink() {
   let scheduleData = useSchedules(
     useCallback(query => query.filter({ completed: false }), [])
   );
+
+  let [filter, setFilter] = useState('');
 
   if (scheduleData == null) {
     return null;
@@ -35,12 +38,23 @@ export default function ScheduleLink() {
 
   return (
     <Page title="Link Schedule" modalSize="medium">
-      <Text style={{ marginBottom: 20 }}>
-        Choose a schedule to link these transactions to:
-      </Text>
+      <View
+        style={{ flexDirection: 'row', marginBottom: 20, alignItems: 'center' }}
+      >
+        <Text>Choose a schedule to link these transactions to:</Text>
+        <View style={{ flex: 1 }} />
+        <Search
+          isInModal
+          width={300}
+          placeholder="Filter schedules…"
+          value={filter}
+          onChange={setFilter}
+        />
+      </View>
 
       <SchedulesTable
         schedules={schedules}
+        filter={filter}
         statuses={statuses}
         minimal={true}
         onSelect={onSelect}

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -133,7 +133,8 @@ export function SchedulesTable({
   allowCompleted,
   style,
   onSelect,
-  onAction
+  onAction,
+  tableStyle
 }) {
   let dateFormat = useSelector(state => {
     return state.prefs.local.dateFormat || 'MM/dd/yyyy';
@@ -265,7 +266,7 @@ export function SchedulesTable({
   }
 
   return (
-    <>
+    <View style={[{ flex: 1 }, tableStyle]}>
       <TableHeader height={ROW_HEIGHT} inset={15} version="v2">
         <Field width="flex">Payee</Field>
         <Field width="flex">Account</Field>
@@ -291,6 +292,6 @@ export function SchedulesTable({
         renderEmpty={filter ? 'No matching schedules' : 'No schedules'}
         allowPopupsEscape={items.length < 6}
       />
-    </>
+    </View>
   );
 }

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -152,7 +152,7 @@ export function SchedulesTable({
     const filterIncludes = str =>
       str
         ? str.toLowerCase().includes(filter.toLowerCase()) ||
-          str.toLowerCase().includes(filter.toLowerCase())
+          filter.toLowerCase().includes(str.toLowerCase())
         : false;
 
     return schedules.filter(schedule => {

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -155,23 +155,25 @@ export function SchedulesTable({
           str.toLowerCase().includes(filter.toLowerCase())
         : true;
 
-    return schedules.filter(s => {
-      let payee = payees.find(p => s._payee === p.id);
-      let account = accounts.find(a => s._account === a.id);
-      let amount = getScheduledAmount(s._amount);
+    return schedules.filter(schedule => {
+      let payee = payees.find(p => schedule._payee === p.id);
+      let account = accounts.find(a => schedule._account === a.id);
+      let amount = getScheduledAmount(schedule._amount);
       let amountStr =
-        (s._amountOp === 'isapprox' || s._amountOp === 'isbetween' ? '~' : '') +
+        (schedule._amountOp === 'isapprox' || schedule._amountOp === 'isbetween'
+          ? '~'
+          : '') +
         (amount > 0 ? '+' : '') +
         integerToCurrency(Math.abs(amount || 0));
-      let dateStr = s.next_date
-        ? monthUtils.format(s.next_date, dateFormat)
+      let dateStr = schedule.next_date
+        ? monthUtils.format(schedule.next_date, dateFormat)
         : null;
 
       return (
         filterIncludes(payee && payee.name) ||
         filterIncludes(account && account.name) ||
         filterIncludes(amountStr) ||
-        filterIncludes(statuses.get(s.id)) ||
+        filterIncludes(statuses.get(schedule.id)) ||
         filterIncludes(dateStr)
       );
     });

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -163,12 +163,16 @@ export function SchedulesTable({
         (s._amountOp === 'isapprox' || s._amountOp === 'isbetween' ? '~' : '') +
         (amount > 0 ? '+' : '') +
         integerToCurrency(Math.abs(amount || 0));
+      let dateStr = s.next_date
+        ? monthUtils.format(s.next_date, dateFormat)
+        : null;
 
       return (
         filterIncludes(payee && payee.name) ||
         filterIncludes(account && account.name) ||
         filterIncludes(amountStr) ||
-        filterIncludes(statuses.get(s.id))
+        filterIncludes(statuses.get(s.id)) ||
+        filterIncludes(dateStr)
       );
     });
   }, [schedules, filter, statuses]);

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -127,6 +127,7 @@ export function SchedulesTable({
   schedules,
   statuses,
   minimal,
+  filtered,
   allowCompleted,
   style,
   onSelect,
@@ -254,7 +255,7 @@ export function SchedulesTable({
         style={[{ flex: 1, backgroundColor: 'transparent' }, style]}
         items={items}
         renderItem={renderItem}
-        renderEmpty="No schedules"
+        renderEmpty={filtered ? 'No matching schedules' : 'No schedules'}
         allowPopupsEscape={items.length < 6}
       />
     </>

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -153,7 +153,7 @@ export function SchedulesTable({
       str
         ? str.toLowerCase().includes(filter.toLowerCase()) ||
           str.toLowerCase().includes(filter.toLowerCase())
-        : true;
+        : false;
 
     return schedules.filter(schedule => {
       let payee = payees.find(p => schedule._payee === p.id);

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
+import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
+import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { View, Button } from 'loot-design/src/components/common';
+import { getScheduledAmount } from 'loot-core/src/shared/schedules';
+import { integerToCurrency } from 'loot-core/src/shared/util';
+import { View, Button, Input } from 'loot-design/src/components/common';
+import { colors } from 'loot-design/src/style';
 
 import { Page } from '../Page';
 
@@ -12,7 +17,11 @@ import { SchedulesTable, ROW_HEIGHT } from './SchedulesTable';
 export default function Schedules() {
   let history = useHistory();
 
+  let [filter, setFilter] = useState('');
+
   let scheduleData = useSchedules();
+  let payees = useCachedPayees();
+  let accounts = useCachedAccounts();
 
   if (scheduleData == null) {
     return null;
@@ -56,8 +65,31 @@ export default function Schedules() {
     }
   }
 
+  const filterIncludes = str =>
+    str
+      ? str.toLowerCase().includes(filter.toLowerCase()) ||
+        str.toLowerCase().includes(filter.toLowerCase())
+      : true;
+
   return (
     <Page title="Schedules">
+      <View style={{ alignItems: 'flex-end' }}>
+        <Input
+          placeholder="Filter schedules..."
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          style={{
+            width: 350,
+            borderColor: 'transparent',
+            backgroundColor: colors.n11,
+            ':focus': {
+              backgroundColor: 'white',
+              '::placeholder': { color: colors.n8 }
+            }
+          }}
+        />
+      </View>
+
       <View
         style={{
           marginTop: 20,
@@ -66,7 +98,29 @@ export default function Schedules() {
         }}
       >
         <SchedulesTable
-          schedules={schedules}
+          schedules={
+            filter
+              ? schedules.filter(s => {
+                  let payee = payees.find(p => s._payee === p.id);
+                  let account = accounts.find(a => s._account === a.id);
+                  let amount = getScheduledAmount(s._amount);
+                  let amountStr =
+                    (s._amountOp === 'isapprox' || s._amountOp === 'isbetween'
+                      ? '~'
+                      : '') +
+                    (amount > 0 ? '+' : '') +
+                    integerToCurrency(Math.abs(amount || 0));
+
+                  return (
+                    filterIncludes(payee && payee.name) ||
+                    filterIncludes(account && account.name) ||
+                    filterIncludes(amountStr) ||
+                    filterIncludes(statuses.get(s.id))
+                  );
+                })
+              : schedules
+          }
+          filtered={filter !== ''}
           statuses={statuses}
           allowCompleted={true}
           onSelect={onEdit}

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -1,12 +1,8 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
-import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { getScheduledAmount } from 'loot-core/src/shared/schedules';
-import { integerToCurrency } from 'loot-core/src/shared/util';
 import { View, Button, Input } from 'loot-design/src/components/common';
 import { colors } from 'loot-design/src/style';
 
@@ -20,8 +16,6 @@ export default function Schedules() {
   let [filter, setFilter] = useState('');
 
   let scheduleData = useSchedules();
-  let payees = useCachedPayees();
-  let accounts = useCachedAccounts();
 
   if (scheduleData == null) {
     return null;
@@ -65,12 +59,6 @@ export default function Schedules() {
     }
   }
 
-  const filterIncludes = str =>
-    str
-      ? str.toLowerCase().includes(filter.toLowerCase()) ||
-        str.toLowerCase().includes(filter.toLowerCase())
-      : true;
-
   return (
     <Page title="Schedules">
       <View style={{ alignItems: 'flex-end' }}>
@@ -98,29 +86,8 @@ export default function Schedules() {
         }}
       >
         <SchedulesTable
-          schedules={
-            filter
-              ? schedules.filter(s => {
-                  let payee = payees.find(p => s._payee === p.id);
-                  let account = accounts.find(a => s._account === a.id);
-                  let amount = getScheduledAmount(s._amount);
-                  let amountStr =
-                    (s._amountOp === 'isapprox' || s._amountOp === 'isbetween'
-                      ? '~'
-                      : '') +
-                    (amount > 0 ? '+' : '') +
-                    integerToCurrency(Math.abs(amount || 0));
-
-                  return (
-                    filterIncludes(payee && payee.name) ||
-                    filterIncludes(account && account.name) ||
-                    filterIncludes(amountStr) ||
-                    filterIncludes(statuses.get(s.id))
-                  );
-                })
-              : schedules
-          }
-          filtered={filter !== ''}
+          schedules={schedules}
+          filter={filter}
           statuses={statuses}
           allowCompleted={true}
           onSelect={onEdit}

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -3,8 +3,7 @@ import { useHistory } from 'react-router-dom';
 
 import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
 import { send } from 'loot-core/src/platform/client/fetch';
-import { View, Button, Input } from 'loot-design/src/components/common';
-import { colors } from 'loot-design/src/style';
+import { View, Button, Search } from 'loot-design/src/components/common';
 
 import { Page } from '../Page';
 
@@ -62,19 +61,10 @@ export default function Schedules() {
   return (
     <Page title="Schedules">
       <View style={{ alignItems: 'flex-end' }}>
-        <Input
-          placeholder="Filter schedules..."
+        <Search
+          placeholder="Filter schedules…"
           value={filter}
-          onChange={e => setFilter(e.target.value)}
-          style={{
-            width: 350,
-            borderColor: 'transparent',
-            backgroundColor: colors.n11,
-            ':focus': {
-              backgroundColor: 'white',
-              '::placeholder': { color: colors.n8 }
-            }
-          }}
+          onChange={setFilter}
         />
       </View>
 

--- a/packages/loot-design/src/components/common.js
+++ b/packages/loot-design/src/components/common.js
@@ -422,6 +422,35 @@ export function InputWithContent({
   );
 }
 
+export function Search({
+  inputRef,
+  value,
+  onChange,
+  placeholder,
+  isInModal,
+  width = 350
+}) {
+  return (
+    <Input
+      inputRef={inputRef}
+      placeholder={placeholder}
+      value={value}
+      onChange={e => onChange(e.target.value)}
+      style={{
+        width,
+        borderColor: isInModal ? null : 'transparent',
+        backgroundColor: isInModal ? null : colors.n11,
+        ':focus': isInModal
+          ? null
+          : {
+              backgroundColor: 'white',
+              '::placeholder': { color: colors.n8 }
+            }
+      }}
+    />
+  );
+}
+
 export function KeyboardButton({ highlighted, children, ...props }) {
   return (
     <Button


### PR DESCRIPTION
You can currently search by payee name, account name, next date, amount, and status (e.g. upcoming/missed).