### PR TITLE
Save name fields on unfocus

### DIFF
--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -126,7 +126,8 @@ export function AccountHeader({
                 <Input
                   defaultValue={accountName}
                   onEnter={e => onSaveName(e.target.value)}
-                  onBlur={() => onExposeName(false)}
+                  onBlur={e => onSaveName(e.target.value)}
+                  onEscape={() => onExposeName(false)}
                   style={{
                     fontSize: 25,
                     fontWeight: 500,

--- a/packages/desktop-client/src/components/common/Input.tsx
+++ b/packages/desktop-client/src/components/common/Input.tsx
@@ -26,6 +26,7 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   style?: CSSProperties;
   inputRef?: Ref<HTMLInputElement>;
   onEnter?: (event: KeyboardEvent<HTMLInputElement>) => void;
+  onEscape?: (event: KeyboardEvent<HTMLInputElement>) => void;
   onUpdate?: (newValue: string) => void;
   focused?: boolean;
 };
@@ -34,6 +35,7 @@ export function Input({
   style,
   inputRef,
   onEnter,
+  onEscape,
   onUpdate,
   focused,
   ...nativeProps
@@ -63,6 +65,10 @@ export function Input({
       onKeyDown={e => {
         if (e.key === 'Enter' && onEnter) {
           onEnter(e);
+        }
+
+        if (e.key === 'Escape' && onEscape) {
+          onEscape(e);
         }
 
         nativeProps.onKeyDown?.(e);

--- a/packages/desktop-client/src/components/sidebar/SidebarWithData.tsx
+++ b/packages/desktop-client/src/components/sidebar/SidebarWithData.tsx
@@ -59,6 +59,17 @@ function EditableBudgetName({ prefs, savePrefs }: EditableBudgetNameProps) {
     { name: 'close', text: 'Close file' },
   ];
 
+  const onSaveChanges = async e => {
+    const inputEl = e.target;
+    const newBudgetName = inputEl.value;
+    if (newBudgetName.trim() !== '') {
+      await savePrefs({
+        budgetName: inputEl.value,
+      });
+      setEditing(false);
+    }
+  };
+
   if (editing) {
     return (
       <InitialFocus>
@@ -69,17 +80,9 @@ function EditableBudgetName({ prefs, savePrefs }: EditableBudgetNameProps) {
             fontWeight: 500,
           }}
           defaultValue={prefs.budgetName}
-          onEnter={async e => {
-            const inputEl = e.target as HTMLInputElement;
-            const newBudgetName = inputEl.value;
-            if (newBudgetName.trim() !== '') {
-              await savePrefs({
-                budgetName: inputEl.value,
-              });
-              setEditing(false);
-            }
-          }}
-          onBlur={() => setEditing(false)}
+          onEnter={onSaveChanges}
+          onBlur={onSaveChanges}
+          onEscape={() => setEditing(false)}
         />
       </InitialFocus>
     );

--- a/upcoming-release-notes/2327.md
+++ b/upcoming-release-notes/2327.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Save budget/account name fields on blur


### PR DESCRIPTION
Resolves a confusing behaviour where clicking outside the field erased changes instead of saving them (this didn't match how transactions behave). This PR makes the title field consistent with how transactions behave.

In detail:
1. Budget and account name fields will save their values on blur.
2. Budget and account name fields can still be cleared by pressing "Escape".