### PR TITLE
Fix a bug in confirm category delete

### DIFF
--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDelete.js
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDelete.js
@@ -69,7 +69,20 @@ export default function ConfirmCategoryDelete({
 
             <View style={{ flex: 1, marginLeft: 10, marginRight: 30 }}>
               <CategoryAutocomplete
-                categoryGroups={categoryGroups}
+                categoryGroups={
+                  group
+                    ? categoryGroups.filter(
+                        g => g.id !== group.id && !!g.is_income === isIncome,
+                      )
+                    : categoryGroups
+                        .filter(g => !!g.is_income === isIncome)
+                        .map(g => ({
+                          ...g,
+                          categories: g.categories.filter(
+                            c => c.id !== category.id,
+                          ),
+                        }))
+                }
                 value={transferCategory}
                 inputProps={{
                   placeholder: 'Select category...',

--- a/upcoming-release-notes/1351.md
+++ b/upcoming-release-notes/1351.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aleetsaiya]
+---
+
+Fix a bug that user can transfer budget to the category (or group) which user want to delete


### PR DESCRIPTION
Found there is a bug should fix after refactoring to `CategoryAutoComplete`

Bug: User can transfer budget to the category (or group) which user want to delete