### PR TITLE
feature: Show account sync indicators when viewing accounts on mobile

### DIFF
--- a/packages/desktop-client/src/components/mobile/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Account.jsx
@@ -78,6 +78,9 @@ export function Account(props) {
   const accounts = useAccounts();
   const payees = usePayees();
 
+  const failedAccounts = useFailedAccounts();
+  const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
+
   const navigate = useNavigate();
   const [transactions, setTransactions] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -225,11 +228,6 @@ export function Account(props) {
   const balance = queries.accountBalance(account);
   const balanceCleared = queries.accountBalanceCleared(account);
   const balanceUncleared = queries.accountBalanceUncleared(account);
-
-  const failedAccounts = useFailedAccounts();
-  const syncingAccountIds = useSelector(
-    (state) => state.account.accountsSyncing,
-  );
 
   return (
     <SchedulesProvider

--- a/packages/desktop-client/src/components/mobile/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Account.jsx
@@ -21,6 +21,7 @@ import {
 import { useAccounts } from '../../../hooks/useAccounts';
 import { useCategories } from '../../../hooks/useCategories';
 import { useDateFormat } from '../../../hooks/useDateFormat';
+import { useFailedAccounts } from '../../../hooks/useFailedAccounts';
 import { useLocalPref } from '../../../hooks/useLocalPref';
 import { useLocalPrefs } from '../../../hooks/useLocalPrefs';
 import { useNavigate } from '../../../hooks/useNavigate';
@@ -225,6 +226,11 @@ export function Account(props) {
   const balanceCleared = queries.accountBalanceCleared(account);
   const balanceUncleared = queries.accountBalanceUncleared(account);
 
+  const failedAccounts = useFailedAccounts();
+  const syncingAccountIds = useSelector(
+    (state) => state.account.accountsSyncing,
+  );
+
   return (
     <SchedulesProvider
       transform={getSchedulesTransform(accountId, isSearching)}
@@ -238,6 +244,8 @@ export function Account(props) {
               {...state}
               key={numberFormat + hideFraction}
               account={account}
+              pending={syncingAccountIds.includes(account.id)}
+              failed={failedAccounts && failedAccounts.has(account.id)}
               accounts={accounts}
               categories={categories.list}
               payees={state.payees}

--- a/packages/desktop-client/src/components/mobile/accounts/AccountDetails.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountDetails.jsx
@@ -66,6 +66,8 @@ function TransactionSearchInput({ accountName, onSearch }) {
 
 export function AccountDetails({
   account,
+  pending,
+  failed,
   prependTransactions,
   transactions,
   accounts,
@@ -90,7 +92,30 @@ export function AccountDetails({
 
   return (
     <Page
-      title={account.name}
+      title={
+          !account.bankId ? account.name :
+            <View
+              style={{
+                flexDirection: 'row',
+              }}>
+              <div
+                style={{
+                  margin: 'auto',
+                  marginRight: 3,
+                  width: 8,
+                  height: 8,
+                  borderRadius: 8,
+                  backgroundColor: pending
+                    ? theme.sidebarItemBackgroundPending
+                    : failed
+                      ? theme.sidebarItemBackgroundFailed
+                      : theme.sidebarItemBackgroundPositive,
+                  transition: 'transform .3s',
+                }}
+              />
+              {account.name}
+            </View>
+      }
       headerLeftContent={<MobileBackButton />}
       headerRightContent={
         <ButtonLink

--- a/packages/desktop-client/src/components/mobile/accounts/AccountDetails.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountDetails.jsx
@@ -93,28 +93,32 @@ export function AccountDetails({
   return (
     <Page
       title={
-          !account.bankId ? account.name :
-            <View
+        !account.bankId ? (
+          account.name
+        ) : (
+          <View
+            style={{
+              flexDirection: 'row',
+            }}
+          >
+            <div
               style={{
-                flexDirection: 'row',
-              }}>
-              <div
-                style={{
-                  margin: 'auto',
-                  marginRight: 3,
-                  width: 8,
-                  height: 8,
-                  borderRadius: 8,
-                  backgroundColor: pending
-                    ? theme.sidebarItemBackgroundPending
-                    : failed
-                      ? theme.sidebarItemBackgroundFailed
-                      : theme.sidebarItemBackgroundPositive,
-                  transition: 'transform .3s',
-                }}
-              />
-              {account.name}
-            </View>
+                margin: 'auto',
+                marginRight: 3,
+                width: 8,
+                height: 8,
+                borderRadius: 8,
+                backgroundColor: pending
+                  ? theme.sidebarItemBackgroundPending
+                  : failed
+                    ? theme.sidebarItemBackgroundFailed
+                    : theme.sidebarItemBackgroundPositive,
+                transition: 'transform .3s',
+              }}
+            />
+            {account.name}
+          </View>
+        )
       }
       headerLeftContent={<MobileBackButton />}
       headerRightContent={

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -5,6 +5,7 @@ import { replaceModal, syncAndDownload } from 'loot-core/src/client/actions';
 import * as queries from 'loot-core/src/client/queries';
 
 import { useAccounts } from '../../../hooks/useAccounts';
+import { useFailedAccounts } from '../../../hooks/useFailedAccounts';
 import { useCategories } from '../../../hooks/useCategories';
 import { useLocalPref } from '../../../hooks/useLocalPref';
 import { useNavigate } from '../../../hooks/useNavigate';
@@ -54,7 +55,7 @@ function AccountHeader({ name, amount, style = {} }) {
   );
 }
 
-function AccountCard({ account, updated, getBalanceQuery, onSelect }) {
+function AccountCard({ account, updated, connected, pending, failed, getBalanceQuery, onSelect }) {
   return (
     <View
       style={{
@@ -97,11 +98,16 @@ function AccountCard({ account, updated, getBalanceQuery, onSelect }) {
             {account.bankId && (
               <View
                 style={{
-                  backgroundColor: theme.noticeBackgroundDark,
+                  backgroundColor: pending
+                    ? theme.sidebarItemBackgroundPending
+                    : failed
+                      ? theme.sidebarItemBackgroundFailed
+                      : theme.sidebarItemBackgroundPositive,
                   marginRight: '8px',
                   width: 8,
                   height: 8,
                   borderRadius: 8,
+                  opacity: connected ? 1 : 0,
                 }}
               />
             )}
@@ -153,6 +159,10 @@ function AccountList({
   onSelectAccount,
   onSync,
 }) {
+  const failedAccounts = useFailedAccounts();
+  const syncingAccountIds = useSelector(
+    (state) => state.account.accountsSyncing,
+  );
   const budgetedAccounts = accounts.filter(account => account.offbudget === 0);
   const offbudgetAccounts = accounts.filter(account => account.offbudget === 1);
   const noBackgroundColorStyle = {
@@ -194,7 +204,10 @@ function AccountList({
             <AccountCard
               account={acct}
               key={acct.id}
-              updated={updatedAccounts.includes(acct.id)}
+              updated={updatedAccounts && updatedAccounts.includes(acct.id)}
+              connected={!!acct.bank}
+              pending={syncingAccountIds.includes(acct.id)}
+              failed={failedAccounts && failedAccounts.has(acct.id)}
               getBalanceQuery={getBalanceQuery}
               onSelect={onSelectAccount}
             />
@@ -211,7 +224,10 @@ function AccountList({
             <AccountCard
               account={acct}
               key={acct.id}
-              updated={updatedAccounts.includes(acct.id)}
+              updated={updatedAccounts && updatedAccounts.includes(acct.id)}
+              connected={!!acct.bank}
+              pending={syncingAccountIds.includes(acct.id)}
+              failed={failedAccounts && failedAccounts.has(acct.id)}
               getBalanceQuery={getBalanceQuery}
               onSelect={onSelectAccount}
             />

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -94,6 +94,17 @@ function AccountCard({ account, updated, getBalanceQuery, onSelect }) {
               alignItems: 'center',
             }}
           >
+            {account.bankId && (
+              <View
+                style={{
+                  backgroundColor: theme.noticeBackgroundDark,
+                  marginRight: '8px',
+                  width: 8,
+                  height: 8,
+                  borderRadius: 8,
+                }}
+              />
+            )}
             <TextOneLine
               style={{
                 ...styles.text,
@@ -106,17 +117,6 @@ function AccountCard({ account, updated, getBalanceQuery, onSelect }) {
             >
               {account.name}
             </TextOneLine>
-            {account.bankId && (
-              <View
-                style={{
-                  backgroundColor: theme.noticeBackgroundDark,
-                  marginLeft: '-23px',
-                  width: 8,
-                  height: 8,
-                  borderRadius: 8,
-                }}
-              />
-            )}
           </View>
         </View>
         <CellValue

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -5,8 +5,8 @@ import { replaceModal, syncAndDownload } from 'loot-core/src/client/actions';
 import * as queries from 'loot-core/src/client/queries';
 
 import { useAccounts } from '../../../hooks/useAccounts';
-import { useFailedAccounts } from '../../../hooks/useFailedAccounts';
 import { useCategories } from '../../../hooks/useCategories';
+import { useFailedAccounts } from '../../../hooks/useFailedAccounts';
 import { useLocalPref } from '../../../hooks/useLocalPref';
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useSetThemeColor } from '../../../hooks/useSetThemeColor';
@@ -55,7 +55,15 @@ function AccountHeader({ name, amount, style = {} }) {
   );
 }
 
-function AccountCard({ account, updated, connected, pending, failed, getBalanceQuery, onSelect }) {
+function AccountCard({
+  account,
+  updated,
+  connected,
+  pending,
+  failed,
+  getBalanceQuery,
+  onSelect,
+}) {
   return (
     <View
       style={{
@@ -160,9 +168,7 @@ function AccountList({
   onSync,
 }) {
   const failedAccounts = useFailedAccounts();
-  const syncingAccountIds = useSelector(
-    (state) => state.account.accountsSyncing,
-  );
+  const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
   const budgetedAccounts = accounts.filter(account => account.offbudget === 0);
   const offbudgetAccounts = accounts.filter(account => account.offbudget === 1);
   const noBackgroundColorStyle = {

--- a/upcoming-release-notes/2476.md
+++ b/upcoming-release-notes/2476.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Show account sync indicators when viewing accounts on mobile.


### PR DESCRIPTION
This is a first attempt at fixing #2473.  It adds account sync indicators to the account details page when on mobile:

<img width="410" alt="image" src="https://github.com/actualbudget/actual/assets/1115390/d1589eb6-f4cb-4a33-967b-32c1d355e647">

It also does a few tweaks to how the sync indicators are handled on mobile:

- It left-aligns the indicators, so they are in a column. This mimics the non-mobile behavior.
- It updates them to show failed/pending status (currently it always shows green).
- It updates to use the same theme colors as the non-mobile indicators.

<img width="103" alt="image" src="https://github.com/actualbudget/actual/assets/1115390/f8f2a0ca-d590-495e-8961-c928b8a43157">
