### PR TITLE
[Goals]: don't run templates in hidden groups

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -49,7 +49,7 @@ async function getCategories() {
     INNER JOIN category_groups on categories.cat_group = category_groups.id 
     WHERE categories.tombstone = 0 AND categories.hidden = 0 
     AND category_groups.hidden = 0
-    `
+    `,
   );
 }
 

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -44,7 +44,12 @@ export function runCheckTemplates() {
 
 async function getCategories() {
   return await db.all(
-    'SELECT * FROM v_categories WHERE tombstone = 0 AND hidden = 0',
+    `
+    SELECT categories.* FROM categories 
+    INNER JOIN category_groups on categories.cat_group = category_groups.id 
+    WHERE categories.tombstone = 0 AND categories.hidden = 0 
+    AND category_groups.hidden = 0
+    `
   );
 }
 

--- a/upcoming-release-notes/2100.md
+++ b/upcoming-release-notes/2100.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Goals: Don't run templates on non-hidden categories inside of hidden groups


### PR DESCRIPTION
Fixes an issue where non-hidden categories in hidden groups would get run during template processing
