### PR TITLE
Rely on date determined by server for GoCardless transactions

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -291,10 +291,6 @@ async function normalizeGoCardlessTransactions(transactions, acctId) {
 
   let normalized = [];
   for (let trans of transactions) {
-    if (!trans.date) {
-      trans.date = trans.valueDate || trans.bookingDate;
-    }
-
     if (!trans.amount) {
       trans.amount = trans.transactionAmount.amount;
     }
@@ -815,7 +811,7 @@ export async function syncGoCardlessAccount(
 
     const oldestDate =
       transactions.length > 0
-        ? oldestTransaction.valueDate || oldestTransaction.bookingDate
+        ? oldestTransaction.date
         : monthUtils.currentDay();
 
     const payee = await getStartingBalancePayee();

--- a/upcoming-release-notes/1499.md
+++ b/upcoming-release-notes/1499.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Rely on date determined by server for GoCardless transactions


### PR DESCRIPTION
Because different banks use the date fields in vastly different ways we now let the server's bank integrations decide which date we should use.

Depends on actualbudget/actual-server#243.
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
