### PR TITLE
Bugfix: remove select component inner scrollbar

### DIFF
--- a/packages/desktop-client/src/components/common/Select.tsx
+++ b/packages/desktop-client/src/components/common/Select.tsx
@@ -64,7 +64,7 @@ export default function Select<Value extends string>({
         <span
           style={{
             display: 'flex',
-            overflowX: 'hidden',
+            overflow: 'hidden',
             textOverflow: 'ellipsis',
             whiteSpace: 'nowrap',
             maxWidth: `calc(100% - ${arrowSize + 5}px)`,

--- a/upcoming-release-notes/1458.md
+++ b/upcoming-release-notes/1458.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aleetsaiya]
+---
+
+In some situations the text in the Select component will be too big, which will make the inner vertical scrollbar appear. This PR is to hide the vertical scrollbar.


### PR DESCRIPTION
In some situations the text in the Select component will be too big, which will make the inner vertical scrollbar appear. This PR is to hide the vertical scrollbar.

![截圖 2023-08-04 下午3 06 38](https://github.com/actualbudget/actual/assets/67775387/be6c066d-de44-4944-b02e-5d265c84bc61)
