### PR TITLE
Goals schedule infinite loop

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -2,10 +2,8 @@ import {
   differenceInCalendarMonths,
   addMonths,
   addWeeks,
-  addDays,
   format,
-  addMinutes,
-} from 'date-fns';
+  } from 'date-fns';
 
 import * as monthUtils from '../../shared/months';
 import {
@@ -527,6 +525,7 @@ async function applyCategoryTemplate(
             to_budget += Math.round(diff / num_months);
           }
         } else {
+
           let increment = budgeted;
           if (to_budget + increment < budgetAvailable || !priority) {
             to_budget += increment;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -4,6 +4,8 @@ import {
   addWeeks,
   addDays,
   format,
+  addHours,
+  addMinutes,
 } from 'date-fns';
 
 import * as monthUtils from '../../shared/months';
@@ -535,6 +537,7 @@ async function applyCategoryTemplate(
                 monthly_target += target;
               }
               next_date = addDays(next_date, 1);
+              next_date = addMinutes(next_date, next_date.getTimezoneOffset());
               next_date_string = getNextDate(dateCond, next_date);
               next_date = new Date(next_date_string);
             }

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -3,7 +3,7 @@ import {
   addMonths,
   addWeeks,
   format,
-  } from 'date-fns';
+} from 'date-fns';
 
 import * as monthUtils from '../../shared/months';
 import {
@@ -505,9 +505,6 @@ async function applyCategoryTemplate(
         let conditions = rule.serialize().conditions;
         let { date: dateCond, amount: amountCond } =
           extractScheduleConds(conditions);
-        let isRepeating =
-          Object(dateCond.value) === dateCond.value &&
-          'frequency' in dateCond.value;
         let next_date_string = getNextDate(dateCond, current_month);
         let num_months = differenceInCalendarMonths(
           new Date(next_date_string),
@@ -525,7 +522,6 @@ async function applyCategoryTemplate(
             to_budget += Math.round(diff / num_months);
           }
         } else {
-
           let increment = budgeted;
           if (to_budget + increment < budgetAvailable || !priority) {
             to_budget += increment;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -4,7 +4,6 @@ import {
   addWeeks,
   addDays,
   format,
-  addHours,
   addMinutes,
 } from 'date-fns';
 
@@ -528,23 +527,7 @@ async function applyCategoryTemplate(
             to_budget += Math.round(diff / num_months);
           }
         } else {
-          let monthly_target = 0;
-          let next_month = addMonths(current_month, 1);
-          let next_date = new Date(next_date_string);
-          if (isRepeating) {
-            while (next_date.getTime() < next_month.getTime()) {
-              if (next_date.getTime() >= current_month.getTime()) {
-                monthly_target += target;
-              }
-              next_date = addDays(next_date, 1);
-              next_date = addMinutes(next_date, next_date.getTimezoneOffset());
-              next_date_string = getNextDate(dateCond, next_date);
-              next_date = new Date(next_date_string);
-            }
-          } else {
-            monthly_target = target;
-          }
-          let increment = monthly_target - balance + budgeted;
+          let increment = budgeted;
           if (to_budget + increment < budgetAvailable || !priority) {
             to_budget += increment;
           } else {

--- a/upcoming-release-notes/1024.md
+++ b/upcoming-release-notes/1024.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Bugfix: Fix infinite loop condition when using Goals schedule keyword


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/983

The only time I was able to cause the infinite loop to be entered is when I tried applying the templates 1 month after a recurring scheduled transaction.  By removing the condition for the while loop, none of the calculations changed for single or multiple entries that use the 'schedule' keyword.

I'm including a test budget that has three scheduled recurring transactions. Two are dated to start in the future and one is dated to start in the past.  The Food category utilizes all 3 schedules.  General, Bills, and Bills (Flexible) utilize the schedules individually.

If you import the budget into this PR, no infinite loop exists and when you apply the templates in July (assume May is current month), there will be no UI hangup.  If the same is done in the current Master branch, the UI will become unresponsive for July.  The same budgeted values should appear in both.

[2023-05-11-My-Finances-1-2e281df.zip](https://github.com/actualbudget/actual/files/11452379/2023-05-11-My-Finances-1-2e281df.zip)
