### PR TITLE
Fix parse errors with OFX data with no transactions

### DIFF
--- a/packages/loot-core/src/server/accounts/ofx2json.ts
+++ b/packages/loot-core/src/server/accounts/ofx2json.ts
@@ -87,7 +87,7 @@ function getInvStmtTrn(ofx) {
 }
 
 function getAsArray(value) {
-  return Array.isArray(value) ? value : [value];
+  return Array.isArray(value) ? value : value === undefined ? [] : [value];
 }
 
 function mapOfxTransaction(stmtTrn): OFXTransaction {

--- a/upcoming-release-notes/2342.md
+++ b/upcoming-release-notes/2342.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix parse errors with OFX data with no transactions


### PR DESCRIPTION
- Return an empty array instead of an array of undefined

Related to parse error seen in https://github.com/actualbudget/actual/issues/2331
