### PR TITLE
Change lookback and look forward time frames when fuzzy matching imported transactions

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -468,7 +468,7 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
 
     // If it didn't match, query data needed for fuzzy matching
     if (!match) {
-      // Look 5 day ahead and 5 days back when fuzzy matching. This
+      // Look 5 days ahead and 5 days back when fuzzy matching. This
       // needs to select all fields that need to be read from the
       // matched transaction. See the final pass below for the needed
       // fields.
@@ -631,7 +631,7 @@ export async function reconcileTransactions(acctId, transactions) {
 
     // If it didn't match, query data needed for fuzzy matching
     if (!match) {
-      // Look 5 day ahead and 5 days back when fuzzy matching. This
+      // Look 5 days ahead and 5 days back when fuzzy matching. This
       // needs to select all fields that need to be read from the
       // matched transaction. See the final pass below for the needed
       // fields.

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -468,7 +468,7 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
 
     // If it didn't match, query data needed for fuzzy matching
     if (!match) {
-      // Look 1 day ahead and 4 days back when fuzzy matching. This
+      // Look 5 day ahead and 5 days back when fuzzy matching. This
       // needs to select all fields that need to be read from the
       // matched transaction. See the final pass below for the needed
       // fields.
@@ -476,8 +476,8 @@ export async function reconcileGoCardlessTransactions(acctId, transactions) {
         `SELECT id, is_parent, date, imported_id, payee, category, notes, reconciled FROM v_transactions
            WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND is_child = 0`,
         [
-          db.toDateRepr(monthUtils.subDays(trans.date, 4)),
-          db.toDateRepr(monthUtils.addDays(trans.date, 1)),
+          db.toDateRepr(monthUtils.subDays(trans.date, 5)),
+          db.toDateRepr(monthUtils.addDays(trans.date, 5)),
           trans.amount || 0,
           acctId,
         ],
@@ -631,7 +631,7 @@ export async function reconcileTransactions(acctId, transactions) {
 
     // If it didn't match, query data needed for fuzzy matching
     if (!match) {
-      // Look 1 day ahead and 4 days back when fuzzy matching. This
+      // Look 5 day ahead and 5 days back when fuzzy matching. This
       // needs to select all fields that need to be read from the
       // matched transaction. See the final pass below for the needed
       // fields.
@@ -639,8 +639,8 @@ export async function reconcileTransactions(acctId, transactions) {
         `SELECT id, is_parent, date, imported_id, payee, category, notes, reconciled FROM v_transactions
            WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND is_child = 0`,
         [
-          db.toDateRepr(monthUtils.subDays(trans.date, 4)),
-          db.toDateRepr(monthUtils.addDays(trans.date, 1)),
+          db.toDateRepr(monthUtils.subDays(trans.date, 5)),
+          db.toDateRepr(monthUtils.addDays(trans.date, 5)),
           trans.amount || 0,
           acctId,
         ],


### PR DESCRIPTION
Currently, when a new transaction is imported, if the transaction doesn't match an existing transaction with the same imported ID, Actual tries to fuzzy match the transaction with an existing transaction. To do this, Actual selects all existing transactions 4 days prior and 1 day after the imported transaction date. It then runs some logic to try to find a matching existing transaction from the ones selected.

The problem is 4 days prior and 1 day after is too restricting. The few issues are:
1) There's no reason why the match logic shouldn't be symmetrical (so 4 days prior and 4 days after)

2) Quite frequently, this logic fails to find the right transaction because the imported transaction might be 2 days after or 5 days prior. This is extremely noticeable with transfers between accounts. Here's an example:

Scenario A
- I have a monthly transfer from Account A to Account B of $50. The transfer is initiated from Account A
- On Jan 2nd, Account A records the outgoing transfer of $50. Actual sees this transaction and it's set as a transfer to Account B
- On Jan 7th, Account B gets the incoming transfer of $50. Because this newly imported transaction "happened" 5 days after the imported transaction, it doesn't get matched and a new transfer to Account A is created

Scenario B
- Let's imagine I delete the transaction on Jan 2nd
- Because SimpleFin and GoCardless download all transactions 90 days prior, the transaction on Jan 2nd gets downloaded again
- This time, it only tries to fuzzy match transaction up till Jan 3rd and doesn't see the Jan 7th transaction
- Every new download of transactions lead to duplicate, unmatched transactions and have to continually be deleted.

Please review this PR and approve. Also, for some context, YNAB 5 actually uses 10 days prior and 10 days after for fuzzy matching (https://support.ynab.com/en_us/approving-and-matching-transactions-a-guide-ByYNZaQ1i).