### PR TITLE
Create category rules for ynab imports

### DIFF
--- a/packages/api/methods.js
+++ b/packages/api/methods.js
@@ -58,8 +58,17 @@ export function setBudgetCarryover(month, categoryId, flag) {
   return send('api/budget-set-carryover', { month, categoryId, flag });
 }
 
-export function addTransactions(accountId, transactions) {
-  return send('api/transactions-add', { accountId, transactions });
+export function addTransactions(
+  accountId,
+  transactions,
+  { learnCategories = false, runTransfers = false } = {},
+) {
+  return send('api/transactions-add', {
+    accountId,
+    transactions,
+    learnCategories: learnCategories,
+    runTransfers: runTransfers,
+  });
 }
 
 export function importTransactions(accountId, transactions) {

--- a/packages/api/methods.js
+++ b/packages/api/methods.js
@@ -66,8 +66,8 @@ export function addTransactions(
   return send('api/transactions-add', {
     accountId,
     transactions,
-    learnCategories: learnCategories,
-    runTransfers: runTransfers,
+    learnCategories,
+    runTransfers,
   });
 }
 

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -740,8 +740,8 @@ export async function addTransactions(
   if (runTransfers || learnCategories) {
     let res = await batchUpdateTransactions({
       added,
-      learnCategories: learnCategories,
-      runTransfers: runTransfers,
+      learnCategories,
+      runTransfers,
     });
     newTransactions = res.added.map(t => t.id);
   } else {

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -705,7 +705,7 @@ export async function reconcileTransactions(acctId, transactions) {
 export async function addTransactions(
   acctId,
   transactions,
-  { runTransfers = true } = {},
+  { runTransfers = true, learnCategories = false } = {},
 ) {
   const added = [];
 
@@ -737,8 +737,12 @@ export async function addTransactions(
   await createNewPayees(payeesToCreate, added);
 
   let newTransactions;
-  if (runTransfers) {
-    let res = await batchUpdateTransactions({ added });
+  if (runTransfers || learnCategories) {
+    let res = await batchUpdateTransactions({
+      added,
+      learnCategories: learnCategories,
+      runTransfers: runTransfers,
+    });
     newTransactions = res.added.map(t => t.id);
   } else {
     await batchMessages(async () => {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -393,9 +393,14 @@ handlers['api/transactions-import'] = withMutation(async function ({
 handlers['api/transactions-add'] = withMutation(async function ({
   accountId,
   transactions,
+  runTransfers = false,
+  learnCategories = false,
 }) {
   checkFileOpen();
-  await addTransactions(accountId, transactions, { runTransfers: false });
+  await addTransactions(accountId, transactions, {
+    runTransfers: runTransfers,
+    learnCategories: learnCategories,
+  });
   return 'ok';
 });
 

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -398,8 +398,8 @@ handlers['api/transactions-add'] = withMutation(async function ({
 }) {
   checkFileOpen();
   await addTransactions(accountId, transactions, {
-    runTransfers: runTransfers,
-    learnCategories: learnCategories,
+    runTransfers,
+    learnCategories,
   });
   return 'ok';
 });

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -213,7 +213,9 @@ async function importTransactions(
         })
         .filter(x => x);
 
-      await actual.addTransactions(entityIdMap.get(accountId), toImport);
+      await actual.addTransactions(entityIdMap.get(accountId), toImport, {
+        learnCategories: true,
+      });
     }),
   );
 }

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -234,7 +234,9 @@ async function importTransactions(
         })
         .filter(x => x);
 
-      await actual.addTransactions(entityIdMap.get(accountId), toImport);
+      await actual.addTransactions(entityIdMap.get(accountId), toImport, {
+        learnCategories: true,
+      });
     }),
   );
 }

--- a/upcoming-release-notes/1944.md
+++ b/upcoming-release-notes/1944.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [twk3]
+---
+
+Create category rules during ynab imports


### PR DESCRIPTION
- Enable learnCategories support in ynab transaction importing
- Exposes learnCategories up through the api
- Adds runTransfer conditions to batchUpdateTransactions so importer can still skip transfer processing


Part of https://github.com/actualbudget/actual/issues/1943