### PR TITLE
node-libofx: add transaction_acct_name function

### DIFF
--- a/packages/node-libofx/emscripten.cpp
+++ b/packages/node-libofx/emscripten.cpp
@@ -69,6 +69,13 @@ extern "C" {
 
     // Transaction accessors
 
+    char *transaction_acct_name(OfxTransactionData *trans) {
+      if (trans->account_ptr && trans->account_ptr->account_id_valid) {
+        return trans->account_ptr->account_id;
+      }
+      return "";
+    }
+
     double transaction_amount(OfxTransactionData *trans) {
         return trans->amount;
     }

--- a/packages/node-libofx/ffi.js
+++ b/packages/node-libofx/ffi.js
@@ -8,11 +8,11 @@ function create(libofx) {
     ofx_set_transaction_cb: libofx.cwrap('ofx_set_transaction_cb', null, [
       'number',
       'number',
-      'number'
+      'number',
     ]),
 
     transaction_amount: libofx.cwrap('transaction_amount', 'number', [
-      'number'
+      'number',
     ]),
     transaction_fi_id: libofx.cwrap('transaction_fi_id', 'string', ['number']),
     transaction_date: libofx.cwrap('transaction_date', 'number', ['number']),
@@ -22,10 +22,13 @@ function create(libofx) {
 
     set_ofx_version: libofx.cwrap('set_ofx_version', null, [
       'number',
-      'string'
+      'string',
     ]),
     set_app_id: libofx.cwrap('set_app_id', null, ['number', 'string']),
-    set_app_version: libofx.cwrap('set_app_version', null, ['number', 'string'])
+    set_app_version: libofx.cwrap('set_app_version', null, [
+      'number',
+      'string',
+    ]),
   };
 }
 

--- a/packages/node-libofx/ffi.js
+++ b/packages/node-libofx/ffi.js
@@ -11,6 +11,9 @@ function create(libofx) {
       'number',
     ]),
 
+    transaction_acct_name: libofx.cwrap('transaction_acct_name', 'string', [
+      'number',
+    ]),
     transaction_amount: libofx.cwrap('transaction_amount', 'number', [
       'number',
     ]),

--- a/upcoming-release-notes/670.md
+++ b/upcoming-release-notes/670.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+`node-libofx`: add transaction_acct_name function


### PR DESCRIPTION
I am currently not working on adding support for importing to multiple accounts, but I wanted to give anyone who takes that on a starting point by updating the underlying C library to provide access to the account name field.
