### PR TITLE
[End of Month Cleanup] Remove automatic funding of rollover categories

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -118,48 +118,6 @@ async function processCleanup(month: string): Promise<Notification> {
     }
   }
 
-  //fund rollover categories after non-rollover categories
-  for (let c = 0; c < categories.length; c++) {
-    const category = categories[c];
-    const budgetAvailable = await getSheetValue(sheetName, `to-budget`);
-    const balance = await getSheetValue(sheetName, `leftover-${category.id}`);
-    const budgeted = await getSheetValue(sheetName, `budget-${category.id}`);
-    const to_budget = budgeted + Math.abs(balance);
-    const categoryId = category.id;
-    let carryover = await db.first(
-      `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
-      [db_month, categoryId],
-    );
-
-    if (carryover === null) {
-      carryover = { carryover: 0 };
-    }
-
-    if (
-      balance < 0 &&
-      Math.abs(balance) <= budgetAvailable &&
-      !category.is_income &&
-      carryover.carryover === 1
-    ) {
-      await setBudget({
-        category: category.id,
-        month,
-        amount: to_budget,
-      });
-    } else if (
-      balance < 0 &&
-      !category.is_income &&
-      carryover.carryover === 1 &&
-      Math.abs(balance) > budgetAvailable
-    ) {
-      await setBudget({
-        category: category.id,
-        month,
-        amount: budgeted + budgetAvailable,
-      });
-    }
-  }
-
   const budgetAvailable = await getSheetValue(sheetName, `to-budget`);
   if (budgetAvailable <= 0) {
     warnings.push('No funds are available to reallocate.');

--- a/upcoming-release-notes/2409.md
+++ b/upcoming-release-notes/2409.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+End of month cleanup - revert logic introduced in 2295. Ignore rollover categories.


### PR DESCRIPTION
#2295 introduced the logic to automatically fund rollover categories after non-rollover categories and before utilizing the sink categories.  This PR reverts that logic.  The documentation will be amended to recommend using the 'sink' term on rollover balance categories if the desire is to fund those categories.  This approach allows both workflows.