### PR TITLE
:bug: Avoid passing a boolean to the import trans category title

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -376,7 +376,9 @@ function Transaction({
       <Field
         width="flex"
         title={
-          categoryList.includes(transaction.category) && transaction.category
+          categoryList.includes(transaction.category)
+            ? transaction.category
+            : undefined
         }
       >
         {categoryList.includes(transaction.category) && transaction.category}

--- a/upcoming-release-notes/2278.md
+++ b/upcoming-release-notes/2278.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix 'false' passed as title in import transactions modal


### PR DESCRIPTION
- Fixes an error regarding passing `false` to title when category is not available

