### PR TITLE
Goals: fix leftover 1 cent in remainder goal

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -622,9 +622,9 @@ async function applyCategoryTemplate(
           // can over budget with the rounding, so checking that
           if (to_budget >= budgetAvailable + budgeted) {
             to_budget = budgetAvailable + budgeted;
-          // check if there is 1 cent leftover from rounding
-          } else if (budgetAvailable-to_budget==1) {
-            to_budget=to_budget+1;
+            // check if there is 1 cent leftover from rounding
+          } else if (budgetAvailable - to_budget === 1) {
+            to_budget = to_budget + 1;
           }
         }
         break;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -97,7 +97,7 @@ async function processTemplate(
     let remainder_scale = 1;
     if (priority === lowestPriority) {
       let available_now = await getSheetValue(sheetName, `to-budget`);
-      remainder_scale = Math.round(available_now / remainder_weight_total);
+      remainder_scale = available_now / remainder_weight_total;
     }
 
     for (let c = 0; c < categories.length; c++) {
@@ -622,6 +622,9 @@ async function applyCategoryTemplate(
           // can over budget with the rounding, so checking that
           if (to_budget >= budgetAvailable + budgeted) {
             to_budget = budgetAvailable + budgeted;
+          // check if there is 1 cent leftover from rounding
+          } else if (budgetAvailable-to_budget==1) {
+            to_budget=to_budget+1;
           }
         }
         break;

--- a/upcoming-release-notes/1400.md
+++ b/upcoming-release-notes/1400.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [youngcw]
 ---
 
-Goals: Fix leftover 0.01 when using remainder goal
+Goals: Fix leftover $0.01 when using remainder goal

--- a/upcoming-release-notes/1400.md
+++ b/upcoming-release-notes/1400.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: Fix leftover 0.01 when using remainder goal


### PR DESCRIPTION
Depending on the remainder scaling and weights there is sometimes 1 cent leftover after the remainder pass in the goals.  I allowed the scale factor to include sub cents, which sometimes fixes the issue, and an explicit check.  This way high weight templates will pull in the extra most of the time as expected, but if the weights are about even then the last one run will get the floating 1 cent.  I think there could still be an edge case when the total weights is very high with respect to funds available, but its likely not a big deal.
