### PR TITLE
:bug: (mobile) hide sync button if sync is not active

### DIFF
--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -149,6 +149,21 @@ export function SyncButton({ style }: SyncButtonProps) {
     return unlisten;
   }, []);
 
+  const mobileColor =
+    syncState === 'error'
+      ? colors.r7
+      : syncState === 'disabled' ||
+        syncState === 'offline' ||
+        syncState === 'local'
+      ? colors.n9
+      : style.color;
+  const activeStyle = css(
+    // mobile
+    media(`(max-width: ${tokens.breakpoint_small})`, {
+      color: mobileColor,
+    }),
+  );
+
   return (
     <Button
       type="bare"
@@ -156,14 +171,7 @@ export function SyncButton({ style }: SyncButtonProps) {
         style,
         {
           WebkitAppRegion: 'none',
-          color:
-            syncState === 'error'
-              ? colors.r7
-              : syncState === 'disabled' ||
-                syncState === 'offline' ||
-                syncState === 'local'
-              ? colors.n9
-              : null,
+          color: mobileColor,
         },
         media(`(min-width: ${tokens.breakpoint_small})`, {
           color:
@@ -176,6 +184,8 @@ export function SyncButton({ style }: SyncButtonProps) {
               : null,
         }),
       )}
+      hoveredStyle={activeStyle}
+      activeStyle={activeStyle}
       onClick={sync}
     >
       {syncState === 'error' ? (

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -22,6 +22,7 @@ import Card from '../common/Card';
 import Label from '../common/Label';
 import Text from '../common/Text';
 import View from '../common/View';
+import { useServerURL } from '../ServerContext';
 import CellValue from '../spreadsheet/CellValue';
 import format from '../spreadsheet/format';
 import NamespaceContext from '../spreadsheet/NamespaceContext';
@@ -1011,6 +1012,8 @@ function BudgetHeader({
   onPrevMonth,
   onNextMonth,
 }) {
+  let serverURL = useServerURL();
+
   // let [menuOpen, setMenuOpen] = useState(false);
 
   // let onMenuSelect = type => {
@@ -1108,18 +1111,20 @@ function BudgetHeader({
             />
           </Button>
 
-          <SyncButton
-            style={{
-              color: 'white',
-              position: 'absolute',
-              top: 0,
-              bottom: 0,
-              right: 0,
-              backgroundColor: 'transparent',
-              paddingLeft: 12,
-              paddingRight: 12,
-            }}
-          />
+          {serverURL && (
+            <SyncButton
+              style={{
+                color: 'white',
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                right: 0,
+                backgroundColor: 'transparent',
+                paddingLeft: 12,
+                paddingRight: 12,
+              }}
+            />
+          )}
           {/* <Button
             type="bare"
             onClick={() => setMenuOpen(true)}

--- a/upcoming-release-notes/1546.md
+++ b/upcoming-release-notes/1546.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Mobile: hide sync button when sync is not active


### PR DESCRIPTION
Two fixes for mobile:

1. hide sync button if sync is not active
2. after clicking the sync button - do not change the color to black


After:
<img width="387" alt="Screenshot 2023-08-19 at 21 09 33" src="https://github.com/actualbudget/actual/assets/886567/ad277170-4928-412f-bd60-1c2dd544fb59">

Before:
<img width="368" alt="Screenshot 2023-08-19 at 21 10 25" src="https://github.com/actualbudget/actual/assets/886567/6b7a1168-b4a0-43f1-a18d-abed8d205b8c">
