### PR TITLE
:wrench:  make start:browser the default cmd instead of start:desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     ]
   },
   "scripts": {
-    "start": "npm-run-all --parallel 'start:desktop-*'",
+    "start": "yarn start:browser",
+    "start:desktop": "npm-run-all --parallel 'start:desktop-*'",
     "start:desktop-node": "yarn workspace loot-core watch:node",
     "start:desktop-client": "yarn workspace @actual-app/web watch",
     "start:desktop-electron": "yarn workspace Actual watch",

--- a/upcoming-release-notes/977.md
+++ b/upcoming-release-notes/977.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Make `yarn start:browser` the default `start` command instead of `start:desktop` which currently doesn't realiably work


### PR DESCRIPTION
When people first start out with actual they usually run `yarn start`. And oftentimes it doesn't work.. because we haven't yet fixed the electron (desktop) version.

Swapping the default `start` command to use `start:browser`. This should help newcomers get started more easily.