### PR TITLE
:bug:  fix number formatter not listening to state changes

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -22,6 +22,7 @@
     "@types/react-modal": "^3.16.0",
     "@types/react-redux": "^7.1.25",
     "@types/react-router-dom": "^5.3.3",
+    "@types/reselect": "^2.2.0",
     "@types/uuid": "^9.0.2",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "chokidar": "^3.5.3",
@@ -71,5 +72,8 @@
     "setupFilesAfterEnv": [
       "<rootDir>/src/setupTests.js"
     ]
+  },
+  "dependencies": {
+    "reselect": "^4.1.8"
   }
 }

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -22,7 +22,6 @@
     "@types/react-modal": "^3.16.0",
     "@types/react-redux": "^7.1.25",
     "@types/react-router-dom": "^5.3.3",
-    "@types/reselect": "^2.2.0",
     "@types/uuid": "^9.0.2",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "chokidar": "^3.5.3",

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -71,8 +71,5 @@
     "setupFilesAfterEnv": [
       "<rootDir>/src/setupTests.js"
     ]
-  },
-  "dependencies": {
-    "reselect": "^4.1.8"
   }
 }

--- a/packages/desktop-client/src/components/spreadsheet/CellValue.tsx
+++ b/packages/desktop-client/src/components/spreadsheet/CellValue.tsx
@@ -9,7 +9,7 @@ import {
   type ConditionalPrivacyFilterProps,
 } from '../PrivacyFilter';
 
-import format from './format';
+import { useFormat } from './format';
 import useSheetName from './useSheetName';
 import useSheetValue from './useSheetValue';
 
