### PR TITLE
[Goals]: Sort the priorities properly

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -197,7 +197,9 @@ async function processTemplate(
 
   // sort and filter down to just the requested priorities
   priority_list = priority_list
-    .sort()
+    .sort(function (a, b) {
+      return a - b;
+    })
     .filter((item, index, curr) => curr.indexOf(item) === index);
 
   let { remainder_found, remainder_priority, remainder_weight_total } =

--- a/upcoming-release-notes/2000.md
+++ b/upcoming-release-notes/2000.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: Fix priority sorting


### PR DESCRIPTION
Priority sorting was using alphabetical sorting instead of numeric sorting.  This fixes it to sort as expected.

Fixes #1999 
