### PR TITLE
Priorities for goals

### DIFF
--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.js
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.js
@@ -379,10 +379,6 @@ export function BudgetSummary({ month, isGoalTemplatesEnabled }) {
                         name: 'apply-goal-template',
                         text: 'Apply budget template',
                       },
-                      isGoalTemplatesEnabled && {
-                        name: 'overwrite-goal-template',
-                        text: 'Overwrite with budget template',
-                      },
                     ]}
                   />
                 </Tooltip>

--- a/packages/loot-core/src/client/actions/queries.ts
+++ b/packages/loot-core/src/client/actions/queries.ts
@@ -30,13 +30,6 @@ export function applyBudgetAction(month, type, args) {
           addNotification(await send('budget/apply-goal-template', { month })),
         );
         break;
-      case 'overwrite-goal-template':
-        dispatch(
-          addNotification(
-            await send('budget/overwrite-goal-template', { month }),
-          ),
-        );
-        break;
       case 'hold':
         await send('budget/hold-for-next-month', {
           month,

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -19,10 +19,6 @@ app.method(
   mutator(undoable(goalActions.applyTemplate)),
 );
 app.method(
-  'budget/overwrite-goal-template',
-  mutator(undoable(goalActions.overwriteTemplate)),
-);
-app.method(
   'budget/hold-for-next-month',
   mutator(undoable(actions.holdForNextMonth)),
 );

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -1,24 +1,25 @@
 // https://peggyjs.org
 
 expr
-  = percent: percent _ of _ category: $([^\r\n\t]+)
-    { return { type: 'percentage', percent: +percent, category } }
-  / amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
-    { return { type: 'week', amount, weeks, starting, limit } }
-  / amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
+  = priority: priority? _? percent: percent _ of _ category: name
+    { return { type: 'percentage', percent: +percent, category, priority: +priority }}
+  / priority: priority? _? amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
+    { return { type: 'week', amount, weeks, starting, limit, priority: +priority }}
+  / priority: priority? _? amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
     { return {
       type: from ? 'spend' : 'by',
       amount,
       month,
       ...(repeat ? repeat[3] : {}),
-      from
+      from,
+      priority: +priority
     } }
-  / monthly: amount limit: limit?
-    { return { type: 'simple', monthly, limit } }
-  / upTo _ limit: amount
-    { return { type: 'simple', limit } }
-  / schedule _ name: name
-  	{ return { type: 'schedule', name} }
+  / priority: priority? _? monthly: amount limit: limit?
+    { return { type: 'simple', monthly, limit, priority: +priority  } }
+  / priority: priority? _? upTo _ limit: amount
+    { return { type: 'simple', limit , priority: +priority } }
+  / priority: priority? _? schedule _ name: name
+    { return { type: 'schedule', name, priority: +priority } }
 
 repeat 'repeat interval'
   = 'month'i { return { annual: false } }
@@ -42,6 +43,7 @@ repeatEvery = 'repeat'i _ 'every'i
 starting = 'starting'i
 upTo = 'up'i _ 'to'i
 schedule = 'schedule'i
+priority = '-'i number: number _ {return number}
 
 _ 'space' = ' '+
 d 'digit' = [0-9]

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -241,8 +241,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
         if (to_budget + increment < budgetAvailable) {
           to_budget += increment;
         } else {
+          to_budget = budgetAvailable;
           errors.push(`Available funds are insufficient.`);
-          return { errors };
         }
         break;
       }
@@ -281,8 +281,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
           if (to_budget + increment < budgetAvailable) {
             to_budget += increment;
           } else {
+            to_budget = budgetAvailable;
             errors.push(`Available funds are insufficient.`);
-            return { errors };
           }
         }
         break;
@@ -308,8 +308,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
             if (to_budget + amount < budgetAvailable) {
               to_budget += amount;
             } else {
+              to_budget = budgetAvailable;
               errors.push(`Available funds are insufficient.`);
-              return { errors };
             }
             w = addWeeks(w, weeks);
           }
@@ -365,8 +365,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
         if (increment < budgetAvailable) {
           to_budget = increment;
         } else {
+          to_budget = budgetAvailable;
           errors.push(`Available funds are insufficient.`);
-          return { errors };
         }
         break;
       }
@@ -397,8 +397,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
         if (increment < budgetAvailable) {
           to_budget = increment;
         } else {
+          to_budget = budgetAvailable;
           errors.push(`Available funds are insufficient.`);
-          return { errors };
         }
         break;
       }
@@ -453,8 +453,8 @@ async function applyCategoryTemplate(category, template_lines, month, force) {
           if (to_budget + increment < budgetAvailable) {
             to_budget += increment;
           } else {
+            to_budget = budgetAvailable;
             errors.push(`Available funds are insufficient.`);
-            return { errors };
           }
         }
         break;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -19,10 +19,6 @@ import { setBudget, getSheetValue } from './actions';
 import { parse } from './goal-template.pegjs';
 
 export function applyTemplate({ month }) {
-  return processTemplate(month, false);
-}
-
-export function overwriteTemplate({ month }) {
   return processTemplate(month, true);
 }
 

--- a/packages/loot-core/src/server/budget/types/handlers.d.ts
+++ b/packages/loot-core/src/server/budget/types/handlers.d.ts
@@ -9,8 +9,6 @@ export interface BudgetHandlers {
 
   'budget/apply-goal-template': (...args: unknown[]) => Promise<unknown>;
 
-  'budget/overwrite-goal-template': (...args: unknown[]) => Promise<unknown>;
-
   'budget/hold-for-next-month': (...args: unknown[]) => Promise<unknown>;
 
   'budget/reset-hold': (...args: unknown[]) => Promise<unknown>;


### PR DESCRIPTION
This attempts to add priorities for goal templates and addresses most of https://github.com/actualbudget/actual/issues/958.

I couldn't find a good way to preserve both "Apply" and "Overwrite" operations, so this PR does away with the "Apply".  Every box with a budgeted value will be overwritten if a template goal is present.

The added syntax to define priorities is as follows:
#template    -- priority 0, highest priority
#template-1  --priority 1, 2nd highest priority
#template-2 --priority 2, 3rd highest priority
#template-N --priority N, as many as you'd like.

Leaving as a draft as this may not be the preferred implementation but I wanted others to be able to try it with netlify.