### PR TITLE
Swap custom bare button colors to the color prop

### DIFF
--- a/packages/desktop-client/src/ResponsiveProvider.tsx
+++ b/packages/desktop-client/src/ResponsiveProvider.tsx
@@ -5,6 +5,7 @@ import { useViewportSize } from '@react-aria/utils';
 import { breakpoints } from './tokens';
 
 type TResponsiveContext = {
+  atLeastSmallWidth: boolean;
   atLeastMediumWidth: boolean;
   isNarrowWidth: boolean;
   isSmallWidth: boolean;
@@ -33,6 +34,7 @@ export function ResponsiveProvider(props: { children: ReactNode }) {
   // To check if we're at least small width, check !isNarrowWidth
   const viewportInfo = {
     // atLeastMediumWidth is provided to avoid checking (isMediumWidth || isWideWidth)
+    atLeastSmallWidth: width >= breakpoints.small,
     atLeastMediumWidth: width >= breakpoints.medium,
     isNarrowWidth: width < breakpoints.small,
     isSmallWidth: width >= breakpoints.small && width < breakpoints.medium,

--- a/packages/desktop-client/src/components/LoggedInUser.js
+++ b/packages/desktop-client/src/components/LoggedInUser.js
@@ -84,7 +84,7 @@ export default function LoggedInUser({ hideIfNoServer, style, color }) {
 
   return (
     <View style={[{ flexDirection: 'row', alignItems: 'center' }, style]}>
-      <Button type="bare" onClick={() => setMenuOpen(true)} style={{ color }}>
+      <Button type="bare" onClick={() => setMenuOpen(true)} color={color}>
         {serverMessage()}
       </Button>
 

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -121,12 +121,8 @@ export default function NotesButton({
       <Button
         type="bare"
         className={!hasNotes && !tooltipOpen ? 'hover-visible' : ''}
-        style={[
-          { color: defaultColor },
-          style,
-          hasNotes && { display: 'flex !important' },
-          tooltipOpen && { color: colors.n1 },
-        ]}
+        color={tooltipOpen ? colors.n1 : defaultColor}
+        style={[style, hasNotes && { display: 'flex !important' }]}
         {...tooltip.getOpenEvents()}
       >
         <CustomNotesPaper style={{ width, height }} />

--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -163,12 +163,12 @@ function Notification({
                 onRemove();
                 setLoading(false);
               }}
+              color="currentColor"
               style={{
                 backgroundColor: 'transparent',
                 border: `1px solid ${
                   positive ? colors.g5 : error ? colors.r4 : colors.y3
                 }`,
-                color: 'currentColor',
                 fontSize: 14,
                 flexShrink: 0,
                 '&:hover, &:active': {
@@ -187,7 +187,8 @@ function Notification({
         {sticky && (
           <Button
             type="bare"
-            style={{ flexShrink: 0, color: 'currentColor' }}
+            color="currentColor"
+            style={{ flexShrink: 0 }}
             onClick={onRemove}
           >
             <Delete style={{ width: 9, height: 9, color: 'currentColor' }} />

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -24,9 +24,9 @@ export function ThemeSelector() {
       }}
     >
       {theme === 'light' ? (
-        <MoonStars style={{ width: 13, height: 13, color: 'inherit' }} />
+        <MoonStars style={{ width: 13, height: 13 }} />
       ) : (
-        <Sun style={{ width: 13, height: 13, color: 'inherit' }} />
+        <Sun style={{ width: 13, height: 13 }} />
       )}
     </Button>
   );

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -68,11 +68,7 @@ function UncategorizedButton() {
   let count = useSheetValue(queries.uncategorizedCount());
   return (
     count !== 0 && (
-      <ButtonLink
-        type="bare"
-        to="/accounts/uncategorized"
-        style={{ color: colors.r5 }}
-      >
+      <ButtonLink type="bare" to="/accounts/uncategorized" color={colors.r5}>
         {count} uncategorized {count === 1 ? 'transaction' : 'transactions'}
       </ButtonLink>
     )
@@ -104,6 +100,8 @@ function PrivacyButton() {
 export function SyncButton({ style }) {
   let cloudFileId = useSelector(state => state.prefs.local.cloudFileId);
   let { sync } = useActions();
+
+  let { atLeastSmallWidth } = useResponsive();
 
   let [syncing, setSyncing] = useState(false);
   let [syncState, setSyncState] = useState(null);
@@ -144,30 +142,20 @@ export function SyncButton({ style }) {
   return (
     <Button
       type="bare"
-      style={css(
-        style,
-        {
-          WebkitAppRegion: 'none',
-          color:
-            syncState === 'error'
-              ? colors.r7
-              : syncState === 'disabled' ||
-                syncState === 'offline' ||
-                syncState === 'local'
-              ? colors.n9
-              : null,
-        },
-        media(`(min-width: ${tokens.breakpoint_small})`, {
-          color:
-            syncState === 'error'
-              ? colors.r4
-              : syncState === 'disabled' ||
-                syncState === 'offline' ||
-                syncState === 'local'
-              ? colors.n6
-              : null,
-        }),
-      )}
+      color={
+        syncState === 'error'
+          ? atLeastSmallWidth
+            ? colors.r4
+            : colors.r7
+          : syncState === 'disabled' ||
+            syncState === 'offline' ||
+            syncState === 'local'
+          ? atLeastSmallWidth
+            ? colors.n6
+            : colors.n9
+          : null
+      }
+      style={[style, { WebkitAppRegion: 'none' }]}
       onClick={sync}
     >
       {syncState === 'error' ? (
@@ -311,6 +299,7 @@ export default function Titlebar({ style }) {
         <Button
           type="bare"
           style={{ marginRight: 8 }}
+          color={colors.n5}
           onPointerEnter={e => {
             if (e.pointerType === 'mouse') {
               sidebar.setHidden(false);
@@ -329,7 +318,7 @@ export default function Titlebar({ style }) {
         >
           <NavigationMenu
             className="menu"
-            style={{ width: 15, height: 15, color: colors.n5, left: 0 }}
+            style={{ width: 15, height: 15, left: 0 }}
           />
         </Button>
       )}
@@ -340,11 +329,7 @@ export default function Titlebar({ style }) {
           element={
             location.state?.goBack ? (
               <Button type="bare" onClick={() => navigate(-1)}>
-                <ArrowLeft
-                  width={10}
-                  height={10}
-                  style={{ marginRight: 5, color: 'currentColor' }}
-                />{' '}
+                <ArrowLeft width={10} height={10} style={{ marginRight: 5 }} />{' '}
                 Back
               </Button>
             ) : null

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -8,8 +8,6 @@ import React, {
 import { useSelector } from 'react-redux';
 import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 
-import { css, media } from 'glamor';
-
 import * as Platform from 'loot-core/src/client/platform';
 import * as queries from 'loot-core/src/client/queries';
 import { listen } from 'loot-core/src/platform/client/fetch';
@@ -23,7 +21,6 @@ import SvgEyeSlashed from '../icons/v2/EyeSlashed';
 import NavigationMenu from '../icons/v2/NavigationMenu';
 import { useResponsive } from '../ResponsiveProvider';
 import { colors } from '../style';
-import tokens from '../tokens';
 
 import AccountSyncCheck from './accounts/AccountSyncCheck';
 import AnimatedRefresh from './AnimatedRefresh';

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.js
@@ -85,13 +85,12 @@ export default function AccountSyncCheck() {
     <View>
       <Button
         type="bare"
+        color={colors.r5}
         style={{
           flexDirection: 'row',
           alignItems: 'center',
-          color: colors.r5,
           backgroundColor: colors.r10,
           padding: '4px 8px',
-          borderRadius: 4,
         }}
         onClick={() => setOpen(true)}
       >

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -1077,12 +1077,9 @@ function BudgetHeader({
           style={[
             buttonStyle,
             { position: 'absolute', top: 0, bottom: 0, right: 0 },
+            { fontSize: 15, fontWeight: '500' },
           ]}
-          textStyle={{
-            color: colors.n11,
-            fontSize: 15,
-            fontWeight: '500',
-          }}
+          color={colors.n11}
         >
           Done
         </Button>
@@ -1092,13 +1089,10 @@ function BudgetHeader({
             type="bare"
             onClick={nextEnabled && onNextMonth}
             // hitSlop={{ top: 5, bottom: 5, left: 30, right: 5 }}
+            color={colors.n11}
             style={[buttonStyle, { opacity: nextEnabled ? 1 : 0.6 }]}
           >
-            <ArrowThinRight
-              style={{ color: colors.n11 }}
-              width="15"
-              height="15"
-            />
+            <ArrowThinRight width="15" height="15" />
           </Button>
 
           <SyncButton

--- a/packages/desktop-client/src/components/budget/misc.js
+++ b/packages/desktop-client/src/components/budget/misc.js
@@ -355,13 +355,10 @@ function SidebarCategory({
             e.stopPropagation();
             setMenuOpen(true);
           }}
-          style={{ color: 'currentColor', padding: 3 }}
+          color="currentColor"
+          style={{ padding: 3 }}
         >
-          <CheveronDown
-            width={14}
-            height={14}
-            style={{ color: 'currentColor' }}
-          />
+          <CheveronDown width={14} height={14} />
         </Button>
         {menuOpen && (
           <Tooltip
@@ -687,13 +684,10 @@ const BudgetTotals = memo(function BudgetTotals({
           onClick={() => {
             setMenuOpen(true);
           }}
-          style={{ color: 'currentColor', padding: 3 }}
+          color={colors.n5}
+          style={{ padding: 3 }}
         >
-          <DotsHorizontalTriple
-            width={15}
-            height={15}
-            style={{ color: colors.n5 }}
-          />
+          <DotsHorizontalTriple width={15} height={15} />
           {menuOpen && (
             <Tooltip
               position="bottom-right"

--- a/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
@@ -353,12 +353,13 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
               type="bare"
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
+              color={colors.n6}
             >
               <ExpandOrCollapseIcon
                 width={13}
                 height={13}
                 // The margin is to make it the exact same size as the dots button
-                style={{ color: colors.n6, margin: 1 }}
+                style={{ margin: 1 }}
               />
             </Button>
           </View>
@@ -397,12 +398,8 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
               />
             </View>
             <View style={{ userSelect: 'none' }}>
-              <Button type="bare" onClick={onMenuOpen}>
-                <DotsHorizontalTriple
-                  width={15}
-                  height={15}
-                  style={{ color: colors.n5 }}
-                />
+              <Button type="bare" onClick={onMenuOpen} color={colors.n5}>
+                <DotsHorizontalTriple width={15} height={15} />
               </Button>
               {menuOpen && (
                 <Tooltip

--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
@@ -326,12 +326,13 @@ export function BudgetSummary({
               type="bare"
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
+              color={colors.n6}
             >
               <ExpandOrCollapseIcon
                 width={13}
                 height={13}
                 // The margin is to make it the exact same size as the dots button
-                style={{ color: colors.n6, margin: 1 }}
+                style={{ margin: 1 }}
               />
             </Button>
           </View>
@@ -370,12 +371,8 @@ export function BudgetSummary({
               />
             </View>
             <View style={{ userSelect: 'none', marginLeft: 2 }}>
-              <Button type="bare" onClick={onMenuOpen}>
-                <DotsHorizontalTriple
-                  width={15}
-                  height={15}
-                  style={{ color: colors.n5 }}
-                />
+              <Button type="bare" onClick={onMenuOpen} color={colors.n5}>
+                <DotsHorizontalTriple width={15} height={15} />
               </Button>
               {menuOpen && (
                 <Tooltip

--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -17,7 +17,6 @@ type ButtonProps = HTMLPropsWithStyle<HTMLButtonElement> & {
   color?: string;
   hoveredStyle?: CSSProperties;
   activeStyle?: CSSProperties;
-  textStyle?: CSSProperties;
   bounce?: boolean;
   as?: 'button';
 };

--- a/packages/desktop-client/src/components/filters/FiltersMenu.js
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.js
@@ -95,11 +95,11 @@ function OpButton({ op, selected, style, onClick }) {
   return (
     <Button
       type="bare"
+      color={selected ? 'white' : null}
       style={[
         { backgroundColor: colors.n10, marginBottom: 5 },
         style,
         selected && {
-          color: 'white',
           '&,:hover,:active': { backgroundColor: colors.b4 },
         },
       ]}

--- a/packages/desktop-client/src/components/manager/BudgetList.js
+++ b/packages/desktop-client/src/components/manager/BudgetList.js
@@ -320,10 +320,8 @@ export default function BudgetList() {
       >
         <Button
           type="bare"
-          style={{
-            marginLeft: 10,
-            color: colors.n4,
-          }}
+          color={colors.n4}
+          style={{ marginLeft: 10 }}
           onClick={e => {
             e.preventDefault();
             pushModal('import');

--- a/packages/desktop-client/src/components/manager/ConfigServer.js
+++ b/packages/desktop-client/src/components/manager/ConfigServer.js
@@ -168,7 +168,7 @@ export default function ConfigServer() {
         }}
       >
         {currentUrl ? (
-          <Button type="bare" style={{ color: colors.n4 }} onClick={onSkip}>
+          <Button type="bare" color={colors.n4} onClick={onSkip}>
             Stop using a server
           </Button>
         ) : (
@@ -176,8 +176,8 @@ export default function ConfigServer() {
             {!isElectron() && (
               <Button
                 type="bare"
+                color={colors.n4}
                 style={{
-                  color: colors.n4,
                   margin: 5,
                   marginRight: 15,
                 }}
@@ -188,7 +188,8 @@ export default function ConfigServer() {
             )}
             <Button
               type="bare"
-              style={{ color: colors.n4, margin: 5 }}
+              color={colors.n4}
+              style={{ margin: 5 }}
               onClick={onSkip}
             >
               Don’t use a server

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
@@ -87,7 +87,8 @@ export default function Bootstrap() {
         buttons={
           <Button
             type="bare"
-            style={{ fontSize: 15, color: colors.b4, marginRight: 15 }}
+            color={colors.b4}
+            style={{ fontSize: 15, marginRight: 15 }}
             onClick={onDemo}
           >
             Try Demo

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -114,7 +114,8 @@ export default function Login() {
       >
         <Button
           type="bare"
-          style={{ fontSize: 15, color: colors.b4, marginLeft: 10 }}
+          color={colors.b4}
+          style={{ fontSize: 15, marginLeft: 10 }}
           onClick={onDemo}
         >
           Try Demo &rarr;

--- a/packages/desktop-client/src/components/schedules/EditSchedule.js
+++ b/packages/desktop-client/src/components/schedules/EditSchedule.js
@@ -702,13 +702,10 @@ export default function ScheduleDetails() {
               </Button>{' '}
               <Button
                 type="bare"
-                style={{
-                  color:
-                    state.transactionsMode === 'matched'
-                      ? colors.b4
-                      : colors.n7,
-                  fontSize: 14,
-                }}
+                color={
+                  state.transactionsMode === 'matched' ? colors.b4 : colors.n7
+                }
+                style={{ fontSize: 14 }}
                 onClick={() => onSwitchTransactions('matched')}
               >
                 Find matching transactions

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -868,11 +868,7 @@ export function SelectedItemsButton({ name, keyHandlers, items, onSelect }) {
     <View>
       <KeyHandlers keys={keyHandlers || {}} />
 
-      <Button
-        type="bare"
-        style={{ color: colors.b3 }}
-        onClick={() => setMenuOpen(true)}
-      >
+      <Button type="bare" color={colors.b3} onClick={() => setMenuOpen(true)}>
         <ExpandArrow width={8} height={8} style={{ marginRight: 5 }} />
         {selectedItems.size} {name}
       </Button>

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.js
@@ -495,11 +495,11 @@ function HeaderCell({
         <Button
           type="bare"
           onClick={onClick}
+          color={colors.n4}
           style={{
             whiteSpace: 'nowrap',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-            color: colors.n4,
             fontWeight: 300,
             marginLeft: marginLeft,
             marginRight: marginRight,
@@ -636,7 +636,6 @@ function PayeeIcons({
     marginRight: 2,
     width: 23,
     height: 23,
-    color: 'inherit',
   };
 
   let scheduleIconStyle = { width: 13, height: 13 };
@@ -648,6 +647,7 @@ function PayeeIcons({
   return schedule ? (
     <Button
       type="bare"
+      color="inherit"
       style={buttonStyle}
       onClick={e => {
         e.stopPropagation();
@@ -663,6 +663,7 @@ function PayeeIcons({
   ) : transferAccount ? (
     <Button
       type="bare"
+      color="inherit"
       style={buttonStyle}
       onClick={e => {
         e.stopPropagation();

--- a/upcoming-release-notes/1424.md
+++ b/upcoming-release-notes/1424.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix the colors of a few buttons when hovered


### PR DESCRIPTION
The reasoning for this is that we now allow theming all states of the button, including hover. the `:hover { ... }` styles for the button override the styles further down that are not specifically applied to the hover state. 

Now that I’m writing this description, I’m realizing that an alternate fix could be to manually apply the custom `style` prop to both hover and active styles. What do you think?