### PR TITLE
:bug:  fix: bring back rollover arrow in budget page

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -48,7 +48,7 @@ export default function BalanceWithCarryover({
             alignSelf: 'center',
             marginLeft: 2,
             position: 'absolute',
-            right: -4,
+            right: -8,
             top: 0,
             bottom: 0,
             justifyContent: 'center',

--- a/packages/desktop-client/src/components/budget/report/components.tsx
+++ b/packages/desktop-client/src/components/budget/report/components.tsx
@@ -360,6 +360,7 @@ export const CategoryMonth = memo(function CategoryMonth({
       {!category.is_income && (
         <Field
           name="balance"
+          truncate={false}
           width="flex"
           style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
         >

--- a/packages/desktop-client/src/components/budget/rollover/rollover-components.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/rollover-components.tsx
@@ -311,6 +311,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
       </Field>
       <Field
         name="balance"
+        truncate={false}
         width="flex"
         style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
       >

--- a/upcoming-release-notes/1856.md
+++ b/upcoming-release-notes/1856.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix: bring back rollover arrows in budget page


### PR DESCRIPTION
Closes #1845

<img width="136" alt="Screenshot 2023-11-03 at 18 31 04" src="https://github.com/actualbudget/actual/assets/886567/5193c0a5-8c04-474e-bd2d-18d9775a9150">
