### PR TITLE
Save AmountInput changes on unmount

### DIFF
--- a/packages/desktop-client/src/components/util/AmountInput.js
+++ b/packages/desktop-client/src/components/util/AmountInput.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { amountToInteger } from 'loot-core/src/shared/util';
@@ -58,6 +58,15 @@ export function AmountInput({
       onBlur?.();
     }
   }
+
+  // Save changes when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (value !== initialValue) {
+        fireChange(value, negative);
+      }
+    };
+  }, [initialValue, value, negative]);
 
   return (
     <InputWithContent

--- a/upcoming-release-notes/1883.md
+++ b/upcoming-release-notes/1883.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix AmountInput change not being saved when another editable field is clicked while editing


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fix AmountInput change not being saved when another editable field is clicked while editing.

Steps to reproduce:
1. Edit a category's budget
2. Click on another category budget or any category name 