### PR TITLE
change copy-migrations shebang to bash

### DIFF
--- a/packages/loot-core/bin/copy-migrations
+++ b/packages/loot-core/bin/copy-migrations
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 ROOT=`dirname $(dirname "$0")`
 DEST="$1"

--- a/upcoming-release-notes/1056.md
+++ b/upcoming-release-notes/1056.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [fry]
+---
+
+Change copy-migrations shebang to bash. yarn build failed on copy-migrations because /bin/sh is not bash on WSL and doesn't expect -e


### PR DESCRIPTION
yarn build failed on copy-migrations because /bin/sh is not bash on WSL and doesn't expect -e
