### PR TITLE
:bug: (nordigen) fallback to bookingDate if valueDate is not set

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -298,7 +298,7 @@ async function normalizeNordigenTransactions(transactions, acctId) {
   let normalized = [];
   for (let trans of transactions) {
     if (!trans.date) {
-      trans.date = trans.valueDate;
+      trans.date = trans.valueDate || trans.bookingDate;
     }
 
     if (!trans.amount) {


### PR DESCRIPTION
Fallback to `bookingDate` if `valueDate` is empty.

Fix for: https://github.com/actualbudget/actual/issues/724#issuecomment-1464914546