### PR TITLE
Export `api/methods.js` at the top level again

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -6,7 +6,10 @@ import * as injected from './injected';
 let actualApp;
 export const internal = bundle.lib;
 
+// DEPRECATED: remove the next line in @actual-app/api v7
 export * as methods from './methods';
+
+export * from './methods';
 export * as utils from './utils';
 
 export async function init(config = {}) {

--- a/upcoming-release-notes/1054.md
+++ b/upcoming-release-notes/1054.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Re-export the API methods at the top level of the `@actual-budget/api` package like they were in the past. Note: If you were using the `api.methods.<method>` syntax to access API methods in recent versions, that is now deprecated and will stop working with the next major release of the API package.


### PR DESCRIPTION
This allows using the API as documented. In #877, I think this was unintentionally converted to be a named export.