### PR TITLE
[Enhancement] Goals: Schedules with exactly one month repeat are force to full

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -57,6 +57,12 @@ export async function goalsSchedule(
       );
       const startDate = dateConditions.value.start ?? dateConditions.value;
       const started = startDate <= monthUtils.addMonths(current_month, 1);
+      template[ll].full =
+        template[ll].full === null &&
+        target_frequency === 'monthly' &&
+        target_interval === 1
+          ? true
+          : false;
       t.push({
         template: template[ll],
         target,


### PR DESCRIPTION
This makes a slight behavior change to schedules that repeat every month.  Since Actual is month-based, a sinking fund for a monthly expense doesn't make much sense.  This will schedule the full amount of the schedule if the schedule repeats every month.  A small change in behavior may be noticed if this schedule is mixed with other schedules in the same category that are sinking funds (i.e. every 2, 4 or 8 months, etc).