### PR TITLE
[Bug] Goals: Monthly schedule can cause error

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -649,7 +649,9 @@ async function applyCategoryTemplate(
               dateConditions,
               monthUtils._parse(current_month),
             );
-            let target_interval = dateConditions.value.interval;
+            let target_interval = dateConditions.value.interval
+              ? dateConditions.value.interval
+              : 1;
             let target_frequency = dateConditions.value.frequency;
             let isRepeating =
               Object(dateConditions.value) === dateConditions.value &&

--- a/upcoming-release-notes/1478.md
+++ b/upcoming-release-notes/1478.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals: Fix error that can occur with monthly schedules


### PR DESCRIPTION
The 'interval' value from the schedules is not set if the schedule is monthly.  This change will check for a valid number for the interval value and if it does not exist will default to 1 (monthly).
