### PR TITLE
Fix sync-related errors that show up in the console when not using a server

### DIFF
--- a/packages/desktop-client/src/components/ServerContext.js
+++ b/packages/desktop-client/src/components/ServerContext.js
@@ -14,14 +14,6 @@ export const useServerURL = () => useContext(ServerContext).url;
 export const useServerVersion = () => useContext(ServerContext).version;
 export const useSetServerURL = () => useContext(ServerContext).setURL;
 
-async function getServerUrl() {
-  let url = (await send('get-server-url')) || '';
-  if (url === 'https://not-configured/') {
-    url = '';
-  }
-  return url;
-}
-
 async function getServerVersion() {
   let { error, version } = await send('get-server-version');
   if (error) {
@@ -36,7 +28,7 @@ export function ServerProvider({ children }) {
 
   useEffect(() => {
     async function run() {
-      setServerURL(await getServerUrl());
+      setServerURL(await send('get-server-url'));
       setVersion(await getServerVersion());
     }
     run();
@@ -46,7 +38,7 @@ export function ServerProvider({ children }) {
     async (url, opts = {}) => {
       let { error } = await send('set-server-url', { ...opts, url });
       if (!error) {
-        setServerURL(await getServerUrl());
+        setServerURL(await send('get-server-url'));
         setVersion(await getServerVersion());
       }
       return { error };

--- a/packages/desktop-client/src/components/manager/subscribe/common.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/common.tsx
@@ -41,7 +41,8 @@ export function useBootstrapped() {
       };
 
       let url = await send('get-server-url');
-      if (url == null) {
+      let bootstrapped = await send('get-did-bootstrap');
+      if (url == null && !bootstrapped) {
         // A server hasn't been specified yet
         let serverURL = window.location.origin;
         let result = await send('subscribe-needs-bootstrap', {

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 
 const DEFAULT_FEATURE_FLAG_STATE: Record<string, boolean> = {
+  reportBudget: false,
   syncAccount: false,
   goalTemplatesEnabled: false,
 };

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -77,9 +77,7 @@ export async function getAccounts(userId, userKey, id) {
 
 export async function getNordigenAccounts(userId, userKey, id) {
   const userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) {
-    return;
-  }
+  if (!userToken || !getServer()) return;
 
   let res = await post(
     getServer().NORDIGEN_SERVER + '/accounts',
@@ -184,9 +182,7 @@ async function downloadNordigenTransactions(
   since,
 ) {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) {
-    return;
-  }
+  if (!userToken || !getServer()) return;
 
   const endDate = new Date().toISOString().split('T')[0];
 

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -77,7 +77,7 @@ export async function getAccounts(userId, userKey, id) {
 
 export async function getNordigenAccounts(userId, userKey, id) {
   const userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) return;
+  if (!userToken) return;
 
   let res = await post(
     getServer().NORDIGEN_SERVER + '/accounts',
@@ -182,7 +182,7 @@ async function downloadNordigenTransactions(
   since,
 ) {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) return;
+  if (!userToken) return;
 
   const endDate = new Date().toISOString().split('T')[0];
 

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -326,7 +326,7 @@ export async function possiblyUpload() {
 }
 
 export async function removeFile(fileId) {
-  const [[, userToken]] = await asyncStorage.multiGet(['user-token']);
+  let userToken = await asyncStorage.getItem('user-token');
 
   await post(getServer().SYNC_SERVER + '/delete-user-file', {
     token: userToken,

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -336,7 +336,7 @@ export async function removeFile(fileId) {
 
 export async function listRemoteFiles() {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken) {
+  if (!userToken || !getServer()) {
     return null;
   }
 

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -336,7 +336,7 @@ export async function removeFile(fileId) {
 
 export async function listRemoteFiles() {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return null;
   }
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1674,7 +1674,7 @@ handlers['subscribe-set-user'] = async function ({ token }) {
 
 handlers['subscribe-get-user'] = async function () {
   if (!getServer()) {
-    if (await asyncStorage.getItem('did-bootstrap')) {
+    if (!(await asyncStorage.getItem('did-bootstrap'))) {
       return null;
     }
     return { offline: false };

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -2419,6 +2419,7 @@ export async function initApp(isDev, socketName) {
   // }
 
   const url = await asyncStorage.getItem('server-url');
+  // TODO: remove this first part of the `if` block after a few releases
   if (url === 'https://not-configured/') {
     await asyncStorage.setItem('server-url', null);
     await asyncStorage.setItem('did-bootstrap', true);

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -2181,7 +2181,7 @@ async function loadBudget(id) {
   // Older versions didn't tag the file with the current user, so do
   // so now
   if (!prefs.getPrefs().userId) {
-    let [[, userId]] = await asyncStorage.multiGet(['user-token']);
+    let userId = await asyncStorage.getItem('user-token');
     prefs.savePrefs({ userId });
   }
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1131,7 +1131,7 @@ handlers['accounts-sync'] = async function ({ id }) {
 handlers['secret-set'] = async function ({ name, value }) {
   let userToken = await asyncStorage.getItem('user-token');
 
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'unauthorized' };
   }
 
@@ -1155,7 +1155,7 @@ handlers['secret-set'] = async function ({ name, value }) {
 handlers['secret-check'] = async function (name) {
   let userToken = await asyncStorage.getItem('user-token');
 
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'unauthorized' };
   }
 
@@ -1174,7 +1174,7 @@ handlers['nordigen-poll-web-token'] = async function ({
   requisitionId,
 }) {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) return null;
+  if (!userToken) return null;
 
   let startTime = Date.now();
   stopPolling = false;
@@ -1225,7 +1225,7 @@ handlers['nordigen-poll-web-token'] = async function ({
 handlers['nordigen-status'] = async function () {
   const userToken = await asyncStorage.getItem('user-token');
 
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'unauthorized' };
   }
 
@@ -1241,7 +1241,7 @@ handlers['nordigen-status'] = async function () {
 handlers['nordigen-get-banks'] = async function (country) {
   const userToken = await asyncStorage.getItem('user-token');
 
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'unauthorized' };
   }
 
@@ -1266,7 +1266,7 @@ handlers['nordigen-create-web-token'] = async function ({
 }) {
   let userToken = await asyncStorage.getItem('user-token');
 
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'unauthorized' };
   }
 
@@ -1417,7 +1417,7 @@ handlers['account-unlink'] = mutator(async function ({ id }) {
   // No more accounts are associated with this bank. We can remove
   // it from Nordigen.
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return 'ok';
   }
 
@@ -1710,7 +1710,7 @@ handlers['subscribe-get-user'] = async function () {
 
 handlers['subscribe-change-password'] = async function ({ password }) {
   let userToken = await asyncStorage.getItem('user-token');
-  if (!userToken || !getServer()) {
+  if (!userToken) {
     return { error: 'not-logged-in' };
   }
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1674,6 +1674,9 @@ handlers['subscribe-set-user'] = async function ({ token }) {
 
 handlers['subscribe-get-user'] = async function () {
   if (!getServer()) {
+    if (await asyncStorage.getItem('did-bootstrap')) {
+      return null;
+    }
     return { offline: false };
   }
 
@@ -1782,7 +1785,8 @@ handlers['set-server-url'] = async function ({ url, validate = true }) {
     }
   }
 
-  asyncStorage.setItem('server-url', url);
+  await asyncStorage.setItem('server-url', url);
+  await asyncStorage.setItem('did-bootstrap', true);
   setServer(url);
   return {};
 };
@@ -2413,6 +2417,7 @@ export async function initApp(isDev, socketName) {
   const url = await asyncStorage.getItem('server-url');
   if (url === 'https://not-configured/') {
     await asyncStorage.setItem('server-url', null);
+    await asyncStorage.setItem('did-bootstrap', true);
   } else if (url) {
     setServer(url);
   }

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1672,10 +1672,6 @@ handlers['subscribe-bootstrap'] = async function ({ password }) {
   return { error: 'internal' };
 };
 
-handlers['subscribe-set-user'] = async function ({ token }) {
-  await asyncStorage.setItem('user-token', token);
-};
-
 handlers['subscribe-get-user'] = async function () {
   if (!getServer()) {
     if (!(await asyncStorage.getItem('did-bootstrap'))) {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1773,7 +1773,9 @@ handlers['get-server-url'] = async function () {
 };
 
 handlers['set-server-url'] = async function ({ url, validate = true }) {
-  if (url != null) {
+  if (url == null) {
+    await asyncStorage.removeItem('user-token');
+  } else {
     if (validate) {
       // Validate the server is running
       let { error } = await runHandler(handlers['subscribe-needs-bootstrap'], {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1626,6 +1626,10 @@ handlers['key-test'] = async function ({ fileId, password }) {
   return {};
 };
 
+handlers['get-did-bootstrap'] = async function () {
+  return Boolean(await asyncStorage.getItem('did-bootstrap'));
+};
+
 handlers['subscribe-needs-bootstrap'] = async function ({
   url,
 }: { url? } = {}) {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -2416,14 +2416,19 @@ export async function initApp(isDev, socketName) {
   // }
   // }
 
-  const url = await asyncStorage.getItem('server-url');
-  // TODO: remove this first part of the `if` block after a few releases
+  let url = await asyncStorage.getItem('server-url');
+
+  // TODO: remove this if statement after a few releases
   if (url === 'https://not-configured/') {
+    url = null;
     await asyncStorage.setItem('server-url', null);
     await asyncStorage.setItem('did-bootstrap', true);
-  } else if (url) {
-    setServer(url);
   }
+
+  if (!url) {
+    await asyncStorage.removeItem('user-token');
+  }
+  setServer(url);
 
   connection.init(socketName, app.handlers);
 

--- a/packages/loot-core/src/types/main-handlers.d.ts
+++ b/packages/loot-core/src/types/main-handlers.d.ts
@@ -258,8 +258,6 @@ export interface MainHandlers {
 
   'subscribe-bootstrap': (arg: { password }) => Promise<{ error: string }>;
 
-  'subscribe-set-user': (arg: { token }) => Promise<unknown>;
-
   'subscribe-get-user': () => Promise<{ offline: boolean } | null>;
 
   'subscribe-change-password': (arg: {

--- a/packages/loot-core/src/types/main-handlers.d.ts
+++ b/packages/loot-core/src/types/main-handlers.d.ts
@@ -248,6 +248,8 @@ export interface MainHandlers {
 
   'key-test': (arg: { fileId; password }) => Promise<unknown>;
 
+  'get-did-bootstrap': () => Promise<boolean>;
+
   'subscribe-needs-bootstrap': (
     args: { url } = {},
   ) => Promise<

--- a/upcoming-release-notes/984.md
+++ b/upcoming-release-notes/984.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Stop frontend from attempting to connect to an invalid server when no server is configured


### PR DESCRIPTION
Previously, the frontend would attempt to make real requests to `https://not-configured/`, which of course failed. I’ve changed the internal structure to have the lack of a server expressed as a `null` server. A new `did-bootstrap` browser-level setting has been added to track if the user clicked “Don’t use a server.”

Finally, I updated the auth logic for methods that call out to the server to make them consistent and use the early return style which reduces indentation.