### PR TITLE
[Bug] End of month cleanup error

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -58,15 +58,7 @@ async function processCleanup(month: string): Promise<Notification> {
     );
 
     if (carryover === null) {
-      await setBudget({
-        category: category.id,
-        month,
-        amount: budgeted,
-      });
-      carryover = await db.first(
-        `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
-        [db_month, categoryId],
-      );
+      carryover = { carryover: 0 };
     }
 
     if (

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -57,6 +57,18 @@ async function processCleanup(month: string): Promise<Notification> {
       [db_month, categoryId],
     );
 
+    if (carryover === null) {
+      await setBudget({
+        category: category.id,
+        month,
+        amount: budgeted,
+      });
+      carryover = await db.first(
+        `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
+        [db_month, categoryId],
+      );
+    }
+
     if (
       balance < 0 &&
       Math.abs(balance) <= budgetAvailable &&

--- a/upcoming-release-notes/1750.md
+++ b/upcoming-release-notes/1750.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+End of month cleanup - fixed condition that caused an error with null carryover value


### PR DESCRIPTION
This feels like a hack. There's probably a more elegant way to handle this condition.  The report is correct in that the carryover isn't created initially.  To replicate the error:

1. Start a fresh budget
2. Add an account with a starting balance
3. Add a single transaction and assign a category
4. DO NOT FILL ANY BUDGET CELLS
5. Enable goal templates
6. Run the end of the month cleanup script.

The master branch will show the error that is reported.  What I have done here is check for the null value.  If a null value is found, set the budget cell to it's current value.  By doing this, the database tables get updated and carryover will no longer be reported as null.

https://github.com/actualbudget/actual/issues/1748