### PR TITLE
Don't update transaction date when syncing from GoCardless.

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -498,7 +498,6 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
 
       // Update the transaction
       const updates = {
-        date: trans.date,
         imported_id: trans.imported_id || null,
         payee: existing.payee || trans.payee || null,
         category: existing.category || trans.category || null,

--- a/upcoming-release-notes/1559.md
+++ b/upcoming-release-notes/1559.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Don't update transaction date when syncing from GoCardless.


### PR DESCRIPTION
We should not override the date in case the user has manually corrected it.