### PR TITLE
Allow configuring the server from any page on the management app

### DIFF
--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -241,7 +241,7 @@ class ManagementApp extends React.Component {
 
           <Switch>
             <Route exact path="/config-server" component={null} />
-            <Route exact path="/" component={ServerURL} />
+            <Route path="/" component={ServerURL} />
           </Switch>
           <Version />
         </View>


### PR DESCRIPTION
Currently, the “Server URL: X [change]” text is only shown on the files list. With this change, it is also visible on the login, bootstrap, and server error pages. This way, even if you don’t have the password to the server stored in your local config, you can still change to a new server or stop using a server.

Testing steps:
1. Connect to a running Actual Server.
2. Log out.
3. Try to change to a different server, or stop using a server.