### PR TITLE
spelling error in FixSplit.js

### DIFF
--- a/packages/desktop-client/src/components/settings/FixSplits.js
+++ b/packages/desktop-client/src/components/settings/FixSplits.js
@@ -79,8 +79,8 @@ export default function FixSplitsTool() {
         <strong>Repair split transactions</strong> if you are experiencing bugs
         relating to split transactions and the “Reset budget cache” button above
         does not help, this tool may fix them. Some examples of bugs include
-        seeing blank payees on splits or incorrect account balances.
-        This tool does two things:
+        seeing blank payees on splits or incorrect account balances. This tool does two things:
+
       </Text>
       <ul style={{ margin: 0, paddingLeft: '1.5em' }}>
         <li style={{ marginBottom: '0.5em' }}>

--- a/packages/desktop-client/src/components/settings/FixSplits.js
+++ b/packages/desktop-client/src/components/settings/FixSplits.js
@@ -79,7 +79,8 @@ export default function FixSplitsTool() {
         <strong>Repair split transactions</strong> if you are experiencing bugs
         relating to split transactions and the “Reset budget cache” button above
         does not help, this tool may fix them. Some examples of bugs include
-        seeing blank payees on splits or incorrect account balances. This tool does two things:
+        seeing blank payees on splits or incorrect account balances. This tool
+        does two things:
 
       </Text>
       <ul style={{ margin: 0, paddingLeft: '1.5em' }}>

--- a/packages/desktop-client/src/components/settings/FixSplits.js
+++ b/packages/desktop-client/src/components/settings/FixSplits.js
@@ -78,9 +78,9 @@ export default function FixSplitsTool() {
       <Text>
         <strong>Repair split transactions</strong> if you are experiencing bugs
         relating to split transactions and the “Reset budget cache” button above
-        does not help. If you see blank payees on splits or account balances (or
-        any balances) are incorrect, this tool may fix them. This tool does two
-        things:
+        does not help, this tool may fix them. Some examples of bugs include
+        seeing blank payees on splits or incorrect account balances.
+        This tool does two things:
       </Text>
       <ul style={{ margin: 0, paddingLeft: '1.5em' }}>
         <li style={{ marginBottom: '0.5em' }}>

--- a/packages/desktop-client/src/components/settings/FixSplits.js
+++ b/packages/desktop-client/src/components/settings/FixSplits.js
@@ -81,7 +81,6 @@ export default function FixSplitsTool() {
         does not help, this tool may fix them. Some examples of bugs include
         seeing blank payees on splits or incorrect account balances. This tool
         does two things:
-
       </Text>
       <ul style={{ margin: 0, paddingLeft: '1.5em' }}>
         <li style={{ marginBottom: '0.5em' }}>

--- a/upcoming-release-notes/1363.md
+++ b/upcoming-release-notes/1363.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [migillett]
+---
+
+Fixed spelling errors in the "Repair split transactions" section of the settings page.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

There was a spelling error on the settings page that was bothering me. Fixed a run-on sentence and a fragment.
