### PR TITLE
Fix completed feature request handling

### DIFF
--- a/.github/workflows/issues-feature-implemented.yml
+++ b/.github/workflows/issues-feature-implemented.yml
@@ -3,6 +3,9 @@ name: Handle completed feature requests
 on:
   pull_request:
     types: [closed]
+    
+permissions:
+  issues: write
 
 jobs:
   handle-feature-requests:

--- a/upcoming-release-notes/1183.md
+++ b/upcoming-release-notes/1183.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Fix automatic comment on completed feature requests


### PR DESCRIPTION
I noticed that this run failed: https://github.com/actualbudget/actual/actions/runs/5366199111/jobs/9735490726

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
