### PR TITLE
:bug: (import) fix reconciled transactions getting overriden on import

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -436,7 +436,7 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
       // matched transaction. See the final pass below for the needed
       // fields.
       fuzzyDataset = await db.all(
-        `SELECT id, is_parent, date, imported_id, payee, category, notes FROM v_transactions
+        `SELECT id, is_parent, date, imported_id, payee, category, notes, reconciled FROM v_transactions
            WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND is_child = 0`,
         [
           db.toDateRepr(monthUtils.subDays(trans.date, 4)),
@@ -494,6 +494,11 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
   // Finally, generate & commit the changes
   for (const { trans, subtransactions, match } of transactionsStep3) {
     if (match) {
+      // Skip updating already reconciled (locked) transactions
+      if (match.reconciled) {
+        continue;
+      }
+
       // TODO: change the above sql query to use aql
       const existing = {
         ...match,
@@ -594,7 +599,7 @@ export async function reconcileTransactions(acctId, transactions) {
       // matched transaction. See the final pass below for the needed
       // fields.
       fuzzyDataset = await db.all(
-        `SELECT id, is_parent, date, imported_id, payee, category, notes FROM v_transactions
+        `SELECT id, is_parent, date, imported_id, payee, category, notes, reconciled FROM v_transactions
            WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND is_child = 0`,
         [
           db.toDateRepr(monthUtils.subDays(trans.date, 4)),
@@ -652,6 +657,11 @@ export async function reconcileTransactions(acctId, transactions) {
   // Finally, generate & commit the changes
   for (const { trans, subtransactions, match } of transactionsStep3) {
     if (match) {
+      // Skip updating already reconciled (locked) transactions
+      if (match.reconciled) {
+        continue;
+      }
+
       // TODO: change the above sql query to use aql
       const existing = {
         ...match,

--- a/upcoming-release-notes/2140.md
+++ b/upcoming-release-notes/2140.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix imported transactions overriding reconciled (locked) transaction data


### PR DESCRIPTION
reconciled (locked) transactions should not get updated upon importing

Closes #2103

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
