### PR TITLE
Add a few more ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     ),
 
     'react/jsx-no-useless-fragment': 'error',
+    'react/self-closing-comp': 'error',
 
     'rulesdir/typography': 'error',
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,7 @@ module.exports = {
     'react/self-closing-comp': 'error',
 
     'rulesdir/typography': 'error',
+    'rulesdir/prefer-if-statement': 'error',
 
     // https://github.com/eslint/eslint/issues/16954
     // https://github.com/eslint/eslint/issues/16953

--- a/packages/desktop-client/src/components/Background.js
+++ b/packages/desktop-client/src/components/Background.js
@@ -16,7 +16,7 @@ function Background({ selected }) {
         background: `url(${BG}) no-repeat center center fixed`,
         backgroundSize: '100% 100%',
       })}
-    ></div>
+    />
   );
 }
 

--- a/packages/desktop-client/src/components/Modals.js
+++ b/packages/desktop-client/src/components/Modals.js
@@ -164,7 +164,7 @@ function Modals({
               actions={actions}
               onMoveExternal={options.onMoveExternal}
               onClose={() => {
-                options.onClose && options.onClose();
+                options.onClose?.();
                 send('poll-web-token-stop');
               }}
               onSuccess={options.onSuccess}
@@ -186,7 +186,7 @@ function Modals({
               actions={actions}
               onMoveExternal={options.onMoveExternal}
               onClose={() => {
-                options.onClose && options.onClose();
+                options.onClose?.();
                 send('nordigen-poll-web-token-stop');
               }}
               onSuccess={options.onSuccess}

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -46,7 +46,7 @@ function NotesTooltip({
           })}
           value={notes || ''}
           onChange={e => setNotes(e.target.value)}
-        ></textarea>
+        />
       ) : (
         <Text
           {...css({

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -255,7 +255,7 @@ class AccountInternal extends PureComponent {
   };
 
   refetchTransactions = async () => {
-    this.paged && this.paged.run();
+    this.paged?.run();
   };
 
   fetchTransactions = () => {
@@ -295,7 +295,7 @@ class AccountInternal extends PureComponent {
         const firstLoad = prevData == null;
 
         if (firstLoad) {
-          this.table.current && this.table.current.setRowAnimation(false);
+          this.table.current?.setRowAnimation(false);
 
           if (isFiltered) {
             this.props.splitsExpandedDispatch({
@@ -324,11 +324,11 @@ class AccountInternal extends PureComponent {
             }
 
             if (firstLoad) {
-              this.table.current && this.table.current.scrollToTop();
+              this.table.current?.scrollToTop();
             }
 
             setTimeout(() => {
-              this.table.current && this.table.current.setRowAnimation(true);
+              this.table.current?.setRowAnimation(true);
             }, 0);
           },
         );

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -825,9 +825,10 @@ class AccountInternal extends PureComponent {
       this.setState({ conditionsOp: getFilter.conditionsOp });
       this.applyFilters([...getFilter.conditions]);
     } else {
-      savedFilter.status &&
-        this.setState({ conditionsOp: savedFilter.conditionsOp }) &&
+      if (savedFilter.status) {
+        this.setState({ conditionsOp: savedFilter.conditionsOp });
         this.applyFilters([...savedFilter.conditions]);
+      }
     }
     this.setState({ filterId: { ...this.state.filterId, ...savedFilter } });
   };
@@ -852,15 +853,17 @@ class AccountInternal extends PureComponent {
 
   onDeleteFilter = filter => {
     this.applyFilters(this.state.filters.filter(f => f !== filter));
-    this.state.filters.length === 1
-      ? this.setState({ filterId: [] }) &&
-        this.setState({ conditionsOp: 'and' })
-      : this.setState({
-          filterId: {
-            ...this.state.filterId,
-            status: this.state.filterId && 'changed',
-          },
-        });
+    if (this.state.filters.length === 1) {
+      this.setState({ filterId: [] });
+      this.setState({ conditionsOp: 'and' });
+    } else {
+      this.setState({
+        filterId: {
+          ...this.state.filterId,
+          status: this.state.filterId && 'changed',
+        },
+      });
+    }
   };
 
   onApplyFilter = async cond => {

--- a/packages/desktop-client/src/components/accounts/MobileAccount.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.js
@@ -121,7 +121,7 @@ function Account(props) {
             tables.includes('category_mapping') ||
             tables.includes('payee_mapping')
           ) {
-            paged && paged.run();
+            paged?.run();
           }
 
           if (tables.includes('payees') || tables.includes('payee_mapping')) {
@@ -260,7 +260,7 @@ function Account(props) {
                   //   />
                   // }
                   onLoadMore={() => {
-                    paged && paged.fetchNext();
+                    paged?.fetchNext();
                   }}
                   onSearch={onSearch}
                   onSelectTransaction={() => {}} // onSelectTransaction}

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -76,7 +76,7 @@ function fireUpdate(onUpdate, strict, suggestions, index, value) {
     }
   }
 
-  onUpdate && onUpdate(selected, value);
+  onUpdate?.(selected, value);
 }
 
 function defaultRenderInput(props) {
@@ -363,7 +363,7 @@ function SingleAutocomplete({
               focused,
               ...inputProps,
               onFocus: e => {
-                inputProps.onFocus && inputProps.onFocus(e);
+                inputProps.onFocus?.(e);
 
                 if (openOnFocus) {
                   setIsOpen(true);
@@ -372,11 +372,11 @@ function SingleAutocomplete({
               onBlur: e => {
                 // @ts-expect-error Should this be e.nativeEvent
                 e.preventDownshiftDefault = true;
-                inputProps.onBlur && inputProps.onBlur(e);
+                inputProps.onBlur?.(e);
 
                 if (!tableBehavior) {
                   if (e.target.value === '') {
-                    onSelect && onSelect(null, e.target.value);
+                    onSelect?.(null, e.target.value);
                     setSelectedItem(null);
                     setIsOpen(false);
                     return;
@@ -421,11 +421,11 @@ function SingleAutocomplete({
                       // No highlighted item, still allow the table to save the item
                       // as `null`, even though we're allowing the table to move
                       e.preventDefault();
-                      onKeyDown && onKeyDown(e);
+                      onKeyDown?.(e);
                     }
                   } else if (shouldSaveFromKey(e)) {
                     e.preventDefault();
-                    onKeyDown && onKeyDown(e);
+                    onKeyDown?.(e);
                   }
                 }
 
@@ -454,7 +454,7 @@ function SingleAutocomplete({
               onChange: (e: ChangeEvent<HTMLInputElement>) => {
                 const { onChange } = inputProps || {};
                 // @ts-expect-error unsure if onChange needs an event or a string
-                onChange && onChange(e.target.value);
+                onChange?.(e.target.value);
               },
             }),
           )}
@@ -555,7 +555,7 @@ function MultiAutocomplete({
       onRemoveItem(selectedItems[selectedItems.length - 1]);
     }
 
-    prevOnKeyDown && prevOnKeyDown(e);
+    prevOnKeyDown?.(e);
   }
 
   return (

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
@@ -217,7 +217,7 @@ export default function PayeeAutocomplete({
 
   async function handleSelect(value, rawInputValue) {
     if (tableBehavior) {
-      onSelect && onSelect(makeNew(value, rawInputValue));
+      onSelect?.(makeNew(value, rawInputValue));
     } else {
       let create = () => dispatch(createPayee(rawInputValue));
 
@@ -228,7 +228,7 @@ export default function PayeeAutocomplete({
           value = await create();
         }
       }
-      onSelect && onSelect(value);
+      onSelect?.(value);
     }
   }
 
@@ -348,7 +348,7 @@ export default function PayeeAutocomplete({
                     }
                   }
                   onClick={() => {
-                    onUpdate && onUpdate(null);
+                    onUpdate?.(null);
                     setFocusTransferPayees(!focusTransferPayees);
                   }}
                 />

--- a/packages/desktop-client/src/components/common.tsx
+++ b/packages/desktop-client/src/components/common.tsx
@@ -156,7 +156,7 @@ export function ButtonLink({
       }}
       {...props}
       onClick={e => {
-        props.onClick && props.onClick(e);
+        props.onClick?.(e);
         navigate(to);
       }}
     />

--- a/packages/desktop-client/src/components/common/Input.tsx
+++ b/packages/desktop-client/src/components/common/Input.tsx
@@ -55,13 +55,13 @@ const Input = ({
           onEnter(e);
         }
 
-        nativeProps.onKeyDown && nativeProps.onKeyDown(e);
+        nativeProps.onKeyDown?.(e);
       }}
       onChange={e => {
         if (onUpdate) {
           onUpdate(e.target.value);
         }
-        nativeProps.onChange && nativeProps.onChange(e);
+        nativeProps.onChange?.(e);
       }}
     />
   );

--- a/packages/desktop-client/src/components/common/InputWithContent.tsx
+++ b/packages/desktop-client/src/components/common/InputWithContent.tsx
@@ -59,11 +59,11 @@ export default function InputWithContent({
         ]}
         onFocus={e => {
           setFocused(true);
-          props.onFocus && props.onFocus(e);
+          props.onFocus?.(e);
         }}
         onBlur={e => {
           setFocused(false);
-          props.onBlur && props.onBlur(e);
+          props.onBlur?.(e);
         }}
       />
       {rightContent}

--- a/packages/desktop-client/src/components/common/Menu.tsx
+++ b/packages/desktop-client/src/components/common/Menu.tsx
@@ -81,7 +81,7 @@ export default function Menu({
           e.preventDefault();
           const item = items[hoveredIndex];
           if (hoveredIndex !== null && item !== Menu.line) {
-            onMenuSelect && onMenuSelect(item.name);
+            onMenuSelect?.(item.name);
           }
           break;
         default:

--- a/packages/desktop-client/src/components/modals/EditRule.js
+++ b/packages/desktop-client/src/components/modals/EditRule.js
@@ -725,7 +725,7 @@ export default function EditRule({
         rule.id = newId;
       }
 
-      originalOnSave && originalOnSave(rule);
+      originalOnSave?.(rule);
       modalProps.onClose();
     }
   }

--- a/packages/desktop-client/src/components/modals/FixEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKey.js
@@ -45,7 +45,7 @@ export default function FixEncryptionKey({
       }
 
       actions.popModal();
-      onSuccess && onSuccess();
+      onSuccess?.();
     }
   }
 

--- a/packages/desktop-client/src/components/modals/NordigenExternalMsg.js
+++ b/packages/desktop-client/src/components/modals/NordigenExternalMsg.js
@@ -115,7 +115,7 @@ export default function NordigenExternalMsg({
   }
 
   function onClose() {
-    originalOnClose && originalOnClose();
+    originalOnClose?.();
     modalProps.onClose();
   }
 

--- a/packages/desktop-client/src/components/modals/PlaidExternalMsg.js
+++ b/packages/desktop-client/src/components/modals/PlaidExternalMsg.js
@@ -43,7 +43,7 @@ export default function PlaidExternalMsg({
   }
 
   function onClose() {
-    originalOnClose && originalOnClose();
+    originalOnClose?.();
     modalProps.onClose();
   }
 

--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -378,7 +378,7 @@ export const ManagePayees = forwardRef(
 
     function applyFilter(f) {
       if (filter !== f) {
-        table.current && table.current.setRowAnimation(false);
+        table.current?.setRowAnimation(false);
         setFilter(f);
         resetAnimation.current = true;
       }
@@ -395,7 +395,7 @@ export const ManagePayees = forwardRef(
         // actually update its contents until the next tick or
         // something? The table keeps being animated without this
         setTimeout(() => {
-          table.current && table.current.setRowAnimation(true);
+          table.current?.setRowAnimation(true);
         }, 0);
         resetAnimation.current = false;
       }

--- a/packages/desktop-client/src/components/reports/useReport.js
+++ b/packages/desktop-client/src/components/reports/useReport.js
@@ -12,7 +12,7 @@ function useReport(sheetName, getData) {
       cleanup = c;
     });
     return () => {
-      cleanup && cleanup();
+      cleanup?.();
     };
   }, [getData]);
 

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.js
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.js
@@ -284,7 +284,7 @@ export function SchedulesTable({
             Recurring
           </Field>
         )}
-        {!minimal && <Field width={40}></Field>}
+        {!minimal && <Field width={40} />}
       </TableHeader>
       <Table
         rowHeight={ROW_HEIGHT}

--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -312,13 +312,13 @@ export default function DateSelect({
           if (!embedded && openOnFocus) {
             setOpen(true);
           }
-          inputProps && inputProps.onFocus && inputProps.onFocus(e);
+          inputProps?.onFocus?.(e);
         }}
         onBlur={e => {
           if (!embedded) {
             setOpen(false);
           }
-          inputProps && inputProps.onBlur && inputProps.onBlur(e);
+          inputProps?.onBlur?.(e);
 
           if (!tableBehavior) {
             // If value is empty, that drives what gets selected.

--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -138,9 +138,7 @@ let DatePicker = forwardRef(
       }
     }, [value, dateFormat]);
 
-    return (
-      <View style={[pickerStyles, { flex: 1 }]} innerRef={mountPoint}></View>
-    );
+    return <View style={[pickerStyles, { flex: 1 }]} innerRef={mountPoint} />;
   },
 );
 

--- a/packages/desktop-client/src/components/select/DateSelect.js
+++ b/packages/desktop-client/src/components/select/DateSelect.js
@@ -100,7 +100,7 @@ let DatePicker = forwardRef(
           }
           if (newDate) {
             picker.current.setDate(newDate, true);
-            onUpdate && onUpdate(newDate);
+            onUpdate?.(newDate);
           }
         },
       }),
@@ -211,21 +211,21 @@ export default function DateSelect({
       // the right day/month format from it
       let test = d.parse(value, getDayMonthFormat(dateFormat), new Date());
       if (d.isValid(test)) {
-        onUpdate && onUpdate(d.format(test, 'yyyy-MM-dd'));
+        onUpdate?.(d.format(test, 'yyyy-MM-dd'));
         setSelectedValue(d.format(test, dateFormat));
       }
     } else if (getShortYearRegex(dateFormat).test(value)) {
       // Support entering the year as only two digits (4/5/19)
       let test = d.parse(value, getShortYearFormat(dateFormat), new Date());
       if (d.isValid(test)) {
-        onUpdate && onUpdate(d.format(test, 'yyyy-MM-dd'));
+        onUpdate?.(d.format(test, 'yyyy-MM-dd'));
         setSelectedValue(d.format(test, dateFormat));
       }
     } else {
       let test = d.parse(value, dateFormat, new Date());
       if (d.isValid(test)) {
         let date = d.format(test, 'yyyy-MM-dd');
-        onUpdate && onUpdate(date);
+        onUpdate?.(date);
         setSelectedValue(value);
       }
     }
@@ -254,7 +254,7 @@ export default function DateSelect({
         }
       } else {
         setOpen(true);
-        onUpdate && onUpdate(defaultValue);
+        onUpdate?.(defaultValue);
       }
     } else if (shouldSaveFromKey(e)) {
       setValue(selectedValue);
@@ -272,7 +272,7 @@ export default function DateSelect({
       }
 
       let { onKeyDown } = inputProps || {};
-      onKeyDown && onKeyDown(e);
+      onKeyDown?.(e);
     } else if (!open) {
       setOpen(true);
       if (inputRef.current) {
@@ -347,7 +347,7 @@ export default function DateSelect({
             dateFormat={dateFormat}
             onUpdate={date => {
               setSelectedValue(d.format(date, dateFormat));
-              onUpdate && onUpdate(d.format(date, 'yyyy-MM-dd'));
+              onUpdate?.(d.format(date, 'yyyy-MM-dd'));
             }}
             onSelect={date => {
               setValue(d.format(date, dateFormat));

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
@@ -326,7 +326,7 @@ function RecurringScheduleTooltip({ config: currentConfig, onClose, onSave }) {
           onBlur={e => updateField('interval', e.target.value)}
           onEnter={e => updateField('interval', e.target.value)}
           defaultValue={config.interval || 1}
-        ></Input>
+        />
         <CustomSelect
           options={FREQUENCY_OPTIONS.map(opt => [opt.id, opt.name])}
           value={config.frequency}

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -389,7 +389,9 @@ function InputValue({
 
   function onBlur_(e) {
     onUpdate?.(value);
-    onBlur && fireBlur(onBlur, e);
+    if (onBlur) {
+      fireBlur(onBlur, e);
+    }
   }
 
   function onKeyDown(e) {
@@ -1297,7 +1299,7 @@ export function useTableNavigator(data, fields) {
       innerRef: containerRef,
 
       onKeyDown: e => {
-        userProps && userProps.onKeyDown && userProps.onKeyDown(e);
+        userProps?.onKeyDown?.(e);
         if (e.isPropagationStopped()) {
           return;
         }

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -52,7 +52,7 @@ function fireBlur(onBlur, e) {
     // We only fire the blur event if the app is still focused
     // because the blur event is fired when the app goes into
     // the background and we want to ignore that
-    onBlur && onBlur(e);
+    onBlur?.(e);
   } else {
     // Otherwise, stop React from bubbling this event and swallow it
     e.stopPropagation();
@@ -273,7 +273,7 @@ export function Cell({
                     Math.abs(e.clientX - mouseCoords.current[0]) < 5 &&
                     Math.abs(e.clientY - mouseCoords.current[1]) < 5
                   ) {
-                    onExpose && onExpose(name);
+                    onExpose?.(name);
                   }
                 }
           }
@@ -388,7 +388,7 @@ function InputValue({
   let [value, setValue] = useState(defaultValue);
 
   function onBlur_(e) {
-    onUpdate && onUpdate(value);
+    onUpdate?.(value);
     onBlur && fireBlur(onBlur, e);
   }
 
@@ -404,7 +404,7 @@ function InputValue({
         setValue(defaultValue);
       }
     } else if (shouldSaveFromKey(e)) {
-      onUpdate && onUpdate(value);
+      onUpdate?.(value);
     }
   }
 
@@ -509,14 +509,14 @@ export function CustomCell({
     // the app unfocuses, and it's unintuitive to save the value since
     // the input will be focused again when the app regains focus
     if (document.hasFocus()) {
-      onUpdate && onUpdate(value);
+      onUpdate?.(value);
       fireBlur(onBlur, e);
     }
   }
 
   function onKeyDown(e) {
     if (shouldSaveFromKey(e)) {
-      onUpdate && onUpdate(value);
+      onUpdate?.(value);
     }
   }
 
@@ -529,7 +529,7 @@ export function CustomCell({
           onUpdate: val => setValue(val),
           onSave: val => {
             setValue(val);
-            onUpdate && onUpdate(val);
+            onUpdate?.(val);
           },
           shouldSaveFromKey,
           inputStyle: inputCellStyle,
@@ -551,7 +551,7 @@ export function DeleteCell({ onDelete, style, ...props }: DeleteCellProps) {
       style={[{ alignItems: 'center', userSelect: 'none' }, style]}
       onClick={e => {
         e.stopPropagation();
-        onDelete && onDelete();
+        onDelete?.();
       }}
     >
       {() => <DeleteIcon width={7} height={7} />}
@@ -591,7 +591,7 @@ export const CellButton = forwardRef<HTMLDivElement, CellButtonProps>(
           if (e.key === 'x' || e.key === ' ') {
             e.preventDefault();
             if (!disabled) {
-              onSelect && onSelect(e);
+              onSelect?.(e);
             }
           }
         }}
@@ -615,8 +615,8 @@ export const CellButton = forwardRef<HTMLDivElement, CellButtonProps>(
             ? null
             : e => {
                 if (!disabled) {
-                  onSelect && onSelect(e);
-                  onEdit && onEdit();
+                  onSelect?.(e);
+                  onEdit?.();
                 }
               }
         }
@@ -650,8 +650,8 @@ export function SelectCell({
       style={[{ alignItems: 'center', userSelect: 'none' }, style]}
       onClick={e => {
         e.stopPropagation();
-        onSelect && onSelect(e);
-        onEdit && onEdit();
+        onSelect?.(e);
+        onEdit?.();
       }}
     >
       {() => (
@@ -961,7 +961,7 @@ export const Table = forwardRef<TableHandleRef, TableProps>(
       },
 
       scrollToTop: () => {
-        list.current && list.current.scrollTo(0);
+        list.current?.scrollTo(0);
       },
 
       getScrolledItem: () => {
@@ -974,7 +974,7 @@ export const Table = forwardRef<TableHandleRef, TableProps>(
       },
 
       setRowAnimation: flag => {
-        list.current && list.current.setRowAnimation(flag);
+        list.current?.setRowAnimation(flag);
       },
 
       edit(id, field, shouldScroll) {
@@ -987,11 +987,11 @@ export const Table = forwardRef<TableHandleRef, TableProps>(
       },
 
       anchor() {
-        list.current && list.current.anchor();
+        list.current?.anchor();
       },
 
       unanchor() {
-        list.current && list.current.unanchor();
+        list.current?.unanchor();
       },
 
       isAnchored() {
@@ -1004,7 +1004,7 @@ export const Table = forwardRef<TableHandleRef, TableProps>(
       // before it's mounted
       if (!listInitialized.current && listContainer.current) {
         // Animation is on by default
-        list.current && list.current.setRowAnimation(true);
+        list.current?.setRowAnimation(true);
         listInitialized.current = true;
       }
     });

--- a/packages/desktop-client/src/components/tooltips.js
+++ b/packages/desktop-client/src/components/tooltips.js
@@ -14,7 +14,7 @@ export function useTooltip() {
     getOpenEvents: (events = {}) => ({
       onClick: e => {
         e.stopPropagation();
-        events.onClick && events.onClick(e);
+        events.onClick?.(e);
         setIsOpen(true);
       },
     }),
@@ -54,13 +54,13 @@ export class Tooltip extends Component {
       }
 
       if (node === document.documentElement) {
-        this.props.onClose && this.props.onClose();
+        this.props.onClose?.();
       }
     };
 
     let escHandler = e => {
       if (e.key === 'Escape') {
-        this.props.onClose && this.props.onClose();
+        this.props.onClose?.();
       }
     };
 

--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -369,8 +369,7 @@ function ListBox(props) {
     listBoxRef.current.addEventListener('scroll', loadMoreTransactions);
 
     return () => {
-      listBoxRef.current &&
-        listBoxRef.current.removeEventListener('scroll', loadMoreTransactions);
+      listBoxRef.current?.removeEventListener('scroll', loadMoreTransactions);
     };
   }, [state.collection]);
 

--- a/packages/desktop-client/src/components/transactions/SelectedTransactions.js
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactions.js
@@ -148,6 +148,6 @@ export function SelectedTransactionsButton({
             onEdit(name, [...selectedItems]);
         }
       }}
-    ></SelectedItemsButton>
+    />
   );
 }

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.js
@@ -82,7 +82,7 @@ function LiveTransactionTable(props) {
 
   useEffect(() => {
     if (transactions === props.transactions) return;
-    props.onTransactionsChange && props.onTransactionsChange(transactions);
+    props.onTransactionsChange?.(transactions);
   }, [transactions]);
 
   const onSplit = id => {

--- a/packages/desktop-client/src/hooks/useSelected.js
+++ b/packages/desktop-client/src/hooks/useSelected.js
@@ -270,7 +270,7 @@ export function SelectedProviderWithItems({
   let selected = useSelected(name, items, initialSelectedIds);
 
   useEffect(() => {
-    registerDispatch && registerDispatch(selected.dispatch);
+    registerDispatch?.(selected.dispatch);
   }, [registerDispatch]);
 
   return (

--- a/packages/desktop-electron/updater.js
+++ b/packages/desktop-electron/updater.js
@@ -39,7 +39,7 @@ autoUpdater.on('error', message => {
 });
 
 function fireEvent(type, args) {
-  emitEvent && emitEvent(type, args);
+  emitEvent?.(type, args);
   lastEvent = type;
 }
 

--- a/packages/eslint-plugin-actual/lib/rules/__tests__/prefer-if-statement.js
+++ b/packages/eslint-plugin-actual/lib/rules/__tests__/prefer-if-statement.js
@@ -1,0 +1,139 @@
+/* eslint-disable rulesdir/typography */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+
+const rule = require('../prefer-if-statement');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2020,
+    ecmaFeatures: { jsx: true },
+  },
+});
+ruleTester.run('prefer-if-statement', rule, {
+  valid: [
+    `if (foo && bar) { console.log('Hello, world!'); }`,
+    `myFunc(foo && bar);`,
+    `if (foo || bar) { console.log('Hello, world!'); }`,
+    `myFunc(foo || bar);`,
+    `if (foo ? bar : baz) { console.log('Hello, world!'); }`,
+    `<div>{foo && bar}</div>`,
+    `<div>{foo || bar}</div>`,
+    `<div>{foo ? bar : baz}</div>`,
+  ],
+
+  invalid: [
+    {
+      code: 'foo && bar;',
+      output: null,
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '&&' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo || bar;',
+      output: null,
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '||' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo ? bar : baz;',
+      output: null,
+      errors: [{ messageId: 'ternary', type: 'ExpressionStatement' }],
+    },
+    {
+      code: 'function foo() { bar && baz; }',
+      output: null,
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '&&' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'function foo() { bar || baz; }',
+      output: null,
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '||' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'function foo() { bar ? baz : qux; }',
+      output: null,
+      errors: [{ messageId: 'ternary', type: 'ExpressionStatement' }],
+    },
+    {
+      code: 'foo && foo();',
+      output: 'foo?.();',
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '&&' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo || foo();',
+      output: null,
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '||' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo.bar && foo.bar();',
+      output: 'foo.bar?.();',
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '&&' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo.bar && foo.bar.baz();',
+      output: 'foo.bar?.baz();',
+      errors: [
+        {
+          messageId: 'logical',
+          data: { op: '&&' },
+          type: 'ExpressionStatement',
+        },
+      ],
+    },
+    {
+      code: 'foo ? bar() : baz();',
+      output: null,
+      errors: [{ messageId: 'ternary', type: 'ExpressionStatement' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-actual/lib/rules/__tests__/typography.js
+++ b/packages/eslint-plugin-actual/lib/rules/__tests__/typography.js
@@ -7,7 +7,7 @@
 
 const RuleTester = require('eslint').RuleTester;
 
-const rule = require('../../../lib/rules/typography');
+const rule = require('../typography');
 
 //------------------------------------------------------------------------------
 // Tests

--- a/packages/eslint-plugin-actual/lib/rules/prefer-if-statement.js
+++ b/packages/eslint-plugin-actual/lib/rules/prefer-if-statement.js
@@ -1,0 +1,87 @@
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+let suggestion = 'Consider using an if statement or optional chaining instead.';
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Detects usage of logical or ternary expressions at the statement level',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      logical: `Avoid using the {{op}} operator at the top level. ${suggestion}`,
+      ternary: `Avoid using ternary operators at the top level. ${suggestion}`,
+    },
+  },
+
+  create(context) {
+    let sourceCode = context.getSourceCode();
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    /**
+     * Can only auto-fix e.g. `foo && foo(...)` to `foo?.()` or `foo.bar && foo.bar.baz()` to `foo.bar?.baz()`
+     * @param {import('estree').LogicalExpression} node
+     * @return {import('eslint').Rule.ReportFixer | null}
+     */
+    function makeFixer(node) {
+      if (node.operator !== '&&') return null;
+      if (node.right.type !== 'CallExpression') return null;
+
+      // foo.bar && foo.bar(...)
+      if (
+        sourceCode.getText(node.left) === sourceCode.getText(node.right.callee)
+      ) {
+        return fixer =>
+          fixer.replaceTextRange(
+            [node.left.range[1], node.right.callee.range[1]],
+            '?.',
+          );
+      }
+
+      // foo.bar && foo.bar.baz(...)
+      if (
+        node.right.callee.type === 'MemberExpression' &&
+        sourceCode.getText(node.left) ===
+          sourceCode.getText(node.right.callee.object)
+      ) {
+        return fixer =>
+          fixer.replaceTextRange(
+            [node.left.range[1], node.right.callee.object.range[1]],
+            '?',
+          );
+      }
+
+      return null;
+    }
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      ExpressionStatement(node) {
+        if (node.expression.type === 'LogicalExpression') {
+          context.report({
+            node,
+            messageId: 'logical',
+            data: { op: node.expression.operator },
+            fix: makeFixer(node.expression),
+          });
+        } else if (node.expression.type === 'ConditionalExpression') {
+          context.report({ node, messageId: 'ternary' });
+        }
+      },
+    };
+  },
+};

--- a/packages/loot-core/.babelrc
+++ b/packages/loot-core/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-typescript"]
+  "presets": [
+    ["@babel/preset-env", { "bugfixes": true }],
+    "@babel/preset-typescript"
+  ]
 }

--- a/packages/loot-core/webpack/webpack.browser.config.js
+++ b/packages/loot-core/webpack/webpack.browser.config.js
@@ -52,7 +52,10 @@ module.exports = {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: ['@babel/preset-env', '@babel/preset-typescript'],
+            presets: [
+              ['@babel/preset-env', { bugfixes: true }],
+              '@babel/preset-typescript',
+            ],
           },
         },
       },

--- a/upcoming-release-notes/1355.md
+++ b/upcoming-release-notes/1355.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Add a couple of ESLint rules to increase code consistency

--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,16 +5971,16 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.0.0, browserslist@npm:^4.14.5, browserslist@npm:^4.18.1, browserslist@npm:^4.21.3, browserslist@npm:^4.21.4, browserslist@npm:^4.21.5":
-  version: 4.21.5
-  resolution: "browserslist@npm:4.21.5"
+  version: 4.21.9
+  resolution: "browserslist@npm:4.21.9"
   dependencies:
-    caniuse-lite: ^1.0.30001449
-    electron-to-chromium: ^1.4.284
-    node-releases: ^2.0.8
-    update-browserslist-db: ^1.0.10
+    caniuse-lite: ^1.0.30001503
+    electron-to-chromium: ^1.4.431
+    node-releases: ^2.0.12
+    update-browserslist-db: ^1.0.11
   bin:
     browserslist: cli.js
-  checksum: 9755986b22e73a6a1497fd8797aedd88e04270be33ce66ed5d85a1c8a798292a65e222b0f251bafa1c2522261e237d73b08b58689d4920a607e5a53d56dc4706
+  checksum: 80d3820584e211484ad1b1a5cfdeca1dd00442f47be87e117e1dda34b628c87e18b81ae7986fa5977b3e6a03154f6d13cd763baa6b8bf5dd9dd19f4926603698
   languageName: node
   linkType: hard
 
@@ -6257,10 +6257,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001464":
-  version: 1.0.30001482
-  resolution: "caniuse-lite@npm:1.0.30001482"
-  checksum: a5f7681c860a29736f29350ebd81041c40b6aa7b2f94c50ed27284a0507e46dc79536dcfc05432504cfc80a0bf2070e4ad6fa704a9c0f3f32d47bed9059e98c2
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001503":
+  version: 1.0.30001516
+  resolution: "caniuse-lite@npm:1.0.30001516"
+  checksum: 044adf3493b734a356a2922445a30095a0f6de6b9194695cdf74deafe7bef658e85858a31177762c2813f6e1ed2722d832d59eee0ecb2151e93a611ee18cb21f
   languageName: node
   linkType: hard
 
@@ -8049,10 +8049,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.284":
-  version: 1.4.385
-  resolution: "electron-to-chromium@npm:1.4.385"
-  checksum: cb35f5da18d4d92acba99cd6fa842fca30c9afb7a0296ae1c8013011c12d301b8a2003a68c2371baf148fc0c74f132aa7f236223544986a6388b0f433657e860
+"electron-to-chromium@npm:^1.4.431":
+  version: 1.4.461
+  resolution: "electron-to-chromium@npm:1.4.461"
+  checksum: 84960b8fe41a1a97f47962f7ec509d94efffc8361286d55f360f81ce0804029af886796c576eb2c0a6011347ba0903c551476808f0614dc94b4564abaf415e70
   languageName: node
   linkType: hard
 
@@ -13074,10 +13074,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"node-releases@npm:^2.0.8":
-  version: 2.0.10
-  resolution: "node-releases@npm:2.0.10"
-  checksum: d784ecde25696a15d449c4433077f5cce620ed30a1656c4abf31282bfc691a70d9618bae6868d247a67914d1be5cc4fde22f65a05f4398cdfb92e0fc83cadfbc
+"node-releases@npm:^2.0.12":
+  version: 2.0.13
+  resolution: "node-releases@npm:2.0.13"
+  checksum: 17ec8f315dba62710cae71a8dad3cd0288ba943d2ece43504b3b1aa8625bf138637798ab470b1d9035b0545996f63000a8a926e0f6d35d0996424f8b6d36dda3
   languageName: node
   linkType: hard
 
@@ -17884,7 +17884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.10":
+"update-browserslist-db@npm:^1.0.11":
   version: 1.0.11
   resolution: "update-browserslist-db@npm:1.0.11"
   dependencies:


### PR DESCRIPTION
- `react/self-closing-comp` auto fixes `<div></div>` to `<div />` which is equivalent
- the custom `prefer-if-statement` rule detects logical expressions (`foo && bar` / `foo || bar`) or ternaries at the top level and suggests using an if statement or optional chaining. It can also auto-fix the most common usage of this pattern in the codebase, as shown in the third commit.