### PR TITLE
Fix flaky transfer e2e test

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.js
+++ b/packages/desktop-client/e2e/accounts.test.js
@@ -80,6 +80,8 @@ test.describe('Accounts', () => {
         credit: '34.56',
       });
 
+      await page.waitForTimeout(100); // Give time for the previous transaction to be rendered
+
       await accountPage.selectNthTransaction(0);
       await accountPage.selectNthTransaction(1);
       await accountPage.clickSelectAction('Make transfer');

--- a/upcoming-release-notes/2434.md
+++ b/upcoming-release-notes/2434.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix flaky transfer e2e test.


### PR DESCRIPTION
- If tests ran too fast, the transactions wouldn't finish rendering before the select of the transactions was attempted.

