### PR TITLE
[Bugfix] Goal Templates schedules: Add break condition to while loop

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -529,7 +529,10 @@ async function applyCategoryTemplate(
               }
               next_date = addDays(next_date, 1);
               next_date_string = getNextDate(dateCond, next_date);
-              next_date = new Date(next_date_string);
+              let new_next_date = new Date(next_date_string);
+              new_next_date = addDays(new_next_date, 1);
+              if (next_date === new_next_date) break;
+              next_date = new_next_date;
             }
           } else {
             monthly_target = target;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -4,6 +4,8 @@ import {
   addWeeks,
   addDays,
   format,
+  addHours,
+  addMinutes,
 } from 'date-fns';
 
 import * as monthUtils from '../../shared/months';
@@ -528,11 +530,9 @@ async function applyCategoryTemplate(
                 monthly_target += target;
               }
               next_date = addDays(next_date, 1);
+              next_date = addMinutes(next_date,next_date.getTimezoneOffset());
               next_date_string = getNextDate(dateCond, next_date);
-              let new_next_date = new Date(next_date_string);
-              new_next_date = addDays(new_next_date, 1);
-              if (next_date === new_next_date) break;
-              next_date = new_next_date;
+              next_date = new Date(next_date_string);
             }
           } else {
             monthly_target = target;

--- a/upcoming-release-notes/990.md
+++ b/upcoming-release-notes/990.md
@@ -1,3 +1,4 @@
+---
 category: Bugfix
 authors: [shall0pass]
 ---

--- a/upcoming-release-notes/990.md
+++ b/upcoming-release-notes/990.md
@@ -1,0 +1,5 @@
+category: Bugfix
+authors: [shall0pass]
+---
+
+Fixed endless loop condition when using templates schedule keyword


### PR DESCRIPTION
There is a while loop that can get stuck in an endless loop condition.  I don't totally understand why the line 

`next_date = new Date(next_date_string);`

doesn't output the expected result.  So I set up an intermediate variable to create a date then applied the same operation again.  If the two values are the same, I break the loop.

Issue: https://github.com/actualbudget/actual/issues/983