### PR TITLE
[Enhancement] Goal Target with cleanup template

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -3,7 +3,7 @@ import { Notification } from '../../client/state-types/notifications';
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 
-import { setBudget, getSheetValue } from './actions';
+import { setBudget, getSheetValue, setGoal } from './actions';
 import { parse } from './cleanup-template.pegjs';
 
 export function cleanupTemplate({ month }: { month: string }) {
@@ -35,10 +35,19 @@ async function processCleanup(month: string): Promise<Notification> {
           sheetName,
           `budget-${category.id}`,
         );
+        const spent = await getSheetValue(
+          sheetName,
+          `sum-amount-${category.id}`,
+        );
         await setBudget({
           category: category.id,
           month,
           amount: budgeted - balance,
+        });
+        await setGoal({
+          category: category.id,
+          month,
+          goal: -spent,
         });
         num_sources += 1;
       }

--- a/upcoming-release-notes/2282.md
+++ b/upcoming-release-notes/2282.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [shall0pass]
+---
+
+Cleanup utility: Update goal target after end of month cleanup tool is activated for 'source' categories


### PR DESCRIPTION
This change will update the monthly target to match the spent value for the month after applying the 'End of month cleanup' tool.  The end result is that after reallocating funds from source categories to sink categories, the balance will remain green instead of turning yellow for source categories.