### PR TITLE
chore: remove usage of `...css` syntax

### DIFF
--- a/packages/desktop-client/src/components/App.js
+++ b/packages/desktop-client/src/components/App.js
@@ -99,13 +99,13 @@ class App extends Component {
           {process.env.REACT_APP_REVIEW_ID && <DevelopmentTopBar />}
           <div
             key={hiddenScrollbars ? 'hidden-scrollbars' : 'scrollbars'}
-            {...css([
+            className={css([
               {
                 flexGrow: 1,
                 overflow: 'hidden',
               },
               styles.lightScrollbar,
-            ])}
+            ]).toString()}
           >
             {fatalError ? (
               <>

--- a/packages/desktop-client/src/components/AppBackground.js
+++ b/packages/desktop-client/src/components/AppBackground.js
@@ -16,7 +16,7 @@ function AppBackground({ initializing, loadingText }) {
 
       {(loadingText != null || initializing) && (
         <View
-          {...css({
+          className={css({
             position: 'absolute',
             top: 0,
             left: 0,
@@ -25,7 +25,7 @@ function AppBackground({ initializing, loadingText }) {
             paddingTop: 200,
             color: theme.pageText,
             alignItems: 'center',
-          })}
+          }).toString()}
         >
           <Block style={{ marginBottom: 20, fontSize: 18 }}>
             {loadingText}

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -40,25 +40,25 @@ function NotesTooltip({
       {editable ? (
         <textarea
           ref={inputRef}
-          {...css({
+          className={css({
             border: '1px solid ' + colors.border,
             padding: 7,
             minWidth: 300,
             minHeight: 120,
             outline: 'none',
-          })}
+          }).toString()}
           value={notes || ''}
           onChange={e => setNotes(e.target.value)}
         />
       ) : (
         <Text
-          {...css({
+          className={css({
             display: 'block',
             maxWidth: 225,
             padding: 8,
             whiteSpace: 'pre-wrap',
             overflowWrap: 'break-word',
-          })}
+          }).toString()}
         >
           {notes}
         </Text>

--- a/packages/desktop-client/src/components/Titlebar.js
+++ b/packages/desktop-client/src/components/Titlebar.js
@@ -144,7 +144,7 @@ export function SyncButton({ style }) {
   return (
     <Button
       type="bare"
-      style={css(
+      className={css(
         style,
         {
           WebkitAppRegion: 'none',
@@ -167,7 +167,7 @@ export function SyncButton({ style }) {
               ? colors.n6
               : null,
         }),
-      )}
+      ).toString()}
       onClick={sync}
     >
       {syncState === 'error' ? (

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -95,11 +95,11 @@ function defaultRenderItems(items, getItemProps, highlightedIndex) {
           <div
             {...getItemProps({ item })}
             key={name}
-            {...css({
+            className={css({
               padding: 5,
               cursor: 'default',
               backgroundColor: highlightedIndex === index ? colors.n4 : null,
-            })}
+            }).toString()}
           >
             {name}
           </div>

--- a/packages/desktop-client/src/components/budget/BudgetSummaries.js
+++ b/packages/desktop-client/src/components/budget/BudgetSummaries.js
@@ -60,13 +60,13 @@ export default function BudgetSummaries({ SummaryComponent }) {
 
   return (
     <div
-      {...css([
+      className={css([
         { flex: 1, overflow: 'hidden' },
         months.length === 1 && {
           marginLeft: -4,
           marginRight: -4,
         },
-      ])}
+      ]).toString()}
       ref={containerRef}
     >
       <animated.div

--- a/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
@@ -273,12 +273,10 @@ function Saved({ projected, style }: SavedProps) {
         }}
       >
         <View
-          {...css([
-            {
-              fontSize: 25,
-              color: projected ? colors.y3 : isNegative ? colors.r4 : colors.p5,
-            },
-          ])}
+          className={css({
+            fontSize: 25,
+            color: projected ? colors.y3 : isNegative ? colors.r4 : colors.p5,
+          }).toString()}
         >
           <PrivacyFilter blurIntensity={7}>
             {format(saved, 'financial')}
@@ -364,7 +362,7 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
           </View>
 
           <div
-            {...css([
+            className={css([
               {
                 textAlign: 'center',
                 marginTop: 3,

--- a/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/BudgetSummary.tsx
@@ -371,7 +371,7 @@ export function BudgetSummary({ month }: BudgetSummaryProps) {
                 textDecorationSkip: 'ink',
               },
               currentMonth === month && { textDecoration: 'underline' },
-            ])}
+            ]).toString()}
           >
             {monthUtils.format(month, 'MMMM')}
           </div>

--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
@@ -346,7 +346,7 @@ export function BudgetSummary({
                 textDecorationSkip: 'ink',
               },
               currentMonth === month && { fontWeight: 'bold' },
-            ])}
+            ]).toString()}
           >
             {monthUtils.format(month, 'MMMM')}
           </div>

--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
@@ -180,7 +180,7 @@ function ToBudget({
             <Block
               onClick={() => setMenuOpen('actions')}
               data-cellname={sheetName}
-              {...css([
+              className={css([
                 styles.veryLargeText,
                 {
                   fontWeight: 400,
@@ -193,7 +193,7 @@ function ToBudget({
                     borderColor: isNegative ? colors.r4 : colors.p5,
                   },
                 },
-              ])}
+              ]).toString()}
             >
               {format(num, 'financial')}
             </Block>
@@ -337,7 +337,7 @@ export function BudgetSummary({
           </View>
 
           <div
-            {...css([
+            className={css([
               {
                 textAlign: 'center',
                 marginTop: 3,

--- a/packages/desktop-client/src/components/common/AnchorLink.tsx
+++ b/packages/desktop-client/src/components/common/AnchorLink.tsx
@@ -23,7 +23,11 @@ export default function AnchorLink({
   return (
     <NavLink
       to={to}
-      {...css([styles.smallText, style, match ? activeStyle : null])}
+      className={css([
+        styles.smallText,
+        style,
+        match ? activeStyle : null,
+      ]).toString()}
     >
       {children}
     </NavLink>

--- a/packages/desktop-client/src/components/common/Block.tsx
+++ b/packages/desktop-client/src/components/common/Block.tsx
@@ -14,7 +14,7 @@ export default function Block(props: BlockProps) {
     <div
       {...restProps}
       ref={innerRef}
-      className={`${props.className || ''} ${css(props.style)}`}
+      className={`${props.className || ''} ${css(props.style).toString()}`}
     />
   );
 }

--- a/packages/desktop-client/src/components/common/InlineField.tsx
+++ b/packages/desktop-client/src/components/common/InlineField.tsx
@@ -19,7 +19,7 @@ export default function InlineField({
 }: InlineFieldProps) {
   return (
     <label
-      {...css(
+      className={css(
         {
           display: 'flex',
           flexDirection: 'row',
@@ -28,7 +28,7 @@ export default function InlineField({
           width,
         },
         style,
-      )}
+      ).toString()}
     >
       <div
         style={{

--- a/packages/desktop-client/src/components/common/Input.tsx
+++ b/packages/desktop-client/src/components/common/Input.tsx
@@ -37,7 +37,7 @@ export default function Input({
   return (
     <input
       ref={inputRef ? mergeRefs([inputRef, ref]) : ref}
-      {...css(
+      className={css(
         defaultInputStyle,
         {
           whiteSpace: 'nowrap',
@@ -51,7 +51,7 @@ export default function Input({
         },
         styles.smallText,
         style,
-      )}
+      ).toString()}
       {...nativeProps}
       onKeyDown={e => {
         if (e.key === 'Enter' && onEnter) {

--- a/packages/desktop-client/src/components/common/LinkButton.tsx
+++ b/packages/desktop-client/src/components/common/LinkButton.tsx
@@ -14,7 +14,7 @@ export default function LinkButton({
   return (
     <button
       type="button"
-      {...css([
+      className={css([
         {
           textDecoration: 'none',
           color: theme.pageTextLink,
@@ -34,7 +34,7 @@ export default function LinkButton({
         },
         styles.smallText,
         style,
-      ])}
+      ]).toString()}
       {...nativeProps}
     >
       {children}

--- a/packages/desktop-client/src/components/common/Paragraph.tsx
+++ b/packages/desktop-client/src/components/common/Paragraph.tsx
@@ -15,7 +15,9 @@ export default function Paragraph({
   return (
     <div
       {...props}
-      {...css(!isLast && { marginBottom: 15 }, style, { lineHeight: '1.5em' })}
+      className={css(!isLast && { marginBottom: 15 }, style, {
+        lineHeight: '1.5em',
+      }).toString()}
     >
       {children}
     </div>

--- a/packages/desktop-client/src/components/common/Select.tsx
+++ b/packages/desktop-client/src/components/common/Select.tsx
@@ -55,10 +55,10 @@ export default function Select<Value extends string>({
       style={{ lineHeight: '1em', ...wrapperStyle }}
     >
       <ListboxButton
-        {...css([
+        className={css([
           { borderWidth: 0, padding: '2px 5px', borderRadius: 4 },
           style,
-        ])}
+        ]).toString()}
         arrow={<ExpandArrow style={{ width: arrowSize, height: arrowSize }} />}
       >
         <span

--- a/packages/desktop-client/src/components/common/Text.tsx
+++ b/packages/desktop-client/src/components/common/Text.tsx
@@ -16,7 +16,7 @@ const Text = (props: TextProps) => {
     <span
       {...restProps}
       ref={innerRef}
-      className={String(css([props.className, props.style]))}
+      className={css([props.className, props.style]).toString()}
     />
   );
 };

--- a/packages/desktop-client/src/components/forms.tsx
+++ b/packages/desktop-client/src/components/forms.tsx
@@ -68,7 +68,7 @@ export const Checkbox = (props: CheckboxProps) => {
     <input
       type="checkbox"
       {...props}
-      {...css(
+      className={css(
         [
           {
             position: 'relative',
@@ -114,7 +114,7 @@ export const Checkbox = (props: CheckboxProps) => {
           },
         ],
         props.style,
-      )}
+      ).toString()}
     />
   );
 };

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKey.js
@@ -69,7 +69,12 @@ export default function CreateEncryptionKey({
                 </ExternalLink>
               </Paragraph>
               <Paragraph>
-                <ul {...css({ marginTop: 0, '& li': { marginBottom: 8 } })}>
+                <ul
+                  className={css({
+                    marginTop: 0,
+                    '& li': { marginBottom: 8 },
+                  }).toString()}
+                >
                   <li>
                     <strong>Important:</strong> if you forget this password{' '}
                     <em>and</em> you don’t have any local copies of your data,

--- a/packages/desktop-client/src/components/reports/Tooltip.js
+++ b/packages/desktop-client/src/components/reports/Tooltip.js
@@ -43,7 +43,7 @@ class Tooltip extends Component {
 
     return ReactDOM.createPortal(
       <div
-        {...css(
+        className={css(
           {
             position: 'absolute',
             top: 0,
@@ -75,7 +75,7 @@ class Tooltip extends Component {
               content: '" "',
             }),
           style,
-        )}
+        ).toString()}
       >
         {datum.premadeLabel}
       </div>,

--- a/packages/desktop-client/src/components/settings/UI.tsx
+++ b/packages/desktop-client/src/components/settings/UI.tsx
@@ -18,7 +18,7 @@ type SettingProps = {
 export const Setting = ({ primaryAction, style, children }: SettingProps) => {
   return (
     <View
-      {...css([
+      className={css(
         {
           backgroundColor: colors.n9,
           alignSelf: 'flex-start',
@@ -29,7 +29,7 @@ export const Setting = ({ primaryAction, style, children }: SettingProps) => {
           width: '100%',
         },
         style,
-      ])}
+      ).toString()}
     >
       <View
         style={{

--- a/packages/desktop-client/src/components/sidebar.js
+++ b/packages/desktop-client/src/components/sidebar.js
@@ -271,8 +271,7 @@ function Account({
               }}
             >
               <div
-                className="dot"
-                {...css({
+                className={`dot ${css({
                   marginRight: 3,
                   width: 5,
                   height: 5,
@@ -281,7 +280,7 @@ function Account({
                   marginLeft: 2,
                   transition: 'transform .3s',
                   opacity: connected ? 1 : 0,
-                })}
+                })}`}
               />
             </View>
 

--- a/packages/desktop-client/src/components/tooltips.js
+++ b/packages/desktop-client/src/components/tooltips.js
@@ -315,7 +315,11 @@ export class Tooltip extends Component {
       <div ref={el => (this.target = el)}>
         {ReactDOM.createPortal(
           <div
-            {...css(contentStyle, style, styles.darkScrollbar)}
+            className={css(
+              contentStyle,
+              style,
+              styles.darkScrollbar,
+            ).toString()}
             ref={this.contentRef}
             data-testid="tooltip"
             onClick={e => {

--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -411,7 +411,7 @@ function ListBoxSection({ section, state }) {
       {section.rendered && (
         <div
           {...headingProps}
-          {...css(styles.smallText, {
+          className={css(styles.smallText, {
             backgroundColor: colors.n10,
             borderBottom: `1px solid ${colors.n9}`,
             borderTop: `1px solid ${colors.n9}`,
@@ -424,7 +424,7 @@ function ListBoxSection({ section, state }) {
             top: '0',
             width: '100%',
             zIndex: zIndices.SECTION_HEADING,
-          })}
+          }).toString()}
         >
           {section.rendered}
         </div>

--- a/packages/desktop-client/src/icons/AnimatedLoading.js
+++ b/packages/desktop-client/src/icons/AnimatedLoading.js
@@ -12,13 +12,13 @@ const rotation = css.keyframes({
 function AnimatedLoading(props) {
   return (
     <span
-      {...css({
+      className={css({
         animationName: rotation,
         animationDuration: '1.6s',
         animationTimingFunction: 'cubic-bezier(0.17, 0.67, 0.83, 0.67)',
         animationIterationCount: 'infinite',
         lineHeight: 0,
-      })}
+      }).toString()}
     >
       <Loading {...props} />
     </span>

--- a/upcoming-release-notes/1472.md
+++ b/upcoming-release-notes/1472.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [TomAFrench]
+---
+
+Remove usage of `glamor`-specific `...css` spread syntax in styling


### PR DESCRIPTION
Partial progress towards https://github.com/actualbudget/actual/issues/701

This spread syntax seems fairly glamor specific and isn't supported in emotion. This PR then removes the usage of the spread syntax in favour of setting a `className` prop which will make migration easier.