### PR TITLE
Fix budget key tab navigation

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.jsx
@@ -268,8 +268,10 @@ class BudgetTableInner extends Component {
 
 const mapStateToProps = state => {
   const { grouped: categoryGroups } = state.queries.categories;
+  const collapsed = state.prefs.local?.['budget.collapsed'] || [];
   return {
     categoryGroups,
+    collapsed,
   };
 };
 

--- a/upcoming-release-notes/2452.md
+++ b/upcoming-release-notes/2452.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix budget key tab navigation.


### PR DESCRIPTION
- restore the collapsed property

Fixes: https://github.com/actualbudget/actual/issues/2430

Followup to: https://github.com/actualbudget/actual/pull/2293
