### PR TITLE
:bug: (rules) fix filtering in the rules page

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -284,7 +284,6 @@ function ManageRulesContent({
         <View style={{ flex: 1 }}>
           <RulesHeader />
           <SimpleTable
-            data={filteredRules}
             loadMore={loadMore}
             // Hide the last border of the item in the table
             style={{ marginBottom: -1 }}

--- a/packages/desktop-client/src/components/rules/SimpleTable.tsx
+++ b/packages/desktop-client/src/components/rules/SimpleTable.tsx
@@ -1,10 +1,9 @@
-import React, { type ReactNode, useEffect, useRef } from 'react';
+import React, { type ReactNode, type UIEvent, useRef } from 'react';
 
 import { type CSSProperties } from '../../style';
 import View from '../common/View';
 
 type SimpleTableProps = {
-  data: unknown;
   loadMore?: () => void;
   style?: CSSProperties;
   onHoverLeave?: () => void;
@@ -12,31 +11,26 @@ type SimpleTableProps = {
 };
 
 export default function SimpleTable({
-  data,
   loadMore,
   style,
   onHoverLeave,
   children,
 }: SimpleTableProps) {
   const contentRef = useRef<HTMLDivElement>();
-  const contentHeight = useRef<number>();
   const scrollRef = useRef<HTMLDivElement>();
 
-  function onScroll(e) {
-    if (contentHeight.current != null) {
-      if (loadMore && e.target.scrollTop > contentHeight.current - 750) {
-        loadMore();
-      }
+  function onScroll(e: UIEvent<HTMLElement>) {
+    if (
+      loadMore &&
+      Math.abs(
+        e.currentTarget.scrollHeight -
+          e.currentTarget.clientHeight -
+          e.currentTarget.scrollTop,
+      ) < 1
+    ) {
+      loadMore();
     }
   }
-
-  useEffect(() => {
-    if (contentRef.current) {
-      contentHeight.current = contentRef.current.getBoundingClientRect().height;
-    } else {
-      contentHeight.current = null;
-    }
-  }, [contentRef.current, data]);
 
   return (
     <View

--- a/upcoming-release-notes/2141.md
+++ b/upcoming-release-notes/2141.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfix
-authors: [MatissJanis]
+authors: [MatissJanis, jasonmichalski]
 ---
 
 Fix filtering in rules page: apply the filter on the full data set instead of the limited (paginated) data set.

--- a/upcoming-release-notes/2141.md
+++ b/upcoming-release-notes/2141.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix filtering in rules page: apply the filter on the full data set instead of the limited (paginated) data set.


### PR DESCRIPTION
Previously the filtering was applied only to the loaded data. Meaning if there are >1 pages of data - it would initially apply only to the first page. After this fix - the filters are applied to all the pages.
