### PR TITLE
fixed:issue->#1835 Support NYNAB import of transactions that contain subtransactions tha…

### DIFF
--- a/packages/desktop-client/e2e/data/ynab5-demo-budget.json
+++ b/packages/desktop-client/e2e/data/ynab5-demo-budget.json
@@ -1671,9 +1671,50 @@
         "import_payee_name_original": null,
         "debt_transaction_type": null,
         "deleted": false
+      },
+      {
+        "id": "213526fc-ba49-4790-8a96-cc2a50182728",
+        "date": "2023-09-04",
+        "amount": -100000,
+        "memo": "Test transaction",
+        "cleared": "cleared",
+        "approved": true,
+        "flag_color": null,
+        "account_id": "bc1d862f-bab0-41c3-bd1e-6cee8c688e32",
+        "payee_id": "2a20470a-634f-4efa-a7f6-f1c0b0bdda41",
+        "category_id": "36120d44-6c61-4402-985a-891a8d267858",
+        "transfer_account_id": null,
+        "transfer_transaction_id": null,
+        "matched_transaction_id": null,
+        "import_id": null,
+        "import_payee_name": null,
+        "import_payee_name_original": null,
+        "debt_transaction_type": null,
+        "deleted": false
       }
     ],
-    "subtransactions": [],
+    "subtransactions": [
+      {
+        "id": "d8ec8c84-5033-4f7e-8485-66bfe19a70d6",
+        "transaction_id": "213526fc-ba49-4790-8a96-cc2a50182728",
+        "amount": -50000,
+        "memo": "split part a",
+        "payee_id": "2a20470a-634f-4efa-a7f6-f1c0b0bdda41",
+        "category_id": "36120d44-6c61-4402-985a-891a8d267858",
+        "transfer_account_id": null,
+        "deleted": false
+      },
+      {
+        "id": "870d8780-79cf-4197-a341-47d24b2b5a59",
+        "transaction_id": "213526fc-ba49-4790-8a96-cc2a50182728",
+        "amount": -50000,
+        "memo": "split part b",
+        "payee_id": "2a20470a-634f-4efa-a7f6-f1c0b0bdda41",
+        "category_id": null,
+        "transfer_account_id": "125f339b-2a63-481e-84c0-f04d898905d2",
+        "deleted": false
+      }
+    ],
     "scheduled_transactions": [],
     "scheduled_subtransactions": []
   },

--- a/packages/desktop-client/e2e/data/ynab5-demo-budget.json
+++ b/packages/desktop-client/e2e/data/ynab5-demo-budget.json
@@ -1696,7 +1696,7 @@
         "id": "024494a1-f1e0-4667-9fc0-91e4a4262193",
         "date": "2023-09-04",
         "amount": 50000,
-        "memo": "split bart b",
+        "memo": "split part b",
         "cleared": "cleared",
         "approved": true,
         "flag_color": null,

--- a/packages/desktop-client/e2e/data/ynab5-demo-budget.json
+++ b/packages/desktop-client/e2e/data/ynab5-demo-budget.json
@@ -1691,6 +1691,26 @@
         "import_payee_name_original": null,
         "debt_transaction_type": null,
         "deleted": false
