### PR TITLE
Transfer and Off Budget category in mobile

### DIFF
--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -762,7 +762,7 @@ class TransactionEditInner extends PureComponent {
             transaction:
               editingChild && transactions.find(t => t.id === editingChild),
             amountSign: forcedSign,
-            getCategoryName: id => (id ? lookupName(categories, id) : null),
+            getCategoryName: id => lookupName(categories, id),
             navigate,
             onEdit: this.onEdit,
             onStartClose: this.onSaveChild,
@@ -995,7 +995,7 @@ class Transaction extends PureComponent {
       amount = getScheduledAmount(amount);
     }
 
-    let categoryName = category ? lookupName(categories, category) : null;
+    let categoryName = lookupName(categories, category);
 
     let payee = payees && payeeId && getPayeesById(payees)[payeeId];
     let transferAcct =

--- a/packages/desktop-client/src/components/transactions/MobileTransaction.js
+++ b/packages/desktop-client/src/components/transactions/MobileTransaction.js
@@ -129,7 +129,10 @@ function deserializeTransaction(transaction, originalTransaction, dateFormat) {
 }
 
 function lookupName(items, id) {
-  return items.find(item => item.id === id).name;
+  if (!id) {
+    return null;
+  }
+  return items.find(item => item.id === id)?.name;
 }
 
 function Status({ status }) {
@@ -333,16 +336,17 @@ class TransactionEditInner extends PureComponent {
 
     // Child transactions should always default to the signage
     // of the parent transaction
-    let forcedSign = transaction.amount < 0 ? 'negative' : 'positive';
+    const forcedSign = transaction.amount < 0 ? 'negative' : 'positive';
 
-    let account = getAccountsById(accounts)[accountId];
-    let payee = payees && payeeId && getPayeesById(payees)[payeeId];
-    let transferAcct =
+    const account = getAccountsById(accounts)[accountId];
+    const isOffBudget = account && !!account.offbudget;
+    const payee = payees && payeeId && getPayeesById(payees)[payeeId];
+    const transferAcct =
       payee &&
       payee.transfer_acct &&
       getAccountsById(accounts)[payee.transfer_acct];
-
-    let descriptionPretty = getDescriptionPretty(
+    const isBudgetTransfer = transferAcct && !transferAcct.offbudget;
+    const descriptionPretty = getDescriptionPretty(
       transaction,
       payee,
       transferAcct,
@@ -540,11 +544,21 @@ class TransactionEditInner extends PureComponent {
               />
               {!transaction.is_parent ? (
                 <TapField
-                  value={category ? lookupName(categories, category) : null}
-                  disabled={
-                    (account && !!account.offbudget) ||
-                    (transferAcct && !transferAcct.offbudget)
+                  style={{
+                    ...((isBudgetTransfer || isOffBudget) && {
+                      fontStyle: 'italic',
+                      color: theme.pageTextSubdued,
+                      fontWeight: 300,
+                    }),
+                  }}
+                  value={
+                    isOffBudget
+                      ? 'Off Budget'
+                      : isBudgetTransfer
+                      ? 'Transfer'
+                      : lookupName(categories, category)
                   }
+                  disabled={isBudgetTransfer || isOffBudget}
                   // TODO: the button to turn this transaction into a split
                   // transaction was on top of the category button in the native
                   // app, on the right-hand side

--- a/upcoming-release-notes/1955.md
+++ b/upcoming-release-notes/1955.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+"Transafer" and "Off Budget" categories in mobile transaction page

--- a/upcoming-release-notes/1955.md
+++ b/upcoming-release-notes/1955.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [joel-jeremy]
 ---
 
-"Transafer" and "Off Budget" categories in mobile transaction page
+"Transfer" and "Off Budget" categories in mobile transaction page


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
The category field in mobile transaction is disable and empty when the transaction is a transfer or account is off budget. This PR adds a `Transfer` and `Off Budget` text to the field similar to how it is done in the desktop transactions table. 