### PR TITLE
:sparkles: (reports) ability to fine-tune reports with filters

### DIFF
--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -6,6 +6,7 @@ import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 
+import useFilters from '../../hooks/useFilters';
 import { colors, styles } from '../../style';
 import { FilterButton, AppliedFilters } from '../accounts/Filters';
 import { View, Text, Block, P, AlignedText } from '../common';
@@ -17,7 +18,12 @@ import Header from './Header';
 import useReport from './useReport';
 
 function CashFlow() {
-  const [filters, setFilters] = useState([]);
+  const {
+    filters,
+    onApply: onApplyFilter,
+    onDelete: onDeleteFilter,
+    onUpdate: onUpdateFilter,
+  } = useFilters();
 
   const [allMonths, setAllMonths] = useState(null);
   const [start, setStart] = useState(
@@ -81,16 +87,6 @@ function CashFlow() {
   }
 
   const { graphData, totalExpenses, totalIncome } = data;
-
-  const onApplyFilter = newFilter => {
-    setFilters(state => [...state, newFilter]);
-  };
-  const onUpdateFilter = (oldFilter, updatedFilter) => {
-    setFilters(state => state.map(f => (f === oldFilter ? updatedFilter : f)));
-  };
-  const onDeleteFilter = deletedFilter => {
-    setFilters(state => state.filter(f => f !== deletedFilter));
-  };
 
   return (
     <View style={[styles.page, { minWidth: 650, overflow: 'hidden' }]}>

--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -7,6 +7,7 @@ import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 
 import { colors, styles } from '../../style';
+import { FilterButton, AppliedFilters } from '../accounts/Filters';
 import { View, Text, Block, P, AlignedText } from '../common';
 
 import Change from './Change';
@@ -16,6 +17,8 @@ import Header from './Header';
 import useReport from './useReport';
 
 function CashFlow() {
+  const [filters, setFilters] = useState([]);
+
   const [allMonths, setAllMonths] = useState(null);
   const [start, setStart] = useState(
     monthUtils.subMonths(monthUtils.currentMonth(), 30),
@@ -31,8 +34,8 @@ function CashFlow() {
   });
 
   const params = useMemo(
-    () => cashFlowByDate(start, end, isConcise),
-    [start, end, isConcise],
+    () => cashFlowByDate(start, end, isConcise, filters),
+    [start, end, isConcise, filters],
   );
   const data = useReport('cash_flow', params);
 
@@ -79,6 +82,16 @@ function CashFlow() {
 
   const { graphData, totalExpenses, totalIncome } = data;
 
+  const onApplyFilter = newFilter => {
+    setFilters(state => [...state, newFilter]);
+  };
+  const onUpdateFilter = (oldFilter, updatedFilter) => {
+    setFilters(state => state.map(f => (f === oldFilter ? updatedFilter : f)));
+  };
+  const onDeleteFilter = deletedFilter => {
+    setFilters(state => state.filter(f => f !== deletedFilter));
+  };
+
   return (
     <View style={[styles.page, { minWidth: 650, overflow: 'hidden' }]}>
       <Header
@@ -86,9 +99,28 @@ function CashFlow() {
         allMonths={allMonths}
         start={monthUtils.getMonth(start)}
         end={monthUtils.getMonth(end)}
-        show1Month={true}
+        show1Month
         onChangeDates={onChangeDates}
+        extraButtons={<FilterButton onApply={onApplyFilter} />}
       />
+
+      <View
+        style={{
+          marginTop: -10,
+          paddingLeft: 20,
+          paddingRight: 20,
+          backgroundColor: 'white',
+        }}
+      >
+        {filters.length > 0 && (
+          <AppliedFilters
+            filters={filters}
+            onUpdate={onUpdateFilter}
+            onDelete={onDeleteFilter}
+          />
+        )}
+      </View>
+
       <View
         style={{
           backgroundColor: 'white',

--- a/packages/desktop-client/src/components/reports/Header.js
+++ b/packages/desktop-client/src/components/reports/Header.js
@@ -45,7 +45,15 @@ function getFullRange(allMonths) {
   return [start, end];
 }
 
-function Header({ title, start, end, show1Month, allMonths, onChangeDates }) {
+function Header({
+  title,
+  start,
+  end,
+  show1Month,
+  allMonths,
+  onChangeDates,
+  extraButtons,
+}) {
   return (
     <View
       style={{
@@ -68,6 +76,7 @@ function Header({ title, start, end, show1Month, allMonths, onChangeDates }) {
           flexDirection: 'row',
           alignItems: 'center',
           marginTop: 15,
+          gap: 15,
         }}
       >
         <div>
@@ -99,41 +108,24 @@ function Header({ title, start, end, show1Month, allMonths, onChangeDates }) {
             ))}
           </Select>
         </div>
+
+        {extraButtons}
+
         {show1Month && (
-          <Button
-            bare
-            style={{ marginLeft: 15 }}
-            onClick={() => onChangeDates(...getLatestRange(1))}
-          >
+          <Button bare onClick={() => onChangeDates(...getLatestRange(1))}>
             1 month
           </Button>
         )}
-        <Button
-          bare
-          style={{ marginLeft: 15 }}
-          onClick={() => onChangeDates(...getLatestRange(2))}
-        >
+        <Button bare onClick={() => onChangeDates(...getLatestRange(2))}>
           3 months
         </Button>
-        <Button
-          bare
-          style={{ marginLeft: 15 }}
-          onClick={() => onChangeDates(...getLatestRange(5))}
-        >
+        <Button bare onClick={() => onChangeDates(...getLatestRange(5))}>
           6 months
         </Button>
-        <Button
-          bare
-          style={{ marginLeft: 15 }}
-          onClick={() => onChangeDates(...getLatestRange(12))}
-        >
+        <Button bare onClick={() => onChangeDates(...getLatestRange(12))}>
           1 Year
         </Button>
-        <Button
-          bare
-          style={{ marginLeft: 15 }}
-          onClick={() => onChangeDates(...getFullRange(allMonths))}
-        >
+        <Button bare onClick={() => onChangeDates(...getFullRange(allMonths))}>
           All Time
         </Button>
       </View>

--- a/packages/desktop-client/src/components/reports/NetWorth.js
+++ b/packages/desktop-client/src/components/reports/NetWorth.js
@@ -9,6 +9,7 @@ import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 
+import useFilters from '../../hooks/useFilters';
 import { styles } from '../../style';
 import { FilterButton, AppliedFilters } from '../accounts/Filters';
 import { View, P } from '../common';
@@ -21,7 +22,12 @@ import useReport from './useReport';
 import { fromDateRepr } from './util';
 
 function NetWorth({ accounts }) {
-  const [filters, setFilters] = useState([]);
+  const {
+    filters,
+    onApply: onApplyFilter,
+    onDelete: onDeleteFilter,
+    onUpdate: onUpdateFilter,
+  } = useFilters();
 
   const [allMonths, setAllMonths] = useState(null);
   const [start, setStart] = useState(
@@ -68,16 +74,6 @@ function NetWorth({ accounts }) {
     setStart(start);
     setEnd(end);
   }
-
-  const onApplyFilter = newFilter => {
-    setFilters(state => [...state, newFilter]);
-  };
-  const onUpdateFilter = (oldFilter, updatedFilter) => {
-    setFilters(state => state.map(f => (f === oldFilter ? updatedFilter : f)));
-  };
-  const onDeleteFilter = deletedFilter => {
-    setFilters(state => state.filter(f => f !== deletedFilter));
-  };
 
   if (!allMonths || !data) {
     return null;

--- a/packages/desktop-client/src/components/reports/NetWorth.js
+++ b/packages/desktop-client/src/components/reports/NetWorth.js
@@ -10,6 +10,7 @@ import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
 
 import { styles } from '../../style';
+import { FilterButton, AppliedFilters } from '../accounts/Filters';
 import { View, P } from '../common';
 
 import Change from './Change';
@@ -20,6 +21,8 @@ import useReport from './useReport';
 import { fromDateRepr } from './util';
 
 function NetWorth({ accounts }) {
+  const [filters, setFilters] = useState([]);
+
   const [allMonths, setAllMonths] = useState(null);
   const [start, setStart] = useState(
     monthUtils.subMonths(monthUtils.currentMonth(), 5),
@@ -27,8 +30,8 @@ function NetWorth({ accounts }) {
   const [end, setEnd] = useState(monthUtils.currentMonth());
 
   const params = useMemo(
-    () => netWorthSpreadsheet(start, end, accounts),
-    [start, end, accounts],
+    () => netWorthSpreadsheet(start, end, accounts, filters),
+    [start, end, accounts, filters],
   );
   const data = useReport('net_worth', params);
 
@@ -66,6 +69,16 @@ function NetWorth({ accounts }) {
     setEnd(end);
   }
 
+  const onApplyFilter = newFilter => {
+    setFilters(state => [...state, newFilter]);
+  };
+  const onUpdateFilter = (oldFilter, updatedFilter) => {
+    setFilters(state => state.map(f => (f === oldFilter ? updatedFilter : f)));
+  };
+  const onDeleteFilter = deletedFilter => {
+    setFilters(state => state.filter(f => f !== deletedFilter));
+  };
+
   if (!allMonths || !data) {
     return null;
   }
@@ -78,7 +91,26 @@ function NetWorth({ accounts }) {
         start={start}
         end={end}
         onChangeDates={onChangeDates}
+        extraButtons={<FilterButton onApply={onApplyFilter} />}
       />
+
+      <View
+        style={{
+          marginTop: -10,
+          paddingLeft: 20,
+          paddingRight: 20,
+          backgroundColor: 'white',
+        }}
+      >
+        {filters.length > 0 && (
+          <AppliedFilters
+            filters={filters}
+            onUpdate={onUpdateFilter}
+            onDelete={onDeleteFilter}
+          />
+        )}
+      </View>
+
       <View
         style={{
           backgroundColor: 'white',

--- a/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
@@ -44,7 +44,7 @@ export function simpleCashFlow(start, end) {
   };
 }
 
-export function cashFlowByDate(start, end, isConcise, conditions) {
+export function cashFlowByDate(start, end, isConcise, conditions = []) {
   return async (spreadsheet, setData) => {
     let { filters } = await send('make-filters-from-conditions', {
       conditions: conditions.filter(cond => !cond.customName),

--- a/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/cash-flow-spreadsheet.js
@@ -3,6 +3,7 @@ import React from 'react';
 import * as d from 'date-fns';
 
 import q from 'loot-core/src/client/query-helpers';
+import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency, integerToAmount } from 'loot-core/src/shared/util';
 
@@ -43,11 +44,16 @@ export function simpleCashFlow(start, end) {
   };
 }
 
-export function cashFlowByDate(start, end, isConcise) {
+export function cashFlowByDate(start, end, isConcise, conditions) {
   return async (spreadsheet, setData) => {
+    let { filters } = await send('make-filters-from-conditions', {
+      conditions: conditions.filter(cond => !cond.customName),
+    });
+
     function makeQuery(where) {
       let query = q('transactions').filter({
         $and: [
+          ...filters,
           { date: { $transform: '$month', $gte: start } },
           { date: { $transform: '$month', $lte: end } },
         ],
@@ -78,6 +84,7 @@ export function cashFlowByDate(start, end, isConcise) {
       [
         q('transactions')
           .filter({
+            $and: filters,
             date: { $transform: '$month', $lt: start },
             'account.offbudget': false,
           })

--- a/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
@@ -3,6 +3,7 @@ import React from 'react';
 import * as d from 'date-fns';
 
 import q, { runQuery } from 'loot-core/src/client/query-helpers';
+import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 import {
   integerToCurrency,
@@ -13,18 +14,26 @@ import {
 import { AlignedText } from '../../common';
 import { index } from '../util';
 
-export default function createSpreadsheet(start, end, accounts) {
+export default function createSpreadsheet(start, end, accounts, conditions) {
   return async (spreadsheet, setData) => {
     if (accounts.length === 0) {
       return null;
     }
+
+    let { filters } = await send('make-filters-from-conditions', {
+      conditions: conditions.filter(cond => !cond.customName),
+    });
 
     const data = await Promise.all(
       accounts.map(async acct => {
         let [starting, balances] = await Promise.all([
           runQuery(
             q('transactions')
-              .filter({ account: acct.id, date: { $lt: start + '-01' } })
+              .filter({
+                $and: filters,
+                account: acct.id,
+                date: { $lt: start + '-01' },
+              })
               .calculate({ $sum: '$amount' }),
           ).then(({ data }) => data),
 
@@ -33,6 +42,7 @@ export default function createSpreadsheet(start, end, accounts) {
               .filter({
                 account: acct.id,
                 $and: [
+                  ...filters,
                   { date: { $gte: start + '-01' } },
                   { date: { $lte: end + '-31' } },
                 ],

--- a/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
+++ b/packages/desktop-client/src/components/reports/graphs/net-worth-spreadsheet.js
@@ -14,7 +14,12 @@ import {
 import { AlignedText } from '../../common';
 import { index } from '../util';
 
-export default function createSpreadsheet(start, end, accounts, conditions) {
+export default function createSpreadsheet(
+  start,
+  end,
+  accounts,
+  conditions = [],
+) {
   return async (spreadsheet, setData) => {
     if (accounts.length === 0) {
       return null;

--- a/packages/desktop-client/src/hooks/useFilters.ts
+++ b/packages/desktop-client/src/hooks/useFilters.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export default function useFilters<T>(initialFilters: T[] = []) {
+  const [filters, setFilters] = useState<T[]>(initialFilters);
+
+  const onApply = useCallback(
+    (newFilter: T) => {
+      setFilters(state => [...state, newFilter]);
+    },
+    [setFilters],
+  );
+
+  const onUpdate = useCallback(
+    (oldFilter: T, updatedFilter: T) => {
+      setFilters(state =>
+        state.map(f => (f === oldFilter ? updatedFilter : f)),
+      );
+    },
+    [setFilters],
+  );
+
+  const onDelete = useCallback(
+    (deletedFilter: T) => {
+      setFilters(state => state.filter(f => f !== deletedFilter));
+    },
+    [setFilters],
+  );
+
+  return useMemo(
+    () => ({
+      filters,
+      onApply,
+      onUpdate,
+      onDelete,
+    }),
+    [filters, onApply, onUpdate, onDelete],
+  );
+}

--- a/upcoming-release-notes/994.md
+++ b/upcoming-release-notes/994.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Reports: ability to filter the data by payee/account/category/etc.


### PR DESCRIPTION
Low hanging fruit for reports: ability to filter the existing reports.


https://user-images.githubusercontent.com/886567/236334378-6e42e563-f1ab-4c4b-a8b5-55f1a7deba63.mov

With this improvement I hope to inspire more people to take a look at reports and start adding improvements here too. There's lots of things we could do, but here's how I would imagine it:

Eventually there would be a new "reports" page. In this page you select a visualization you want to use (timeseries, table, barchart, sankey? maybe something else too?). You then proceed to set filters to fine-grain your query. As you are doing this - the vizualisation gets auto-updated with fresh data. 

Once you're happy with the results: you click "save". This adds the viz to the reports homepage. You can view it there or you can also click on it to modify it again.

You can also drag&drop the reports to arrange them in whatever way you want. It's basically a dashboard.

**But again: these are just my dreams. This PR does not add all that nice-ness. This PR is only a small step in the direction and this hopefully will inspire more people.**