### PR TITLE
:wrench:  improved dev-server - enable asset cache

### DIFF
--- a/packages/desktop-client/config-overrides.js
+++ b/packages/desktop-client/config-overrides.js
@@ -1,5 +1,6 @@
 const path = require('path');
 
+const chokidar = require('chokidar');
 const {
   addWebpackPlugin,
   addWebpackResolve,
@@ -50,14 +51,22 @@ module.exports = {
         resourceRegExp: /pikaday$/,
       }),
     ),
-    config => {
-      config.cache = false;
-      return config;
-    },
   ),
   devServer: overrideDevServer(config => {
     return {
       ...config,
+      onBeforeSetupMiddleware(server) {
+        chokidar
+          .watch([
+            path.resolve('../loot-core/lib-dist/*.js'),
+            path.resolve('../loot-core/lib-dist/browser/*.js'),
+          ])
+          .on('all', function () {
+            for (const ws of server.webSocketServer.clients) {
+              ws.send(JSON.stringify({ type: 'static-changed' }));
+            }
+          });
+      },
       headers: {
         ...config.headers,
         'Cross-Origin-Opener-Policy': 'same-origin',

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -23,6 +23,7 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/uuid": "^9.0.2",
     "@types/webpack-bundle-analyzer": "^4.6.0",
+    "chokidar": "^3.5.3",
     "cross-env": "^7.0.3",
     "customize-cra": "^1.0.0",
     "date-fns": "^2.29.3",

--- a/upcoming-release-notes/1230.md
+++ b/upcoming-release-notes/1230.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Enable dev-server asset caching

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,6 +91,7 @@ __metadata:
     "@types/react-router-dom": ^5.3.3
     "@types/uuid": ^9.0.2
     "@types/webpack-bundle-analyzer": ^4.6.0
+    chokidar: ^3.5.3
     cross-env: ^7.0.3
     customize-cra: ^1.0.0
     date-fns: ^2.29.3


### PR DESCRIPTION
Bringing back asset caching. This means we won't need to do a full re-build for every change.

I had previously disabled caching because the backend changes (kcab) were not picked up properly. But now that should be fixed too.
