### PR TITLE
Make Select All respect filters and splits

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -1201,6 +1201,7 @@ class AccountInternal extends PureComponent {
             items={allTransactions}
             fetchAllIds={this.fetchAllIds}
             registerDispatch={dispatch => (this.dispatchSelected = dispatch)}
+            selectAllFilter={item => !item._unmatched && !item.is_parent}
           >
             <View style={styles.page}>
               <AccountHeader

--- a/upcoming-release-notes/1864.md
+++ b/upcoming-release-notes/1864.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jamescostian]
+---
+
+Make Select All respect filters and splits


### PR DESCRIPTION
This PR improves the situation described in issue #283. Here's a demo:

# Setup
![Setup](https://github.com/actualbudget/actual/assets/1456118/7bab4bf7-4502-4cae-938c-b5a32e8533a5)

# Select all

## master branch - selects the parent Split, which affects the Selected balance
![Original Select All](https://github.com/actualbudget/actual/assets/1456118/f061d4b5-43eb-4981-83f6-d9c041c60e20)

## This PR
![Improved Select All](https://github.com/actualbudget/actual/assets/1456118/00d4ff73-cae5-4c14-8cf8-558f58d94b45)

# Filter by category, then select all

## master branch - selects the parent Split and the non-Food-category transactions, which affect the Selected balance
![Original Select All while Filtering](https://github.com/actualbudget/actual/assets/1456118/38714b9b-168f-4790-a244-ff503d8b2af2)

## This PR
![Improved Select All while Filtering](https://github.com/actualbudget/actual/assets/1456118/2b1ce7c0-f23c-4eaf-9ee0-d19c963e2bde)