### PR TITLE
Remove no-op applyFilter call

### DIFF
--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -518,8 +518,7 @@ export const ManagePayees = forwardRef(
                 style={{ marginRight: 10 }}
                 onClick={() => {
                   setOrphanedOnly(!orphanedOnly);
-                  const filterInput = document.getElementById('filter-input');
-                  applyFilter(filterInput.value);
+                  applyFilter(filter);
                   tableNavigator.onEdit(null);
                 }}
               >

--- a/upcoming-release-notes/1430.md
+++ b/upcoming-release-notes/1430.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [j-f1]
+---
+
+Remove no-op `applyFilter` call


### PR DESCRIPTION
`applyFilter` exits early if the filter is unchanged, so this call doesn’t do anything.