### PR TITLE
Goals: Cleanup script error

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -37,7 +37,7 @@ async function processCleanup(month) {
       if (template.filter(t => t.type === 'sink').length > 0) {
         sinkCategory.push({ cat: category, temp: template });
         num_sinks += 1;
-        total_weight += template[0].weight;
+        total_weight += template.filter(w => w.type === 'sink')[0].weight;
       }
     }
   }

--- a/upcoming-release-notes/1095.md
+++ b/upcoming-release-notes/1095.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Fixes an error when 'sink' and 'source' are in the same category.


### PR DESCRIPTION
There was one more location where the cleanup script could generate an error.  This should fully resolve the error, along with https://github.com/actualbudget/actual/pull/1084.