### PR TITLE
Fix flickering scroll bar on mobile transaction input (#1782)

### DIFF
--- a/packages/desktop-client/src/components/mobile/MobileAmountInput.js
+++ b/packages/desktop-client/src/components/mobile/MobileAmountInput.js
@@ -169,7 +169,7 @@ class AmountInput extends PureComponent {
           ...style,
         }}
       >
-        <View style={{ overflowY: 'auto' }}>{input}</View>
+        <View style={{ overflowY: 'auto', overflowX: 'hidden' }}>{input}</View>
 
         {/* <Animated.View
           style={{

--- a/upcoming-release-notes/1929.md
+++ b/upcoming-release-notes/1929.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [miqh]
+---
+
+Fix flickering scroll bar that may appear when interacting with the new transaction input amount.


### PR DESCRIPTION
Hello there,

This pull request is in response to positive feedback on my suggestion noted on #1782.

It's been a while since I originally added those observations. After a quick test on my end, I can confirm the minor change is still applicable.

**EDIT:** Noticed a bunch of E2E and VRT failures. If they are legitimate (I'm unsure), perhaps this change needs to be rethought.

---

Closes #1782