### PR TITLE
Remove year from the LICENSE

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 James Long
+Copyright James Long
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Inspired by react: https://github.com/facebook/react/blob/main/LICENSE

I'm no lawyer, but IMO it's safe to remove the year from the license.