### PR TITLE
Update csv amount parser.  Fix #2374

### DIFF
--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -6,7 +6,7 @@ describe('utility functions', () => {
     expect(looselyParseAmount('3.45')).toBe(3.45);
 
     // Parsing is currently limited to 2 decimal places.
-    // Anything other than <. ,> and 2 other chars doesn't count decimal amounts
+    // Only <. ,> and 2 other chars counts as decimal places
     // Proper parsing would include format settings,
     // but currently we are format agnostic
     expect(looselyParseAmount('3.456')).toBe(3456);

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -5,15 +5,16 @@ describe('utility functions', () => {
     expect(looselyParseAmount('3')).toBe(3);
     expect(looselyParseAmount('3.45')).toBe(3.45);
 
-    // Right now it doesn't actually parse an "amount", it just parses
-    // a number. An "amount" is a valid transaction amount, usually a
-    // number with 2 decimal places.
-    expect(looselyParseAmount('3.456')).toBe(3.456);
+    // Parsing is currently limited to 2 decimal places.
+    // Anything other than <. ,> and 2 other chars doesn't count decimal amounts
+    // Proper parsing would include format settings,
+    // but currently we are format agnostic
+    expect(looselyParseAmount('3.456')).toBe(3456);
   });
 
   test('looseParseAmount works with alternate formats', () => {
     expect(looselyParseAmount('3,45')).toBe(3.45);
-    expect(looselyParseAmount('3,456')).toBe(3.456);
+    expect(looselyParseAmount('3,456')).toBe(3456);
   });
 
   test('looseParseAmount works with negative numbers', () => {

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -370,7 +370,7 @@ export function looselyParseAmount(amount: string) {
     amount = amount.replace('(', '-').replace(')', '');
   }
 
-  const m = amount.match(/[.,][^.,]*$/);
+  const m = amount.match(/[.,][^.,]{1,2}$/);
   if (!m || m.index === undefined || m.index === 0) {
     return safeNumber(parseFloat(extractNumbers(amount)));
   }

--- a/upcoming-release-notes/2399.md
+++ b/upcoming-release-notes/2399.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Only match 2 decimal places when parsing amounts for file import


### PR DESCRIPTION
Attempt to fix #2374.  

This puts a strict limit to 1 or 2 decimal places.  The test is complaining because there is one that passes in three decimal places.  Are there regions where decimal amounts have more than 2 digits? If so then this bug is unfixable without a major overhaul of the parsing to have a known data format, where currently the parsing is format agnostic.

Looks like there are a few places that have 3 decimal places for financial data, mostly in the middle east.  Im not sure there is a way to fix the issue without blocking potential users from those countries.  Does anyone else have ideas on how to parse the csv in the issue without limiting to 2 decimal places?
