### PR TITLE
Allow categorise transfer to off budget accounts on mobile

### DIFF
--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -498,7 +498,10 @@ class TransactionEditInner extends PureComponent {
               {!transaction.is_parent ? (
                 <TapField
                   value={category ? lookupName(categories, category) : null}
-                  disabled={(account && !!account.offbudget) || transferAcct}
+                  disabled={
+                    (account && !!account.offbudget) ||
+                    (transferAcct && !transferAcct.offbudget)
+                  }
                   // TODO: the button to turn this transaction into a split
                   // transaction was on top of the category button in the native
                   // app, on the right-hand side

--- a/upcoming-release-notes/1824.md
+++ b/upcoming-release-notes/1824.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Kit-p]
+---
+
+Allow categorise transfer to off budget accounts on mobile


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
This PR allows categorising transactions to off budget accounts (as payee) when using mobile, in order to align with the behavior when using desktop.

Closes #1822