### PR TITLE
Match spacing in autocomplete

### DIFF
--- a/packages/loot-design/src/components/autocomplete-styles.js
+++ b/packages/loot-design/src/components/autocomplete-styles.js
@@ -10,12 +10,12 @@ const colourStyles = {
     outline: 0,
     marginLeft: -1,
     marginRight: 1,
-    padding: '5px 3px',
+    padding: '6px 2px',
     minHeight: 'auto',
   }),
   input: styles => ({
     ...styles,
-    padding: 0,
+    padding: '0 2px',
     margin: 0,
   }),
   menuPortal: styles => ({

--- a/upcoming-release-notes/793.md
+++ b/upcoming-release-notes/793.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [j-f1]
+---
+
+Slightly improve the layout of the new autocomplete.


### PR DESCRIPTION
Now all of the gaps are 4px and (at least in my browser) the typed text lines up exactly with the placeholder.