### PR TITLE
:bug: (electron) always show titlebar

### DIFF
--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -110,7 +110,6 @@ async function createWindow() {
     width: windowState.width,
     height: windowState.height,
     title: 'Actual',
-    titleBarStyle: 'hiddenInset',
     webPreferences: {
       nodeIntegration: false,
       nodeIntegrationInWorker: false,

--- a/upcoming-release-notes/1417.md
+++ b/upcoming-release-notes/1417.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Always show titlebar to fix electron side-nav issues


### PR DESCRIPTION
https://github.com/actualbudget/actual/issues/1047

Before:

![image](https://github.com/actualbudget/actual/assets/886567/782f8c63-7a68-4b2c-ae12-c0c4c3978dd8)


After:

<img width="358" alt="Screenshot 2023-07-29 at 20 12 25" src="https://github.com/actualbudget/actual/assets/886567/2fb80a1f-9951-4856-83cf-5a4f13e7b2bc">
