### PR TITLE
Fix adding date back to a schedule that lost its date

### DIFF
--- a/packages/desktop-client/src/components/accounts/SimpleTransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/SimpleTransactionsTable.js
@@ -146,6 +146,7 @@ const TransactionRow = React.memo(function TransactionRow({
 export default function SimpleTransactionsTable({
   transactions,
   schedules,
+  renderEmpty,
   fields = ['date', 'payee', 'amount'],
   style
 }) {
@@ -185,6 +186,7 @@ export default function SimpleTransactionsTable({
     <Table
       style={style}
       items={serializedTransactions}
+      renderEmpty={renderEmpty}
       headers={
         <>
           <SelectCell

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -700,6 +700,22 @@ export default function ScheduleDetails() {
           )}
 
           <SimpleTransactionsTable
+            renderEmpty={
+              state.transactionsMode === 'matched' &&
+              (() => (
+                <View
+                  style={{ padding: 20, color: colors.n4, textAlign: 'center' }}
+                >
+                  {state.error ? (
+                    <Text style={{ color: colors.r4 }}>
+                      Could not search: {state.error}
+                    </Text>
+                  ) : (
+                    'No transactions found'
+                  )}
+                </View>
+              ))
+            }
             transactions={state.transactions}
             fields={['date', 'payee', 'amount']}
             style={{

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -290,12 +290,17 @@ export default function ScheduleDetails() {
     let unsubscribe;
 
     if (state.schedule && state.transactionsMode === 'matched') {
-      let { conditions } = updateScheduleConditions(
+      let { error, conditions } = updateScheduleConditions(
         state.schedule,
         state.fields
       );
 
       dispatch({ type: 'set-transactions', transactions: [] });
+
+      if (error) {
+        dispatch({ type: 'form-error', error });
+        return;
+      }
 
       // *Extremely* gross hack because the rules are not mapped to
       // public names automatically. We really should be doing that

--- a/packages/loot-core/src/server/schedules/app.js
+++ b/packages/loot-core/src/server/schedules/app.js
@@ -268,8 +268,8 @@ export async function updateSchedule({ schedule, conditions, resetNextDate }) {
           oldConditions.find(c => c.field === 'account')
         ) ||
         !deepEqual(
-          stripType(oldConditions.find(c => c.field === 'date')),
-          stripType(newConditions.find(c => c.field === 'date'))
+          stripType(oldConditions.find(c => c.field === 'date') || {}),
+          stripType(newConditions.find(c => c.field === 'date') || {})
         )
       ) {
         await setNextDate({


### PR DESCRIPTION
Fixes #581. The underlying issue was removing the date.

- handle errors from calling `updateScheduleConditions` and display them in the form
- show “no transactions found” or the error in the transaction list if search results are empty
- fix an error that happened when trying to save a schedule that had previously had its date removed