### PR TITLE
:bug: (nordigen) fallback button to re-init bank-sync for popover blockers

### DIFF
--- a/packages/desktop-client/src/components/modals/NordigenExternalMsg.js
+++ b/packages/desktop-client/src/components/modals/NordigenExternalMsg.js
@@ -6,7 +6,7 @@ import AnimatedLoading from '../../icons/AnimatedLoading';
 import { colors } from '../../style';
 import { Error, Warning } from '../alerts';
 import Autocomplete from '../autocomplete/Autocomplete';
-import { View, Modal, Button, P } from '../common';
+import { View, Modal, Button, P, Link } from '../common';
 import { FormField, FormLabel } from '../forms';
 
 import { COUNTRY_OPTIONS } from './countries';
@@ -226,6 +226,12 @@ export default function NordigenExternalMsg({
                   ? 'Loading accounts...'
                   : null}
               </View>
+
+              {waiting === 'browser' && (
+                <Link onClick={onJump} style={{ marginTop: 10 }}>
+                  (Account linking not opening in a new tab? Click here)
+                </Link>
+              )}
             </View>
           ) : success ? (
             <Button

--- a/upcoming-release-notes/950.md
+++ b/upcoming-release-notes/950.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Nordigen: add fallback link to re-init bank-sync in case the popover was blocked


### PR DESCRIPTION
For: https://github.com/actualbudget/actual/issues/724#issuecomment-1465501335

<img width="560" alt="Screenshot 2023-04-23 at 18 02 06" src="https://user-images.githubusercontent.com/886567/233853836-4c3e0618-ea40-4094-93eb-3854a987d086.png">
