### PR TITLE
:bug: (autocomplete) delay when switching from Select to CreatableSelect

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
@@ -56,7 +56,6 @@ export default function PayeeAutocomplete({
   showMakeTransfer = true,
   showManagePayees = false,
   defaultFocusTransferPayees = false,
-  isCreatable = false,
   onSelect,
   onManagePayees,
   ...props
@@ -78,7 +77,6 @@ export default function PayeeAutocomplete({
 
   const dispatch = useDispatch();
 
-  const useCreatableComponent = isCreatable && focusTransferPayees === false;
   const [inputValue, setInputValue] = useState();
 
   return (
@@ -107,7 +105,6 @@ export default function PayeeAutocomplete({
         // This is actually a new option, so create it
         onSelect(await dispatch(createPayee(selectedValue)));
       }}
-      isCreatable={useCreatableComponent}
       createOptionPosition="first"
       formatCreateLabel={inputValue => (
         <View

--- a/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
@@ -87,6 +87,7 @@ export default function PayeeAutocomplete({
           ? allOptions.filter(item => value.includes(item.value))
           : allOptions.find(item => item.value === value)
       }
+      isValidNewOption={input => input && !focusTransferPayees}
       isMulti={multi}
       inputValue={inputValue}
       onInputChange={setInputValue}

--- a/upcoming-release-notes/836.md
+++ b/upcoming-release-notes/836.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+PayeeAutocomplete: fix long delay when clicking on "make transfer"


### PR DESCRIPTION
When you open the payee autocomplete and click on "make transfer" button in the footer: there is a noticable delay between the renders.

This is because the previous `CreatableSelect` component is unmounted and a new `Select` component gets mounted. The only difference between the two: ability to create new payees.

If we remove this logic and simply always keep the component in the `creatable` state - there are no long re-mounts and thus the flow is not so disruptive. But the downside is: you can create payees whilst in the "transfer" mode.

Not exactly the best solution.. but IMO it's better this way than with the massive delay.

https://github.com/actualbudget/actual/issues/773

