### PR TITLE
Re-enable goal templates by passing flag values to the budget summary component

### DIFF
--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -24,6 +24,7 @@ import { View } from 'loot-design/src/components/common';
 import SpreadsheetContext from 'loot-design/src/components/spreadsheet/SpreadsheetContext';
 import { styles } from 'loot-design/src/style';
 
+import useFeatureFlag from '../../hooks/useFeatureFlag';
 import { TitlebarContext } from '../Titlebar';
 
 let _initialBudgetMonth = null;
@@ -498,6 +499,8 @@ class Budget extends React.PureComponent {
 function BudgetWrapper(props) {
   let spreadsheet = useContext(SpreadsheetContext);
   let titlebar = useContext(TitlebarContext);
+  let isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  let isNewAutocompleteEnabled = useFeatureFlag('newAutocomplete');
 
   let reportComponents = useMemo(
     () => ({
@@ -514,7 +517,13 @@ function BudgetWrapper(props) {
 
   let rolloverComponents = useMemo(
     () => ({
-      SummaryComponent: rollover.BudgetSummary,
+      SummaryComponent: props => (
+        <rollover.BudgetSummary
+          {...props}
+          isGoalTemplatesEnabled={isGoalTemplatesEnabled}
+          isNewAutocompleteEnabled={isNewAutocompleteEnabled}
+        />
+      ),
       ExpenseCategoryComponent: rollover.ExpenseCategoryMonth,
       ExpenseGroupComponent: rollover.ExpenseGroupMonth,
       IncomeCategoryComponent: rollover.IncomeCategoryMonth,

--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -496,11 +496,21 @@ class Budget extends React.PureComponent {
   }
 }
 
+const RolloverBudgetSummary = React.memo(props => {
+  const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  const isNewAutocompleteEnabled = useFeatureFlag('newAutocomplete');
+  return (
+    <rollover.BudgetSummary
+      {...props}
+      isGoalTemplatesEnabled={isGoalTemplatesEnabled}
+      isNewAutocompleteEnabled={isNewAutocompleteEnabled}
+    />
+  );
+});
+
 function BudgetWrapper(props) {
   let spreadsheet = useContext(SpreadsheetContext);
   let titlebar = useContext(TitlebarContext);
-  let isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
-  let isNewAutocompleteEnabled = useFeatureFlag('newAutocomplete');
 
   let reportComponents = useMemo(
     () => ({
@@ -517,13 +527,7 @@ function BudgetWrapper(props) {
 
   let rolloverComponents = useMemo(
     () => ({
-      SummaryComponent: props => (
-        <rollover.BudgetSummary
-          {...props}
-          isGoalTemplatesEnabled={isGoalTemplatesEnabled}
-          isNewAutocompleteEnabled={isNewAutocompleteEnabled}
-        />
-      ),
+      SummaryComponent: RolloverBudgetSummary,
       ExpenseCategoryComponent: rollover.ExpenseCategoryMonth,
       ExpenseGroupComponent: rollover.ExpenseGroupMonth,
       IncomeCategoryComponent: rollover.IncomeCategoryMonth,

--- a/upcoming-release-notes/797.md
+++ b/upcoming-release-notes/797.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [modrzew]
+---
+
+Re-enable goal templates by passing flag values to the budget summary component


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

#786 changed the way feature flags are used in components. While refactoring, the `BudgetSummary` component was refactored to get the value of the `goalTemplatesEnabled` flag from props rather than Redux store, but the value of the flag was never passed down to it. Side effect of that was accidentally disabling goal templates, as the flag value was always `undefined`.

This PR fixes that — the flag value is now passed in so that the goal complete feature can now be correctly enabled. (And  the value of the `newAutocomplete` flag is passed down to the `ToBudget` component as well.)

### Before: ☹️ 

<img width="225" alt="Screenshot 2023-03-21 at 22 30 05" src="https://user-images.githubusercontent.com/2963462/226594392-fe6a7866-ee0a-4f91-9a64-5bb8b15db1d9.png">

### After: 😄 

<img width="217" alt="Screenshot 2023-03-21 at 22 30 21" src="https://user-images.githubusercontent.com/2963462/226594407-8299bfc1-fbb3-4f7e-805b-20ba8055b885.png">
