### PR TITLE
Fix default value of “Move to a category”

### DIFF
--- a/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/loot-design/src/components/budget/rollover/BudgetSummary.js
@@ -225,7 +225,7 @@ function ToBudget({ month, prevMonthName, collapsed, onBudgetAction }) {
                   )}
                   {state.menuOpen === 'transfer' && (
                     <TransferTooltip
-                      initialAmountName="leftover"
+                      initialAmount={availableValue}
                       onClose={() => setState({ menuOpen: null })}
                       onSubmit={(amount, category) => {
                         onBudgetAction(month, 'transfer-available', {


### PR DESCRIPTION
Previously, this seems to have always been 0.

<img width="273" alt="Screenshot_2023-02-04 17 01 04" src="https://user-images.githubusercontent.com/25517624/216791308-e163da77-5495-49bf-8dcd-fe2f1a4b7057.png">
