### PR TITLE
Improve behavior of deleted payees/categories/accounts in rules

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -110,16 +110,16 @@ export function Value({
       } else if (field === 'year') {
         return value ? formatDate(parseISO(value), 'yyyy') : null;
       } else {
-        let name = value;
-        if (data) {
+        if (data && data.length) {
           let item = data.find(item => item.id === value);
           if (item) {
-            name = describe(item);
+            return describe(item);
           } else {
-            name = '(deleted)';
+            return '(deleted)';
           }
+        } else {
+          return '…';
         }
-        return name;
       }
     }
   }

--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -115,6 +115,8 @@ export function Value({
           let item = data.find(item => item.id === value);
           if (item) {
             name = describe(item);
+          } else {
+            name = '(deleted)';
           }
         }
         return name;

--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -510,15 +510,20 @@ function RulesList({
 function mapValue(field, value, { payees, categories, accounts }) {
   if (!value) return '';
 
+  let object = null;
   if (field === 'payee') {
-    return payees.find(p => p.id === value).name;
+    object = payees.find(p => p.id === value);
   } else if (field === 'category') {
-    return categories.find(c => c.id === value).name;
+    object = categories.find(c => c.id === value);
   } else if (field === 'account') {
-    return accounts.find(a => a.id === value).name;
+    object = accounts.find(a => a.id === value);
   } else {
     return value;
   }
+  if (object) {
+    return object.name;
+  }
+  return '(deleted)';
 }
 
 function ruleToString(rule, data) {


### PR DESCRIPTION
Fixes #614. Now you’ll see this:
<img width="194" alt="Screenshot_2023-02-03 14 24 08" src="https://user-images.githubusercontent.com/25517624/216689807-b1fa90b0-b394-4f2c-ac71-58e06654bea8.png">
Searching for `(deleted)` will also work as expected.