### PR TITLE
:bug: (import) disallow importing transactions with too large or small amounts

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -6,7 +6,6 @@ import { format as formatDate_ } from 'loot-core/src/shared/months';
 import {
   amountToCurrency,
   amountToInteger,
-  isSafeNumber,
   looselyParseAmount,
 } from 'loot-core/src/shared/util';
 

--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -397,10 +397,12 @@ function Transaction({
             contentStyle={{
               textAlign: 'right',
               ...styles.tnum,
-              ...(outflow === null ? { color: theme.errorText } : {}),
+              ...(inflow === null && outflow === null
+                ? { color: theme.errorText }
+                : {}),
             }}
             title={
-              outflow === null
+              inflow === null && outflow === null
                 ? 'Invalid: unable to parse the value'
                 : amountToCurrency(outflow)
             }
@@ -412,10 +414,12 @@ function Transaction({
             contentStyle={{
               textAlign: 'right',
               ...styles.tnum,
-              ...(inflow === null ? { color: theme.errorText } : {}),
+              ...(inflow === null && outflow === null
+                ? { color: theme.errorText }
+                : {}),
             }}
             title={
-              inflow === null
+              inflow === null && outflow === null
                 ? 'Invalid: unable to parse the value'
                 : amountToCurrency(inflow)
             }

--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -6,6 +6,7 @@ import { format as formatDate_ } from 'loot-core/src/shared/months';
 import {
   amountToCurrency,
   amountToInteger,
+  isSafeNumber,
   looselyParseAmount,
 } from 'loot-core/src/shared/util';
 
@@ -248,14 +249,19 @@ function applyFieldMappings(transaction, mappings) {
   return result;
 }
 
-function parseAmount(amount, mapper) {
+function parseAmount(amount, mapper, multiplier) {
   if (amount == null) {
     return null;
   }
+
   const parsed =
     typeof amount === 'string' ? looselyParseAmount(amount) : amount;
-  const value = mapper(parsed);
-  return value;
+
+  if (parsed === null) {
+    return null;
+  }
+
+  return mapper(parsed) * multiplier;
 }
 
 function parseAmountFields(
@@ -272,10 +278,10 @@ function parseAmountFields(
     // Split mode is a little weird; first we look for an outflow and
     // if that has a value, we never want to show a number in the
     // inflow. Same for `amount`; we choose outflow first and then inflow
-    const outflow = parseAmount(trans.outflow, n => -Math.abs(n)) * multiplier;
+    const outflow = parseAmount(trans.outflow, n => -Math.abs(n), multiplier);
     const inflow = outflow
       ? 0
-      : parseAmount(trans.inflow, n => Math.abs(n)) * multiplier;
+      : parseAmount(trans.inflow, n => Math.abs(n), multiplier);
 
     return {
       amount: outflow || inflow,
@@ -285,17 +291,21 @@ function parseAmountFields(
   }
   if (inOutMode) {
     return {
-      amount:
-        parseAmount(trans.amount, n =>
-          trans.inOut === outValue ? Math.abs(n) * -1 : Math.abs(n),
-        ) * multiplier,
+      amount: parseAmount(
+        trans.amount,
+        n => (trans.inOut === outValue ? Math.abs(n) * -1 : Math.abs(n)),
+        multiplier,
+      ),
       outflow: null,
       inflow: null,
     };
   }
   return {
-    amount:
-      parseAmount(trans.amount, n => (flipAmount ? n * -1 : n)) * multiplier,
+    amount: parseAmount(
+      trans.amount,
+      n => (flipAmount ? n * -1 : n),
+      multiplier,
+    ),
     outflow: null,
     inflow: null,
   };
@@ -336,7 +346,7 @@ function Transaction({
     [rawTransaction, fieldMappings],
   );
 
-  let { amount, outflow, inflow } = parseAmountFields(
+  const { amount, outflow, inflow } = parseAmountFields(
     transaction,
     splitMode,
     inOutMode,
@@ -344,9 +354,6 @@ function Transaction({
     flipAmount,
     multiplierAmount,
   );
-  amount = amountToCurrency(amount);
-  outflow = amountToCurrency(outflow);
-  inflow = amountToCurrency(inflow);
 
   return (
     <Row
@@ -388,17 +395,33 @@ function Transaction({
         <>
           <Field
             width={90}
-            contentStyle={{ textAlign: 'right', ...styles.tnum }}
-            title={outflow}
+            contentStyle={{
+              textAlign: 'right',
+              ...styles.tnum,
+              ...(outflow === null ? { color: theme.errorText } : {}),
+            }}
+            title={
+              outflow === null
+                ? 'Invalid: unable to parse the value'
+                : amountToCurrency(outflow)
+            }
           >
-            {outflow}
+            {amountToCurrency(outflow)}
           </Field>
           <Field
             width={90}
-            contentStyle={{ textAlign: 'right', ...styles.tnum }}
-            title={inflow}
+            contentStyle={{
+              textAlign: 'right',
+              ...styles.tnum,
+              ...(inflow === null ? { color: theme.errorText } : {}),
+            }}
+            title={
+              inflow === null
+                ? 'Invalid: unable to parse the value'
+                : amountToCurrency(inflow)
+            }
           >
-            {inflow}
+            {amountToCurrency(inflow)}
           </Field>
         </>
       ) : (
@@ -414,10 +437,18 @@ function Transaction({
           )}
           <Field
             width={90}
-            contentStyle={{ textAlign: 'right', ...styles.tnum }}
-            title={amount}
+            contentStyle={{
+              textAlign: 'right',
+              ...styles.tnum,
+              ...(amount === null ? { color: theme.errorText } : {}),
+            }}
+            title={
+              amount === null
+                ? `Invalid: unable to parse the value (${transaction.amount})`
+                : amountToCurrency(amount)
+            }
           >
-            {amount}
+            {amountToCurrency(amount)}
           </Field>
         </>
       )}

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -290,6 +290,14 @@ export function getNumberFormat({
 const MAX_SAFE_NUMBER = 2 ** 51 - 1;
 const MIN_SAFE_NUMBER = -MAX_SAFE_NUMBER;
 
+export function isSafeNumber(value: number): boolean {
+  try {
+    safeNumber(value);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
 export function safeNumber(value: number) {
   if (!Number.isInteger(value)) {
     throw new Error(
@@ -359,7 +367,8 @@ export function integerToAmount(n) {
 // currencies. We extract out the numbers and just ignore separators.
 export function looselyParseAmount(amount: string) {
   function safeNumber(v: number): null | number {
-    return isNaN(v) ? null : v;
+    if (isSafeNumber(v)) return v;
+    return null;
   }
 
   function extractNumbers(v: string): string {

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -290,14 +290,6 @@ export function getNumberFormat({
 const MAX_SAFE_NUMBER = 2 ** 51 - 1;
 const MIN_SAFE_NUMBER = -MAX_SAFE_NUMBER;
 
-export function isSafeNumber(value: number): boolean {
-  try {
-    safeNumber(value);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
 export function safeNumber(value: number) {
   if (!Number.isInteger(value)) {
     throw new Error(
@@ -367,8 +359,16 @@ export function integerToAmount(n) {
 // currencies. We extract out the numbers and just ignore separators.
 export function looselyParseAmount(amount: string) {
   function safeNumber(v: number): null | number {
-    if (isSafeNumber(v)) return v;
-    return null;
+    if (isNaN(v)) {
+      return null;
+    }
+
+    const value = v * 100;
+    if (value > MAX_SAFE_NUMBER || value < MIN_SAFE_NUMBER) {
+      return null;
+    }
+
+    return v;
   }
 
   function extractNumbers(v: string): string {

--- a/upcoming-release-notes/2494.md
+++ b/upcoming-release-notes/2494.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix: disallow importing with invalid transaction amounts (that would result in the app crashing without a way to recover).


### PR DESCRIPTION
Closes #1811

Disallow importing transactions with too large or too small amounts. These transactions are poison pills. We allow to import them, but afterwards they crash the app with no way to recover. So now it will no longer be possible to import with poison pill amounts.

<img width="962" alt="Screenshot 2024-03-23 at 10 46 10" src="https://github.com/actualbudget/actual/assets/886567/1f01dfce-7642-4a8a-979e-8fb0c4c6d750">
