### PR TITLE
Removed reference to blog

### DIFF
--- a/packages/desktop-client/src/components/UpdateNotification.js
+++ b/packages/desktop-client/src/components/UpdateNotification.js
@@ -58,7 +58,7 @@ function UpdateNotification({
                 style={{ color: 'white', textDecoration: 'underline' }}
                 onClick={() =>
                   window.Actual.openURLInBrowser(
-                    'https://actualbudget.com/blog/' + updateInfo.version
+                    'https://actualbudget.github.io/docs/Release-Notes/'
                   )
                 }
               >

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -40,7 +40,7 @@ function Version() {
           zIndex: 5001
         }
       }}
-      href={'https://actualbudget.com/blog/' + window.Actual.ACTUAL_VERSION}
+      href={'https://actualbudget.github.io/docs/Release-Notes/'}
     >
       {`App: v${window.Actual.ACTUAL_VERSION} | Server: ${version}`}
     </Text>


### PR DESCRIPTION
The Actualbudget blog no longer exists, replaced the links with the OSS release notes, this resolves #626 