### PR TITLE
Re-open autocomplete dropdown on change

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -359,6 +359,7 @@ function SingleAutocomplete<T extends Item>({
 
         setValue(value);
         setIsChanged(true);
+        setIsOpen(true);
       }}
       onStateChange={changes => {
         if (

--- a/upcoming-release-notes/2325.md
+++ b/upcoming-release-notes/2325.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Re-open autocomplete dropdown on change


### PR DESCRIPTION
This fixes an annoying bug I noticed: if you have a dropdown open, and select an item, you can't then go and modify what you typed and select a new item without refocusing the field (it just clears a state). Illustration:
1. Find an item
<img width="300" alt="image" src="https://github.com/actualbudget/actual/assets/9922514/4d6f0742-6942-4852-a693-8625a9e6e9bd">

2. Select it
<img width="318" alt="image" src="https://github.com/actualbudget/actual/assets/9922514/ffd151e7-af08-4a3f-a0a0-abb169e9cce0">

3. Try to edit your selection; no dropdown appears again
<img width="312" alt="image" src="https://github.com/actualbudget/actual/assets/9922514/968f9c21-0097-44ec-8026-fd70da5efa3f">

With this PR, step 3 now looks like this:
<img width="317" alt="image" src="https://github.com/actualbudget/actual/assets/9922514/a031bfb0-8ef8-4c2c-aa07-1c3993cdf5eb">

This is useful for certain keyboard-based workflows, as you can `CTRL-A, Backspace` to search for a new category (or`Backspace` a single letter to search common prefixes) instead of `Blur field, refocus field`.