### PR TITLE
Revert ":construction_worker: (ci) adding helper comments for failed CI jobs"

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -66,38 +66,3 @@ jobs:
           name: desktop-client-test-results
           path: packages/desktop-client/test-results/
           retention-days: 30
-      - uses: actions-ecosystem/action-add-labels@v1
-        if: failure()
-        with:
-          labels: ':red_circle: VRT failing'
-      - uses: actions-ecosystem/action-remove-labels@v1
-        if: success()
-        with:
-          labels: ':red_circle: VRT failing'
-      - name: Find Comment
-        uses: peter-evans/find-comment@v2
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: VRT
-      - name: Create comment if failed
-        if: failure()
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            :wave: Looks like VRT (visual regression tests) are failing in this PR. This indicates a problem in the app. It could be either a bug in this PR or a visual change introduced by changing something.
-
-            To fix this: please follow [these instructions](https://github.com/actualbudget/actual/blob/master/packages/desktop-client/README.md#visual-regression) and review the output of the failing CI job to see the generated screenshots.
-
-            We look forward to reviewing this PR once all the CI jobs have passed successfully!
-          edit-mode: replace
-      - name: Update comment when CI job passes
-        if: success() && steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: The VRT tests have passed! Thank you!
-          edit-mode: replace


### PR DESCRIPTION
Reverts actualbudget/actual#2074

Sadly this won't work for forks. They do not have our github token (security) and hence the fork PRs won't have the comment added to them.