### PR TITLE
transaction-import: treat (amount) as -amount

### DIFF
--- a/packages/loot-core/src/shared/util.js
+++ b/packages/loot-core/src/shared/util.js
@@ -377,15 +377,23 @@ export function looselyParseAmount(amount) {
     return isNaN(v) ? null : v;
   }
 
-  let m = amount.match(/[.,][^.,]*$/);
-  if (!m || m.index === 0) {
-    return safeNumber(parseFloat(amount));
+  function extractNumbers(v) {
+    return v.replace(/[^0-9-]/g, '');
   }
 
-  let left = amount.slice(0, m.index);
-  let right = amount.slice(m.index + 1);
+  if (amount.startsWith('(') && amount.endsWith(')')) {
+    amount = amount.replace('(', '-').replace(')', '');
+  }
 
-  return safeNumber(parseFloat(left.replace(/[^0-9-]/g, '') + '.' + right));
+  let m = amount.match(/[.,][^.,]*$/);
+  if (!m || m.index === 0) {
+    return safeNumber(parseFloat(extractNumbers(amount)));
+  }
+
+  let left = extractNumbers(amount.slice(0, m.index));
+  let right = extractNumbers(amount.slice(m.index + 1));
+
+  return safeNumber(parseFloat(left + '.' + right));
 }
 
 export function semverToNumber(str) {

--- a/packages/loot-core/src/shared/util.test.js
+++ b/packages/loot-core/src/shared/util.test.js
@@ -22,6 +22,11 @@ describe('utility functions', () => {
     expect(looselyParseAmount('-3,45')).toBe(-3.45);
   });
 
+  test('looseParseAmount works with parentheses (negative)', () => {
+    expect(looselyParseAmount('(3.45)')).toBe(-3.45);
+    expect(looselyParseAmount('(3)')).toBe(-3);
+  });
+
   test('looseParseAmount ignores non-numeric characters', () => {
     // This is strange behavior because it does not work for just
     // `3_45_23` (it needs a decimal amount). This function should be

--- a/upcoming-release-notes/808.md
+++ b/upcoming-release-notes/808.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [aharbis]
+---
+
+Import transactions with negative amounts represented as `(amount)`


### PR DESCRIPTION
- When parsing an amount string, consider surrounding parentheses to mean the amount is negative.
- Ensures all input to `parseFloat()` is sanitized.

Closes: #807 

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
