### PR TITLE
Show scheduled transactions when viewing "All accounts"

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1635,10 +1635,11 @@ export function Account() {
       q = q.filter({
         $and: [{ '_account.closed': false }],
       });
-      if (params.id)
+      if (params.id) {
         q = q.filter({
           $or: [filterByAccount, filterByPayee],
         });
+      }
       return q.orderBy({ next_date: 'desc' });
     };
   }, [params.id]);

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1634,8 +1634,11 @@ export function Account() {
     return q => {
       q = q.filter({
         $and: [{ '_account.closed': false }],
-        $or: [filterByAccount, filterByPayee],
       });
+      if (params.id)
+        q = q.filter({
+          $or: [filterByAccount, filterByPayee],
+        });
       return q.orderBy({ next_date: 'desc' });
     };
   }, [params.id]);

--- a/upcoming-release-notes/2447.md
+++ b/upcoming-release-notes/2447.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [psybers]
+---
+
+Show scheduled transactions when viewing "All accounts"


### PR DESCRIPTION
This fixes #2397 by having scheduled transactions also show when on the "All accounts" page.

A side effect is it also fixed the issue of past transactions that are linked to schedules not showing the schedule icon.