### PR TITLE
Create .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,1 @@
-0b3c41201ab75888656c8ed116d11d7218f8f06c # 🎨 (prettier) adding trailing commas (#647)
+0b3c41201ab75888656c8ed116d11d7218f8f06c

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+0b3c41201ab75888656c8ed116d11d7218f8f06c # 🎨 (prettier) adding trailing commas (#647)


### PR DESCRIPTION
Running `git config blame.ignoreRevsFile .git-blame-ignore-revs` will set up git’s blame feature to ignore #647. Future changes like that (including code reorgs) can be added here as necessary. Also, I believe GitHub supports this so the web UI will no longer show that PR in blame views.