### PR TITLE
Fix clicking enter will create empty transaction

### DIFF
--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -265,7 +265,7 @@ export default function DateSelect({
       let date = d.parse(selectedValue, dateFormat, new Date());
       onSelect(d.format(date, 'yyyy-MM-dd'));
 
-      if (open && e.key == 'Enter') {
+      if (open && e.key === 'Enter') {
         // This stops the event from propagating up
         e.stopPropagation();
         e.preventDefault();

--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -266,11 +266,9 @@ export default function DateSelect({
       onSelect(d.format(date, 'yyyy-MM-dd'));
 
       if (open) {
-        if (userSelectedValue.current !== selectedValue) {
-          // This stops the event from propagating up
-          e.stopPropagation();
-          e.preventDefault();
-        }
+        // This stops the event from propagating up
+        e.stopPropagation();
+        e.preventDefault();
       }
 
       let { onKeyDown } = inputProps || {};

--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -265,7 +265,7 @@ export default function DateSelect({
       let date = d.parse(selectedValue, dateFormat, new Date());
       onSelect(d.format(date, 'yyyy-MM-dd'));
 
-      if (open) {
+      if (open && e.key == 'Enter') {
         // This stops the event from propagating up
         e.stopPropagation();
         e.preventDefault();

--- a/upcoming-release-notes/1316.md
+++ b/upcoming-release-notes/1316.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aleetsaiya]
+---
+
+Fix clicking enter will create empty transaction issue.


### PR DESCRIPTION
fix #1301

After the change,  upper components will not detect the press enter event before the datepicker is closed.