### PR TITLE
Add OpenID Connect authentication

### DIFF
--- a/packages/desktop-client/src/components/manager/ManagementApp.js
+++ b/packages/desktop-client/src/components/manager/ManagementApp.js
@@ -21,6 +21,7 @@ import Bootstrap from './subscribe/Bootstrap';
 import ChangePassword from './subscribe/ChangePassword';
 import Error from './subscribe/Error';
 import Login from './subscribe/Login';
+import OpenIdCallback from './subscribe/OpenIdCallback';
 import WelcomeScreen from './WelcomeScreen';
 
 function Version() {
@@ -194,6 +195,9 @@ function ManagementApp({
               <Switch>
                 <Route exact path="/login">
                   <Login />
+                </Route>
+                <Route exact path="/login/openid-cb">
+                  <OpenIdCallback />
                 </Route>
                 <Route exact path="/error">
                   <Error />

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 
 import { createBudget } from 'loot-core/src/client/actions/budgets';
-import { loggedIn } from 'loot-core/src/client/actions/user';
 import { send } from 'loot-core/src/platform/client/fetch';
 
 import { colors } from '../../../style';
@@ -16,6 +16,7 @@ export default function Bootstrap() {
   let [error, setError] = useState(null);
 
   let { checked } = useBootstrapped();
+  let history = useHistory();
 
   function getErrorMessage(error) {
     switch (error) {
@@ -37,7 +38,7 @@ export default function Bootstrap() {
     if (error) {
       setError(error);
     } else {
-      dispatch(loggedIn());
+      history.push('/login');
     }
   }
 

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -125,11 +125,10 @@ export default function Login() {
       )}
 
       {loginMethods.includes('openid') && (
-        <form
-          style={{ display: 'flex', flexDirection: 'row', marginTop: 30 }}
-          onSubmit={onSubmitOpenId}
-        >
-          <Button style={{ fontSize: 15 }}>Sign in with OpenId</Button>
+        <form onSubmit={onSubmitOpenId}>
+          <Button primary style={{ fontSize: 15 }}>
+            Sign in with OpenId
+          </Button>
         </form>
       )}
 

--- a/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { loggedIn } from 'loot-core/src/client/actions/user';
+import { send } from 'loot-core/src/platform/client/fetch';
+
+export default function OpenIdCallback() {
+  let dispatch = useDispatch();
+  useEffect(() => {
+    const token = new URLSearchParams(window.location.search).get('token');
+    send('subscribe-set-token', { token }).then(() => {
+      dispatch(loggedIn());
+    });
+  });
+  return null;
+}

--- a/packages/desktop-client/src/components/manager/subscribe/OpenIdForm.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/OpenIdForm.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import { ButtonWithLoading } from '../../common';
+import { useServerURL } from '../../ServerContext';
+
+import { Input } from './common';
+
+export function OpenIdForm({ onSetOpenId, onError }) {
+  let [issuer, setIssuer] = useState('');
+  let [clientId, setClientId] = useState('');
+  let [clientSecret, setClientSecret] = useState('');
+  let serverUrl = useServerURL();
+
+  let [loading, setLoading] = useState(false);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (loading) {
+      return;
+    }
+
+    setLoading(true);
+    await onSetOpenId({
+      issuer,
+      client_id: clientId,
+      client_secret: clientSecret,
+      server_hostname: serverUrl,
+    });
+    setLoading(false);
+  }
+
+  console.log(onSubmit, onError);
+  return (
+    <form
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        marginTop: 30,
+      }}
+      onSubmit={onSubmit}
+    >
+      <Input
+        placeholder="OpenID server"
+        type="text"
+        value={issuer}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setIssuer(e.target.value)
+        }
+      />
+      <Input
+        placeholder="Client ID"
+        type="text"
+        value={clientId}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setClientId(e.target.value)
+        }
+        style={{ marginTop: 10 }}
+      />
+      <Input
+        placeholder="Client secret"
+        type="text"
+        value={clientSecret}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setClientSecret(e.target.value)
+        }
+        style={{ marginTop: 10 }}
+      />
+
+      <ButtonWithLoading primary loading={loading} style={{ marginTop: 15 }}>
+        OK
+      </ButtonWithLoading>
+    </form>
+  );
+}

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1647,9 +1647,9 @@ handlers['subscribe-needs-bootstrap'] = async function ({
   return { bootstrapped: res.data.bootstrapped, hasServer: true };
 };
 
-handlers['subscribe-bootstrap'] = async function ({ password }) {
+handlers['subscribe-bootstrap'] = async function (loginConfig) {
   try {
-    await post(getServer().SIGNUP_SERVER + '/bootstrap', { password });
+    await post(getServer().SIGNUP_SERVER + '/bootstrap', loginConfig);
   } catch (err) {
     return { error: err.reason || 'network-failure' };
   }

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1648,18 +1648,12 @@ handlers['subscribe-needs-bootstrap'] = async function ({
 };
 
 handlers['subscribe-bootstrap'] = async function ({ password }) {
-  let res;
   try {
-    res = await post(getServer().SIGNUP_SERVER + '/bootstrap', { password });
+    await post(getServer().SIGNUP_SERVER + '/bootstrap', { password });
   } catch (err) {
     return { error: err.reason || 'network-failure' };
   }
-
-  if (res.token) {
-    await asyncStorage.setItem('user-token', res.token);
-    return {};
-  }
-  return { error: 'internal' };
+  return {};
 };
 
 handlers['subscribe-get-login-methods'] = async function () {

--- a/packages/loot-core/src/types/main-handlers.d.ts
+++ b/packages/loot-core/src/types/main-handlers.d.ts
@@ -255,6 +255,8 @@ export interface MainHandlers {
     { error: string } | { bootstrapped: unknown; hasServer: boolean }
   >;
 
+  'subscribe-get-login-methods': () => Promise<{ methods: [string] }>;
+
   'subscribe-bootstrap': (arg: { password }) => Promise<{ error: string }>;
 
   'subscribe-get-user': () => Promise<{ offline: boolean } | null>;
@@ -265,7 +267,13 @@ export interface MainHandlers {
 
   'subscribe-sign-in': (arg: { password }) => Promise<{ error: string }>;
 
+  'subscribe-sign-in-openid': (arg: {
+    return_url: URL;
+  }) => Promise<{ error: string } | { redirect_url: URL }>;
+
   'subscribe-sign-out': () => Promise<'ok'>;
+
+  'subscribe-set-token': (arg: { token: string }) => Promise<null>;
 
   'get-server-version': () => Promise<{ error: string } | { version: string }>;
 

--- a/packages/loot-core/src/types/main-handlers.d.ts
+++ b/packages/loot-core/src/types/main-handlers.d.ts
@@ -257,7 +257,7 @@ export interface MainHandlers {
 
   'subscribe-get-login-methods': () => Promise<{ methods: [string] }>;
 
-  'subscribe-bootstrap': (arg: { password }) => Promise<{ error: string }>;
+  'subscribe-bootstrap': (arg: { password }) => Promise<{ error: string } | null>;
 
   'subscribe-get-user': () => Promise<{ offline: boolean } | null>;
 

--- a/packages/loot-core/src/types/main-handlers.d.ts
+++ b/packages/loot-core/src/types/main-handlers.d.ts
@@ -257,7 +257,15 @@ export interface MainHandlers {
 
   'subscribe-get-login-methods': () => Promise<{ methods: [string] }>;
 
-  'subscribe-bootstrap': (arg: { password }) => Promise<{ error: string } | null>;
+  'subscribe-bootstrap': (arg: {
+    password?: string;
+    openid?: {
+      issuer: string;
+      client_id: string;
+      client_secret: string;
+      server_hostname: string;
+    };
+  }) => Promise<{ error: string } | null>;
 
   'subscribe-get-user': () => Promise<{ offline: boolean } | null>;
 


### PR DESCRIPTION
Partially addresses #61 and #515 by adding support for OpenID Connect and generally a more flexible approach to authenticating with the server.

The flow of the bootstrap/login process is
- client sends `/bootstrap` request which now accepts an additional parameter `openid: {issuer, client_id, client_secret, server_hostname}`.
- client can request `GET /login-methods` to receive a list of supported login methods (currently password or openid)
- client sends `POST /login-openid` with `return_url` parameter (pointing back to the frontend), server returns `redirect_url` leading to the openid issuer, client redirects
- user authenticates with openid provider, which redirects to `/login-openid/cb` on server
- server verifies openid authentication, then redirects to `/login/openid-cb` on client, passing the token
- client saves token and registers sign in

Some of the changes in the code and not backwards compatible (most importantly server SQL schema and /account/bootstrap behavior). I'm not sure what the project's approach to such changes is - it might be possible to add in special cases to allow a client to connect to an older server. However, this might not be necessary if users are expected to self-host instances and upgrade the server and client in tandem.
A more pressing issue is database schema migration - I couldn't find any precedent for how this is done in the server so I would appreciate the maintainer's view on the best approach to do this.

For a user that doesn't use OpenID, this PR slightly changes the bootstrap behavior for passwords as well. Namely, after setting up the password in /bootstrap, the user isn't instantly granted access but instead redirected to /login. This is quite an important change for OpenID as otherwise the user has no way of knowing whether the OpenID configuration works at all. In the case of password authentication, misconfiguration is less likely but nevertheless double-checking the user remembers the password doesn't seem too inconvenient to me.

I am not very familiar with React, so let me know if I have broken any coding conventions. Likewise with web design, I welcome improvements to the presentation of the login/bootstrap screens.