### PR TITLE
Fix importing transfers from YNAB4/5

### DIFF
--- a/packages/import-ynab4/importer.js
+++ b/packages/import-ynab4/importer.js
@@ -222,6 +222,7 @@ async function importTransactions(data, entityIdMap) {
             transaction.subTransactions &&
             transaction.subTransactions.map((t, i) => {
               return {
+                id: entityIdMap.get(t.entityId),
                 amount: amountToInteger(t.amount),
                 category: getCategory(t.categoryId),
                 notes: t.memo || null,

--- a/packages/import-ynab5/importer.js
+++ b/packages/import-ynab5/importer.js
@@ -164,6 +164,9 @@ async function importTransactions(data, entityIdMap) {
   for (let transaction of data.transactions) {
     entityIdMap.set(transaction.id, uuidv4());
   }
+  for (let transaction of data.subtransactions) {
+    entityIdMap.set(transaction.id, uuidv4());
+  }
 
   await Promise.all(
     Object.keys(transactionsGrouped).map(async accountId => {
@@ -180,6 +183,7 @@ async function importTransactions(data, entityIdMap) {
           if (subtransactions) {
             subtransactions = subtransactions.map(subtrans => {
               return {
+                id: entityIdMap.get(subtrans.id),
                 amount: amountFromYnab(subtrans.amount),
                 category: entityIdMap.get(subtrans.category_id) || null,
                 notes: subtrans.memo,

--- a/upcoming-release-notes/1224.md
+++ b/upcoming-release-notes/1224.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Imports from YNAB4/nYNAB will now link transfer transactions correctly


### PR DESCRIPTION
Fixes #1220. Previously, the importer wasn’t correctly setting the ID of subtransactions on split transactions. This was mostly fine since the ID wasn’t used for much, but as shown in the referenced issue, if a subtransaction is a transfer, it won’t be correctly matched with its pair in the other account. Future imports will now handle this correctly. I’m not sure if there is a way we could detect and fix this in existing budgets.