### PR TITLE
Stop the demo build bar from shrinking on mobile/small sizes

### DIFF
--- a/packages/desktop-client/src/components/DevelopmentTopBar.tsx
+++ b/packages/desktop-client/src/components/DevelopmentTopBar.tsx
@@ -16,6 +16,7 @@ export default function DevelopmentTopBar() {
           backgroundColor: colors.y8,
           borderBottom: `1px solid ${colors.y6}`,
           zIndex: 1,
+          flexShrink: 0,
         },
       ]}
     >

--- a/upcoming-release-notes/1353.md
+++ b/upcoming-release-notes/1353.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Prevent the “This is a demo build of Actual” bar from shrinking on small screen sizes


### PR DESCRIPTION
Before:
<img width="430" alt="Screenshot_2023-07-16 12 35 04" src="https://github.com/actualbudget/actual/assets/25517624/f8bbe589-8578-476f-b804-27e77fb69613">
