### PR TITLE
Specify minimum node version for @actual-app/api nom package

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,6 +3,9 @@
   "version": "6.2.1",
   "license": "MIT",
   "description": "An API for Actual",
+  "engines": {
+    "node": ">=18.12.0"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/upcoming-release-notes/1934.md
+++ b/upcoming-release-notes/1934.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Marethyu1]
+---
+
+Sets minimum node version to 18.12.0 for @actual-app/api npm package


### PR DESCRIPTION
so that a warning comes up if you try to install the package with lower version of node then what is required

Should hopefully fix #1903
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
