### PR TITLE
Don’t force user to re-enter password after changing it

### DIFF
--- a/packages/desktop-client/src/components/manager/subscribe/ChangePassword.js
+++ b/packages/desktop-client/src/components/manager/subscribe/ChangePassword.js
@@ -34,10 +34,8 @@ export default function ChangePassword() {
       setError(error);
     } else {
       setMessage('Password successfully changed');
-
-      setTimeout(() => {
-        history.push('/');
-      }, 1500);
+      await send('subscribe-sign-in', { password });
+      history.push('/');
     }
   }
 


### PR DESCRIPTION
Now, when you enter the new password, we will log in with the new password and then send you to the file list.