### PR TITLE
fix missing borders in single category drop down in report budget

### DIFF
--- a/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
+++ b/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
@@ -189,9 +189,11 @@ export const CategoryMonth = memo(function CategoryMonth({
           <View
             style={{
               flexShrink: 0,
-              marginRight: 0,
-              marginLeft: 3,
+              paddingLeft: 3,
               justifyContent: 'center',
+              borderTopWidth: 1,
+              borderBottomWidth: 1,
+              borderColor: theme.tableBorder,
             }}
           >
             <Button

--- a/upcoming-release-notes/2195.md
+++ b/upcoming-release-notes/2195.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Add missing borders in report budget table


### PR DESCRIPTION
Fix the missing border on the category budget dropdown in report budget.

New:
![image](https://github.com/actualbudget/actual/assets/28542559/774d0cec-c6f7-46e2-b818-f43733b02a9e)

Existing:
![image](https://github.com/actualbudget/actual/assets/28542559/efe49723-81ba-413c-8a2f-d57433d42edc)



