### PR TITLE
Fix transactions button background color

### DIFF
--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -902,7 +902,7 @@ export function SelectedItemsButton({ name, keyHandlers, items, onSelect }) {
         <Tooltip
           position="bottom-right"
           width={200}
-          style={{ padding: 0, backgroundColor: 'transparent' }}
+          style={{ padding: 0, backgroundColor: theme.menuBackground }}
           onClose={() => setMenuOpen(false)}
         >
           <Menu

--- a/upcoming-release-notes/1494.md
+++ b/upcoming-release-notes/1494.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Cldfire]
+---
+
+Fix transactions button background color


### PR DESCRIPTION
It seems #1436 caused a regression in the background color of the transactions button.

`demo.actualbudget.org` right now looks like:

<img width="365" alt="Screenshot 2023-08-08 at 7 12 24 PM" src="https://github.com/actualbudget/actual/assets/13814214/b13ca87a-d1e1-4dd7-9275-3bd933b2fc07">

With the fix in this PR:

<img width="309" alt="Screenshot 2023-08-08 at 7 12 50 PM" src="https://github.com/actualbudget/actual/assets/13814214/5f25d4d0-fc25-4187-9ddd-bcf7d0aa2889">

It looks like the transparent background was added explicitly in #1436: https://github.com/actualbudget/actual/pull/1436/files#diff-816cd66052d6811e3d3cac9f19920d8b57c09d3c3b0c882c4fc768d314776d45R905

It's not entirely clear to me why that was done, @carkom was there a specific reason for that change?