### PR TITLE
:construction_worker:  auto-close feature requests

### DIFF
--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -1,0 +1,30 @@
+name: Close feature requests with automated message
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  needs-votes:
+    if: github.event.label.name == 'feature'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: needs votes
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :sparkles: Thanks for sharing your idea! :sparkles:
+
+            This repository is now using lodash style issue management for enhancements. This means enhancement issues will now be closed instead of leaving them open.
+
+            The enhancement backlog can be found here: https://github.com/actualbudget/actual/issues?utf8=%E2%9C%93&q=label%3Aneeds-votes+sort%3Areactions-%2B1-desc+
+
+            Don’t forget to upvote the top comment with 👍!
+      - name: Close Issue
+        run: gh issue close --comment "Auto-closing issue" "1"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -9,9 +9,16 @@ jobs:
     if: contains(github.event.issue.labels.*.name, 'feature')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: needs votes
+      - name: Add reactions
+        uses: aidan-mundy/react-to-issue@v1.1.1
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          reactions: '+1'
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v3
         with:
@@ -25,6 +32,6 @@ jobs:
 
             Don’t forget to upvote the top comment with 👍!
       - name: Close Issue
-        run: gh issue close --comment "Auto-closing issue" "1"
+        run: gh issue close --comment "Auto-closing issue" "${{ github.event.issue.number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -26,12 +26,12 @@ jobs:
           body: |
             :sparkles: Thanks for sharing your idea! :sparkles:
 
-            This repository is now using lodash style issue management for enhancements. This means enhancement issues will now be closed instead of leaving them open.
+            This repository is now using lodash style issue management for enhancements. This means enhancement issues will now be closed instead of leaving them open. This doesn’t mean we don’t accept feature requests, though! We will consider implementing ones that receive many upvotes, and we welcome contributions for any feature requests marked as needing votes (just post a comment first so we can help you make a successful contribution).
 
             The enhancement backlog can be found here: https://github.com/actualbudget/actual/issues?utf8=%E2%9C%93&q=label%3Aneeds-votes+sort%3Areactions-%2B1-desc+
 
             Don’t forget to upvote the top comment with 👍!
       - name: Close Issue
-        run: gh issue close --comment "Auto-closing issue" "${{ github.event.issue.number }}"
+        run: gh issue close "${{ github.event.issue.number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   needs-votes:
-    if: github.event.label.name == 'feature'
+    if: contains(github.event.issue.labels.*.name, 'feature')
     runs-on: ubuntu-latest
     steps:
       - uses: actions-ecosystem/action-add-labels@v1

--- a/upcoming-release-notes/954.md
+++ b/upcoming-release-notes/954.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MatissJanis]
 ---
 
-Automatically close feature request issues (CICD)
+Automatically close feature request issues so the open issue list can focus on bugs

--- a/upcoming-release-notes/954.md
+++ b/upcoming-release-notes/954.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Automatically close feature request issues (CICD)


### PR DESCRIPTION
We have too many open issues in `actual`. This makes maintaining the list very difficult. Especially because many of the issues are feature requests.

So to better manage the issue list: I'd propose we follow the strategy lodash uses. All feature requests are automatically closed with a new label added to them. These feature requests can then be voted on and/or commented in the closed state. If sufficiently many people vote on the issue (via emojis), then the dev team might consider implementing it. If nobody votes on it - nothing happens. But then these issues are not cluttering our list.

What this new github action does:
- if the issue is labeled with "feature"
- adds a comment explaining the situation
- adds label "needs votes"
- adds a "+1" reaction to the root message
- closes the issue

Let me know what you think.