### PR TITLE
Fix importing transactions in Safari and clean up openFileDialog API

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -63,15 +63,14 @@ global.Actual = {
       input.style.position = 'absolute';
       input.style.top = '0px';
       input.style.left = '0px';
-      input.dispatchEvent(
-        new MouseEvent('click', {
-          view: window,
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
+      input.style.display = 'none';
 
-      input.addEventListener('change', e => {
+      input.onchange = e => {
+        // Remove the file input from the DOM so we don't keep accumulating them.
+        //
+        // Unfortunately the `change` event does not seem to be fired on cancel
+        // in Safari, so the element may be left in the DOM.
+        document.body.removeChild(input);
         let file = e.target.files[0];
         let filename = file.name.replace(/.*(\.[^.]*)/, 'file$1');
 
@@ -89,7 +88,13 @@ global.Actual = {
             alert('Error reading file');
           };
         }
-      });
+      };
+
+      // In Safari the file input has to be in the DOM for change events to
+      // reliably fire.
+      document.body.appendChild(input);
+
+      input.click();
     });
   },
 

--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -52,8 +52,19 @@ global.Actual = {
 
   openFileDialog: async ({ filters = [], properties }) => {
     return new Promise(resolve => {
-      let input = document.createElement('input');
+      let createdElement = false;
+      // Attempt to reuse an already-created file input.
+      let input = document.body.querySelector(
+        'input[id="open-file-dialog-input"]',
+      );
+      if (!input) {
+        createdElement = true;
+        input = document.createElement('input');
+      }
+
       input.type = 'file';
+      input.id = 'open-file-dialog-input';
+      input.value = null;
 
       let filter = filters.find(filter => filter.extensions);
       if (filter) {
@@ -66,11 +77,6 @@ global.Actual = {
       input.style.display = 'none';
 
       input.onchange = e => {
-        // Remove the file input from the DOM so we don't keep accumulating them.
-        //
-        // Unfortunately the `change` event does not seem to be fired on cancel
-        // in Safari, so the element may be left in the DOM.
-        document.body.removeChild(input);
         let file = e.target.files[0];
         let filename = file.name.replace(/.*(\.[^.]*)/, 'file$1');
 
@@ -92,7 +98,9 @@ global.Actual = {
 
       // In Safari the file input has to be in the DOM for change events to
       // reliably fire.
-      document.body.appendChild(input);
+      if (createdElement) {
+        document.body.appendChild(input);
+      }
 
       input.click();
     });

--- a/packages/desktop-client/src/components/modals/ImportTransactions.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.js
@@ -671,8 +671,8 @@ function ImportTransactions({
     setFieldMappings({ ...fieldMappings, ...newFieldMappings });
   }
 
-  function onNewFile() {
-    const res = window.Actual.openFileDialog({
+  async function onNewFile() {
+    const res = await window.Actual.openFileDialog({
       filters: [
         { name: 'Financial Files', extensions: ['qif', 'ofx', 'qfx', 'csv'] },
       ],

--- a/upcoming-release-notes/1349.md
+++ b/upcoming-release-notes/1349.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Cldfire]
+---
+
+Fix bug causing transaction import in Safari to be unreliable


### PR DESCRIPTION
Closes https://github.com/actualbudget/actual/issues/1313.

See my comments on the issue for investigation into what was happening. It seems WebKit wants the file input in the DOM to reliably fire `change` events when the user makes a selection. I set the input to `display: none` to make sure that even if it sticks around in the DOM for some reason it's not interactive.