### PR TITLE
:bug: Mobile account transaction list: Fix sticky date section headers

### DIFF
--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -1069,7 +1069,6 @@ export class TransactionList extends Component {
           label=""
           loadMore={onLoadMore}
           selectionMode="none"
-          style={{ flex: '1 auto', height: '100%', overflowY: 'auto' }}
         >
           {sections.length === 0 ? (
             <Section>
@@ -1162,7 +1161,6 @@ function ListBox(props) {
           padding: 0,
           listStyle: 'none',
           margin: 0,
-          overflowY: 'auto',
           width: '100%',
         }}
       >

--- a/upcoming-release-notes/1698.md
+++ b/upcoming-release-notes/1698.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [trevdor]
+---
+
+Mobile account transaction list: Restore sticky date section headers


### PR DESCRIPTION
When pull-to-refresh wrapped the transaction list, sticky date headers stopped being sticky.
Let's restore the stickiness.