### PR TITLE
@typescript-eslint/no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,14 +15,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
   rules: {
     'prettier/prettier': 'error',
-    'no-unused-vars': [
-      'error',
-      {
-        args: 'none',
-        varsIgnorePattern: '^_',
-        ignoreRestSiblings: true,
-      },
-    ],
+    'no-unused-vars': 'off',
 
     'no-restricted-globals': ['error'].concat(
       require('confusing-browser-globals').filter(g => g !== 'self'),
@@ -74,6 +67,13 @@ module.exports = {
     'prefer-const': 'off',
     'prefer-spread': 'off',
     '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        args: 'none',
+        varsIgnorePattern: '^_',
+        ignoreRestSiblings: true,
+      },
+    ],
   },
 };

--- a/packages/desktop-client/src/components/accounts/MobileAccount.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.js
@@ -182,7 +182,7 @@ function Account(props) {
     setSearchText(text);
   };
 
-  // eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSelectTransaction = transaction => {
     if (isPreviewId(transaction.id)) {
       let parts = transaction.id.split('/');

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -158,7 +158,7 @@ export class BudgetCell extends React.PureComponent {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function BudgetGroupPreview({ group, pending, style }) {
   //   let opacity = useMemo(() => new Animated.Value(0), []);
 
@@ -204,7 +204,7 @@ function BudgetGroupPreview({ group, pending, style }) {
   );
 }
 
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function BudgetCategoryPreview({ name, pending, style }) {
   return (
     // <Animated.View

--- a/packages/desktop-client/src/components/debug/index.js
+++ b/packages/desktop-client/src/components/debug/index.js
@@ -58,7 +58,7 @@ class Debug extends React.Component {
   async fetchSqlGenResult() {
     let row = {};
     try {
-      // eslint-disable-next-line no-unused-vars, no-eval
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-eval
       row = (0, eval)('(' + this.state.sqlgenRow + ')');
     } catch (e) {}
 

--- a/packages/desktop-client/src/components/sort.js
+++ b/packages/desktop-client/src/components/sort.js
@@ -38,7 +38,7 @@ export function useDraggable({
 }) {
   let _onDragChange = useRef(onDragChange);
 
-  //eslint-disable-next-line no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [{ isDragging }, dragRef] = useDrag({
     item: { type, item },
     collect: monitor => ({ isDragging: monitor.isDragging() }),

--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -47,7 +47,7 @@ const WindowState = require('./window-state.js');
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let clientWin;
-let serverWin; // eslint-disable-line no-unused-vars
+let serverWin; // eslint-disable-line @typescript-eslint/no-unused-vars
 let serverProcess;
 let serverSocket;
 let IS_QUITTING = false;

--- a/packages/loot-core/src/server/spreadsheet/new/parser.ts
+++ b/packages/loot-core/src/server/spreadsheet/new/parser.ts
@@ -133,7 +133,7 @@ function parseAnd(state) {
 function parseNot(state) {
   let left = parseCompare(state);
   while (skipValue(state, types.TOKEN_OPERATOR, 'not')) {
-    // eslint-disable-next-line no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const right = parseCompare(state);
     left = new nodes.UnaryOp(left.lineno, left.colno, 'not', parseNot(state));
   }

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -1,7 +1,6 @@
 export {};
 
 declare global {
-  // eslint-disable-next-line no-unused-vars
   interface Window {
     Actual?: {
       IS_FAKE_WEB: boolean;

--- a/upcoming-release-notes/974.md
+++ b/upcoming-release-notes/974.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [trevdor]
+---
+
+eslint: Switch to TypeScript-aware `no-unused-vars` rule.


### PR DESCRIPTION
Switch to TS version of `no-unused-vars` rule. 
(Trying to use enums on another branch and the JS version throws false warnings.)