### PR TITLE
Fix error cases in displaying filters/rules

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -51,6 +51,7 @@ let SchedulesQuery = liveQueryContext(q('schedules').select('*'));
 export function Value({
   value,
   field,
+  valueIsRaw,
   inline = false,
   data: dataProp,
   describe = x => x.name,
@@ -116,6 +117,9 @@ export function Value({
         case 'payee':
         case 'category':
         case 'account':
+          if (valueIsRaw) {
+            return value;
+          }
           if (data && data.length) {
             let item = data.find(item => item.id === value);
             if (item) {
@@ -123,9 +127,9 @@ export function Value({
             } else {
               return '(deleted)';
             }
-          } else {
-            return '…';
           }
+
+          return '…';
         default:
           throw new Error(`Unknown field ${field}`);
       }

--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -109,7 +109,7 @@ export function Value({
           : null;
       } else if (field === 'year') {
         return value ? formatDate(parseISO(value), 'yyyy') : null;
-      } else if (field === 'notes') {
+      } else if (field === 'notes' || field === 'imported_payee') {
         return value;
       } else {
         if (data && data.length) {

--- a/packages/desktop-client/src/components/ManageRules.js
+++ b/packages/desktop-client/src/components/ManageRules.js
@@ -93,35 +93,41 @@ export function Value({
     } else if (typeof value === 'boolean') {
       return value ? 'true' : 'false';
     } else {
-      if (field === 'amount') {
-        return integerToCurrency(value);
-      } else if (field === 'date') {
-        if (value) {
-          if (value.frequency) {
-            return getRecurringDescription(value);
+      switch (field) {
+        case 'amount':
+          return integerToCurrency(value);
+        case 'date':
+          if (value) {
+            if (value.frequency) {
+              return getRecurringDescription(value);
+            }
+            return formatDate(parseISO(value), dateFormat);
           }
-          return formatDate(parseISO(value), dateFormat);
-        }
-        return null;
-      } else if (field === 'month') {
-        return value
-          ? formatDate(parseISO(value), getMonthYearFormat(dateFormat))
-          : null;
-      } else if (field === 'year') {
-        return value ? formatDate(parseISO(value), 'yyyy') : null;
-      } else if (field === 'notes' || field === 'imported_payee') {
-        return value;
-      } else {
-        if (data && data.length) {
-          let item = data.find(item => item.id === value);
-          if (item) {
-            return describe(item);
+          return null;
+        case 'month':
+          return value
+            ? formatDate(parseISO(value), getMonthYearFormat(dateFormat))
+            : null;
+        case 'year':
+          return value ? formatDate(parseISO(value), 'yyyy') : null;
+        case 'notes':
+        case 'imported_payee':
+          return value;
+        case 'payee':
+        case 'category':
+        case 'account':
+          if (data && data.length) {
+            let item = data.find(item => item.id === value);
+            if (item) {
+              return describe(item);
+            } else {
+              return '(deleted)';
+            }
           } else {
-            return '(deleted)';
+            return '…';
           }
-        } else {
-          return '…';
-        }
+        default:
+          throw new Error(`Unknown field ${field}`);
       }
     }
   }

--- a/packages/desktop-client/src/components/accounts/Filters.js
+++ b/packages/desktop-client/src/components/accounts/Filters.js
@@ -486,7 +486,12 @@ function FilterExpression({
                 {mapField(field, options)}
               </Text>{' '}
               <Text style={{ color: colors.n3 }}>{friendlyOp(op)}</Text>{' '}
-              <Value value={value} field={field} inline={true} />
+              <Value
+                value={value}
+                field={field}
+                inline={true}
+                valueIsRaw={op === 'contains'}
+              />
             </>
           )}
         </div>

--- a/packages/loot-core/src/shared/rules.js
+++ b/packages/loot-core/src/shared/rules.js
@@ -147,7 +147,11 @@ export function parse(item) {
   switch (item.type) {
     case 'number': {
       let parsed = item.value;
-      if (item.field === 'amount' && item.op !== 'isbetween') {
+      if (
+        item.field === 'amount' &&
+        item.op !== 'isbetween' &&
+        parsed != null
+      ) {
         parsed = integerToAmount(parsed);
       }
       return { ...item, value: parsed };

--- a/packages/loot-core/src/shared/rules.js
+++ b/packages/loot-core/src/shared/rules.js
@@ -197,7 +197,7 @@ export function makeValue(value, cond) {
         return {
           ...cond,
           error: null,
-          value: value ? currencyToAmount(value) || 0 : 0,
+          value: value ? currencyToAmount(String(value)) || 0 : 0,
         };
       }
       break;


### PR DESCRIPTION
This PR fixes a few existing edge cases, along with a few I probably introduced in #646. I’ve now tested all of the different filter types both in rules and in the account view, and things seem to work OK.