### PR TITLE
BUGFIX Unused Payees: Corrected an issue where the filter control was not being referenced

### DIFF
--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -528,6 +528,7 @@ export const ManagePayees = forwardRef(
           </View>
           <View style={{ flex: 1 }} />
           <Input
+            id="filter-input"
             placeholder="Filter payees..."
             value={filter}
             onChange={e => {

--- a/upcoming-release-notes/1107.md
+++ b/upcoming-release-notes/1107.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [SudoCerb]
+---
+
+Corrected an issue where toggling the "Show unused payees"/"Show all payees" button would raise a compilation error.


### PR DESCRIPTION
Hi there,

The unused payees button broke in between the initial PR and now - and here's a fix!