### PR TITLE
Don’t allow bulk editing to set a field to null

### DIFF
--- a/packages/loot-design/src/components/modals/EditField.js
+++ b/packages/loot-design/src/components/modals/EditField.js
@@ -28,12 +28,14 @@ function EditField({
   createPayee,
 }) {
   function onSelect(value) {
-    // Process the value if needed
-    if (name === 'amount') {
-      value = amountToInteger(value);
-    }
+    if (value != null) {
+      // Process the value if needed
+      if (name === 'amount') {
+        value = amountToInteger(value);
+      }
 
-    onSubmit(name, value);
+      onSubmit(name, value);
+    }
     modalProps.onClose();
   }
 


### PR DESCRIPTION
Fixes #673. `onSelect(null)` is called when you blur the autocomplete field, so I ignore that call for the purposes of updating the value. This does mean it’s no longer possible to bulk remove a payee/category but I doubt people want to do that.