### PR TITLE
Fix j/k shortcuts to move between transactions on account pages

### DIFF
--- a/packages/desktop-client/src/components/table.js
+++ b/packages/desktop-client/src/components/table.js
@@ -1129,14 +1129,14 @@ export function useTableNavigator(data, fields) {
 
         switch (e.key) {
           case 'ArrowUp':
-          case 'K':
+          case 'k':
             if (e.target.tagName !== 'INPUT') {
               onMove('up');
             }
             break;
 
           case 'ArrowDown':
-          case 'J':
+          case 'j':
             if (e.target.tagName !== 'INPUT') {
               onMove('down');
             }

--- a/upcoming-release-notes/939.md
+++ b/upcoming-release-notes/939.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix j/k shortcuts to move between transactions on account pages


### PR DESCRIPTION
Fixes #937. I also checked through all other uses of `.key` and made sure I didn’t make any other mistakes.