### PR TITLE
[Maintenance] Refactor amount input to typescript

### DIFF
--- a/packages/desktop-client/src/components/common/InputWithContent.tsx
+++ b/packages/desktop-client/src/components/common/InputWithContent.tsx
@@ -6,8 +6,8 @@ import Input, { defaultInputStyle } from './Input';
 import View from './View';
 
 type InputWithContentProps = ComponentProps<typeof Input> & {
-  leftContent: ReactNode;
-  rightContent: ReactNode;
+  leftContent?: ReactNode;
+  rightContent?: ReactNode;
   inputStyle?: CSSProperties;
   focusStyle?: CSSProperties;
   style?: CSSProperties;

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -92,7 +92,6 @@ export function AmountInput({
           )}
         </Button>
       }
-      rightContent={undefined}
       value={value}
       focused={focused}
       style={{ flex: 1, alignItems: 'stretch', ...style }}

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { type MutableRefObject, useRef, useState } from 'react';
 
 import evalArithmetic from 'loot-core/src/shared/arithmetic';
 import { amountToInteger } from 'loot-core/src/shared/util';
@@ -6,11 +6,23 @@ import { amountToInteger } from 'loot-core/src/shared/util';
 import { useMergedRefs } from '../../hooks/useMergedRefs';
 import Add from '../../icons/v1/Add';
 import Subtract from '../../icons/v1/Subtract';
-import { theme } from '../../style';
+import { type CSSProperties, theme } from '../../style';
 import Button from '../common/Button';
 import InputWithContent from '../common/InputWithContent';
 import View from '../common/View';
 import useFormat from '../spreadsheet/useFormat';
+
+type AmountInputProps = {
+  id?: string;
+  inputRef?: MutableRefObject<HTMLInputElement>;
+  initialValue: number;
+  zeroSign?: '-' | '+';
+  onChange?: (value: number) => void;
+  onBlur?: () => void;
+  style?: CSSProperties;
+  textStyle?: CSSProperties;
+  focused?: boolean;
+};
 
 export function AmountInput({
   id,
@@ -22,7 +34,7 @@ export function AmountInput({
   style,
   textStyle,
   focused,
-}) {
+}: AmountInputProps) {
   let format = useFormat();
   let [negative, setNegative] = useState(
     (initialValue === 0 && zeroSign === '-') || initialValue < 0,
@@ -49,8 +61,8 @@ export function AmountInput({
     setValue(value ? value : '');
   }
 
-  let ref = useRef();
-  let mergedRef = useMergedRefs(inputRef, ref);
+  let ref = useRef<HTMLInputElement>();
+  let mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
 
   function onInputAmountBlur(e) {
     fireChange(value, negative);
@@ -80,6 +92,7 @@ export function AmountInput({
           )}
         </Button>
       }
+      rightContent={undefined}
       value={value}
       focused={focused}
       style={{ flex: 1, alignItems: 'stretch', ...style }}

--- a/upcoming-release-notes/1936.md
+++ b/upcoming-release-notes/1936.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [kymckay]
+---
+
+Refactor AmountInput component to TypeScript.


### PR DESCRIPTION
- Small refactor to start exploring the codebase. Maintains parity with the previous JS component.
- Tweaked the props of the `InputWithContent` component to reflect how it is used and quell the typescript errors.
  - Most uses  appear to omit `leftContent` or `rightContent` so this allows for that instead of explicitly passing undefined values.
  - It probably never makes sense to use this component with neither prop, but adding a union with an intersection representing the exclusive optional cases is pretty ugly.

I was going to do `GenericInput` too, but that's some form of factory pattern that requires a bit more thought so keeping this PR tight and simple.

Part of #1483
