### PR TITLE
:arrow_up:  upgrade fast-check to improve unit test perf

### DIFF
--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -49,7 +49,7 @@
     "date-fns": "2.0.0-alpha.27",
     "eslint": "8.35.0",
     "fake-indexeddb": "^3.1.3",
-    "fast-check": "2.13.0",
+    "fast-check": "3.7.1",
     "jest": "^27.0.0",
     "jsverify": "^0.8.4",
     "lru-cache": "^5.1.1",

--- a/packages/loot-core/src/mocks/arbitrary-schema.js
+++ b/packages/loot-core/src/mocks/arbitrary-schema.js
@@ -23,7 +23,7 @@ export function typeArbitrary(typeDesc, name) {
       arb = fc.string();
       break;
     case 'date':
-      arb = fc.integer(0, 365 * 4).map(n => {
+      arb = fc.integer({ min: 0, max: 365 * 4 }).map(n => {
         return addDays('2018-01-01', n);
       });
       break;
@@ -128,9 +128,9 @@ export function makeTransaction({ splitFreq = 1, payeeIds } = {}) {
     schema.transactions,
     {
       ...payeeField,
-      subtransactions: fc.frequency(
-        { arbitrary: fc.constant([]), weight: 1 },
-        { arbitrary: fc.array(subtrans), weight: splitFreq },
+      subtransactions: fc.oneof(
+        { arbitrary: fc.constant([]), weight: 100 },
+        { arbitrary: fc.array(subtrans), weight: splitFreq * 100 },
       ),
     },
     ['subtransactions'],

--- a/packages/loot-core/src/server/sync/migrate.test.js
+++ b/packages/loot-core/src/server/sync/migrate.test.js
@@ -46,9 +46,9 @@ let messageArb = fc
       dataset: fc.constant('transactions'),
       column: fc.constant(toInternalField(field) || field),
       row: fc.oneof(
-        fc.integer(0, 5).map(i => `id${i}`),
-        fc.integer(0, 5).chain(i => {
-          return fc.integer(0, 5).map(j => `id${i}/child${j}`);
+        fc.integer({ min: 0, max: 5 }).map(i => `id${i}`),
+        fc.integer({ min: 0, max: 5 }).chain(i => {
+          return fc.integer({ min: 0, max: 5 }).map(j => `id${i}/child${j}`);
         }),
       ),
       value: value,

--- a/packages/loot-core/src/server/sync/sync.property.test.js
+++ b/packages/loot-core/src/server/sync/sync.property.test.js
@@ -8,7 +8,7 @@ import * as encoder from './encoder';
 import * as sync from './index';
 
 const jsc = require('jsverify');
-const uuidGenerator = jsc.integer(97, 122).smap(
+const uuidGenerator = jsc.integer({ min: 97, max: 122 }).smap(
   x => String.fromCharCode(x),
   x => x.charCodeAt(x),
 );
@@ -104,7 +104,7 @@ function makeGen({ table, row, field, value }) {
     row: row || uuidGenerator,
     column: jsc.constant(field),
     value,
-    timestamp: jsc.integer(1000, 10000).smap(
+    timestamp: jsc.integer({ min: 1000, max: 10000 }).smap(
       x => {
         let clientId;
         switch (jsc.random(0, 1)) {

--- a/upcoming-release-notes/772.md
+++ b/upcoming-release-notes/772.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Upgrade `fast-check` dependency to improve unit test speed

--- a/yarn.lock
+++ b/yarn.lock
@@ -9395,12 +9395,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-check@npm:2.13.0":
-  version: 2.13.0
-  resolution: "fast-check@npm:2.13.0"
+"fast-check@npm:3.7.1":
+  version: 3.7.1
+  resolution: "fast-check@npm:3.7.1"
   dependencies:
-    pure-rand: ^4.1.1
-  checksum: d892d5275afae17cfccb2062207ccd1f03cdb08b80ea6bba48722cc0b58f085eeefde6d5130b2238c62cec6eb75db6834b80aff472beae89dd427f7b5d6b3cc2
+    pure-rand: ^6.0.0
+  checksum: 8bab983cc2a6449ea69c25ec1b048e910b661da2a85c4336e1c993514cbd4a555674194c9191266b96fbb29de1538fceddfde0a00c056a7226021fcd3ed523b9
   languageName: node
   linkType: hard
 
@@ -13296,7 +13296,7 @@ __metadata:
     deep-equal: ^2.0.5
     eslint: 8.35.0
     fake-indexeddb: ^3.1.3
-    fast-check: 2.13.0
+    fast-check: 3.7.1
     google-protobuf: ^3.12.0-rc.1
     jest: ^27.0.0
     jsverify: ^0.8.4
@@ -16562,10 +16562,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^4.1.1":
-  version: 4.2.1
-  resolution: "pure-rand@npm:4.2.1"
-  checksum: 436122e60d3ac309d415d7969377bf22ca11f4da414703989341831accc5d09202e9271707bd85cb89d272b46d8e5f2e02e11a363156f010ea37394a4c646486
+"pure-rand@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "pure-rand@npm:6.0.1"
+  checksum: 4bb565399993b815658a72e359f574ce4f04827a42a905105d61163ae86f456d91595a0e4241e7bce04328fae0638ae70ac0428d93ecb55971c465bd084f8648
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgraded `fast-check` to improve unit test performance.

(ignore `set up environment` step - that is slow only the first time it's ran because of no dependency cache; focus on the "test" step)

Before:
<img width="1305" alt="Screenshot 2023-03-17 at 20 02 37" src="https://user-images.githubusercontent.com/886567/226020436-a36ac0b9-4d4e-4935-8d51-b46284aeea5f.png">


After:
<img width="1307" alt="Screenshot 2023-03-17 at 20 07 47" src="https://user-images.githubusercontent.com/886567/226022545-f2e3ca60-7e6c-4f03-86d3-18993380ae7a.png">
