### PR TITLE
:bug: (report) do not include offbudget transfers in cash-flow card expenses

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -19,12 +19,7 @@ export function simpleCashFlow(start, end) {
         .filter({
           $and: [{ date: { $gte: start } }, { date: { $lte: end } }],
           'account.offbudget': false,
-          $or: [
-            {
-              'payee.transfer_acct.offbudget': true,
-              'payee.transfer_acct': null,
-            },
-          ],
+          'payee.transfer_acct': null,
         })
         .calculate({ $sum: '$amount' });
     }

--- a/upcoming-release-notes/2485.md
+++ b/upcoming-release-notes/2485.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Do not include off-budget transfers in the expenses calculation for cash-flow card (align it with the cash-flow reports page).


### PR DESCRIPTION
Closes #2237

Do not include off-budget transfers in the "expenses" in the cash flow card
<img width="361" alt="Screenshot 2024-03-21 at 18 58 09" src="https://github.com/actualbudget/actual/assets/886567/4d9e220f-62f3-4d02-ac09-5d8c0879b458">

Demo budget file: 
[2024-03-21-_test-budget.zip](https://github.com/actualbudget/actual/files/14705805/2024-03-21-_test-budget.zip)
