### PR TITLE
Remove outdated part of the postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "rebuild-electron": "./node_modules/.bin/electron-rebuild -f -m ./packages/loot-core",
     "rebuild-node": "yarn workspace loot-core rebuild",
     "lint": "cross-env NODE_ENV=development yarn workspaces foreach --verbose run lint --max-warnings 0",
-    "postinstall": "rm -rf ./packages/loot-design/node_modules/react && patch-package"
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "cross-env": "^5.1.5",


### PR DESCRIPTION
Yarn v2 does not put a `node_modules` folder inside of `packages/loot-design` so this cannot possibly do anything. Additionally, `rm` is not available in `cmd.exe` for Windows. Ref: #730.