### PR TITLE
Add public/data to .eslintignore in desktop-client

### DIFF
--- a/packages/desktop-client/.eslintignore
+++ b/packages/desktop-client/.eslintignore
@@ -1,5 +1,6 @@
 bundle.browser.js
 build/
 public/kcab/
+public/data/
 **/node_modules/*
 node_modules/

--- a/upcoming-release-notes/1199.md
+++ b/upcoming-release-notes/1199.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Add `public/data` to `.eslintignore` in `desktop-client`


### PR DESCRIPTION
This fixes an error that you’ll  see about an unused export if you build before linting.