### PR TITLE
[Bugfix] Goals: Database entry

### DIFF
--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -127,8 +127,8 @@ export function setGoal({ month, category, goal }): Promise<void> {
     });
   }
   return db.insert(table, {
-    id: `${month}-${category}`,
-    month,
+    id: `${dbMonth(month)}-${category}`,
+    month: dbMonth(month),
     category,
     goal,
   });

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -127,7 +127,9 @@ export function setGoal({ month, category, goal }): Promise<void> {
     });
   }
   return db.insert(table, {
-    id: month,
+    id: `${month}-${category}`,
+    month,
+    category,
     goal,
   });
 }

--- a/upcoming-release-notes/2281.md
+++ b/upcoming-release-notes/2281.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Fix database entry when applying goal templates


### PR DESCRIPTION
There is an error in the database insertion if the entry doesn't initially exist when applying goal templates.

Previously an entry like this: 
![image](https://github.com/actualbudget/actual/assets/20625555/e53df2c5-b0aa-4941-885c-5df67b88b417)

would be created.  With this change, an entry like this: 
![image](https://github.com/actualbudget/actual/assets/20625555/7d6b2f1c-70ed-49d4-92cc-02bc29c976d1)

will be created.  The issue I was seeing was that the color coded goal templates were not always rendering color, and in the process of tracking the issue down discovered this as the root issue.