### PR TITLE
Use Unicode-aware implementations of LOWER() and UPPER() in SQL queries

### DIFF
--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -85,10 +85,14 @@ export async function asyncTransaction(db, fn) {
 
 export function openDatabase(pathOrBuffer) {
   let db = new Database(pathOrBuffer);
-  // Redefine LOWER() and UPPER() with our own Unicode-aware implementation.
+  // Define Unicode-aware LOWER and UPPER implementation.
   // This is necessary because better-sqlite3 uses SQLite build without ICU support.
-  db.function('LOWER', { deterministic: true }, arg => arg?.toLowerCase());
-  db.function('UPPER', { deterministic: true }, arg => arg?.toUpperCase());
+  db.function('UNICODE_LOWER', { deterministic: true }, arg =>
+    arg?.toLowerCase(),
+  );
+  db.function('UNICODE_UPPER', { deterministic: true }, arg =>
+    arg?.toUpperCase(),
+  );
   return db;
 }
 

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -84,7 +84,12 @@ export async function asyncTransaction(db, fn) {
 }
 
 export function openDatabase(pathOrBuffer) {
-  return new Database(pathOrBuffer);
+  let db = new Database(pathOrBuffer);
+  // Redefine LOWER() and UPPER() with our own Unicode-aware implementation.
+  // This is necessary because better-sqlite3 uses SQLite build without ICU support.
+  db.function('LOWER', { deterministic: true }, arg => arg?.toLowerCase());
+  db.function('UPPER', { deterministic: true }, arg => arg?.toUpperCase());
+  return db;
 }
 
 export function closeDatabase(db) {

--- a/packages/loot-core/src/platform/server/sqlite/index.web.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.web.ts
@@ -184,10 +184,10 @@ export async function openDatabase(pathOrBuffer?: string | Buffer) {
     db = new SQL.Database();
   }
 
-  // Redefine LOWER() and UPPER() with our own Unicode-aware implementation.
+  // Define Unicode-aware LOWER and UPPER implementation.
   // This is necessary because sql.js uses SQLite build without ICU support.
-  db.create_function('LOWER', arg => arg?.toLowerCase());
-  db.create_function('UPPER', arg => arg?.toUpperCase());
+  db.create_function('UNICODE_LOWER', arg => arg?.toLowerCase());
+  db.create_function('UNICODE_UPPER', arg => arg?.toUpperCase());
   return db;
 }
 

--- a/packages/loot-core/src/platform/server/sqlite/index.web.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.web.ts
@@ -186,6 +186,10 @@ export async function openDatabase(pathOrBuffer?: string | Buffer) {
 
   // Define Unicode-aware LOWER and UPPER implementation.
   // This is necessary because sql.js uses SQLite build without ICU support.
+  //
+  // Note that this function should ideally be created with a deterministic flag
+  // to allow SQLite to better optimize calls to it by factoring them out of inner loops
+  // but SQL.js does not support this: https://github.com/sql-js/sql.js/issues/551
   db.create_function('UNICODE_LOWER', arg => arg?.toLowerCase());
   db.create_function('UNICODE_UPPER', arg => arg?.toUpperCase());
   return db;

--- a/packages/loot-core/src/server/accounts/payees.js
+++ b/packages/loot-core/src/server/accounts/payees.js
@@ -4,7 +4,7 @@ export async function createPayee(description) {
   // Check to make sure no payee already exists with exactly the same
   // name
   let row = await db.first(
-    `SELECT id FROM payees WHERE LOWER(name) = ? AND tombstone = 0`,
+    `SELECT id FROM payees WHERE UNICODE_LOWER(name) = ? AND tombstone = 0`,
     [description.toLowerCase()],
   );
 

--- a/packages/loot-core/src/server/aql/compiler.js
+++ b/packages/loot-core/src/server/aql/compiler.js
@@ -564,7 +564,7 @@ const compileFunction = saveStack('function', (state, func) => {
     case '$lower': {
       validateArgLength(args, 1);
       let [arg1] = valArray(state, args, ['string']);
-      return typed(`LOWER(${arg1})`, 'string');
+      return typed(`UNICODE_LOWER(${arg1})`, 'string');
     }
 
     // integer/float functions

--- a/packages/loot-core/src/server/db/index.js
+++ b/packages/loot-core/src/server/db/index.js
@@ -516,9 +516,10 @@ export async function getOrphanedPayees() {
 }
 
 export async function getPayeeByName(name) {
-  return first(`SELECT * FROM payees WHERE LOWER(name) = ? AND tombstone = 0`, [
-    name.toLowerCase(),
-  ]);
+  return first(
+    `SELECT * FROM payees WHERE UNICODE_LOWER(name) = ? AND tombstone = 0`,
+    [name.toLowerCase()],
+  );
 }
 
 export function insertPayeeRule(rule) {

--- a/upcoming-release-notes/865.md
+++ b/upcoming-release-notes/865.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Jackenmen]
+---
+
+Fix case-insensitive matching of strings for uppercase letters from non-English alphabets


### PR DESCRIPTION
Fixes #840 by creating application-defined SQL functions (https://www.sqlite.org/appfunc.html) for Unicode-aware implementations of `LOWER()` and `UPPER()`. This uses `String.prototype.toLower/UpperCase()` JS method.

I initially wanted to just redefine `LOWER()` and `UPPER()` but due to [sql.js not supporting the definition of deterministic functions](https://github.com/sql-js/sql.js/issues/551), I had to just define them as separate functions and use that in the appropriate places. It's probably better like that anyway...