### PR TITLE
:bug: (mobile) redirect to budget page for all 404

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -274,6 +274,9 @@ function FinancesApp() {
                     </WideNotSupported>
                   }
                 />
+
+                {/* redirect all other traffic to the budget page */}
+                <Route path="/*" element={<Navigate to="/budget" replace />} />
               </Routes>
 
               <Modals />

--- a/upcoming-release-notes/1721.md
+++ b/upcoming-release-notes/1721.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Redirect back to budget page if non-existing pages accessed


### PR DESCRIPTION
If no route matched - redirect to the budget page.

I suspect this is why in some cases people report seeing a blank page with no content.

Reproduction:

1. open and login to a server
2. open budget page
3. manually edit the url to point to "/login"
4. before: a blank page opens; after: you are redirected back to "/budget"