### PR TITLE
Include additionalInformation in notes

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -7,7 +7,11 @@ import {
   makeChild as makeChildTransaction,
   recalculateSplit,
 } from '../../shared/transactions';
-import { hasFieldsChanged, amountToInteger, looselyParseAdditionalInformation } from '../../shared/util';
+import {
+  hasFieldsChanged,
+  amountToInteger,
+  looselyParseAdditionalInformation,
+} from '../../shared/util';
 import * as db from '../db';
 import { runMutator } from '../mutators';
 import { post } from '../post';
@@ -363,15 +367,21 @@ async function normalizeGoCardlessTransactions(transactions, acctId) {
     trans.account = acctId;
     trans.payee = await resolvePayee(trans, payee_name, payeesToCreate);
     trans.cleared = Boolean(trans.booked);
-    let remittanceInformation = trans.remittanceInformationUnstructured || ((trans.remittanceInformationUnstructuredArray || []).join(', ')) 
+    let remittanceInformation =
+      trans.remittanceInformationUnstructured ||
+      (trans.remittanceInformationUnstructuredArray || []).join(', ');
     // Handle additional information
-    let additionalInformationParsedForNotes = "";
+    let additionalInformationParsedForNotes = '';
     if (trans.additionalInformation) {
-        let additionalInformationParsed = looselyParseAdditionalInformation(trans.additionalInformation);
-        additionalInformationParsedForNotes = [
-            additionalInformationParsed?.atmPosName ?? "",
-            additionalInformationParsed?.narrative ?? ""
-        ].filter(Boolean).join(' - ');
+      let additionalInformationParsed = looselyParseAdditionalInformation(
+        trans.additionalInformation,
+      );
+      additionalInformationParsedForNotes = [
+        additionalInformationParsed?.atmPosName ?? '',
+        additionalInformationParsed?.narrative ?? '',
+      ]
+        .filter(Boolean)
+        .join(' - ');
     }
 
     normalized.push({
@@ -381,10 +391,9 @@ async function normalizeGoCardlessTransactions(transactions, acctId) {
         payee: trans.payee,
         account: trans.account,
         date: trans.date,
-        notes: [
-              remittanceInformation,
-              additionalInformationParsedForNotes
-          ].filter(Boolean).join(' - '),
+        notes: [remittanceInformation, additionalInformationParsedForNotes]
+          .filter(Boolean)
+          .join(' - '),
         imported_id: trans.transactionId,
         imported_payee: trans.imported_payee,
         cleared: trans.cleared,

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -378,7 +378,7 @@ export function looselyParseAdditionalInformation(additionalInformation) {
         let key = match[2].trim();
         let value = (match[4] || match[5]).trim();
         // Remove square brackets and single quotes and commas
-        value = value.replace(/[\[\]',]/g, '');
+        value = value.replace(/[[\]',]/g, '');
         result[key] = value;
       }
       additionalInformationJson = result;

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -362,3 +362,29 @@ export function sortByKey<T>(arr: T[], key: keyof T): T[] {
     return 0;
   });
 }
+
+export function looselyParseAdditionalInformation(additionalInformation) {
+  let additionalInformationJson;
+  try {
+      additionalInformationJson = JSON.parse(additionalInformation);
+  } catch (e) {
+      try {
+          // It was not valid JSON, attempt to make the payload valid JSON using regex. 
+          let result = {};
+          let matches = additionalInformation.matchAll(/(, )?([^:]+): ((\[.*?\])|([^,]*))/g);
+          for(let match of matches) {
+              let key = match[2].trim();
+              let value = (match[4] || match[5]).trim();
+              // Remove square brackets and single quotes and commas
+              value = value.replace(/[\[\]',]/g, '');
+              result[key] = value;
+          }
+          additionalInformationJson = result;
+      } catch (e) {
+          additionalInformationJson = {};
+      }
+  }
+  return additionalInformationJson;
+}
+
+

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -366,25 +366,25 @@ export function sortByKey<T>(arr: T[], key: keyof T): T[] {
 export function looselyParseAdditionalInformation(additionalInformation) {
   let additionalInformationJson;
   try {
-      additionalInformationJson = JSON.parse(additionalInformation);
+    additionalInformationJson = JSON.parse(additionalInformation);
   } catch (e) {
-      try {
-          // It was not valid JSON, attempt to make the payload valid JSON using regex. 
-          let result = {};
-          let matches = additionalInformation.matchAll(/(, )?([^:]+): ((\[.*?\])|([^,]*))/g);
-          for(let match of matches) {
-              let key = match[2].trim();
-              let value = (match[4] || match[5]).trim();
-              // Remove square brackets and single quotes and commas
-              value = value.replace(/[\[\]',]/g, '');
-              result[key] = value;
-          }
-          additionalInformationJson = result;
-      } catch (e) {
-          additionalInformationJson = {};
+    try {
+      // It was not valid JSON, attempt to make the payload valid JSON using regex.
+      let result = {};
+      let matches = additionalInformation.matchAll(
+        /(, )?([^:]+): ((\[.*?\])|([^,]*))/g,
+      );
+      for (let match of matches) {
+        let key = match[2].trim();
+        let value = (match[4] || match[5]).trim();
+        // Remove square brackets and single quotes and commas
+        value = value.replace(/[\[\]',]/g, '');
+        result[key] = value;
       }
+      additionalInformationJson = result;
+    } catch (e) {
+      additionalInformationJson = {};
+    }
   }
   return additionalInformationJson;
 }
-
-

--- a/upcoming-release-notes/1490.md
+++ b/upcoming-release-notes/1490.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [CharlieMK]
+---
+
+Add selected content of GoCardLess' additionalInformation field to notes


### PR DESCRIPTION
Implements https://github.com/actualbudget/actual/issues/1466 
Nothing changes for users who use a bank that does not use the additionalInformation field. For banks that do, the remittanceInformation is combined with the information from the atmPosName and narrative subfields of the additionalInformation field.
