### PR TITLE
Change the vite chunk filename hash usage

### DIFF
--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -64,7 +64,11 @@ jobs:
 
       - name: Strip content hashes from stats files
         run: |
+          sed -i -E 's/index\.[0-9a-zA-Z_-]{8,}\./index./g' ./head/web-stats.json
+          sed -i -E 's/\.[0-9a-zA-Z_-]{8,}\.chunk\././g' ./head/web-stats.json
           sed -i -E 's/\.[0-9a-f]{8,}\././g' ./head/*.json
+          sed -i -E 's/index\.[0-9a-zA-Z_-]{8,}\./index./g' ./base/web-stats.json
+          sed -i -E 's/\.[0-9a-zA-Z_-]{8,}\.chunk\././g' ./base/web-stats.json
           sed -i -E 's/\.[0-9a-f]{8,}\././g' ./base/*.json
       - uses: twk3/rollup-size-compare-action@v1.0.0
         with:

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -122,10 +122,10 @@ export default defineConfig(async ({ mode }) => {
             } else if (/woff|woff2/.test(extType)) {
               extType = 'media';
             }
-            return `static/${extType}/[name]-[hash][extname]`;
+            return `static/${extType}/[name].[hash][extname]`;
           },
-          chunkFileNames: 'static/js/[name]-[hash].js',
-          entryFileNames: 'static/js/[name]-[hash].js',
+          chunkFileNames: 'static/js/[name].[hash].js',
+          entryFileNames: 'static/js/[name].[hash].js',
         },
       },
     },

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -124,7 +124,7 @@ export default defineConfig(async ({ mode }) => {
             }
             return `static/${extType}/[name].[hash][extname]`;
           },
-          chunkFileNames: 'static/js/[name].[hash].js',
+          chunkFileNames: 'static/js/[name].[hash].chunk.js',
           entryFileNames: 'static/js/[name].[hash].js',
         },
       },

--- a/upcoming-release-notes/2224.md
+++ b/upcoming-release-notes/2224.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [twk3]
+---
+
+Change the vite chunk filename hash to closely match our webpack syntax


### PR DESCRIPTION
## Summary

- Change to more closely match the `.chunk` syntax we use with webpack
- This should improve an issue with our size compare as well

## Details

The improvement for size compare is that our github action is stripping out the hashes before passing the size compare, but was based on the period.

We have the additional difficulty here of rollup using base64 hashes, which can include `_-` which complicates our ability to just strip out what we want.

This should improve the output, but there likely is a few more tweaks to be made, as our current vite stats seem to be missing the css and font sizes, which were previously present in this action.

## Test

Because this action uses `pull_request_target` only the action from master is run. In order to test the changes here I opened a sibling PR using just `pull_reqest`.

You can see the test comment here: https://github.com/actualbudget/actual/pull/2225#issuecomment-1890763133

and if you expand the `View detailed bundle breakdown` you can see the new naming at work in the `Added` section vs the current master naming at work in the `Removed` section.