### PR TITLE
:bookmark: (23.2.9) ability to ignore SharedArrayBuffer error

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "23.2.5",
+  "version": "23.2.9",
   "license": "MIT",
   "files": [
     "build"


### PR DESCRIPTION
We hear the community: some folks (for whatever reason) do not want to use HTTPS. This small update allows people to upgrade to the latest version and ignore the `SharedArrayBuffer` error.

**Ignoring the error is not recommended as it has risks of potentially losing your budget.** Use it cautiously.

https://github.com/actualbudget/actual/issues/637