### PR TITLE
Remove bottom border radius from the payee table

### DIFF
--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -552,7 +552,8 @@ export const ManagePayees = forwardRef(
             style={{
               flex: 1,
               border: '1px solid ' + colors.border,
-              borderRadius: 4,
+              borderTopLeftRadius: 4,
+              borderTopRightRadius: 4,
               overflow: 'hidden',
             }}
           >

--- a/upcoming-release-notes/1334.md
+++ b/upcoming-release-notes/1334.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfix
+category: Enhancement
 authors: [j-f1]
 ---
 

--- a/upcoming-release-notes/1334.md
+++ b/upcoming-release-notes/1334.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Square off the bottom corners of the payee list on the “Payees” page

--- a/upcoming-release-notes/1334.md
+++ b/upcoming-release-notes/1334.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [j-f1]
 ---
 


### PR DESCRIPTION
Since this table extends all the way to the bottom of the screen, the bottom corners should not be curved. (Alternatively, it should have some bottom padding, but I kinda like this look)