### PR TITLE
:bug: Mobile entry will enter positive value instead of negative 

### DIFF
--- a/packages/desktop-client/src/components/mobile/MobileAmountInput.js
+++ b/packages/desktop-client/src/components/mobile/MobileAmountInput.js
@@ -227,13 +227,17 @@ export class FocusableAmountInput extends PureComponent {
     });
   };
 
+  maybeApplyNegative = value => {
+    const absValue = Math.abs(value);
+    return this.state.isNegative ? -absValue : absValue;
+  };
+
   onBlur = value => {
     this.setState({ focused: false, reallyFocused: false });
-    if (this.props.onBlur) {
-      const absValue = Math.abs(value);
-      this.props.onBlur(this.state.isNegative ? -absValue : absValue);
-    }
+    this.props.onBlur?.(this.maybeApplyNegative(value));
   };
+
+  onChange = value => this.props.onChange?.(this.maybeApplyNegative(value));
 
   render() {
     const { textStyle, style, focusedStyle, buttonProps } = this.props;
@@ -244,6 +248,7 @@ export class FocusableAmountInput extends PureComponent {
         <AmountInput
           {...this.props}
           ref={el => (this.amount = el)}
+          onChange={this.onChange}
           onBlur={this.onBlur}
           focused={focused}
           style={[

--- a/upcoming-release-notes/1551.md
+++ b/upcoming-release-notes/1551.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [trevdor]
+---
+
+Mobile: transaction entry screen should apply the same negative/positive logic to Amount whether or not it is focused for editing at the time Add Transaction is pressed.


### PR DESCRIPTION
### Repro steps
1. On mobile, on the new transaction screen, enter an Amount, but don't tap away from the Amount field
2. Tap `Add Transaction`
3. The amount entered is positive.
    * The amount here is negative if you first blur Amount, e.g. by editing another field like Payee before adding the transaction.

### Root cause
Our FocusableAmountInput (used for mobile transaction entry) applies negation logic `onBlur`. We have some "queued changes" logic for catching values a person has changed but not "locked in" via blur -- this exact scenario. It catches the new value of Amount on every change. However, that `onChange` handler did not apply the negation logic that `onBlur` uses.


### Solution
Ensure `FocusableAmountInput` used in `MobileTransaction` conditionally applies negation logic the same way `onChange` as it does `onBlur`. 
The component should keep its internal value manipulations to itself and report a single value to consumers.

Fixes #1520 

