### PR TITLE
:bug: (reports) fix incorrect cashflow balance

### DIFF
--- a/packages/desktop-client/src/components/reports/util.js
+++ b/packages/desktop-client/src/components/reports/util.js
@@ -25,8 +25,8 @@ export function indexCashFlow(data, date, isTransfer) {
   const results = {};
   data.forEach(item => {
     let findExisting = results[item.date]
-      ? results[item.date][item.xfer]
-        ? results[item.date][item.xfer]
+      ? results[item.date][item.isTransfer]
+        ? results[item.date][item.isTransfer]
         : 0
       : 0;
     let result = { [item[isTransfer]]: item.amount + findExisting };

--- a/upcoming-release-notes/1518.md
+++ b/upcoming-release-notes/1518.md
@@ -1,0 +1,6 @@
+---
+ category: Bugfix
+ authors: [martinfrench92]
+ ---
+
+ Fix incorrect cashflow balance

--- a/upcoming-release-notes/1518.md
+++ b/upcoming-release-notes/1518.md
@@ -1,6 +1,6 @@
 ---
- category: Bugfix
- authors: [martinfrench92]
- ---
+category: Bugfix
+authors: [martinfrench92]
+---
 
- Fix incorrect cashflow balance
+Fix incorrect cashflow balance


### PR DESCRIPTION
Fixing a small typo here where multiple transfers across different payees on the same day fail to be summed up resulting in significant balance errors.
