### PR TITLE
[Bugfix] Goals: Schedule overbudget condition

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -177,5 +177,5 @@ export async function goalsSchedule(
     increment = Math.round(increment);
     to_budget += increment;
   }
-  return { to_budget, errors, remainder };
+  return { to_budget, errors, remainder, scheduleFlag };
 }

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -603,6 +603,7 @@ async function applyCategoryTemplate(
         to_budget = goalsReturn.to_budget;
         errors = goalsReturn.errors;
         remainder = goalsReturn.remainder;
+        scheduleFlag = goalsReturn.scheduleFlag;
         break;
       }
       case 'remainder': {

--- a/upcoming-release-notes/1984.md
+++ b/upcoming-release-notes/1984.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goals: Fix Schedule overbudget condition


### PR DESCRIPTION
There was an omission from the recent refactor.  This will pass the scheduleFlag argument back to the main function so that the loop is not run multiple times.

Fixes https://github.com/actualbudget/actual/issues/1983