### PR TITLE
Skip the “Starting Balance” transaction if the balance is 0

### DIFF
--- a/packages/loot-core/src/server/main.js
+++ b/packages/loot-core/src/server/main.js
@@ -861,7 +861,7 @@ handlers['account-create'] = mutator(async function ({
       transfer_acct: id
     });
 
-    if (balance != null) {
+    if (balance != null && balance !== 0) {
       let payee = await getStartingBalancePayee();
 
       await db.insertTransaction({


### PR DESCRIPTION
When creating an account, the “starting balance” transaction will be added only if the balance is nonzero