### PR TITLE
:bug: (rules) creation from account page

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1700,6 +1700,7 @@ class AccountInternal extends React.PureComponent {
 
     let rule = {
       stage: null,
+      conditionsOp: 'and',
       conditions: [payeeCondition],
       actions: [
         {

--- a/upcoming-release-notes/882.md
+++ b/upcoming-release-notes/882.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix rule creation from account page (transaction list)


### PR DESCRIPTION
Reproduction:

1. open netlify deployment
2. open account page
3. select 1x transaction
4. go to the hamburger menu and "create rule"
5. click "save" in the modal
6. before: it does not work - error in console; after: it works