### PR TITLE
:bug:  fix: add missing top border for budget menu icon

### DIFF
--- a/packages/desktop-client/src/components/budget/rollover/rollover-components.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/rollover-components.tsx
@@ -187,9 +187,10 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
           <View
             style={{
               flexShrink: 1,
-              marginRight: 0,
-              marginLeft: 3,
+              paddingLeft: 3,
               justifyContent: 'center',
+              borderTopWidth: 1,
+              borderColor: theme.tableBorder,
             }}
           >
             <Button

--- a/upcoming-release-notes/1855.md
+++ b/upcoming-release-notes/1855.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix: add missing top border for menu popover in budget page


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/1846