### PR TITLE
A few fixes for Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start:desktop-node": "yarn workspace loot-core watch:node",
     "start:desktop-client": "yarn workspace @actual-app/web watch",
     "start:desktop-electron": "yarn workspace desktop-electron watch",
+    "start:electron": "yarn start:desktop",
     "start:browser": "npm-run-all --parallel 'start:browser-*'",
     "start:browser-backend": "yarn workspace loot-core watch:browser",
     "start:browser-frontend": "yarn workspace @actual-app/web start:browser",

--- a/packages/desktop-client/src/components/budget/MonthCountSelector.js
+++ b/packages/desktop-client/src/components/budget/MonthCountSelector.js
@@ -41,6 +41,7 @@ export function MonthCountSelector({ maxMonths, onChange }) {
         flexDirection: 'row',
         marginRight: 20,
         marginTop: -1,
+        WebkitAppRegion: 'no-drag',
         '& svg': {
           transition: 'transform .15s',
         },

--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -84,6 +84,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             (primary ? (disabled ? colors.n7 : colors.p5) : colors.n9),
         color: primary ? 'white' : disabled ? colors.n6 : colors.n1,
         transition: 'box-shadow .25s',
+        WebkitAppRegion: 'no-drag',
         ...styles.smallText,
       },
       { ':hover': !disabled && hoveredStyle },

--- a/packages/desktop-client/src/components/sidebar.js
+++ b/packages/desktop-client/src/components/sidebar.js
@@ -18,14 +18,7 @@ import ArrowButtonLeft1 from '../icons/v2/ArrowButtonLeft1';
 import CalendarIcon from '../icons/v2/Calendar';
 import { styles, colors } from '../style';
 
-import {
-  View,
-  Block,
-  AlignedText,
-  AnchorLink,
-  ButtonLink,
-  Button,
-} from './common';
+import { View, Block, AlignedText, AnchorLink, Button } from './common';
 import { useSidebar } from './FloatableSidebar';
 import { useDraggable, useDroppable, DropHighlight } from './sort.js';
 import CellValue from './spreadsheet/CellValue';
@@ -575,22 +568,6 @@ export function Sidebar({
         style,
       ]}
     >
-      {hasWindowButtons && !sidebar.alwaysFloats && (
-        <ToggleButton
-          style={[
-            {
-              height: isFloating ? 0 : 36,
-              alignItems: 'flex-end',
-              justifyContent: 'center',
-              overflow: 'hidden',
-              WebkitAppRegion: 'drag',
-              paddingRight: 8,
-            },
-          ]}
-          isFloating={isFloating}
-          onFloat={onFloat}
-        />
-      )}
       <View
         style={[
           {
@@ -609,26 +586,9 @@ export function Sidebar({
       >
         {budgetName}
 
-        {!Platform.isBrowser && (
-          <ButtonLink
-            bare
-            to="/settings"
-            style={{
-              // Needed for Windows? No idea why this is displayed as block
-              display: 'inherit',
-              color: colors.n5,
-              marginLeft: hasWindowButtons ? 0 : 5,
-              flexShrink: 0,
-            }}
-            activeStyle={{ color: colors.p7 }}
-          >
-            <Cog width={15} height={15} style={{ color: 'inherit' }} />
-          </ButtonLink>
-        )}
-
         <View style={{ flex: 1, flexDirection: 'row' }} />
 
-        {!hasWindowButtons && !sidebar.alwaysFloats && (
+        {!sidebar.alwaysFloats && (
           <ToggleButton isFloating={isFloating} onFloat={onFloat} />
         )}
       </View>

--- a/upcoming-release-notes/1048.md
+++ b/upcoming-release-notes/1048.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix a couple of bugs/inconsistencies in the Electron app


### PR DESCRIPTION
- Fix clicking buttons in the toolbar on macOS (previously they were not clickable)
- `yarn start:electron` now launches the Electron app
- The sidebar is now identical to the web version