### PR TITLE
:bug:  dismiss update notification only after clicking close

### DIFF
--- a/packages/loot-core/src/client/update-notification.js
+++ b/packages/loot-core/src/client/update-notification.js
@@ -15,9 +15,6 @@ export default async function checkForUpdateNotification(
     return;
   }
 
-  await savePrefs({
-    'flags.updateNotificationShownForVersion': latestVersion,
-  });
   addNotification({
     type: 'message',
     title: 'A new version of Actual is available!',
@@ -29,6 +26,11 @@ export default async function checkForUpdateNotification(
       action: () => {
         window.open('https://actualbudget.github.io/docs/Release-Notes');
       },
+    },
+    onClose: async () => {
+      await savePrefs({
+        'flags.updateNotificationShownForVersion': latestVersion,
+      });
     },
   });
 }

--- a/upcoming-release-notes/854.md
+++ b/upcoming-release-notes/854.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Dismiss the update notification only after clicking the close button


### PR DESCRIPTION
Closes #764

Dismiss the update notification only after clicking "close" button

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
