### PR TITLE
Fix Custom Select unnecessary disabled scrollbar

### DIFF
--- a/packages/desktop-client/src/components/common/CustomSelect.tsx
+++ b/packages/desktop-client/src/components/common/CustomSelect.tsx
@@ -35,7 +35,7 @@ export default function CustomSelect({
         arrow={<ExpandArrow style={{ width: 7, height: 7, paddingTop: 3 }} />}
       />
       <ListboxPopover style={{ zIndex: 10000, outline: 0, borderRadius: 4 }}>
-        <ListboxList style={{ maxHeight: 250, overflowY: 'scroll' }}>
+        <ListboxList style={{ maxHeight: 250, overflowY: 'auto' }}>
           {options.map(([value, label]) => (
             <ListboxOption
               key={value}

--- a/upcoming-release-notes/1314.md
+++ b/upcoming-release-notes/1314.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aleetsaiya]
+---
+
+Fix Custom Select unnecessary disabled scrollbar


### PR DESCRIPTION
Currently `CustomSelect` will always have scrollbar even the height is not higher than the max height. 

Change the style to make the scrollbar only show when the content overflow the max height.

Before:
<img width="534" alt="截圖 2023-07-08 下午11 18 54" src="https://github.com/actualbudget/actual/assets/67775387/de0d3c9a-8e22-4fcf-b1da-22c6012ed3a3">

After:
<img width="533" alt="截圖 2023-07-08 下午11 18 39" src="https://github.com/actualbudget/actual/assets/67775387/e303ea33-195d-4e47-b914-74c115ebf05a">

Reference discussion: #1294 