### PR TITLE
Show a modal to confirm unlinking accounts

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -15,6 +15,7 @@ import { CategoryMenu } from './modals/CategoryMenu';
 import { CloseAccount } from './modals/CloseAccount';
 import { ConfirmCategoryDelete } from './modals/ConfirmCategoryDelete';
 import { ConfirmTransactionEdit } from './modals/ConfirmTransactionEdit';
+import { ConfirmUnlinkAccount } from './modals/ConfirmUnlinkAccount';
 import { CreateAccount } from './modals/CreateAccount';
 import { CreateEncryptionKey } from './modals/CreateEncryptionKey';
 import { CreateLocalAccount } from './modals/CreateLocalAccount';
@@ -123,6 +124,15 @@ export function Modals() {
               category={options.category}
               group={options.group}
               onDelete={options.onDelete}
+            />
+          );
+
+        case 'confirm-unlink-account':
+          return (
+            <ConfirmUnlinkAccount
+              modalProps={modalProps}
+              accountName={options.accountName}
+              onUnlink={options.onUnlink}
             />
           );
 

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -590,7 +590,12 @@ class AccountInternal extends PureComponent {
         });
         break;
       case 'unlink':
-        this.props.unlinkAccount(accountId);
+        this.props.pushModal('confirm-unlink-account', {
+          accountName: account.name,
+          onUnlink: () => {
+            this.props.unlinkAccount(accountId);
+          },
+        });
         break;
       case 'close':
         this.props.openAccountCloseModal(accountId);

--- a/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
@@ -1,0 +1,57 @@
+// @ts-strict-ignore
+import React from 'react';
+
+import { Button } from '../common/Button';
+import { Modal } from '../common/Modal';
+import { Paragraph } from '../common/Paragraph';
+import { View } from '../common/View';
+import { type CommonModalProps } from '../Modals';
+
+type ConfirmUnlinkAccountProps = {
+  modalProps: CommonModalProps;
+  accountName: string,
+  onUnlink: () => void;
+};
+
+export function ConfirmUnlinkAccount({
+  modalProps,
+  accountName,
+  onUnlink,
+}: ConfirmUnlinkAccountProps) {
+  return (
+    <Modal title="Confirm Unlink" {...modalProps} style={{ flex: 0 }}>
+      {() => (
+        <View style={{ lineHeight: 1.5 }}>
+          <Paragraph>
+            Are you sure you want to unlink <strong>{accountName}</strong>?
+          </Paragraph>
+
+          <Paragraph>
+            Transactions will no longer be synchronized with this account
+            and must be manually entered.
+          </Paragraph>
+
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'flex-end',
+            }}
+          >
+            <Button style={{ marginRight: 10 }} onClick={modalProps.onClose}>
+              Cancel
+            </Button>
+            <Button
+              type="primary"
+              onClick={() => {
+                onUnlink();
+                modalProps.onClose();
+              }}
+            >
+              Unlink
+            </Button>
+          </View>
+        </View>
+      )}
+    </Modal>
+  );
+}

--- a/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import React from 'react';
 
 import { Button } from '../common/Button';

--- a/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmUnlinkAccount.tsx
@@ -9,7 +9,7 @@ import { type CommonModalProps } from '../Modals';
 
 type ConfirmUnlinkAccountProps = {
   modalProps: CommonModalProps;
-  accountName: string,
+  accountName: string;
   onUnlink: () => void;
 };
 
@@ -27,8 +27,8 @@ export function ConfirmUnlinkAccount({
           </Paragraph>
 
           <Paragraph>
-            Transactions will no longer be synchronized with this account
-            and must be manually entered.
+            Transactions will no longer be synchronized with this account and
+            must be manually entered.
           </Paragraph>
 
           <View

--- a/upcoming-release-notes/2441.md
+++ b/upcoming-release-notes/2441.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Show a modal to confirm unlinking accounts.


### PR DESCRIPTION
This PR fixes #2440 by adding a modal that shows whenever someone clicks "Unlink account" from the account menu.  The modal will confirm if they want to unlink and provide and option to cancel.