### PR TITLE
fix budget header collapsed colors

### DIFF
--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/BudgetSummary.tsx
@@ -191,7 +191,7 @@ export function BudgetSummary({
               alignItems: 'center',
               padding: '10px 20px',
               justifyContent: 'space-between',
-              backgroundColor: theme.tableHeaderBackground,
+              backgroundColor: theme.tableBackground,
               borderTop: '1px solid ' + theme.tableBorder,
             }}
           >

--- a/upcoming-release-notes/2313.md
+++ b/upcoming-release-notes/2313.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix collapsed budget header colors


### PR DESCRIPTION
Fixes the issue brought up [on discord here](https://discord.com/channels/937901803608096828/1027831756545609789/1202623348669161482).  Light theme still works as expected.

Before:
![image](https://github.com/actualbudget/actual/assets/28542559/b696eb5f-85f2-4c17-9ca7-fbb945315b46)

After:
![image](https://github.com/actualbudget/actual/assets/28542559/e8d62dd8-c7be-4e8f-80da-7a8186b56089)

