### PR TITLE
Enhance logic for ignoring messages

### DIFF
--- a/upcoming-release-notes/1318.md
+++ b/upcoming-release-notes/1318.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Ignore messages that could cause a sync error when loading a file that was originally created on an older version of Actual


### PR DESCRIPTION
Fixes #1296, closes #1317

Add new logic to how we ignore messages that makes it easier if we have to drop other kinds of messages in the future.

Recommendation: ignore whitespace when reviewing.