### PR TITLE
Move desktop-client deps to devDeps

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -11,6 +11,11 @@
     "@playwright/test": "^1.29.1",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.2",
     "@reach/listbox": "^0.11.2",
+    "@react-aria/focus": "^3.8.0",
+    "@react-aria/listbox": "^3.6.1",
+    "@react-aria/utils": "^3.13.3",
+    "@react-stately/collections": "^3.4.3",
+    "@react-stately/list": "^3.5.3",
     "@reactions/component": "^2.0.2",
     "@svgr/webpack": "2.4.1",
     "babel-eslint": "9.0.0",
@@ -42,6 +47,7 @@
     "glamor": "^2.20.40",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "identity-obj-proxy": "3.0.0",
+    "inter-ui": "^3.19.3",
     "load-js": "^3.0.3",
     "mini-css-extract-plugin": "0.4.3",
     "mitt": "^1.1.2",
@@ -64,6 +70,7 @@
     "react-redux": "7.2.1",
     "react-router": "5.2.0",
     "react-router-dom": "5.2.0",
+    "react-router-dom-v5-compat": "^6.4.1",
     "react-spring": "^8.0.27",
     "react-virtualized-auto-sizer": "^1.0.2",
     "redux": "^4.0.5",
@@ -90,14 +97,5 @@
   },
   "browserslist": [
     "electron 3.0"
-  ],
-  "dependencies": {
-    "@react-aria/focus": "^3.8.0",
-    "@react-aria/listbox": "^3.6.1",
-    "@react-aria/utils": "^3.13.3",
-    "@react-stately/collections": "^3.4.3",
-    "@react-stately/list": "^3.5.3",
-    "inter-ui": "^3.19.3",
-    "react-router-dom-v5-compat": "^6.4.1"
-  }
+  ]
 }


### PR DESCRIPTION
Currently `actual-server` has to pull in these packages when installing for production, which is unnecessary since they’re already bundled into the published package. This also triggers peer dependency warnings