### PR TITLE
Updated account ordering in the account autocomplete popup

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -771,6 +771,7 @@ export const Transaction = memo(function Transaction(props) {
             inputStyle,
           }) => (
             <AccountAutocomplete
+              includeClosedAccounts={false}
               value={accountId}
               accounts={accounts}
               shouldSaveFromKey={shouldSaveFromKey}

--- a/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
@@ -27,7 +27,9 @@ export function AccountList({
           const showGroup = lastItem
             ? item.offbudget !== lastItem.offbudget
             : true;
-          const group = item.offbudget ? 'Off Budget' : 'For Budget';
+          const group = `${item.closed ? 'Closed ' : ''}${
+            item.offbudget ? 'Off Budget' : 'For Budget'
+          }`;
           lastItem = item;
 
           return [

--- a/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
@@ -25,11 +25,18 @@ export function AccountList({
       >
         {items.map((item, idx) => {
           const showGroup = lastItem
-            ? item.offbudget !== lastItem.offbudget
+            ? (item.offbudget !== lastItem.offbudget && !item.closed) ||
+              (item.closed !== lastItem.closed && !item.offbudget)
             : true;
-          const group = `${item.closed ? 'Closed ' : ''}${
-            item.offbudget ? 'Off Budget' : 'For Budget'
+
+          const group = `${
+            item.closed
+              ? 'Closed Accounts'
+              : item.offbudget
+              ? 'Off Budget'
+              : 'For Budget'
           }`;
+
           lastItem = item;
 
           return [

--- a/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.js
@@ -76,16 +76,26 @@ export default function AccountAutocomplete({
 }) {
   let accounts = useCachedAccounts() || [];
 
+  //remove closed accounts if needed
+  //then sort by closed, then offbudget
+  accounts = accounts
+    .filter(item => {
+      return includeClosedAccounts ? item : !item.closed;
+    })
+    .sort((a, b) => {
+      if (a.closed === b.closed) {
+        return a.offbudget === b.offbudget ? 0 : a.offbudget ? 1 : -1;
+      } else {
+        return a.closed ? 1 : -1;
+      }
+    });
+
   return (
     <Autocomplete
       strict={true}
       highlightFirst={true}
       embedded={embedded}
-      suggestions={
-        includeClosedAccounts
-          ? accounts
-          : accounts.filter(a => a.closed === false)
-      }
+      suggestions={accounts}
       renderItems={(items, getItemProps, highlightedIndex) => (
         <AccountList
           items={items}

--- a/upcoming-release-notes/1034.md
+++ b/upcoming-release-notes/1034.md
@@ -1,0 +1,7 @@
+---
+category: Enhancements
+authors: Miodec
+---
+
+Updated account order inside the account autocomplete popup to: On Budget, Off Budget, Closed Accounts
+Removed closed accounts from suggestions when creating a new transaction

--- a/upcoming-release-notes/1034.md
+++ b/upcoming-release-notes/1034.md
@@ -3,5 +3,4 @@ category: Enhancements
 authors: [Miodec]
 ---
 
-Updated account order inside the account autocomplete popup to: On Budget, Off Budget, Closed Accounts
-Removed closed accounts from suggestions when creating a new transaction
+Updated account order inside the account autocomplete popup to: On Budget, Off Budget, Closed Accounts. Removed closed accounts from suggestions when creating a new transaction.

--- a/upcoming-release-notes/1034.md
+++ b/upcoming-release-notes/1034.md
@@ -1,6 +1,6 @@
 ---
 category: Enhancements
-authors: Miodec
+authors: [Miodec]
 ---
 
 Updated account order inside the account autocomplete popup to: On Budget, Off Budget, Closed Accounts


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Changes in the pr:
 - Removed closed accounts when adding a transaction 
 - Updated ordering of the account autocomplete popup
   Previous ordering seemed to put closed accounts at the top, then order accounts by name. This PR makes the accounts appear in the same order as they do on the left panel - on budget first, then off budget, then closed accounts.

(increased max height just for the screenshots)
Before:
![Screenshot 2023-05-15 at 19 09 07](https://github.com/actualbudget/actual/assets/13181393/a8727443-5934-4c42-9e6b-ec22cc768234)

After, without closed accounts (adding a transaction):
![Screenshot 2023-05-15 at 19 09 42](https://github.com/actualbudget/actual/assets/13181393/7a9e77c0-4fb7-4c6a-9c7d-7b4e3eab9e95)

After, including closed accounts:
![Screenshot 2023-05-15 at 19 10 11](https://github.com/actualbudget/actual/assets/13181393/ec91d17a-7a2e-407e-bfab-395224b198b5)


First PR to this project - let me know if i messed something up.

