### PR TITLE
:bug: (nordigen) expired bank-links

### DIFF
--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 
 import * as actions from 'loot-core/src/client/actions';
 
@@ -50,16 +51,13 @@ function getErrorMessage(type, code) {
 }
 
 function AccountSyncCheck({
-  id,
+  match: {
+    params: { id },
+  },
   accounts,
   failedAccounts,
-  syncAndDownload,
-  markAccountSuccess,
   unlinkAccount,
   pushModal,
-  closeModal,
-  getAccounts,
-  addNotification,
 }) {
   let [open, setOpen] = useState(false);
   if (!failedAccounts) {
@@ -145,10 +143,12 @@ function AccountSyncCheck({
   );
 }
 
-export default connect(
-  state => ({
-    accounts: state.queries.accounts,
-    failedAccounts: state.account.failedAccounts,
-  }),
-  actions,
-)(AccountSyncCheck);
+export default withRouter(
+  connect(
+    state => ({
+      accounts: state.queries.accounts,
+      failedAccounts: state.account.failedAccounts,
+    }),
+    actions,
+  )(AccountSyncCheck),
+);

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import * as actions from 'loot-core/src/client/actions';
 
@@ -51,14 +51,12 @@ function getErrorMessage(type, code) {
 }
 
 function AccountSyncCheck({
-  match: {
-    params: { id },
-  },
   accounts,
   failedAccounts,
   unlinkAccount,
   pushModal,
 }) {
+  let { id } = useParams();
   let [open, setOpen] = useState(false);
   if (!failedAccounts) {
     return null;
@@ -143,12 +141,10 @@ function AccountSyncCheck({
   );
 }
 
-export default withRouter(
-  connect(
-    state => ({
-      accounts: state.queries.accounts,
-      failedAccounts: state.account.failedAccounts,
-    }),
-    actions,
-  )(AccountSyncCheck),
-);
+export default connect(
+  state => ({
+    accounts: state.queries.accounts,
+    failedAccounts: state.account.failedAccounts,
+  }),
+  actions,
+)(AccountSyncCheck);

--- a/packages/desktop-client/src/hooks/useNordigenStatus.ts
+++ b/packages/desktop-client/src/hooks/useNordigenStatus.ts
@@ -7,7 +7,7 @@ import useSyncServerStatus from './useSyncServerStatus';
 export default function useNordigenStatus() {
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [status] = useSyncServerStatus();
+  const status = useSyncServerStatus();
 
   useEffect(() => {
     async function fetch() {

--- a/upcoming-release-notes/1133.md
+++ b/upcoming-release-notes/1133.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Nordigen: fix bank-sync expiry functionality


### PR DESCRIPTION
Further Nordigen fixes for expired bank-links. With the recent changes to the router, we had broken this functionality.

<img width="488" alt="Screenshot 2023-06-14 at 09 00 21" src="https://github.com/actualbudget/actual/assets/886567/8e7516e0-121a-46e0-9e52-24748b161173">
<img width="437" alt="Screenshot 2023-06-14 at 09 00 30" src="https://github.com/actualbudget/actual/assets/886567/88b36549-1073-4269-b42f-1553c164316f">
