### PR TITLE
Restore ability to use console.log in vite

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -18,7 +18,7 @@
     "@svgr/cli": "^8.0.1",
     "@swc/core": "^1.3.82",
     "@swc/helpers": "^0.5.1",
-    "@swc/plugin-remove-console": "^1.5.105",
+    "@swc/plugin-react-remove-properties": "^1.5.108",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",
     "@types/react": "^18.2.0",

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -150,7 +150,12 @@ export default defineConfig(async ({ mode }) => {
       injectShims(),
       addWatchers(),
       react({
-        plugins: [['@swc/plugin-remove-console', {}]],
+        plugins: [
+          [
+            '@swc/plugin-react-remove-properties',
+            { properties: ['^data-debug'] },
+          ],
+        ],
         devTarget: 'es2022',
       }),
       viteTsconfigPaths({ root: '../..' }),

--- a/upcoming-release-notes/2233.md
+++ b/upcoming-release-notes/2233.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Restore ability to use console.log in vite

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,7 +69,7 @@ __metadata:
     "@svgr/cli": "npm:^8.0.1"
     "@swc/core": "npm:^1.3.82"
     "@swc/helpers": "npm:^0.5.1"
-    "@swc/plugin-remove-console": "npm:^1.5.105"
+    "@swc/plugin-react-remove-properties": "npm:^1.5.108"
     "@testing-library/react": "npm:14.0.0"
     "@testing-library/user-event": "npm:14.4.3"
     "@types/react": "npm:^18.2.0"
@@ -3752,10 +3752,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/plugin-remove-console@npm:^1.5.105":
-  version: 1.5.105
-  resolution: "@swc/plugin-remove-console@npm:1.5.105"
-  checksum: b82710090c3202a473771a9c6a67da3fd5136e19d8214b967de8d3010139d95727f0834920cbb3a4fb284d68f363a4650d32f692c5293854e902b5fa33c3fbab
+"@swc/plugin-react-remove-properties@npm:^1.5.108":
+  version: 1.5.108
+  resolution: "@swc/plugin-react-remove-properties@npm:1.5.108"
+  checksum: 7d849702d036353f2d58515aa20e4557379fccda3d48b2a38835415e3a37fe1ce1c560fbc64e164a8fc09b833c42ecc4a39775cc1d6da8ba83860a464ddcb24f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Swap our swc plugin to remove-react-properties
- Configure remove-react-properties to preserve our testids

We need to pass a swc-plugin in order for swc to be used during build (using it at build matches what we did for webpack prior to vite), otherwise it only gets used for the dev server. The remove console plugin was doing what it promised! (I had misread it's config when I added it, and thought I had effectively disabled it by passing an empty config).

The plugins we have to choose from are here: https://github.com/swc-project/plugins/tree/main/packages

I don't think any of them are necessary for actual at this time, so I choose the remove react properties plugin. I had to configure it a bit with some property, otherwise it will strip out all our data-testids by default. So now it strips out any use of `data-debug`. Which we haven't used to-date.