### PR TITLE
Add a warning when SharedArrayBuffer is not available

### DIFF
--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -10,6 +10,14 @@ self.addEventListener('message', e => {
       let version = msg.version;
       let hash = msg.hash;
 
+      if (!self.SharedArrayBuffer) {
+        self.postMessage({
+          type: 'app-init-failure',
+          SharedArrayBufferMissing: true
+        });
+        return;
+      }
+
       // eslint-disable-next-line
       importScripts(`${process.env.PUBLIC_URL}/kcab/kcab.worker.${hash}.js`);
 

--- a/packages/desktop-client/src/components/FatalError.js
+++ b/packages/desktop-client/src/components/FatalError.js
@@ -27,6 +27,21 @@ class FatalError extends React.Component {
           private browsing.
         </Text>
       );
+    } else if (error.SharedArrayBufferMissing) {
+      // SharedArrayBuffer isn't available
+      msg = (
+        <Text>
+          Server misconfiguration alert! Actual requires access to{' '}
+          <code>SharedArrayBuffer</code> in order to function properly. If
+          you’re seeing this error, either your browser does not support{' '}
+          <code>SharedArrayBuffer</code>, or your server is not sending the
+          appropriate headers, or you are not using HTTPS. See{' '}
+          <a href="https://actualbudget.github.io/docs/Troubleshooting/SharedArrayBuffer">
+            our troubleshooting documentation
+          </a>{' '}
+          for more information.
+        </Text>
+      );
     } else {
       // This indicates the backend failed to initialize. Show the
       // user something at least so they aren't looking at a blank

--- a/packages/desktop-client/src/components/FatalError.js
+++ b/packages/desktop-client/src/components/FatalError.js
@@ -31,11 +31,10 @@ class FatalError extends React.Component {
       // SharedArrayBuffer isn't available
       msg = (
         <Text>
-          Server misconfiguration alert! Actual requires access to{' '}
-          <code>SharedArrayBuffer</code> in order to function properly. If
-          you’re seeing this error, either your browser does not support{' '}
-          <code>SharedArrayBuffer</code>, or your server is not sending the
-          appropriate headers, or you are not using HTTPS. See{' '}
+          Actual requires access to <code>SharedArrayBuffer</code> in order to
+          function properly. If you’re seeing this error, either your browser
+          does not support <code>SharedArrayBuffer</code>, or your server is not
+          sending the appropriate headers, or you are not using HTTPS. See{' '}
           <a href="https://actualbudget.github.io/docs/Troubleshooting/SharedArrayBuffer">
             our troubleshooting documentation
           </a>{' '}

--- a/packages/desktop-client/src/index.js
+++ b/packages/desktop-client/src/index.js
@@ -69,18 +69,6 @@ window.$send = send;
 window.$query = runQuery;
 window.$q = q;
 
-if (!window.SharedArrayBuffer) {
-  alert(
-    'Server misconfiguration alert! Actual requires access to' +
-      ' SharedArrayBuffer in order to function properly. If' +
-      ' you’re seeing this warning, either your browser does not' +
-      ' support SharedArrayBuffer, or your server is not' +
-      ' sending the appropriate headers. See ' +
-      'https://github.com/actualbudget/actual/issues/511 for more' +
-      ' information.'
-  );
-}
-
 ReactDOM.render(
   <Provider store={store}>
     <App />

--- a/packages/desktop-client/src/index.js
+++ b/packages/desktop-client/src/index.js
@@ -69,6 +69,18 @@ window.$send = send;
 window.$query = runQuery;
 window.$q = q;
 
+if (!window.SharedArrayBuffer) {
+  alert(
+    'Server misconfiguration alert! Actual requires access to' +
+      ' SharedArrayBuffer in order to function properly. If' +
+      ' you’re seeing this warning, either your browser does not' +
+      ' support SharedArrayBuffer, or your server is not' +
+      ' sending the appropriate headers. See ' +
+      'https://github.com/actualbudget/actual/issues/511 for more' +
+      ' information.'
+  );
+}
+
 ReactDOM.render(
   <Provider store={store}>
     <App />


### PR DESCRIPTION
This message could definitely use some improvement (maybe by linking to a doc with instructions to fix?). I considered hooking it up as an in-app notification, but I wasn’t sure if that would show up at the right time, and this feels severe enough to demand immediate action before continuing to use the app.