### PR TITLE
Show all payees by default for child transactions

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.js
@@ -206,7 +206,6 @@ export default function PayeeAutocomplete({
   inputProps,
   showMakeTransfer = true,
   showManagePayees = false,
-  defaultFocusTransferPayees = false,
   tableBehavior,
   embedded,
   closeOnBlur,
@@ -228,9 +227,7 @@ export default function PayeeAutocomplete({
     accounts = cachedAccounts;
   }
 
-  let [focusTransferPayees, setFocusTransferPayees] = useState(
-    defaultFocusTransferPayees,
-  );
+  let [focusTransferPayees, setFocusTransferPayees] = useState(false);
   let [rawPayee, setRawPayee] = useState('');
   let hasPayeeInput = !!rawPayee;
   let payeeSuggestions = useMemo(() => {

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.js
@@ -594,7 +594,6 @@ function PayeeCell({
             }}
             showManagePayees={true}
             tableBehavior={true}
-            defaultFocusTransferPayees={transaction.is_child}
             focused={true}
             onUpdate={onUpdate}
             onSelect={onSave}

--- a/upcoming-release-notes/1573.md
+++ b/upcoming-release-notes/1573.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Show all payees by default for child transactions.


### PR DESCRIPTION
Previously we would default to only show transfer payees in the payee selection dropdown for child transactions.  This is confusing and there doesn't seem to be any obvious reason for this, so this commit removes that behavior.

Feature request #1567 was opened due to this behavior being rather confusing.