### PR TITLE
[Maintenance] Pass HTTPS flag to dev container to enable HTTPS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
   actual-development:
     build: .
     image: actual-development
+    environment:
+      - HTTPS
     ports:
       - '3001:3001'
     volumes:

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -37,6 +37,12 @@ First start a dev instance:
 ```sh
 HTTPS=true yarn start
 ```
+
+or using the dev container:
+```
+HTTPS=true docker compose up --build
+```
+
 Note the network IP address and port the dev instance is listening on.
 
 Next, navigate to the root of your project folder, run the standartised docker container, and launch the visual regression tests from within it.

--- a/upcoming-release-notes/2316.md
+++ b/upcoming-release-notes/2316.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jaarasys-henria]
+---
+
+Enable passing HTTPS env variable flag to dev container for easy HTTPS enabling.


### PR DESCRIPTION
Quality of Life enhancement. Stumbled upon this when running the Visual Regression Tests. Update the VRT docs to reflect dev container usage together with the HTTPS flag as well.