### PR TITLE
:bug:  reset reconciliation status when switching accounts

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -425,6 +425,7 @@ class AccountInternal extends PureComponent {
           showBalances: nextProps.showBalances,
           balances: null,
           showCleared: nextProps.showCleared,
+          reconcileAmount: null,
         },
         () => {
           this.fetchTransactions();

--- a/upcoming-release-notes/1547.md
+++ b/upcoming-release-notes/1547.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Reset reconciliation bar when switching accounts


### PR DESCRIPTION
Closes #1327

Reproduction:

1. open transaction table
2. perform reconciliation to open the reconciliation top-message
3. switch account
4. before: the reconciliation bar is still active; after: the reconciliation bar resets
