### PR TITLE
Fix handling for shortcuts

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -124,7 +124,7 @@ document.addEventListener('keydown', e => {
       window.__actionsForMenu.closeBudget();
     }
     // Cmd/Ctrl+z
-    else if (e.key === 'z' || e.key === 'Z') {
+    else if (e.key.toLowerCase() === 'z') {
       if (
         e.target.tagName === 'INPUT' ||
         e.target.tagName === 'TEXTAREA' ||
@@ -133,8 +133,7 @@ document.addEventListener('keydown', e => {
         return;
       }
       e.preventDefault();
-      // shift+z
-      if (e.key === 'Z') {
+      if (e.shiftKey) {
         // Redo
         window.__actionsForMenu.redo();
       } else {

--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -119,12 +119,12 @@ global.Actual = {
 document.addEventListener('keydown', e => {
   if (e.metaKey || e.ctrlKey) {
     // Cmd/Ctrl+o
-    if (e.key === 'O') {
+    if (e.key === 'o') {
       e.preventDefault();
       window.__actionsForMenu.closeBudget();
     }
     // Cmd/Ctrl+z
-    else if (e.key === 'Z') {
+    else if (e.key === 'z' || e.key === 'Z') {
       if (
         e.target.tagName === 'INPUT' ||
         e.target.tagName === 'TEXTAREA' ||
@@ -133,7 +133,8 @@ document.addEventListener('keydown', e => {
         return;
       }
       e.preventDefault();
-      if (e.shiftKey) {
+      // shift+z
+      if (e.key === 'Z') {
         // Redo
         window.__actionsForMenu.redo();
       } else {

--- a/packages/desktop-client/src/components/table.js
+++ b/packages/desktop-client/src/components/table.js
@@ -486,7 +486,7 @@ export const CellButton = React.forwardRef(
         className="cell-button"
         tabIndex="0"
         onKeyDown={e => {
-          if (e.key === 'X' || e.key === ' ') {
+          if (e.key === 'x' || e.key === ' ') {
             e.preventDefault();
             if (!disabled) {
               onSelect && onSelect();

--- a/upcoming-release-notes/926.md
+++ b/upcoming-release-notes/926.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix undo keyboard shortcut being ignored


### PR DESCRIPTION
It turns out that `event.key` for ctrl/cmd+Z is `z`, and it’s `Z` for ctrl/cmd+shift+Z.