### PR TITLE
:art: (mobile) settings page header

### DIFF
--- a/packages/desktop-client/src/components/Page.js
+++ b/packages/desktop-client/src/components/Page.js
@@ -22,22 +22,25 @@ export function usePageType() {
   return React.useContext(PageTypeContext);
 }
 
-function PageTitle({ name }) {
+function PageTitle({ name, style }) {
   if (isMobile()) {
     return (
       <View
-        style={{
-          alignItems: 'center',
-          backgroundColor: colors.b2,
-          color: 'white',
-          flexDirection: 'row',
-          flex: '1 0 auto',
-          fontSize: 18,
-          fontWeight: 500,
-          height: 50,
-          justifyContent: 'center',
-          overflowY: 'auto',
-        }}
+        style={[
+          {
+            alignItems: 'center',
+            backgroundColor: colors.b2,
+            color: 'white',
+            flexDirection: 'row',
+            flex: '1 0 auto',
+            fontSize: 18,
+            fontWeight: 500,
+            height: 50,
+            justifyContent: 'center',
+            overflowY: 'auto',
+          },
+          style,
+        ]}
       >
         {name}
       </View>
@@ -46,20 +49,23 @@ function PageTitle({ name }) {
 
   return (
     <Text
-      style={{
-        fontSize: 25,
-        fontWeight: 500,
-        paddingLeft: HORIZONTAL_PADDING,
-        paddingRight: HORIZONTAL_PADDING,
-        marginBottom: 15,
-      }}
+      style={[
+        {
+          fontSize: 25,
+          fontWeight: 500,
+          paddingLeft: HORIZONTAL_PADDING,
+          paddingRight: HORIZONTAL_PADDING,
+          marginBottom: 15,
+        },
+        style,
+      ]}
     >
       {name}
     </Text>
   );
 }
 
-export function Page({ title, modalSize, children }) {
+export function Page({ title, modalSize, children, titleStyle }) {
   let { type, current } = usePageType();
   let history = useHistory();
 
@@ -84,7 +90,7 @@ export function Page({ title, modalSize, children }) {
 
   return (
     <View style={isMobile() ? undefined : styles.page}>
-      <PageTitle name={title} />
+      <PageTitle name={title} style={titleStyle} />
       <View
         style={
           isMobile()

--- a/packages/desktop-client/src/components/Page.js
+++ b/packages/desktop-client/src/components/Page.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { styles } from '../style';
+import { colors, styles } from '../style';
+import { isMobile } from '../util';
 
 import { Modal, View, Text } from './common';
 
 let PageTypeContext = React.createContext({ type: 'page' });
+
+const HORIZONTAL_PADDING = isMobile() ? 10 : 20;
 
 export function PageTypeProvider({ type, current, children }) {
   return (
@@ -20,8 +23,37 @@ export function usePageType() {
 }
 
 function PageTitle({ name }) {
+  if (isMobile()) {
+    return (
+      <View
+        style={{
+          alignItems: 'center',
+          backgroundColor: colors.b2,
+          color: 'white',
+          flexDirection: 'row',
+          flex: '1 0 auto',
+          fontSize: 18,
+          fontWeight: 500,
+          height: 50,
+          justifyContent: 'center',
+          overflowY: 'auto',
+        }}
+      >
+        {name}
+      </View>
+    );
+  }
+
   return (
-    <Text style={{ fontSize: 25, fontWeight: 500, marginBottom: 15 }}>
+    <Text
+      style={{
+        fontSize: 25,
+        fontWeight: 500,
+        paddingLeft: HORIZONTAL_PADDING,
+        paddingRight: HORIZONTAL_PADDING,
+        marginBottom: 15,
+      }}
+    >
       {name}
     </Text>
   );
@@ -51,9 +83,21 @@ export function Page({ title, modalSize, children }) {
   }
 
   return (
-    <View style={[styles.page, { paddingLeft: 20, paddingRight: 20, flex: 1 }]}>
+    <View style={isMobile() ? undefined : styles.page}>
       <PageTitle name={title} />
-      {children}
+      <View
+        style={
+          isMobile()
+            ? { overflowY: 'auto', padding: HORIZONTAL_PADDING }
+            : {
+                paddingLeft: HORIZONTAL_PADDING,
+                paddingRight: HORIZONTAL_PADDING,
+                flex: 1,
+              }
+        }
+      >
+        {children}
+      </View>
     </View>
   );
 }

--- a/packages/desktop-client/src/components/accounts/MobileAccounts.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccounts.js
@@ -10,6 +10,7 @@ import Wallet from '../../icons/v1/Wallet';
 import { colors, styles } from '../../style';
 import { withThemeColor } from '../../util/withThemeColor';
 import { Button, Text, TextOneLine, View } from '../common';
+import { Page } from '../Page';
 import CellValue from '../spreadsheet/CellValue';
 
 export function AccountHeader({ name, amount }) {
@@ -195,53 +196,30 @@ export class AccountList extends React.Component {
     }
 
     const accountContent = (
-      <View style={{ overflowY: 'auto' }}>
-        <View
-          style={{
-            alignItems: 'center',
-            backgroundColor: colors.b2,
-            color: 'white',
-            flexDirection: 'row',
-            flex: '1 0 auto',
-            fontSize: 18,
-            fontWeight: 500,
-            height: 50,
-            justifyContent: 'center',
-            overflowY: 'auto',
-          }}
-        >
-          Accounts
-        </View>
-        <View
-          style={{
-            backgroundColor: colors.n10,
-            overflowY: 'auto',
-            padding: 10,
-          }}
-        >
-          <AccountHeader name="Budgeted" amount={getOnBudgetBalance()} />
-          {budgetedAccounts.map((acct, idx) => (
-            <AccountCard
-              account={acct}
-              key={acct.id}
-              updated={updatedAccounts.includes(acct.id)}
-              getBalanceQuery={getBalanceQuery}
-              onSelect={onSelectAccount}
-            />
-          ))}
+      <Page title="Accounts">
+        <AccountHeader name="Budgeted" amount={getOnBudgetBalance()} />
+        {budgetedAccounts.map((acct, idx) => (
+          <AccountCard
+            account={acct}
+            key={acct.id}
+            updated={updatedAccounts.includes(acct.id)}
+            getBalanceQuery={getBalanceQuery}
+            onSelect={onSelectAccount}
+          />
+        ))}
 
-          <AccountHeader name="Off budget" amount={getOffBudgetBalance()} />
-          {offbudgetAccounts.map((acct, idx) => (
-            <AccountCard
-              account={acct}
-              key={acct.id}
-              updated={updatedAccounts.includes(acct.id)}
-              getBalanceQuery={getBalanceQuery}
-              onSelect={onSelectAccount}
-            />
-          ))}
+        <AccountHeader name="Off budget" amount={getOffBudgetBalance()} />
+        {offbudgetAccounts.map((acct, idx) => (
+          <AccountCard
+            account={acct}
+            key={acct.id}
+            updated={updatedAccounts.includes(acct.id)}
+            getBalanceQuery={getBalanceQuery}
+            onSelect={onSelectAccount}
+          />
+        ))}
 
-          {/*<Label
+        {/*<Label
           title="RECENT TRANSACTIONS"
           style={{
             textAlign: 'center',
@@ -250,8 +228,7 @@ export class AccountList extends React.Component {
             marginLeft: 10
           }}
           />*/}
-        </View>
-      </View>
+      </Page>
     );
 
     return (

--- a/packages/desktop-client/src/components/settings/index.js
+++ b/packages/desktop-client/src/components/settings/index.js
@@ -128,7 +128,17 @@ function Settings({
         marginInline: globalPrefs.floatingSidebar && !isMobile() ? 'auto' : 0,
       }}
     >
-      <Page title="Settings">
+      <Page
+        title="Settings"
+        titleStyle={
+          isMobile()
+            ? {
+                backgroundColor: colors.n11,
+                color: colors.n1,
+              }
+            : undefined
+        }
+      >
         <View style={{ flexShrink: 0, gap: 30 }}>
           {isMobile() && (
             <View

--- a/packages/desktop-client/src/components/settings/index.js
+++ b/packages/desktop-client/src/components/settings/index.js
@@ -183,7 +183,7 @@ function Settings({
   );
 }
 
-export default withThemeColor(colors.n10)(
+export default withThemeColor(colors.n11)(
   connect(
     state => ({
       prefs: state.prefs.local,

--- a/upcoming-release-notes/887.md
+++ b/upcoming-release-notes/887.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [MatissJanis]
 ---
 

--- a/upcoming-release-notes/887.md
+++ b/upcoming-release-notes/887.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [MatissJanis]
+---
+
+Mobile: unify "settings" page header with the style of "accounts" page


### PR DESCRIPTION
Improving the `Settings` page header on mobile devices. And unifying the implementation in mobile `Accounts` page to use the generic `Page` component.

Before:
<img width="365" alt="Screenshot 2023-04-11 at 19 59 14" src="https://user-images.githubusercontent.com/886567/231262712-aad50ce2-afea-49c7-a7c5-945f18d14641.png">


After:
<img width="372" alt="Screenshot 2023-04-11 at 19 59 06" src="https://user-images.githubusercontent.com/886567/231262680-26b1c50a-501a-4e97-8590-59c24789c573.png">
