### PR TITLE
Expand / collapse all categories

### DIFF
--- a/packages/desktop-client/src/components/budget/misc.js
+++ b/packages/desktop-client/src/components/budget/misc.js
@@ -181,6 +181,15 @@ class BudgetTable extends Component {
     });
   };
 
+  expandAllCategories = () => {
+    this.props.setCollapsed([]);
+  };
+
+  collapseAllCategories = () => {
+    let { setCollapsed, categoryGroups } = this.props;
+    setCollapsed(categoryGroups.map(g => g.id));
+  };
+
   render() {
     let {
       type,
@@ -253,6 +262,8 @@ class BudgetTable extends Component {
           <BudgetTotals
             MonthComponent={dataComponents.BudgetTotalsComponent}
             toggleHiddenCategories={this.toggleHiddenCategories}
+            expandAllCategories={this.expandAllCategories}
+            collapseAllCategories={this.collapseAllCategories}
           />
           <IntersectionBoundary.Provider value={this.budgetCategoriesRef}>
             <View
@@ -658,6 +669,8 @@ function RenderMonths({ component: Component, editingIndex, args, style }) {
 const BudgetTotals = memo(function BudgetTotals({
   MonthComponent,
   toggleHiddenCategories,
+  expandAllCategories,
+  collapseAllCategories,
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
@@ -714,6 +727,10 @@ const BudgetTotals = memo(function BudgetTotals({
                 onMenuSelect={type => {
                   if (type === 'toggleVisibility') {
                     toggleHiddenCategories();
+                  } else if (type === 'expandAllCategories') {
+                    expandAllCategories();
+                  } else if (type === 'collapseAllCategories') {
+                    collapseAllCategories();
                   }
                   setMenuOpen(false);
                 }}
@@ -721,6 +738,14 @@ const BudgetTotals = memo(function BudgetTotals({
                   {
                     name: 'toggleVisibility',
                     text: 'Toggle hidden categories',
+                  },
+                  {
+                    name: 'expandAllCategories',
+                    text: 'Expand all categories',
+                  },
+                  {
+                    name: 'collapseAllCategories',
+                    text: 'Collapse all categories',
                   },
                 ]}
               />

--- a/packages/desktop-client/src/components/budget/misc.js
+++ b/packages/desktop-client/src/components/budget/misc.js
@@ -737,15 +737,15 @@ const BudgetTotals = memo(function BudgetTotals({
                 items={[
                   {
                     name: 'toggleVisibility',
-                    text: 'Toggle hidden categories',
+                    text: 'Toggle hidden',
                   },
                   {
                     name: 'expandAllCategories',
-                    text: 'Expand all categories',
+                    text: 'Expand all',
                   },
                   {
                     name: 'collapseAllCategories',
-                    text: 'Collapse all categories',
+                    text: 'Collapse all',
                   },
                 ]}
               />

--- a/upcoming-release-notes/1143.md
+++ b/upcoming-release-notes/1143.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Expand / collapse all categories


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

This PR is for the first item listed in #559: `Expand All / Collapse All Categories`

For the expand / collapse all categories functionality, I was choosing between having a single `Expand / collapse all categories` button or one for each: `Expand all categories` and `Collapse all categories` buttons. 

For the initial implementation, I have opted with the latter. Please let me know which one is the right way to go or if there are other suggestions and I'll just accordingly.

![image](https://github.com/actualbudget/actual/assets/20313680/64d0e498-1139-4dd0-9b7f-4d478ab947aa)
