### PR TITLE
Set the filename/filetype before attempting to parse

### DIFF
--- a/packages/loot-design/src/components/modals/ImportTransactions.js
+++ b/packages/loot-design/src/components/modals/ImportTransactions.js
@@ -582,6 +582,10 @@ export function ImportTransactions({
   async function parse(filename, options) {
     setLoadingState('parsing');
 
+    let filetype = getFileType(filename);
+    setFilename(filename);
+    setFileType(filetype);
+
     let { errors, transactions } = await parseTransactions(filename, options);
 
     setLoadingState(null);
@@ -593,10 +597,6 @@ export function ImportTransactions({
         message: errors[0].message || 'Internal error',
       });
     } else {
-      let filetype = getFileType(filename);
-      setFilename(filename);
-      setFileType(filetype);
-
       if (filetype === 'csv' || filetype === 'qif') {
         setFlipAmount(prefs[`flip-amount-${accountId}-${filetype}`] || false);
       }


### PR DESCRIPTION
Fixes #19 by setting the file type before attempting the parse. You’ll now be able to change the import options even if the first import attempt failed.

<img width="826" alt="Screenshot_2023-03-10 07 40 23" src="https://user-images.githubusercontent.com/25517624/224318498-565e1835-8820-4eaf-9e58-df33bb46d744.png">
