### PR TITLE
:bug: (nordigen) perform status check only if server is online

### DIFF
--- a/packages/desktop-client/src/hooks/useNordigenStatus.ts
+++ b/packages/desktop-client/src/hooks/useNordigenStatus.ts
@@ -2,9 +2,12 @@ import { useEffect, useState } from 'react';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 
+import useSyncServerStatus from './useSyncServerStatus';
+
 export default function useNordigenStatus() {
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [status] = useSyncServerStatus();
 
   useEffect(() => {
     async function fetch() {
@@ -16,8 +19,10 @@ export default function useNordigenStatus() {
       setIsLoading(false);
     }
 
-    fetch();
-  }, [setConfigured, setIsLoading]);
+    if (status === 'online') {
+      fetch();
+    }
+  }, [status]);
 
   return {
     configured,

--- a/upcoming-release-notes/1127.md
+++ b/upcoming-release-notes/1127.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Nordigen: do not perform status check if server is offline


### PR DESCRIPTION
Small bugfix for nordigen.

Do not perform the server status check if the user is actually offline.