### PR TITLE
Fix “delete file” modal layout

### DIFF
--- a/packages/desktop-client/src/components/manager/DeleteFile.js
+++ b/packages/desktop-client/src/components/manager/DeleteFile.js
@@ -39,9 +39,10 @@ export default function DeleteMenu({ modalProps, actions, file }) {
         <View
           style={{
             padding: 15,
+            gap: 15,
             paddingTop: 0,
             paddingBottom: 25,
-            width: 500,
+            maxWidth: 512,
             lineHeight: '1.5em',
           }}
         >
@@ -61,7 +62,6 @@ export default function DeleteMenu({ modalProps, actions, file }) {
                   backgroundColor: colors.r4,
                   alignSelf: 'center',
                   border: 0,
-                  marginTop: 10,
                   padding: '10px 30px',
                   fontSize: 14,
                 }}
@@ -74,32 +74,28 @@ export default function DeleteMenu({ modalProps, actions, file }) {
 
           {file.id && (
             <>
-              <Text style={[isRemote && { marginTop: 20 }]}>
-                {isRemote ? (
-                  <Text>
-                    You can also delete just the local copy. This will remove
-                    all local data and the file will be listed as available for
-                    download.
-                  </Text>
-                ) : (
-                  <Text>
-                    {file.state === 'broken' ? (
-                      <Text>
-                        This is a <strong>hosted file</strong> but it was
-                        created by another user. You can only delete the local
-                        copy.
-                      </Text>
-                    ) : (
-                      <Text>
-                        This a <strong>local file</strong> which is not stored
-                        on a server.
-                      </Text>
-                    )}{' '}
-                    Deleting it will remove it and all of its backups
-                    permanently.
-                  </Text>
-                )}
-              </Text>
+              {isRemote ? (
+                <Text>
+                  You can also delete just the local copy. This will remove all
+                  local data and the file will be listed as available for
+                  download.
+                </Text>
+              ) : (
+                <Text>
+                  {file.state === 'broken' ? (
+                    <>
+                      This is a <strong>hosted file</strong> but it was created
+                      by another user. You can only delete the local copy.
+                    </>
+                  ) : (
+                    <>
+                      This a <strong>local file</strong> which is not stored on
+                      a server.
+                    </>
+                  )}{' '}
+                  Deleting it will remove it and all of its backups permanently.
+                </Text>
+              )}
 
               <ButtonWithLoading
                 primary={!isRemote}

--- a/upcoming-release-notes/1066.md
+++ b/upcoming-release-notes/1066.md
@@ -1,6 +1,6 @@
 ---
 category: Maintenance
-authors: [trevdor]
+authors: [trevdor, j-f1]
 ---
 
 Upgrade to react-router v6 and adopt v6 routing conventions.

--- a/upcoming-release-notes/1170.md
+++ b/upcoming-release-notes/1170.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix “delete file” modal layout


### PR DESCRIPTION
- on desktop, it was 500px instead of 512px wide which left it positioned left of center
- on mobile, it was also 500px wide which overflowed the screen
