### PR TITLE
Fix when pressing Enter adds an extra split transaction when no split remains

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1967,10 +1967,9 @@ export const TransactionTable = forwardRef((props, ref) => {
       afterSave(() => {
         const transactions = latestState.current.transactions;
         const idx = transactions.findIndex(t => t.id === id);
-        const parentIdx = transactions.findIndex(
+        const parent = transactions.find(
           t => t.id === transactions[idx]?.parent_id,
         );
-        const parent = transactions[parentIdx];
 
         if (
           isLastChild(transactions, idx) &&

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1967,7 +1967,10 @@ export const TransactionTable = forwardRef((props, ref) => {
       afterSave(() => {
         const transactions = latestState.current.transactions;
         const idx = transactions.findIndex(t => t.id === id);
-        const parent = transactionMap.get(transactions[idx]?.parent_id);
+        const parentIdx = transactions.findIndex(
+          t => t.id === transactions[idx]?.parent_id,
+        );
+        const parent = transactions[parentIdx];
 
         if (
           isLastChild(transactions, idx) &&

--- a/upcoming-release-notes/2144.md
+++ b/upcoming-release-notes/2144.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jasonmichalski]
+---
+
+Fix when pressing Enter adds an extra split transaction when no split remains


### PR DESCRIPTION
Fixes #2041 

A race condition existed where the parent transaction in `transactionMap` was not yet updated to reflect the recently added child transaction when `onCheckEnter()` is called.

This PR gets the parent transaction from the same transactions array that the child transaction is retrieved from, which reflects the latest split calculation / error state.