### PR TITLE
fix: Don't allow duplicate cat-groups in budget at renaming

### DIFF
--- a/packages/desktop-client/src/components/budget/MobileBudget.tsx
+++ b/packages/desktop-client/src/components/budget/MobileBudget.tsx
@@ -20,8 +20,6 @@ import { SyncRefresh } from '../SyncRefresh';
 
 import { BudgetTable } from './MobileBudgetTable';
 import { prewarmMonth, switchBudgetType } from './util';
-import { addNotification } from 'loot-core/client/actions';
-import { useDispatch } from 'react-redux';
 
 type BudgetInnerProps = {
   categories: CategoryEntity[];
@@ -76,8 +74,6 @@ function BudgetInner(props: BudgetInnerProps) {
   const numberFormat = _numberFormat || 'comma-dot';
   const [hideFraction = false] = useLocalPref('hideFraction');
 
-  const dispatch = useDispatch();
-
   useEffect(() => {
     async function init() {
       const { start, end } = await send('get-budget-bounds');
@@ -130,8 +126,10 @@ function BudgetInner(props: BudgetInnerProps) {
         }
 
         const lowerName = name.toLowerCase();
-        if (categoryGroups.some(g => g.name.toLocaleLowerCase() === lowerName)) {
-          return `Error group with name '${name}' already exists.`
+        if (
+          categoryGroups.some(g => g.name.toLocaleLowerCase() === lowerName)
+        ) {
+          return `Error group with name ‘${name}’ already exists.`;
         }
         return null;
       },
@@ -152,8 +150,8 @@ function BudgetInner(props: BudgetInnerProps) {
   };
 
   const onSaveGroup = group => {
-           updateGroup(group);
-      };
+    updateGroup(group);
+  };
 
   const onDeleteGroup = async groupId => {
     const group = categoryGroups?.find(g => g.id === groupId);
@@ -358,7 +356,7 @@ function BudgetInner(props: BudgetInnerProps) {
       onDelete: onDeleteGroup,
       onValidate: name => {
         console.log(name);
-      }
+      },
     });
   };
 

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -275,10 +275,10 @@ function BudgetInner(props: BudgetProps) {
       .filter(g => g.name.toUpperCase() === group.name.toUpperCase())
       .filter(g => group.id === 'new' || group.id !== g.id);
 
-    /*if (matchingGroups.length > 0) {
+    if (matchingGroups.length > 0) {
       groupNameAlreadyExistsNotification(matchingGroups[0]);
       return;
-    }*/
+    }
 
     if (group.id === 'new') {
       dispatch(createGroup(group.name));

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -260,7 +260,26 @@ function BudgetInner(props: BudgetProps) {
     }
   };
 
-  const onSaveGroup = group => {
+  const groupNameAlreadyExistsNotification = group => {
+    dispatch(
+      addNotification({
+        type: 'error',
+        message: `A ${group.hidden ? 'hidden ' : ''}’${group.name}’ category group already exists.`,
+      }),
+    );
+  };
+
+  const onSaveGroup = async group => {
+    const categories = await send('get-categories');
+    const matchingGroups = categories.grouped
+      .filter(g => g.name.toUpperCase() === group.name.toUpperCase())
+      .filter(g => group.id === 'new' || group.id !== g.id);
+
+    /*if (matchingGroups.length > 0) {
+      groupNameAlreadyExistsNotification(matchingGroups[0]);
+      return;
+    }*/
+
     if (group.id === 'new') {
       dispatch(createGroup(group.name));
     } else {

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -327,7 +327,18 @@ export async function insertCategoryGroup(group) {
   return insertWithUUID('category_groups', group);
 }
 
-export function updateCategoryGroup(group) {
+export async function updateCategoryGroup(group) {
+  // Don't allow duplicate group
+  const existingGroup = await first(
+    `SELECT id, name, hidden FROM category_groups WHERE UPPER(name) = ? and tombstone = 0 LIMIT 1`,
+    [group.name.toUpperCase()],
+  );
+  if (existingGroup) {
+    throw new Error(
+      `A ${existingGroup.hidden ? 'hidden ' : ''}’${existingGroup.name}’ category group already exists.`,
+    );
+  }
+
   group = categoryGroupModel.validate(group, { update: true });
   return update('category_groups', group);
 }

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -330,8 +330,8 @@ export async function insertCategoryGroup(group) {
 export async function updateCategoryGroup(group) {
   // Don't allow duplicate group
   const existingGroup = await first(
-    `SELECT id, name, hidden FROM category_groups WHERE UPPER(name) = ? and tombstone = 0 LIMIT 1`,
-    [group.name.toUpperCase()],
+    `SELECT id, name, hidden FROM category_groups WHERE UPPER(name) = ? AND tombstone = 0 AND id <> ? LIMIT 1`,
+    [group.name.toUpperCase(), group.id],
   );
   if (existingGroup) {
     throw new Error(

--- a/upcoming-release-notes/2439.md
+++ b/upcoming-release-notes/2439.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [FlorianLang06,dhruvramdev]
+---
+
+Don't allow duplicate category groups (at creating and renaming)


### PR DESCRIPTION
Checks:

 - UI Level check to check for checking duplicate group name (create and rename)
 - DB level check for the same (create and rename/update)

Inspired from PR #2262 
Fixes: #2428 
