### PR TITLE
:bug:  normalize value when switching between single/multi select

### DIFF
--- a/packages/desktop-client/src/components/accounts/Filters.js
+++ b/packages/desktop-client/src/components/accounts/Filters.js
@@ -244,7 +244,7 @@ function ConfigureField({
               field={field}
               subfield={subfield}
               type={type === 'id' && op === 'contains' ? 'string' : type}
-              value={value}
+              value={normalizeValue(value, op === 'oneOf')}
               multi={op === 'oneOf'}
               style={{ marginTop: 10 }}
               onChange={v => dispatch({ type: 'set-value', value: v })}
@@ -529,4 +529,19 @@ export function AppliedFilters({ filters, editingFilter, onUpdate, onDelete }) {
       ))}
     </View>
   );
+}
+
+function normalizeValue(value, isMulti) {
+  if (isMulti) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    return value.split(', ');
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+
+  return value;
 }

--- a/upcoming-release-notes/855.md
+++ b/upcoming-release-notes/855.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Normalize value when single/multi select is changed


### PR DESCRIPTION
Closes #779

Normalize the input value when switching between single/multi select fields. Most visible when using the "notes" field filter.