### PR TITLE
Goals: fix broken parser

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -1,9 +1,11 @@
+// https://peggyjs.org
+
 expr
-  = priority: priority? percent: percent _ of _ category: name
+  = priority: priority? _? percent: percent _ of _ category: name
     { return { type: 'percentage', percent: +percent, category, priority: +priority }}
-  / priority: priority? amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
+  / priority: priority? _? amount: amount _ repeatEvery _ weeks: weekCount _ starting _ starting: date limit: limit?
     { return { type: 'week', amount, weeks, starting, limit, priority: +priority }}
-  / priority: priority? amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
+  / priority: priority? _? amount: amount _ by _ month: month from: spendFrom? repeat: (_ repeatEvery _ repeat)?
     { return {
       type: from ? 'spend' : 'by',
       amount,
@@ -12,11 +14,11 @@ expr
       from,
       priority: +priority
     } }
-  / priority: priority? monthly: amount limit: limit?
+  / priority: priority? _? monthly: amount limit: limit?
     { return { type: 'simple', monthly, limit, priority: +priority  } } 
-  / priority: priority? limit: limit
+  / priority: priority? _? limit: limit
     { return { type: 'simple', limit , priority: +priority } }
-  / priority: priority? schedule _ full:full? name: name
+  / priority: priority? _? schedule _ full:full? name: name
   	{ return { type: 'schedule', name, priority: +priority, full } }
   
 

--- a/upcoming-release-notes/1059.md
+++ b/upcoming-release-notes/1059.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: Undo change that broke some template parsing


### PR DESCRIPTION
Revert the parser cleanup that broke parsing for some goal templates.  Undoes some changes from #1052.


@shall0pass How is this.  It works for me on the previously broken templates.
