### PR TITLE
Fix midnight theme autocomplete hover

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -75,20 +75,20 @@ function CategoryList({
           }
 
           const showGroup = item.cat_group !== lastGroup;
+          const title = `${item.group.name}${item.group.hidden ? ' (hidden)' : ''}`;
           lastGroup = item.cat_group;
           return (
             <Fragment key={item.id}>
               {showGroup && item.group?.name && (
                 <Fragment key={item.group.name}>
                   {renderCategoryItemGroupHeader({
-                    title: item.group.name,
+                    title,
                     style: {
                       color:
                         showHiddenItems && item.group?.hidden
                           ? theme.pageTextSubdued
                           : theme.menuAutoCompleteTextHeader,
                     },
-                    item: item.group,
                   })}
                 </Fragment>
               )}

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -75,14 +75,14 @@ function CategoryList({
           }
 
           const showGroup = item.cat_group !== lastGroup;
-          const title = `${item.group.name}${item.group.hidden ? ' (hidden)' : ''}`;
+          const groupName = `${item.group.name}${item.group.hidden ? ' (hidden)' : ''}`;
           lastGroup = item.cat_group;
           return (
             <Fragment key={item.id}>
               {showGroup && item.group?.name && (
                 <Fragment key={item.group.name}>
                   {renderCategoryItemGroupHeader({
-                    title,
+                    title: groupName,
                     style: {
                       color:
                         showHiddenItems && item.group?.hidden

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -75,7 +75,7 @@ function CategoryList({
           }
 
           const showGroup = item.cat_group !== lastGroup;
-          const groupName = `${item.group.name}${item.group.hidden ? ' (hidden)' : ''}`;
+          const groupName = `${item.group?.name}${item.group?.hidden ? ' (hidden)' : ''}`;
           lastGroup = item.cat_group;
           return (
             <Fragment key={item.id}>

--- a/packages/desktop-client/src/components/autocomplete/ItemHeader.tsx
+++ b/packages/desktop-client/src/components/autocomplete/ItemHeader.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';
-
 import { theme } from '../../style/theme';
 import { type CSSProperties } from '../../style/types';
 
@@ -9,16 +7,9 @@ export type ItemHeaderProps = {
   title: string;
   style?: CSSProperties;
   type?: string;
-  item?: CategoryGroupEntity;
 };
 
-export function ItemHeader({
-  title,
-  style,
-  type,
-  item,
-  ...props
-}: ItemHeaderProps) {
+export function ItemHeader({ title, style, type, ...props }: ItemHeaderProps) {
   return (
     <div
       style={{
@@ -30,7 +21,6 @@ export function ItemHeader({
       {...props}
     >
       {title}
-      {item?.hidden ? ' (hidden)' : null}
     </div>
   );
 }

--- a/packages/desktop-client/src/style/themes/midnight.ts
+++ b/packages/desktop-client/src/style/themes/midnight.ts
@@ -58,7 +58,7 @@ export const menuBorder = colorPalette.gray800;
 export const menuBorderHover = colorPalette.purple300;
 export const menuKeybindingText = colorPalette.gray500;
 export const menuAutoCompleteBackground = colorPalette.gray600;
-export const menuAutoCompleteBackgroundHover = colorPalette.gray400;
+export const menuAutoCompleteBackgroundHover = colorPalette.gray300;
 export const menuAutoCompleteText = colorPalette.gray100;
 export const menuAutoCompleteTextHeader = colorPalette.purple200;
 

--- a/upcoming-release-notes/2461.md
+++ b/upcoming-release-notes/2461.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix midnight theme autocomplete hover color.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Also thrown in a change to make ItemHeader component not depend on category groups as it's also used by other types of autocomplete components

Before:
![image](https://github.com/actualbudget/actual/assets/20313680/d3bdca6c-613b-49e2-a6e4-0cf58058a60a)

After:
![image](https://github.com/actualbudget/actual/assets/20313680/2f515cab-295d-4bcc-9997-0adcfd93eebc)
