### PR TITLE
Strip a trailing slash off of server URLs

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1776,9 +1776,7 @@ handlers['set-server-url'] = async function ({ url, validate = true }) {
   if (url == null) {
     await asyncStorage.removeItem('user-token');
   } else {
-    if (url.endsWith('/')) {
-      url = url.slice(0, -1);
-    }
+    url = url.replace(/\/+$/, '');
 
     if (validate) {
       // Validate the server is running

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1776,6 +1776,10 @@ handlers['set-server-url'] = async function ({ url, validate = true }) {
   if (url == null) {
     await asyncStorage.removeItem('user-token');
   } else {
+    if (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+
     if (validate) {
       // Validate the server is running
       let { error } = await runHandler(handlers['subscribe-needs-bootstrap'], {

--- a/upcoming-release-notes/1140.md
+++ b/upcoming-release-notes/1140.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Automatically remove a trailing slash from server URLs before saving them


### PR DESCRIPTION
URLs with the trailing slash don’t work well — requests end up being made to `https://example.com//sync/sync` and such which can 404