### PR TITLE
:wrench: add link to community discord for support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -18,6 +18,18 @@ body:
           required: true
     validations:
       required: true
+  - type: checkboxes
+    id: bank-sync-issue
+    attributes:
+      label: 'Is this related to GoCardless, Simplefin or another bank-sync provider?'
+      description: 'Most issues with bank-sync providers are due to a lack of a custom bank-mapper (i.e. payee or other fields not coming through). In such cases you can create a custom bank mapper in [actual-server](https://github.com/actualbudget/actual-server/blob/master/src/app-gocardless/README.md) repository. Other likely issue is misconfigured server - in which case please reach out via the [community Discord](https://discord.gg/pRYNYr4W5A) to get support.'
+      options:
+        - label: 'I have checked my server logs and could not see any errors there'
+        - label: 'I will be attaching my server logs to this issue'
+        - label: 'I will be attaching my client-side (browser) logs to this issue'
+        - label: 'I understand that this issue will be automatically closed if insufficient information is provided'
+    validations:
+      required: false
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Support
+    url: https://discord.gg/pRYNYr4W5A
+    about: Need help with something? Perhaps having issues setting up bank-sync with GoCardless or SimpleFin? Reach out to the community on Discord.

--- a/upcoming-release-notes/2250.md
+++ b/upcoming-release-notes/2250.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Updated Github issues template to direct bug reports to the support channel (Discord)


### PR DESCRIPTION
Lately we have been getting a lot of GoCardless "bug reports" due to either mismatching bank data (due to a missing bank-mapper) or user server misconfigurations. It's very rare that the bank-sync reported issues are actual bug reports.

Hence adding a bit more friction here.

1. a support link will be available directing folks to Discord for support
2. additional block for gocardless bug reports - a bit of friction so we don't need to continue asking for additional information