### PR TITLE
Exclude “isbetween” op from the filter UI

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.js
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.js
@@ -153,7 +153,7 @@ function ConfigureField({
   }, [op]);
 
   let type = FIELD_TYPES.get(field);
-  let ops = TYPE_INFO[type].ops;
+  let ops = TYPE_INFO[type].ops.filter(op => op !== 'isbetween');
 
   // Month and year fields are quite hacky right now! Figure out how
   // to clean this up later

--- a/upcoming-release-notes/1389.md
+++ b/upcoming-release-notes/1389.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Remove non-functional “is between” filter operator


### PR DESCRIPTION
This has never worked, and can be represented more clearly using the greater than and less than operators as two separate filters. Brought up in Discord: https://discord.com/channels/937901803608096828/1132639847778107422