### PR TITLE
:bookmark: (5.1.0) upgrade better-sqlite3 to v8.2

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/api",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "license": "MIT",
   "description": "An API for Actual",
   "main": "index.js",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,7 +17,7 @@
     "build": "yarn workspace loot-core build:api"
   },
   "dependencies": {
-    "better-sqlite3": "^8.1.0",
+    "better-sqlite3": "^8.2.0",
     "node-fetch": "^2.6.9",
     "uuid": "3.3.2"
   }

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -24,7 +24,7 @@
     "@rschedule/json-tools": "^1.2.0",
     "@rschedule/standard-date-adapter": "^1.2.0",
     "absurd-sql": "0.0.53",
-    "better-sqlite3": "^8.1.0",
+    "better-sqlite3": "^8.2.0",
     "core-js": "^3.8.3",
     "csv-parse": "^4.10.1",
     "csv-stringify": "^5.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/api@workspace:packages/api"
   dependencies:
-    better-sqlite3: ^8.1.0
+    better-sqlite3: ^8.2.0
     node-fetch: ^2.6.9
     uuid: 3.3.2
   languageName: unknown
@@ -5739,14 +5739,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "better-sqlite3@npm:8.1.0"
+"better-sqlite3@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "better-sqlite3@npm:8.2.0"
   dependencies:
     bindings: ^1.5.0
     node-gyp: latest
     prebuild-install: ^7.1.0
-  checksum: 7e6b4c33142f4b2ee2e60d3926b4db682feb0d09554efdaf7bea53cd5bef406ca0a5115ab9b411458daa45ba14973252ebd6853a3cdf94e4fd49cc8291730ade
+  checksum: ab8a00bcc33c4a7467f78fcbb103c784705cf170ecc9c8eb1149a89a2153c03a7f65681064667eb214fa7f555797abd8183380a0396ce04eaf36efef921ce103
   languageName: node
   linkType: hard
 
@@ -13756,7 +13756,7 @@ __metadata:
     absurd-sql: 0.0.53
     adm-zip: ^0.5.9
     babel-loader: ^8.0.6
-    better-sqlite3: ^8.1.0
+    better-sqlite3: ^8.2.0
     buffer: ^5.5.0
     core-js: ^3.8.3
     cross-env: ^7.0.3


### PR DESCRIPTION
A new release for `api` too so we could start using `better-sqlite3` v8 in `actual-server`.