### PR TITLE
Fix check for crypto.subtle

### DIFF
--- a/packages/desktop-client/src/components/settings/Encryption.js
+++ b/packages/desktop-client/src/components/settings/Encryption.js
@@ -9,9 +9,7 @@ import { Setting } from './UI';
 
 export default function EncryptionSettings({ prefs, pushModal }) {
   const serverURL = useServerURL();
-  const missingCryptoAPI = !(
-    window.crypto && Object.hasOwnProperty.call(crypto, 'subtle')
-  );
+  const missingCryptoAPI = !(window.crypto && crypto.subtle);
 
   function onChangeKey() {
     pushModal('create-encryption-key', { recreate: true });


### PR DESCRIPTION
It turns out `hasOwnProperty(crypto, 'subtle')` always returns false.