### PR TITLE
Bump GoCardless access validity from 30 to 90 days

### DIFF
--- a/packages/desktop-client/src/gocardless.ts
+++ b/packages/desktop-client/src/gocardless.ts
@@ -18,7 +18,7 @@ function _authorize(
       const resp = await send('gocardless-create-web-token', {
         upgradingAccountId,
         institutionId,
-        accessValidForDays: 30,
+        accessValidForDays: 90,
       });
 
       if ('error' in resp) return resp;

--- a/upcoming-release-notes/2518.md
+++ b/upcoming-release-notes/2518.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyrias]
+---
+
+Bump GoCardless access validity from 30 to 90 days.


### PR DESCRIPTION
All banks are supposed to provide at least 90 days of access.

As of July 2023 EEA banks are required to allow access for up to 180 days[0], but this does not apply to UK banks, and apparently there might still be EEA banks which don't comply with the new regulations.

We should consider eventually defaulting to 180 days and allowing per-bank and maybe per-country overrides, but bumping it to 90 days immediately provides a better user experience.

  [0]: https://nordigen.zendesk.com/hc/en-gb/articles/13239212055581-EEA-180-day-access

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
