### PR TITLE
Goals: speed up and a bugfix

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -104,9 +104,7 @@ async function processTemplate(month, force, category_templates) {
   }
   await setGoalBudget({
     month,
-    templateBudget: setToZero.filter(
-      f => f.isTemplate === true,
-    ),
+    templateBudget: setToZero.filter(f => f.isTemplate === true),
   });
 
   // find all remainder templates, place them after all other templates

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -61,7 +61,6 @@ async function setGoalBudget({ month, templateBudget }) {
 }
 
 async function processTemplate(month, force, category_templates) {
-  let templateBudget = [];
   let num_applied = 0;
   let errors = [];
   let lowestPriority = 0;
@@ -106,7 +105,7 @@ async function processTemplate(month, force, category_templates) {
   await setGoalBudget({
     month,
     templateBudget: setToZero.filter(
-      f => f.isTemplate === true && f.isIncome === 0,
+      f => f.isTemplate === true,
     ),
   });
 
@@ -136,6 +135,7 @@ async function processTemplate(month, force, category_templates) {
     ? await getSheetValue(sheetName, `total-saved`)
     : await getSheetValue(sheetName, `to-budget`);
   for (let priority = 0; priority <= lowestPriority; priority++) {
+    let templateBudget = [];
     // setup scaling for remainder
     let remainder_scale = 1;
     if (priority === lowestPriority) {
@@ -231,6 +231,11 @@ async function processTemplate(month, force, category_templates) {
       }
     }
     await setGoalBudget({ month, templateBudget });
+    // higher priority levels wont budget anything 
+    //  if there is nothing remaining anyway
+    if (available_remaining<=0){
+      break;
+    }
   }
 
   if (!force) {

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -231,11 +231,6 @@ async function processTemplate(month, force, category_templates) {
       }
     }
     await setGoalBudget({ month, templateBudget });
-    // higher priority levels wont budget anything 
-    //  if there is nothing remaining anyway
-    if (available_remaining<=0){
-      break;
-    }
   }
 
   if (!force) {

--- a/upcoming-release-notes/1718.md
+++ b/upcoming-release-notes/1718.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: fix bug in report budget templates, and add a speedup


### PR DESCRIPTION
Fixed a bug where report budget income templates would compound instead of replacing previous values.

Fixed an issue where the list of budgeted values to apply to the db would persist between priority runs.  This caused every processed template to be applied again in all future priority runs.  That wasn't very noticeable when accessing locally, but on slower networks it would bog down the process a lot as each db change would be sent to the server.
