### PR TITLE
Partition GitHub Actions cache based on Node version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
       id: cache
       with:
         path: '**/node_modules'
-        key: yarn-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+        key: yarn-v1-${{ runner.os }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('**/yarn.lock') }}
     - name: Install
       run: yarn --immutable
       shell: bash

--- a/upcoming-release-notes/1118.md
+++ b/upcoming-release-notes/1118.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Partition GitHub Actions cache based on Node version


### PR DESCRIPTION
This should fix the test failures on `master` — currently tests are failing because the cache was created with an old version of Node.