### PR TITLE
[Goals]: fully skip budgeted categories when only applying

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -151,7 +151,6 @@ async function processTemplate(
 ): Promise<Notification> {
   let num_applied = 0;
   let errors = [];
-  let originalCategoryBalance = [];
   const idealTemplate = [];
   const setToZero = [];
   let priority_list = [];
@@ -186,12 +185,6 @@ async function processTemplate(
           isIncome: category.is_income,
           isTemplate: template ? true : false,
         });
-        //originalCategoryBalance.push({
-        //  category: category.id,
-        //  amount: budgeted,
-        //  isIncome: category.is_income,
-        //  isTemplate: template ? true : false,
-        //});
       }
     }
   }

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -156,7 +156,7 @@ async function processTemplate(
   let priority_list = [];
 
   const categories = await getCategories();
-  let categories_remove = [];
+  const categories_remove = [];
 
   //clears templated categories
   for (let c = 0; c < categories.length; c++) {
@@ -175,10 +175,12 @@ async function processTemplate(
         priority_list.push(template[l].priority);
       }
     }
-    if (budgeted) { 
-      if (!force) {// if not overwritting ignore these categories
-        categories_remove.push(category);
-      } else { // if we are overwritting add this category to list to zero
+    if (budgeted) {
+      if (!force) {
+        // save index of category to remove
+        categories_remove.push(c);
+      } else {
+        // if we are overwritting add this category to list to zero
         setToZero.push({
           category: category.id,
           amount: 0,
@@ -189,11 +191,11 @@ async function processTemplate(
     }
   }
 
-  // remove the categories we are skipping because of not force
-  for (let i = 0; i < categories_remove.length; i++) {
-    const c = categories_remove[i];
-    const index = categories.indexOf(c);
-    categories.splice(index,1);
+  // remove the categories we are skipping
+  // Go backwards through the list so the indexes don't change
+  // on the categories we need
+  for (let i = categories_remove.length - 1; i >= 0; i--) {
+    categories.splice(categories_remove[i], 1);
   }
 
   // zero out the categories that need it

--- a/upcoming-release-notes/2099.md
+++ b/upcoming-release-notes/2099.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+[Goals]: Fix over budget condition with using apply instead of overwrite


### PR DESCRIPTION
If someone had pre-budgeted a category and only applied the templates instead of overwrote with templates, the over budget checks wouldn't consider the amounts budgeted in those already budgeted categories, causing over budget.

This changes the process of leaving existing budgets by removing those categories from the list of templated categories, instead of saving and reapplying the previous amount.

Ive attatched a test budget that shows what was happing.
There are two templates that together budget the available funds.  They both have priorities set so they shouldn't be allowed to over budget.  The one category has a budgeted value.  

Select "Apply Budget Templates" and see the over budget even though that shouldn't be allowed.
[2023-12-17-_test-budget.zip](https://github.com/actualbudget/actual/files/13699054/2023-12-17-_test-budget.zip)

