### PR TITLE
[WIP] Category autocomplete: allow user to toggle making group name searchable

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -1,11 +1,12 @@
-import React, {
-  type ComponentProps,
+import {
   Fragment,
   useMemo,
+  type ComponentProps,
+  type ComponentType,
   type ReactNode,
   type SVGProps,
-  type ComponentType,
 } from 'react';
+import { useSelector } from 'react-redux';
 
 import { css } from 'glamor';
 
@@ -16,11 +17,11 @@ import {
 
 import { SvgSplit } from '../../icons/v0';
 import { useResponsive } from '../../ResponsiveProvider';
-import { type CSSProperties, theme } from '../../style';
+import { theme, type CSSProperties } from '../../style';
 import { Text } from '../common/Text';
 import { View } from '../common/View';
 
-import { Autocomplete, defaultFilterSuggestion } from './Autocomplete';
+import { Autocomplete } from './Autocomplete';
 
 type CategorySuggestion = CategoryEntity & { group?: CategoryGroupEntity };
 
@@ -119,6 +120,10 @@ export function CategoryAutocomplete({
   renderCategoryItem,
   ...props
 }: CategoryAutocompleteProps) {
+
+  const categorySuggestionsGroupNames = useSelector(
+    state => state.prefs?.local?.['ui.categorySuggestionsGroupNames'],
+  );
   const categorySuggestions: Array<
     CategoryEntity & { group?: CategoryGroupEntity }
   > = useMemo(
@@ -137,6 +142,20 @@ export function CategoryAutocomplete({
       ),
     [showSplitOption, categoryGroups],
   );
+
+  function filterCategorySuggestions(suggestions: CategorySuggestion[], value) {
+    return suggestions.filter(suggestion => {
+      return (
+        suggestion.id === 'split' ||
+        (categorySuggestionsGroupNames
+          ? [suggestion.name, suggestion.group.name]
+              .join(' ')
+              .toLowerCase()
+              .includes(value.toLowerCase())
+          : suggestion.name.toLowerCase().includes(value.toLowerCase()))
+      );
+    });
+  }
 
   return (
     <Autocomplete
@@ -324,16 +343,4 @@ export function CategoryItem({
 
 function defaultRenderCategoryItem(props: CategoryItemProps) {
   return <CategoryItem {...props} />;
-}
-
-function filterCategorySuggestions(suggestions: CategorySuggestion[], value) {
-  return suggestions.filter(suggestion => {
-    return (
-      suggestion.id === 'split' ||
-      [suggestion.name, suggestion.group.name]
-        .join(' ')
-        .toLowerCase()
-        .includes(value.toLowerCase())
-    );
-  });
 }

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -120,7 +120,6 @@ export function CategoryAutocomplete({
   renderCategoryItem,
   ...props
 }: CategoryAutocompleteProps) {
-
   const categorySuggestionsGroupNames = useSelector(
     state => state.prefs?.local?.['ui.categorySuggestionsGroupNames'],
   );

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -22,8 +22,10 @@ import { View } from '../common/View';
 
 import { Autocomplete, defaultFilterSuggestion } from './Autocomplete';
 
+type CategorySuggestion = CategoryEntity & { group?: CategoryGroupEntity };
+
 export type CategoryListProps = {
-  items: Array<CategoryEntity & { group?: CategoryGroupEntity }>;
+  items: Array<CategorySuggestion>;
   getItemProps?: (arg: { item }) => Partial<ComponentProps<typeof View>>;
   highlightedIndex: number;
   embedded: boolean;
@@ -150,14 +152,7 @@ export function CategoryAutocomplete({
         }
         return 0;
       }}
-      filterSuggestions={(suggestions, value) => {
-        return suggestions.filter(suggestion => {
-          return (
-            suggestion.id === 'split' ||
-            defaultFilterSuggestion(suggestion, value)
-          );
-        });
-      }}
+      filterSuggestions={filterCategorySuggestions}
       suggestions={categorySuggestions}
       renderItems={(items, getItemProps, highlightedIndex) => (
         <CategoryList
@@ -329,4 +324,16 @@ export function CategoryItem({
 
 function defaultRenderCategoryItem(props: CategoryItemProps) {
   return <CategoryItem {...props} />;
+}
+
+function filterCategorySuggestions(suggestions: CategorySuggestion[], value) {
+  return suggestions.filter(suggestion => {
+    return (
+      suggestion.id === 'split' ||
+      [suggestion.name, suggestion.group.name]
+        .join(' ')
+        .toLowerCase()
+        .includes(value.toLowerCase())
+    );
+  });
 }

--- a/packages/desktop-client/src/components/settings/AccountSettings.tsx
+++ b/packages/desktop-client/src/components/settings/AccountSettings.tsx
@@ -1,0 +1,39 @@
+import { useSelector } from 'react-redux';
+
+import { useActions } from '../../hooks/useActions';
+import { Text } from '../common/Text';
+import { Checkbox } from '../forms';
+
+import { Setting } from './UI';
+
+export function AccountSettings() {
+  const { savePrefs } = useActions();
+  const categorySuggestionsGroupNames = useSelector(
+    state => state.prefs.local['ui.categorySuggestionsGroupNames'],
+  );
+
+  return (
+    <Setting
+      primaryAction={
+        <Text style={{ display: 'flex' }}>
+          <Checkbox
+            id="settings-categorySuggestionsGroupNames"
+            checked={categorySuggestionsGroupNames}
+            onChange={e =>
+              savePrefs({
+                'ui.categorySuggestionsGroupNames': e.currentTarget.checked,
+              })
+            }
+          />
+          <label htmlFor="settings-categorySuggestionsGroupNames">
+            Include your group names in category suggestions
+          </label>
+        </Text>
+      }
+    >
+      <Text>
+        <strong>Accounts</strong> are where your transations are displayed, with the option to organize all your records into categories.
+      </Text>
+    </Setting>
+  );
+}

--- a/packages/desktop-client/src/components/settings/AccountSettings.tsx
+++ b/packages/desktop-client/src/components/settings/AccountSettings.tsx
@@ -32,7 +32,8 @@ export function AccountSettings() {
       }
     >
       <Text>
-        <strong>Accounts</strong> are where your transations are displayed, with the option to organize all your records into categories.
+        <strong>Accounts</strong> are where your transations are displayed, with
+        the option to organize all your records into categories.
       </Text>
     </Setting>
   );

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -21,6 +21,7 @@ import { FormField, FormLabel } from '../forms';
 import { Page } from '../Page';
 import { useServerVersion } from '../ServerContext';
 
+import { AccountSettings } from './AccountSettings';
 import { EncryptionSettings } from './Encryption';
 import { ExperimentalFeatures } from './Experimental';
 import { ExportBudget } from './Export';
@@ -167,6 +168,7 @@ export function Settings() {
         {!Platform.isBrowser && <GlobalSettings />}
 
         <ThemeSettings />
+        <AccountSettings />
         <FormatSettings />
         <EncryptionSettings />
         <ExportBudget />

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -24,6 +24,7 @@ export type LocalPrefs = Partial<
     isPrivacyEnabled: boolean;
     budgetName: string;
     'ui.showClosedAccounts': boolean;
+    'ui.categorySuggestionsGroupNames': boolean;
     'expand-splits': boolean;
     [key: `show-extra-balances-${string}`]: boolean;
     [key: `hide-cleared-${string}`]: boolean;

--- a/upcoming-release-notes/2211.md
+++ b/upcoming-release-notes/2211.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [postonsundays]
 ---
 

--- a/upcoming-release-notes/2211.md
+++ b/upcoming-release-notes/2211.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [postonsundays]
+---
+
+components: adds group.name to suggestion value being filtered in CategoryAutocomplete.tsx to improve UX when searching for categories


### PR DESCRIPTION
A bit of user friction I've encountered when categorizing a transaction is not being able to see all the categories I have under a certain group (e.g. Health). The app used to have the group name to the list of values being searched so that by simply typing "Health", I can see all the possible sub-categories in one place, but was removed following a discussion around UX in #1615. 

A potential solution is giving users the choice whether they want this extra bit of functionality. This PR will add the option to toggle including group names in the categories in the dashboard settings and creates a more comprehensive `filterCategorySuggestions` function in the `CategoryAutocomplete` component to check if the user has enabled this feature.

### Main changes
- adds `ui.categorySuggestionsGroupNames` to local preferences
- creates new "Accounts" panel in settings where including groups name in suggestions can be toggled - open to suggestions on the wording of the title / checkbox

### Extra work
- Adds a `CategorySuggestion` type in the file so the expanded object with `group` component can be used in more methods

![Screenshot 2024-01-10 at 17 00 14](https://github.com/actualbudget/actual/assets/98259928/ee873b20-73fd-4aba-9882-888bcd21b2f2)
![Screenshot 2024-01-10 at 19 50 54](https://github.com/actualbudget/actual/assets/98259928/328bb1fd-95d2-497e-a6aa-7a51e2069611)
