### PR TITLE
:bug: (mobile) fix schedule status positioning

### DIFF
--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -175,6 +175,7 @@ function Status({ status }) {
         fontSize: 11,
         color,
         fontStyle: 'italic',
+        textAlign: 'left',
       }}
     >
       {titleFirst(status)}

--- a/upcoming-release-notes/1669.md
+++ b/upcoming-release-notes/1669.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Mobile: fix schedule status label positioning


### PR DESCRIPTION

Before:
<img width="217" alt="Screenshot 2023-09-07 at 20 35 30" src="https://github.com/actualbudget/actual/assets/886567/860d790d-8076-4d91-8e6d-2d34a8be38f0">


After:
<img width="187" alt="Screenshot 2023-09-07 at 20 33 47" src="https://github.com/actualbudget/actual/assets/886567/b76040d2-7f47-4ba5-b804-1425f55e9843">
