### PR TITLE
Add ability to import categories from CSV

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -462,6 +462,7 @@ class AccountInternal extends PureComponent {
   onImport = async () => {
     const accountId = this.props.accountId;
     const account = this.props.accounts.find(acct => acct.id === accountId);
+    const categories = await this.props.getCategories();
 
     if (account) {
       const res = await window.Actual.openFileDialog({
@@ -476,6 +477,7 @@ class AccountInternal extends PureComponent {
       if (res) {
         this.props.pushModal('import-transactions', {
           accountId,
+          categories,
           filename: res[0],
           onImported: didChange => {
             if (didChange) {

--- a/upcoming-release-notes/1801.md
+++ b/upcoming-release-notes/1801.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ScottFries,blakegearin]
+---
+
+Add ability to import categories from CSV


### PR DESCRIPTION
Picking up from PR #82 

## Summary
* Added category parsing to CSV imports to detect category and map to existing categories

## Evidence
![Recording 2023-10-15 221320](https://github.com/actualbudget/actual/assets/6807985/8633fd54-4e40-4c2c-bf74-3913616c1825)


## Notes
* It is currently possible to enable this functionality with rules, however, one would need to be made for each category and another field would need to be used to hold category identifiers, such as `Notes`
* Currently category IDs are not explicitly stated in the UI as far as I'm aware
* A checkbox could be added to the `Import Options` section to toggle this functionality on and off, though this is functionality only works with existing category names and all other values are ignored; this could be easily changed to create unrecognized categories, like the `Payee` field

