### PR TITLE
Show correct payee for scheduled transactions on budgeted accounts page

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.js
@@ -393,10 +393,7 @@ function getPayeePretty(transaction, payee, transferAcct) {
         </div>
       </View>
     );
-  } else if (payee && !payee.transfer_acct) {
-    // Check to make sure this isn't a transfer because in the rare
-    // occasion that the account has been deleted but the payee is
-    // still there, we don't want to show the name.
+  } else if (payee) {
     return payee.name;
   } else if (payeeId && payeeId.startsWith('new:')) {
     return payeeId.slice('new:'.length);
@@ -981,7 +978,7 @@ const Transaction = memo(function Transaction(props) {
           valueStyle={valueStyle}
           transaction={transaction}
           payee={payee}
-          transferAcct={transferAcct}
+          transferAcct={showAccount ? null : transferAcct}
           importedPayee={importedPayee}
           isPreview={isPreview}
           onEdit={onEdit}

--- a/upcoming-release-notes/1379.md
+++ b/upcoming-release-notes/1379.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kyrias]
+---
+
+Show the correct payee of scheduled transactions on "For budget" account page.


### PR DESCRIPTION
Previously the "budgeted accounts" page would show the account in the payee column for scheduled transactions.  I'm not sure if this is the correct fix since I'm a bit confused by the exact intent with the various variables that appear to be used for multiple things, but this appears to at least fix the issue.

One weird thing I noticed is that scheduled transactions also show up on the "off budget accounts" page but they _don't_ show up on the "all accounts" page.

Resolves #1333.  Resolves #1026.