### PR TITLE
[Bugfix] Goals: Fix Schedule Infinite loop

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -91,7 +91,6 @@ export async function goalsSchedule(
                 monthUtils._parse(next_date),
               );
             }
-            console.log(diffDays);
           }
           t[ll].target = -monthlyTarget;
           totalScheduledGoal += target;

--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -74,11 +74,24 @@ export async function goalsSchedule(
           );
           while (next_date < next_month) {
             monthlyTarget += -target;
+            let current_date = next_date;
             next_date = monthUtils.addDays(next_date, 1);
             next_date = getNextDate(
               dateConditions,
               monthUtils._parse(next_date),
             );
+            let diffDays = monthUtils.differenceInCalendarDays(
+              next_date,
+              current_date,
+            );
+            if (!diffDays) {
+              next_date = monthUtils.addDays(next_date, 3);
+              next_date = getNextDate(
+                dateConditions,
+                monthUtils._parse(next_date),
+              );
+            }
+            console.log(diffDays);
           }
           t[ll].target = -monthlyTarget;
           totalScheduledGoal += target;

--- a/packages/loot-core/src/shared/months.ts
+++ b/packages/loot-core/src/shared/months.ts
@@ -137,6 +137,13 @@ export function differenceInCalendarMonths(
   return d.differenceInCalendarMonths(_parse(month1), _parse(month2));
 }
 
+export function differenceInCalendarDays(
+  month1: DateLike,
+  month2: DateLike,
+): number {
+  return d.differenceInCalendarDays(_parse(month1), _parse(month2));
+}
+
 export function subMonths(month: string | Date, n: number) {
   return d.format(d.subMonths(_parse(month), n), 'yyyy-MM');
 }

--- a/upcoming-release-notes/1917.md
+++ b/upcoming-release-notes/1917.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals: Fix infinite loop situation with Schedule keyword


### PR DESCRIPTION
Resolves #1913 

When the next_date loop is executed, it is iterated in 1 day increments looking for a 'next schedule'.  What was happening was the loop had a current date that occurred on a weekend and when we went to get the next occurrence (which should land on the weekend) it was returning that occurrence 1 day before.  So each time the loop was set back 1 day before adding the 1 day and we had an infinite loop condition.  I've added a check to look for how many days difference the current date and the next date are, and if that value is 0, it will add 3 days instead of 1.  I used 3 to resolve the same situation had the schedule landed on a Sunday.