### PR TITLE
:bug: (nordigen) fix detection of -0.00 "debited" transactions

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -312,7 +312,7 @@ async function normalizeNordigenTransactions(transactions, acctId) {
     }
 
     let payee_name;
-    if (trans.amount >= 0) {
+    if (trans.amount > 0 || Object.is(Number(trans.amount), 0)) {
       const nameParts = [];
       nameParts.push(
         title(

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -312,6 +312,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
     }
 
     let payee_name;
+    // When the amount is equal to 0, we need to determine
+    // if this is a "Credited" or "Debited" transaction. This means
+    // that it matters whether the amount is a positive or negative zero.
     if (trans.amount > 0 || Object.is(Number(trans.amount), 0)) {
       const nameParts = [];
       nameParts.push(


### PR DESCRIPTION
Check if the transaction amount is a positive 0 rather than -0.
I went for casting the string with `Number` but I could instead replace the whole condition with `!trans.amount.startsWith('-')` or with `trans.amount > 0 || trans.amount == '0.00'` if either of these variants are preferred.

Fix for https://github.com/actualbudget/actual/issues/724#issuecomment-1464907064