### PR TITLE
[Bug]: payees not selectable in schedule creation modal #912 

### DIFF
--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useHistory } from 'react-router-dom';
 
 import { pushModal } from 'loot-core/src/client/actions/modals';
+import { useCachedAccounts } from 'loot-core/src/client/data-hooks/accounts';
 import { useCachedPayees } from 'loot-core/src/client/data-hooks/payees';
 import q, { runQuery, liveQuery } from 'loot-core/src/client/query-helpers';
 import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
@@ -85,7 +86,8 @@ export default function ScheduleDetails() {
 
   let { id, initialFields } = useParams();
   let adding = id == null;
-  let payees = useCachedPayees({ idKey: true });
+  const accounts = useCachedAccounts();
+  const payees = useCachedPayees();
   let history = useHistory();
   let globalDispatch = useDispatch();
   let dateFormat = useSelector(state => {
@@ -465,6 +467,8 @@ export default function ScheduleDetails() {
         <FormField style={{ flex: 1 }}>
           <FormLabel title="Payee" htmlFor="payee-field" />
           <PayeeAutocomplete
+            payees={payees}
+            accounts={accounts}
             value={state.fields.payee}
             inputId="payee-field"
             inputProps={{ id: 'payee-field', placeholder: '(none)' }}

--- a/upcoming-release-notes/920.md
+++ b/upcoming-release-notes/920.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [biohzrddd]
+---
+
+Fix missing payees in Schedule dialog


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fixes #912 . Added missing cached accounts and payees to input to PayeeAutocomplete. Not sure what `{ idKey: true }` does?
[Screencast from 04-17-2023 08:36:30 PM.webm](https://user-images.githubusercontent.com/10577752/232593040-6c6cb08a-226e-468b-b88d-b461da2cf2a3.webm)
