### PR TITLE
:wrench: (cross-env) add missing dep and upgrade all to same version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postinstall": "patch-package"
   },
   "devDependencies": {
-    "cross-env": "^5.1.5",
+    "cross-env": "^7.0.3",
     "eslint": "^8.37.0",
     "eslint-config-react-app": "7.0.1",
     "eslint-plugin-prettier": "4.2.1",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@electron/notarize": "1.2.3",
     "@electron/rebuild": "3.2.13",
+    "cross-env": "^7.0.3",
     "electron": "24.1.3",
     "electron-builder": "23.6.0"
   }

--- a/upcoming-release-notes/1106.md
+++ b/upcoming-release-notes/1106.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Align `cross-env` versions in all packages; add it to `desktop-electron`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5003,7 +5003,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "actual@workspace:."
   dependencies:
-    cross-env: ^5.1.5
+    cross-env: ^7.0.3
     eslint: ^8.37.0
     eslint-config-react-app: 7.0.1
     eslint-plugin-prettier: 4.2.1
@@ -7280,18 +7280,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-env@npm:^5.1.5":
-  version: 5.2.1
-  resolution: "cross-env@npm:5.2.1"
-  dependencies:
-    cross-spawn: ^6.0.5
-  bin:
-    cross-env: dist/bin/cross-env.js
-    cross-env-shell: dist/bin/cross-env-shell.js
-  checksum: 364f72482f0d6b65c6d560b942ce9da7e71ea66ec2eaa8226f7127b49094355277aadd23e6ff922c1d154a6ab1ad828ebc4ec8af9b44a39936d9013fb23ae4df
-  languageName: node
-  linkType: hard
-
 "cross-env@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-env@npm:7.0.3"
@@ -8068,6 +8056,7 @@ __metadata:
   dependencies:
     "@electron/notarize": 1.2.3
     "@electron/rebuild": 3.2.13
+    cross-env: ^7.0.3
     electron: 24.1.3
     electron-builder: 23.6.0
     electron-is-dev: 2.0.0


### PR DESCRIPTION
1. Upgrade all `cross-env` versions to be the same
2. Added `cross-env` to `desktop-electron` - it was used there, but was missing as a dep