### PR TITLE
:bug: (autocomplete) consistent input height between multi/single input

### DIFF
--- a/packages/loot-design/src/components/autocomplete-styles.js
+++ b/packages/loot-design/src/components/autocomplete-styles.js
@@ -62,10 +62,12 @@ const colourStyles = {
     padding: '3px 20px',
     fontSize: 13,
   }),
-  valueContainer: styles => ({
+  valueContainer: (styles, { isMulti, selectProps }) => ({
     ...styles,
     padding: 'none',
     overflow: 'visible',
+    marginTop: isMulti && selectProps.value?.length ? -4 : undefined,
+    marginBottom: isMulti && selectProps.value?.length ? -4 : undefined,
   }),
   clearIndicator: styles => ({
     ...styles,
@@ -75,8 +77,6 @@ const colourStyles = {
   multiValue: styles => ({
     ...styles,
     backgroundColor: colors.b9,
-    marginTop: -4,
-    marginBottom: -4,
   }),
 };
 

--- a/packages/loot-design/src/components/autocomplete-styles.js
+++ b/packages/loot-design/src/components/autocomplete-styles.js
@@ -62,13 +62,22 @@ const colourStyles = {
     padding: '3px 20px',
     fontSize: 13,
   }),
-  valueContainer: styles => ({ ...styles, padding: 'none' }),
+  valueContainer: styles => ({
+    ...styles,
+    padding: 'none',
+    overflow: 'visible',
+  }),
   clearIndicator: styles => ({
     ...styles,
     padding: 'none',
     '> svg': { height: 15, width: 15 },
   }),
-  multiValue: styles => ({ ...styles, backgroundColor: colors.b9 }),
+  multiValue: styles => ({
+    ...styles,
+    backgroundColor: colors.b9,
+    marginTop: -4,
+    marginBottom: -4,
+  }),
 };
 
 export default colourStyles;

--- a/upcoming-release-notes/787.md
+++ b/upcoming-release-notes/787.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+New autocomplete: making consistent height between multi/single value inputs


### PR DESCRIPTION
Making consistent height between multi/single input autocomplete.


Before:
<img width="333" alt="Screenshot 2023-03-18 at 19 18 14" src="https://user-images.githubusercontent.com/886567/226132111-21aae538-f42f-43be-8281-93283ed77ec1.png">


After:
<img width="321" alt="Screenshot 2023-03-18 at 19 17 21" src="https://user-images.githubusercontent.com/886567/226131970-df46e053-6794-48e6-a68f-99c66cce6551.png">
<img width="325" alt="Screenshot 2023-03-18 at 19 17 15" src="https://user-images.githubusercontent.com/886567/226131982-a449aee7-70d6-4445-a5b2-a4a476ee10ba.png">
