### PR TITLE
[Maintenance] Adding Aria labels for accessibility

### DIFF
--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -188,7 +188,7 @@ export default function NotesButton({
     >
       <Button
         type="bare"
-        aria-label="View Notes"
+        aria-label="View notes"
         className={!hasNotes && !tooltipOpen ? 'hover-visible' : ''}
         style={{
           color: defaultColor,

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -188,7 +188,7 @@ export default function NotesButton({
     >
       <Button
         type="bare"
-        aria-label="View"
+        aria-label="View Notes"
         className={!hasNotes && !tooltipOpen ? 'hover-visible' : ''}
         style={{
           color: defaultColor,

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -188,6 +188,7 @@ export default function NotesButton({
     >
       <Button
         type="bare"
+        aria-label="View"
         className={!hasNotes && !tooltipOpen ? 'hover-visible' : ''}
         style={{
           color: defaultColor,

--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -197,6 +197,7 @@ function Notification({
         {sticky && (
           <Button
             type="bare"
+            aria-label="Close"
             style={{ flexShrink: 0, color: 'currentColor' }}
             onClick={onRemove}
           >

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -21,7 +21,7 @@ export function ThemeSelector({ style }: ThemeSelectorProps) {
   return isNarrowWidth ? null : (
     <Button
       type="bare"
-      aria-label="Switch Theme"
+      aria-label="Switch theme"
       onClick={() => {
         saveGlobalPrefs({
           theme: theme === 'dark' ? 'light' : 'dark',

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -21,6 +21,7 @@ export function ThemeSelector({ style }: ThemeSelectorProps) {
   return isNarrowWidth ? null : (
     <Button
       type="bare"
+      aria-label="Switch Theme"
       onClick={() => {
         saveGlobalPrefs({
           theme: theme === 'dark' ? 'light' : 'dark',

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -114,7 +114,7 @@ function PrivacyButton({ style }) {
   return (
     <Button
       type="bare"
-      aria-label="Toggle Privacy Filter"
+      aria-label="Toggle Privacy"
       onClick={() => savePrefs({ isPrivacyEnabled: !isPrivacyEnabled })}
       style={style}
     >

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -114,6 +114,7 @@ function PrivacyButton({ style }) {
   return (
     <Button
       type="bare"
+      aria-label="Toggle Privacy Filter"
       onClick={() => savePrefs({ isPrivacyEnabled: !isPrivacyEnabled })}
       style={style}
     >
@@ -227,6 +228,7 @@ export function SyncButton({ style, isMobile = false }: SyncButtonProps) {
 
       <Button
         type="bare"
+        aria-label="Sync"
         style={
           isMobile
             ? {

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -114,7 +114,7 @@ function PrivacyButton({ style }) {
   return (
     <Button
       type="bare"
-      aria-label="Toggle Privacy"
+      aria-label={`${isPrivacyEnabled ? 'Disable' : 'Enable'} privacy mode`}
       onClick={() => savePrefs({ isPrivacyEnabled: !isPrivacyEnabled })}
       style={style}
     >

--- a/packages/desktop-client/src/components/UpdateNotification.tsx
+++ b/packages/desktop-client/src/components/UpdateNotification.tsx
@@ -77,6 +77,7 @@ export default function UpdateNotification() {
               )
               <Button
                 type="bare"
+                aria-label="Close"
                 style={{ display: 'inline', padding: '1px 7px 2px 7px' }}
                 onClick={() => closeNotification(setAppState)}
               >

--- a/packages/desktop-client/src/components/accounts/Header.js
+++ b/packages/desktop-client/src/components/accounts/Header.js
@@ -168,7 +168,7 @@ export function AccountHeader({
                 )}
                 <Button
                   type="bare"
-                  aria-label="Edit"
+                  aria-label="Edit account name"
                   className="hover-visible"
                   onClick={() => onExposeName(true)}
                 >

--- a/packages/desktop-client/src/components/accounts/Header.js
+++ b/packages/desktop-client/src/components/accounts/Header.js
@@ -168,6 +168,7 @@ export function AccountHeader({
                 )}
                 <Button
                   type="bare"
+                  aria-label="Edit"
                   className="hover-visible"
                   onClick={() => onExposeName(true)}
                 >

--- a/packages/desktop-client/src/components/budget/BudgetTotals.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.tsx
@@ -55,6 +55,7 @@ const BudgetTotals = memo(function BudgetTotals({
         <View style={{ flexGrow: '1' }}>Category</View>
         <Button
           type="bare"
+          aria-label="Menu"
           onClick={() => {
             setMenuOpen(true);
           }}

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -349,6 +349,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
             <>
               <Button
                 type="bare"
+                aria-label="Menu"
                 style={{ padding: 10 }}
                 {...tooltip.getOpenEvents()}
               >
@@ -633,6 +634,7 @@ const ExpenseGroupTotals = memo(function ExpenseGroupTotals({
             <>
               <Button
                 type="bare"
+                aria-label="Menu"
                 style={{ padding: 10 }}
                 {...tooltip.getOpenEvents()}
               >
@@ -887,6 +889,7 @@ const IncomeGroupTotals = memo(function IncomeGroupTotals({
             <>
               <Button
                 type="bare"
+                aria-label="Menu"
                 style={{ padding: 10 }}
                 {...tooltip.getOpenEvents()}
               >
@@ -1091,6 +1094,7 @@ const IncomeCategory = memo(function IncomeCategory({
             <>
               <Button
                 type="bare"
+                aria-label="Menu"
                 style={{ padding: 10 }}
                 {...tooltip.getOpenEvents()}
               >
@@ -2107,6 +2111,7 @@ function BudgetHeader({
           <>
             <Button
               type="bare"
+              aria-label="Menu"
               hoveredStyle={{
                 color: theme.mobileHeaderText,
                 background: theme.mobileHeaderTextHover,

--- a/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
@@ -84,7 +84,7 @@ export default function BudgetSummary({ month }: BudgetSummaryProps) {
           >
             <Button
               type="bare"
-              aria-label="Toggle Summary"
+              aria-label={`${collapsed ? 'Expand' : 'Collapse'} Summary`}
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >

--- a/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
@@ -84,7 +84,7 @@ export default function BudgetSummary({ month }: BudgetSummaryProps) {
           >
             <Button
               type="bare"
-              aria-label={`${collapsed ? 'Expand' : 'Collapse'} Summary`}
+              aria-label={`${collapsed ? 'Expand' : 'Collapse'} month summary`}
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >

--- a/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/BudgetSummary.tsx
@@ -84,6 +84,7 @@ export default function BudgetSummary({ month }: BudgetSummaryProps) {
           >
             <Button
               type="bare"
+              aria-label="Toggle Summary"
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >
@@ -129,7 +130,7 @@ export default function BudgetSummary({ month }: BudgetSummaryProps) {
               />
             </View>
             <View style={{ userSelect: 'none' }}>
-              <Button type="bare" onClick={onMenuOpen}>
+              <Button type="bare" aria-label="Menu" onClick={onMenuOpen}>
                 <DotsHorizontalTriple
                   width={15}
                   height={15}

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
@@ -86,7 +86,7 @@ export default function BudgetSummary({
           >
             <Button
               type="bare"
-              aria-label={`${collapsed ? 'Expand' : 'Collapse'} Month Summary`}
+              aria-label={`${collapsed ? 'Expand' : 'Collapse'} month summary`}
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
@@ -86,6 +86,7 @@ export default function BudgetSummary({
           >
             <Button
               type="bare"
+              aria-label="Toggle Summary"
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >
@@ -132,7 +133,7 @@ export default function BudgetSummary({
               />
             </View>
             <View style={{ userSelect: 'none', marginLeft: 2 }}>
-              <Button type="bare" onClick={onMenuOpen}>
+              <Button type="bare" aria-label="Menu" onClick={onMenuOpen}>
                 <DotsHorizontalTriple
                   width={15}
                   height={15}

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
@@ -86,7 +86,7 @@ export default function BudgetSummary({
           >
             <Button
               type="bare"
-              aria-label="Toggle Summary"
+              aria-label={`${collapsed ? 'Expand' : 'Collapse'} Month Summary`}
               className="hover-visible"
               onClick={onToggleSummaryCollapse}
             >

--- a/packages/desktop-client/src/components/manager/BudgetList.js
+++ b/packages/desktop-client/src/components/manager/BudgetList.js
@@ -63,6 +63,7 @@ function DetailButton({ state, onDelete }) {
     <View>
       <Button
         type="bare"
+        aria-label="Menu"
         onClick={e => {
           e.stopPropagation();
           setMenuOpen(true);
@@ -235,6 +236,7 @@ function RefreshButton({ onRefresh }) {
   return (
     <Button
       type="bare"
+      aria-label="Refresh"
       style={{ padding: 10, marginRight: 5 }}
       onClick={_onRefresh}
     >

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -98,6 +98,7 @@ function OverflowMenu({
     <View>
       <Button
         type="bare"
+        aria-label="Menu"
         onClick={e => {
           e.stopPropagation();
           setOpen(true);

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
@@ -243,7 +243,7 @@ function MonthlyPatterns({ config, dispatch }) {
           />
           <Button
             type="bare"
-            aria-label="Remove Recurrence"
+            aria-label="Remove recurrence"
             style={{ padding: 7 }}
             onClick={() =>
               dispatch({

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
@@ -256,7 +256,7 @@ function MonthlyPatterns({ config, dispatch }) {
           </Button>
           <Button
             type="bare"
-            aria-label="Add Recurrence"
+            aria-label="Add recurrence"
             style={{ padding: 7, marginLeft: 5 }}
             onClick={() => dispatch({ type: 'add-recurrence' })}
           >

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.js
@@ -243,6 +243,7 @@ function MonthlyPatterns({ config, dispatch }) {
           />
           <Button
             type="bare"
+            aria-label="Remove Recurrence"
             style={{ padding: 7 }}
             onClick={() =>
               dispatch({
@@ -255,6 +256,7 @@ function MonthlyPatterns({ config, dispatch }) {
           </Button>
           <Button
             type="bare"
+            aria-label="Add Recurrence"
             style={{ padding: 7, marginLeft: 5 }}
             onClick={() => dispatch({ type: 'add-recurrence' })}
           >

--- a/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
+++ b/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
@@ -17,7 +17,7 @@ function ToggleButton({ style, isFloating, onFloat }: ToggleButtonProps) {
     <View className="float" style={{ ...style, flexShrink: 0 }}>
       <Button
         type="bare"
-        aria-label={`${isFloating ? 'Pin' : 'Unpin'} Sidebar`}
+        aria-label={`${isFloating ? 'Pin' : 'Unpin'} sidebar`}
         onClick={onFloat}
         color={theme.buttonMenuBorder}
       >

--- a/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
+++ b/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
@@ -15,7 +15,12 @@ type ToggleButtonProps = {
 function ToggleButton({ style, isFloating, onFloat }: ToggleButtonProps) {
   return (
     <View className="float" style={{ ...style, flexShrink: 0 }}>
-      <Button type="bare" onClick={onFloat} color={theme.buttonMenuBorder}>
+      <Button
+        type="bare"
+        aria-label="Toggle Sidebar"
+        onClick={onFloat}
+        color={theme.buttonMenuBorder}
+      >
         {isFloating ? (
           <Pin
             style={{

--- a/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
+++ b/packages/desktop-client/src/components/sidebar/ToggleButton.tsx
@@ -17,7 +17,7 @@ function ToggleButton({ style, isFloating, onFloat }: ToggleButtonProps) {
     <View className="float" style={{ ...style, flexShrink: 0 }}>
       <Button
         type="bare"
-        aria-label="Toggle Sidebar"
+        aria-label={`${isFloating ? 'Pin' : 'Unpin'} Sidebar`}
         onClick={onFloat}
         color={theme.buttonMenuBorder}
       >

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.js
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.js
@@ -663,6 +663,7 @@ function PayeeIcons({
       {transferAccount && (
         <Button
           type="bare"
+          aria-label="Transfer"
           style={buttonStyle}
           onClick={e => {
             e.stopPropagation();

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -88,7 +88,7 @@ export function AmountInput({
       leftContent={
         <Button
           type="bare"
-          aria-label="Toggle Positive/Negative"
+          aria-label={`Make ${negative ? 'Positive' : 'Negative'}`}
           style={{ padding: '0 7px' }}
           onPointerUp={onSwitch}
           onPointerDown={e => e.preventDefault()}

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -88,6 +88,7 @@ export function AmountInput({
       leftContent={
         <Button
           type="bare"
+          aria-label="Toggle Positive/Negative"
           style={{ padding: '0 7px' }}
           onPointerUp={onSwitch}
           onPointerDown={e => e.preventDefault()}

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -88,7 +88,7 @@ export function AmountInput({
       leftContent={
         <Button
           type="bare"
-          aria-label={`Make ${negative ? 'Positive' : 'Negative'}`}
+          aria-label={`Make ${negative ? 'positive' : 'negative'}`}
           style={{ padding: '0 7px' }}
           onPointerUp={onSwitch}
           onPointerDown={e => e.preventDefault()}

--- a/upcoming-release-notes/2025.md
+++ b/upcoming-release-notes/2025.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Adding aria-labels to some buttons for greater accessibility


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should 
only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Adding aria-labels to some buttons to improve accessibility score. 

Notes: 
- There's still loads of issues left - I've only tackled a few here
- Color contrast is a common issue across pages
- Might want to start adding data-test-id to elements to make the Puppeteer tests more resilient