### PR TITLE
Fix page not found error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Actual app is split up into a few packages:
 - desktop-client - The desktop UI
 - desktop-electron - The desktop app
 
-More information on the project structure is available in our [community documentation](https://actualbudget.org/docs/contributing/project-layout).
+More information on the project structure is available in our [community documentation](https://actualbudget.org/docs/contributing/project-details).
 
 ## Feature Requests
 

--- a/upcoming-release-notes/1297.md
+++ b/upcoming-release-notes/1297.md
@@ -1,0 +1,5 @@
+---
+category: Maintenance
+authors: aleetsaiya
+---
+Fix a link will direct user to page not found.

--- a/upcoming-release-notes/1297.md
+++ b/upcoming-release-notes/1297.md
@@ -1,5 +1,5 @@
 ---
 category: Maintenance
-authors: aleetsaiya
+authors: [aleetsaiya]
 ---
 Fix a link will direct user to page not found.


### PR DESCRIPTION
The "community documentation" link below Code Structure headline in `README` will direct user to page not found error