### PR TITLE
Support month names when importing transactions

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.js
@@ -43,6 +43,18 @@ export function parseDate(str, order) {
 
   const dateGroups = (a, b) => str => {
     const parts = str
+      .replace(/\bjan(\.|uary)?\b/i, '01')
+      .replace(/\bfeb(\.|ruary)?\b/i, '02')
+      .replace(/\bmar(\.|ch)?\b/i, '03')
+      .replace(/\bapr(\.|il)?\b/i, '04')
+      .replace(/\bmay\.?\b/i, '05')
+      .replace(/\bjun(\.|e)?\b/i, '06')
+      .replace(/\bjul(\.|y)?\b/i, '07')
+      .replace(/\baug(\.|ust)?\b/i, '08')
+      .replace(/\bsep(\.|tember)?\b/i, '09')
+      .replace(/\boct(\.|ober)?\b/i, '10')
+      .replace(/\bnov(\.|ember)?\b/i, '11')
+      .replace(/\bdec(\.|ember)?\b/i, '12')
       .replace(/^[^\d]+/, '')
       .replace(/[^\d]+$/, '')
       .split(/[^\d]+/);

--- a/packages/desktop-client/src/components/modals/ImportTransactions.test.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.test.js
@@ -8,8 +8,9 @@ describe('Import transactions', function () {
       { str: 42, order: 'yyyy mm dd' },
       { str: {}, order: 'yyyy mm dd' },
       { str: [], order: 'yyyy mm dd' },
+      { str: 'Decimal 24 2020', order: 'mm dd yyyy' },
+      { str: '24 aDec 2020', order: 'dd mm yyyy' },
       { str: 'invalid', order: 'yyyy mm dd' },
-      { str: '2020 Dec 24', order: 'yyyy mm dd' },
       { str: '12 24 20', order: 'mm dd yyyy' },
       { str: '20 12 24', order: 'yyyy mm dd' },
       { str: '2020 12 24', order: 'yy mm dd' },
@@ -40,6 +41,9 @@ describe('Import transactions', function () {
       {
         order: 'yyyy mm dd',
         cases: [
+          ['2020 Dec 24', '2020-12-24'],
+          ['2020 Dec. 24', '2020-12-24'],
+          ['2020 December 24', '2020-12-24'],
           ['20201224', '2020-12-24'],
           ['2020 12 24', '2020-12-24'],
           ['2020-1-2', '2020-01-02'],
@@ -54,6 +58,9 @@ describe('Import transactions', function () {
       {
         order: 'yy mm dd',
         cases: [
+          ['20 Dec 24', '2020-12-24'],
+          ['20 Dec. 24', '2020-12-24'],
+          ['20 December 24', '2020-12-24'],
           ['201224', '2020-12-24'],
           ['20 12 24', '2020-12-24'],
           ['20-12-24', '2020-12-24'],
@@ -67,6 +74,9 @@ describe('Import transactions', function () {
       {
         order: 'mm dd yyyy',
         cases: [
+          ['Dec 24, 2020', '2020-12-24'],
+          ['Dec. 24, 2020', '2020-12-24'],
+          ['December 24, 2020', '2020-12-24'],
           ['12242020', '2020-12-24'],
           ['1 24 2020', '2020-01-24'],
           ['01 24 2020', '2020-01-24'],
@@ -81,6 +91,9 @@ describe('Import transactions', function () {
       {
         order: 'mm dd yy',
         cases: [
+          ['Dec 24, 20', '2020-12-24'],
+          ['Dec. 24, 20', '2020-12-24'],
+          ['December 24, 20', '2020-12-24'],
           ['122420', '2020-12-24'],
           ['12 24 20 ', '2020-12-24'],
           ['12-24-20', '2020-12-24'],
@@ -96,6 +109,9 @@ describe('Import transactions', function () {
       {
         order: 'dd mm yyyy',
         cases: [
+          ['24 Dec 2020', '2020-12-24'],
+          ['24 Dec. 2020', '2020-12-24'],
+          ['24 December 2020', '2020-12-24'],
           ['24122020', '2020-12-24'],
           ['24 12 2020 ', '2020-12-24'],
           ['2 12 2020', '2020-12-02'],
@@ -112,6 +128,9 @@ describe('Import transactions', function () {
       {
         order: 'dd mm yy',
         cases: [
+          ['24 Dec 20', '2020-12-24'],
+          ['24 Dec. 20', '2020-12-24'],
+          ['24 December 20', '2020-12-24'],
           ['241220', '2020-12-24'],
           ['2412 20 ', '2020-12-24'],
           ['24-12-20', '2020-12-24'],

--- a/upcoming-release-notes/1862.md
+++ b/upcoming-release-notes/1862.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jamescostian]
+---
+
+Allow month names and abbreviations in dates (e.g. "December 24 2020") when importing


### PR DESCRIPTION
Support dates like "Dec 24, 2020" and "december 24, 2020".

My new 401k provider gives CSVs that look like this:

```csv
Requested date,Fulfilled date,Transaction type,Pre-tax,Roth,Employer,Total,Transaction Id
"Dec 24, 2020","Dec 24, 2020",Payroll,1.00,2.00,3.00,4.00,TXN-REDACTED
```

This patch allows me to import their CSVs without having to adjust the file before importing it.