### PR TITLE
Allow editing filters

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -109,6 +109,8 @@ export function Value({
           : null;
       } else if (field === 'year') {
         return value ? formatDate(parseISO(value), 'yyyy') : null;
+      } else if (field === 'notes') {
+        return value;
       } else {
         if (data && data.length) {
           let item = data.find(item => item.id === value);

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -636,6 +636,7 @@ const AccountHeader = React.memo(
     onBatchEdit,
     onBatchUnlink,
     onApplyFilter,
+    onUpdateFilter,
     onDeleteFilter,
     onScheduleAction
   }) => {
@@ -915,7 +916,11 @@ const AccountHeader = React.memo(
           </Stack>
 
           {filters && filters.length > 0 && (
-            <AppliedFilters filters={filters} onDelete={onDeleteFilter} />
+            <AppliedFilters
+              filters={filters}
+              onUpdate={onUpdateFilter}
+              onDelete={onDeleteFilter}
+            />
           )}
         </View>
         {reconcileAmount != null && (
@@ -1608,6 +1613,13 @@ class AccountInternal extends React.PureComponent {
     await this.refetchTransactions();
   };
 
+  onUpdateFilter = (oldFilter, updatedFilter) => {
+    debugger;
+    this.applyFilters(
+      this.state.filters.map(f => (f === oldFilter ? updatedFilter : f))
+    );
+  };
+
   onDeleteFilter = filter => {
     this.applyFilters(this.state.filters.filter(f => f !== filter));
   };
@@ -1755,6 +1767,7 @@ class AccountInternal extends React.PureComponent {
                   onBatchDuplicate={this.onBatchDuplicate}
                   onBatchEdit={this.onBatchEdit}
                   onBatchUnlink={this.onBatchUnlink}
+                  onUpdateFilter={this.onUpdateFilter}
                   onDeleteFilter={this.onDeleteFilter}
                   onApplyFilter={this.onApplyFilter}
                   onScheduleAction={this.onScheduleAction}

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1614,7 +1614,6 @@ class AccountInternal extends React.PureComponent {
   };
 
   onUpdateFilter = (oldFilter, updatedFilter) => {
-    debugger;
     this.applyFilters(
       this.state.filters.map(f => (f === oldFilter ? updatedFilter : f))
     );

--- a/packages/desktop-client/src/components/accounts/Filters.js
+++ b/packages/desktop-client/src/components/accounts/Filters.js
@@ -409,27 +409,37 @@ function FilterExpression({
           borderRadius: 4,
           flexDirection: 'row',
           alignItems: 'center',
-          padding: 5,
-          paddingLeft: 10,
           marginBottom: 10,
           marginRight: 10
         },
         style
       ]}
     >
-      <div>
-        {customName ? (
-          <Text style={{ color: colors.p4 }}>{customName}</Text>
-        ) : (
-          <>
-            <Text style={{ color: colors.p4 }}>{mapField(field, options)}</Text>{' '}
-            <Text style={{ color: colors.n3 }}>{friendlyOp(op)}</Text>{' '}
-            <Value value={value} field={field} inline={true} />
-          </>
-        )}
-      </div>
-      <Button bare style={{ marginLeft: 3 }} onClick={onDelete}>
-        <DeleteIcon style={{ width: 8, height: 8, color: colors.n4 }} />
+      <Button bare style={{ marginRight: -7 }}>
+        <div style={{ paddingBlock: 1, paddingLeft: 5, paddingRight: 2 }}>
+          {customName ? (
+            <Text style={{ color: colors.p4 }}>{customName}</Text>
+          ) : (
+            <>
+              <Text style={{ color: colors.p4 }}>
+                {mapField(field, options)}
+              </Text>{' '}
+              <Text style={{ color: colors.n3 }}>{friendlyOp(op)}</Text>{' '}
+              <Value value={value} field={field} inline={true} />
+            </>
+          )}
+        </div>
+      </Button>
+      <Button bare onClick={onDelete}>
+        <DeleteIcon
+          style={{
+            width: 8,
+            height: 8,
+            color: colors.n4,
+            margin: 5,
+            marginLeft: 3
+          }}
+        />
       </Button>
     </View>
   );


### PR DESCRIPTION
Fixes #643. The left side of the filter is now a button.
<img width="265" alt="Screenshot_2023-02-10 13 43 30" src="https://user-images.githubusercontent.com/25517624/218172427-c71e6f95-60a7-4722-8289-321bc7d9ccd9.png">
Clicking on it opens the same editor you get when creating a new filter. This required some code changes to allow pre-filling an existing filter (rather than starting a new one).
<img width="332" alt="Screenshot_2023-02-10 13 44 21" src="https://user-images.githubusercontent.com/25517624/218172568-9b794eb3-80f0-463a-b287-8b9873195cd0.png">