+      },
+      {
+        "id": "024494a1-f1e0-4667-9fc0-91e4a4262193",
+        "date": "2023-09-04",
+        "amount": 50000,
+        "memo": "split bart b",
+        "cleared": "cleared",
+        "approved": true,
+        "flag_color": null,
+        "account_id": "125f339b-2a63-481e-84c0-f04d898905d2",
+        "payee_id": "",
+        "category_id": null,
+        "transfer_account_id": "bc1d862f-bab0-41c3-bd1e-6cee8c688e32",
+        "transfer_transaction_id": "213526fc-ba49-4790-8a96-cc2a50182728",
+        "matched_transaction_id": "",
+        "import_id": null,
+        "import_payee_name": null,
+        "import_payee_name_original": null,
+        "debt_transaction_type": null,
+        "deleted": false
       }
     ],
     "subtransactions": [

--- a/packages/desktop-client/e2e/onboarding.test.js
+++ b/packages/desktop-client/e2e/onboarding.test.js
@@ -60,10 +60,10 @@ test.describe('Onboarding', () => {
     await expect(budgetPage.budgetTable).toBeVisible({ timeout: 30000 });
 
     const accountPage = await navigation.goToAccountPage('Checking');
-    await expect(accountPage.accountBalance).toHaveText('700.00');
+    await expect(accountPage.accountBalance).toHaveText('600.00');
 
     await navigation.goToAccountPage('Saving');
-    await expect(accountPage.accountBalance).toHaveText('200.00');
+    await expect(accountPage.accountBalance).toHaveText('250.00');
   });
 
   test('creates a new budget file by importing Actual budget', async () => {

--- a/packages/loot-core/src/server/importers/ynab5-types.d.ts
+++ b/packages/loot-core/src/server/importers/ynab5-types.d.ts
@@ -25,7 +25,7 @@ export namespace YNAB5 {
     id: string;
     name: string;
     deleted: boolean;
-    transfer_acct: string | null
+    transfer_acct?: string
   }
 
   interface CategoryGroup {

--- a/packages/loot-core/src/server/importers/ynab5-types.d.ts
+++ b/packages/loot-core/src/server/importers/ynab5-types.d.ts
@@ -61,6 +61,7 @@ export namespace YNAB5 {
     category_id: string;
     memo: string;
     amount: number;
+    transfer_account_id: string;
   }
 
   interface Month {

--- a/packages/loot-core/src/server/importers/ynab5-types.d.ts
+++ b/packages/loot-core/src/server/importers/ynab5-types.d.ts
@@ -25,7 +25,7 @@ export namespace YNAB5 {
     id: string;
     name: string;
     deleted: boolean;
-    transfer_acct?: string
+    transfer_acct?: string;
   }
 
   interface CategoryGroup {

--- a/packages/loot-core/src/server/importers/ynab5-types.d.ts
+++ b/packages/loot-core/src/server/importers/ynab5-types.d.ts
@@ -25,6 +25,7 @@ export namespace YNAB5 {
     id: string;
     name: string;
     deleted: boolean;
+    transfer_acct: string | null
   }
 
   interface CategoryGroup {

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -9,7 +9,6 @@ import * as monthUtils from '../../shared/months';
 import { sortByKey, groupBy } from '../../shared/util';
 
 import { YNAB5 } from './ynab5-types';
-import Payee = YNAB5.Payee;
 
 function amountFromYnab(amount: number) {
   // ynabs multiplies amount by 1000 and actual by 100
@@ -144,9 +143,12 @@ async function importTransactions(
   let transactionsGrouped = groupBy(data.transactions, 'account_id');
   let subtransactionsGrouped = groupBy(data.subtransactions, 'transaction_id');
 
-  const payeesByTransferAcct = payees.filter((payee: Payee) => payee?.transfer_acct)
-    .map((payee: Payee) => [payee.transfer_acct, payee])
-  const payeeTransferAcctHashMap = new Map<string, Payee>(payeesByTransferAcct);
+  const payeesByTransferAcct = payees
+    .filter((payee: YNAB5.Payee) => payee?.transfer_acct)
+    .map((payee: YNAB5.Payee) => [payee.transfer_acct, payee]);
+  const payeeTransferAcctHashMap = new Map<string, YNAB5.Payee>(
+    payeesByTransferAcct,
+  );
 
   // Go ahead and generate ids for all of the transactions so we can
   // reliably resolve transfers
@@ -185,8 +187,12 @@ async function importTransactions(
               ? subtransactions.map(subtrans => {
                   let payee = null;
                   if (subtrans.transfer_account_id) {
-                    const mappedTransferAccountId = entityIdMap.get(subtrans.transfer_account_id);
-                    payee = payeeTransferAcctHashMap.get(mappedTransferAccountId)?.id;
+                    const mappedTransferAccountId = entityIdMap.get(
+                      subtrans.transfer_account_id,
+                    );
+                    payee = payeeTransferAcctHashMap.get(
+                      mappedTransferAccountId,
+                    )?.id;
                   }
 
                   return {

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -178,11 +178,21 @@ async function importTransactions(
               entityIdMap.get(transaction.transfer_transaction_id) || null,
             subtransactions: subtransactions
               ? subtransactions.map(subtrans => {
+                  let payee = null;
+                  if (subtrans.transfer_account_id) {
+                    payee = payees.find(
+                      p =>
+                        p.transfer_acct ===
+                        entityIdMap.get(subtrans.transfer_account_id),
+                    ).id;
+                  }
+
                   return {
                     id: entityIdMap.get(subtrans.id),
                     amount: amountFromYnab(subtrans.amount),
                     category: entityIdMap.get(subtrans.category_id) || null,
                     notes: subtrans.memo,
+                    payee: payee,
                   };
                 })
               : null,

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -192,7 +192,7 @@ async function importTransactions(
                     amount: amountFromYnab(subtrans.amount),
                     category: entityIdMap.get(subtrans.category_id) || null,
                     notes: subtrans.memo,
-                    payee: payee,
+                    payee,
                   };
                 })
               : null,

--- a/upcoming-release-notes/1836.md
+++ b/upcoming-release-notes/1836.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Marethyu1]
+---
+
+UPDATES NYNAB import to support importing transactions that contain sub transactions that are account transfers


### PR DESCRIPTION
…t are transfers

A subtransaction is considered a transfer from ynab if
- the transfer_account_id is set
- the category_id is null (transfers dont have categories)

This addresses #1835 

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
