### PR TITLE
Allow MEMO to be nested in NAME in OFX parser

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.js
@@ -623,7 +623,7 @@ export function ImportTransactions({
           message:
             'Import was successful, but please [file a bug report](https://github.com/actualbudget/actual/issues/new?assignees=&labels=bug%2Cneeds+triage&template=bug-report.yml&title=%5BBug%5D%3A+New+OFX+Importer:+bad+new+parse:) and attach a redacted version of the file so we can fix our new algorithm.',
         });
-        errors = [];
+        errors = []; // dont set errors cause everythings still working.
         transactions = results.transactions;
       } else if (results.which === 'none') {
         // Results were the same between the two!

--- a/upcoming-release-notes/1044.md
+++ b/upcoming-release-notes/1044.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Sinistersnare]
+---
+
+Allow MEMO field to be nested in NAME field in OFX parser.


### PR DESCRIPTION
This comes as a result of some discussion on Discord.

Here is a test-case: https://gist.github.com/sinistersnare/a0b9604f0db25a58cd3f739d427f7f16. Should I add this as a unit-test?