### PR TITLE
Integrate useMemo into useLiveQuery

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,12 @@ module.exports = {
 
     // TODO: re-enable these rules
     'react-hooks/exhaustive-deps': 'off',
+    // 'react-hooks/exhaustive-deps': [
+    //   'error',
+    //   {
+    //     additionalHooks: 'useLiveQuery',
+    //   },
+    // ],
 
     'import/no-useless-path-segments': 'error',
     'import/order': [

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useState, useEffect, useMemo } from 'react';
+import React, { createRef, useState, useEffect } from 'react';
 
 import { type CSSProperties, css } from 'glamor';
 
@@ -82,9 +82,7 @@ export default function NotesButton({
 }: NotesButtonProps) {
   let [hover, setHover] = useState(false);
   let tooltip = useTooltip();
-  let data = useLiveQuery(
-    useMemo(() => q('notes').filter({ id }).select('*'), [id]),
-  );
+  let data = useLiveQuery(() => q('notes').filter({ id }).select('*'), [id]);
   let note = data && data.length > 0 ? data[0].note : null;
   let hasNotes = note && note !== '';
 

--- a/packages/loot-core/src/client/data-hooks/accounts.tsx
+++ b/packages/loot-core/src/client/data-hooks/accounts.tsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { getAccountsById } from 'loot-core/src/client/reducers/queries';
 
 export function useAccounts() {
-  return useLiveQuery(q('accounts').select('*'));
+  return useLiveQuery(useMemo(() => q('accounts').select('*'), []));
 }
 
 let AccountsContext = createContext(null);

--- a/packages/loot-core/src/client/data-hooks/accounts.tsx
+++ b/packages/loot-core/src/client/data-hooks/accounts.tsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext } from 'react';
 
 import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { getAccountsById } from 'loot-core/src/client/reducers/queries';
 
 export function useAccounts() {
-  return useLiveQuery(useMemo(() => q('accounts').select('*'), []));
+  return useLiveQuery(() => q('accounts').select('*'), []);
 }
 
 let AccountsContext = createContext(null);

--- a/packages/loot-core/src/client/data-hooks/payees.tsx
+++ b/packages/loot-core/src/client/data-hooks/payees.tsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext } from 'react';
 
 import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { getPayeesById } from 'loot-core/src/client/reducers/queries';
 
 export function usePayees() {
-  return useLiveQuery(useMemo(() => q('payees').select('*'), []));
+  return useLiveQuery(() => q('payees').select('*'), []);
 }
 
 let PayeesContext = createContext(null);

--- a/packages/loot-core/src/client/data-hooks/payees.tsx
+++ b/packages/loot-core/src/client/data-hooks/payees.tsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 
 import q from 'loot-core/src/client/query-helpers';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { getPayeesById } from 'loot-core/src/client/reducers/queries';
 
 export function usePayees() {
-  return useLiveQuery(q('payees').select('*'));
+  return useLiveQuery(useMemo(() => q('payees').select('*'), []));
 }
 
 let PayeesContext = createContext(null);

--- a/packages/loot-core/src/client/query-hooks.tsx
+++ b/packages/loot-core/src/client/query-hooks.tsx
@@ -4,7 +4,10 @@ import React, {
   useContext,
   useMemo,
   useEffect,
+  type DependencyList,
 } from 'react';
+
+import { type Query } from 'loot-core/src/shared/query';
 
 import { liveQuery, LiveQuery, PagedQuery } from './query-helpers';
 
@@ -70,19 +73,16 @@ export function pagedQueryContext(query, opts) {
   return makeContext(query, opts, PagedQuery);
 }
 
-export function useLiveQuery(query, opts?) {
+export function useLiveQuery(makeQuery: () => Query, deps: DependencyList) {
   let [data, setData] = useState(null);
+  let query = useMemo(makeQuery, deps);
 
   useEffect(() => {
-    let live = liveQuery(
-      query,
-      async data => {
-        if (live) {
-          setData(data);
-        }
-      },
-      opts,
-    );
+    let live = liveQuery(query, async data => {
+      if (live) {
+        setData(data);
+      }
+    });
 
     return () => {
       live.unsubscribe();

--- a/upcoming-release-notes/1064.md
+++ b/upcoming-release-notes/1064.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Integrate `useMemo` into `useLiveQuery`


### PR DESCRIPTION
Since each `q` call returns a brand new `Query` object, it will always be necessary to use `useMemo` to cache the value to avoid recreating the query. As a result, I’ve made `useLiveQuery` pass its arguments directly into `useMemo`, so you can’t forget to do so.

Fixes a performance regression from #1061.