### PR TITLE
Add option to make a transfer from two selected transactions

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.js
+++ b/packages/desktop-client/e2e/accounts.test.js
@@ -7,6 +7,7 @@ test.describe('Accounts', () => {
   let page;
   let navigation;
   let configurationPage;
+  let accountPage;
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
@@ -22,7 +23,7 @@ test.describe('Accounts', () => {
   });
 
   test('creates a new account and views the initial balance transaction', async () => {
-    const accountPage = await navigation.createAccount({
+    accountPage = await navigation.createAccount({
       name: 'New Account',
       offBudget: false,
       balance: 100,
@@ -38,7 +39,7 @@ test.describe('Accounts', () => {
   });
 
   test('closes an account', async () => {
-    const accountPage = await navigation.goToAccountPage('Roth IRA');
+    accountPage = await navigation.goToAccountPage('Roth IRA');
 
     await expect(accountPage.accountName).toHaveText('Roth IRA');
 
@@ -49,5 +50,51 @@ test.describe('Accounts', () => {
 
     await expect(accountPage.accountName).toHaveText('Closed: Roth IRA');
     await expect(page).toMatchThemeScreenshots();
+  });
+
+  test.describe('Budgeted Accounts', () => {
+    // Reset filters
+    test.afterEach(async () => {
+      await accountPage.removeFilter(0);
+    });
+
+    test('creates a transfer from two existing transactions', async () => {
+      accountPage = await navigation.goToAccountPage('For budget');
+      await expect(accountPage.accountName).toHaveText('Budgeted Accounts');
+
+      await accountPage.filterByNote('Test Acc Transfer');
+
+      await accountPage.createSingleTransaction({
+        account: 'Ally Savings',
+        payee: '',
+        notes: 'Test Acc Transfer',
+        category: 'Food',
+        debit: '34.56',
+      });
+
+      await accountPage.createSingleTransaction({
+        account: 'HSBC',
+        payee: '',
+        notes: 'Test Acc Transfer',
+        category: 'Food',
+        credit: '34.56',
+      });
+
+      await accountPage.selectNthTransaction(0);
+      await accountPage.selectNthTransaction(1);
+      await accountPage.clickSelectAction('Make transfer');
+
+      let transaction = accountPage.getNthTransaction(0);
+      await expect(transaction.payee).toHaveText('Ally Savings');
+      await expect(transaction.category).toHaveText('Transfer');
+      await expect(transaction.credit).toHaveText('34.56');
+      await expect(transaction.account).toHaveText('HSBC');
+
+      transaction = accountPage.getNthTransaction(1);
+      await expect(transaction.payee).toHaveText('HSBC');
+      await expect(transaction.category).toHaveText('Transfer');
+      await expect(transaction.debit).toHaveText('34.56');
+      await expect(transaction.account).toHaveText('Ally Savings');
+    });
   });
 });

--- a/packages/desktop-client/e2e/page-models/account-page.js
+++ b/packages/desktop-client/e2e/page-models/account-page.js
@@ -25,6 +25,9 @@ export class AccountPage {
 
     this.filterButton = this.page.getByRole('button', { name: 'Filter' });
     this.filterSelectTooltip = this.page.getByTestId('filters-select-tooltip');
+
+    this.selectButton = this.page.getByTestId('transactions-select-button');
+    this.selectTooltip = this.page.getByTestId('transactions-select-tooltip');
   }
 
   /**
@@ -68,20 +71,32 @@ export class AccountPage {
     await this.cancelTransactionButton.click();
   }
 
+  async selectNthTransaction(index) {
+    const row = this.transactionTableRow.nth(index);
+    await row.getByTestId('select').click();
+  }
+
   /**
    * Retrieve the data for the nth-transaction.
    * 0-based index
    */
   getNthTransaction(index) {
     const row = this.transactionTableRow.nth(index);
+    const account = row.getByTestId('account');
 
     return {
+      ...(account ? { account } : {}),
       payee: row.getByTestId('payee'),
       notes: row.getByTestId('notes'),
       category: row.getByTestId('category'),
       debit: row.getByTestId('debit'),
       credit: row.getByTestId('credit'),
     };
+  }
+
+  async clickSelectAction(action) {
+    await this.selectButton.click();
+    await this.selectTooltip.getByRole('button', { name: action }).click();
   }
 
   /**
@@ -107,6 +122,15 @@ export class AccountPage {
   }
 
   /**
+   * Filter to a specific note
+   */
+  async filterByNote(note) {
+    const filterTooltip = await this.filterBy('Note');
+    await this.page.keyboard.type(note);
+    await filterTooltip.applyButton.click();
+  }
+
+  /**
    * Remove the nth filter
    */
   async removeFilter(idx) {
@@ -117,6 +141,12 @@ export class AccountPage {
   }
 
   async _fillTransactionFields(transactionRow, transaction) {
+    if (transaction.account) {
+      await transactionRow.getByTestId('account').click();
+      await this.page.keyboard.type(transaction.account);
+      await this.page.keyboard.press('Tab');
+    }
+
     if (transaction.payee) {
       await transactionRow.getByTestId('payee').click();
       await this.page.keyboard.type(transaction.payee);

--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -79,6 +79,7 @@ export function AccountHeader({
   onCondOpChange,
   onDeleteFilter,
   onScheduleAction,
+  onSetTransfer,
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const searchInput = useRef(null);
@@ -93,6 +94,9 @@ export function AccountHeader({
     // All accounts - check for any syncable account
     canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
   }
+
+  // Only show the ability to make linked transfers on multi-account views.
+  const showMakeTransfer = !account;
 
   function onToggleSplits() {
     if (tableRef.current) {
@@ -276,8 +280,10 @@ export function AccountHeader({
               onEdit={onBatchEdit}
               onUnlink={onBatchUnlink}
               onCreateRule={onCreateRule}
+              onSetTransfer={onSetTransfer}
               onScheduleAction={onScheduleAction}
               pushModal={pushModal}
+              showMakeTransfer={showMakeTransfer}
             />
           )}
           <Button

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -801,6 +801,7 @@ export function SelectedItemsButton({ name, keyHandlers, items, onSelect }) {
         type="bare"
         style={{ color: theme.pageTextPositive }}
         onClick={() => setMenuOpen(true)}
+        data-testid={name + '-select-button'}
       >
         <SvgExpandArrow
           width={8}
@@ -816,6 +817,7 @@ export function SelectedItemsButton({ name, keyHandlers, items, onSelect }) {
           width={200}
           style={{ padding: 0, backgroundColor: theme.menuBackground }}
           onClose={() => setMenuOpen(false)}
+          data-testid={name + '-select-tooltip'}
         >
           <Menu
             onMenuSelect={name => {

--- a/packages/desktop-client/src/components/transactions/SelectedTransactions.jsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactions.jsx
@@ -56,6 +56,11 @@ export function SelectedTransactionsButton({
     const fromTrans = getTransaction(transactions[0]);
     const toTrans = getTransaction(transactions[1]);
 
+    // previously selected transactions aren't always present in current transaction list
+    if (!fromTrans || !toTrans) {
+      return false;
+    }
+
     return validForTransfer(fromTrans, toTrans);
   }, [selectedItems, getTransaction]);
 

--- a/packages/desktop-client/src/components/transactions/SelectedTransactions.jsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactions.jsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
 
+import { validForTransfer } from 'loot-core/src/client/transfer';
+
 import { useSelectedItems } from '../../hooks/useSelected';
 import { Menu } from '../common/Menu';
 import { SelectedItemsButton } from '../table';
@@ -54,18 +56,7 @@ export function SelectedTransactionsButton({
     const fromTrans = getTransaction(transactions[0]);
     const toTrans = getTransaction(transactions[1]);
 
-    if (
-      // no subtransactions
-      // not already a transfer
-      [fromTrans, toTrans].every(tran => {
-        return tran.transfer_id == null && tran.is_child === false;
-      }) &&
-      fromTrans.account !== toTrans.account && // belong to different accounts
-      fromTrans.amount + toTrans.amount === 0 // amount must zero each other out
-    ) {
-      return true;
-    }
-    return false;
+    return validForTransfer(fromTrans, toTrans);
   }, [selectedItems, getTransaction]);
 
   return (

--- a/packages/loot-core/src/client/transfer.test.ts
+++ b/packages/loot-core/src/client/transfer.test.ts
@@ -1,0 +1,75 @@
+// @ts-strict-ignore
+import * as db from '../server/db';
+
+import * as transfer from './transfer';
+
+beforeEach(global.emptyDatabase());
+
+async function prepareDatabase() {
+  await db.insertAccount({ id: 'one', name: 'one' });
+  await db.insertAccount({ id: 'two', name: 'two' });
+  await db.insertPayee({ name: '', transfer_acct: 'one' });
+  await db.insertPayee({ name: '', transfer_acct: 'two' });
+}
+
+async function createTransaction(account: string, amount: number, extra = {}) {
+  const transaction = {
+    id: null,
+    account,
+    amount,
+    payee: await db.insertPayee({ name: 'Non-transfer ' + account }),
+    date: '2017-01-01',
+    ...extra,
+  };
+  transaction.id = await db.insertTransaction(transaction);
+  return await db.getTransaction(transaction.id);
+}
+
+describe('Transfer', () => {
+  test('Transfers are properly verified', async () => {
+    await prepareDatabase();
+
+    // happy path, two valid transactions
+    expect(
+      transfer.validForTransfer(
+        await createTransaction('one', 5),
+        await createTransaction('two', -5),
+      ),
+    ).toBeTruthy();
+
+    // amount not zeroed out
+    expect(
+      transfer.validForTransfer(
+        await createTransaction('one', 5),
+        await createTransaction('two', 5),
+      ),
+    ).toBeFalsy();
+
+    // amount not match
+    expect(
+      transfer.validForTransfer(
+        await createTransaction('one', 5),
+        await createTransaction('two', -6),
+      ),
+    ).toBeFalsy();
+
+    // accounts match
+    expect(
+      transfer.validForTransfer(
+        await createTransaction('one', 5),
+        await createTransaction('one', -5),
+      ),
+    ).toBeFalsy();
+
+    // one already a transfer
+    const existingTransfer = await createTransaction('one', 5);
+    expect(
+      transfer.validForTransfer(
+        await createTransaction('one', 5),
+        await createTransaction('two', -5, {
+          transfer_id: existingTransfer.id,
+        }),
+      ),
+    ).toBeFalsy();
+  });
+});

--- a/packages/loot-core/src/client/transfer.ts
+++ b/packages/loot-core/src/client/transfer.ts
@@ -1,0 +1,19 @@
+import type { TransactionEntity } from '../types/models';
+
+export function validForTransfer(
+  fromTransaction: TransactionEntity,
+  toTransaction: TransactionEntity,
+) {
+  if (
+    // no subtransactions
+    // not already a transfer
+    [fromTransaction, toTransaction].every(tran => {
+      return tran.transfer_id == null && tran.is_child === false;
+    }) &&
+    fromTransaction.account !== toTransaction.account && // belong to different accounts
+    fromTransaction.amount + toTransaction.amount === 0 // amount must zero each other out
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/upcoming-release-notes/2398.md
+++ b/upcoming-release-notes/2398.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [twk3]
+---
+
+Add option to make a transfer from two selected transactions.


### PR DESCRIPTION
## Summary

Add an option in the selected transactions menu in mutli-account budget pages (all accounts, for budget/etc), that allows you to relate two transactions across accounts as a transfer. 

## Feature

Feature: https://github.com/actualbudget/actual/issues/1891

## Details

- Transactions amount must match
- Transactions must be from different acounts
- Split transactions not eligible

## Workflows

Single account pages don't show the option at all in the selection menu:

![SingleAccountSelectTransactionsTooltip](https://github.com/actualbudget/actual/assets/2806882/80a5a90d-68c1-4ab3-8cb9-c4ccd3f79331)


Multi account pages always show the option in the selection menu, but disabled when the selections are not valid for the transfer action:

![MultiAccountSingleTransactionTooltip](https://github.com/actualbudget/actual/assets/2806882/3c89119b-a747-4842-9908-814477192d87)

For valid selections the action is enabled in the selection tooltip:

![MultiAccountValidTransferTooltip](https://github.com/actualbudget/actual/assets/2806882/3b2bc1a3-e712-4adb-922c-d48f4c6d4164)


## Final PR Tasks
- [x] extract the can-be-transfer logic to transfers.ts and reuse in both places
- [x] Add tests
- [x] Docs PR: https://github.com/actualbudget/docs/pull/321
