### PR TITLE
Allow creating a payee with a name matching an existing account

### DIFF
--- a/packages/loot-design/src/components/PayeeAutocomplete.js
+++ b/packages/loot-design/src/components/PayeeAutocomplete.js
@@ -287,7 +287,10 @@ export default function PayeeAutocomplete({
         filtered.filtered = isf;
 
         if (filtered.length >= 2 && filtered[0].id === 'new') {
-          if (filtered[1].name.toLowerCase() === value.toLowerCase()) {
+          if (
+            filtered[1].name.toLowerCase() === value.toLowerCase() &&
+            !filtered[1].transfer_acct
+          ) {
             return filtered.slice(1);
           }
         }


### PR DESCRIPTION
Fixes #280. That said, I’m not sure if this is a good feature — might it be confusing to have e.g. both a payee and an account named HSBC?