### PR TITLE
Revert "Show correct payee for scheduled transactions on budgeted accounts page"

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.js
@@ -393,7 +393,10 @@ function getPayeePretty(transaction, payee, transferAcct) {
         </div>
       </View>
     );
-  } else if (payee) {
+  } else if (payee && !payee.transfer_acct) {
+    // Check to make sure this isn't a transfer because in the rare
+    // occasion that the account has been deleted but the payee is
+    // still there, we don't want to show the name.
     return payee.name;
   } else if (payeeId && payeeId.startsWith('new:')) {
     return payeeId.slice('new:'.length);
@@ -986,7 +989,7 @@ const Transaction = memo(function Transaction(props) {
           valueStyle={valueStyle}
           transaction={transaction}
           payee={payee}
-          transferAcct={showAccount ? null : transferAcct}
+          transferAcct={transferAcct}
           importedPayee={importedPayee}
           isPreview={isPreview}
           onEdit={onEdit}

--- a/upcoming-release-notes/1379.md
+++ b/upcoming-release-notes/1379.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [kyrias]
----
-
-Show the correct payee of scheduled transactions on "For budget" account page.


### PR DESCRIPTION
Reverts actualbudget/actual#1379

**Why?** this causes a pretty visible bug.

Reproduction: 

1. create test budget
2. create a bunch of transfer transactions
3. switch to "all accounts" view
4. expectation: transfers have the "->"/"<-" arrow icons; reality: the icons are missing