### PR TITLE
Support arbitrary currency symbols in expressions

### DIFF
--- a/packages/loot-core/src/shared/arithmetic.js
+++ b/packages/loot-core/src/shared/arithmetic.js
@@ -36,8 +36,7 @@ function parsePrimary(state) {
     next(state);
   }
 
-  // TODO: Support currency symbols better
-  if (char(state) === '$') {
+  if (/\p{Sc}/u.test(char(state))) {
     next(state);
   }
 


### PR DESCRIPTION
This does allow e.g. `$50+£20 → 70` which is not semantically valid, but hopefully people will notice that 🤞