### PR TITLE
:bug: Link Schedules modal list of schedules grows too long

### DIFF
--- a/packages/desktop-client/src/components/schedules/LinkSchedule.tsx
+++ b/packages/desktop-client/src/components/schedules/LinkSchedule.tsx
@@ -73,9 +73,11 @@ export default function ScheduleLink({
 
       <View
         style={{
+          flex: `1 1 ${
+            (ROW_HEIGHT - 1) * (Math.max(schedules.length, 1) + 1)
+          }px`,
           marginTop: 15,
-          flexBasis: (ROW_HEIGHT - 1) * (Math.max(schedules.length, 1) + 1),
-          overflow: 'hidden',
+          maxHeight: '50vh',
         }}
       >
         <SchedulesTable

--- a/packages/desktop-client/src/components/schedules/index.js
+++ b/packages/desktop-client/src/components/schedules/index.js
@@ -71,9 +71,8 @@ export default function Schedules() {
 
       <View
         style={{
-          marginTop: 15,
           flexBasis: (ROW_HEIGHT - 1) * (Math.max(schedules.length, 1) + 1),
-          overflow: 'hidden',
+          marginTop: 15,
         }}
       >
         <SchedulesTable


### PR DESCRIPTION
Follow-up for #1501. The Schedules list height needs an upper bound as [observed here](https://github.com/actualbudget/actual/pull/1501#issuecomment-1686520747).

### Testing Notes
1. Check the Schedules screen with no schedules. Should show the "No schedules" text and have this empty height:
    <img width="628" alt="Screenshot 2023-08-22 at 9 28 33 AM" src="https://github.com/actualbudget/actual/assets/5862724/e12c3392-9e6b-4897-8bf1-9e0f9ff319d5">

2. Check the Link Schedule modal. Even with many schedules, the list should be capped at a reasonable length, like so:
    <img width="712" alt="Screenshot 2023-08-22 at 9 27 41 AM" src="https://github.com/actualbudget/actual/assets/5862724/7923f09a-adc9-4e2c-9d4f-5cb26b621b60">
