### PR TITLE
Accept `.blob` files when importing Actual export

### DIFF
--- a/packages/loot-design/src/components/manager/ImportActual.js
+++ b/packages/loot-design/src/components/manager/ImportActual.js
@@ -25,7 +25,7 @@ function Import({ modalProps, availableImports }) {
   async function onImport() {
     const res = await window.Actual.openFileDialog({
       properties: ['openFile'],
-      filters: [{ name: 'actual', extensions: ['zip'] }],
+      filters: [{ name: 'actual', extensions: ['zip', 'blob'] }],
     });
     if (res) {
       setImporting(true);


### PR DESCRIPTION
I'm not sure if this is something you want but it was a simple change so I figured I might as well contribute it. This PR allows the user to upload `.blob` files that they may have gotten from server's `user-files/` folder. This can be useful if the user didn't export the file but has server backups.