### PR TITLE
:bug: (budget) link from budget to transactions not working

### DIFF
--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -1,5 +1,6 @@
 import React, { memo, PureComponent, useContext, useMemo } from 'react';
 import { connect } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import * as actions from 'loot-core/src/client/actions';
 import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
@@ -331,7 +332,7 @@ class Budget extends PureComponent {
   };
 
   onShowActivity = (categoryName, categoryId, month) => {
-    window.__history.push({
+    this.props.history.push({
       pathname: '/accounts',
       state: {
         goBack: true,
@@ -519,6 +520,7 @@ const RolloverBudgetSummary = memo(props => {
 function BudgetWrapper(props) {
   let spreadsheet = useSpreadsheet();
   let titlebar = useContext(TitlebarContext);
+  let history = useHistory();
 
   let reportComponents = useMemo(
     () => ({
@@ -563,6 +565,7 @@ function BudgetWrapper(props) {
         rolloverComponents={rolloverComponents}
         spreadsheet={spreadsheet}
         titlebar={titlebar}
+        history={history}
       />
     </View>
   );

--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -331,7 +331,7 @@ class Budget extends PureComponent {
   };
 
   onShowActivity = (categoryName, categoryId, month) => {
-    this.props.history.push({
+    window.__history.push({
       pathname: '/accounts',
       state: {
         goBack: true,

--- a/upcoming-release-notes/1067.md
+++ b/upcoming-release-notes/1067.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix link to spent transactions for a budget category


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Clicking the a category in the "spent" column for the budget table was not working because `this.props.history` is undefined.

```
Uncaught TypeError: Cannot read properties of undefined (reading 'push')
```