### PR TITLE
changed default months to 5 in cash flow report

### DIFF
--- a/packages/desktop-client/src/components/reports/CashFlow.js
+++ b/packages/desktop-client/src/components/reports/CashFlow.js
@@ -33,7 +33,7 @@ function CashFlow() {
 
   const [allMonths, setAllMonths] = useState(null);
   const [start, setStart] = useState(
-    monthUtils.subMonths(monthUtils.currentMonth(), 30),
+    monthUtils.subMonths(monthUtils.currentMonth(), 5),
   );
   const [end, setEnd] = useState(monthUtils.currentDay());
 

--- a/upcoming-release-notes/1723.md
+++ b/upcoming-release-notes/1723.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shaankhosla]
+---
+
+Changed the default number of months shown in the Cash Flow report from 30 to 5.

--- a/upcoming-release-notes/1723.md
+++ b/upcoming-release-notes/1723.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfix
+category: Enhancements
 authors: [shaankhosla]
 ---
 


### PR DESCRIPTION
This is a very minor change. It bothered me that the after opening the Cash Flow report, the default number of months is so large (30 months shown). I've changed this to 5 months which is what the Net Worth graph does.

I also thought about changing it to all months until the date of the first transaction but decided against this.