### PR TITLE
:bug: (autocomplete) set min-height used to calculate the flip (top-bottom)

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
@@ -133,6 +133,7 @@ export default function PayeeAutocomplete({
       components={{
         MenuList: MenuListWithFooter,
       }}
+      minMenuHeight={300}
       footer={
         <AutocompleteFooter show={showMakeTransfer || showManagePayees}>
           {showMakeTransfer && (

--- a/upcoming-release-notes/837.md
+++ b/upcoming-release-notes/837.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+PayeeAutocomplete: fix flipping of the menu when it's opened near the bottom of the page


### PR DESCRIPTION
Correctly flip top/bottom the payee autocomplete. Other autocompletes don't have this problem because they don't have a custom "footer". Whereas this one has it.. and it messes with `react-select` calculations.

Before:
<img width="652" alt="Screenshot 2023-03-31 at 22 37 56" src="https://user-images.githubusercontent.com/886567/229237777-0c2a27ea-79a0-46ba-9e79-814d6a7f250b.png">


After:
<img width="370" alt="Screenshot 2023-03-31 at 22 38 30" src="https://user-images.githubusercontent.com/886567/229237787-f5966d47-c890-4911-9a02-78de07b8751f.png">