@@ -34,6 +34,7 @@ function CellValue({
 }: CellValueProps) {
   let { fullSheetName } = useSheetName(binding);
   let sheetValue = useSheetValue(binding);
+  let format = useFormat();
 
   return useMemo(
     () => (
@@ -66,6 +67,7 @@ function CellValue({
       getStyle,
       fullSheetName,
       formatter,
+      format,
       sheetValue,
     ],
   );

--- a/packages/desktop-client/src/components/spreadsheet/format.ts
+++ b/packages/desktop-client/src/components/spreadsheet/format.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
+import { createSelector } from 'reselect';
+
+import type { State } from 'loot-core/src/client/state-types';
 import { integerToCurrency, getNumberFormat } from 'loot-core/src/shared/util';
 
 /**
@@ -47,13 +50,17 @@ export default function format(
   }
 }
 
-export function useFormat() {
-  const numberFormat = useSelector(state =>
+const selectNumberFormat = createSelector(
+  (state: State) => state.prefs.local,
+  prefs =>
     getNumberFormat({
-      format: state.prefs.local.numberFormat,
-      hideFraction: state.prefs.local.hideFraction,
+      format: prefs.numberFormat,
+      hideFraction: prefs.hideFraction,
     }),
-  );
+);
+
+export function useFormat() {
+  const numberFormat = useSelector(selectNumberFormat);
 
   return useCallback(
     (value: unknown, type = 'string') =>

--- a/packages/desktop-client/src/components/spreadsheet/format.ts
+++ b/packages/desktop-client/src/components/spreadsheet/format.ts
@@ -23,7 +23,7 @@ export default function format(
       return '' + value;
     case 'financial-with-sign':
       let formatted = format(value, 'financial', formatter);
-      if (value >= 0) {
+      if (typeof value === 'number' && value >= 0) {
         return '+' + formatted;
       }
       return formatted;

--- a/packages/desktop-client/src/components/spreadsheet/format.ts
+++ b/packages/desktop-client/src/components/spreadsheet/format.ts
@@ -1,10 +1,8 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 
-import { createSelector } from 'reselect';
-
-import type { State } from 'loot-core/src/client/state-types';
-import { integerToCurrency, getNumberFormat } from 'loot-core/src/shared/util';
+import { selectNumberFormat } from 'loot-core/src/client/selectors';
+import { integerToCurrency } from 'loot-core/src/shared/util';
 
 /**
  * @deprecated Please do not use this directly. Use `useFormat` hook
@@ -49,15 +47,6 @@ export default function format(
       throw new Error('Unknown format type: ' + type);
   }
 }
-
-const selectNumberFormat = createSelector(
-  (state: State) => state.prefs.local,
-  prefs =>
-    getNumberFormat({
-      format: prefs.numberFormat,
-      hideFraction: prefs.hideFraction,
-    }),
-);
 
 export function useFormat() {
   const numberFormat = useSelector(selectNumberFormat);

--- a/packages/desktop-client/src/components/spreadsheet/format.ts
+++ b/packages/desktop-client/src/components/spreadsheet/format.ts
@@ -1,6 +1,16 @@
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 
-export default function format(value, type = 'string'): string {
+import { integerToCurrency, getNumberFormat } from 'loot-core/src/shared/util';
+
+/**
+ * @deprecated Please do not use this directly. Use `useFormat` hook
+ */
+export default function format(
+  value: unknown,
+  type = 'string',
+  formatter?: Intl.NumberFormat,
+): string {
   switch (type) {
     case 'string':
       const val = JSON.stringify(value);
@@ -12,14 +22,14 @@ export default function format(value, type = 'string'): string {
     case 'number':
       return '' + value;
     case 'financial-with-sign':
-      let formatted = format(value, 'financial');
+      let formatted = format(value, 'financial', formatter);
       if (value >= 0) {
         return '+' + formatted;
       }
       return formatted;
     case 'financial':
       if (value == null || value === '' || value === 0) {
-        return integerToCurrency(0);
+        return integerToCurrency(0, formatter);
       } else if (typeof value === 'string') {
         const parsed = parseFloat(value);
         value = isNaN(parsed) ? 0 : parsed;
@@ -31,8 +41,23 @@ export default function format(value, type = 'string'): string {
         );
       }
 
-      return integerToCurrency(value);
+      return integerToCurrency(value, formatter);
     default:
       throw new Error('Unknown format type: ' + type);
   }
+}
+
+export function useFormat() {
+  const numberFormat = useSelector(state =>
+    getNumberFormat({
+      format: state.prefs.local.numberFormat,
+      hideFraction: state.prefs.local.hideFraction,
+    }),
+  );
+
+  return useCallback(
+    (value: unknown, type = 'string') =>
+      format(value, type, numberFormat.formatter),
+    [numberFormat],
+  );
 }

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -37,6 +37,7 @@
     "node-libofx": "*",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
+    "reselect": "^4.1.8",
     "stream-browserify": "^3.0.0",
     "ws": "8.13.0"
   },

--- a/packages/loot-core/src/client/selectors.ts
+++ b/packages/loot-core/src/client/selectors.ts
@@ -1,0 +1,17 @@
+import { createSelector } from 'reselect';
+
+import { getNumberFormat } from '../shared/util';
+
+import type { State } from './state-types';
+
+const getState = (state: State) => state;
+
+const getPrefsState = createSelector(getState, state => state.prefs);
+const getLocalPrefsState = createSelector(getPrefsState, prefs => prefs.local);
+
+export const selectNumberFormat = createSelector(getLocalPrefsState, prefs =>
+  getNumberFormat({
+    format: prefs.numberFormat,
+    hideFraction: prefs.hideFraction,
+  }),
+);

--- a/upcoming-release-notes/1423.md
+++ b/upcoming-release-notes/1423.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix number formatting setting not affecting sidenav

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,7 +90,6 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.2
     redux: ^4.0.5
     redux-thunk: ^2.3.0
-    reselect: ^4.1.8
     sass: ^1.63.6
     uuid: ^9.0.0
     victory: ^36.6.8
@@ -12596,6 +12595,7 @@ __metadata:
     path-browserify: ^1.0.1
     peggy: 3.0.2
     process: ^0.11.10
+    reselect: ^4.1.8
     slash: 3.0.0
     snapshot-diff: ^0.10.0
     source-map: ^0.7.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,7 +60,6 @@ __metadata:
     "@types/react-modal": ^3.16.0
     "@types/react-redux": ^7.1.25
     "@types/react-router-dom": ^5.3.3
-    "@types/reselect": ^2.2.0
     "@types/uuid": ^9.0.2
     "@types/webpack-bundle-analyzer": ^4.6.0
     chokidar: ^3.5.3
@@ -4507,15 +4506,6 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: db3d92b423150222a666329f7aa3023e3e942044700557b8a7d161530847e621aec9f56c9e7f71761b06dd164c8a7b17ad52355863efe80963dffa5537e8e5fd
-  languageName: node
-  linkType: hard
-
-"@types/reselect@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@types/reselect@npm:2.2.0"
-  dependencies:
-    reselect: "*"
-  checksum: 034b5796c16316b60561fca01503111ecddde638178efc20c7293f07ef7d9cbc2bffce267899381f630fa9ffef3bfed54384fe87756e97132b4dc2881f585e19
   languageName: node
   linkType: hard
 
@@ -15976,7 +15966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:*, reselect@npm:^4.1.8":
+"reselect@npm:^4.1.8":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,7 @@ __metadata:
     "@types/react-modal": ^3.16.0
     "@types/react-redux": ^7.1.25
     "@types/react-router-dom": ^5.3.3
+    "@types/reselect": ^2.2.0
     "@types/uuid": ^9.0.2
     "@types/webpack-bundle-analyzer": ^4.6.0
     chokidar: ^3.5.3
@@ -90,6 +91,7 @@ __metadata:
     react-virtualized-auto-sizer: ^1.0.2
     redux: ^4.0.5
     redux-thunk: ^2.3.0
+    reselect: ^4.1.8
     sass: ^1.63.6
     uuid: ^9.0.0
     victory: ^36.6.8
@@ -4505,6 +4507,15 @@ __metadata:
     "@types/scheduler": "*"
     csstype: ^3.0.2
   checksum: db3d92b423150222a666329f7aa3023e3e942044700557b8a7d161530847e621aec9f56c9e7f71761b06dd164c8a7b17ad52355863efe80963dffa5537e8e5fd
+  languageName: node
+  linkType: hard
+
+"@types/reselect@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@types/reselect@npm:2.2.0"
+  dependencies:
+    reselect: "*"
+  checksum: 034b5796c16316b60561fca01503111ecddde638178efc20c7293f07ef7d9cbc2bffce267899381f630fa9ffef3bfed54384fe87756e97132b4dc2881f585e19
   languageName: node
   linkType: hard
 
@@ -15962,6 +15973,13 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
+  languageName: node
+  linkType: hard
+
+"reselect@npm:*, reselect@npm:^4.1.8":
+  version: 4.1.8
+  resolution: "reselect@npm:4.1.8"
+  checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1415

Fix number formatter not listening to state changes. This is not a fully comprehensive solution. We will need to run a migration campaign to port over from direct usage of `format` util to `useFormat`, but this is a first step that solves the most glaring issue.