### PR TITLE
Fixes editing closed account names issue #616

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -717,7 +717,7 @@ const AccountHeader = React.memo(
                       marginBottom: 5
                     }}
                   >
-                    {accountName}
+                    {account.closed ? 'Closed: ' + accountName : accountName}
                   </View>
 
                   {account && <NotesButton id={`account-${account.id}`} />}
@@ -739,7 +739,7 @@ const AccountHeader = React.memo(
                 <View
                   style={{ fontSize: 25, fontWeight: 500, marginBottom: 5 }}
                 >
-                  {accountName}
+                  {account.closed ? 'Closed: ' + accountName : accountName}
                 </View>
               )}
             </View>
@@ -1391,7 +1391,7 @@ class AccountInternal extends React.PureComponent {
       return null;
     }
 
-    return (account.closed ? 'Closed: ' : '') + account.name;
+    return account.name;
   }
 
   getBalanceQuery(account, id) {

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1324,12 +1324,12 @@ class AccountInternal extends React.PureComponent {
 
   onSaveName = name => {
     if (name.trim().length) {
-    const accountId = this.props.accountId;
-    const account = this.props.accounts.find(
-      account => account.id === accountId
-    );
-    this.props.updateAccount({ ...account, name });
-    this.setState({ editingName: false });
+      const accountId = this.props.accountId;
+      const account = this.props.accounts.find(
+        account => account.id === accountId
+      );
+      this.props.updateAccount({ ...account, name });
+      this.setState({ editingName: false });
     }
   };
 

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -717,7 +717,9 @@ const AccountHeader = React.memo(
                       marginBottom: 5
                     }}
                   >
-                    {account.closed ? 'Closed: ' + accountName : accountName}
+                    {account && account.closed
+                      ? 'Closed: ' + accountName
+                      : accountName}
                   </View>
 
                   {account && <NotesButton id={`account-${account.id}`} />}
@@ -739,7 +741,9 @@ const AccountHeader = React.memo(
                 <View
                   style={{ fontSize: 25, fontWeight: 500, marginBottom: 5 }}
                 >
-                  {account.closed ? 'Closed: ' + accountName : accountName}
+                  {account && account.closed
+                    ? 'Closed: ' + accountName
+                    : accountName}
                 </View>
               )}
             </View>
@@ -1319,12 +1323,14 @@ class AccountInternal extends React.PureComponent {
   };
 
   onSaveName = name => {
+    if (name.trim().length) {
     const accountId = this.props.accountId;
     const account = this.props.accounts.find(
       account => account.id === accountId
     );
     this.props.updateAccount({ ...account, name });
     this.setState({ editingName: false });
+    }
   };
 
   onToggleExtraBalances = () => {


### PR DESCRIPTION
This fix removes the mutation of the closed account name string and conditionally prefixes "Closed: " to closed account name title

fixes #616, fixes #622

https://user-images.githubusercontent.com/2892349/216729993-519bdde3-3e08-4a25-b58b-a4b1e7bc2050.mov

