### PR TITLE
Goals: Add option to percent goal to use available funds

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -99,7 +99,6 @@ async function processTemplate(month, force) {
     if (priority === lowestPriority) {
       remainder_scale = Math.round(available_start / remainder_weight_total);
     }
-    
 
     for (let c = 0; c < categories.length; c++) {
       let category = categories[c];

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -90,14 +90,15 @@ async function processTemplate(month, force) {
   // so the remainders don't get skiped
   if (remainder_found) lowestPriority = remainder_priority;
 
+  let sheetName = monthUtils.sheetForMonth(month);
+  let available_start = await getSheetValue(sheetName, `to-budget`);
   for (let priority = 0; priority <= lowestPriority; priority++) {
-    let sheetName = monthUtils.sheetForMonth(month);
-    let available_start = await getSheetValue(sheetName, `to-budget`);
 
     // setup scaling for remainder
     let remainder_scale = 1;
     if (priority === lowestPriority) {
-      remainder_scale = Math.round(available_start / remainder_weight_total);
+      let available_now = await getSheetValue(sheetName, `to-budget`);
+      remainder_scale = Math.round(available_now / remainder_weight_total);
     }
 
     for (let c = 0; c < categories.length; c++) {

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -93,7 +93,6 @@ async function processTemplate(month, force) {
   let sheetName = monthUtils.sheetForMonth(month);
   let available_start = await getSheetValue(sheetName, `to-budget`);
   for (let priority = 0; priority <= lowestPriority; priority++) {
-
     // setup scaling for remainder
     let remainder_scale = 1;
     if (priority === lowestPriority) {

--- a/upcoming-release-notes/1254.md
+++ b/upcoming-release-notes/1254.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Goals: Add 'available funds' option to the percentage goal


### PR DESCRIPTION
When using the percent goal you can only use current month income.  When operating under a month ahead strategy you are saving this months moneys for next month, so the percentage goal loses most of its usefulness.  This PR adds the option to use the current available funds as the base for the percent calculation.  

This will use the funds that were available at the start of the template run regardless of priority level to match the income based option as much as possible.

