### PR TITLE
Switch from en-ZA to en-SE for space-comma NumberFormat

### DIFF
--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -219,7 +219,7 @@ export function getNumberFormat({ format, hideFraction } = numberFormatConfig) {
 
   switch (format) {
     case 'space-comma':
-      locale = 'en-ZA';
+      locale = 'en-SE';
       regex = /[^-0-9,]/g;
       separator = ',';
       break;

--- a/upcoming-release-notes/1938.md
+++ b/upcoming-release-notes/1938.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix space-comma format for newer NodeJS versions (18.18, and 21.x), fixes #1937


### PR DESCRIPTION
- Fixes space-comma format for newer NodeJS versions (18.18, and 21.x)

en_ZA no longer follows space-comma format in ICU 73 data, so switching to en_SE to restore functionality.

The locale details for en_SE can be found here: https://github.com/unicode-org/icu/blob/main/icu4c/source/data/locales/en_SE.txt

Fix for https://github.com/actualbudget/actual/issues/1937

