### PR TITLE
Bug: Cleanup script

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -82,10 +82,11 @@ async function processCleanup(month) {
       `budget-${sinkCategory[c].cat.id}`,
     );
     let categoryId = sinkCategory[c].cat.id;
+    let weight = sinkCategory[c].temp.filter(w=> w.type === 'sink')[0].weight;
     let to_budget =
       budgeted +
       Math.round(
-        (sinkCategory[c].temp[0].weight / total_weight) * budgetAvailable,
+        (weight / total_weight) * budgetAvailable,
       );
     if (c === sinkCategory.length - 1) {
       let currentBudgetAvailable = await getSheetValue(sheetName, `to-budget`);

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -82,12 +82,9 @@ async function processCleanup(month) {
       `budget-${sinkCategory[c].cat.id}`,
     );
     let categoryId = sinkCategory[c].cat.id;
-    let weight = sinkCategory[c].temp.filter(w=> w.type === 'sink')[0].weight;
+    let weight = sinkCategory[c].temp.filter(w => w.type === 'sink')[0].weight;
     let to_budget =
-      budgeted +
-      Math.round(
-        (weight / total_weight) * budgetAvailable,
-      );
+      budgeted + Math.round((weight / total_weight) * budgetAvailable);
     if (c === sinkCategory.length - 1) {
       let currentBudgetAvailable = await getSheetValue(sheetName, `to-budget`);
       if (to_budget > currentBudgetAvailable) {

--- a/upcoming-release-notes/1084.md
+++ b/upcoming-release-notes/1084.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Fix error if sink/source were defined in same category.


### PR DESCRIPTION
The cleanup script could sometimes throw an error if 'sink' and 'source' were in the same category in the wrong order.  This PR filters out the 'source' line if it exists and only uses the first 'sink' template line if it exists.
