### PR TITLE
:bug:  changing pages while adding a transaction

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -216,6 +216,7 @@ class AccountInternal extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    // If the active account changes - close the transaction entry mode
     if (this.state.isAdding && this.props.accountId !== prevProps.accountId) {
       this.setState({ isAdding: false });
     }

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -216,6 +216,10 @@ class AccountInternal extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    if (this.state.isAdding && this.props.accountId !== prevProps.accountId) {
+      this.setState({ isAdding: false });
+    }
+
     // If the user was on a different screen and is now coming back to
     // the transactions, automatically refresh the transaction to make
     // sure we have updated state

--- a/upcoming-release-notes/1305.md
+++ b/upcoming-release-notes/1305.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Close the "add transaction" entry mode when switching between accounts


### PR DESCRIPTION
Reported on Discord:

```
Hello,

I found a bug when entering multiple transactions and  jumping from one account to another. Here are the repro steps

Step 1. Select Account 1 on the For budget list on the left pane.
Step 2. Click +Add new 
Step 3. Enter your transaction and click Add
Step 4. Change to Account 2
Step 5. Enter your second transaction and click Add

The second transaction is going to be registered under Account 1. 

Note that after adding the first transaction, the new transaction line remains, as shown on the screenshot.

Also, if you then add a third transaction on Account 3, it's going to be registered under Account 2, so it seems that internally, the value of which account to register the transaction under is updated only after the transaction is saved. 

This can unexpectedly lead to duplicate transactions on different accounts, as it looks like transaction 2 is not registered under Account 2, but if you enter it again in Account 2 it will be created properly.
```