### PR TITLE
:wrench: (ci) fork the electron build job - master and PR

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -13,8 +13,8 @@ on:
       - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -1,0 +1,50 @@
+name: Electron
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CI: true
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        run: pip.exe install setuptools
+      - if: ${{ ! startsWith(matrix.os, 'windows') }}
+        run: python3 -m pip install setuptools
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Build Electron
+        run: ./bin/package-electron
+        env:
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      - name: Upload Build
+        uses: actions/upload-artifact@v3
+        with:
+          name: actual-electron-${{ matrix.os }}
+          path: |
+            packages/desktop-electron/dist/*.dmg
+            packages/desktop-electron/dist/*.exe
+            packages/desktop-electron/dist/*.AppImage

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -8,9 +8,6 @@ env:
   CI: true
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
 
 concurrency:
@@ -36,11 +33,6 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build Electron
         run: ./bin/package-electron
-        env:
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       - name: Upload Build
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -11,8 +11,8 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/upcoming-release-notes/2209.md
+++ b/upcoming-release-notes/2209.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+electron: split the build script in 2x parts to fix it failing when no code signing cert is provided (PRs from forks).


### PR DESCRIPTION
Electron builds in PRs are now failing. Apparently even if an empty `CSC_LINK` env variable is set - it kicks off code signing. Which will obviously not work.. and should not work in PRs coming from forks.

So I'm splitting the electron build job in 2x: one that runs on master (and code signs & notarizes the build) and one that runs on PRs (no code signing).

https://github.com/electron-userland/electron-builder/issues/6921