### PR TITLE
Goals: Use setZero function within goal templates for speed improvement

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -7,7 +7,7 @@ import { amountToInteger, integerToAmount } from '../../shared/util';
 import * as db from '../db';
 import { getRuleForSchedule, getNextDate } from '../schedules/app';
 
-import { setBudget, getSheetValue } from './actions';
+import { setBudget, setZero, getSheetValue } from './actions';
 import { parse } from './goal-template.pegjs';
 
 export function applyTemplate({ month }) {
@@ -63,13 +63,9 @@ async function processTemplate(month, force) {
             ? template[l].priority
             : lowestPriority;
       }
-      await setBudget({
-        category: category.id,
-        month,
-        amount: 0,
-      });
     }
   }
+  setZero({ month });
   // find all remainder templates, place them after all other templates
   let remainder_found;
   let remainder_priority = lowestPriority + 1;

--- a/upcoming-release-notes/1344.md
+++ b/upcoming-release-notes/1344.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [shall0pass]
+---
+
+Goals: Use setZero function within goal templates for speed improvement


### PR DESCRIPTION
I have a budget with 57 templates, which causes a noticeable lag.  I've used performance.now() to show that my templates take 4-4.5 seconds to calculate and fill.  This PR uses the setZero function that already exists to reduce that time to 3-3.2 seconds, a substantial improvement.