### PR TITLE
Goals: Remainder option

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -15,12 +15,14 @@ expr
       priority: +priority
     } }
   / priority: priority? _? monthly: amount limit: limit?
-    { return { type: 'simple', monthly, limit, priority: +priority  } } 
+    { return { type: 'simple', monthly, limit, priority: +priority } }
   / priority: priority? _? limit: limit
     { return { type: 'simple', limit , priority: +priority } }
   / priority: priority? _? schedule _ full:full? name: name
-  	{ return { type: 'schedule', name, priority: +priority, full } }
-  
+    { return { type: 'schedule', name, priority: +priority, full } }
+  / priority: priority? _? remainder: remainder
+    { return { type: 'remainder', priority: null, weight: remainder } }
+
 
 repeat 'repeat interval'
   = 'month'i { return { annual: false } }
@@ -48,6 +50,7 @@ upTo = 'up'i _ 'to'i
 schedule = 'schedule'i
 full = 'full'i _ {return true}
 priority = '-'i number: number _ {return number}
+remainder = 'remainder'i _? weight: positive? { return +weight || 1 }
 
 _ 'space' = ' '+
 d 'digit' = [0-9]

--- a/upcoming-release-notes/1101.md
+++ b/upcoming-release-notes/1101.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Goals:  Add remainder option to budget all extra funds automatically.


### PR DESCRIPTION
Added the option to add a remainder goal template.  This will use the remaining available funds and dump them into the respective category. There is optional weighting.  The remainder templates will be forced to the lowest priority as to run after all other templates.

Usage: `#template remainder <weight>`  Add the template line to any categories you want to catch any remaining funds such as savings.  The amount added to the category will equal `remaining_budget/total_of_weights*weight`. The default weight is 1.
