### PR TITLE
Fix electron export issue

### DIFF
--- a/packages/loot-core/src/platform/server/sqlite/index.d.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.d.ts
@@ -29,4 +29,4 @@ export async function openDatabase(pathOrBuffer?: string | Buffer): Database;
 
 export function closeDatabase(db): void;
 
-export function exportDatabase(db): void;
+export async function exportDatabase(db): Buffer;

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -1,5 +1,8 @@
 import Database from 'better-sqlite3';
 
+import { v4 as uuidv4 } from 'uuid';
+import { removeFile, readFile } from '../fs';
+
 function verifyParamTypes(sql, arr) {
   arr.forEach(val => {
     if (typeof val !== 'string' && typeof val !== 'number' && val !== null) {
@@ -100,6 +103,15 @@ export function closeDatabase(db) {
   return db.close();
 }
 
-export function exportDatabase(db) {
-  return db.serialize();
+export async function exportDatabase(db) {
+  // electron does not support better-sqlite serialize since v21
+  // save to file and read in the raw data. 
+  let name = `backup-for-export-${uuidv4()}.db`;
+
+  await db.backup(name);
+
+  let data = await readFile(name);
+  await removeFile(name);
+
+  return data;
 }

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
-
 import { v4 as uuidv4 } from 'uuid';
+
 import { removeFile, readFile } from '../fs';
 
 function verifyParamTypes(sql, arr) {
@@ -105,7 +105,7 @@ export function closeDatabase(db) {
 
 export async function exportDatabase(db) {
   // electron does not support better-sqlite serialize since v21
-  // save to file and read in the raw data. 
+  // save to file and read in the raw data.
   let name = `backup-for-export-${uuidv4()}.db`;
 
   await db.backup(name);

--- a/packages/loot-core/src/platform/server/sqlite/index.web.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.web.ts
@@ -199,6 +199,6 @@ export function closeDatabase(db) {
   db.close();
 }
 
-export function exportDatabase(db) {
+export async function exportDatabase(db) {
   return db.export();
 }

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -148,7 +148,12 @@ export async function exportBuffer() {
       `,
     );
 
-    let dbContent = sqlite.exportDatabase(memDb);
+    await memDb.backup(`backup-for-export.db`);
+
+    rawDbContent = await fs.readFile('backup-for-export.db', 'binary');
+
+    await fs.removeFile('backup-for-export.db');
+
     sqlite.closeDatabase(memDb);
 
     // mark it as a file that needs a new clock so when a new client
@@ -160,7 +165,7 @@ export async function exportBuffer() {
     meta.resetClock = true;
     let metaContent = Buffer.from(JSON.stringify(meta), 'utf8');
 
-    zipped.addFile('db.sqlite', dbContent);
+    zipped.addFile('db.sqlite', rawDbContent);
     zipped.addFile('metadata.json', metaContent);
   });
 

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -148,11 +148,7 @@ export async function exportBuffer() {
       `,
     );
 
-    await memDb.backup(`backup-for-export.db`);
-
-    rawDbContent = await fs.readFile('backup-for-export.db', 'binary');
-
-    await fs.removeFile('backup-for-export.db');
+    let dbContent = await sqlite.exportDatabase(memDb);
 
     sqlite.closeDatabase(memDb);
 
@@ -165,7 +161,7 @@ export async function exportBuffer() {
     meta.resetClock = true;
     let metaContent = Buffer.from(JSON.stringify(meta), 'utf8');
 
-    zipped.addFile('db.sqlite', rawDbContent);
+    zipped.addFile('db.sqlite', dbContent);
     zipped.addFile('metadata.json', metaContent);
   });
 

--- a/upcoming-release-notes/1242.md
+++ b/upcoming-release-notes/1242.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Shazib]
+---
+
+Fixed exporting data from Desktop (Electon) app.


### PR DESCRIPTION
Solves #1238

If we are happy with this approach, which I don't _love_, I'll tidy it up a bit first, check the file doesn't exist, use a random(er) name, wrap it in a functon etc.

Basically the `better-sqlite` `serialize` function can't be used, as I guess under the surface its allocating a chunk of memory in C.

I tried to wrap all this logic inside the `exportDatabase` function in `/server/sqlite/index.electron.ts` but I had a lot of problems trying to import `fs` there if anyone can give advice.
