### PR TITLE
:sparkles: (export) adding error handling & improving dev-exp for electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "start:browser-backend": "yarn workspace loot-core watch:browser",
     "start:browser-frontend": "yarn workspace @actual-app/web start:browser",
     "build:browser": "./bin/package-browser",
+    "build:desktop": "./bin/package-electron",
     "build:api": "yarn workspace @actual-app/api build",
     "test": "yarn workspaces foreach --parallel --verbose run test",
     "test:debug": "yarn workspaces foreach --verbose run test",

--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -76,11 +76,11 @@ if (isDev) {
 }
 
 function createBackgroundProcess(socketName) {
-  serverProcess = fork(__dirname + '/server.js', [
-    '--subprocess',
-    app.getVersion(),
-    socketName,
-  ]);
+  serverProcess = fork(
+    __dirname + '/server.js',
+    ['--subprocess', app.getVersion(), socketName],
+    isDev ? { execArgv: ['--inspect'] } : undefined,
+  );
 
   serverProcess.on('message', msg => {
     switch (msg.type) {
@@ -120,6 +120,10 @@ async function createWindow() {
     },
   });
   win.setBackgroundColor('#E8ECF0');
+
+  if (isDev) {
+    win.webContents.openDevTools();
+  }
 
   const unlistenToState = WindowState.listen(win, windowState);
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -2063,7 +2063,15 @@ handlers['import-budget'] = async function ({ filepath, type }) {
 };
 
 handlers['export-budget'] = async function () {
-  return await cloudStorage.exportBuffer();
+  try {
+    return {
+      data: await cloudStorage.exportBuffer(),
+    };
+  } catch (err) {
+    err.message = 'Error exporting budget: ' + err.message;
+    captureException(err);
+    return { error: 'internal-error' };
+  }
 };
 
 async function loadBudget(id) {

--- a/packages/loot-core/src/types/server-handlers.d.ts
+++ b/packages/loot-core/src/types/server-handlers.d.ts
@@ -328,7 +328,7 @@ export interface ServerHandlers {
     type: 'ynab4' | 'ynab5' | 'actual';
   }) => Promise<{ error?: string }>;
 
-  'export-budget': () => Promise<Buffer | null>;
+  'export-budget': () => Promise<{ data: Buffer } | { error: string }>;
 
   'upload-file-web': (arg: {
     filename: string;


### PR DESCRIPTION
Improving error handling for export functionality. Now it will no longer crash the websocket server if export fails. Instead it shows a user-friendly error message.

<img width="605" alt="Screenshot 2023-08-05 at 21 15 54" src="https://github.com/actualbudget/actual/assets/886567/caa8b11f-4215-4195-a7a7-836a709d86e2">

Also some small dev-exp improvements.
