### PR TITLE
Add clear typings to the modals

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import { send } from 'loot-core/src/platform/client/fetch';
 
 import { useActions } from '../hooks/useActions';
-import useFeatureFlag from '../hooks/useFeatureFlag';
 import useSyncServerStatus from '../hooks/useSyncServerStatus';
 
 import BudgetSummary from './modals/BudgetSummary';
@@ -34,7 +33,6 @@ export default function Modals() {
   const budgetId = useSelector(
     state => state.prefs.local && state.prefs.local.id,
   );
-  const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const actions = useActions();
 
   const syncServerStatus = useSyncServerStatus();
@@ -89,7 +87,6 @@ export default function Modals() {
               externalAccounts={options.accounts}
               requisitionId={options.requisitionId}
               localAccounts={accounts.filter(acct => acct.closed === 0)}
-              // upgradingAccountId={options.upgradingAccountId}
               actions={actions}
             />
           );

--- a/packages/desktop-client/src/hooks/useActions.ts
+++ b/packages/desktop-client/src/hooks/useActions.ts
@@ -6,7 +6,6 @@ import { bindActionCreators } from 'redux';
 import * as actions from 'loot-core/src/client/actions';
 
 // https://react-redux.js.org/api/hooks#recipe-useactions
-// eslint-disable-next-line import/no-unused-modules
 export function useActions() {
   const dispatch = useDispatch();
   return useMemo(() => {

--- a/packages/loot-core/src/client/actions/budgets.ts
+++ b/packages/loot-core/src/client/actions/budgets.ts
@@ -80,6 +80,7 @@ export function loadBudget(
           );
 
           if (showBackups) {
+            // @ts-expect-error manager modals are not yet typed
             dispatch(pushModal('load-backup', { budgetId: id }));
           }
         } else {

--- a/packages/loot-core/src/client/actions/modals.ts
+++ b/packages/loot-core/src/client/actions/modals.ts
@@ -1,13 +1,24 @@
 import * as constants from '../constants';
+import type { Modal } from '../state-types/modals';
 
 import type { ActionResult } from './types';
 
-export function pushModal(name: string, options: unknown): ActionResult {
-  return { type: constants.PUSH_MODAL, name, options };
+export function pushModal<M extends Modal>(
+  name: M['name'],
+  options: M['options'],
+): ActionResult {
+  // @ts-expect-error TS is unable to determine that `name` and `options` match
+  let modal: M = { name, options };
+  return { type: constants.PUSH_MODAL, modal };
 }
 
-export function replaceModal(name: string, options: unknown): ActionResult {
-  return { type: constants.REPLACE_MODAL, name, options };
+export function replaceModal<M extends Modal>(
+  name: M['name'],
+  options: M['options'],
+): ActionResult {
+  // @ts-expect-error TS is unable to determine that `name` and `options` match
+  let modal: M = { name, options };
+  return { type: constants.REPLACE_MODAL, modal };
 }
 
 export function popModal(): ActionResult {

--- a/packages/loot-core/src/client/reducers/modals.ts
+++ b/packages/loot-core/src/client/reducers/modals.ts
@@ -12,15 +12,12 @@ function update(state = initialState, action: Action): ModalsState {
     case constants.PUSH_MODAL:
       return {
         ...state,
-        modalStack: [
-          ...state.modalStack,
-          { name: action.name, options: action.options },
-        ],
+        modalStack: [...state.modalStack, action.modal],
       };
     case constants.REPLACE_MODAL:
       return {
         ...state,
-        modalStack: [{ name: action.name, options: action.options }],
+        modalStack: [action.modal],
       };
     case constants.POP_MODAL:
       return { ...state, modalStack: state.modalStack.slice(0, -1) };

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -1,21 +1,95 @@
+import type { AccountEntity } from '../../types/models';
+import type { RuleEntity } from '../../types/models/rule';
 import type * as constants from '../constants';
 
-// TODO: type this more throughly
 type Modal = {
-  name: string;
-  options: unknown;
+  [K in keyof FinanceModals]: {
+    name: K;
+    options: FinanceModals[K];
+  };
+}[keyof FinanceModals];
+
+// There is a separate (overlapping!) set of modals for the management app. Fun!
+type FinanceModals = {
+  'import-transactions': {
+    accountId: string;
+    filename: string;
+    onImported: (didChange: boolean) => void;
+  };
+
+  'add-account': null;
+  'add-local-account': null;
+  'close-account': {
+    account: AccountEntity;
+    balance: number;
+    canDelete: boolean;
+  };
+  'select-linked-accounts': {
+    accounts: unknown[];
+    requisitionId: string;
+    upgradingAccountId: string;
+  };
+  'configure-linked-accounts': never;
+
+  'confirm-category-delete': { onDelete: () => void } & (
+    | { category: string }
+    | { group: string }
+  );
+
+  'load-backup': null;
+
+  'manage-rules': { payeeId: string } | null;
+  'edit-rule': {
+    rule: RuleEntity;
+    onSave: (rule: RuleEntity) => void;
+  };
+  'merge-unused-payees': {
+    payeeIds: string[];
+    targetPayeeId: string;
+  };
+
+  'plaid-external-msg': {
+    onMoveExternal: () => Promise<void>;
+    onClose?: () => void;
+    onSuccess: (data: unknown) => Promise<void>;
+  };
+
+  'nordigen-init': {
+    onSuccess: () => void;
+  };
+  'nordigen-external-msg': {
+    onMoveExternal: (arg: {
+      institutionId: string;
+    }) => Promise<{ error: string } | { data: unknown }>;
+    onClose?: () => void;
+    onSuccess: (data: unknown) => Promise<void>;
+  };
+
+  'create-encryption-key': { recreate: boolean } | null;
+  'fix-encryption-key': {
+    hasExistingKey: boolean;
+    cloudFileId: string;
+    onSuccess?: () => void;
+  };
+
+  'edit-field': {
+    name: string;
+    onSubmit: (name: string, value: string) => void;
+  };
+
+  'budget-summary': {
+    month: string;
+  };
 };
 
 export type PushModalAction = {
   type: typeof constants.PUSH_MODAL;
-  name: string;
-  options: unknown;
+  modal: Modal;
 };
 
 export type ReplaceModalAction = {
   type: typeof constants.REPLACE_MODAL;
-  name: string;
-  options: unknown;
+  modal: Modal;
 };
 
 export type PopModalAction = {

--- a/upcoming-release-notes/1359.md
+++ b/upcoming-release-notes/1359.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Port the modal infrastructure to TypeScript


### PR DESCRIPTION
This makes sure the right parameters are passed when pushing a modal, and is the first use of the `useActions` hook.