### PR TITLE
Fix form submission on TransferTooltip when pressing enter

### DIFF
--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -83,11 +83,7 @@ export default function TransferTooltip({
         onUpdate={id => {}}
         onSelect={id => setCategory(id)}
         inputProps={{
-          onKeyDown: e => {
-            if (e.keyCode === 13) {
-              submit();
-            }
-          }
+          onEnter: () => submit()
         }}
       />
 

--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -82,9 +82,7 @@ export default function TransferTooltip({
         openOnFocus={true}
         onUpdate={id => {}}
         onSelect={id => setCategory(id)}
-        inputProps={{
-          onEnter: () => submit()
-        }}
+        inputProps={{ onEnter: () => submit() }}
       />
 
       <View

--- a/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
+++ b/packages/loot-design/src/components/budget/rollover/TransferTooltip.js
@@ -82,7 +82,7 @@ export default function TransferTooltip({
         openOnFocus={true}
         onUpdate={id => {}}
         onSelect={id => setCategory(id)}
-        inputProps={{ onEnter: () => submit() }}
+        inputProps={{ onEnter: submit }}
       />
 
       <View


### PR DESCRIPTION
Resolves #284! It looks like this behavior was intended previously but didn't work because the Input component catches the Enter key and calls onEnter instead.

![CleanShot 2023-02-04 at 11 25 10](https://user-images.githubusercontent.com/3413011/216785983-4bf6613b-f35a-4fd5-9c34-3e1dc2ddcbe3.gif)
