### PR TITLE
Sync on visibility change

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -140,8 +140,15 @@ function AppWrapper() {
       }
     }
 
-    function onVisibilityChange() {
-      sync();
+    let isSyncing = false;
+
+    async function onVisibilityChange() {
+      if (!isSyncing) {
+        console.debug('triggering sync because of visibility change');
+        isSyncing = true;
+        await sync();
+        isSyncing = false;
+      }
     }
 
     window.addEventListener('focus', checkScrollbars);
@@ -151,7 +158,7 @@ function AppWrapper() {
       window.removeEventListener('focus', checkScrollbars);
       window.removeEventListener('visibilitychange', onVisibilityChange);
     };
-  }, []);
+  }, [sync]);
 
   return (
     <ResponsiveProvider>

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -128,7 +128,7 @@ function AppWrapper() {
     state => state.prefs.local && state.prefs.local.cloudFileId,
   );
   let loadingText = useSelector(state => state.app.loadingText);
-  let { loadBudget, closeBudget, loadGlobalPrefs } = useActions();
+  let { loadBudget, closeBudget, loadGlobalPrefs, sync } = useActions();
   const [hiddenScrollbars, setHiddenScrollbars] = useState(
     hasHiddenScrollbars(),
   );
@@ -140,9 +140,17 @@ function AppWrapper() {
       }
     }
 
-    window.addEventListener('focus', checkScrollbars);
+    function onVisibilityChange() {
+      sync();
+    }
 
-    return () => window.removeEventListener('focus', checkScrollbars);
+    window.addEventListener('focus', checkScrollbars);
+    window.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', checkScrollbars);
+      window.removeEventListener('visibilitychange', onVisibilityChange);
+    };
   }, []);
 
   return (

--- a/upcoming-release-notes/1549.md
+++ b/upcoming-release-notes/1549.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Cldfire]
+---
+
+Trigger a sync when the user returns to Actual in order to present fresh data.


### PR DESCRIPTION
This is a nice, straightforward improvement we can make to syncing before going all the way and refreshing all clients when the server receives new data (#1496).

See the [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) for the event:

> The `visibilitychange` event is fired at the document when the contents of its tab have become visible or have been hidden.
> 
> ...
> 
> This event fires with a `visibilityState` of `hidden` when a user navigates to a new page, switches tabs, closes the tab, minimizes or closes the browser, or, on mobile, switches from the browser to a different app. Transitioning to `hidden` is the last event that's reliably observable by the page, so developers should treat it as the likely end of the user's session (for example, for [sending analytics data](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon)).

Syncing when we receive this event ensures that we're presenting fresh data to the user when they come back to the tab, browser window, or mobile PWA, rather than forcing them to manually trigger a sync.