### PR TITLE
:bookmark: (23.3.2) nordigen fixes

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "23.3.0",
+  "version": "23.3.2",
   "license": "MIT",
   "files": [
     "build"


### PR DESCRIPTION
Why not `23.3.1`? Because we already released that version for `actual-server`