### PR TITLE
Template: Apply schedule template only on needed month

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -1,11 +1,9 @@
-// https://peggyjs.org
-
 expr
-  = priority: priority? _? percent: percent _ of _ category: name
+  = priority: priority? percent: percent _ of _ category: name
     { return { type: 'percentage', percent: +percent, category, priority: +priority }}
-  / priority: priority? _? amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
+  / priority: priority? amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
     { return { type: 'week', amount, weeks, starting, limit, priority: +priority }}
-  / priority: priority? _? amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
+  / priority: priority? amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
     { return {
       type: from ? 'spend' : 'by',
       amount,
@@ -13,22 +11,23 @@ expr
       ...(repeat ? repeat[3] : {}),
       from,
       priority: +priority
-    } }
-  / priority: priority? _? monthly: amount limit: limit?
-    { return { type: 'simple', monthly, limit, priority: +priority  } }
-  / priority: priority? _? limit: limit
+    } } 
+  / priority: priority? monthly: amount limit: limit?
+    { return { type: 'simple', monthly, limit, priority: +priority  } } 
+  / priority: priority? limit: limit
     { return { type: 'simple', limit , priority: +priority } }
-  / priority: priority? _? schedule _ name: name
-    { return { type: 'schedule', name, priority: +priority } }
+  / priority: priority? schedule _ full:full? name: name
+  	{ return { type: 'schedule', name, priority: +priority, full } }
+  
 
 repeat 'repeat interval'
-  = 'month'i { return { annual: false } }
-  / months: d _ 'months'i { return { annual: false, repeat: +months } }
-  / 'year'i { return { annual: true } }
-  / years: d _ 'years'i { return { annual: true, repeat: +years } }
+  = 'month'i { return { annual: false } } 
+  / months: d _ 'months'i { return { annual: false, repeat: +months } } 
+  / 'year'i { return { annual: true } } 
+  / years: d _ 'years'i { return { annual: true, repeat: +years } } 
 
-limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } }
-		/ _? upTo _ amount: amount { return {amount: amount, hold: false } }
+limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } } 
+    / _? upTo _ amount: amount { return {amount: amount, hold: false } } 
 
 
 weekCount
@@ -45,7 +44,8 @@ repeatEvery = 'repeat'i _ 'every'i
 starting = 'starting'i
 upTo = 'up'i _ 'to'i
 schedule = 'schedule'i
-priority = '-'i number: number _ {return number}
+full = 'full'i _ {return true}
+priority = '-'i number: number _ {return +number}
 
 _ 'space' = ' '+
 d 'digit' = [0-9]
@@ -59,3 +59,4 @@ date = $(month '-' day)
 currencySymbol 'currency symbol' = symbol: . & { return /\p{Sc}/u.test(symbol) }
 
 name 'Name' = $([^\r\n\t]+)
+

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -11,7 +11,7 @@ expr
       ...(repeat ? repeat[3] : {}),
       from,
       priority: +priority
-    } } 
+    } }
   / priority: priority? monthly: amount limit: limit?
     { return { type: 'simple', monthly, limit, priority: +priority  } } 
   / priority: priority? limit: limit
@@ -21,13 +21,13 @@ expr
   
 
 repeat 'repeat interval'
-  = 'month'i { return { annual: false } } 
-  / months: d _ 'months'i { return { annual: false, repeat: +months } } 
-  / 'year'i { return { annual: true } } 
-  / years: d _ 'years'i { return { annual: true, repeat: +years } } 
+  = 'month'i { return { annual: false } }
+  / months: d _ 'months'i { return { annual: false, repeat: +months } }
+  / 'year'i { return { annual: true } }
+  / years: d _ 'years'i { return { annual: true, repeat: +years } }
 
-limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } } 
-    / _? upTo _ amount: amount { return {amount: amount, hold: false } } 
+limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } }
+  / _? upTo _ amount: amount { return {amount: amount, hold: false } }
 
 
 weekCount
@@ -45,7 +45,7 @@ starting = 'starting'i
 upTo = 'up'i _ 'to'i
 schedule = 'schedule'i
 full = 'full'i _ {return true}
-priority = '-'i number: number _ {return +number}
+priority = '-'i number: number _ {return number}
 
 _ 'space' = ' '+
 d 'digit' = [0-9]

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -27,7 +27,7 @@ repeat 'repeat interval'
   / years: d _ 'years'i { return { annual: true, repeat: +years } }
 
 limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } }
-  / _? upTo _ amount: amount { return {amount: amount, hold: false } }
+        / _? upTo _ amount: amount { return {amount: amount, hold: false } }
 
 
 weekCount

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -489,9 +489,6 @@ async function applyCategoryTemplate(
         }
         break;
       }
-      case 'error':
-        return { errors };
-      default:
       case 'schedule': {
         let { id: schedule_id } = await db.first(
           'SELECT id FROM schedules WHERE name = ?',
@@ -506,6 +503,14 @@ async function applyCategoryTemplate(
           new Date(next_date_string),
           current_month,
         );
+
+        if (template.full === true) {
+          if (num_months === 1) {
+            to_budget = -getScheduledAmount(amountCond.value);
+          }
+          break;
+        }
+
         if (l === 0) remainder = last_month_balance;
         remainder = -getScheduledAmount(amountCond.value) - remainder;
         let target = 0;
@@ -537,6 +542,9 @@ async function applyCategoryTemplate(
         }
         break;
       }
+      case 'error':
+        return { errors };
+      default:
     }
   }
 

--- a/upcoming-release-notes/1052.md
+++ b/upcoming-release-notes/1052.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [youngcw]
 ---
 

--- a/upcoming-release-notes/1052.md
+++ b/upcoming-release-notes/1052.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [youngcw]
+---
+
+Templates: Add option to only apply schedule template to the month of the schedule instead of spreading out the charge.


### PR DESCRIPTION
Add option to schedule templates to budget the full amount only in the needed month.  Default behavior stays the same of spreading the expense out over the available range.

To use the option, use a template like `#template schedule full SCHEDULE_NAME`


Also some minor cleanup.
