### PR TITLE
🐛 (nordigen) fallback to array version of remittanceInformationUnstructured if necessary

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -316,7 +316,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
       const nameParts = [];
       nameParts.push(
         title(
-          trans.debtorName || trans.remittanceInformationUnstructured || '',
+          trans.debtorName
+          || trans.remittanceInformationUnstructured
+          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
         ),
       );
       if (trans.debtorAccount && trans.debtorAccount.iban) {
@@ -333,7 +335,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
       const nameParts = [];
       nameParts.push(
         title(
-          trans.creditorName || trans.remittanceInformationUnstructured || '',
+          trans.creditorName
+          || trans.remittanceInformationUnstructured
+          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
         ),
       );
       if (trans.creditorAccount && trans.creditorAccount.iban) {

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -316,9 +316,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
       const nameParts = [];
       nameParts.push(
         title(
-          trans.debtorName
-          || trans.remittanceInformationUnstructured
-          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
+          trans.debtorName ||
+            trans.remittanceInformationUnstructured ||
+            (trans.remittanceInformationUnstructuredArray || []).join(', '),
         ),
       );
       if (trans.debtorAccount && trans.debtorAccount.iban) {
@@ -335,9 +335,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
       const nameParts = [];
       nameParts.push(
         title(
-          trans.creditorName
-          || trans.remittanceInformationUnstructured
-          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
+          trans.creditorName ||
+            trans.remittanceInformationUnstructured ||
+            (trans.remittanceInformationUnstructuredArray || []).join(', '),
         ),
       );
       if (trans.creditorAccount && trans.creditorAccount.iban) {
@@ -370,8 +370,9 @@ async function normalizeNordigenTransactions(transactions, acctId) {
         payee: trans.payee,
         account: trans.account,
         date: trans.date,
-        notes: trans.remittanceInformationUnstructured
-          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
+        notes:
+          trans.remittanceInformationUnstructured ||
+          (trans.remittanceInformationUnstructuredArray || []).join(', '),
         imported_id: trans.transactionId,
         imported_payee: trans.imported_payee,
       },

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -371,7 +371,7 @@ async function normalizeNordigenTransactions(transactions, acctId) {
         account: trans.account,
         date: trans.date,
         notes: trans.remittanceInformationUnstructured
-          || (trans.remittanceInformationUnstructured || []).join(', '),
+          || (trans.remittanceInformationUnstructuredArray || []).join(', '),
         imported_id: trans.transactionId,
         imported_payee: trans.imported_payee,
       },

--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -370,7 +370,8 @@ async function normalizeNordigenTransactions(transactions, acctId) {
         payee: trans.payee,
         account: trans.account,
         date: trans.date,
-        notes: trans.remittanceInformationUnstructured,
+        notes: trans.remittanceInformationUnstructured
+          || (trans.remittanceInformationUnstructured || []).join(', '),
         imported_id: trans.transactionId,
         imported_payee: trans.imported_payee,
       },


### PR DESCRIPTION
Try falling back to `remittanceInformationUnstructuredArray.join(', ')` when neither `debtor/creditorName` nor `remittanceInformationUnstructured` fields are present.

Addresses a suggestion from https://github.com/actualbudget/actual/issues/724#issuecomment-1464907064