### PR TITLE
Fix navigating to the per-category per-month page

### DIFF
--- a/packages/desktop-client/src/components/budget/index.js
+++ b/packages/desktop-client/src/components/budget/index.js
@@ -332,8 +332,7 @@ class Budget extends PureComponent {
   };
 
   onShowActivity = (categoryName, categoryId, month) => {
-    this.props.navigate({
-      pathname: '/accounts',
+    this.props.navigate('/accounts', {
       state: {
         goBack: true,
         filterName: `${categoryName} (${monthUtils.format(


### PR DESCRIPTION
I checked through other references to `navigate` and none of them appeared to be affected.