### PR TITLE
Disable ESLint when building in CI

### DIFF
--- a/packages/desktop-client/config-overrides.js
+++ b/packages/desktop-client/config-overrides.js
@@ -1,5 +1,6 @@
 const {
   addWebpackResolve,
+  disableEsLint,
   override,
   overrideDevServer,
   babelInclude,
@@ -13,6 +14,7 @@ module.exports = {
       path.resolve('../loot-core'),
       path.resolve('../loot-design'),
     ]),
+    process.env.CI && disableEsLint(),
     addWebpackResolve({
       extensions: [
         ...(process.env.IS_GENERIC_BROWSER ? ['.browser.js'] : []),

--- a/upcoming-release-notes/763.md
+++ b/upcoming-release-notes/763.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Disable ESLint when building in CI


### PR DESCRIPTION
This way formatting issues won’t prevent the preview from building (and it should build a bit faster due to not having to run ESLint).