### PR TITLE
Goal Templates: add option to prevent removing funds when using "up to" in goal

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -27,7 +27,9 @@ repeat 'repeat interval'
   / 'year'i { return { annual: true } }
   / years: d _ 'years'i { return { annual: true, repeat: +years } }
 
-limit = _ upTo? _ amount: amount { return amount }
+limit =  _ upTo _ amount: amount '+' { return {amount: amount, hold: true } }
+		/ _ upTo _ amount: amount { return {amount: amount, hold: false } }
+
 
 weekCount
   = week { return null }

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -16,7 +16,7 @@ expr
     } }
   / priority: priority? _? monthly: amount limit: limit?
     { return { type: 'simple', monthly, limit, priority: +priority  } }
-  / priority: priority? _? upTo _ limit: amount
+  / priority: priority? _? limit: limit
     { return { type: 'simple', limit , priority: +priority } }
   / priority: priority? _? schedule _ name: name
     { return { type: 'schedule', name, priority: +priority } }
@@ -27,8 +27,8 @@ repeat 'repeat interval'
   / 'year'i { return { annual: true } }
   / years: d _ 'years'i { return { annual: true, repeat: +years } }
 
-limit =  _ upTo _ amount: amount '+' { return {amount: amount, hold: true } }
-		/ _ upTo _ amount: amount { return {amount: amount, hold: false } }
+limit =  _? upTo _ amount: amount '+' { return {amount: amount, hold: true } }
+		/ _? upTo _ amount: amount { return {amount: amount, hold: false } }
 
 
 weekCount

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -27,7 +27,7 @@ repeat 'repeat interval'
   / 'year'i { return { annual: true } }
   / years: d _ 'years'i { return { annual: true, repeat: +years } }
 
-limit =  _? upTo _ amount: amount '+' { return {amount: amount, hold: true } }
+limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } }
 		/ _? upTo _ amount: amount { return {amount: amount, hold: false } }
 
 

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -299,6 +299,7 @@ async function applyCategoryTemplate(
   let budgetAvailable = await getSheetValue(sheetName, `to-budget`);
   let to_budget = budgeted;
   let limit;
+  let hold;
   let last_month_balance = balance - spent - budgeted;
   let totalTarget = 0;
   let totalMonths = 0;
@@ -313,7 +314,8 @@ async function applyCategoryTemplate(
             errors.push(`More than one “up to” limit found.`);
             return { errors };
           } else {
-            limit = amountToInteger(template.limit);
+            limit = amountToInteger(template.limit.amount);
+            hold = amountToInteger(template.limit.hold);
           }
         }
         let increment = 0;
@@ -323,7 +325,9 @@ async function applyCategoryTemplate(
         } else {
           increment = limit;
         }
-        if (to_budget + increment < budgetAvailable || !priority) {
+        if (to_budget>= limit && hold) {
+            to_budget=0;
+        } else if{ (to_budget + increment < budgetAvailable || !priority) {
           to_budget += increment;
         } else {
           if (budgetAvailable > 0) to_budget += budgetAvailable;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -551,7 +551,7 @@ async function applyCategoryTemplate(
   }
 
   if (limit != null) {
-    if ( hold && balance > limit ) {
+    if (hold && balance > limit) {
       to_budget = 0;
     } else if (to_budget + last_month_balance > limit) {
       to_budget = limit - last_month_balance;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -315,7 +315,7 @@ async function applyCategoryTemplate(
             return { errors };
           } else {
             limit = amountToInteger(template.limit.amount);
-            hold = amountToInteger(template.limit.hold);
+            hold = template.limit.hold;
           }
         }
         let increment = 0;
@@ -325,9 +325,7 @@ async function applyCategoryTemplate(
         } else {
           increment = limit;
         }
-        if (to_budget>= limit && hold) {
-            to_budget=0;
-        } else if{ (to_budget + increment < budgetAvailable || !priority) {
+        if (to_budget + increment < budgetAvailable || !priority) {
           to_budget += increment;
         } else {
           if (budgetAvailable > 0) to_budget += budgetAvailable;
@@ -385,7 +383,8 @@ async function applyCategoryTemplate(
             errors.push(`More than one “up to” limit found.`);
             return { errors };
           } else {
-            limit = amountToInteger(template.limit);
+            limit = amountToInteger(template.limit.amount);
+            hold = template.limit.hold;
           }
         }
         let w = new Date(template.starting);
@@ -552,7 +551,9 @@ async function applyCategoryTemplate(
   }
 
   if (limit != null) {
-    if (to_budget + last_month_balance > limit) {
+    if ( hold && balance > limit ) {
+      to_budget = 0;
+    } else if (to_budget + last_month_balance > limit) {
       to_budget = limit - last_month_balance;
     }
   }

--- a/upcoming-release-notes/1004.md
+++ b/upcoming-release-notes/1004.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Add option to not remove funds when using an "up to" goal template.


### PR DESCRIPTION
By default when using the "up to" feature of a template, funds above the limit are removed to bring the category balance down to the limit.  This adds the ability to prevent funds removal.  The syntax is `#template up to 100+` where the `+` signals to not add negative budgeted amounts.  This will add funds up to 100 but not pull back to 100.

My use case:
I get a partial internet reimbursement through work once a year.  When the reimbursement comes in I categorize it directly as "internet" so I have extra funds sitting in that category to be used for the next few months.  I want to have a template add money only if its needed but not remove funds if there is extra.