### PR TITLE
:fire:  remove closed-source subscription notification code

### DIFF
--- a/packages/loot-core/src/server/main.js
+++ b/packages/loot-core/src/server/main.js
@@ -1368,16 +1368,6 @@ handlers['key-test'] = async function ({ fileId, password }) {
   return {};
 };
 
-handlers['should-pitch-subscribe'] = async function () {
-  let seenSubscribe = await asyncStorage.getItem('seenSubscribe');
-  return seenSubscribe !== 'true';
-};
-
-handlers['has-pitched-subscribe'] = async function () {
-  await asyncStorage.setItem('seenSubscribe', 'true');
-  return 'ok';
-};
-
 handlers['subscribe-needs-bootstrap'] = async function ({ url } = {}) {
   if (getServer(url).BASE_SERVER === UNCONFIGURED_SERVER) {
     return { bootstrapped: true };


### PR DESCRIPTION
In the closed-source version of actual this was used to promp the user to subscribe. This is no longer the case, but it was never cleaned up.