### PR TITLE
:loud_sound:  improving 'invalid-schema' error logs

### DIFF
--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -77,7 +77,7 @@ function apply(msg: Message, prev?: boolean) {
   if (dataset === 'prefs') {
     // Do nothing, it doesn't exist in the db
   } else {
-    var query;
+    let query;
     try {
       if (prev) {
         query = {

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -77,21 +77,21 @@ function apply(msg: Message, prev?: boolean) {
   if (dataset === 'prefs') {
     // Do nothing, it doesn't exist in the db
   } else {
-    let query;
+    var query;
     try {
       if (prev) {
         query = {
-          sql: db.cache(`UPDATE ${dataset} SET ${column} = ? WHERE id = ?`),
+          sql: `UPDATE ${dataset} SET ${column} = ? WHERE id = ?`,
           params: [value, row],
         };
       } else {
         query = {
-          sql: db.cache(`INSERT INTO ${dataset} (id, ${column}) VALUES (?, ?)`),
+          sql: `INSERT INTO ${dataset} (id, ${column}) VALUES (?, ?)`,
           params: [row, value],
         };
       }
 
-      db.runQuery(query.sql, query.params);
+      db.runQuery(db.cache(query.sql), query.params);
     } catch (error) {
       throw new SyncError('invalid-schema', {
         error: { message: error.message, stack: error.stack },
@@ -564,11 +564,13 @@ export const fullSync = once(async function (): Promise<
         app.events.emit('sync', {
           type: 'error',
           subtype: 'out-of-sync',
+          meta: e.meta,
         });
       } else if (e.reason === 'invalid-schema') {
         app.events.emit('sync', {
           type: 'error',
           subtype: 'invalid-schema',
+          meta: e.meta,
         });
       } else if (
         e.reason === 'decrypt-failure' ||
@@ -580,7 +582,7 @@ export const fullSync = once(async function (): Promise<
           meta: e.meta,
         });
       } else {
-        app.events.emit('sync', { type: 'error' });
+        app.events.emit('sync', { type: 'error', meta: e.meta });
       }
     } else if (e instanceof PostError) {
       console.log(e);

--- a/upcoming-release-notes/1302.md
+++ b/upcoming-release-notes/1302.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Improved error logs for `invalid-schema` issues


### PR DESCRIPTION
The logs for `invalid-schema` were not logging the used query or the metadata. So fixing this.

It would make debugging issues such as https://github.com/actualbudget/actual/issues/1296 easier.