### PR TITLE
[Goals] Schedule top off amount

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -187,6 +187,7 @@ export async function goalsSchedule(
     errors = errors.concat(t.errors);
 
     console.log('There are ' + t.t.length + ' templates.');
+    t.t.forEach(template => console.log(template.name));
 
     const t_payMonthOf = t.t.filter(
       c =>

--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -198,20 +198,10 @@ export async function goalsSchedule(
       isReflectBudget();
 
     const t_payMonthOf = t.t.filter(isPayMonthOf);
-
     const t_sinking = t.t
       .filter(c => !isPayMonthOf(c))
       .sort((a, b) => a.next_date_string.localeCompare(b.next_date_string));
-
-    console.log(
-      'There are ' +
-        t_payMonthOf.length +
-        ' templates that are simple schedules.',
-    );
-    console.log('There are ' + t_sinking.length + ' sinking fund templates.');
-
     const totalPayMonthOf = await getPayMonthOfTotal(t_payMonthOf);
-
     const totalSinking = await getSinkingTotal(t_sinking);
     const totalSinkingBaseContribution =
       await getSinkingBaseContributionTotal(t_sinking);
@@ -224,7 +214,13 @@ export async function goalsSchedule(
         remainder,
         last_month_balance,
       );
-      to_budget += Math.round(totalPayMonthOf + totalSinkingContribution);
+      if (t_sinking.length === 0) {
+        to_budget +=
+          Math.round(totalPayMonthOf + totalSinkingContribution) -
+          last_month_balance;
+      } else {
+        to_budget += Math.round(totalPayMonthOf + totalSinkingContribution);
+      }
     }
   }
   return { to_budget, errors, remainder, scheduleFlag };

--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -186,46 +186,28 @@ export async function goalsSchedule(
     const t = await createScheduleList(template, current_month, category);
     errors = errors.concat(t.errors);
 
-    console.log('There are ' + template.length + ' schedule templates found.');
-    template.forEach(template => console.log(template));
+    const isPayMonthOf = c =>
+      c.full ||
+      (c.target_frequency === 'monthly' &&
+        c.target_interval === 1 &&
+        c.num_months === 0) ||
+      (c.target_frequency === 'weekly' &&
+        c.target_interval >= 0 &&
+        c.num_months === 0) ||
+      c.target_frequency === 'daily' ||
+      isReflectBudget();
 
-    console.log('There are ' + t.t.length + ' matched schedules.');
-    t.t.forEach(template => console.log(template.name));
+    const t_payMonthOf = t.t.filter(isPayMonthOf);
 
-    const t_payMonthOf = t.t.filter(
-      c =>
-        c.full ||
-        (c.target_frequency === 'monthly' &&
-          c.target_interval === 1 &&
-          c.num_months === 0) ||
-        (c.target_frequency === 'weekly' &&
-          c.target_interval >= 0 &&
-          c.num_months === 0) ||
-        c.target_frequency === 'daily' ||
-        isReflectBudget(),
-    );
+    const t_sinking = t.t
+      .filter(c => !isPayMonthOf(c))
+      .sort((a, b) => a.next_date_string.localeCompare(b.next_date_string));
 
     console.log(
       'There are ' +
         t_payMonthOf.length +
         ' templates that are simple schedules.',
     );
-
-    const t_sinking = t.t
-      .filter(
-        c =>
-          (!c.full &&
-            c.target_frequency === 'monthly' &&
-            c.target_interval > 1) ||
-          (!c.full &&
-            c.target_frequency === 'monthly' &&
-            c.num_months > 0 &&
-            c.target_interval === 1) ||
-          (!c.full && c.target_frequency === 'yearly') ||
-          (!c.full && c.target_frequency === undefined),
-      )
-      .sort((a, b) => a.next_date_string.localeCompare(b.next_date_string));
-
     console.log('There are ' + t_sinking.length + ' sinking fund templates.');
 
     const totalPayMonthOf = await getPayMonthOfTotal(t_payMonthOf);

--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -186,7 +186,10 @@ export async function goalsSchedule(
     const t = await createScheduleList(template, current_month, category);
     errors = errors.concat(t.errors);
 
-    console.log('There are ' + t.t.length + ' templates.');
+    console.log('There are ' + template.length + ' schedule templates found.');
+    template.forEach(template => console.log(template));
+
+    console.log('There are ' + t.t.length + ' matched schedules.');
     t.t.forEach(template => console.log(template.name));
 
     const t_payMonthOf = t.t.filter(

--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -186,6 +186,8 @@ export async function goalsSchedule(
     const t = await createScheduleList(template, current_month, category);
     errors = errors.concat(t.errors);
 
+    console.log('There are ' + t.t.length + ' templates.');
+
     const t_payMonthOf = t.t.filter(
       c =>
         c.full ||
@@ -197,6 +199,12 @@ export async function goalsSchedule(
           c.num_months === 0) ||
         c.target_frequency === 'daily' ||
         isReflectBudget(),
+    );
+
+    console.log(
+      'There are ' +
+        t_payMonthOf.length +
+        ' templates that are simple schedules.',
     );
 
     const t_sinking = t.t
@@ -213,6 +221,8 @@ export async function goalsSchedule(
           (!c.full && c.target_frequency === undefined),
       )
       .sort((a, b) => a.next_date_string.localeCompare(b.next_date_string));
+
+    console.log('There are ' + t_sinking.length + ' sinking fund templates.');
 
     const totalPayMonthOf = await getPayMonthOfTotal(t_payMonthOf);
 

--- a/upcoming-release-notes/2404.md
+++ b/upcoming-release-notes/2404.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+[Goals] If no sinking funds are used, apply existing category balance to simple schedules to 'top off' the category.


### PR DESCRIPTION
A simple schedule, one that is recurring monthly and is budgeted fully every month, would not consider an existing balance.  This PR adds 2 things.
1.  If a simple schedule, not combined with schedule it is greater than 1 month (sinking fund), has a category balance and that balance is less than needed to complete the schedule... the budgeted amount will only add the difference needed to complete the schedule.
     Example:   75 is needed for this month, 50 is in the category from last month.  The budgeted amount will be 25.   (Previously, it would be 75.)

2.  The filter for finding schedules is simplified and less error prone.  The only filter specified is one for monthly recurring or 'full' schedules.  This PR implements a negate filter for all other schedules so it's more guaranteed not to inadvertently drop one from the list.