### PR TITLE
Ask for confirmation when editing date of a locked transaction

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -864,7 +864,7 @@ class AccountInternal extends PureComponent {
       }
     };
 
-    if (name === 'amount' || name === 'payee' || name === 'account') {
+    if (name === 'amount' || name === 'payee' || name === 'account' || name === 'date') {
       const { data } = await runQuery(
         q('transactions')
           .filter({ id: { $oneof: ids }, reconciled: true })

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -754,7 +754,8 @@ const Transaction = memo(function Transaction(props) {
         (name === 'credit' ||
           name === 'debit' ||
           name === 'payee' ||
-          name === 'account')
+          name === 'account' ||
+          name === 'date')
       ) {
         if (showReconciliationWarning === false) {
           setShowReconciliationWarning(true);

--- a/upcoming-release-notes/2134.md
+++ b/upcoming-release-notes/2134.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Jackenmen]
+---
+
+Ask for confirmation when editing date of a locked transaction


### PR DESCRIPTION
Simple change adding `date` to the fields that should trigger a confirmation prompt when editing a locked transaction. Aside from the amount, it seems like preventing accidental changes in transaction date is the most important reason that something would not be considered consistent with the bank statement - the order of transactions.

This addition only affects places that already had such a check in the first place - i.e. the mobile UI is unaffected since it triggers the confirmation prompt regardless of the field that is edited.