### PR TITLE
Enable 'curly' rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,8 @@ module.exports = {
     'prettier/prettier': 'error',
     'no-unused-vars': 'off',
 
+    curly: ['error', 'multi-line', 'consistent'],
+
     'no-restricted-globals': ['error'].concat(
       require('confusing-browser-globals').filter(g => g !== 'self'),
     ),

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -56,15 +56,17 @@ async function processTemplate(month, force) {
       monthUtils.sheetForMonth(month),
       `budget-${category.id}`,
     );
-    if (budgeted)
+    if (budgeted) {
       originalCategoryBalance.push({ cat: category, amount: budgeted });
+    }
     let template = category_templates[category.id];
     if (template) {
-      for (let l = 0; l < template.length; l++)
+      for (let l = 0; l < template.length; l++) {
         lowestPriority =
           template[l].priority > lowestPriority
             ? template[l].priority
             : lowestPriority;
+      }
       await setBudget({
         category: category.id,
         month,
@@ -92,16 +94,18 @@ async function processTemplate(month, force) {
           priorityCheck = lowPriority;
           skipSchedule = priorityCheck !== priority ? true : false;
           isScheduleOrBy = true;
-          if (!skipSchedule && errorNotice)
+          if (!skipSchedule && errorNotice) {
             errors.push(
               category.name +
                 ': Schedules and By templates should all have the same priority.  Using priority ' +
                 priorityCheck,
             );
+          }
         }
         if (!skipSchedule) {
-          if (!isScheduleOrBy)
+          if (!isScheduleOrBy) {
             template = template.filter(t => t.priority === priority);
+          }
           if (template.length > 0) {
             errors = errors.concat(
               template

--- a/upcoming-release-notes/1015.md
+++ b/upcoming-release-notes/1015.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Enable ESLint’s `curly` rule


### PR DESCRIPTION
Multi-line `if`/`for` statements in JS can be confusing since there aren’t braces to indicate which code is enclosed in the statement. I set the configuration to `multi-line` to enforce usage of braces for multi-line statement bodies, but still allow things like `if (foo) return;`. I additionally added the `consistent` option to require braces for all elements of an if/else chain if one element has it. As you can see, this set of options pretty closely matches the existing code style.

I was going to comment in #1008 about this stylistic change but realized that it’s (IMO) a little impolite to ask for code style changes unless they can be automatically enforced.

Note that `if (foo) { \n return; \n }` is still valid and won’t be collapsed. I tried to automatically collapse all such cases but it was a lot of files and I didn’t want to pick out the useful from the useless differences.