### PR TITLE
:fire:  remove unused `tableNavigatorOpts` code-path

### DIFF
--- a/packages/loot-design/src/components/payees.js
+++ b/packages/loot-design/src/components/payees.js
@@ -342,7 +342,6 @@ export const ManagePayees = React.forwardRef(
       payees,
       ruleCounts,
       categoryGroups,
-      tableNavigatorOpts, // TODO: remove as it's unused
       initialSelectedIds,
       ruleActions,
       onBatchChange,
@@ -455,18 +454,15 @@ export const ManagePayees = React.forwardRef(
 
     let buttonsDisabled = selected.items.size === 0;
 
-    let tableNavigator = useTableNavigator(
-      filteredPayees,
-      item =>
-        ['select', 'name', 'rule-count'].filter(name => {
-          switch (name) {
-            case 'select':
-              return item.transfer_acct == null;
-            default:
-              return true;
-          }
-        }),
-      tableNavigatorOpts,
+    let tableNavigator = useTableNavigator(filteredPayees, item =>
+      ['select', 'name', 'rule-count'].filter(name => {
+        switch (name) {
+          case 'select':
+            return item.transfer_acct == null;
+          default:
+            return true;
+        }
+      }),
     );
 
     let payeesById = getPayeesById(payees);

--- a/packages/loot-design/src/components/table.js
+++ b/packages/loot-design/src/components/table.js
@@ -999,11 +999,10 @@ export const Table = React.forwardRef(
   },
 );
 
-export function useTableNavigator(data, fields, opts = {}) {
+export function useTableNavigator(data, fields) {
   let getFields = typeof fields !== 'function' ? () => fields : fields;
-  let { initialEditingId, initialFocusedField, moveKeys } = opts;
-  let [editingId, setEditingId] = useState(initialEditingId || null);
-  let [focusedField, setFocusedField] = useState(initialFocusedField || null);
+  let [editingId, setEditingId] = useState(null);
+  let [focusedField, setFocusedField] = useState(null);
   let containerRef = useRef();
 
   // See `onBlur` for why we need this
@@ -1128,47 +1127,37 @@ export function useTableNavigator(data, fields, opts = {}) {
           return;
         }
 
-        let fieldKeys =
-          moveKeys && moveKeys[focusedField] && moveKeys[focusedField];
+        switch (e.code) {
+          case 'ArrowUp':
+          case 'KeyK':
+            if (e.target.tagName !== 'INPUT') {
+              onMove('up');
+            }
+            break;
 
-        if (fieldKeys && fieldKeys[e.keyCode]) {
-          e.preventDefault();
-          e.stopPropagation();
+          case 'ArrowDown':
+          case 'KeyJ':
+            if (e.target.tagName !== 'INPUT') {
+              onMove('down');
+            }
+            break;
 
-          onMove(fieldKeys[e.keyCode]);
-        } else {
-          switch (e.code) {
-            case 'ArrowUp':
-            case 'KeyK':
-              if (e.target.tagName !== 'INPUT') {
-                onMove('up');
-              }
-              break;
+          case 'Enter':
+          case 'Tab':
+            e.preventDefault();
+            e.stopPropagation();
 
-            case 'ArrowDown':
-            case 'KeyJ':
-              if (e.target.tagName !== 'INPUT') {
-                onMove('down');
-              }
-              break;
-
-            case 'Enter':
-            case 'Tab':
-              e.preventDefault();
-              e.stopPropagation();
-
-              onMove(
-                e.code === 'Enter'
-                  ? e.shiftKey
-                    ? 'up'
-                    : 'down'
-                  : e.shiftKey
-                  ? 'left'
-                  : 'right',
-              );
-              break;
-            default:
-          }
+            onMove(
+              e.code === 'Enter'
+                ? e.shiftKey
+                  ? 'up'
+                  : 'down'
+                : e.shiftKey
+                ? 'left'
+                : 'right',
+            );
+            break;
+          default:
         }
       },
 

--- a/upcoming-release-notes/781.md
+++ b/upcoming-release-notes/781.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove unused `tableNavigatorOpts` code-path


### PR DESCRIPTION
Just cleaning up things: removing an unused code-path.