### PR TITLE
:bug: (goCardless) patch incomplete migration

### DIFF
--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -83,11 +83,14 @@ export function AccountHeader({
   const [menuOpen, setMenuOpen] = useState(false);
   const searchInput = useRef(null);
   const splitsExpanded = useSplitsExpanded();
+  const syncServerStatus = useSyncServerStatus();
+  const isUsingServer = syncServerStatus !== 'no-server';
+  const isServerOffline = syncServerStatus === 'offline';
 
-  let canSync = account && account.account_id;
+  let canSync = account && account.account_id && isUsingServer;
   if (!account) {
     // All accounts - check for any syncable account
-    canSync = !!accounts.find(account => !!account.account_id);
+    canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
   }
 
   function onToggleSplits() {
@@ -210,7 +213,11 @@ export function AccountHeader({
           style={{ marginTop: 12 }}
         >
           {((account && !account.closed) || canSync) && (
-            <Button type="bare" onClick={canSync ? onSync : onImport}>
+            <Button
+              type="bare"
+              onClick={canSync ? onSync : onImport}
+              disabled={canSync && isServerOffline}
+            >
               {canSync ? (
                 <>
                   <AnimatedRefresh
@@ -222,7 +229,7 @@ export function AccountHeader({
                     }
                     style={{ marginRight: 4 }}
                   />{' '}
-                  Sync
+                  {isServerOffline ? 'Sync offline' : 'Sync'}
                 </>
               ) : (
                 <>

--- a/packages/loot-core/migrations/1704572023730_add_account_sync_source.sql
+++ b/packages/loot-core/migrations/1704572023730_add_account_sync_source.sql
@@ -2,10 +2,4 @@ BEGIN TRANSACTION;
 
 ALTER TABLE accounts ADD COLUMN account_sync_source TEXT;
 
-UPDATE accounts SET
-  account_sync_source = CASE
-    WHEN account_id THEN 'goCardless'
-    ELSE NULL
-  END;
-
 COMMIT;

--- a/packages/loot-core/migrations/1704572023731_add_missing_goCardless_sync_source.sql
+++ b/packages/loot-core/migrations/1704572023731_add_missing_goCardless_sync_source.sql
@@ -1,0 +1,9 @@
+BEGIN TRANSACTION;
+
+UPDATE accounts
+SET
+  account_sync_source = 'goCardless'
+WHERE account_id IS NOT NULL
+  AND account_sync_source IS NULL;
+
+COMMIT;

--- a/upcoming-release-notes/2308.md
+++ b/upcoming-release-notes/2308.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix GoCardless bank sync breaking after a flaky SimpleFin db migration.


### PR DESCRIPTION
Patching a migration that for whatever reason did not update the `account_sync_source` field. Thus `goCardless` broke for some random accounts.

Also patching the `sync` button in the UI:
- the sync button should not be visible if the server is not connected (thus bank-sync will be unavailable)
- the sync button should be disabled if the customer if offline (thus also the bank-sync will not be available until reconnection)