### PR TITLE
:bug:  remove 'we have been notified' copy

### DIFF
--- a/packages/desktop-client/src/components/manager/Import.js
+++ b/packages/desktop-client/src/components/manager/Import.js
@@ -8,7 +8,7 @@ function getErrorMessage(error) {
     case 'not-ynab4':
       return 'This file is not valid. Please select a .ynab4 file';
     default:
-      return 'An unknown error occurred while importing. Sorry! We have been notified of this issue.';
+      return 'An unknown error occurred while importing. Please report this as a new issue on Github.';
   }
 }
 

--- a/packages/desktop-client/src/components/manager/ImportActual.js
+++ b/packages/desktop-client/src/components/manager/ImportActual.js
@@ -19,7 +19,7 @@ function getErrorMessage(error) {
     case 'invalid-metadata-file':
       return 'The metadata file in the given archive is corrupted.';
     default:
-      return 'An unknown error occurred while importing. Sorry! We have been notified of this issue.';
+      return 'An unknown error occurred while importing. Please report this as a new issue on Github.';
   }
 }
 

--- a/packages/desktop-client/src/components/manager/ImportYNAB4.js
+++ b/packages/desktop-client/src/components/manager/ImportYNAB4.js
@@ -11,7 +11,7 @@ function getErrorMessage(error) {
     case 'not-ynab4':
       return 'This file is not valid. Please select a compressed ynab4 zip file.';
     default:
-      return 'An unknown error occurred while importing. Sorry! We have been notified of this issue.';
+      return 'An unknown error occurred while importing. Please report this as a new issue on Github.';
   }
 }
 

--- a/packages/desktop-client/src/components/manager/ImportYNAB5.js
+++ b/packages/desktop-client/src/components/manager/ImportYNAB5.js
@@ -20,7 +20,7 @@ function getErrorMessage(error) {
     case 'not-ynab5':
       return 'This file is not valid. Please select a JSON file exported from nYNAB.';
     default:
-      return 'An unknown error occurred while importing. Sorry! We have been notified of this issue.';
+      return 'An unknown error occurred while importing. Please report this as a new issue on Github.';
   }
 }
 

--- a/packages/loot-core/src/client/actions/notifications.ts
+++ b/packages/loot-core/src/client/actions/notifications.ts
@@ -16,7 +16,7 @@ export function addGenericErrorNotification() {
     type: 'error',
     message:
       'Something internally went wrong. You may want to restart the app if anything looks wrong. ' +
-      'We have been notified of the issue and will try to fix it soon.',
+      'Please report this as a new issue on Github.',
   });
 }
 

--- a/upcoming-release-notes/1155.md
+++ b/upcoming-release-notes/1155.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove misleading 'we have been notified' error messages


### PR DESCRIPTION
Closes #1069

I've not actually tested this change. Which is why I'm not changing it to direct links (as they might not work).

Instead I'm just applying a very quick patch so the message would not be misleading anymore.