### PR TITLE
fix(nordigen/sync): Use bookingDate as fallback during sync

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.js
+++ b/packages/loot-core/src/server/accounts/sync.js
@@ -816,7 +816,7 @@ export async function syncNordigenAccount(userId, userKey, id, acctId, bankId) {
 
     const oldestDate =
       transactions.length > 0
-        ? oldestTransaction.valueDate
+        ? oldestTransaction.valueDate || oldestTransaction.bookingDate
         : monthUtils.currentDay();
 
     const payee = await getStartingBalancePayee();


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/724#issuecomment-1468453526

And add the missing fallback condition that wasn't catered in https://github.com/actualbudget/actual/pull/745
