### PR TITLE
:sparkles:  add netlify development banner

### DIFF
--- a/packages/desktop-client/config-overrides.js
+++ b/packages/desktop-client/config-overrides.js
@@ -15,8 +15,9 @@ if (process.env.CI) {
 }
 
 // Forward Netlify env variables
-if (process.env.REVIEW_ID)
+if (process.env.REVIEW_ID) {
   process.env.REACT_APP_REVIEW_ID = process.env.REVIEW_ID;
+}
 
 module.exports = {
   webpack: override(

--- a/packages/desktop-client/config-overrides.js
+++ b/packages/desktop-client/config-overrides.js
@@ -14,6 +14,10 @@ if (process.env.CI) {
   process.env.DISABLE_ESLINT_PLUGIN = 'true';
 }
 
+// Forward Netlify env variables
+if (process.env.REVIEW_ID)
+  process.env.REACT_APP_REVIEW_ID = process.env.REVIEW_ID;
+
 module.exports = {
   webpack: override(
     babelInclude([path.resolve('src'), path.resolve('../loot-core')]),

--- a/packages/desktop-client/src/components/App.js
+++ b/packages/desktop-client/src/components/App.js
@@ -14,6 +14,7 @@ import { ResponsiveProvider } from '../ResponsiveProvider';
 import { styles, hasHiddenScrollbars } from '../style';
 
 import AppBackground from './AppBackground';
+import DevelopmentTopBar from './DevelopmentTopBar';
 import FatalError from './FatalError';
 import FinancesApp from './FinancesApp';
 import ManagementApp from './manager/ManagementApp';
@@ -103,6 +104,8 @@ class App extends Component {
             styles.lightScrollbar,
           ])}
         >
+          {process.env.REACT_APP_REVIEW_ID && <DevelopmentTopBar />}
+
           {fatalError ? (
             <>
               <AppBackground />

--- a/packages/desktop-client/src/components/DevelopmentTopBar.tsx
+++ b/packages/desktop-client/src/components/DevelopmentTopBar.tsx
@@ -15,15 +15,16 @@ export default function DevelopmentTopBar() {
           color: colors.y2,
           backgroundColor: colors.y8,
           borderBottom: `1px solid ${colors.y6}`,
+          zIndex: 1,
         },
       ]}
     >
-      <View>This is a development build of Actual.</View>
+      <View>This is a demo build of Actual.</View>
       <View>
         <ExternalLink
           to={`https://github.com/actualbudget/actual/pull/${process.env.REACT_APP_REVIEW_ID}`}
         >
-          Open the PR: #{process.env.REVIEW_ID}
+          Open the PR: #{process.env.REACT_APP_REVIEW_ID}
         </ExternalLink>
       </View>
     </View>

--- a/packages/desktop-client/src/components/DevelopmentTopBar.tsx
+++ b/packages/desktop-client/src/components/DevelopmentTopBar.tsx
@@ -1,0 +1,31 @@
+import { colors } from '../style';
+
+import { ExternalLink } from './common';
+import View from './common/View';
+
+export default function DevelopmentTopBar() {
+  return (
+    <View
+      style={[
+        {
+          padding: '6px 20px',
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          color: colors.y2,
+          backgroundColor: colors.y8,
+          borderBottom: `1px solid ${colors.y6}`,
+        },
+      ]}
+    >
+      <View>This is a development build of Actual.</View>
+      <View>
+        <ExternalLink
+          to={`https://github.com/actualbudget/actual/pull/${process.env.REACT_APP_REVIEW_ID}`}
+        >
+          Open the PR: #{process.env.REVIEW_ID}
+        </ExternalLink>
+      </View>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/FatalError.js
+++ b/packages/desktop-client/src/components/FatalError.js
@@ -39,7 +39,7 @@ class FatalError extends Component {
           does not support <code>SharedArrayBuffer</code>, or your server is not
           sending the appropriate headers, or you are not using HTTPS. See{' '}
           <ExternalLink
-            muted
+            linkColor="muted"
             to="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
           >
             our troubleshooting documentation
@@ -55,7 +55,10 @@ class FatalError extends Component {
         <Text>
           There was a problem loading the app in this browser version. If this
           continues to be a problem, you can{' '}
-          <ExternalLink muted to="https://github.com/actualbudget/releases">
+          <ExternalLink
+            linkColor="muted"
+            to="https://github.com/actualbudget/releases"
+          >
             download the desktop app
           </ExternalLink>
           .
@@ -83,7 +86,10 @@ class FatalError extends Component {
           <Text>{msg}</Text>
           <Text>
             Please get{' '}
-            <ExternalLink muted to="https://actualbudget.org/contact">
+            <ExternalLink
+              linkColor="muted"
+              to="https://actualbudget.org/contact"
+            >
               in touch
             </ExternalLink>{' '}
             for support

--- a/upcoming-release-notes/1229.md
+++ b/upcoming-release-notes/1229.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Added a Netlify banner for easy jumping back to the PR


### PR DESCRIPTION
Adding a Netlify deployment banner so it would be easy to jump back to the PR from a preview link.

<img width="1031" alt="Screenshot 2023-06-29 at 21 40 59" src="https://github.com/actualbudget/actual/assets/886567/46dd8fee-dca1-4f80-8e49-ef3eee169f16">
