### PR TITLE
:bug: (transactions) create transaction when clicking enter

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -1619,9 +1619,6 @@ export let TransactionTable = React.forwardRef((props, ref) => {
             // add split
             onAddSplit(lastTransaction.id);
           } else if (
-            (newNavigator.focusedField === 'debit' ||
-              newNavigator.focusedField === 'credit' ||
-              newNavigator.focusedField === 'cleared') &&
             newNavigator.editingId === lastTransaction.id &&
             (!isSplit || !lastTransaction.error)
           ) {

--- a/packages/desktop-client/src/components/accounts/TransactionsTable.test.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.test.js
@@ -643,7 +643,7 @@ describe('Transactions', () => {
 
     input = await editNewField(container, 'notes');
     await userEvent.clear(input);
-    await userEvent.type(input, 'a transaction[Enter]');
+    await userEvent.type(input, 'a transaction');
 
     input = await editNewField(container, 'debit');
     expect(input.value).toBe('0.00');

--- a/upcoming-release-notes/992.md
+++ b/upcoming-release-notes/992.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Allow creating transactions by clicking "enter" in the notes/payee/category field


### PR DESCRIPTION
Closes #943

Creates the transaction when clicking "enter". Irrelevant of which field is currently active.