### PR TITLE
Fix cancel add category group

### DIFF
--- a/packages/desktop-client/src/components/budget/SidebarGroup.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarGroup.tsx
@@ -185,7 +185,6 @@ function SidebarGroup({
         onBlur={() => onEdit(null)}
         style={{ fontWeight: 600 }}
         inputProps={{
-          value: undefined,
           style: { marginLeft: 20 },
           placeholder: temporary ? 'New Group Name' : '',
         }}

--- a/upcoming-release-notes/1975.md
+++ b/upcoming-release-notes/1975.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [williamk19]
+---
+
+Bug fixes for cancel add category group.


### PR DESCRIPTION
There's a bug when user cancel add group (leave the input blank and click outside input). I've manage it with delete `value: undefined` in inputProps following SidebarCategory.tsx code.

![Screenshot_1](https://github.com/actualbudget/actual/assets/59714670/295b14c3-2100-421e-bbe8-335809486108)
