### PR TITLE
[Bugfix]: Goals - Fixed an overbudgeting condition

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -213,6 +213,9 @@ async function processTemplate(month, force, category_templates) {
               );
             if (to_budget != null) {
               num_applied++;
+              if (to_budget > available_remaining && priority > 0) {
+                to_budget = available_remaining;
+              }
               templateBudget.push({
                 category: category.id,
                 amount: to_budget + prev_budgeted,

--- a/upcoming-release-notes/1738.md
+++ b/upcoming-release-notes/1738.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals - Fixed an overbudgeting condition


### PR DESCRIPTION
If a category had two templates, it was possible to overbudget in a category if the priority level was lower.  I've attached a test budget.

To replicate, set the Food budget to zero and then apply the templates.  demo.actualbudget.org and this PR will provide different calculated fills.

[PR_test-budget.zip](https://github.com/actualbudget/actual/files/12728677/PR_test-budget.zip)
