### PR TITLE
Fix submit form on enter key pressed

### DIFF
--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -143,8 +143,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...(typeof as === 'string'
           ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (css(buttonStyle) as any)
-          : { style: buttonStyle, type: isSubmit ? 'submit' : 'button' })}
+          : { style: buttonStyle })}
         disabled={disabled}
+        type={isSubmit ? 'submit' : 'button'}
         {...nativeProps}
       >
         {children}

--- a/packages/desktop-client/src/components/modals/FixEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKey.js
@@ -127,7 +127,8 @@ export default function FixEncryptionKey({
               <Button
                 style={{ marginRight: 10 }}
                 onClick={() => modalProps.onBack()}
-                type="button"
+                type="normal"
+                isSubmit={false}
               >
                 Back
               </Button>

--- a/packages/desktop-client/src/components/modals/FixEncryptionKey.js
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKey.js
@@ -128,7 +128,6 @@ export default function FixEncryptionKey({
                 style={{ marginRight: 10 }}
                 onClick={() => modalProps.onBack()}
                 type="normal"
-                isSubmit={false}
               >
                 Back
               </Button>

--- a/upcoming-release-notes/1634.md
+++ b/upcoming-release-notes/1634.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [syukronrm]
+---
+
+Fix pressing Enter on Encryption Key cancels entry instead of update the key


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fix #1582 

**Root Cause**
Adding prop `type="button"` on `<Button>` doesn't work because it doesn't proparagated to HTML `<button>`.

**Changes**
- On Back button: add `isSubmit=false`.
- On Button component: Any `<Button>` with prop `type="primary"` should have be propagated as `<button type="submit">`, except if it's explicitly has prop `isSubmit=false`.
