### PR TITLE
Remove unused args

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,8 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {
-        args: 'none',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
         ignoreRestSiblings: true,
       },

--- a/packages/desktop-client/craco.config.ts
+++ b/packages/desktop-client/craco.config.ts
@@ -22,7 +22,7 @@ if (process.env.REVIEW_ID) {
 
 module.exports = {
   webpack: {
-    configure: (webpackConfig, { env, paths }) => {
+    configure: webpackConfig => {
       webpackConfig.mode =
         process.env.NODE_ENV === 'development' ? 'development' : 'production';
 
@@ -92,7 +92,7 @@ module.exports = {
       return webpackConfig;
     },
   },
-  devServer: (devServerConfig, { env, paths, proxy, allowedHost }) => {
+  devServer: devServerConfig => {
     devServerConfig.onBeforeSetupMiddleware = server => {
       chokidar
         .watch([

--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -51,7 +51,7 @@ global.Actual = {
     window.location.reload();
   },
 
-  openFileDialog: async ({ filters = [], properties }) => {
+  openFileDialog: async ({ filters = [] }) => {
     return new Promise(resolve => {
       let createdElement = false;
       // Attempt to reuse an already-created file input.
@@ -91,7 +91,7 @@ global.Actual = {
               .uploadFile(filename, ev.target.result)
               .then(() => resolve([filepath]));
           };
-          reader.onerror = function (ev) {
+          reader.onerror = function () {
             alert('Error reading file');
           };
         }
@@ -107,7 +107,7 @@ global.Actual = {
     });
   },
 
-  saveFile: (contents, defaultFilename, dialogTitle) => {
+  saveFile: (contents, defaultFilename) => {
     const temp = document.createElement('a');
     temp.style = 'display: none';
     temp.download = defaultFilename;
@@ -121,9 +121,9 @@ global.Actual = {
   openURLInBrowser: url => {
     window.open(url, '_blank');
   },
-  onEventFromMain: (type, handler) => {},
+  onEventFromMain: () => {},
   applyAppUpdate: () => {},
-  updateAppMenu: isBudgetOpen => {},
+  updateAppMenu: () => {},
 
   getServerSocket: async () => {
     return worker;

--- a/packages/desktop-client/src/components/FixedSizeList.js
+++ b/packages/desktop-client/src/components/FixedSizeList.js
@@ -8,7 +8,7 @@ import View from './common/View';
 
 const IS_SCROLLING_DEBOUNCE_INTERVAL = 150;
 
-const defaultItemKey = (index, data) => index;
+const defaultItemKey = index => index;
 
 function ResizeObserver({ onResize, children }) {
   let ref = useResizeObserver(onResize);
@@ -241,7 +241,7 @@ export default class FixedSizeList extends PureComponent {
     }
   };
 
-  onHeaderResize = rect => {
+  onHeaderResize = () => {
     // this.setState({ headerHeight: rect.height });
   };
 
@@ -268,7 +268,7 @@ export default class FixedSizeList extends PureComponent {
   }
 
   getItemOffset = index => index * this.props.itemSize;
-  getItemSize = index => this.props.itemSize;
+  getItemSize = () => this.props.itemSize;
   getEstimatedTotalSize = () => this.props.itemSize * this.props.itemCount;
 
   getOffsetForIndexAndAlignment = (index, align, scrollOffset) => {

--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -236,7 +236,7 @@ function ManageRulesContent({
         onSave: async newRule => {
           let newRules = await loadRules();
 
-          setRules(rules => {
+          setRules(() => {
             let newIdx = newRules.findIndex(rule => rule.id === newRule.id);
             return newRules.slice(0, newIdx + 75);
           });

--- a/packages/desktop-client/src/components/accounts/Account.js
+++ b/packages/desktop-client/src/components/accounts/Account.js
@@ -227,7 +227,7 @@ class AccountInternal extends PureComponent {
       }
     };
 
-    let onUndo = async ({ tables, messages, undoTag }) => {
+    let onUndo = async ({ tables, messages }) => {
       await maybeRefetch(tables);
 
       // If all the messages are dealing with transactions, find the
@@ -514,7 +514,7 @@ class AccountInternal extends PureComponent {
           });
         }
       },
-      mappedData => {
+      () => {
         return data;
       },
     );

--- a/packages/desktop-client/src/components/accounts/MobileAccount.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.js
@@ -40,7 +40,7 @@ const getSchedulesTransform = memoizeOne((id, hasSearch) => {
   };
 });
 
-function PreviewTransactions({ accountId, children }) {
+function PreviewTransactions({ children }) {
   let scheduleData = useCachedSchedules();
 
   if (scheduleData == null) {

--- a/packages/desktop-client/src/components/accounts/MobileAccounts.js
+++ b/packages/desktop-client/src/components/accounts/MobileAccounts.js
@@ -124,7 +124,7 @@ function AccountCard({ account, updated, getBalanceQuery, onSelect }) {
   );
 }
 
-function EmptyMessage({ onAdd }) {
+function EmptyMessage() {
   return (
     <View style={{ flex: 1, padding: 30 }}>
       <Text style={styles.text}>

--- a/packages/desktop-client/src/components/budget/MobileBudget.js
+++ b/packages/desktop-client/src/components/budget/MobileBudget.js
@@ -353,7 +353,7 @@ class Budget extends Component {
 
     return (
       <SyncRefresh onSync={this.sync}>
-        {({ refreshing, onRefresh }) => (
+        {({ onRefresh }) => (
           <BudgetTable
             // This key forces the whole table rerender when the number
             // format changes

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -132,7 +132,7 @@ function BudgetCell({
     });
   }
 
-  function onAmountClick(e) {
+  function onAmountClick() {
     onEdit?.(categoryId);
   }
 

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -146,7 +146,7 @@ function SidebarCategory({
     >
       <InputCell
         value={category.name}
-        formatter={value => displayed}
+        formatter={() => displayed}
         width="flex"
         exposed={editing || temporary}
         onUpdate={value => {

--- a/packages/desktop-client/src/components/budget/SidebarGroup.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarGroup.tsx
@@ -43,7 +43,6 @@ function SidebarGroup({
   dragPreview,
   innerRef,
   style,
-  borderColor = theme.tableBorder,
   onEdit,
   onSave,
   onDelete,
@@ -62,7 +61,7 @@ function SidebarGroup({
         userSelect: 'none',
         WebkitUserSelect: 'none',
       }}
-      onClick={e => {
+      onClick={() => {
         onToggleCollapse(group.id);
       }}
     >
@@ -168,7 +167,7 @@ function SidebarGroup({
     >
       <InputCell
         value={group.name}
-        formatter={value => displayed}
+        formatter={() => displayed}
         width="flex"
         exposed={editing}
         onUpdate={value => {

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -506,7 +506,7 @@ const RolloverBudgetSummary = memo<{ month: string }>(props => {
   );
 });
 
-export default function BudgetWrapper(props) {
+export default function BudgetWrapper() {
   let startMonth = useSelector(state => state.prefs.local['budget.startMonth']);
   let collapsedPrefs = useSelector(
     state => state.prefs.local['budget.collapsed'],

--- a/packages/desktop-client/src/components/budget/report/components.tsx
+++ b/packages/desktop-client/src/components/budget/report/components.tsx
@@ -163,7 +163,7 @@ function BalanceTooltip({
       onClose={tooltip.close}
     >
       <Menu
-        onMenuSelect={type => {
+        onMenuSelect={() => {
           onBudgetAction(monthIndex, 'carryover', {
             category: categoryId,
             flag: !carryover,

--- a/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BudgetSummary.tsx
@@ -274,7 +274,7 @@ export function BudgetSummary({
   } = useRollover();
 
   let [menuOpen, setMenuOpen] = useState(false);
-  function onMenuOpen(e) {
+  function onMenuOpen() {
     setMenuOpen(true);
   }
 

--- a/packages/desktop-client/src/components/budget/rollover/CoverTooltip.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverTooltip.tsx
@@ -47,7 +47,7 @@ export default function CoverTooltip({
             categoryGroups={categoryGroups}
             value={null}
             openOnFocus={true}
-            onUpdate={id => {}}
+            onUpdate={() => {}}
             onSelect={id => setCategory(id)}
             inputProps={{
               inputRef: node,

--- a/packages/desktop-client/src/components/budget/rollover/TransferTooltip.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/TransferTooltip.tsx
@@ -98,7 +98,7 @@ export default function TransferTooltip({
         categoryGroups={categoryGroups}
         value={null}
         openOnFocus={true}
-        onUpdate={id => {}}
+        onUpdate={() => {}}
         onSelect={id => setCategory(id)}
         inputProps={{ onEnter: submit, placeholder: '(none)' }}
       />

--- a/packages/desktop-client/src/components/common/Menu.tsx
+++ b/packages/desktop-client/src/components/common/Menu.tsx
@@ -158,7 +158,7 @@ export default function Menu({
             }}
             onMouseEnter={() => setHoveredIndex(idx)}
             onMouseLeave={() => setHoveredIndex(null)}
-            onClick={e =>
+            onClick={() =>
               !item.disabled && onMenuSelect && onMenuSelect(item.name)
             }
           >

--- a/packages/desktop-client/src/components/mobile/MobileAmountInput.js
+++ b/packages/desktop-client/src/components/mobile/MobileAmountInput.js
@@ -48,7 +48,7 @@ class AmountInput extends PureComponent {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps, _prevState) {
     if (!prevProps.focused && this.props.focused) {
       this.focus();
     }

--- a/packages/desktop-client/src/components/modals/EditRule.js
+++ b/packages/desktop-client/src/components/modals/EditRule.js
@@ -122,7 +122,7 @@ export function OpSelect({
   );
 }
 
-function EditorButtons({ onAdd, onDelete, style }) {
+function EditorButtons({ onAdd, onDelete }) {
   return (
     <>
       {onDelete && (
@@ -309,7 +309,7 @@ let actionFields = [
   'date',
   'amount',
 ].map(field => [field, mapField(field)]);
-function ActionEditor({ ops, action, editorStyle, onChange, onDelete, onAdd }) {
+function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
   let { field, op, value, type, error, inputKey = 'initial' } = action;
 
   return (

--- a/packages/desktop-client/src/components/modals/ImportTransactions.js
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.js
@@ -133,7 +133,7 @@ function getFileType(filepath) {
   return rawType;
 }
 
-function ParsedDate({ parseDateFormat, showParsed, dateFormat, date }) {
+function ParsedDate({ parseDateFormat, dateFormat, date }) {
   let parsed =
     date &&
     formatDate(
@@ -185,29 +185,29 @@ function getInitialMappings(transactions) {
   }
 
   let dateField = key(
-    fields.find(([name, value]) => name.toLowerCase().includes('date')) ||
-      fields.find(([name, value]) => value.match(/^\d+[-/]\d+[-/]\d+$/)),
+    fields.find(([name]) => name.toLowerCase().includes('date')) ||
+      fields.find(([value]) => value.match(/^\d+[-/]\d+[-/]\d+$/)),
   );
 
   let amountField = key(
-    fields.find(([name, value]) => name.toLowerCase().includes('amount')) ||
-      fields.find(([name, value]) => value.match(/^-?[.,\d]+$/)),
+    fields.find(([name]) => name.toLowerCase().includes('amount')) ||
+      fields.find(([value]) => value.match(/^-?[.,\d]+$/)),
   );
 
   let payeeField = key(
-    fields.find(([name, value]) => name !== dateField && name !== amountField),
+    fields.find(([name]) => name !== dateField && name !== amountField),
   );
 
   let notesField = key(
     fields.find(
-      ([name, value]) =>
+      ([name]) =>
         name !== dateField && name !== amountField && name !== payeeField,
     ),
   );
 
   let inOutField = key(
     fields.find(
-      ([name, value]) =>
+      ([name]) =>
         name !== dateField &&
         name !== amountField &&
         name !== payeeField &&
@@ -974,7 +974,7 @@ export default function ImportTransactions({ modalProps, options }) {
                 </View>
               );
             }}
-            renderItem={({ key, style, item, editing, focusedField }) => (
+            renderItem={({ key, style, item }) => (
               <View key={key} style={style}>
                 <Transaction
                   transaction={item}

--- a/packages/desktop-client/src/components/modals/SingleInput.tsx
+++ b/packages/desktop-client/src/components/modals/SingleInput.tsx
@@ -72,7 +72,7 @@ function SingleInput({
               paddingBottom: 15,
             }}
           >
-            <Button onPointerUp={e => _onSubmit(value)}>{buttonText}</Button>
+            <Button onPointerUp={() => _onSubmit(value)}>{buttonText}</Button>
           </View>
         </>
       )}

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.js
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.js
@@ -63,7 +63,7 @@ export default function ManagePayeesWithData({ initialSelectedIds }) {
     };
   }, []);
 
-  async function onUndo({ tables, messages, meta, url }, scroll = false) {
+  async function onUndo({ tables, messages, meta }, _scroll = false) {
     if (!tables.includes('payees') && !tables.includes('payee_mapping')) {
       return;
     }

--- a/packages/desktop-client/src/components/payees/index.js
+++ b/packages/desktop-client/src/components/payees/index.js
@@ -170,7 +170,6 @@ const PayeeTable = forwardRef(
       navigator,
       categoryGroups,
       highlightedRows,
-      ruleActions,
       onUpdate,
       onViewRules,
       onCreateRule,

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -80,7 +80,7 @@ export default function CategorySelector({
                   <Checkbox
                     id={`form_${categoryGroup.id}`}
                     checked={allCategoriesInGroupSelected}
-                    onChange={e => {
+                    onChange={() => {
                       const selectedCategoriesExcludingGroupCategories =
                         selectedCategories.filter(
                           selectedCategory =>
@@ -118,7 +118,7 @@ export default function CategorySelector({
                       paddingLeft: 10,
                     }}
                   >
-                    {categoryGroup.categories.map((category, index) => {
+                    {categoryGroup.categories.map(category => {
                       const isChecked = selectedCategories.some(
                         selectedCategory => selectedCategory.id === category.id,
                       );
@@ -135,7 +135,7 @@ export default function CategorySelector({
                           <Checkbox
                             id={`form_${category.id}`}
                             checked={isChecked}
-                            onChange={e => {
+                            onChange={() => {
                               if (isChecked) {
                                 setSelectedCategories(
                                   selectedCategories.filter(

--- a/packages/desktop-client/src/components/reports/Header.js
+++ b/packages/desktop-client/src/components/reports/Header.js
@@ -63,7 +63,6 @@ function Header({
   onDeleteFilter,
   onCondOpChange,
   headerPrefixItems,
-  selectGraph,
 }) {
   let location = useLocation();
   let path = location.pathname;

--- a/packages/desktop-client/src/components/reports/ReportSidebar.js
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.js
@@ -54,7 +54,6 @@ export function ReportSidebar({
   allMonths,
   graphType,
   setGraphType,
-  setViewLegend,
   typeDisabled,
   setTypeDisabled,
   groupBy,

--- a/packages/desktop-client/src/components/reports/ReportSummary.js
+++ b/packages/desktop-client/src/components/reports/ReportSummary.js
@@ -136,7 +136,7 @@ export function ReportSummary({
   );
 }
 
-export function ReportLegend({ data, legend, groupBy }) {
+export function ReportLegend({ legend, groupBy }) {
   return (
     <View
       style={{

--- a/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
@@ -127,7 +127,7 @@ function AreaGraph({ style, data, balanceTypeOp, compact }: AreaGraphProps) {
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         data.monthData && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -146,7 +146,6 @@ function BarGraph({
   empty,
   balanceTypeOp,
   compact,
-  domain,
 }: BarGraphProps) {
   const colorScale = getColorScale('qualitative');
   const yAxis = ['Month', 'Year'].includes(groupBy) ? 'date' : 'name';
@@ -171,7 +170,7 @@ function BarGraph({
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         data[splitData] && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/BarLineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarLineGraph.tsx
@@ -35,7 +35,7 @@ type CustomTooltipProps = {
   label?: string;
 };
 
-const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     return (
       <div
@@ -78,12 +78,7 @@ type BarLineGraphProps = {
   };
 };
 
-function BarLineGraph({
-  style,
-  graphData,
-  compact,
-  domain,
-}: BarLineGraphProps) {
+function BarLineGraph({ style, graphData, compact }: BarLineGraphProps) {
   const tickFormatter = tick => {
     return `${Math.round(tick).toLocaleString()}`; // Formats the tick values as strings with commas
   };
@@ -95,7 +90,7 @@ function BarLineGraph({
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         graphData && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -40,7 +40,7 @@ type CustomTooltipProps = {
   label?: string;
 };
 
-const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     return (
       <div
@@ -111,7 +111,6 @@ function DonutGraph({
   empty,
   balanceTypeOp,
   compact,
-  domain,
 }: DonutGraphProps) {
   const colorScale = getColorScale('qualitative');
   const yAxis = ['Month', 'Year'].includes(groupBy) ? 'date' : 'name';
@@ -132,7 +131,7 @@ function DonutGraph({
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         data[splitData] && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -34,7 +34,7 @@ type CustomTooltipProps = {
   label?: string;
 };
 
-const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length) {
     return (
       <div
@@ -77,7 +77,7 @@ type LineGraphProps = {
   };
 };
 
-function LineGraph({ style, graphData, compact, domain }: LineGraphProps) {
+function LineGraph({ style, graphData, compact }: LineGraphProps) {
   const tickFormatter = tick => {
     return `${Math.round(tick).toLocaleString()}`; // Formats the tick values as strings with commas
   };
@@ -89,7 +89,7 @@ function LineGraph({ style, graphData, compact, domain }: LineGraphProps) {
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         graphData && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -26,12 +26,7 @@ type NetWorthGraphProps = {
   };
 };
 
-function NetWorthGraph({
-  style,
-  graphData,
-  compact,
-  domain,
-}: NetWorthGraphProps) {
+function NetWorthGraph({ style, graphData, compact }: NetWorthGraphProps) {
   const tickFormatter = tick => {
     return `${Math.round(tick).toLocaleString()}`; // Formats the tick values as strings with commas
   };
@@ -69,7 +64,7 @@ function NetWorthGraph({
   };
 
   // eslint-disable-next-line react/no-unstable-nested-components
-  const CustomTooltip = ({ active, payload, label }: CustomTooltipProps) => {
+  const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
     if (active && payload && payload.length) {
       return (
         <div
@@ -112,7 +107,7 @@ function NetWorthGraph({
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         graphData && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
@@ -113,7 +113,7 @@ function SankeyGraph({ style, data, compact }: SankeyProps) {
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) => (
+      {width => (
         <ResponsiveContainer>
           <Sankey
             data={sankeyData}

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -126,7 +126,6 @@ function StackedBarGraph({
   data,
   balanceTypeOp,
   compact,
-  domain,
 }: StackedBarGraphProps) {
   const colorScale = getColorScale('qualitative');
 
@@ -145,7 +144,7 @@ function StackedBarGraph({
         ...(compact && { height: 'auto' }),
       }}
     >
-      {(width, height, portalHost) =>
+      {(width, height) =>
         data.stackedData && (
           <ResponsiveContainer>
             <div>

--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -57,7 +57,7 @@ export function cashFlowByDate(
     });
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
-    function makeQuery(where) {
+    function makeQuery(_where) {
       let query = q('transactions')
         .filter({
           [conditionsOpKey]: [...filters],

--- a/packages/desktop-client/src/components/select/DateSelect.tsx
+++ b/packages/desktop-client/src/components/select/DateSelect.tsx
@@ -343,7 +343,7 @@ export default function DateSelect({
         {...inputProps}
         inputRef={inputRef}
         value={value}
-        onPointerUp={e => {
+        onPointerUp={() => {
           if (!embedded) {
             setOpen(true);
           }

--- a/packages/desktop-client/src/components/sidebar/Accounts.tsx
+++ b/packages/desktop-client/src/components/sidebar/Accounts.tsx
@@ -77,7 +77,7 @@ function Accounts({
     setIsDragging(drag.state === 'start');
   }
 
-  let makeDropPadding = (i, length) => {
+  let makeDropPadding = (i, _length) => {
     if (i === 0) {
       return {
         paddingTop: isDragging ? 15 : 0,
@@ -156,7 +156,7 @@ function Accounts({
       )}
 
       {showClosedAccounts &&
-        closedAccounts.map((account, i) => (
+        closedAccounts.map(account => (
           <Account
             key={account.id}
             name={account.name}

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -850,7 +850,7 @@ type TableWithNavigatorProps = TableProps & {
 export const TableWithNavigator = forwardRef<
   TableHandleRef,
   TableWithNavigatorProps
->(({ fields, ...props }, ref) => {
+>(({ fields, ...props }) => {
   let navigator = useTableNavigator(props.items, fields);
   return <Table {...props} navigator={navigator} />;
 });
@@ -905,7 +905,6 @@ export const Table: <T extends TableItem>(
       style,
       navigator,
       onScroll,
-      version = 'v1',
       allowPopupsEscape,
       isSelected,
       saveScrollWidth,
@@ -1044,7 +1043,7 @@ export const Table: <T extends TableItem>(
       );
     }
 
-    function onItemsRendered({ overscanStartIndex, overscanStopIndex }) {
+    function onItemsRendered({ overscanStopIndex }) {
       if (loadMore && overscanStopIndex > items.length - 100) {
         loadMore();
       }
@@ -1136,9 +1135,7 @@ export const Table: <T extends TableItem>(
                         renderRow={renderRow}
                         itemCount={count || items.length}
                         itemSize={rowHeight - 1}
-                        itemKey={
-                          getItemKey || ((index, data) => items[index].id)
-                        }
+                        itemKey={getItemKey || (index => items[index].id)}
                         indexForKey={key =>
                           items.findIndex(item => item.id === key)
                         }

--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -228,7 +228,7 @@ class TransactionEditInner extends PureComponent {
     this.props.navigate(`/accounts/${account.id}`, { replace: true });
   };
 
-  onSaveChild = childTransaction => {
+  onSaveChild = () => {
     this.setState({ editingChild: null });
   };
 
@@ -871,7 +871,7 @@ function TransactionEditUnconnected(props) {
         navigate={navigate}
         // TODO: ChildEdit is complicated and heavily relies on RN
         // renderChildEdit={props => <ChildEdit {...props} />}
-        renderChildEdit={props => {}}
+        renderChildEdit={() => {}}
         dateFormat={dateFormat}
         // TODO: was this a mistake in the original code?
         // onTapField={this.onTapField}

--- a/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.js
@@ -36,7 +36,6 @@ function serializeTransaction(transaction, dateFormat) {
 const TransactionRow = memo(function TransactionRow({
   transaction,
   fields,
-  payees,
   categories,
   accounts,
   selected,
@@ -137,7 +136,6 @@ const TransactionRow = memo(function TransactionRow({
 
 export default function SimpleTransactionsTable({
   transactions,
-  schedules,
   renderEmpty,
   fields = ['date', 'payee', 'amount'],
   style,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.js
@@ -774,7 +774,7 @@ describe('Transactions', () => {
     updateProps({ transactions });
 
     function expectErrorToNotExist(transactions) {
-      transactions.forEach((transaction, idx) => {
+      transactions.forEach(transaction => {
         expect(transaction.error).toBeFalsy();
       });
     }

--- a/packages/desktop-client/src/global-events.js
+++ b/packages/desktop-client/src/global-events.js
@@ -7,7 +7,7 @@ export function handleGlobalEvents(actions, store) {
     actions.setAppState({ updateInfo: info });
   });
 
-  global.Actual.onEventFromMain('update-error', msg => {
+  global.Actual.onEventFromMain('update-error', () => {
     // Ignore errors. We don't want to constantly bug the user if they
     // always have a flaky connection or have intentionally disabled
     // updates. They will see the error in the about page if they try
@@ -18,7 +18,7 @@ export function handleGlobalEvents(actions, store) {
     actions.saveGlobalPrefs({ theme });
   };
 
-  listen('server-error', info => {
+  listen('server-error', () => {
     actions.addGenericErrorNotification();
   });
 

--- a/packages/desktop-electron/security.js
+++ b/packages/desktop-electron/security.js
@@ -1,7 +1,7 @@
 const electron = require('electron');
 
 electron.app.on('web-contents-created', function (event, contents) {
-  contents.on('will-attach-webview', function (event, webPreferences, params) {
+  contents.on('will-attach-webview', function (event, webPreferences) {
     delete webPreferences.preloadURL;
     delete webPreferences.preload;
 
@@ -15,11 +15,11 @@ electron.app.on('web-contents-created', function (event, contents) {
     event.preventDefault();
   });
 
-  contents.on('will-navigate', (event, navigationUrl) => {
+  contents.on('will-navigate', event => {
     event.preventDefault();
   });
 
-  contents.on('new-window', (event, navigationUrl) => {
+  contents.on('new-window', event => {
     event.preventDefault();
   });
 });

--- a/packages/desktop-electron/updater.js
+++ b/packages/desktop-electron/updater.js
@@ -43,7 +43,7 @@ function fireEvent(type, args) {
   lastEvent = type;
 }
 
-function start(handler) {
+function start() {
   if (updateTimer) {
     return null;
   }
@@ -53,7 +53,7 @@ function start(handler) {
 
     updateTimer = setInterval(() => {
       if (!isCheckingForUpdates) {
-        autoUpdater.checkForUpdates().catch(err => {
+        autoUpdater.checkForUpdates().catch(() => {
           // Do nothing with the error (make sure it's not logged to sentry)
         });
       }
@@ -74,7 +74,7 @@ function stop() {
 
 function check() {
   if (!isDev && !isCheckingForUpdates) {
-    autoUpdater.checkForUpdates().catch(err => {
+    autoUpdater.checkForUpdates().catch(() => {
       // Do nothing with the error (make sure it's not logged to sentry)
     });
   }

--- a/packages/loot-core/migrations/1632571489012_remove_cache.js
+++ b/packages/loot-core/migrations/1632571489012_remove_cache.js
@@ -1,4 +1,4 @@
-export default async function runMigration(db, uuid) {
+export default async function runMigration(db) {
   function getValue(node) {
     return node.expr != null ? node.expr : node.cachedValue;
   }

--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -199,7 +199,7 @@ export function setLastTransaction(
 }
 
 export function parseTransactions(filepath, options) {
-  return async (dispatch: Dispatch) => {
+  return async () => {
     return await send('transactions-parse-file', {
       filepath,
       options,

--- a/packages/loot-core/src/client/actions/queries.ts
+++ b/packages/loot-core/src/client/actions/queries.ts
@@ -217,7 +217,7 @@ export function updateGroup(group) {
 }
 
 export function deleteGroup(id, transferId?) {
-  return async function (dispatch, getState) {
+  return async function (dispatch) {
     await send('category-group-delete', { id, transferId });
     await dispatch(getCategories());
     // See `deleteCategory` for why we need this

--- a/packages/loot-core/src/client/query-helpers.test.ts
+++ b/packages/loot-core/src/client/query-helpers.test.ts
@@ -361,7 +361,7 @@ describe('query helpers', () => {
 
     await tracer.expect('server-query', [{ result: { $count: '*' } }]);
     await tracer.expect('server-query', ['id']);
-    await tracer.expect('data', data => {});
+    await tracer.expect('data', () => {});
 
     paged.fetchNext();
     paged.fetchNext();
@@ -369,7 +369,7 @@ describe('query helpers', () => {
     paged.fetchNext();
 
     await tracer.expect('server-query', ['id']);
-    await tracer.expect('data', data => {});
+    await tracer.expect('data', () => {});
 
     // Wait a bit and make sure nothing comes through
     let p = Promise.race([tracer.expect('server-query'), wait(200)]);

--- a/packages/loot-core/src/platform/client/fetch/index.web.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.web.ts
@@ -69,7 +69,7 @@ function connectSocket(port, onOpen) {
     }
   };
 
-  client.onopen = event => {
+  client.onopen = () => {
     // Send any messages that were queued while closed
     if (messageQueue.length > 0) {
       messageQueue.forEach(msg => {
@@ -150,7 +150,7 @@ export const unlisten: T.Unlisten = function (name) {
 };
 
 async function closeSocket(onClose) {
-  socketClient.onclose = event => {
+  socketClient.onclose = () => {
     socketClient = null;
     onClose();
   };

--- a/packages/loot-core/src/platform/exceptions/index.browser.ts
+++ b/packages/loot-core/src/platform/exceptions/index.browser.ts
@@ -4,4 +4,4 @@ export const captureException: T.CaptureException = function (exc) {
   console.log('[Exception]', exc);
 };
 
-export const captureBreadcrumb: T.CaptureBreadcrumb = function (breadcrumb) {};
+export const captureBreadcrumb: T.CaptureBreadcrumb = function () {};

--- a/packages/loot-core/src/platform/exceptions/index.electron.ts
+++ b/packages/loot-core/src/platform/exceptions/index.electron.ts
@@ -4,4 +4,4 @@ export const captureException: T.CaptureException = function (exc) {
   console.log('[Exception]', exc);
 };
 
-export const captureBreadcrumb: T.CaptureBreadcrumb = function (breadcrumb) {};
+export const captureBreadcrumb: T.CaptureBreadcrumb = function () {};

--- a/packages/loot-core/src/platform/exceptions/index.testing.ts
+++ b/packages/loot-core/src/platform/exceptions/index.testing.ts
@@ -1,5 +1,5 @@
 import type * as T from '.';
 
-export const captureException: T.CaptureException = function (exc) {};
+export const captureException: T.CaptureException = function () {};
 
-export const captureBreadcrumb: T.CaptureBreadcrumb = function (info) {};
+export const captureBreadcrumb: T.CaptureBreadcrumb = function () {};

--- a/packages/loot-core/src/platform/exceptions/index.web.ts
+++ b/packages/loot-core/src/platform/exceptions/index.web.ts
@@ -4,4 +4,4 @@ export const captureException: T.CaptureException = function (exc) {
   console.log('[Exception]', exc);
 };
 
-export const captureBreadcrumb: T.CaptureBreadcrumb = function (breadcrumb) {};
+export const captureBreadcrumb: T.CaptureBreadcrumb = function () {};

--- a/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
@@ -33,7 +33,7 @@ export const setItem: T.SetItem = async function (key, value) {
   new Promise((resolve, reject) => {
     let req = objectStore.put(value, key);
     req.onerror = e => reject(e);
-    req.onsuccess = e => resolve(undefined);
+    req.onsuccess = () => resolve(undefined);
     commit(transaction);
   });
 };
@@ -47,7 +47,7 @@ export const removeItem: T.RemoveItem = async function (key) {
   return new Promise((resolve, reject) => {
     let req = objectStore.delete(key);
     req.onerror = e => reject(e);
-    req.onsuccess = e => resolve(undefined);
+    req.onsuccess = () => resolve(undefined);
     commit(transaction);
   });
 };
@@ -83,7 +83,7 @@ export const multiSet: T.MultiSet = async function (keyValues) {
       return new Promise((resolve, reject) => {
         let req = objectStore.put(value, key);
         req.onerror = e => reject(e);
-        req.onsuccess = e => resolve(undefined);
+        req.onsuccess = () => resolve(undefined);
       });
     }),
   );
@@ -103,7 +103,7 @@ export const multiRemove: T.MultiRemove = async function (keys) {
       return new Promise((resolve, reject) => {
         let req = objectStore.delete(key);
         req.onerror = e => reject(e);
-        req.onsuccess = e => resolve(undefined);
+        req.onsuccess = () => resolve(undefined);
       });
     }),
   );

--- a/packages/loot-core/src/platform/server/connection/index.api.ts
+++ b/packages/loot-core/src/platform/server/connection/index.api.ts
@@ -2,7 +2,7 @@ import type * as T from '.';
 
 export const init: T.Init = function () {};
 
-export const send: T.Send = function (type, args) {
+export const send: T.Send = function () {
   // Nothing
 };
 

--- a/packages/loot-core/src/platform/server/fs/index.web.ts
+++ b/packages/loot-core/src/platform/server/fs/index.web.ts
@@ -312,7 +312,7 @@ export const removeDirRecursively = async function (dirpath) {
   }
 };
 
-export const getModifiedTime = async function (filepath) {
+export const getModifiedTime = async function () {
   throw new Error(
     'getModifiedTime not supported on the web (only used for backups)',
   );

--- a/packages/loot-core/src/platform/server/indexeddb/index.web.ts
+++ b/packages/loot-core/src/platform/server/indexeddb/index.web.ts
@@ -33,7 +33,7 @@ function _openDatabase() {
 
     openRequest.onblocked = e => console.log('blocked', e);
 
-    openRequest.onerror = event => {
+    openRequest.onerror = () => {
       console.log('openRequest error');
       reject(new Error('indexeddb-failure: Could not open IndexedDB'));
     };
@@ -101,7 +101,7 @@ export const getStore: T.GetStore = function (db, name) {
 export const get: T.Get = async function (store, key, mapper = x => x) {
   return new Promise((resolve, reject) => {
     let req = store.get(key);
-    req.onsuccess = e => {
+    req.onsuccess = () => {
       resolve(mapper(req.result));
     };
     req.onerror = e => reject(e);
@@ -111,7 +111,7 @@ export const get: T.Get = async function (store, key, mapper = x => x) {
 export const set: T.Set = async function (store, item) {
   return new Promise((resolve, reject) => {
     let req = store.put(item);
-    req.onsuccess = e => resolve(undefined);
+    req.onsuccess = () => resolve(undefined);
     req.onerror = e => reject(e);
   });
 };
@@ -119,7 +119,7 @@ export const set: T.Set = async function (store, item) {
 export const del: T.Del = async function (store, key) {
   return new Promise((resolve, reject) => {
     let req = store.delete(key);
-    req.onsuccess = e => resolve(undefined);
+    req.onsuccess = () => resolve(undefined);
     req.onerror = e => reject(e);
   });
 };

--- a/packages/loot-core/src/server/__mocks__/post.ts
+++ b/packages/loot-core/src/server/__mocks__/post.ts
@@ -3,6 +3,6 @@ export {
   handleRequestBinary as postBinary,
 } from '../tests/mockSyncServer';
 
-export const get = function (url) {
+export const get = function () {
   throw new Error('get unimplemented');
 };

--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -489,7 +489,7 @@ describe('Rule', () => {
     ];
 
     let foundRules = [];
-    iterateIds(rules, 'description', (rule, value) => {
+    iterateIds(rules, 'description', rule => {
       foundRules.push(rule.getId());
     });
     expect(foundRules).toEqual(['first', 'second', 'second', 'third']);

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -518,7 +518,7 @@ export class Rule {
     });
   }
 
-  execActions(object) {
+  execActions(_object) {
     let changes = {};
     this.actions.forEach(action => action.exec(changes));
     return changes;

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -252,7 +252,7 @@ handlers['api/finish-import'] = async function () {
   await handlers['get-budget-bounds']();
   await sheet.waitOnSpreadsheet();
 
-  await cloudStorage.upload().catch(err => {});
+  await cloudStorage.upload().catch(() => {});
 
   connection.send('finish-import');
   IMPORT_MODE = false;
@@ -420,7 +420,7 @@ handlers['api/transactions-get'] = async function ({
   return data;
 };
 
-handlers['api/transactions-filter'] = async function ({ text, accountId }) {
+handlers['api/transactions-filter'] = async function () {
   throw new Error('`filterTransactions` is deprecated, use `runQuery` instead');
 };
 

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -991,7 +991,7 @@ export function compileQuery(
 
   let {
     tableViews = {},
-    tableFilters = name => [],
+    tableFilters = () => [],
     customizeQuery = queryState => queryState,
   } = schemaConfig;
 

--- a/packages/loot-core/src/server/bench.ts
+++ b/packages/loot-core/src/server/bench.ts
@@ -8,7 +8,7 @@ const queries = fs
   .split('___BOUNDARY')
   .map(q => q.trim());
 
-function runQueries(n?) {
+function runQueries() {
   for (let i = 0; i < queries.length; i++) {
     if (queries[i] !== '') {
       db.runQuery(queries[i], [], true);

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -326,7 +326,7 @@ export async function possiblyUpload() {
   }
 
   // Don't block on uploading
-  upload().catch(err => {});
+  upload().catch(() => {});
 }
 
 export async function removeFile(fileId) {

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -601,12 +601,7 @@ export async function getTransaction(id) {
   return rows[0];
 }
 
-export async function getTransactionsByDate(
-  accountId,
-  startDate,
-  endDate,
-  options = {},
-) {
+export async function getTransactionsByDate() {
   throw new Error('`getTransactionsByDate` is deprecated');
 }
 

--- a/packages/loot-core/src/server/importers/actual.ts
+++ b/packages/loot-core/src/server/importers/actual.ts
@@ -42,5 +42,5 @@ export default async function importActual(_filepath: string, buffer: Buffer) {
   await handlers['load-budget']({ id });
   await handlers['get-budget-bounds']();
   await waitOnSpreadsheet();
-  await cloudStorage.upload().catch(err => {});
+  await cloudStorage.upload().catch(() => {});
 }

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -198,7 +198,7 @@ async function importTransactions(
 
             subtransactions:
               transaction.subTransactions &&
-              transaction.subTransactions.map((t, i) => {
+              transaction.subTransactions.map(t => {
                 return {
                   id: entityIdMap.get(t.entityId),
                   amount: amountToInteger(t.amount),

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1849,7 +1849,7 @@ handlers['delete-budget'] = async function ({ id, cloudFileId }) {
   // If it's a cloud file, you can delete it from the server by
   // passing its cloud id
   if (cloudFileId) {
-    await cloudStorage.removeFile(cloudFileId).catch(err => {});
+    await cloudStorage.removeFile(cloudFileId).catch(() => {});
   }
 
   // If a local file exists, you can delete it by passing its local id

--- a/packages/loot-core/src/server/migrate/cli.ts
+++ b/packages/loot-core/src/server/migrate/cli.ts
@@ -45,7 +45,7 @@ function create(migrationName) {
   fs.writeFileSync(up, 'BEGIN TRANSACTION;\n\nCOMMIT;', 'utf8');
 }
 
-async function list(db) {
+async function list(_db) {
   const migrationsDir = getMigrationsDir();
   const applied = await getAppliedMigrations(getDatabase());
   const all = await getMigrationList(migrationsDir);

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -550,7 +550,7 @@ app.method('schedule/get-upcoming-dates', getUpcomingDates);
 
 app.service(trackJSONPaths);
 
-app.events.on('sync', ({ type, subtype }) => {
+app.events.on('sync', ({ type }) => {
   let completeEvent =
     type === 'success' || type === 'error' || type === 'unauthorized';
 

--- a/packages/loot-core/src/server/schedules/find-schedules.ts
+++ b/packages/loot-core/src/server/schedules/find-schedules.ts
@@ -48,7 +48,7 @@ function getRank(day1, day2) {
   return 1 / (dayDiff + 1);
 }
 
-function matchSchedules(allOccurs, config, partialMatchRank = 0.5) {
+function matchSchedules(allOccurs, config, _partialMatchRank = 0.5) {
   allOccurs = [...allOccurs].reverse();
   let baseOccur = allOccurs[0];
   let occurs = allOccurs.slice(1);
@@ -363,7 +363,7 @@ export async function findSchedules() {
   }
 
   let schedules = [...groupBy(allSchedules, 'payee').entries()].map(
-    ([payeeId, schedules]) => {
+    ([schedules]) => {
       schedules.sort((s1, s2) => s2.rank - s1.rank);
       let winner = schedules[0];
 

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.ts
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.ts
@@ -77,7 +77,7 @@ export default class Spreadsheet {
     return this.nodes.has(name);
   }
 
-  add(name, expr, value) {
+  add(name, expr) {
     this.set(name, expr);
   }
 

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -130,7 +130,7 @@ async function fetchAll(table, ids) {
     }
 
     sql += ` WHERE `;
-    sql += partIds.map(id => `${column} = ?`).join(' OR ');
+    sql += partIds.map(() => `${column} = ?`).join(' OR ');
 
     try {
       let rows = await db.runQuery(sql, partIds, true);

--- a/packages/loot-core/src/server/tests/mockSyncServer.ts
+++ b/packages/loot-core/src/server/tests/mockSyncServer.ts
@@ -81,7 +81,7 @@ handlers['/plaid/handoff_public_token'] = () => {
   // Do nothing
 };
 
-handlers['/plaid/accounts'] = ({ client_id, group_id, item_id }) => {
+handlers['/plaid/accounts'] = () => {
   // Ignore the parameters and just return the accounts.
   return { accounts: currentMockData.accounts };
 };

--- a/packages/loot-core/src/shared/async.test.ts
+++ b/packages/loot-core/src/shared/async.test.ts
@@ -59,7 +59,7 @@ describe('async', () => {
   test('sequential fn should still flush queue when error is thrown', async () => {
     const test = async fn => {
       fn(1);
-      fn(2, { throwError: true }).catch(err => {});
+      fn(2, { throwError: true }).catch(() => {});
       await fn(3);
     };
 
@@ -85,7 +85,7 @@ describe('async', () => {
       // happened in here, it wouldn't effect anything else)
       expect(data).toEqual([1, 1, 1, 2]);
     });
-    fn(2, { throwError: true }).catch(err => {
+    fn(2, { throwError: true }).catch(() => {
       // Same as above
       expect(data).toEqual([1, 1, 1, 2, 3]);
     });

--- a/upcoming-release-notes/1927.md
+++ b/upcoming-release-notes/1927.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jaas666]
+---
+
+Enables argument checking for linter and removes unused arguments from project.


### PR DESCRIPTION
Should close #1907 

No linting errors or warnings after changes but I'd still review carefully as there are a bunch of files with changes.

Also, there are two errors that I noticed when running tests but they don't seem to be related to changes on this PR. These errors might need new issues created.

Running `npm run test`:
```
[loot-core]: FAIL src/shared/util.test.ts
[loot-core]:   ● utility functions › number formatting works with space-comma format
[loot-core]: 
[loot-core]:     expect(received).toBe(expected) // Object.is equality
[loot-core]: 
[loot-core]:     Expected: "1 234,56"
[loot-core]:     Received: "1,234.56"
[loot-core]: 
[loot-core]:       69 |     let formatter = getNumberFormat().formatter;
[loot-core]:       70 |     // grouping separator space char is a non-breaking space, or UTF-16 \xa0
[loot-core]:     > 71 |     expect(formatter.format(Number('1234.56'))).toBe('1\xa0234,56');
[loot-core]:          |                                                 ^
[loot-core]:       72 |
[loot-core]:       73 |     setNumberFormat({ format: 'space-comma', hideFraction: true });
[loot-core]:       74 |     formatter = getNumberFormat().formatter;
[loot-core]: 
[loot-core]:       at Object.<anonymous> (src/shared/util.test.ts:71:49)
```



Running `npm run typecheck`:
```
packages/desktop-client/src/components/table.tsx:889:14 - error TS2322: Type 'ForwardRefExoticComponent<TableProps<TableItem> & RefAttributes<TableHandleRef>>' is not assignable to type '<T extends TableItem>(props: TableProps<T> & { ref?: Ref<TableHandleRef>; }) => ReactElement<any, string | JSXElementConstructor<any>>'.
  Type 'ReactNode' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.
    Type 'string' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>>'.

889 export const Table: <T extends TableItem>(
                 ~~~~~


Found 1 error in packages/desktop-client/src/components/table.tsx:889
```
