### PR TITLE
Update logic for showing and rendering the “Show unused payees” button

### DIFF
--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -510,21 +510,27 @@ export const ManagePayees = forwardRef(
             )}
           </View>
           <View>
-            <Button
-              bare
-              style={{
-                marginRight: '10px',
-              }}
-              disabled={!(orphanedPayees?.length > 0) && !orphanedOnly}
-              onClick={() => {
-                setOrphanedOnly(!orphanedOnly);
-                const filterInput = document.getElementById('filter-input');
-                applyFilter(filterInput.value);
-                tableNavigator.onEdit(null);
-              }}
-            >
-              {orphanedOnly ? 'Show all payees' : 'Show unused payees'}
-            </Button>
+            {(orphanedOnly ||
+              (orphanedPayees && orphanedPayees.length > 0)) && (
+              <Button
+                bare
+                style={{ marginRight: 10 }}
+                onClick={() => {
+                  setOrphanedOnly(!orphanedOnly);
+                  const filterInput = document.getElementById('filter-input');
+                  applyFilter(filterInput.value);
+                  tableNavigator.onEdit(null);
+                }}
+              >
+                {orphanedOnly
+                  ? 'Show all payees'
+                  : `Show ${
+                      orphanedPayees.length === 1
+                        ? '1 unused payee'
+                        : `${orphanedPayees.length} unused payees`
+                    }`}
+              </Button>
+            )}
           </View>
           <View style={{ flex: 1 }} />
           <Input

--- a/upcoming-release-notes/1335.md
+++ b/upcoming-release-notes/1335.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [j-f1]
+---
+
+Hide the “Show unused payees” button unless it is relevant


### PR DESCRIPTION
- The button will now be hidden by default so that users who don’t have any unused payees won’t have to think about it (since we merge by default, unused payees should be pretty rare)
- The number of unused payees will be shown on the button to help understand how much cleanup needs to be done