### PR TITLE
[WIP] Cashflow forecast

### DIFF
--- a/packages/desktop-client/src/components/reports/Header.jsx
+++ b/packages/desktop-client/src/components/reports/Header.jsx
@@ -10,25 +10,20 @@ import Select from '../common/Select';
 import View from '../common/View';
 import { FilterButton, AppliedFilters } from '../filters/FiltersMenu';
 
-export function validateStart(allMonths, start, end, forecast) {
+export function validateStart(allMonths, start, end) {
   const earliest = allMonths[allMonths.length - 1].name;
   if (end < start) {
     end = monthUtils.addMonths(start, 6);
   }
-  return boundedRange(earliest, start, end, forecast);
+  return boundedRange(earliest, start, end);
 }
 
-export function validateEnd(allMonths, start, end, forecast) {
+export function validateEnd(allMonths, start, end) {
   const earliest = allMonths[allMonths.length - 1].name;
   if (start > end) {
     start = monthUtils.subMonths(end, 6);
   }
   return boundedRange(earliest, start, end);
-}
-
-function validateForecast(allMonths, start, end, forecast) {
-  const earliest = allMonths[allMonths.length - 1].name;
-  return boundedRange(earliest, start, end, forecast);
 }
 
 export function validateRange(allMonths, start, end) {
@@ -43,7 +38,7 @@ export function validateRange(allMonths, start, end) {
   return [start, end];
 }
 
-function boundedRange(earliest, start, end, forecast) {
+function boundedRange(earliest, start, end) {
   const latest = monthUtils.currentMonth();
   if (end > latest) {
     end = latest;
@@ -51,22 +46,19 @@ function boundedRange(earliest, start, end, forecast) {
   if (start < earliest) {
     start = earliest;
   }
-  if (end != latest) {
-    forecast = latest;
-  }
-  return [start, end, forecast];
+  return [start, end];
 }
 
-export function getLatestRange(offset, forecast) {
+export function getLatestRange(offset) {
   const end = monthUtils.currentMonth();
   const start = monthUtils.subMonths(end, offset);
-  return [start, end, forecast];
+  return [start, end];
 }
 
-export function getFullRange(allMonths, forecast) {
+export function getFullRange(allMonths) {
   const start = allMonths[allMonths.length - 1].name;
   const end = monthUtils.currentMonth();
-  return [start, end, forecast];
+  return [start, end];
 }
 
 function Header({
@@ -128,7 +120,7 @@ function Header({
           >
             <Select
               onChange={newValue =>
-                onChangeDates(...validateStart(allMonths, newValue, end, forecast))
+                onChangeDates(...validateStart(allMonths, newValue, end), forecast)
               }
               value={start}
               defaultLabel={monthUtils.format(start, 'MMMM, yyyy')}
@@ -137,7 +129,7 @@ function Header({
             <View>to</View>
             <Select
               onChange={newValue =>
-                onChangeDates(...validateEnd(allMonths, start, newValue, forecast))
+                onChangeDates(...validateEnd(allMonths, start, newValue), forecast)
               }
               value={end}
               options={allMonths.map(({ name, pretty }) => [name, pretty])}
@@ -146,7 +138,7 @@ function Header({
             {forecast && <Select
               style={{ backgroundColor: 'white' }}
               onChange={newValue =>
-                onChangeDates(...validateForecast(allMonths, start, end, newValue))
+                onChangeDates(...validateStart(allMonths, start, end), newValue)
               }
               value={forecast}
               options={allForecasts.map(({ name, pretty }) => [name, pretty])}
@@ -159,32 +151,32 @@ function Header({
           {show1Month && (
             <Button
               type="bare"
-              onClick={() => onChangeDates(...getLatestRange(1, forecast))}
+              onClick={() => onChangeDates(...getLatestRange(1), forecast)}
             >
               1 month
             </Button>
           )}
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(2, forecast))}
+            onClick={() => onChangeDates(...getLatestRange(2), forecast)}
           >
             3 months
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(5, forecast))}
+            onClick={() => onChangeDates(...getLatestRange(5), forecast)}
           >
             6 months
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(11, forecast))}
+            onClick={() => onChangeDates(...getLatestRange(11), forecast)}
           >
             1 Year
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getFullRange(allMonths, forecast))}
+            onClick={() => onChangeDates(...getFullRange(allMonths), forecast)}
           >
             All Time
           </Button>

--- a/packages/desktop-client/src/components/reports/Header.jsx
+++ b/packages/desktop-client/src/components/reports/Header.jsx
@@ -120,7 +120,10 @@ function Header({
           >
             <Select
               onChange={newValue =>
-                onChangeDates(...validateStart(allMonths, newValue, end), forecast)
+                onChangeDates(
+                  ...validateStart(allMonths, newValue, end),
+                  forecast,
+                )
               }
               value={start}
               defaultLabel={monthUtils.format(start, 'MMMM, yyyy')}
@@ -129,21 +132,29 @@ function Header({
             <View>to</View>
             <Select
               onChange={newValue =>
-                onChangeDates(...validateEnd(allMonths, start, newValue), forecast)
+                onChangeDates(
+                  ...validateEnd(allMonths, start, newValue),
+                  forecast,
+                )
               }
               value={end}
               options={allMonths.map(({ name, pretty }) => [name, pretty])}
             />
             {forecast && <View>+</View>}
-            {forecast && <Select
-              style={{ backgroundColor: 'white' }}
-              onChange={newValue =>
-                onChangeDates(...validateStart(allMonths, start, end), newValue)
-              }
-              value={forecast}
-              options={allForecasts.map(({ name, pretty }) => [name, pretty])}
-              disabledKeys={disabled}
-            />}
+            {forecast && (
+              <Select
+                style={{ backgroundColor: 'white' }}
+                onChange={newValue =>
+                  onChangeDates(
+                    ...validateStart(allMonths, start, end),
+                    newValue,
+                  )
+                }
+                value={forecast}
+                options={allForecasts.map(({ name, pretty }) => [name, pretty])}
+                disabledKeys={disabled}
+              />
+            )}
           </View>
 
           {filters && <FilterButton onApply={onApply} type="accounts" />}

--- a/packages/desktop-client/src/components/reports/Header.jsx
+++ b/packages/desktop-client/src/components/reports/Header.jsx
@@ -10,20 +10,25 @@ import Select from '../common/Select';
 import View from '../common/View';
 import { FilterButton, AppliedFilters } from '../filters/FiltersMenu';
 
-export function validateStart(allMonths, start, end) {
+export function validateStart(allMonths, start, end, forecast) {
   const earliest = allMonths[allMonths.length - 1].name;
   if (end < start) {
     end = monthUtils.addMonths(start, 6);
   }
-  return boundedRange(earliest, start, end);
+  return boundedRange(earliest, start, end, forecast);
 }
 
-export function validateEnd(allMonths, start, end) {
+export function validateEnd(allMonths, start, end, forecast) {
   const earliest = allMonths[allMonths.length - 1].name;
   if (start > end) {
     start = monthUtils.subMonths(end, 6);
   }
   return boundedRange(earliest, start, end);
+}
+
+function validateForecast(allMonths, start, end, forecast) {
+  const earliest = allMonths[allMonths.length - 1].name;
+  return boundedRange(earliest, start, end, forecast);
 }
 
 export function validateRange(allMonths, start, end) {
@@ -49,13 +54,13 @@ function boundedRange(earliest, start, end) {
   return [start, end];
 }
 
-export function getLatestRange(offset) {
+export function getLatestRange(offset, forecast) {
   const end = monthUtils.currentMonth();
   const start = monthUtils.subMonths(end, offset);
   return [start, end];
 }
 
-export function getFullRange(allMonths) {
+export function getFullRange(allMonths, forecast) {
   const start = allMonths[allMonths.length - 1].name;
   const end = monthUtils.currentMonth();
   return [start, end];
@@ -65,8 +70,11 @@ function Header({
   title,
   start,
   end,
+  forecast,
   show1Month,
   allMonths,
+  allForecasts,
+  disabled,
   onChangeDates,
   filters,
   conditionsOp,
@@ -117,7 +125,7 @@ function Header({
           >
             <Select
               onChange={newValue =>
-                onChangeDates(...validateStart(allMonths, newValue, end))
+                onChangeDates(...validateStart(allMonths, newValue, end, forecast))
               }
               value={start}
               defaultLabel={monthUtils.format(start, 'MMMM, yyyy')}
@@ -126,11 +134,21 @@ function Header({
             <View>to</View>
             <Select
               onChange={newValue =>
-                onChangeDates(...validateEnd(allMonths, start, newValue))
+                onChangeDates(...validateEnd(allMonths, start, newValue, forecast))
               }
               value={end}
               options={allMonths.map(({ name, pretty }) => [name, pretty])}
             />
+            {forecast && <View>+</View>}
+            {forecast && <Select
+              style={{ backgroundColor: 'white' }}
+              onChange={newValue =>
+                onChangeDates(...validateForecast(allMonths, start, end, newValue))
+              }
+              value={forecast}
+              options={allForecasts.map(({ name, pretty }) => [name, pretty])}
+              disabledKeys={disabled}
+            />}
           </View>
 
           {filters && <FilterButton onApply={onApply} type="accounts" />}
@@ -138,32 +156,32 @@ function Header({
           {show1Month && (
             <Button
               type="bare"
-              onClick={() => onChangeDates(...getLatestRange(1))}
+              onClick={() => onChangeDates(...getLatestRange(1, forecast))}
             >
               1 month
             </Button>
           )}
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(2))}
+            onClick={() => onChangeDates(...getLatestRange(2, forecast))}
           >
             3 months
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(5))}
+            onClick={() => onChangeDates(...getLatestRange(5, forecast))}
           >
             6 months
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getLatestRange(11))}
+            onClick={() => onChangeDates(...getLatestRange(11, forecast))}
           >
             1 Year
           </Button>
           <Button
             type="bare"
-            onClick={() => onChangeDates(...getFullRange(allMonths))}
+            onClick={() => onChangeDates(...getFullRange(allMonths, forecast))}
           >
             All Time
           </Button>

--- a/packages/desktop-client/src/components/reports/Header.jsx
+++ b/packages/desktop-client/src/components/reports/Header.jsx
@@ -43,7 +43,7 @@ export function validateRange(allMonths, start, end) {
   return [start, end];
 }
 
-function boundedRange(earliest, start, end) {
+function boundedRange(earliest, start, end, forecast) {
   const latest = monthUtils.currentMonth();
   if (end > latest) {
     end = latest;
@@ -51,19 +51,22 @@ function boundedRange(earliest, start, end) {
   if (start < earliest) {
     start = earliest;
   }
-  return [start, end];
+  if (end != latest) {
+    forecast = latest;
+  }
+  return [start, end, forecast];
 }
 
 export function getLatestRange(offset, forecast) {
   const end = monthUtils.currentMonth();
   const start = monthUtils.subMonths(end, offset);
-  return [start, end];
+  return [start, end, forecast];
 }
 
 export function getFullRange(allMonths, forecast) {
   const start = allMonths[allMonths.length - 1].name;
   const end = monthUtils.currentMonth();
-  return [start, end];
+  return [start, end, forecast];
 }
 
 function Header({

--- a/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
@@ -10,13 +10,20 @@ import {
   VictoryGroup,
 } from 'victory';
 
-import { theme, colors } from '../../../style';
+import { theme } from '../../../style';
 import { chartTheme } from '../chart-theme';
 import Container from '../Container';
 import Tooltip from '../Tooltip';
 
 type CashFlowGraphProps = {
-  graphData: { expenses; income; balances; futureBalances; futureExpenses; futureIncome };
+  graphData: {
+    expenses;
+    income;
+    balances;
+    futureBalances;
+    futureExpenses;
+    futureIncome;
+  };
   isConcise: boolean;
 };
 function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
@@ -42,11 +49,11 @@ function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
               <VictoryBar data={graphData.income} />
               <VictoryBar
                 data={graphData.futureExpenses}
-                style={{ data: { fill: colors.r8 } }}
+                style={{ data: { fill: theme.reportsRedFaded } }}
               />
               <VictoryBar
                 data={graphData.futureIncome}
-                style={{ data: { fill: colors.b8 } }}
+                style={{ data: { fill: theme.reportsBlueFaded } }}
               />
             </VictoryGroup>
             <VictoryLine
@@ -62,13 +69,15 @@ function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
               labelComponent={<Tooltip portalHost={portalHost} />}
               labels={x => x.premadeLabel}
               style={{
-                data: { stroke: colors.n8 },
+                data: { stroke: theme.pageTextSubdued },
               }}
             />
             <VictoryAxis
               // eslint-disable-next-line rulesdir/typography
               tickFormat={x => d.format(x, isConcise ? "MMM ''yy" : 'MMM d')}
-              tickValues={graphData.balances.map(item => item.x).concat(graphData.futureBalances.map(item => item.x))}
+              tickValues={graphData.balances
+                .map(item => item.x)
+                .concat(graphData.futureBalances.map(item => item.x))}
               tickCount={Math.min(5, graphData.balances.length)}
               offsetY={50}
             />

--- a/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
@@ -10,13 +10,13 @@ import {
   VictoryGroup,
 } from 'victory';
 
-import { theme } from '../../../style';
+import { theme, colors } from '../../../style';
 import { chartTheme } from '../chart-theme';
 import Container from '../Container';
 import Tooltip from '../Tooltip';
 
 type CashFlowGraphProps = {
-  graphData: { expenses; income; balances };
+  graphData: { expenses; income; balances; futureBalances; futureExpenses; futureIncome };
   isConcise: boolean;
 };
 function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
@@ -40,6 +40,14 @@ function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
                 style={{ data: { fill: chartTheme.colors.red } }}
               />
               <VictoryBar data={graphData.income} />
+              <VictoryBar
+                data={graphData.futureExpenses}
+                style={{ data: { fill: colors.r8 } }}
+              />
+              <VictoryBar
+                data={graphData.futureIncome}
+                style={{ data: { fill: colors.b8 } }}
+              />
             </VictoryGroup>
             <VictoryLine
               data={graphData.balances}
@@ -49,10 +57,18 @@ function CashFlowGraph({ graphData, isConcise }: CashFlowGraphProps) {
                 data: { stroke: theme.pageTextLight },
               }}
             />
+            <VictoryLine
+              data={graphData.futureBalances}
+              labelComponent={<Tooltip portalHost={portalHost} />}
+              labels={x => x.premadeLabel}
+              style={{
+                data: { stroke: colors.n8 },
+              }}
+            />
             <VictoryAxis
               // eslint-disable-next-line rulesdir/typography
               tickFormat={x => d.format(x, isConcise ? "MMM ''yy" : 'MMM d')}
-              tickValues={graphData.balances.map(item => item.x)}
+              tickValues={graphData.balances.map(item => item.x).concat(graphData.futureBalances.map(item => item.x))}
               tickCount={Math.min(5, graphData.balances.length)}
               offsetY={50}
             />

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -20,6 +20,8 @@ import Header from '../Header';
 import { cashFlowByDate } from '../spreadsheets/cash-flow-spreadsheet';
 import useReport from '../useReport';
 
+import useFeatureFlag from '../../../hooks/useFeatureFlag';
+
 export default function CashFlow(): JSX.Element {
   const {
     filters,
@@ -37,7 +39,8 @@ export default function CashFlow(): JSX.Element {
     monthUtils.subMonths(monthUtils.currentMonth(), 5),
   );
   const [end, setEnd] = useState(monthUtils.currentDay());
-  const [forecast, setForecast] = useState(monthUtils.addDays(monthUtils.currentDay(), 31));
+  const forecastFeatureFlag = useFeatureFlag('cashflowForecast');
+  const [forecast, setForecast] = useState(forecastFeatureFlag ? monthUtils.addDays(monthUtils.currentDay(), 31) : monthUtils.currentMonth());
 
   const [isConcise, setIsConcise] = useState(() => {
     const numDays = d.differenceInCalendarDays(
@@ -97,7 +100,7 @@ export default function CashFlow(): JSX.Element {
 
     setStart(start + '-01');
     setEnd(endDay);
-    setForecast(forecast);
+    setForecast(forecastFeatureFlag ? (end == monthUtils.currentMonth() ? forecast : monthUtils.currentMonth()) : monthUtils.currentMonth());
     setIsConcise(isConcise);
     end != monthUtils.currentMonth() ? setDisabled(forecastMonths.slice(1).map(forecast => (
       forecast.name
@@ -120,7 +123,7 @@ export default function CashFlow(): JSX.Element {
         start={monthUtils.getMonth(start)}
         end={monthUtils.getMonth(end)}
         show1Month
-        forecast={forecast}
+        forecast={forecastFeatureFlag ? forecast : null}
         onChangeDates={onChangeDates}
         onApply={onApplyFilter}
         filters={filters}

--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -125,13 +125,18 @@ export function cashFlowByDate(
 
     const schedules = await Promise.all(
       data.map(schedule => {
-        return sendCatch('schedule/get-occurrences-to-date', {
-          config: schedule._date,
-          end: forecast,
-        }).then(({ data }) => {
-          schedule._dates = data;
+        if (typeof schedule._date !== 'string') {
+          return sendCatch('schedule/get-occurrences-to-date', {
+            config: schedule._date,
+            end: forecast,
+          }).then(({ data }) => {
+            schedule._dates = data;
+            return schedule;
+          });
+        } else {
+          schedule._dates = [schedule._date];
           return schedule;
-        });
+        }
       }),
     );
 
@@ -184,7 +189,7 @@ function recalculate(
   const futureIncome = [];
   const futureExpense = [];
   schedules.forEach(schedule => {
-    schedule._dates.forEach(date => {
+    schedule._dates?.forEach(date => {
       const futureTx = {
         date: isConcise ? monthUtils.monthFromDate(date) : date,
         isTransfer: schedule.isTransfer != null,

--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -201,12 +201,19 @@ function recalculate(data, start, end, forecast, isConcise, schedules, filters) 
         monthUtils.getMonth(end),
       )
     : monthUtils.dayRangeInclusive(start, end);
-  const forecastDates = isConcise
+  
+  let forecastDates;
+  if (forecast == monthUtils.currentMonth()) { 
+    forecastDates = []
+  } else {
+    forecastDates = isConcise
     ? monthUtils.rangeInclusive(
         monthUtils.getMonth(end),
         monthUtils.getMonth(forecast),
       )
     : monthUtils.dayRangeInclusive(end, forecast);
+  }
+  
   const incomes = indexCashFlow(convIncome, 'date', 'isTransfer');
   const expenses = indexCashFlow(convExpense, 'date', 'isTransfer');
   const futureIncomes = indexCashFlow(futureIncome, 'date', 'isTransfer');

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -98,6 +98,10 @@ export default function ExperimentalFeatures() {
             <FeatureToggle flag="experimentalOfxParser">
               Experimental OFX parser
             </FeatureToggle>
+
+            <FeatureToggle flag="cashflowForecast">
+              Cashflow Forecast
+            </FeatureToggle>
           </View>
         ) : (
           <LinkButton

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -9,7 +9,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesEnabled: false,
   customReports: false,
   experimentalOfxParser: true,
-  cashflowForecast: false
+  cashflowForecast: false,
 };
 
 export default function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -9,6 +9,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesEnabled: false,
   customReports: false,
   experimentalOfxParser: true,
+  cashflowForecast: false
 };
 
 export default function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/desktop-client/src/style/themes/light.ts
+++ b/packages/desktop-client/src/style/themes/light.ts
@@ -186,5 +186,7 @@ export const pillTextSelected = colorPalette.blue900;
 export const pillBorderSelected = colorPalette.purple500;
 
 export const reportsRed = colorPalette.red300;
+export const reportsRedFaded = colorPalette.red200;
 export const reportsBlue = colorPalette.blue400;
+export const reportsBlueFaded = colorPalette.blue200;
 export const reportsLabel = colorPalette.navy900;

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -390,6 +390,22 @@ async function getUpcomingDates({ config, count }) {
   }
 }
 
+async function getOccurrencesToDate({ config, end }) {
+  let rules = recurConfigToRSchedule(config);
+
+  try {
+    let schedule = new RSchedule({ rrules: rules });
+
+    return schedule
+      .occurrences({ start: d.startOfDay(new Date()), end: end })
+      .toArray()
+      .map(date => dayFromDate(date.date));
+  } catch (err) {
+    captureBreadcrumb(config);
+    throw err;
+  }
+}
+
 // Services
 
 function onRuleUpdate(rule) {
@@ -559,6 +575,7 @@ app.method(
 );
 app.method('schedule/discover', discoverSchedules);
 app.method('schedule/get-upcoming-dates', getUpcomingDates);
+app.method('schedule/get-occurrences-to-date', getOccurrencesToDate);
 
 app.service(trackJSONPaths);
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -391,13 +391,13 @@ async function getUpcomingDates({ config, count }) {
 }
 
 async function getOccurrencesToDate({ config, end }) {
-  let rules = recurConfigToRSchedule(config);
+  const rules = recurConfigToRSchedule(config);
 
   try {
-    let schedule = new RSchedule({ rrules: rules });
+    const schedule = new RSchedule({ rrules: rules });
 
     return schedule
-      .occurrences({ start: d.startOfDay(new Date()), end: end })
+      .occurrences({ start: d.startOfDay(new Date()), end })
       .toArray()
       .map(date => dayFromDate(date.date));
   } catch (err) {

--- a/packages/loot-core/src/server/schedules/types/handlers.ts
+++ b/packages/loot-core/src/server/schedules/types/handlers.ts
@@ -30,4 +30,9 @@ export interface SchedulesHandlers {
     config;
     count: number;
   }) => Promise<string[]>;
+
+  'schedule/get-occurrences-to-date': (arg: {
+    config;
+    end: Date;
+  }) => Promise<string[]>;
 }

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -6,7 +6,8 @@ export type FeatureFlag =
   | 'reportBudget'
   | 'goalTemplatesEnabled'
   | 'customReports'
-  | 'experimentalOfxParser';
+  | 'experimentalOfxParser'
+  | 'cashflowForecast';
 
 export type LocalPrefs = Partial<
   {


### PR DESCRIPTION
Having a crack at implementing a form of cashflow forecasting as discussed in #187, #517, #716.

The concept is pretty simple - take all the schedules, get the occurrences of them up to the desired forecast date, check for transfers to create a balancing transaction (if required based on filtering), run them through the calculator for balances and show them as a seperate set of 'future' expense, income bars and balance line.

Would appreciate a good review and some feedback on:
- the approach
- alignment with conventions
- plain old bad practices
- is the 'experimental' flag masking enough?
- anything unclear etc...

Some edge cases up for debate:
- Should a transfer to an off budget account show as an expense/income? Currently in the historical cashflow they don't... So I've kept that convention. 
- Should a transfer to/from an account that is not in the graph filtering show up as an expense/income? Currently the change of balance is captured but it's not shown as a clear expense/income.

Thanks!