### PR TITLE
More import-related ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
     // ],
 
     'import/no-useless-path-segments': 'error',
+    'import/no-duplicates': ['error', { 'prefer-inline': true }],
     'import/order': [
       'error',
       {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,5 +133,22 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['./packages/loot-core/src/**/*'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['loot-core/**'],
+                message:
+                  'Please use relative imports in loot-core instead of importing from `loot-core/*`',
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/desktop-client/src/components/SidebarWithData.js
+++ b/packages/desktop-client/src/components/SidebarWithData.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { connect } from 'react-redux';
-import { useDispatch } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { withRouter, useHistory } from 'react-router';
 
 import { bindActionCreators } from 'redux';

--- a/packages/desktop-client/src/components/accounts/MobileTransaction.js
+++ b/packages/desktop-client/src/components/accounts/MobileTransaction.js
@@ -15,8 +15,11 @@ import memoizeOne from 'memoize-one';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import { getScheduledAmount } from 'loot-core/src/shared/schedules';
-import { titleFirst } from 'loot-core/src/shared/util';
-import { integerToCurrency, groupById } from 'loot-core/src/shared/util';
+import {
+  titleFirst,
+  integerToCurrency,
+  groupById,
+} from 'loot-core/src/shared/util';
 
 import ArrowsSynchronize from '../../icons/v2/ArrowsSynchronize';
 import CheckCircle1 from '../../icons/v2/CheckCircle1';

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -4,8 +4,10 @@ import { useHistory } from 'react-router-dom';
 
 import { createBudget } from 'loot-core/src/client/actions/budgets';
 import { signOut, loggedIn } from 'loot-core/src/client/actions/user';
-import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
-import { isElectron } from 'loot-core/src/shared/environment';
+import {
+  isNonProductionEnvironment,
+  isElectron,
+} from 'loot-core/src/shared/environment';
 
 import { useSetThemeColor } from '../../hooks';
 import { colors } from '../../style';

--- a/packages/loot-core/src/client/data-hooks/accounts.tsx
+++ b/packages/loot-core/src/client/data-hooks/accounts.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext } from 'react';
 
-import q from 'loot-core/src/client/query-helpers';
-import { useLiveQuery } from 'loot-core/src/client/query-hooks';
-import { getAccountsById } from 'loot-core/src/client/reducers/queries';
+import q from '../query-helpers';
+import { useLiveQuery } from '../query-hooks';
+import { getAccountsById } from '../reducers/queries';
 
 export function useAccounts() {
   return useLiveQuery(() => q('accounts').select('*'), []);

--- a/packages/loot-core/src/client/data-hooks/payees.tsx
+++ b/packages/loot-core/src/client/data-hooks/payees.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext } from 'react';
 
-import q from 'loot-core/src/client/query-helpers';
-import { useLiveQuery } from 'loot-core/src/client/query-hooks';
-import { getPayeesById } from 'loot-core/src/client/reducers/queries';
+import q from '../query-helpers';
+import { useLiveQuery } from '../query-hooks';
+import { getPayeesById } from '../reducers/queries';
 
 export function usePayees() {
   return useLiveQuery(() => q('payees').select('*'), []);

--- a/packages/loot-core/src/client/data-hooks/schedules.tsx
+++ b/packages/loot-core/src/client/data-hooks/schedules.tsx
@@ -1,10 +1,7 @@
 import React, { createContext, useEffect, useState, useContext } from 'react';
 
-import q, { liveQuery } from 'loot-core/src/client/query-helpers';
-import {
-  getStatus,
-  getHasTransactionsQuery,
-} from 'loot-core/src/shared/schedules';
+import { getStatus, getHasTransactionsQuery } from '../../shared/schedules';
+import q, { liveQuery } from '../query-helpers';
 
 function loadStatuses(schedules, onData) {
   return liveQuery(getHasTransactionsQuery(schedules), onData, {

--- a/packages/loot-core/src/client/query-hooks.tsx
+++ b/packages/loot-core/src/client/query-hooks.tsx
@@ -7,7 +7,7 @@ import React, {
   type DependencyList,
 } from 'react';
 
-import { type Query } from 'loot-core/src/shared/query';
+import { type Query } from '../shared/query';
 
 import { liveQuery, LiveQuery, PagedQuery } from './query-helpers';
 

--- a/upcoming-release-notes/1070.md
+++ b/upcoming-release-notes/1070.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Add a few more `eslint-plugin-import` rules to keep our imports tidy


### PR DESCRIPTION
- Enforce that imports from the same package are merged into a single import
- In `loot-core`, require that imports of other `loot-core` files use a relative import (like the vast majority of such imports) rather than specifiers starting with `loot-core/` (probably a result of moving files out of other packages into `loot-core`)