### PR TITLE
:art: (fix) gocardless success button color

### DIFF
--- a/packages/desktop-client/src/components/modals/GoCardlessExternalMsg.js
+++ b/packages/desktop-client/src/components/modals/GoCardlessExternalMsg.js
@@ -293,8 +293,6 @@ export default function GoCardlessExternalMsg({
                 fontSize: 15,
                 fontWeight: 600,
                 marginTop: 10,
-                backgroundColor: theme.noticeBackgroundDark,
-                borderColor: theme.noticeBackgroundDark,
               }}
               onClick={onContinue}
             >

--- a/packages/desktop-client/src/components/modals/PlaidExternalMsg.tsx
+++ b/packages/desktop-client/src/components/modals/PlaidExternalMsg.tsx
@@ -103,8 +103,6 @@ export default function PlaidExternalMsg({
                 fontSize: 15,
                 fontWeight: 600,
                 marginTop: 10,
-                backgroundColor: theme.noticeBackgroundDark,
-                borderColor: theme.noticeBorder,
               }}
               onClick={onContinue}
             >

--- a/upcoming-release-notes/1970.md
+++ b/upcoming-release-notes/1970.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Style: change GoCardless success button color


### PR DESCRIPTION
Why do this change? The button had green default color and then on hover it turned purple. Which is pretty weird.. Instead we can just use the default colors for it. Makes things easier

| Before | After |
|--------|--------|
|<img width="573" alt="Screenshot 2023-11-25 at 17 59 23" src="https://github.com/actualbudget/actual/assets/886567/d5cfadb1-561f-4156-bdba-129c1363c997">| <img width="577" alt="Screenshot 2023-11-25 at 17 58 53" src="https://github.com/actualbudget/actual/assets/886567/4f8ec876-18f4-4f07-9378-a7b33a514623"> | 
