### PR TITLE
:bug: (autocomplete) set min-width of the autocomplete

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/autocomplete-styles.js
+++ b/packages/desktop-client/src/components/autocomplete/autocomplete-styles.js
@@ -21,6 +21,7 @@ const colourStyles = {
   menuPortal: styles => ({
     ...styles,
     zIndex: 5000,
+    minWidth: 200,
   }),
   menu: (styles, { selectProps }) => ({
     ...styles,

--- a/upcoming-release-notes/834.md
+++ b/upcoming-release-notes/834.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [MatissJanis]
+---
+
+Autocomplete: set min-width of the menu


### PR DESCRIPTION
Implement min-width for the autocomplete to make it look better on small screens.

https://github.com/actualbudget/actual/issues/773#issuecomment-1482254636

<img width="304" alt="Screenshot 2023-03-31 at 19 02 06" src="https://user-images.githubusercontent.com/886567/229195868-7d858f18-0c1a-4a9d-95be-5dd0e4aef92c.png">
