### PR TITLE
:arrow_up:  finish react v18 upgrade: react-dom change

### DIFF
--- a/packages/desktop-client/src/index.js
+++ b/packages/desktop-client/src/index.js
@@ -8,9 +8,9 @@ import '@reach/listbox/styles.css';
 import 'inter-ui/inter.css';
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
+import { createRoot } from 'react-dom/client';
 import {
   createStore,
   combineReducers,
@@ -70,11 +70,12 @@ window.$send = send;
 window.$query = runQuery;
 window.$q = q;
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(
   <Provider store={store}>
     <ServerProvider>
       <App />
     </ServerProvider>
   </Provider>,
-  document.getElementById('root'),
 );

--- a/upcoming-release-notes/776.md
+++ b/upcoming-release-notes/776.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Finish React v18 upgrade: react-dom change


### PR DESCRIPTION
Finishing off the React v18 upgrade by doing a change in `react-dom`. Effectively this upgrades from v17 to v18.

https://react.dev/blog/2022/03/08/react-18-upgrade-guide