### PR TITLE
[IDEA] Moving the add group button to the context menu

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetCategories.js
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.js
@@ -36,7 +36,6 @@ const BudgetCategories = memo(
     onReorderGroup,
     onShowNewCategory,
     onHideNewCategory,
-    onShowNewGroup,
     onHideNewGroup,
   }) => {
     const items = useMemo(() => {

--- a/packages/desktop-client/src/components/budget/BudgetCategories.js
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.js
@@ -242,7 +242,6 @@ const BudgetCategories = memo(
                 >
                   <IncomeHeader
                     MonthComponent={dataComponents.IncomeHeaderComponent}
-                    onShowNewGroup={onShowNewGroup}
                   />
                 </View>
               );

--- a/packages/desktop-client/src/components/budget/BudgetTable.js
+++ b/packages/desktop-client/src/components/budget/BudgetTable.js
@@ -230,6 +230,7 @@ class BudgetTable extends Component {
         >
           <BudgetTotals
             MonthComponent={dataComponents.BudgetTotalsComponent}
+            showNewCategoryGroup={onShowNewGroup}
             toggleHiddenCategories={this.toggleHiddenCategories}
             expandAllCategories={this.expandAllCategories}
             collapseAllCategories={this.collapseAllCategories}

--- a/packages/desktop-client/src/components/budget/BudgetTable.js
+++ b/packages/desktop-client/src/components/budget/BudgetTable.js
@@ -273,7 +273,6 @@ class BudgetTable extends Component {
                   onReorderGroup={this.onReorderGroup}
                   onShowNewCategory={onShowNewCategory}
                   onHideNewCategory={onHideNewCategory}
-                  onShowNewGroup={onShowNewGroup}
                   onHideNewGroup={onHideNewGroup}
                   onBudgetAction={this.onBudgetAction}
                   onShowActivity={this.onShowActivity}

--- a/packages/desktop-client/src/components/budget/BudgetTotals.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.tsx
@@ -12,6 +12,7 @@ import { getScrollbarWidth } from './util';
 
 type BudgetTotalsProps = {
   MonthComponent: ComponentProps<typeof RenderMonths>['component'];
+  showNewCategoryGroup: () => void;
   toggleHiddenCategories: () => void;
   expandAllCategories: () => void;
   collapseAllCategories: () => void;
@@ -19,6 +20,7 @@ type BudgetTotalsProps = {
 
 const BudgetTotals = memo(function BudgetTotals({
   MonthComponent,
+  showNewCategoryGroup,
   toggleHiddenCategories,
   expandAllCategories,
   collapseAllCategories,
@@ -77,7 +79,9 @@ const BudgetTotals = memo(function BudgetTotals({
             >
               <Menu
                 onMenuSelect={type => {
-                  if (type === 'toggle-visibility') {
+                  if (type === 'add-category-group') {
+                    showNewCategoryGroup();
+                  } else if (type === 'toggle-visibility') {
                     toggleHiddenCategories();
                   } else if (type === 'expandAllCategories') {
                     expandAllCategories();
@@ -87,6 +91,10 @@ const BudgetTotals = memo(function BudgetTotals({
                   setMenuOpen(false);
                 }}
                 items={[
+                  {
+                    name: 'add-category-group',
+                    text: 'Add category group',
+                  },
                   {
                     name: 'toggle-visibility',
                     text: 'Toggle hidden categories',

--- a/packages/desktop-client/src/components/budget/IncomeHeader.tsx
+++ b/packages/desktop-client/src/components/budget/IncomeHeader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Button from '../common/Button';
 import View from '../common/View';
 
 import RenderMonths from './RenderMonths';
@@ -10,20 +9,9 @@ type IncomeHeaderProps = {
   onShowNewGroup: () => void;
 };
 
-function IncomeHeader({ MonthComponent, onShowNewGroup }: IncomeHeaderProps) {
+function IncomeHeader({ MonthComponent }: IncomeHeaderProps) {
   return (
     <View style={{ flexDirection: 'row', flex: 1 }}>
-      <View
-        style={{
-          width: 200,
-          alignItems: 'flex-start',
-          justifyContent: 'flex-start',
-        }}
-      >
-        <Button onClick={onShowNewGroup} style={{ fontSize: 12, margin: 10 }}>
-          Add Group
-        </Button>
-      </View>
       <RenderMonths
         component={MonthComponent}
         style={{ border: 0, justifyContent: 'flex-end' }}

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.js
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.js
@@ -1579,17 +1579,6 @@ function BudgetGroups({
           );
         })}
 
-      <View
-        style={{
-          alignItems: 'flex-start',
-          justifyContent: 'flex-start',
-        }}
-      >
-        <Button onPointerUp={onAddGroup} style={{ fontSize: 12, margin: 10 }}>
-          Add Group
-        </Button>
-      </View>
-
       {incomeGroup && (
         <IncomeGroup
           type={type}
@@ -1750,6 +1739,7 @@ export function BudgetTable(props) {
           !editMode ? (
             <BudgetMenu
               onEditMode={onEditMode}
+              onAddGroup={onAddGroup}
               onToggleHiddenCategories={onToggleHiddenCategories}
               onSwitchBudgetType={_onSwitchBudgetType}
             />
@@ -1992,6 +1982,7 @@ export function BudgetTable(props) {
 
 function BudgetMenu({
   onEditMode,
+  onAddGroup,
   onToggleHiddenCategories,
   onSwitchBudgetType,
 }) {
@@ -2003,6 +1994,9 @@ function BudgetMenu({
     switch (name) {
       case 'edit-mode':
         onEditMode?.(true);
+        break;
+      case 'add-category-group':
+        onAddGroup?.();
         break;
       case 'toggle-hidden-categories':
         onToggleHiddenCategories?.();
@@ -2045,6 +2039,7 @@ function BudgetMenu({
             onMenuSelect={onMenuSelect}
             items={[
               { name: 'edit-mode', text: 'Edit mode' },
+              { name: 'add-category-group', text: 'Add category group' },
               {
                 name: 'toggle-hidden-categories',
                 text: 'Toggle hidden categories',

--- a/packages/desktop-client/src/style/styles.ts
+++ b/packages/desktop-client/src/style/styles.ts
@@ -8,7 +8,7 @@ import { theme } from './theme';
 import { type CSSProperties } from './types';
 
 export const styles = {
-  incomeHeaderHeight: 70,
+  incomeHeaderHeight: 50,
   cardShadow: '0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)',
   monthRightPadding: 5,
   menuBorderRadius: 4,

--- a/upcoming-release-notes/2057.md
+++ b/upcoming-release-notes/2057.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Moving the "Add group" button to the Category context menu


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Related to this idea:  #2051

I'm putting this out there to see what people think of it.

This would move the "Add group" button to the category context menu. The idea is it would save vertical space and contain the "Add category group" functionality to the Category menu - instead of a button below the budget table.

I'm not sure about what the design process is with this app, I'm wonder if there's a community member who's willing to help with where to put the buttons/what colours to use etc.

**Desktop**
![desktop](https://github.com/actualbudget/actual/assets/5285928/b35c9f66-35c9-43ae-8dc6-e6af6d260839)

**Mobile**
![mobile](https://github.com/actualbudget/actual/assets/5285928/aad06257-30b8-4bc8-be4c-5fca7481c4ee)

