### PR TITLE
fix: Mobile menu blocks items #2040

### DIFF
--- a/packages/desktop-client/src/components/accounts/MobileAccounts.jsx
+++ b/packages/desktop-client/src/components/accounts/MobileAccounts.jsx
@@ -13,6 +13,7 @@ import { Button } from '../common/Button';
 import { Text } from '../common/Text';
 import { TextOneLine } from '../common/TextOneLine';
 import { View } from '../common/View';
+import { ROW_HEIGHT as MOBILE_NAV_HEIGHT } from '../mobile/MobileNavTabs';
 import { Page } from '../Page';
 import { PullToRefresh } from '../responsive/PullToRefresh';
 import { CellValue } from '../spreadsheet/CellValue';
@@ -175,7 +176,11 @@ function AccountList({
         </Button>
       }
       padding={0}
-      style={{ flex: 1, backgroundColor: theme.mobilePageBackground }}
+      style={{
+        flex: 1,
+        backgroundColor: theme.mobilePageBackground,
+        paddingBottom: MOBILE_NAV_HEIGHT,
+      }}
     >
       {accounts.length === 0 && <EmptyMessage />}
       <PullToRefresh onRefresh={onSync}>

--- a/packages/desktop-client/src/components/budget/MobileBudgetTable.jsx
+++ b/packages/desktop-client/src/components/budget/MobileBudgetTable.jsx
@@ -24,6 +24,7 @@ import { Label } from '../common/Label';
 import { Menu } from '../common/Menu';
 import { Text } from '../common/Text';
 import { View } from '../common/View';
+import { ROW_HEIGHT as MOBILE_NAV_HEIGHT } from '../mobile/MobileNavTabs';
 import { Page } from '../Page';
 import { PullToRefresh } from '../responsive/PullToRefresh';
 import { CellValue } from '../spreadsheet/CellValue';
@@ -1362,7 +1363,12 @@ export function BudgetTable({
             //   style={{ backgroundColor: colors.n10 }}
             //   automaticallyAdjustContentInsets={false}
             // >
-            <View data-testid="budget-table">
+            <View
+              data-testid="budget-table"
+              style={{
+                paddingBottom: MOBILE_NAV_HEIGHT,
+              }}
+            >
               <BudgetGroups
                 type={type}
                 categoryGroups={categoryGroups}

--- a/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
@@ -20,7 +20,7 @@ import { theme, styles, type CSSProperties } from '../../style';
 import { View } from '../common/View';
 import { useScroll } from '../ScrollProvider';
 
-const ROW_HEIGHT = 70;
+export const ROW_HEIGHT = 70;
 const COLUMN_COUNT = 3;
 
 export function MobileNavTabs() {

--- a/packages/desktop-client/src/components/responsive/PullToRefresh.tsx
+++ b/packages/desktop-client/src/components/responsive/PullToRefresh.tsx
@@ -1,8 +1,6 @@
 import React, { type ComponentProps } from 'react';
 import BasePullToRefresh from 'react-simple-pull-to-refresh';
 
-import { ROW_HEIGHT as MOBILE_NAV_HEIGHT } from '../mobile/MobileNavTabs';
-
 import { css } from 'glamor';
 
 type PullToRefreshProps = ComponentProps<typeof BasePullToRefresh>;
@@ -20,7 +18,6 @@ export function PullToRefresh(props: PullToRefreshProps) {
             },
             '& .ptr__children': {
               overflow: 'hidden auto',
-              paddingBottom: MOBILE_NAV_HEIGHT,
             },
           }),
         )}

--- a/packages/desktop-client/src/components/responsive/PullToRefresh.tsx
+++ b/packages/desktop-client/src/components/responsive/PullToRefresh.tsx
@@ -1,6 +1,8 @@
 import React, { type ComponentProps } from 'react';
 import BasePullToRefresh from 'react-simple-pull-to-refresh';
 
+import { ROW_HEIGHT as MOBILE_NAV_HEIGHT } from '../mobile/MobileNavTabs';
+
 import { css } from 'glamor';
 
 type PullToRefreshProps = ComponentProps<typeof BasePullToRefresh>;
@@ -18,6 +20,7 @@ export function PullToRefresh(props: PullToRefreshProps) {
             },
             '& .ptr__children': {
               overflow: 'hidden auto',
+              paddingBottom: MOBILE_NAV_HEIGHT,
             },
           }),
         )}

--- a/upcoming-release-notes/2352.md
+++ b/upcoming-release-notes/2352.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [skymaiden]
+---
+
+Fix overlapping mobile nav bar.


### PR DESCRIPTION
Suggested quick fix for https://github.com/actualbudget/actual/issues/2040. 
Adds padding to the bottom of pages where the mobile navigation bar is displayed, to avoid the fixed position of the bar overlapping page content.
Bug was especially visible on Safari iOS.