### PR TITLE
Fix failure to create category with deleted name

### DIFF
--- a/packages/loot-core/src/server/db/index.test.ts
+++ b/packages/loot-core/src/server/db/index.test.ts
@@ -38,6 +38,21 @@ describe('Database', () => {
     expect((await db.getCategories()).length).toBe(1);
   });
 
+  test('using a deleted category name works', async () => {
+    await db.insertCategoryGroup({ id: 'group1', name: 'group1' });
+    const id = await db.insertCategory({
+      name: 'foo',
+      cat_group: 'group1',
+    });
+    await db.deleteCategory({ id });
+    expect((await db.getCategories()).length).toBe(0);
+    await db.insertCategory({
+      name: 'foo',
+      cat_group: 'group1',
+    });
+    expect((await db.getCategories()).length).toBe(1);
+  });
+
   test('transactions are sorted by date', async () => {
     await insertTransactions([
       { date: '2018-01-05', account: 'foo', amount: -23 },

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -348,7 +348,7 @@ export async function insertCategory(
   await batchMessages(async () => {
     // Dont allow duplicated names in groups
     const existingCatInGroup = await first(
-      `SELECT id FROM categories WHERE cat_group = ? and UPPER(name) = ? LIMIT 1`,
+      `SELECT id FROM categories WHERE cat_group = ? and UPPER(name) = ? and tombstone = 0 LIMIT 1`,
       [category.cat_group, category.name.toUpperCase()],
     );
     if (existingCatInGroup) {

--- a/upcoming-release-notes/2002.md
+++ b/upcoming-release-notes/2002.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kymckay]
+---
+
+Prevent deleted categories blocking creation of new categories with the same name.


### PR DESCRIPTION
I'm not 100% familiar with the design of the data model so may have misinterpreted what's going on here, but how I read this:

- The tombstone flag is used to soft delete categories.
- When creating a new category, duplicate names within a group are prevented.
- When checking for duplicate names, the tombstone flag was unchecked which meant deleted categories were falsely blocking creation.

I had a look at category deleteion logic to verify that simply including the tombstone flag in this check is sane and see that there's a category mapping being maintained to redirect one category to another on deletion. So from what I can tell the correct behaviour here is to allow a new category with the previously deleted name, rather than to revive the old category (to preserve that old mapping lineage).

Fixes #1963
