### PR TITLE
Apply button styles again to hover and active states

### DIFF
--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -190,7 +190,7 @@ function Notification({
             style={{ flexShrink: 0, color: 'currentColor' }}
             onClick={onRemove}
           >
-            <Delete style={{ width: 9, height: 9, color: 'currentColor' }} />
+            <Delete style={{ width: 9, height: 9 }} />
           </Button>
         )}
       </Stack>
@@ -207,9 +207,7 @@ function Notification({
             justifyContent: 'center',
           }}
         >
-          <AnimatedLoading
-            style={{ width: 20, height: 20, color: 'currentColor' }}
-          />
+          <AnimatedLoading style={{ width: 20, height: 20 }} />
         </View>
       )}
     </View>

--- a/packages/desktop-client/src/components/SidebarWithData.js
+++ b/packages/desktop-client/src/components/SidebarWithData.js
@@ -79,8 +79,8 @@ function EditableBudgetName({ prefs, savePrefs }) {
     return (
       <Button
         type="bare"
-        color={colors.n9}
         style={{
+          color: colors.n9,
           fontSize: 16,
           fontWeight: 500,
           marginLeft: -5,

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -340,11 +340,7 @@ export default function Titlebar({ style }) {
           element={
             location.state?.goBack ? (
               <Button type="bare" onClick={() => navigate(-1)}>
-                <ArrowLeft
-                  width={10}
-                  height={10}
-                  style={{ marginRight: 5, color: 'currentColor' }}
-                />{' '}
+                <ArrowLeft width={10} height={10} style={{ marginRight: 5 }} />{' '}
                 Back
               </Button>
             ) : null

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -1077,12 +1077,12 @@ function BudgetHeader({
           style={[
             buttonStyle,
             { position: 'absolute', top: 0, bottom: 0, right: 0 },
+            {
+              color: colors.n11,
+              fontSize: 15,
+              fontWeight: 500,
+            },
           ]}
-          textStyle={{
-            color: colors.n11,
-            fontSize: 15,
-            fontWeight: '500',
-          }}
         >
           Done
         </Button>

--- a/packages/desktop-client/src/components/budget/misc.js
+++ b/packages/desktop-client/src/components/budget/misc.js
@@ -357,11 +357,7 @@ function SidebarCategory({
           }}
           style={{ color: 'currentColor', padding: 3 }}
         >
-          <CheveronDown
-            width={14}
-            height={14}
-            style={{ color: 'currentColor' }}
-          />
+          <CheveronDown width={14} height={14} />
         </Button>
         {menuOpen && (
           <Tooltip

--- a/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
@@ -397,12 +397,12 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
               />
             </View>
             <View style={{ userSelect: 'none' }}>
-              <Button type="bare" onClick={onMenuOpen}>
-                <DotsHorizontalTriple
-                  width={15}
-                  height={15}
-                  style={{ color: colors.n5 }}
-                />
+              <Button
+                type="bare"
+                style={{ color: colors.n5 }}
+                onClick={onMenuOpen}
+              >
+                <DotsHorizontalTriple width={15} height={15} />
               </Button>
               {menuOpen && (
                 <Tooltip

--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
@@ -370,12 +370,12 @@ export function BudgetSummary({
               />
             </View>
             <View style={{ userSelect: 'none', marginLeft: 2 }}>
-              <Button type="bare" onClick={onMenuOpen}>
-                <DotsHorizontalTriple
-                  width={15}
-                  height={15}
-                  style={{ color: colors.n5 }}
-                />
+              <Button
+                type="bare"
+                style={{ color: colors.n5 }}
+                onClick={onMenuOpen}
+              >
+                <DotsHorizontalTriple width={15} height={15} />
               </Button>
               {menuOpen && (
                 <Tooltip

--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -14,7 +14,6 @@ type ButtonProps = HTMLPropsWithStyle<HTMLButtonElement> & {
   type?: ButtonType;
   isSubmit?: boolean;
   disabled?: boolean;
-  color?: string;
   hoveredStyle?: CSSProperties;
   activeStyle?: CSSProperties;
   textStyle?: CSSProperties;
@@ -79,7 +78,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       hover,
       type = 'normal',
       isSubmit = type === 'primary',
-      color,
       style,
       disabled,
       hoveredStyle,
@@ -98,7 +96,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       hoveredStyle,
       {
         backgroundColor: backgroundColorHover[type],
-        color: color || textColorHover[type],
+        color: textColorHover[type],
       },
     ];
     activeStyle = [

--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -131,7 +131,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           type === 'bare'
             ? 'none'
             : '1px solid ' + borderColor[typeWithDisabled],
-        color: color || textColor[typeWithDisabled],
+        color: textColor[typeWithDisabled],
         transition: 'box-shadow .25s',
         WebkitAppRegion: 'no-drag',
         ...styles.smallText,

--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -94,6 +94,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     hoveredStyle = [
       type !== 'bare' && styles.shadow,
+      style,
       hoveredStyle,
       {
         backgroundColor: backgroundColorHover[type],
@@ -112,6 +113,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
                 : theme.buttonNormalShadow),
             transition: 'none',
           },
+      style,
       activeStyle,
     ];
 
@@ -138,9 +140,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       },
       { ':hover': !disabled && hoveredStyle },
       { ':active': !disabled && activeStyle },
+      style,
       hover && hoveredStyle,
       pressed && activeStyle,
-      style,
     ];
 
     return (

--- a/packages/desktop-client/src/components/manager/BudgetList.js
+++ b/packages/desktop-client/src/components/manager/BudgetList.js
@@ -122,13 +122,7 @@ function FileState({ file }) {
         marginTop: 8,
       }}
     >
-      <Icon
-        style={{
-          width: 18,
-          height: 18,
-          color: 'currentColor',
-        }}
-      />
+      <Icon style={{ width: 18, height: 18 }} />
 
       <Text style={{ marginLeft: 5 }}>{status}</Text>
     </View>

--- a/packages/desktop-client/src/components/sidebar.js
+++ b/packages/desktop-client/src/components/sidebar.js
@@ -446,7 +446,7 @@ function Accounts({
 function ToggleButton({ style, isFloating, onFloat }) {
   return (
     <View className="float" style={[style, { flexShrink: 0 }]}>
-      <Button type="bare" onClick={onFloat} color={colors.n5}>
+      <Button type="bare" onClick={onFloat} style={{ color: colors.n5 }}>
         {isFloating ? (
           <Pin
             style={{

--- a/upcoming-release-notes/1428.md
+++ b/upcoming-release-notes/1428.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [j-f1]
+---
+
+Fix minor visual issues with some buttons across the app


### PR DESCRIPTION
Supersedes #1424. This allows `<Button style={{ color: 'salmon' }}>` to override both the hover and active styles of the button as well as the normal style.