### PR TITLE
Fixed a bug where it was possible to make a transfer to the same account as the one making the transfer.

### DIFF
--- a/packages/desktop-client/src/components/accounts/TransactionsTable.js
+++ b/packages/desktop-client/src/components/accounts/TransactionsTable.js
@@ -403,6 +403,7 @@ function PayeeCell({
 
   // Filter out the account we're currently in as it is not a valid transfer
   accounts = accounts.filter(account => account.id !== accountId);
+  payees = payees.filter(payee => payee.transfer_acct !== accountId);
 
   return (
     <CustomCell

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
@@ -181,10 +181,15 @@ export default function PayeeAutocomplete({
   onUpdate,
   onSelect,
   onManagePayees,
+  accounts,
   ...props
 }) {
   let payees = useCachedPayees();
-  let accounts = useCachedAccounts();
+  let cachedAccounts = useCachedAccounts();
+
+  if (!accounts) {
+    accounts = cachedAccounts;
+  }
 
   let [focusTransferPayees, setFocusTransferPayees] = useState(
     defaultFocusTransferPayees,

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
@@ -182,11 +182,15 @@ export default function PayeeAutocomplete({
   onSelect,
   onManagePayees,
   accounts,
+  payees,
   ...props
 }) {
-  let payees = useCachedPayees();
-  let cachedAccounts = useCachedAccounts();
+  let cachedPayees = useCachedPayees();
+  if (!payees) {
+    payees = cachedPayees;
+  }
 
+  let cachedAccounts = useCachedAccounts();
   if (!accounts) {
     accounts = cachedAccounts;
   }

--- a/upcoming-release-notes/1038.md
+++ b/upcoming-release-notes/1038.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Miodec]
+---
+
+Fixed a bug where it was possible to make a transfer to the same account as the one making the transfer.


### PR DESCRIPTION
The payee autocomplete was always using cached accounts. Added a check to see if accounts was already passed in as a parameter - only using cached if it wasnt.
