### PR TITLE
Fix error when viewing uncategorized transactions when there are upcoming scheduled transactions.

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1641,9 +1641,13 @@ export function Account() {
         $and: [{ '_account.closed': false }],
       });
       if (params.id) {
-        q = q.filter({
-          $or: [filterByAccount, filterByPayee],
-        });
+        if (params.id === 'uncategorized') {
+          q = q.filter({ 'next_date': null });
+        } else {
+          q = q.filter({
+            $or: [filterByAccount, filterByPayee],
+          });
+        }
       }
       return q.orderBy({ next_date: 'desc' });
     };

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1642,7 +1642,7 @@ export function Account() {
       });
       if (params.id) {
         if (params.id === 'uncategorized') {
-          q = q.filter({ 'next_date': null });
+          q = q.filter({ next_date: null });
         } else {
           q = q.filter({
             $or: [filterByAccount, filterByPayee],

--- a/upcoming-release-notes/2475.md
+++ b/upcoming-release-notes/2475.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [psybers]
+---
+
+Fix error when viewing uncategorized transactions when there are upcoming scheduled transactions.


### PR DESCRIPTION
This fixes #2454 so that when viewing uncategorized transactions, it does not attempt to show any upcoming scheduled transactions.  The error message goes away, and no upcoming transactions are shown.