### PR TITLE
:bug: Fix a missing ref param warning for forwardRef

### DIFF
--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -848,13 +848,14 @@ type TableHandleRef<T extends TableItem = TableItem> = {
 type TableWithNavigatorProps = TableProps & {
   fields;
 };
-export const TableWithNavigator = forwardRef<
-  TableHandleRef<TableItem>,
-  TableWithNavigatorProps
->(({ fields, ...props }) => {
+
+export function TableWithNavigator({
+  fields,
+  ...props
+}: TableWithNavigatorProps) {
   const navigator = useTableNavigator(props.items, fields);
   return <Table {...props} navigator={navigator} />;
-});
+}
 
 type TableItem = { id: number | string };
 

--- a/upcoming-release-notes/2277.md
+++ b/upcoming-release-notes/2277.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix a missing ref param warning for forwardRef


### PR DESCRIPTION
- Drop unused usage of forwardRef on TableWithNavigator

Fixes a warning being throw in the console and during web tests regarding a missing ref parameter to forwardRef.

Example of the warning can be seen in the current master tests here: https://github.com/actualbudget/actual/actions/runs/7622910204/job/20761871770#step:4:29


