### PR TITLE
Reduce client build size by 1MB

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
   "resolutions": {
     "react-error-overlay": "6.0.9"
   },
-  "packageManager": "yarn@3.4.1"
+  "packageManager": "yarn@3.4.1",
+  "browserslist": [
+    "electron 12.0",
+    "defaults"
+  ]
 }

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -60,8 +60,5 @@
       "<rootDir>/src/setupTests.js",
       "<rootDir>/../loot-design/src/setupTests.js"
     ]
-  },
-  "browserslist": [
-    "electron 3.0"
-  ]
+  }
 }

--- a/packages/loot-design/package.json
+++ b/packages/loot-design/package.json
@@ -45,8 +45,5 @@
   "manifest": "manifest.json",
   "pathAliases": {
     "react-art": "../../node_modules/node-noop"
-  },
-  "browserslist": [
-    "electron 3.0"
-  ]
+  }
 }


### PR DESCRIPTION
before:

```
kcab.worker.4bdc73a8d45eb2115156.js (2.1 MiB)
xfo.kcab.worker.4bdc73a8d45eb2115156.js (1010 KiB)
```

after:

```
kcab.worker.39f5fba82d7bc7477962.js (1.41 MiB)
xfo.kcab.worker.39f5fba82d7bc7477962.js (1000 KiB)
```

What’s changed:

- `loot-core` did not have a `browserslist` config, so `@babel/preset-env` assumes we want to [transpile all the way back to ES5](https://babeljs.io/docs/options#no-targets). I’ve removed the `browserslist` config from each of the `package.json` files and moved it to the root so this doesn’t happen again.
- I updated the target from `electron 3.0` to `electron 12.0` to match our Electron dependency
- I’ve added `defaults` (currently equivalent to `> 0.5%, last 2 versions, Firefox ESR, not dead`) which is [recommended by browserslist](https://browsersl.ist/#q=defaults). We could consider tightening this, but it doesn’t offer a ton of space savings at this point to just target Electron 12.
- Since much less transpilation will be happening, stack traces (dev and prod) will be much easier to read!