### PR TITLE
Adding filter for reconciled transactions

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -48,6 +48,7 @@ const filterFields = [
   'category',
   'amount',
   'cleared',
+  'reconciled',
   'saved',
 ].map(field => [field, mapField(field)]);
 

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -41,6 +41,7 @@ export const FIELD_TYPES = new Map(
     category: 'id',
     account: 'id',
     cleared: 'boolean',
+    reconciled: 'boolean',
     saved: 'saved',
   }),
 );

--- a/upcoming-release-notes/2108.md
+++ b/upcoming-release-notes/2108.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [davidkus]
+---
+
+Adding filter for reconciled transactions.


### PR DESCRIPTION
PR #1789 added a flag for reconciled transactions. This PR adds a new filter that lets you filter reconciled transactions.


https://github.com/actualbudget/actual/assets/5488094/dcf29674-7954-4a7b-ad36-ad1d8e096e3c

