### PR TITLE
:bug: (autocomplete) remove portal from table view for smoother experience

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -387,7 +387,6 @@ function PayeeCell({
   transaction,
   payee,
   transferAcct,
-  importedPayee,
   isPreview,
   onEdit,
   onUpdate,
@@ -403,7 +402,7 @@ function PayeeCell({
       name="payee"
       value={payeeId}
       valueStyle={[valueStyle, inherited && { color: colors.n8 }]}
-      formatter={value => getPayeePretty(transaction, payee, transferAcct)}
+      formatter={() => getPayeePretty(transaction, payee, transferAcct)}
       exposed={focused}
       onExpose={!isPreview && (name => onEdit(id, name))}
       onUpdate={async value => {
@@ -448,6 +447,7 @@ function PayeeCell({
               onSelect={onSave}
               onManagePayees={() => onManagePayees(payeeId)}
               isCreatable
+              menuPortalTarget={undefined}
             />
           </>
         );
@@ -776,6 +776,7 @@ export const Transaction = React.memo(function Transaction(props) {
               inputProps={{ onBlur, onKeyDown, style: inputStyle }}
               onUpdate={onUpdate}
               onSelect={onSave}
+              menuPortalTarget={undefined}
             />
           )}
         </CustomCell>
@@ -985,6 +986,7 @@ export const Transaction = React.memo(function Transaction(props) {
               inputProps={{ onBlur, onKeyDown, style: inputStyle }}
               onUpdate={onUpdate}
               onSelect={onSave}
+              menuPortalTarget={undefined}
             />
           )}
         </CustomCell>

--- a/packages/desktop-client/src/components/autocomplete/autocomplete-styles.js
+++ b/packages/desktop-client/src/components/autocomplete/autocomplete-styles.js
@@ -25,6 +25,7 @@ const colourStyles = {
   }),
   menu: (styles, { selectProps }) => ({
     ...styles,
+    minWidth: 200,
     backgroundColor: colors.n1,
     marginTop: 2,
     marginBottom: 2,

--- a/upcoming-release-notes/839.md
+++ b/upcoming-release-notes/839.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Autocomplete: remove portalization from usage in transaction table in order to improve the UX


### PR DESCRIPTION
Removing portaliztion of the autocomplete from the table view in order to improve the scrolling experience.

Before:

https://user-images.githubusercontent.com/886567/229307705-b013bcde-aaf6-4eec-b269-9cae37370637.mov



After:

https://user-images.githubusercontent.com/886567/229307664-2de32356-f2c6-4e90-a0fa-aec88747756c.mov

