### PR TITLE
Fix calculation of how many table rows to render

### DIFF
--- a/packages/desktop-client/src/components/FixedSizeList.js
+++ b/packages/desktop-client/src/components/FixedSizeList.js
@@ -336,7 +336,7 @@ export default class FixedSizeList extends PureComponent {
 
   getStopIndexForStartIndex = (startIndex, scrollOffset) => {
     const offset = startIndex * this.props.itemSize;
-    const size = this.props.width;
+    const size = this.props.height;
     const numVisibleItems = Math.ceil(
       (size + scrollOffset - offset) / this.props.itemSize,
     );

--- a/upcoming-release-notes/1262.md
+++ b/upcoming-release-notes/1262.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix tables appearing to have a blank area in tall-but-narrow windows


### PR DESCRIPTION
Fixes #1241

This was probably not noticed because most of the time the screen is wider than it is tall, so it just results in showing more rows than necessary.