### PR TITLE
Experimental OFX parser

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -56,7 +56,8 @@
     "sass": "^1.63.6",
     "uuid": "^9.0.0",
     "victory": "^36.6.8",
-    "webpack-bundle-analyzer": "^4.9.0"
+    "webpack-bundle-analyzer": "^4.9.0",
+    "xml2js": "^0.6.2"
   },
   "scripts": {
     "start": "cross-env PORT=3001 react-app-rewired start",

--- a/packages/desktop-client/src/components/modals/ImportTransactions.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.js
@@ -11,6 +11,7 @@ import {
 } from 'loot-core/src/shared/util';
 
 import { useActions } from '../../hooks/useActions';
+import useFeatureFlag from '../../hooks/useFeatureFlag';
 import { colors, styles } from '../../style';
 import Button, { ButtonWithLoading } from '../common/Button';
 import Input from '../common/Input';
@@ -585,12 +586,19 @@ export default function ImportTransactions({ modalProps, options }) {
 
   let [clearOnImport, setClearOnImport] = useState(true);
 
+  const enableExperimentalOfxParser = useFeatureFlag('experimentalOfxParser');
+
   async function parse(filename, options) {
     setLoadingState('parsing');
 
     let filetype = getFileType(filename);
     setFilename(filename);
     setFileType(filetype);
+
+    options = {
+      ...options,
+      enableExperimentalOfxParser,
+    };
 
     let { errors, transactions } = await parseTransactions(filename, options);
     setLoadingState(null);

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -100,6 +100,9 @@ export default function ExperimentalFeatures() {
             </FeatureToggle>
 
             <FeatureToggle flag="privacyMode">Privacy mode</FeatureToggle>
+            <FeatureToggle flag="experimentalOfxParser">
+              Experimental OFX parser
+            </FeatureToggle>
 
             <ThemeFeature />
           </View>

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -8,6 +8,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesEnabled: false,
   privacyMode: true,
   themes: false,
+  experimentalOfxParser: false,
 };
 
 export default function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -8,7 +8,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesEnabled: false,
   privacyMode: true,
   themes: false,
-  experimentalOfxParser: false,
+  experimentalOfxParser: true,
 };
 
 export default function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/loot-core/src/mocks/files/8859-1.qfx
+++ b/packages/loot-core/src/mocks/files/8859-1.qfx
@@ -45,7 +45,7 @@ NEWFILEUID:NONE
 <DTPOSTED>20221019120000
 <TRNAMT>-20.00
 <FITID>wSoKuCS77
-<NAME>Paiement facture/Carte prépayée
+<NAME>Paiement facture/Carte prÃ©payÃ©e
 <MEMO>PWW
 </STMTTRN>
 </BANKTRANLIST>

--- a/packages/loot-core/src/server/accounts/ofx2json.ts
+++ b/packages/loot-core/src/server/accounts/ofx2json.ts
@@ -1,0 +1,103 @@
+import { parseStringPromise } from 'xml2js';
+
+import { dayFromDate } from '../../shared/months';
+
+type OFXTransaction = {
+  amount: string;
+  fitId: string;
+  name: string;
+  date: string;
+  memo: string;
+  type: string;
+};
+
+type OFXParseResult = {
+  headers: Record<string, unknown>;
+  transactions: OFXTransaction[];
+};
+
+function sgml2Xml(sgml) {
+  return sgml
+    .replace(/&/g, '&#038;') // Replace ampersands
+    .replace(/&amp;/g, '&#038;')
+    .replace(/>\s+</g, '><') // remove whitespace inbetween tag close/open
+    .replace(/\s+</g, '<') // remove whitespace before a close tag
+    .replace(/>\s+/g, '>') // remove whitespace after a close tag
+    .replace(/\.(?=[^<>]*>)/g, '') // Remove dots in tag names
+    .replace(/<(\w+?)>([^<]+)/g, '<$1>$2</<added>$1>') // Add a new end-tags for the ofx elements
+    .replace(/<\/<added>(\w+?)>(<\/\1>)?/g, '</$1>'); // Remove duplicate end-tags
+}
+
+async function parseXml(content) {
+  return await parseStringPromise(content, { explicitArray: false });
+}
+
+function getStmtTrn(data) {
+  const ofx = data?.['OFX'];
+  const isCc = ofx?.['CREDITCARDMSGSRSV1'] != null;
+  const msg = isCc ? ofx?.['CREDITCARDMSGSRSV1'] : ofx?.['BANKMSGSRSV1'];
+  const stmtTrnRs = msg?.[`${isCc ? 'CC' : ''}STMTTRNRS`];
+  const stmtRs = stmtTrnRs?.[`${isCc ? 'CC' : ''}STMTRS`];
+  const bankTranList = stmtRs?.['BANKTRANLIST'];
+  // Could be an array or a single object.
+  // xml2js serializes single item to an object and multiple to an array.
+  const stmtTrn = bankTranList?.['STMTTRN'];
+  if (!Array.isArray(stmtTrn)) {
+    return [stmtTrn];
+  }
+  return stmtTrn;
+}
+
+function mapOfxTransaction(stmtTrn): OFXTransaction {
+  // YYYYMMDDHHMMSS format. We just need the date.
+  const dtPosted = stmtTrn['DTPOSTED'];
+  const transactionDate = dtPosted
+    ? new Date(
+        Number(dtPosted.substring(0, 4)), // year
+        Number(dtPosted.substring(4, 6)) - 1, // month (zero-based index)
+        Number(dtPosted.substring(6, 8)), // date
+      )
+    : null;
+
+  return {
+    amount: stmtTrn['TRNAMT'],
+    type: stmtTrn['TRNTYPE'],
+    fitId: stmtTrn['FITID'],
+    date: dayFromDate(transactionDate),
+    name: stmtTrn['NAME'],
+    memo: stmtTrn['MEMO'],
+  };
+}
+
+export default async function parse(ofx: string): Promise<OFXParseResult> {
+  // firstly, split into the header attributes and the footer sgml
+  const contents = ofx.split('<OFX>', 2);
+
+  // firstly, parse the headers
+  const headerString = contents[0].split(/\r?\n/);
+  const headers = {};
+  headerString.forEach(attrs => {
+    if (attrs) {
+      const headAttr = attrs.split(/:/, 2);
+      headers[headAttr[0]] = headAttr[1];
+    }
+  });
+
+  // make the SGML and the XML
+  const content = `<OFX>${contents[1]}`;
+
+  // Parse the XML/SGML portion of the file into an object
+  // Try as XML first, and if that fails do the SGML->XML mangling
+  let dataParsed = null;
+  try {
+    dataParsed = await parseXml(content);
+  } catch (e) {
+    const sanitized = sgml2Xml(content);
+    dataParsed = await parseXml(sanitized);
+  }
+
+  return {
+    headers: headers,
+    transactions: getStmtTrn(dataParsed).map(mapOfxTransaction),
+  };
+}

--- a/packages/loot-core/src/server/accounts/parse-file.test.ts
+++ b/packages/loot-core/src/server/accounts/parse-file.test.ts
@@ -35,7 +35,9 @@ async function importFileWithRealTime(
 ) {
   // Emscripten requires a real Date.now!
   global.restoreDateNow();
-  let { errors, transactions } = await parseFile(filepath);
+  let { errors, transactions } = await parseFile(filepath, {
+    enableExperimentalOfxParser: true,
+  });
   global.restoreFakeDateNow();
 
   if (transactions) {

--- a/packages/loot-core/src/server/accounts/parse-file.ts
+++ b/packages/loot-core/src/server/accounts/parse-file.ts
@@ -1,10 +1,10 @@
 import csv2json from 'csv-parse/lib/sync';
-import { parseStringPromise } from 'xml2js';
 
 import * as fs from '../../platform/server/fs';
 import { dayFromDate } from '../../shared/months';
 import { looselyParseAmount } from '../../shared/util';
 
+import ofx2json from './ofx2json';
 import qif2json from './qif2json';
 
 type ParseError = { message: string; internal: string };
@@ -113,13 +113,12 @@ async function parseQIF(filepath): Promise<ParseFileResult> {
 }
 
 async function parseOFX(filepath): Promise<ParseFileResult> {
-  let errors = Array<ParseError>();
-  let contents = await fs.readFile(filepath);
+  const errors = Array<ParseError>();
+  const contents = await fs.readFile(filepath);
 
-  let transactions;
+  let data;
   try {
-    let data = await parse(contents);
-    transactions = getStmtTrn(data).map(mapTransaction);
+    data = await ofx2json(contents);
   } catch (err) {
     errors.push({
       message: 'Failed importing file',
@@ -130,95 +129,20 @@ async function parseOFX(filepath): Promise<ParseFileResult> {
 
   return {
     errors,
-    transactions: transactions ?? [],
+    transactions: data.transactions.map(trans => {
+      // Banks don't always implement the OFX standard properly
+      // If no payee is available try and fallback to memo
+      const useName = trans.name != null;
+      return {
+        amount: trans.amount,
+        imported_id: trans.fitId,
+        date: trans.date,
+        payee_name: useName ? trans.name : trans.memo,
+        imported_payee: useName ? trans.name : trans.memo,
+        notes: useName ? trans.memo || null : null, //memo used for payee
+      };
+    }),
   };
-}
-
-function getStmtTrn(data) {
-  let ofx = data?.['OFX'];
-  let isCc = ofx?.['CREDITCARDMSGSRSV1'] != null;
-  let msg = isCc ? ofx?.['CREDITCARDMSGSRSV1'] : ofx?.['BANKMSGSRSV1'];
-  let stmtTrnRs = msg?.[`${isCc ? 'CC' : ''}STMTTRNRS`];
-  let stmtRs = stmtTrnRs?.[`${isCc ? 'CC' : ''}STMTRS`];
-  let bankTranList = stmtRs?.['BANKTRANLIST'];
-  // Could be an array or a single object.
-  // xml2js serializes single item to an object and multiple to an array.
-  let stmtTrn = bankTranList?.['STMTTRN'];
-  if (!Array.isArray(stmtTrn)) {
-    return [stmtTrn];
-  }
-  return stmtTrn;
-}
-
-function mapTransaction(stmtTrn) {
-  // Banks don't always implement the OFX standard properly
-  // If no payee is available try and fallback to memo
-  let useName = stmtTrn['NAME'] != null;
-  // YYYYMMDDHHMMSS format. We just need the date.
-  let dtPosted = stmtTrn['DTPOSTED'];
-  let transactionDate = dtPosted
-    ? new Date(
-        Number(dtPosted.substring(0, 4)), // year
-        Number(dtPosted.substring(4, 6)) - 1, // month (zero-based index)
-        Number(dtPosted.substring(6, 8)), // date
-      )
-    : null;
-
-  return {
-    amount: stmtTrn['TRNAMT'],
-    imported_id: stmtTrn['FITID'],
-    date: dayFromDate(transactionDate),
-    payee_name: useName ? stmtTrn['NAME'] : stmtTrn['MEMO'],
-    imported_payee: useName ? stmtTrn['NAME'] : stmtTrn['MEMO'],
-    notes: useName ? stmtTrn['MEMO'] || null : null, //memo used for payee
-  };
-}
-
-function sgml2Xml(sgml) {
-  return sgml
-    .replace(/&/g, '&#038;') // Replace ampersand
-    .replace(/&amp;/g, '&#038;')
-    .replace(/>\s+</g, '><') // remove whitespace inbetween tag close/open
-    .replace(/\s+</g, '<') // remove whitespace before a close tag
-    .replace(/>\s+/g, '>') // remove whitespace after a close tag
-    .replace(/\.(?=[^<>]*>)/g, '') // Remove dots in tag names
-    .replace(/<(\w+?)>([^<]+)/g, '<$1>$2</<added>$1>') // Add a new end-tags for the ofx elements
-    .replace(/<\/<added>(\w+?)>(<\/\1>)?/g, '</$1>'); // Remove duplicate end-tags
-}
-
-async function parseXml(content) {
-  return await parseStringPromise(content, { explicitArray: false });
-}
-
-async function parse(data) {
-  // firstly, split into the header attributes and the footer sgml
-  const ofx = data.split('<OFX>', 2);
-
-  // firstly, parse the headers
-  const headerString = ofx[0].split(/\r?\n/);
-  const header = {};
-  headerString.forEach(attrs => {
-    const headAttr = attrs.split(/:/, 2);
-    header[headAttr[0]] = headAttr[1];
-  });
-
-  // make the SGML and the XML
-  const content = `<OFX>${ofx[1]}`;
-
-  // Parse the XML/SGML portion of the file into an object
-  // Try as XML first, and if that fails do the SGML->XML mangling
-  let dataParsed = null;
-  try {
-    dataParsed = await parseXml(content);
-  } catch (e) {
-    let sanitized = sgml2Xml(content);
-    dataParsed = await parseXml(sanitized);
-  }
-
-  // put the headers into the returned data
-  dataParsed.header = header;
-
-  return dataParsed;
 }
 
 async function parseOFXNodeLibOFX(filepath, options): Promise<ParseFileResult> {

--- a/packages/loot-core/src/server/accounts/parse-file.ts
+++ b/packages/loot-core/src/server/accounts/parse-file.ts
@@ -1,4 +1,5 @@
 import csv2json from 'csv-parse/lib/sync';
+import { parseStringPromise } from 'xml2js';
 
 import * as fs from '../../platform/server/fs';
 import { dayFromDate } from '../../shared/months';
@@ -16,8 +17,9 @@ export async function parseFile(
   filepath,
   options?: {
     delimiter?: string;
-    hasHeaderRow: boolean;
+    hasHeaderRow?: boolean;
     fallbackMissingPayeeToMemo?: boolean;
+    enableExperimentalOfxParser?: boolean;
   },
 ): Promise<ParseFileResult> {
   let errors = Array<ParseError>();
@@ -34,7 +36,11 @@ export async function parseFile(
         return parseCSV(filepath, options);
       case '.ofx':
       case '.qfx':
-        return parseOFX(filepath, options);
+        if (options.enableExperimentalOfxParser) {
+          return parseOFX(filepath);
+        } else {
+          return parseOFXNodeLibOFX(filepath, options);
+        }
       default:
     }
   }
@@ -43,12 +49,12 @@ export async function parseFile(
     message: 'Invalid file type',
     internal: '',
   });
-  return { errors, transactions: undefined };
+  return { errors, transactions: [] };
 }
 
 async function parseCSV(
   filepath,
-  options: { delimiter?: string; hasHeaderRow: boolean } = {
+  options: { delimiter?: string; hasHeaderRow?: boolean } = {
     hasHeaderRow: true,
   },
 ): Promise<ParseFileResult> {
@@ -105,12 +111,116 @@ async function parseQIF(filepath): Promise<ParseFileResult> {
   };
 }
 
-async function parseOFX(
-  filepath,
-  options: { fallbackMissingPayeeToMemo?: boolean } = {
-    fallbackMissingPayeeToMemo: true,
-  },
-): Promise<ParseFileResult> {
+async function parseOFX(filepath): Promise<ParseFileResult> {
+  let errors = Array<ParseError>();
+  let contents = await fs.readFile(filepath);
+
+  let transactions;
+  try {
+    let data = await parse(contents);
+    transactions = getStmtTrn(data).map(mapTransaction);
+  } catch (err) {
+    errors.push({
+      message: 'Failed importing file',
+      internal: err.stack,
+    });
+    return { errors };
+  }
+
+  return {
+    errors,
+    transactions: transactions ?? [],
+  };
+}
+
+function getStmtTrn(data) {
+  let ofx = data?.['OFX'];
+  let isCc = ofx?.['CREDITCARDMSGSRSV1'] != null;
+  let msg = isCc ? ofx?.['CREDITCARDMSGSRSV1'] : ofx?.['BANKMSGSRSV1'];
+  let stmtTrnRs = msg?.[`${isCc ? 'CC' : ''}STMTTRNRS`];
+  let stmtRs = stmtTrnRs?.[`${isCc ? 'CC' : ''}STMTRS`];
+  let bankTranList = stmtRs?.['BANKTRANLIST'];
+  // Could be an array or a single object.
+  // xml2js serializes single item to an object and multiple to an array.
+  let stmtTrn = bankTranList?.['STMTTRN'];
+  if (!Array.isArray(stmtTrn)) {
+    return [stmtTrn];
+  }
+  return stmtTrn;
+}
+
+function mapTransaction(stmtTrn) {
+  // Banks don't always implement the OFX standard properly
+  // If no payee is available try and fallback to memo
+  let useName = stmtTrn['NAME'] != null;
+  // YYYYMMDDHHMMSS format. We just need the date.
+  let dtPosted = stmtTrn['DTPOSTED'];
+  let transactionDate = dtPosted
+    ? new Date(
+        Number(dtPosted.substring(0, 4)), // year
+        Number(dtPosted.substring(4, 6)) - 1, // month (zero-based index)
+        Number(dtPosted.substring(6, 8)), // date
+      )
+    : null;
+
+  return {
+    amount: stmtTrn['TRNAMT'],
+    imported_id: stmtTrn['FITID'],
+    date: dayFromDate(transactionDate),
+    payee_name: useName ? stmtTrn['NAME'] : stmtTrn['MEMO'],
+    imported_payee: useName ? stmtTrn['NAME'] : stmtTrn['MEMO'],
+    notes: useName ? stmtTrn['MEMO'] || null : null, //memo used for payee
+  };
+}
+
+function sgml2Xml(sgml) {
+  return sgml
+    .replace(/&/g, '&#038;') // Replace ampersand
+    .replace(/&amp;/g, '&#038;')
+    .replace(/>\s+</g, '><') // remove whitespace inbetween tag close/open
+    .replace(/\s+</g, '<') // remove whitespace before a close tag
+    .replace(/>\s+/g, '>') // remove whitespace after a close tag
+    .replace(/\.(?=[^<>]*>)/g, '') // Remove dots in tag names
+    .replace(/<(\w+?)>([^<]+)/g, '<$1>$2</<added>$1>') // Add a new end-tags for the ofx elements
+    .replace(/<\/<added>(\w+?)>(<\/\1>)?/g, '</$1>'); // Remove duplicate end-tags
+}
+
+async function parseXml(content) {
+  return await parseStringPromise(content, { explicitArray: false });
+}
+
+async function parse(data) {
+  // firstly, split into the header attributes and the footer sgml
+  const ofx = data.split('<OFX>', 2);
+
+  // firstly, parse the headers
+  const headerString = ofx[0].split(/\r?\n/);
+  const header = {};
+  headerString.forEach(attrs => {
+    const headAttr = attrs.split(/:/, 2);
+    header[headAttr[0]] = headAttr[1];
+  });
+
+  // make the SGML and the XML
+  const content = `<OFX>${ofx[1]}`;
+
+  // Parse the XML/SGML portion of the file into an object
+  // Try as XML first, and if that fails do the SGML->XML mangling
+  let dataParsed = null;
+  try {
+    dataParsed = await parseXml(content);
+  } catch (e) {
+    let sanitized = sgml2Xml(content);
+    dataParsed = await parseXml(sanitized);
+  }
+
+  // put the headers into the returned data
+  dataParsed.header = header;
+
+  return dataParsed;
+}
+
+async function parseOFXNodeLibOFX(filepath, options): Promise<ParseFileResult> {
   let { getOFXTransactions, initModule } = await import(
     /* webpackChunkName: 'xfo' */ 'node-libofx'
   );

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -5,7 +5,8 @@ export type FeatureFlag =
   | 'reportBudget'
   | 'goalTemplatesEnabled'
   | 'privacyMode'
-  | 'themes';
+  | 'themes'
+  | 'experimentalOfxParser';
 
 export type LocalPrefs = Partial<
   {

--- a/packages/loot-core/webpack/webpack.browser.config.js
+++ b/packages/loot-core/webpack/webpack.browser.config.js
@@ -43,6 +43,8 @@ module.exports = {
       // used by memfs in a check which we can ignore I think
       url: false,
       zlib: require.resolve('browserify-zlib'),
+      // used by xml2js
+      timers: false,
     },
   },
   module: {

--- a/upcoming-release-notes/1600.md
+++ b/upcoming-release-notes/1600.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Experimental OFX parser meant to replace node-libofx

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,7 @@ __metadata:
     uuid: ^9.0.0
     victory: ^36.6.8
     webpack-bundle-analyzer: ^4.9.0
+    xml2js: ^0.6.2
   languageName: unknown
   linkType: soft
 
@@ -16825,7 +16826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:^1.2.4, sax@npm:~1.2.4":
+"sax@npm:>=0.6.0, sax@npm:^1.2.4, sax@npm:~1.2.4":
   version: 1.2.4
   resolution: "sax@npm:1.2.4"
   checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
@@ -20249,10 +20250,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml2js@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "xml2js@npm:0.6.2"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 458a83806193008edff44562c0bdb982801d61ee7867ae58fd35fab781e69e17f40dfeb8fc05391a4648c9c54012066d3955fe5d993ffbe4dc63399023f32ac2
+  languageName: node
+  linkType: hard
+
 "xmlbuilder@npm:>=11.0.1, xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
   checksum: 14f7302402e28d1f32823583d121594a9dca36408d40320b33f598bd589ca5163a352d076489c9c64d2dc1da19a790926a07bf4191275330d4de2b0d85bb1843
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Closes https://github.com/actualbudget/actual/issues/798. When this parser is stable enough, we can remove the node-libofx project/dependency.

Current parsing implementation supports CREDITCARDMSGSRSV1 and BANKMSGSRSV1 for credit card and bank statements respectively.

To test the new OFX parser, it needs to be enabled via the `Experimental features` setting:
![image](https://github.com/actualbudget/actual/assets/20313680/d2dac928-4294-48a6-915b-84b1892c4064)
