### PR TITLE
:white_check_mark: (e2e) improve stability of budget e2e tests

### DIFF
--- a/packages/desktop-client/e2e/page-models/budget-page.js
+++ b/packages/desktop-client/e2e/page-models/budget-page.js
@@ -35,11 +35,13 @@ export class BudgetPage {
   async getBalanceForRow(idx) {
     return Math.round(
       parseFloat(
-        await this.budgetTable
-          .getByTestId('row')
-          .nth(idx)
-          .getByTestId('balance')
-          .textContent(),
+        (
+          await this.budgetTable
+            .getByTestId('row')
+            .nth(idx)
+            .getByTestId('balance')
+            .textContent()
+        ).replace(/,/g, ''),
       ) * 100,
     );
   }

--- a/upcoming-release-notes/845.md
+++ b/upcoming-release-notes/845.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Improve stability of budget e2e test file


### PR DESCRIPTION
Sometimes the test failed because..


`parseFloat("1,234.55") === 1)`