### PR TITLE
fixed:issue->#1606 component overlapping when editing account name

### DIFF
--- a/packages/desktop-client/src/components/accounts/Header.js
+++ b/packages/desktop-client/src/components/accounts/Header.js
@@ -116,8 +116,8 @@ export function AccountHeader({
       <View style={{ ...styles.pageContent, paddingBottom: 10, flexShrink: 0 }}>
         <View
           style={{
-            marginTop: 5,
-            marginBottom: 5,
+            marginTop: 7,
+            marginBottom: 7,
             alignItems: 'flex-start',
           }}
         >

--- a/packages/desktop-client/src/components/accounts/Header.js
+++ b/packages/desktop-client/src/components/accounts/Header.js
@@ -114,7 +114,13 @@ export function AccountHeader({
       />
 
       <View style={{ ...styles.pageContent, paddingBottom: 10, flexShrink: 0 }}>
-        <View style={{ marginTop: 2, alignItems: 'flex-start' }}>
+        <View
+          style={{
+            marginTop: 5,
+            marginBottom: 5,
+            alignItems: 'flex-start',
+          }}
+        >
           <View>
             {editingName ? (
               <InitialFocus>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
## issue 1606
Component are overlapping when editing account name
## fixes
Added a margin-bottom of 5 in view box of account name, also increment the margin-top by 3 resulting in margin-top: 5 to maintain the symmetry.

## Video output
[Screencast from 2023-09-04 16-33-58.webm](https://github.com/actualbudget/actual/assets/55751461/547ad239-85f5-4648-b377-57bce460cd02)


