### PR TITLE
Disable ESLint in CI again

### DIFF
--- a/packages/desktop-client/config-overrides.js
+++ b/packages/desktop-client/config-overrides.js
@@ -2,16 +2,18 @@ const path = require('path');
 
 const {
   addWebpackResolve,
-  disableEsLint,
   override,
   overrideDevServer,
   babelInclude,
 } = require('customize-cra');
 
+if (process.env.CI) {
+  process.env.DISABLE_ESLINT_PLUGIN = 'true';
+}
+
 module.exports = {
   webpack: override(
     babelInclude([path.resolve('src'), path.resolve('../loot-core')]),
-    process.env.CI && disableEsLint(),
     addWebpackResolve({
       extensions: [
         ...(process.env.IS_GENERIC_BROWSER

--- a/packages/desktop-client/src/util.js
+++ b/packages/desktop-client/src/util.js
@@ -4,7 +4,7 @@ export function getModalRoute(name) {
 }
 
 export function isMobile() {
-  let details = navigator.userAgent
-  let regexp = /Mobi|android|iphone|kindle|ipad/i
-  return regexp.test(details)
+  let details = navigator.userAgent;
+  let regexp = /Mobi|android|iphone|kindle|ipad/i;
+  return regexp.test(details);
 }

--- a/packages/desktop-client/src/util.js
+++ b/packages/desktop-client/src/util.js
@@ -4,7 +4,7 @@ export function getModalRoute(name) {
 }
 
 export function isMobile() {
-  let details = navigator.userAgent;
-  let regexp = /Mobi|android|iphone|kindle|ipad/i;
-  return regexp.test(details);
+  let details = navigator.userAgent
+  let regexp = /Mobi|android|iphone|kindle|ipad/i
+  return regexp.test(details)
 }

--- a/upcoming-release-notes/869.md
+++ b/upcoming-release-notes/869.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Disable ESLint when building in CI (since we have a separate linting job)


### PR DESCRIPTION
This should speed up builds in CI, and must not have gotten caught when upgrading `react-scripts`.
ref: arackaf/customize-cra#278