### PR TITLE
Darkmode: fix theming on budget table

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetCategories.js
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.js
@@ -149,7 +149,7 @@ const BudgetCategories = memo(
       <View
         style={{
           marginBottom: 10,
-          backgroundColor: 'white',
+          backgroundColor: theme.tableBackground,
           overflow: 'hidden',
           boxShadow: styles.cardShadow,
           borderRadius: '0 0 4px 4px',
@@ -235,7 +235,7 @@ const BudgetCategories = memo(
                 <View
                   style={{
                     height: styles.incomeHeaderHeight,
-                    backgroundColor: 'white',
+                    backgroundColor: theme.tableBackground,
                   }}
                 >
                   <IncomeHeader

--- a/packages/desktop-client/src/components/budget/BudgetTable.js
+++ b/packages/desktop-client/src/components/budget/BudgetTable.js
@@ -2,7 +2,7 @@ import React, { createRef, Component } from 'react';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { styles } from '../../style';
+import { theme, styles} from '../../style';
 import View from '../common/View';
 import { IntersectionBoundary } from '../tooltips';
 
@@ -189,7 +189,7 @@ class BudgetTable extends Component {
               backgroundColor: 'transparent',
             },
             '& ::-webkit-scrollbar-thumb:vertical': {
-              backgroundColor: 'white',
+              backgroundColor: theme.tableHeaderBackground,
             },
           }),
         }}

--- a/packages/desktop-client/src/components/budget/BudgetTable.js
+++ b/packages/desktop-client/src/components/budget/BudgetTable.js
@@ -2,7 +2,7 @@ import React, { createRef, Component } from 'react';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
-import { theme, styles} from '../../style';
+import { theme, styles } from '../../style';
 import View from '../common/View';
 import { IntersectionBoundary } from '../tooltips';
 

--- a/packages/desktop-client/src/components/budget/BudgetTotals.js
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.js
@@ -21,7 +21,7 @@ const BudgetTotals = memo(function BudgetTotals({
     <View
       data-testid="budget-totals"
       style={{
-        backgroundColor: 'white',
+        backgroundColor: theme.tableHeaderBackground,
         flexDirection: 'row',
         flexShrink: 0,
         boxShadow: styles.cardShadow,

--- a/packages/desktop-client/src/components/budget/BudgetTotals.js
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.js
@@ -21,7 +21,7 @@ const BudgetTotals = memo(function BudgetTotals({
     <View
       data-testid="budget-totals"
       style={{
-        backgroundColor: theme.tableHeaderBackground,
+        backgroundColor: theme.tableBackground,
         flexDirection: 'row',
         flexShrink: 0,
         boxShadow: styles.cardShadow,

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.js
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { theme } from '../../style';
 import View from '../common/View';
 import { useDraggable, useDroppable, DropHighlight } from '../sort';
 import { Row } from '../table';
@@ -46,7 +47,7 @@ function ExpenseCategory({
       innerRef={dropRef}
       collapsed={true}
       style={{
-        backgroundColor: 'transparent',
+        backgroundColor: theme.tableBackground,
         opacity: cat.hidden ? 0.5 : undefined,
       }}
     >

--- a/packages/desktop-client/src/style/themes/dark.ts
+++ b/packages/desktop-client/src/style/themes/dark.ts
@@ -24,7 +24,7 @@ export const cardBorder = colorPalette.purple400;
 export const cardShadow = colorPalette.navy700;
 
 export const tableBackground = colorPalette.navy800;
-export const altTableBackground = tableBackground;
+export const altTableBackground = colorPalette.navy700;
 export const alt2TableBackground = tableBackground;
 export const tableRowBackgroundHover = colorPalette.navy700;
 export const tableText = colorPalette.navy150;

--- a/upcoming-release-notes/1795.md
+++ b/upcoming-release-notes/1795.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Dark Theme: add theming to budget table where it was missing


### PR DESCRIPTION
Much of the budget table wasn't themed, but had hard coded colors.  This moves over to the theme values.  Dark theme I think needs edited to fix the group colors.

Existing
![image](https://github.com/actualbudget/actual/assets/28542559/51c59367-f9e7-4367-8d49-5f49d2cf3c83)

New:
![image](https://github.com/actualbudget/actual/assets/28542559/b4d25082-4eb8-4c20-8461-3ced4cba67a3)

