### PR TITLE
Add "error" Page for special accounts in Mobile

### DIFF
--- a/packages/desktop-client/src/components/accounts/MobileAccount.jsx
+++ b/packages/desktop-client/src/components/accounts/MobileAccount.jsx
@@ -22,7 +22,10 @@ import {
 import useCategories from '../../hooks/useCategories';
 import useNavigate from '../../hooks/useNavigate';
 import { useSetThemeColor } from '../../hooks/useSetThemeColor';
-import { theme } from '../../style';
+import { theme, styles } from '../../style';
+import Button from '../common/Button';
+import Text from '../common/Text';
+import View from '../common/View';
 
 import AccountDetails from './MobileAccountDetails';
 
@@ -169,6 +172,27 @@ export default function Account(props) {
 
   if (!accounts || !accounts.length) {
     return null;
+  }
+
+  if (
+    accountId === 'budgeted' ||
+    accountId === 'offbudget' ||
+    accountId === 'uncategorized'
+  ) {
+    return (
+      <View style={{ flex: 1, padding: 30 }}>
+        <Text style={(styles.text, { textAlign: 'center' })}>
+          There is no Mobile View at the moment
+        </Text>
+        <Button
+          type="normal"
+          style={{ fontSize: 15, marginLeft: 10, marginTop: 10 }}
+          onClick={() => navigate('/accounts')}
+        >
+          Go back to Mobile Accounts
+        </Button>
+      </View>
+    );
   }
 
   const account = accounts.find(acct => acct.id === accountId);

--- a/upcoming-release-notes/2114.md
+++ b/upcoming-release-notes/2114.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [HansiWursti]
+---
+
+mobile: error page for special account urls


### PR DESCRIPTION
Hello,

if you access the mobile view from a "special" account url the website crashes:

/accounts/budgeted
/accounts/offbudget
/accounts/uncategorized

To recreate resize your browser while accessing one of the mentioned urls.

The Problem in my opinion is that these accounts not really exist and so account is later undefined and not able to be queried for the balance etc.

My simple fix is a little "error" page with a button back to the Accounts Overview:

![Bildschirmfoto am 2023-12-22 um 20 00 38](https://github.com/actualbudget/actual/assets/21249374/3bc90419-c6ae-49d5-8e52-eae965d9920f)


Thank you