### PR TITLE
Remove double scrollbar as the screen is big enough

### DIFF
--- a/packages/desktop-client/src/components/FixedSizeList.js
+++ b/packages/desktop-client/src/components/FixedSizeList.js
@@ -206,7 +206,7 @@ export default class FixedSizeList extends PureComponent {
             style={{
               height,
               width,
-              overflow: 'auto',
+              overflow: 'hidden auto',
               ...style,
             }}
           >

--- a/packages/desktop-client/src/style/styles.ts
+++ b/packages/desktop-client/src/style/styles.ts
@@ -31,7 +31,9 @@ export const styles = {
   },
   page: {
     flex: 1,
-    minHeight: 700, // ensure we can scroll on small screens
+    ['@media (max-height: 550px)']: {
+      minHeight: 700, // ensure we can scroll on small screens
+    },
     paddingTop: 8, // height of the titlebar
     [`@media (min-width: ${tokens.breakpoint_small})`]: {
       paddingTop: 36,

--- a/packages/desktop-client/src/style/styles.ts
+++ b/packages/desktop-client/src/style/styles.ts
@@ -31,7 +31,7 @@ export const styles = {
   },
   page: {
     flex: 1,
-    ['@media (max-height: 550px)']: {
+    '@media (max-height: 550px)': {
       minHeight: 700, // ensure we can scroll on small screens
     },
     paddingTop: 8, // height of the titlebar

--- a/upcoming-release-notes/1385.md
+++ b/upcoming-release-notes/1385.md
@@ -2,4 +2,4 @@
 category: Bugfix
 authors: [aleetsaiya]
 ---
-Remove double scrollbar while the viewport is big enough
+Remove double scrollbar while the viewport is big enough and remove the horizontal scrollbar under the transaction table.

--- a/upcoming-release-notes/1385.md
+++ b/upcoming-release-notes/1385.md
@@ -1,0 +1,5 @@
+---
+category: Bugfix
+authors: [aleetsaiya]
+---
+Remove double scrollbar while the viewport is big enough


### PR DESCRIPTION
Resolves #1358 

This change will make users can scroll the whole page while the viewport height is lower than `550px`, but cannot when higher.

I don't really sure which is the "good" height number to determine should users have ability to scroll the whole page or not.

The double scrollbar is helpful to the budget page because the upper component always stand `250px` height. The outer scrollbar make users have ability to scroll down to focus on another part. Otherwise, their screen will always be occupied by the upper component.
<img width="776" alt="截圖 2023-07-23 上午2 16 20" src="https://github.com/actualbudget/actual/assets/67775387/2873b7b9-e02f-4e3c-97d6-16427a29cba0">

However, to the transaction table page. This outer scrollbar is meaningless from my perspective, because the upper component is very small, even right now I've limited the height to ensure the outer scrollbar only appear when the viewport height is lower than `550px`, it still meaningless from my persepctive.

Maybe I should custom the height limitation for different page or current is good enought?

<img width="770" alt="截圖 2023-07-23 上午2 30 03" src="https://github.com/actualbudget/actual/assets/67775387/9accca03-84fe-451f-8ea4-5e017787f4a6">


