### PR TITLE
[Maintenance] Refactor payee table to typescript

### DIFF
--- a/packages/desktop-client/src/components/payees/ManagePayees.js
+++ b/packages/desktop-client/src/components/payees/ManagePayees.js
@@ -15,8 +15,8 @@ import { groupById } from 'loot-core/src/shared/util';
 
 import useSelected, {
   SelectedProvider,
-  useSelectedItems,
   useSelectedDispatch,
+  useSelectedItems,
 } from '../../hooks/useSelected';
 import useStableCallback from '../../hooks/useStableCallback';
 import ExpandArrow from '../../icons/v0/ExpandArrow';

--- a/packages/desktop-client/src/components/payees/ManagePayees.js
+++ b/packages/desktop-client/src/components/payees/ManagePayees.js
@@ -308,7 +308,6 @@ export const ManagePayees = forwardRef(
                 payees={filteredPayees}
                 ruleCounts={ruleCounts}
                 categoryGroups={categoryGroups}
-                highlightedRows={highlightedRows}
                 navigator={tableNavigator}
                 onUpdate={onUpdate}
                 onViewRules={onViewRules}

--- a/packages/desktop-client/src/components/payees/PayeeMenu.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeMenu.tsx
@@ -1,3 +1,5 @@
+import { type PayeeEntity } from 'loot-core/src/types/models';
+
 import Delete from '../../icons/v0/Delete';
 import Merge from '../../icons/v0/Merge';
 import { theme } from '../../style';
@@ -5,13 +7,21 @@ import Menu from '../common/Menu';
 import View from '../common/View';
 import { Tooltip } from '../tooltips';
 
+type PayeeMenuProps = {
+  payeesById: Record<PayeeEntity['id'], PayeeEntity>;
+  selectedPayees: Set<PayeeEntity['id']>;
+  onDelete: () => void;
+  onMerge: () => Promise<void>;
+  onClose: () => void;
+};
+
 export default function PayeeMenu({
   payeesById,
   selectedPayees,
   onDelete,
   onMerge,
   onClose,
-}) {
+}: PayeeMenuProps) {
   // Transfer accounts are never editable
   let isDisabled = [...selectedPayees].some(
     id => payeesById[id] == null || payeesById[id].transfer_acct,

--- a/packages/desktop-client/src/components/payees/PayeeTable.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTable.tsx
@@ -4,6 +4,7 @@ import {
   useLayoutEffect,
   useState,
   type ComponentProps,
+  type ComponentRef,
 } from 'react';
 
 import { type PayeeEntity } from 'loot-core/src/types/models';
@@ -27,25 +28,22 @@ type PayeeTableProps = {
   'onUpdate' | 'onViewRules' | 'onCreateRule'
 >;
 
-const PayeeTable = forwardRef(
+const PayeeTable = forwardRef<
+  ComponentRef<typeof Table<PayeeWithId>>,
+  PayeeTableProps
+>(
   (
-    {
-      payees,
-      ruleCounts,
-      navigator,
-      onUpdate,
-      onViewRules,
-      onCreateRule,
-    }: PayeeTableProps,
-    ref: ComponentProps<typeof Table>['ref'],
+    { payees, ruleCounts, navigator, onUpdate, onViewRules, onCreateRule },
+    ref,
   ) => {
     let [hovered, setHovered] = useState(null);
     let selectedItems = useSelectedItems();
 
     useLayoutEffect(() => {
       let firstSelected = [...selectedItems][0] as string;
-      // @ts-expect-error something off with this type (see: Table L967)
-      ref.current.scrollTo(firstSelected, 'center');
+      if (typeof ref !== 'function') {
+        ref.current.scrollTo(firstSelected, 'center');
+      }
       navigator.onEdit(firstSelected, 'select');
     }, []);
 

--- a/packages/desktop-client/src/components/payees/PayeeTable.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTable.tsx
@@ -1,10 +1,31 @@
-import { forwardRef, useState, useLayoutEffect, useCallback } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+  useState,
+  type ComponentProps,
+} from 'react';
+
+import { type PayeeEntity } from 'loot-core/src/types/models';
 
 import { useSelectedItems } from '../../hooks/useSelected';
 import View from '../common/View';
-import { Table } from '../table';
+import { Table, type TableNavigator } from '../table';
 
 import PayeeTableRow from './PayeeTableRow';
+
+// Table items require an ID to work, it's optional in the loot-core
+// model so would need to verify accuracy of that before changing there
+type PayeeWithId = PayeeEntity & Required<Pick<PayeeEntity, 'id'>>;
+
+type PayeeTableProps = {
+  payees: PayeeWithId[];
+  ruleCounts: Map<PayeeWithId['id'], number>;
+  navigator: TableNavigator<PayeeWithId>;
+} & Pick<
+  ComponentProps<typeof PayeeTableRow>,
+  'onUpdate' | 'onViewRules' | 'onCreateRule'
+>;
 
 const PayeeTable = forwardRef(
   (
@@ -12,20 +33,18 @@ const PayeeTable = forwardRef(
       payees,
       ruleCounts,
       navigator,
-      categoryGroups,
-      highlightedRows,
-      ruleActions,
       onUpdate,
       onViewRules,
       onCreateRule,
-    },
-    ref,
+    }: PayeeTableProps,
+    ref: ComponentProps<typeof Table>['ref'],
   ) => {
     let [hovered, setHovered] = useState(null);
     let selectedItems = useSelectedItems();
 
     useLayoutEffect(() => {
-      let firstSelected = [...selectedItems][0];
+      let firstSelected = [...selectedItems][0] as string;
+      // @ts-expect-error something off with this type (see: Table L967)
       ref.current.scrollTo(firstSelected, 'center');
       navigator.onEdit(firstSelected, 'select');
     }, []);
@@ -36,7 +55,7 @@ const PayeeTable = forwardRef(
 
     return (
       <View style={{ flex: 1 }} onMouseLeave={() => setHovered(null)}>
-        <Table
+        <Table<PayeeWithId>
           ref={ref}
           items={payees}
           navigator={navigator}
@@ -45,9 +64,7 @@ const PayeeTable = forwardRef(
               <PayeeTableRow
                 payee={item}
                 ruleCount={ruleCounts.get(item.id) || 0}
-                categoryGroups={categoryGroups}
                 selected={selectedItems.has(item.id)}
-                highlighted={highlightedRows && highlightedRows.has(item.id)}
                 editing={editing}
                 focusedField={focusedField}
                 hovered={hovered === item.id}

--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -1,12 +1,21 @@
 import { memo } from 'react';
 
+import { type PayeeEntity } from 'loot-core/src/types/models';
+
 import { useSelectedDispatch } from '../../hooks/useSelected';
 import ArrowThinRight from '../../icons/v1/ArrowThinRight';
-import { theme } from '../../style';
+import { type CSSProperties, theme } from '../../style';
 import Text from '../common/Text';
-import { Row, Cell, InputCell, SelectCell, CellButton } from '../table';
+import { Cell, CellButton, InputCell, Row, SelectCell } from '../table';
 
-function RuleButton({ ruleCount, focused, onEdit, onClick }) {
+type RuleButtonProps = {
+  ruleCount: number;
+  focused: boolean;
+  onEdit: () => void;
+  onClick: () => void;
+};
+
+function RuleButton({ ruleCount, focused, onEdit, onClick }: RuleButtonProps) {
   return (
     <Cell
       name="rule-count"
@@ -26,7 +35,6 @@ function RuleButton({ ruleCount, focused, onEdit, onClick }) {
         }}
         onEdit={onEdit}
         onSelect={onClick}
-        onFocus={onEdit}
       >
         <Text style={{ paddingRight: 5 }}>
           {ruleCount > 0 ? (
@@ -43,9 +51,29 @@ function RuleButton({ ruleCount, focused, onEdit, onClick }) {
   );
 }
 
+type EditablePayeeFields = keyof Pick<PayeeEntity, 'name'>;
+
+type PayeeTableRowProps = {
+  payee: PayeeEntity;
+  ruleCount: number;
+  selected: boolean;
+  hovered: boolean;
+  editing: boolean;
+  focusedField: string;
+  onHover?: (id: PayeeEntity['id']) => void;
+  onEdit: (id: PayeeEntity['id'], field: string) => void;
+  onUpdate: (
+    id: PayeeEntity['id'],
+    field: EditablePayeeFields,
+    value: unknown,
+  ) => void;
+  onViewRules: (id: PayeeEntity['id']) => void;
+  onCreateRule: (id: PayeeEntity['id']) => void;
+  style?: CSSProperties;
+};
+
 const PayeeTableRow = memo(
   ({
-    style,
     payee,
     ruleCount,
     selected,
@@ -57,7 +85,8 @@ const PayeeTableRow = memo(
     onHover,
     onEdit,
     onUpdate,
-  }) => {
+    style,
+  }: PayeeTableRowProps) => {
     let { id } = payee;
     let dispatchSelected = useSelectedDispatch();
     let borderColor = selected ? theme.tableBorderSelected : theme.tableBorder;

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -833,12 +833,12 @@ let rowStyle: CSSProperties = {
   width: '100%',
 };
 
-type TableHandleRef = {
-  scrollTo: (id: number, alignment?: string) => void;
+type TableHandleRef<T extends TableItem = TableItem> = {
+  scrollTo: (id: T['id'], alignment?: string) => void;
   scrollToTop: () => void;
-  getScrolledItem: () => TableItem['id'];
+  getScrolledItem: () => T['id'];
   setRowAnimation: (flag) => void;
-  edit(id: number, field, shouldScroll): void;
+  edit(id: number, field: string, shouldScroll: boolean): void;
   anchor(): void;
   unanchor(): void;
   isAnchored(): boolean;
@@ -848,7 +848,7 @@ type TableWithNavigatorProps = TableProps & {
   fields;
 };
 export const TableWithNavigator = forwardRef<
-  TableHandleRef,
+  TableHandleRef<TableItem>,
   TableWithNavigatorProps
 >(({ fields, ...props }, ref) => {
   let navigator = useTableNavigator(props.items, fields);
@@ -887,7 +887,7 @@ type TableProps<T extends TableItem = TableItem> = {
 };
 
 export const Table: <T extends TableItem>(
-  props: TableProps<T> & { ref?: Ref<TableHandleRef> },
+  props: TableProps<T> & { ref?: Ref<TableHandleRef<T>> },
 ) => ReactElement = forwardRef<TableHandleRef, TableProps>(
   (
     {

--- a/upcoming-release-notes/1948.md
+++ b/upcoming-release-notes/1948.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [kymckay]
+---
+
+Refactor Payee table to TypeScript and harden generic `Table` component typing.


### PR DESCRIPTION
The diff might be hard to compare on this one as I'm factoring components out of the large `index.js` file (unclear why that's an index file to begin with). The main changes are:
- Components are the same, but with typing for the props.
- Hardening of parameters and props for the `Table` component and associated `useTableNavigator` hook. This was needed to correctly propagate types through to the table item rendering function and elsewhere that fields and IDs are exposed.

The main oddities in here:
- The `PayeeEntity` type defined in `loot-core`'s models has an optional `id`. That is incompatible with the `TableItem` type expected by the `Table` component. Potentially that optionality is incorrect, but rather than scour the codebase to confirm if that's the case I've just added a `PayeeWithId` type which makes the ID required for this component.
- There's something incorrect about the `Ref` type from the `Table` forwarded ref. There's an existing code comment for that and I've  also disabled linting where I'm pulling that type through to the `ref` parameter for `PayeeTable` too. I think the way it's typed in `Table` might just be wrong, but preferred to forge ahead with this incremental improvement then spend a lot of time digging into that.
- You'll notice I'm removing the `highlightedRows` prop passed to `PayeeTable`. That's because the table was using it to fill the `highlighted` prop given to each table item - except that the `PayeeTableRow` (previously just `Payee`) component doesn't have or use that prop. There's some state management updating the value of that variable in the parent, but I decided to leave that in place until giving the parent a more thorough review later.