### PR TITLE
Sync more often when using the API

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -28,6 +28,7 @@ export async function init(config = {}) {
 
 export async function shutdown() {
   if (actualApp) {
+    await actualApp.send('sync');
     await actualApp.send('close-budget');
     actualApp = null;
   }

--- a/packages/api/methods.js
+++ b/packages/api/methods.js
@@ -25,6 +25,10 @@ export async function downloadBudget(syncId, { password } = {}) {
   return send('api/download-budget', { syncId, password });
 }
 
+export async function sync() {
+  return send('api/sync');
+}
+
 export async function batchBudgetUpdates(func) {
   await send('api/batch-budget-start');
   try {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -198,6 +198,14 @@ handlers['api/download-budget'] = async function ({ syncId, password }) {
   }
 };
 
+handlers['api/sync'] = async function () {
+  let { id } = prefs.getPrefs();
+  let result = await handlers['sync-budget']({ id });
+  if (result.error) {
+    throw new Error(getSyncError(result.error, id));
+  }
+};
+
 handlers['api/start-import'] = async function ({ budgetName }) {
   // Notify UI to close budget
   await handlers['close-budget']();

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -163,7 +163,7 @@ handlers['api/download-budget'] = async function ({ syncId, password }) {
   );
   if (localBudget) {
     await handlers['load-budget']({ id: localBudget.id });
-    let result = await handlers['sync-budget']({ id: localBudget.id });
+    let result = await handlers['sync-budget']();
     if (result.error) {
       throw new Error(getSyncError(result.error, localBudget.id));
     }
@@ -200,7 +200,7 @@ handlers['api/download-budget'] = async function ({ syncId, password }) {
 
 handlers['api/sync'] = async function () {
   let { id } = prefs.getPrefs();
-  let result = await handlers['sync-budget']({ id });
+  let result = await handlers['sync-budget']();
   if (result.error) {
     throw new Error(getSyncError(result.error, id));
   }

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1891,7 +1891,7 @@ handlers['download-budget'] = async function ({ fileId }) {
 
   let id = result.id;
   await handlers['load-budget']({ id });
-  result = await handlers['sync-budget']({ id });
+  result = await handlers['sync-budget']();
   await handlers['close-budget']();
   if (result.error) {
     return result;
@@ -1900,7 +1900,7 @@ handlers['download-budget'] = async function ({ fileId }) {
 };
 
 // open and sync, but don’t close
-handlers['sync-budget'] = async function ({ id }) {
+handlers['sync-budget'] = async function () {
   setSyncingMode('enabled');
   await initialFullSync();
 

--- a/packages/loot-core/src/types/main.handlers.d.ts
+++ b/packages/loot-core/src/types/main.handlers.d.ts
@@ -287,7 +287,7 @@ export interface MainHandlers {
 
   'download-budget': (arg: { fileId; replace }) => Promise<{ error; id }>;
 
-  'sync-budget': (arg: { id }) => Promise<unknown>;
+  'sync-budget': () => Promise<Record<string, never>>;
 
   'load-budget': (arg: { id }) => Promise<{ error }>;
 

--- a/upcoming-release-notes/1075.md
+++ b/upcoming-release-notes/1075.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [j-f1]
 ---
 

--- a/upcoming-release-notes/1075.md
+++ b/upcoming-release-notes/1075.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [j-f1]
+---
+
+Add a new `sync` method to the API, also sync before shutting down.


### PR DESCRIPTION
- Sync before closing the budget
- Add an explicit `sync()` method to the API