### PR TITLE
Fix e2e test to not assume it’s been run on Feb 28, 2023

### DIFF
--- a/packages/desktop-client/e2e/schedules.test.js
+++ b/packages/desktop-client/e2e/schedules.test.js
@@ -57,11 +57,16 @@ test.describe('Schedules', () => {
     // go to rules page
     const rulesPage = await navigation.goToRulesPage();
     expect(await rulesPage.getNthRule(0)).toMatchObject({
-      actions: ['link schedule Home Depot (2023-02-28)'],
+      // actions: ['link schedule Home Depot (2023-02-28)'],
+      actions: [
+        expect.stringMatching(
+          /^link schedule Home Depot \(\d{4}-\d{2}-\d{2}\)$/,
+        ),
+      ],
       conditions: [
         'payee is Home Depot',
         'account is HSBC',
-        'date is approx Every month on the 28th',
+        expect.stringMatching(/^date is approx Every month on the/),
         'amount is approx -25.00',
       ],
     });


### PR DESCRIPTION
Some people are saying that it will not always be February 28, 2023. Updated the e2e test to be a bit more lenient just in case the current date changes at some point in the future. ;)