### PR TITLE
fix broken schedule amount sign in firefox

### DIFF
--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -89,7 +89,7 @@ export function AmountInput({
         <Button
           type="bare"
           style={{ padding: '0 7px' }}
-          disabled={!focused}
+          //disabled={!focused}
           onPointerUp={onSwitch}
           onPointerDown={e => e.preventDefault()}
           ref={buttonRef}


### PR DESCRIPTION
fixes #1922 

The amount sign in the schedule editor was broken and would not work at all in firefox.  Chrome seemed to partially work, but wouldn't show the hover effect.

Im open to a more sophisticated fix than this.
