### PR TITLE
Update coloring of newly added icons

### DIFF
--- a/packages/desktop-client/src/icons/v2/MoonStars.js
+++ b/packages/desktop-client/src/icons/v2/MoonStars.js
@@ -7,7 +7,7 @@ const SvgMoonStars = props => (
     className="bi bi-moon-stars"
     viewBox="0 0 16 16"
     style={{
-      color: '#242134',
+      color: 'inherit',
       ...props.style,
     }}
   >

--- a/packages/desktop-client/src/icons/v2/Sun.js
+++ b/packages/desktop-client/src/icons/v2/Sun.js
@@ -7,7 +7,7 @@ const SvgSun = props => (
     className="bi bi-sun"
     viewBox="0 0 16 16"
     style={{
-      color: '#242134',
+      color: 'inherit',
       ...props.style,
     }}
   >

--- a/upcoming-release-notes/1378.md
+++ b/upcoming-release-notes/1378.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Fix the color of the newly added icons


### PR DESCRIPTION
I changed the default icon color in #1368, but didn't apply that change to the icons added in #1367. This does that.