### PR TITLE
Mobile: Show proper name of income group

### DIFF
--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -692,7 +692,7 @@ class IncomeBudgetGroup extends Component {
 
         <Card style={{ marginTop: 0 }}>
           <IncomeCategory
-            name="Income"
+            name={group.name}
             budget={
               type === 'report' ? reportBudget.groupBudgeted(group.id) : null
             }

--- a/upcoming-release-notes/1679.md
+++ b/upcoming-release-notes/1679.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Mobile: Show true name of income group


### PR DESCRIPTION
The name of the income group on mobile was hard coded to "Income".  This uses the name set by the user, including emojis. 
