### PR TITLE
Release note README link update

### DIFF
--- a/upcoming-release-notes/1449.md
+++ b/upcoming-release-notes/1449.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [shall0pass]
+---
+
+Update link in README for release notes

--- a/upcoming-release-notes/README.md
+++ b/upcoming-release-notes/README.md
@@ -1,1 +1,1 @@
-See the [Writing Good Release Notes](https://github.com/actualbudget/docs#writing-good-release-notes) section of the README for the documentation repo for more information on how to create a release notes file here.
+See the [Writing Good Release Notes](https://actualbudget.org/docs/contributing/#writing-good-release-notes) section of the README for the documentation repo for more information on how to create a release notes file here.


### PR DESCRIPTION
The current link in the README directs to a github page that has a link to the documentation page on how to write release notes.  I've updated the link here to just go straight to the documenation page on how to write good release notes.