### PR TITLE
Clean up __history usage

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -246,11 +246,6 @@ function FinancesApp(props) {
       }
     };
 
-    // I'm not sure if this is the best approach but we need this to
-    // globally. We could instead move various workflows inside global
-    // React components, but that's for another day.
-    window.__history = patchedHistory;
-
     undo.setUndoState('url', window.location.href);
 
     const cleanup = patchedHistory.listen(location => {
@@ -304,6 +299,8 @@ function FinancesApp(props) {
 
   return (
     <Router history={patchedHistory}>
+      <ExposeNavigate />
+
       <View style={{ height: '100%', backgroundColor: colors.n10 }}>
         <GlobalKeys />
 

--- a/packages/desktop-client/src/components/FinancesApp.js
+++ b/packages/desktop-client/src/components/FinancesApp.js
@@ -27,6 +27,7 @@ import PiggyBank from '../icons/v1/PiggyBank';
 import Wallet from '../icons/v1/Wallet';
 import { useResponsive } from '../ResponsiveProvider';
 import { colors, styles } from '../style';
+import ExposeNavigate from '../util/ExposeNavigate';
 import { getLocationState, makeLocationState } from '../util/location-state';
 import { getIsOutdated, getLatestVersion } from '../util/versions';
 

--- a/packages/desktop-client/src/components/LoggedInUser.js
+++ b/packages/desktop-client/src/components/LoggedInUser.js
@@ -34,7 +34,7 @@ function LoggedInUser({
 
   async function onChangePassword() {
     await closeBudget();
-    window.__history.push('/change-password');
+    window.__navigate('/change-password');
   }
 
   async function onMenuSelect(type) {
@@ -46,14 +46,14 @@ function LoggedInUser({
         break;
       case 'sign-in':
         await closeBudget();
-        window.__history.push('/login');
+        window.__navigate('/login');
         break;
       case 'sign-out':
         signOut();
         break;
       case 'config-server':
         await closeBudget();
-        window.__history.push('/config-server');
+        window.__navigate('/config-server');
         break;
       default:
     }

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -84,7 +84,7 @@ export default function ConfigServer() {
   async function onCreateTestFile() {
     await setServerUrl(null);
     await dispatch(createBudget({ testMode: true }));
-    window.__history.push('/');
+    window.__navigate('/');
   }
 
   return (

--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -8,6 +8,7 @@ import * as actions from 'loot-core/src/client/actions';
 
 import { colors } from '../../style';
 import tokens from '../../tokens';
+import ExposeNavigate from '../../util/ExposeNavigate';
 import { View, Text } from '../common';
 import LoggedInUser from '../LoggedInUser';
 import Notifications from '../Notifications';
@@ -59,7 +60,6 @@ function ManagementApp({
   loadAllFiles,
 }) {
   const [history] = useState(createBrowserHistory);
-  window.__history = history;
 
   // runs on mount only
   useEffect(() => {
@@ -108,6 +108,7 @@ function ManagementApp({
 
   return (
     <Router history={history}>
+      <ExposeNavigate />
       <View style={{ height: '100%' }}>
         <View
           style={{

--- a/packages/desktop-client/src/global-events.js
+++ b/packages/desktop-client/src/global-events.js
@@ -36,11 +36,13 @@ export function handleGlobalEvents(actions, store) {
   });
 
   listen('schedules-offline', ({ payees }) => {
-    let history = window.__history;
-    if (history) {
-      history.push(`/schedule/posts-offline-notification`, {
-        locationPtr: history.location,
-        payees,
+    let navigate = window.__navigate;
+    if (navigate) {
+      navigate(`/schedule/posts-offline-notification`, {
+        state: {
+          locationPtr: navigate.location,
+          payees,
+        },
       });
     }
   });

--- a/packages/desktop-client/src/util/ExposeNavigate.js
+++ b/packages/desktop-client/src/util/ExposeNavigate.js
@@ -1,7 +1,10 @@
+import { useLayoutEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function ExposeNavigate() {
   let navigate = useNavigate();
-  window.__navigate = navigate;
+  useLayoutEffect(() => {
+    window.__navigate = navigate;
+  }, [navigate]);
   return null;
 }

--- a/packages/desktop-client/src/util/ExposeNavigate.js
+++ b/packages/desktop-client/src/util/ExposeNavigate.js
@@ -1,0 +1,7 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function ExposeNavigate() {
+  let navigate = useNavigate();
+  window.__navigate = navigate;
+  return null;
+}

--- a/packages/desktop-electron/menu.js
+++ b/packages/desktop-electron/menu.js
@@ -131,7 +131,9 @@ function getMenu(isDev, createWindow) {
           enabled: false,
           click: function (menuItem, focusedWin) {
             focusedWin.webContents.executeJavaScript(
-              '__history && __history.push("/schedule/discover", { locationPtr: __history.location })',
+              // TODO: fix
+              // '__navigate && __history.push("/schedule/discover", { locationPtr: __history.location })',
+              'alert("Not implemented")',
             );
           },
         },

--- a/packages/loot-core/src/client/actions/budgets.ts
+++ b/packages/loot-core/src/client/actions/budgets.ts
@@ -165,7 +165,7 @@ export function importBudget(filepath, type) {
     dispatch(closeModal());
 
     await dispatch(loadPrefs());
-    window.__history.push('/budget');
+    window.__navigate('/budget');
   };
 }
 

--- a/packages/loot-core/src/client/upgrade-notifications.ts
+++ b/packages/loot-core/src/client/upgrade-notifications.ts
@@ -5,7 +5,6 @@ import * as Platform from './platform';
 export default function checkForUpgradeNotifications(
   addNotification,
   resetSync,
-  // Note: history is only available on desktop
   history,
 ) {
   // TODO: Probably should only show one of these at at time?
@@ -33,10 +32,9 @@ export default function checkForUpgradeNotifications(
             button: Platform.env !== 'mobile' && {
               title: 'Find schedules',
               action: async () => {
-                window.__history &&
-                  window.__history.push('/schedule/discover', {
-                    locationPtr: window.__history.location,
-                  });
+                history.push('/schedule/discover', {
+                  locationPtr: history.location,
+                });
               },
             },
             onClose: () => {
@@ -47,26 +45,24 @@ export default function checkForUpgradeNotifications(
         }
 
         case 'repair-splits':
-          if (history) {
-            addNotification({
-              type: 'message',
-              title: 'Split transactions now support transfers & payees',
-              message:
-                'The payee field is now available on split transactions, allowing you to perform transfers on individual split transactions.\n\nAll existing split transactions have a blank payee and we recommend using the tool below to set the payee from the parent. [View a video walkthrough](https://www.youtube.com/watch?v=5kTtAsB0Oqk)',
-              sticky: true,
-              id: 'repair-splits',
-              button: {
-                title: 'Repair splits...',
-                action: () =>
-                  history.push('/tools/fix-splits', {
-                    locationPtr: history.location,
-                  }),
-              },
-              onClose: () => {
-                send('seen-upgrade-notification', { type: 'repair-splits' });
-              },
-            });
-          }
+          addNotification({
+            type: 'message',
+            title: 'Split transactions now support transfers & payees',
+            message:
+              'The payee field is now available on split transactions, allowing you to perform transfers on individual split transactions.\n\nAll existing split transactions have a blank payee and we recommend using the tool below to set the payee from the parent. [View a video walkthrough](https://www.youtube.com/watch?v=5kTtAsB0Oqk)',
+            sticky: true,
+            id: 'repair-splits',
+            button: {
+              title: 'Repair splits...',
+              action: () =>
+                history.push('/tools/fix-splits', {
+                  locationPtr: history.location,
+                }),
+            },
+            onClose: () => {
+              send('seen-upgrade-notification', { type: 'repair-splits' });
+            },
+          });
           break;
 
         default:

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -8,9 +8,6 @@ declare global {
       openURLInBrowser: (url: string) => void;
     };
 
-    __history?: {
-      location;
-      push(url: string, opts?: unknown): void;
-    };
+    __navigate?: ReturnType<import('react-router')['useNavigate']>;
   }
 }


### PR DESCRIPTION
This introduces a new global `__navigate` function connected to the current router. This is useful when swapping between routers (such as when opening/closing a file) or when doing menu actions from within Electron.

There’s still an issue here around how modals work. Presently, modals are represented as a linked list, with the user-visible URL displaying the URL of the topmost modal, and a chain of `locationPtr` objects in state that go through the open modals in order, before eventually ending up on the page that forms the backdrop of all open modals. This approach has a couple of downsides:

- If you refresh the page while a modal is open, the modal will fill the screen
  - This does not always happen; for example, the Create Account modal does not interact with the router at all, but the Create Schedule button does do this
  - Some modals (such as Create Schedule) break if they are opened before the page behind them can load
- Naïve components (including the sidebar) will lose the selected state because they only look at the URL of the topmost modal, while they should actually be looking at the last element of the linked location list.

Here are a couple of directions we could take to alleviate these issues:

- Switch to a query param (like `?modal[]=/schedule/discover&modal[]=/foo/bar`) that displays open modals in the URL while also preserving the full history chain upon reload
- Store the modal stack entirely in some sort of global state so that the URL never changes when opening a modal

What do you think about these options? (also, we can move this discussion to an issue/discord/another forum if desired)