### PR TITLE
[Goals] Negate schedule amount to budget if income

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -17,6 +17,7 @@ export async function goalsSchedule(
   last_month_balance,
   to_budget,
   errors,
+  category,
 ) {
   if (!scheduleFlag) {
     scheduleFlag = true;
@@ -34,12 +35,13 @@ export async function goalsSchedule(
       const conditions = rule.serialize().conditions;
       const { date: dateConditions, amount: amountCondition } =
         extractScheduleConds(conditions);
+      const sign = category.is_income ? 1 : -1;
       const target =
         amountCondition.op === 'isbetween'
-          ? -Math.round(
+          ? sign * Math.round(
               amountCondition.value.num1 + amountCondition.value.num2,
             ) / 2
-          : -amountCondition.value;
+          : sign * amountCondition.value;
       const next_date_string = getNextDate(
         dateConditions,
         monthUtils._parse(current_month),

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -591,7 +591,7 @@ async function applyCategoryTemplate(
           to_budget,
           errors,
         );
-        to_budget = goalsReturn.to_budget;
+        to_budget = category.is_income ? -goalsReturn.to_budget : goalsReturn.to_budget;
         errors = goalsReturn.errors;
         remainder = goalsReturn.remainder;
         scheduleFlag = goalsReturn.scheduleFlag;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -590,8 +590,9 @@ async function applyCategoryTemplate(
           last_month_balance,
           to_budget,
           errors,
+          category,
         );
-        to_budget = category.is_income ? -goalsReturn.to_budget : goalsReturn.to_budget;
+        to_budget = goalsReturn.to_budget;
         errors = goalsReturn.errors;
         remainder = goalsReturn.remainder;
         scheduleFlag = goalsReturn.scheduleFlag;

--- a/upcoming-release-notes/2125.md
+++ b/upcoming-release-notes/2125.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mk-french]
+---
+
+Goals: Negate schedule amount to budget if income


### PR DESCRIPTION
When referencing a schedule in a goal template for an income category, the amount to budget comes in as a negative amount. This PR fixes that by correctly signing the amount to budget if the category is an income category. 