### PR TITLE
Make GoCardless fetch transactions from 7 days before the last imported transaction

### DIFF
--- a/upcoming-release-notes/1484.md
+++ b/upcoming-release-notes/1484.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Fetch GoCardless transactions from the last 90 days or since first transaction.


### PR DESCRIPTION
This lets us fetch and process as few transactions as possible, while still allowing for fetching data back to 90 days ago if we haven't imported transactions for a while.