### PR TITLE
fix parser bug where by goals couldn't repeat on months/years >9

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -24,9 +24,9 @@ expr
 
 repeat 'repeat interval'
   = 'month'i { return { annual: false } }
-  / months: d _ 'months'i { return { annual: false, repeat: +months } }
+  / months: positive _ 'months'i { return { annual: false, repeat: +months } }
   / 'year'i { return { annual: true } }
-  / years: d _ 'years'i { return { annual: true, repeat: +years } }
+  / years: positive _ 'years'i { return { annual: true, repeat: +years } }
 
 limit =  _? upTo _ amount: amount _ 'hold'i { return {amount: amount, hold: true } }
         / _? upTo _ amount: amount { return {amount: amount, hold: false } }
@@ -52,6 +52,7 @@ priority = '-'i number: number _ {return number}
 _ 'space' = ' '+
 d 'digit' = [0-9]
 number 'number' = $(d+)
+positive = $([1-9][0-9]*)
 amount 'amount' = currencySymbol? _? amount: $(d+ ('.' (d d?)?)?) { return +amount }
 percent 'percentage' = percent: $(d+) _? '%' { return +percent }
 year 'year' = $(d d d d)

--- a/upcoming-release-notes/1083.md
+++ b/upcoming-release-notes/1083.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: Fix bug that made repeat values >9 fail parsing.


### PR DESCRIPTION
Fix bug brought up in discord where `#template $100 by 2023-06 repeat every 12 months` would fail.

The parser was looking for a single digit so would max out at 9.

I added a new value to the parser "positive" that allows any number larger than 0, and used that for the by goals.

