### PR TITLE
Allow bypassing SharedArrayBuffer override

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -27,7 +27,9 @@ function createBackendWorker() {
     version: ACTUAL_VERSION,
     isDev: IS_DEV,
     hash: process.env.REACT_APP_BACKEND_WORKER_HASH,
-    allowBuggyFallback: localStorage.getItem('SharedArrayBufferOverride')
+    isSharedArrayBufferOverrideEnabled: localStorage.getItem(
+      'SharedArrayBufferOverride'
+    )
   });
 
   if (IS_DEV || IS_PERF_BUILD) {

--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -18,11 +18,16 @@ function createBackendWorker() {
   worker = new BackendWorker();
   initSQLBackend(worker);
 
+  if (window.SharedArrayBuffer) {
+    localStorage.removeItem('SharedArrayBufferOverride');
+  }
+
   worker.postMessage({
     type: 'init',
     version: ACTUAL_VERSION,
     isDev: IS_DEV,
-    hash: process.env.REACT_APP_BACKEND_WORKER_HASH
+    hash: process.env.REACT_APP_BACKEND_WORKER_HASH,
+    allowBuggyFallback: localStorage.getItem('SharedArrayBufferOverride')
   });
 
   if (IS_DEV || IS_PERF_BUILD) {

--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -10,7 +10,7 @@ self.addEventListener('message', e => {
       let version = msg.version;
       let hash = msg.hash;
 
-      if (!self.SharedArrayBuffer && !msg.allowBuggyFallback) {
+      if (!self.SharedArrayBuffer && !msg.isSharedArrayBufferOverrideEnabled) {
         self.postMessage({
           type: 'app-init-failure',
           SharedArrayBufferMissing: true

--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -10,7 +10,7 @@ self.addEventListener('message', e => {
       let version = msg.version;
       let hash = msg.hash;
 
-      if (!self.SharedArrayBuffer) {
+      if (!self.SharedArrayBuffer && !msg.allowBuggyFallback) {
         self.postMessage({
           type: 'app-init-failure',
           SharedArrayBufferMissing: true

--- a/packages/desktop-client/src/components/FatalError.js
+++ b/packages/desktop-client/src/components/FatalError.js
@@ -143,7 +143,7 @@ class FatalError extends React.Component {
 export default FatalError;
 
 function SharedArrayBufferOverride() {
-  let [expanded, setExpanded] = useState(true);
+  let [expanded, setExpanded] = useState(false);
   let [understand, setUnderstand] = useState(false);
 
   return expanded ? (

--- a/packages/desktop-client/src/components/FatalError.js
+++ b/packages/desktop-client/src/components/FatalError.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   View,
@@ -10,6 +10,7 @@ import {
   Link,
   Button
 } from 'loot-design/src/components/common';
+import { Checkbox } from 'loot-design/src/components/forms';
 import { colors } from 'loot-design/src/style';
 
 class FatalError extends React.Component {
@@ -38,7 +39,7 @@ class FatalError extends React.Component {
           <a href="https://actualbudget.github.io/docs/Troubleshooting/SharedArrayBuffer">
             our troubleshooting documentation
           </a>{' '}
-          for more information.
+          to learn more. <SharedArrayBufferOverride />
         </Text>
       );
     } else {
@@ -140,3 +141,52 @@ class FatalError extends React.Component {
   }
 }
 export default FatalError;
+
+function SharedArrayBufferOverride() {
+  let [expanded, setExpanded] = useState(true);
+  let [understand, setUnderstand] = useState(false);
+
+  return expanded ? (
+    <>
+      <P style={{ marginTop: 10 }}>
+        Actual uses <code>SharedArrayBuffer</code> to allow usage from multiple
+        tabs at once and to ensure correct behavior when switching files. While
+        it can run without access to <code>SharedArrayBuffer</code>, you may
+        encounter data loss or notice multiple budget files being merged with
+        each other.
+      </P>
+      <label
+        style={{ display: 'flex', alignItems: 'center', marginBottom: 10 }}
+      >
+        <Checkbox checked={understand} onChange={setUnderstand} /> I understand
+        the risks, run Actual in the unsupported fallback mode
+      </label>
+      <Button
+        disabled={!understand}
+        onClick={() => {
+          window.localStorage.setItem('SharedArrayBufferOverride', 'true');
+          window.location.reload();
+        }}
+      >
+        Open Actual
+      </Button>
+    </>
+  ) : (
+    <Link
+      onClick={() => setExpanded(true)}
+      style={{
+        color: `inherit !important`,
+        marginLeft: 5,
+        border: 'none !important',
+        background: 'none !important',
+        padding: '0 !important',
+        textDecoration: 'underline !important',
+        boxShadow: 'none !important',
+        display: 'inline !important',
+        font: 'inherit !important'
+      }}
+    >
+      Advanced options
+    </Link>
+  );
+}

--- a/packages/loot-core/src/client/actions/budgets.js
+++ b/packages/loot-core/src/client/actions/budgets.js
@@ -119,6 +119,9 @@ export function closeBudget() {
       dispatch(setAppState({ loadingText: 'Closing...' }));
       await send('close-budget');
       dispatch(setAppState({ loadingText: null }));
+      if (localStorage.getItem('SharedArrayBufferOverride')) {
+        location.reload();
+      }
     }
   };
 }


### PR DESCRIPTION
Clicking through sets a value in `localStorage` that bypasses the error.

<img width="501" alt="Screenshot_2023-02-08 12 51 38" src="https://user-images.githubusercontent.com/25517624/217611782-6993dad8-744e-4c38-b8c8-e2bab21689dc.png">
<img width="581" alt="Screenshot_2023-02-08 12 51 43" src="https://user-images.githubusercontent.com/25517624/217611793-6f759113-4ad0-42a0-bde2-3bb3cf50f4e8.png">
<img width="540" alt="Screenshot_2023-02-08 12 51 48" src="https://user-images.githubusercontent.com/25517624/217611799-b525fc10-af1e-460e-bf44-397c1dad7afc.png">