### PR TITLE
:bug: (signup) fix setting up for the first time with missing protocol

### DIFF
--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -49,7 +49,7 @@ export default function ConfigServer() {
     let { error } = await setServerUrl(url);
 
     if (
-      error === 'network-failure' &&
+      ['network-failure', 'get-server-failure'].includes(error) &&
       !url.startsWith('http://') &&
       !url.startsWith('https://')
     ) {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1628,8 +1628,12 @@ handlers['get-did-bootstrap'] = async function () {
 handlers['subscribe-needs-bootstrap'] = async function ({
   url,
 }: { url? } = {}) {
-  if (!getServer(url)) {
-    return { bootstrapped: true, hasServer: false };
+  try {
+    if (!getServer(url)) {
+      return { bootstrapped: true, hasServer: false };
+    }
+  } catch (err) {
+    return { error: 'get-server-failure' };
   }
 
   let res;

--- a/packages/loot-core/src/server/server-config.ts
+++ b/packages/loot-core/src/server/server-config.ts
@@ -32,8 +32,7 @@ export function getServer(url?: string): ServerConfig | null {
       SYNC_SERVER: joinURL(url, '/sync'),
       SIGNUP_SERVER: joinURL(url, '/account'),
       PLAID_SERVER: joinURL(url, '/plaid'),
-      // TODO: change to use `/gocardless` after v23.8.0
-      GOCARDLESS_SERVER: joinURL(url, '/nordigen'),
+      GOCARDLESS_SERVER: joinURL(url, '/gocardless'),
     };
   }
   return config;

--- a/upcoming-release-notes/1657.md
+++ b/upcoming-release-notes/1657.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix signup page not allowing to use domains without protocol


### PR DESCRIPTION
Reproduction:

1. open demo
2. when prompted for server: enter `xxxxxxxx.fly.dev` (important: WITHOUT http/https protocol)
3. click "login"
4. branch demo link will work; master demo link will blow up