### PR TITLE
Validates minimum node version to 18.12.0 for @actual-app/api npm package

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -13,10 +13,25 @@ export * as methods from './methods';
 export * from './methods';
 export * as utils from './utils';
 
+function validateNodeVersion() {
+  if (process?.versions?.node) {
+    const nodeVersion = process?.versions?.node;
+    const majorVersionString = nodeVersion.split('.')[0];
+    const majorVersionNumber = parseInt(majorVersionString);
+    if (majorVersionNumber < 18) {
+      throw new Error(
+        `@actual-app/api requires a node version >= 18. Found that you are using: ${nodeVersion}. Please upgrade to a higher version`,
+      );
+    }
+  }
+}
+
 export async function init(config = {}) {
   if (actualApp) {
     return;
   }
+
+  validateNodeVersion();
 
   global.fetch = (...args) =>
     import('node-fetch').then(({ default: fetch }) => fetch(...args));

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-unused-modules */
 
+// eslint-disable-next-line import/extensions
 import * as bundle from './app/bundle.api.js';
 import * as injected from './injected';
 import { validateNodeVersion } from './validateNodeVersion';

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -16,11 +16,18 @@ export * as utils from './utils';
 function validateNodeVersion() {
   if (process?.versions?.node) {
     const nodeVersion = process?.versions?.node;
-    const majorVersionString = nodeVersion.split('.')[0];
+    const splitVersion = nodeVersion.split('.');
+    const majorVersionString = splitVersion[0];
+    const minorVersionString = splitVersion[1];
+
     const majorVersionNumber = parseInt(majorVersionString);
-    if (majorVersionNumber < 18) {
+    const minorVersionNumber = parseInt(minorVersionString);
+    if (
+      majorVersionNumber < 18 ||
+      (majorVersionNumber === 18 && minorVersionNumber < 12)
+    ) {
       throw new Error(
-        `@actual-app/api requires a node version >= 18. Found that you are using: ${nodeVersion}. Please upgrade to a higher version`,
+        `@actual-app/api requires a node version >= 18.12.0. Found that you are using: ${nodeVersion}. Please upgrade to a higher version`,
       );
     }
   }

--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-unused-modules */
 
-// eslint-disable-next-line import/extensions
 import * as bundle from './app/bundle.api.js';
 import * as injected from './injected';
+import { validateNodeVersion } from './validateNodeVersion';
 
 let actualApp;
 export const internal = bundle.lib;
@@ -12,26 +12,6 @@ export * as methods from './methods';
 
 export * from './methods';
 export * as utils from './utils';
-
-function validateNodeVersion() {
-  if (process?.versions?.node) {
-    const nodeVersion = process?.versions?.node;
-    const splitVersion = nodeVersion.split('.');
-    const majorVersionString = splitVersion[0];
-    const minorVersionString = splitVersion[1];
-
-    const majorVersionNumber = parseInt(majorVersionString);
-    const minorVersionNumber = parseInt(minorVersionString);
-    if (
-      majorVersionNumber < 18 ||
-      (majorVersionNumber === 18 && minorVersionNumber < 12)
-    ) {
-      throw new Error(
-        `@actual-app/api requires a node version >= 18.12.0. Found that you are using: ${nodeVersion}. Please upgrade to a higher version`,
-      );
-    }
-  }
-}
 
 export async function init(config = {}) {
   if (actualApp) {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^9.1.1",
+    "compare-versions": "^6.1.0",
     "node-fetch": "^3.3.2",
     "uuid": "^9.0.0"
   },

--- a/packages/api/validateNodeVersion.js
+++ b/packages/api/validateNodeVersion.js
@@ -1,0 +1,16 @@
+import { satisfies } from 'compare-versions';
+
+import * as packageJson from './package.json';
+
+export function validateNodeVersion() {
+  if (process?.versions?.node) {
+    const nodeVersion = process?.versions?.node;
+    const minimumNodeVersion = packageJson.engines.node;
+
+    if (!satisfies(nodeVersion, minimumNodeVersion)) {
+      throw new Error(
+        `@actual-app/api requires a node version ${minimumNodeVersion}. Found that you are using: ${nodeVersion}. Please upgrade to a higher version`,
+      );
+    }
+  }
+}

--- a/upcoming-release-notes/1980.md
+++ b/upcoming-release-notes/1980.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfix
+category: Enhancements
 authors: [Marethyu1]
 ---
 

--- a/upcoming-release-notes/1980.md
+++ b/upcoming-release-notes/1980.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Marethyu1]
+---
+
+Validates minimum node version to 18.12.0 for @actual-app/api npm package

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,6 +25,7 @@ __metadata:
   dependencies:
     "@types/uuid": "npm:^9.0.2"
     better-sqlite3: "npm:^9.1.1"
+    compare-versions: "npm:^6.1.0"
     node-fetch: "npm:^3.3.2"
     typescript: "npm:^5.0.2"
     uuid: "npm:^9.0.0"
@@ -7166,6 +7167,13 @@ __metadata:
   version: 0.1.2
   resolution: "compare-version@npm:0.1.2"
   checksum: 0ceaf50b5f912c8eb8eeca19375e617209d200abebd771e9306510166462e6f91ad764f33f210a3058ee27c83f2f001a7a4ca32f509da2d207d0143a3438a020
+  languageName: node
+  linkType: hard
+
+"compare-versions@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "compare-versions@npm:6.1.0"
+  checksum: 20f349e7f8ad784704c68265f4e660e2abbe2c3d5c75793184fccb85f0c5c0263260e01fdd4488376f6b74b0f069e16c9684463f7316b075716fb1581eb36b77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Doing this as part of #1903 


<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
