### PR TITLE
:bug: (crdt) export Clock as a type to fix warning

### DIFF
--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/crdt",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "CRDT layer of Actual",
   "main": "dist/index.js",

--- a/packages/crdt/src/crdt/index.ts
+++ b/packages/crdt/src/crdt/index.ts
@@ -8,6 +8,6 @@ export {
   makeClientId,
   serializeClock,
   deserializeClock,
-  Clock,
+  type Clock,
   Timestamp,
 } from './timestamp';

--- a/packages/crdt/src/main.ts
+++ b/packages/crdt/src/main.ts
@@ -7,7 +7,7 @@ export {
   makeClientId,
   serializeClock,
   deserializeClock,
-  Clock,
+  type Clock,
   Timestamp,
 } from './crdt';
 

--- a/upcoming-release-notes/1434.md
+++ b/upcoming-release-notes/1434.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+`crdt`: export `Clock` as a type - fix a console warning


### PR DESCRIPTION
Fixes:

```
WARNING in ./packages/crdt/src/crdt/index.ts 3:0-126
export 'Clock' (reexported as 'Clock') was not found in './timestamp' (possible exports: Timestamp, deserializeClock, getClock, makeClientId, makeClock, serializeClock, setClock)
 @ ./packages/crdt/src/main.ts 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129 2:0-129
 @ ./packages/crdt/index.ts 1:0-27 1:0-27
 @ ./packages/loot-core/src/server/main.ts 3:0-41 1996:4-17 1996:38-55 1997:90-109 1997:110-1[23](https://github.com/actualbudget/actual/actions/runs/5711879798/job/15474279705?pr=1432#step:4:24)
```

https://github.com/actualbudget/actual/actions/runs/5711879798/job/15474279705?pr=1432