### PR TITLE
:arrow_up:  upgrade node-fetch to ^2.6.9

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "better-sqlite3": "^7.5.0",
-    "node-fetch": "^1.6.3",
+    "node-fetch": "^2.6.9",
     "uuid": "3.3.2"
   }
 }

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -48,7 +48,7 @@
     "electron-log": "4.3.2",
     "electron-updater": "4.3.8",
     "loot-core": "*",
-    "node-fetch": "^1.6.3",
+    "node-fetch": "^2.6.9",
     "node-ipc": "9.1.4"
   },
   "devDependencies": {

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -32,7 +32,7 @@
     "google-protobuf": "^3.12.0-rc.1",
     "md5": "^2.3.0",
     "mitt": "^2.1.0",
-    "node-fetch": "^1.6.3",
+    "node-fetch": "^2.6.9",
     "node-libofx": "*",
     "regenerator-runtime": "^0.13.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@ __metadata:
   resolution: "@actual-app/api@workspace:packages/api"
   dependencies:
     better-sqlite3: ^7.5.0
-    node-fetch: ^1.6.3
+    node-fetch: ^2.6.9
     uuid: 3.3.2
   languageName: unknown
   linkType: soft
@@ -5122,7 +5122,7 @@ __metadata:
     electron-rebuild: 2.3.5
     electron-updater: 4.3.8
     loot-core: "*"
-    node-fetch: ^1.6.3
+    node-fetch: ^2.6.9
     node-ipc: 9.1.4
   languageName: unknown
   linkType: soft
@@ -15614,7 +15614,7 @@ __metadata:
     mock-require: ^3.0.2
     mockdate: ^3.0.5
     murmurhash: ^0.0.2
-    node-fetch: ^1.6.3
+    node-fetch: ^2.6.9
     node-libofx: "*"
     npm-run-all: ^4.1.3
     perf-deets: ^1.0.15
@@ -16985,13 +16985,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^1.0.1, node-fetch@npm:^1.6.3":
+"node-fetch@npm:^1.0.1":
   version: 1.7.3
   resolution: "node-fetch@npm:1.7.3"
   dependencies:
     encoding: ^0.1.11
     is-stream: ^1.0.1
   checksum: 3bb0528c05d541316ebe52770d71ee25a6dce334df4231fd55df41a644143e07f068637488c18a5b0c43f05041dbd3346752f9e19b50df50569a802484544d5b
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.9":
+  version: 2.6.9
+  resolution: "node-fetch@npm:2.6.9"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: acb04f9ce7224965b2b59e71b33c639794d8991efd73855b0b250921382b38331ffc9d61bce502571f6cc6e11a8905ca9b1b6d4aeb586ab093e2756a1fd190d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrading node-fetch to fix security issues. Especially important in `actual-server` (which imports `@actual-app/api`)

- https://cwe.mitre.org/data/definitions/173.html
- https://cwe.mitre.org/data/definitions/200.html
- https://cwe.mitre.org/data/definitions/601.html
