### PR TITLE
Goals: Fix calculated fill when using multiple 'up to' statements in different priority levels

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -356,7 +356,7 @@ async function applyCategoryTemplate(
         } else {
           increment = limit;
         }
-        if (to_budget + increment < budgetAvailable || !priority) {
+        if (increment < budgetAvailable || !priority) {
           to_budget += increment;
         } else {
           if (budgetAvailable > 0) to_budget += budgetAvailable;

--- a/upcoming-release-notes/1312.md
+++ b/upcoming-release-notes/1312.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals:  Fix calculated fill when using multiple 'up to' statements in different priority levels


### PR DESCRIPTION
Using the 'up to' keywords can have unexpected results when there are two statements in the same category with different priority levels.

The current fill can be different than what is expected.
![upto_multi_priority_current](https://github.com/actualbudget/actual/assets/20625555/5345c4d8-ae91-4f21-9982-f431506cd3d4)

This PR would change this behavior to the following.
![upto_multi_priority_fix](https://github.com/actualbudget/actual/assets/20625555/f3ef894c-1f4e-491b-a442-f4ec34f3a90f)