### PR TITLE
[Bug] Goals: Fix schedules 'in between' calculation

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -645,7 +645,12 @@ async function applyCategoryTemplate(
             let conditions = rule.serialize().conditions;
             let { date: dateConditions, amount: amountCondition } =
               extractScheduleConds(conditions);
-            let target = -amountCondition.value;
+            let target =
+              amountCondition.op === 'isbetween'
+                ? -Math.round(
+                    amountCondition.value.num1 + amountCondition.value.num2,
+                  ) / 2
+                : -amountCondition.value;
             let next_date_string = getNextDate(
               dateConditions,
               monthUtils._parse(current_month),
@@ -682,7 +687,7 @@ async function applyCategoryTemplate(
                   monthUtils._parse(current_month),
                 );
                 while (next_date < next_month) {
-                  monthlyTarget += amountCondition.value;
+                  monthlyTarget += -target;
                   next_date = monthUtils.addDays(next_date, 1);
                   next_date = getNextDate(
                     dateConditions,

--- a/upcoming-release-notes/1753.md
+++ b/upcoming-release-notes/1753.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals - Fix schedules 'in between' calculation


### PR DESCRIPTION
The templates conditions were not finding a value when 'in between' was chosen from schedules.  This adds a check on the schedule amount type, and if 'in between' is found will return the median value.  I believe this matches the behavior of the scheduled transaction in the ledger.  It may make more sense to fill the maximum amount here for a budgeted value.  I'm interested in any comments on what the expected behavior should be.
 
Fixes: https://github.com/actualbudget/actual/issues/1747