### PR TITLE
Remove usage of `realpath`

### DIFF
--- a/packages/loot-core/bin/copy-migrations
+++ b/packages/loot-core/bin/copy-migrations
@@ -1,11 +1,9 @@
 #!/bin/sh -e
 
-dest_dir=$(realpath "$1")
+ROOT=`dirname $(dirname "$0")`
+DEST="$1"
 
-ROOT=`dirname "$0"`
-cd "$ROOT"
-
-rm -rf "$dest_dir"/migrations
-mkdir -p "$dest_dir"/migrations
-cp ../migrations/* "$dest_dir"/migrations/
-cp ../default-db.sqlite "$dest_dir"
+rm -rf "$DEST"/migrations
+mkdir -p "$DEST"/migrations
+cp "$ROOT"/migrations/* "$DEST"/migrations/
+cp "$ROOT"/default-db.sqlite "$DEST"

--- a/upcoming-release-notes/893.md
+++ b/upcoming-release-notes/893.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Remove usage of `realpath` command in build script


### PR DESCRIPTION
It turns out this command is not installed by default on macOS. Fortunately the code doesn’t really require it to be used.