### PR TITLE
Improve clarity of informational message in “merge unused payees” modal

### DIFF
--- a/packages/desktop-client/src/components/modals/MergeUnusedPayees.js
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayees.js
@@ -122,8 +122,14 @@ export default function MergeUnusedPayees({
 
             <Information>
               Merging will remove the payee and transfer any existing rules to
-              the new payee. If checked below, a rule will be created to do this
-              rename while importing transactions.
+              the new payee.
+              {!isEditingRule && (
+                <>
+                  {' '}
+                  If checked below, a rule will be created to do this rename
+                  while importing transactions.
+                </>
+              )}
             </Information>
 
             {!isEditingRule && (


### PR DESCRIPTION
The message currently mentions a checkbox “below” but when the modal is triggered while manually applying a rule, the checkbox is hidden. In this case, the offending sentence will now be hidden.