### PR TITLE
Don’t reset checked transactions when creating a schedule

### DIFF
--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -292,8 +292,6 @@ export default function ScheduleDetails() {
         state.fields,
       );
 
-      dispatch({ type: 'set-transactions', transactions: [] });
-
       if (error) {
         dispatch({ type: 'form-error', error });
         return;

--- a/upcoming-release-notes/946.md
+++ b/upcoming-release-notes/946.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Don’t reset checked transactions when creating a schedule


### PR DESCRIPTION
Fixes #942.