### PR TITLE
Custom Reports: fix broken table

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
@@ -50,10 +50,9 @@ export function ReportTable({
   });
 
   const renderItem = useCallback(
-    ({ item, groupByItem, mode, style, key, monthsCount }) => {
+    ({ item, groupByItem, mode, style, monthsCount }) => {
       return (
         <ReportTableRow
-          key={key}
           item={item}
           balanceTypeOp={balanceTypeOp}
           groupByItem={groupByItem}

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
@@ -32,9 +32,10 @@ export function ReportTableList({
     style?: CSSProperties;
   };
   function RenderRow({ index, parent_index, style }: RenderRowProps) {
-    const item = parent_index === undefined
-      ? data[index]
-      : data[parent_index].categories[index];
+    const item =
+      parent_index === undefined
+        ? data[index]
+        : data[parent_index].categories[index];
 
     return renderItem({
       item,
@@ -68,6 +69,7 @@ export function ReportTableList({
                       {item.categories.map((category, i) => {
                         return (
                           <RenderRow
+                            key={category.id}
                             index={i}
                             parent_index={index}
                           />

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
@@ -27,22 +27,20 @@ export function ReportTableList({
   const groupByItem = ['Month', 'Year'].includes(groupBy) ? 'date' : 'name';
 
   type RenderRowProps = {
-    key: string;
     index: number;
     parent_index?: number;
     style?: CSSProperties;
   };
-  function RenderRow({ index, parent_index, style, key }: RenderRowProps) {
-    const item = parent_index
-      ? data[parent_index].categories[index]
-      : data[index];
+  function RenderRow({ index, parent_index, style }: RenderRowProps) {
+    const item = parent_index === undefined
+      ? data[index]
+      : data[parent_index].categories[index];
 
     return renderItem({
       item,
       groupByItem,
       mode,
       style,
-      key,
       monthsCount,
     });
   }
@@ -55,7 +53,6 @@ export function ReportTableList({
             {data ? (
               <>
                 <RenderRow
-                  key={item.id}
                   index={index}
                   style={
                     item.categories && {
@@ -71,7 +68,6 @@ export function ReportTableList({
                       {item.categories.map((category, i) => {
                         return (
                           <RenderRow
-                            key={category.id}
                             index={i}
                             parent_index={index}
                           />

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -31,6 +31,7 @@ export const ReportTableRow = memo(
     const average = amountToInteger(item[balanceTypeOp]) / monthsCount;
     return (
       <Row
+        key={item.id}
         collapsed={true}
         style={{
           color: theme.tableText,

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
@@ -91,8 +91,9 @@ export function ReportTableTotals({
                   key={amountToCurrency(item[balanceTypeOp])}
                   value={amountToCurrency(item[balanceTypeOp])}
                   title={
-                    Math.abs(item[balanceTypeOp]) > 100000 &&
-                    amountToCurrency(item[balanceTypeOp])
+                    Math.abs(item[balanceTypeOp]) > 100000
+                      ? amountToCurrency(item[balanceTypeOp])
+                      : undefined
                   }
                   width="flex"
                   privacyFilter
@@ -108,8 +109,9 @@ export function ReportTableTotals({
                   }}
                   value={amountToCurrency(data.totalAssets)}
                   title={
-                    Math.abs(data.totalAssets) > 100000 &&
-                    amountToCurrency(data.totalAssets)
+                    Math.abs(data.totalAssets) > 100000
+                      ? amountToCurrency(data.totalAssets)
+                      : undefined
                   }
                   width="flex"
                   privacyFilter
@@ -121,8 +123,9 @@ export function ReportTableTotals({
                   }}
                   value={amountToCurrency(data.totalDebts)}
                   title={
-                    Math.abs(data.totalDebts) > 100000 &&
-                    amountToCurrency(data.totalDebts)
+                    Math.abs(data.totalDebts) > 100000
+                      ? amountToCurrency(data.totalDebts)
+                      : undefined
                   }
                   width="flex"
                   privacyFilter
@@ -136,8 +139,9 @@ export function ReportTableTotals({
           }}
           value={amountToCurrency(data[balanceTypeOp])}
           title={
-            Math.abs(data[balanceTypeOp]) > 100000 &&
-            amountToCurrency(data[balanceTypeOp])
+            Math.abs(data[balanceTypeOp]) > 100000
+              ? amountToCurrency(data[balanceTypeOp])
+              : undefined
           }
           width="flex"
           privacyFilter
@@ -149,8 +153,9 @@ export function ReportTableTotals({
           }}
           value={integerToCurrency(Math.round(average))}
           title={
-            Math.abs(Math.round(average / 100)) > 100000 &&
-            integerToCurrency(Math.round(average))
+            Math.abs(Math.round(average / 100)) > 100000
+              ? integerToCurrency(Math.round(average))
+              : undefined
           }
           width="flex"
           privacyFilter

--- a/upcoming-release-notes/2249.md
+++ b/upcoming-release-notes/2249.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [carkom]
+---
+
+Fixing a bug where custom reports table graph crashes due to a type mismatch error.


### PR DESCRIPTION
I had a comparison typescript matching issue that causes the table graph in custom reports to crash.