### PR TITLE
:white_check_mark: reducing flakiness of tests by removing randomization

### DIFF
--- a/packages/loot-core/src/mocks/index.js
+++ b/packages/loot-core/src/mocks/index.js
@@ -55,9 +55,8 @@ function _generateTransaction(data) {
   return {
     id: id,
     amount: data.amount || Math.floor(Math.random() * 10000 - 7000),
-    payee: data.payee || (Math.random() < 0.9 ? 'payed-to' : 'guy'),
-    notes:
-      Math.random() < 0.1 ? 'A really long note that should overflow' : 'Notes',
+    payee: data.payee || 'payed-to',
+    notes: 'Notes',
     account: data.account,
     date: data.date || monthUtils.currentDay(),
     category: data.category,

--- a/upcoming-release-notes/771.md
+++ b/upcoming-release-notes/771.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Reducing unit test flakiness by removing randomization


### PR DESCRIPTION
This is not a full fix for the flakiness. One of the test cases will still be flaky. But at least this fixes the other test cases thus improving stability.