### PR TITLE
change the pie chart background color in the report status

### DIFF
--- a/packages/desktop-client/src/components/budget/report/budgetsummary/ExpenseProgress.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/ExpenseProgress.tsx
@@ -34,7 +34,7 @@ export function ExpenseProgress({ current, target }: ExpenseProgressProps) {
     <PieProgress
       progress={frac}
       color={over ? theme.errorText : theme.noticeTextLight}
-      backgroundColor={over ? theme.errorBackground : theme.pageBackground}
+      backgroundColor={over ? theme.errorBackground : theme.tableBackground}
       style={{ width: 20, height: 20 }}
     />
   );

--- a/packages/desktop-client/src/components/budget/report/budgetsummary/IncomeProgress.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/IncomeProgress.tsx
@@ -28,7 +28,7 @@ export function IncomeProgress({ current, target }: IncomeProgressProps) {
     <PieProgress
       progress={frac}
       color={over ? theme.errorText : theme.noticeTextLight}
-      backgroundColor={over ? theme.errorBackground : theme.pageBackground}
+      backgroundColor={over ? theme.errorBackground : theme.tableBackground}
       style={{ width: 20, height: 20 }}
     />
   );

--- a/upcoming-release-notes/2196.md
+++ b/upcoming-release-notes/2196.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Improve report budget pie chart colors


### PR DESCRIPTION
I was thinking that the color of the report budget pie chart background looked a bit off, especially in dark mode.  This would change the color to match the table background instead of the page background.

Existing:
![image](https://github.com/actualbudget/actual/assets/28542559/d6be0344-b8e9-481c-baef-ce91298607e9)
![image](https://github.com/actualbudget/actual/assets/28542559/30f72b00-c66a-47cf-a70a-631884edb318)



New:
![image](https://github.com/actualbudget/actual/assets/28542559/09516c18-6c97-499a-8533-928cdd8a5c2f)
![image](https://github.com/actualbudget/actual/assets/28542559/20b73401-756d-44fe-a670-408a71aa1258)


