### PR TITLE
Add button and 'esc' shortcut to clear transaction filter

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -57,6 +57,7 @@ import ArrowsShrink3 from 'loot-design/src/svg/v2/ArrowsShrink3';
 import CheckCircle1 from 'loot-design/src/svg/v2/CheckCircle1';
 import DownloadThickBottom from 'loot-design/src/svg/v2/DownloadThickBottom';
 import Pencil1 from 'loot-design/src/svg/v2/Pencil1';
+import SvgRemove from 'loot-design/src/svg/v2/Remove';
 import SearchAlternate from 'loot-design/src/svg/v2/SearchAlternate';
 
 import { authorizeBank } from '../../plaid';
@@ -821,9 +822,30 @@ const AccountHeader = React.memo(
                   }}
                 />
               }
+              rightContent={
+                search && (
+                  <Button
+                    bare
+                    style={{ padding: 8 }}
+                    onClick={() => onSearch('')}
+                    title="Clear search term"
+                  >
+                    <SvgRemove
+                      style={{
+                        width: 8,
+                        height: 8,
+                        color: 'inherit',
+                      }}
+                    />
+                  </Button>
+                )
+              }
               inputRef={searchInput}
               value={search}
               placeholder="Search"
+              onKeyDown={e => {
+                if (e.key === 'Escape') onSearch('');
+              }}
               getStyle={focused => [
                 {
                   backgroundColor: 'transparent',


### PR DESCRIPTION
Closes https://github.com/actualbudget/actual/issues/664!

Adding a little button to clear the search term, as well as listening for the 'Esc' key to clear that way too.


https://user-images.githubusercontent.com/3413011/221344831-bee98cbd-b27b-4c16-843c-bdfd6232f6f6.mp4
