### PR TITLE
:bug: (autocomplete) show 'create payee' only if no payee matched

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
@@ -91,7 +91,7 @@ export default function PayeeAutocomplete({
         }
 
         const lowercaseInput = input.toLowerCase();
-        const hasExistingOption = !!allOptions.find(
+        const hasExistingOption = allOptions.some(
           option => option.label.toLowerCase() === lowercaseInput,
         );
 

--- a/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/NewPayeeAutocomplete.js
@@ -85,21 +85,21 @@ export default function PayeeAutocomplete({
           ? allOptions.filter(item => value.includes(item.value))
           : allOptions.find(item => item.value === value)
       }
-      isValidNewOption={input => input && !focusTransferPayees}
+      isValidNewOption={input => {
+        if (focusTransferPayees || !input) {
+          return false;
+        }
+
+        const lowercaseInput = input.toLowerCase();
+        const hasExistingOption = !!allOptions.find(
+          option => option.label.toLowerCase() === lowercaseInput,
+        );
+
+        return !hasExistingOption;
+      }}
       isMulti={multi}
       onSelect={onSelect}
       onCreateOption={async selectedValue => {
-        const existingOption = allOptions.find(option =>
-          option.label.toLowerCase().includes(selectedValue?.toLowerCase()),
-        );
-
-        // Prevent creating duplicates
-        if (existingOption) {
-          onSelect(existingOption.value);
-          return;
-        }
-
-        // This is actually a new option, so create it
         onSelect(await dispatch(createPayee(selectedValue)));
       }}
       createOptionPosition="first"

--- a/upcoming-release-notes/881.md
+++ b/upcoming-release-notes/881.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Autocomplete: do not show "create payee" option if the typed-in payee is an exact match of an existing payee


### PR DESCRIPTION
https://github.com/actualbudget/actual/issues/773

---

Before:

"create payee" is visible for exact matches


After:

"create payee" is visible only if NOT exactly matched
<img width="341" alt="Screenshot 2023-04-09 at 19 55 22" src="https://user-images.githubusercontent.com/886567/230791343-b0e8a350-321f-4a84-a1c0-5a8bf30b0a70.png">
<img width="332" alt="Screenshot 2023-04-09 at 19 55 34" src="https://user-images.githubusercontent.com/886567/230791353-51d1502d-6d2e-44a8-a865-1dfbd141ce4e.png">

