### PR TITLE
Fix load more when scrolling to end of rules table

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -284,7 +284,6 @@ function ManageRulesContent({
         <View style={{ flex: 1 }}>
           <RulesHeader />
           <SimpleTable
-            data={filteredRules}
             loadMore={loadMore}
             // Hide the last border of the item in the table
             style={{ marginBottom: -1 }}

--- a/packages/desktop-client/src/components/rules/SimpleTable.tsx
+++ b/packages/desktop-client/src/components/rules/SimpleTable.tsx
@@ -1,10 +1,9 @@
-import React, { type ReactNode, useEffect, useRef } from 'react';
+import React, { type ReactNode, type UIEvent, useRef } from 'react';
 
 import { type CSSProperties } from '../../style';
 import View from '../common/View';
 
 type SimpleTableProps = {
-  data: unknown;
   loadMore?: () => void;
   style?: CSSProperties;
   onHoverLeave?: () => void;
@@ -12,31 +11,26 @@ type SimpleTableProps = {
 };
 
 export default function SimpleTable({
-  data,
   loadMore,
   style,
   onHoverLeave,
   children,
 }: SimpleTableProps) {
   const contentRef = useRef<HTMLDivElement>();
-  const contentHeight = useRef<number>();
   const scrollRef = useRef<HTMLDivElement>();
 
-  function onScroll(e) {
-    if (contentHeight.current != null) {
-      if (loadMore && e.target.scrollTop > contentHeight.current - 750) {
-        loadMore();
-      }
+  function onScroll(e: UIEvent<HTMLElement>) {
+    if (
+      loadMore &&
+      Math.abs(
+        e.currentTarget.scrollHeight -
+          e.currentTarget.clientHeight -
+          e.currentTarget.scrollTop,
+      ) < 1
+    ) {
+      loadMore();
     }
   }
-
-  useEffect(() => {
-    if (contentRef.current) {
-      contentHeight.current = contentRef.current.getBoundingClientRect().height;
-    } else {
-      contentHeight.current = null;
-    }
-  }, [contentRef.current, data]);
 
   return (
     <View


### PR DESCRIPTION
Builds on https://github.com/actualbudget/actual/pull/2141 to fix the load more rules functionality mentioned in #1502.

I've tested on my display with chrome and firefox, and this seems to do the trick and simplifies some extraneous useEffect.  More testers would be welcome!

Note this PR is branched off matiss/fix-1502, so the request is to get merged into that branch and not master... If you want to handle it some other way, let me know and i can update.