### PR TITLE
:bug: (typescript) patching sendCatch type

### DIFF
--- a/packages/loot-core/src/platform/client/fetch/index.d.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.d.ts
@@ -7,6 +7,14 @@ export type Init = typeof init;
 export function send<K extends keyof Handlers>(
   name: K,
   args?: Parameters<Handlers[K]>[0],
+  options?: { catchErrors: true },
+): ReturnType<
+  | { data: Handlers[K] }
+  | { error: { type: 'APIError' | 'InternalError'; message: string } }
+>;
+export function send<K extends keyof Handlers>(
+  name: K,
+  args?: Parameters<Handlers[K]>[0],
   options?: { catchErrors?: boolean },
 ): ReturnType<Handlers[K]>;
 export type Send = typeof send;

--- a/packages/loot-core/src/platform/client/fetch/index.d.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.d.ts
@@ -14,7 +14,10 @@ export type Send = typeof send;
 export function sendCatch<K extends keyof Handlers>(
   name: K,
   args?: Parameters<Handlers[K]>[0],
-): ReturnType<Handlers[K]>;
+): ReturnType<
+  | { data: Handlers[K] }
+  | { error: { type: 'APIError' | 'InternalError'; message: string } }
+>;
 export type SendCatch = typeof sendCatch;
 
 export function listen<K extends keyof ServerEvents>(

--- a/packages/loot-core/src/platform/client/fetch/index.web.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.web.ts
@@ -78,7 +78,6 @@ export const init: T.Init = async function () {
   return new Promise(connectSocket);
 };
 
-// @ts-expect-error Figure out why typechecker is suddenly breaking here
 export const send: T.Send = function (
   name,
   args,

--- a/upcoming-release-notes/2343.md
+++ b/upcoming-release-notes/2343.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Patching an incorrect TypeScript type definition used for `sendCatch` method return value.


### PR DESCRIPTION
Patching a incorrect return type for `sendCatch` method.