### PR TITLE
Update .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 packages/api/app/bundle.api.js
 packages/api/dist
+packages/api/migrations
 
 packages/crdt/dist
 


### PR DESCRIPTION
The real migration files exist in `loot-core`. These are just copies.