### PR TITLE
:chart_with_upwards_trend: adding extra console.log lines for bank-sync to help with troubleshooting

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -185,6 +185,8 @@ async function downloadGoCardlessTransactions(
   const userToken = await asyncStorage.getItem('user-token');
   if (!userToken) return;
 
+  console.log('Pulling transactions from GoCardless');
+
   const res = await post(
     getServer().GOCARDLESS_SERVER + '/transactions',
     {
@@ -209,6 +211,8 @@ async function downloadGoCardlessTransactions(
     startingBalance,
   } = res;
 
+  console.log('Response:', res);
+
   return {
     transactions: all,
     accountBalance: balances,
@@ -219,6 +223,8 @@ async function downloadGoCardlessTransactions(
 async function downloadSimpleFinTransactions(acctId, since) {
   const userToken = await asyncStorage.getItem('user-token');
   if (!userToken) return;
+
+  console.log('Pulling transactions from SimpleFin');
 
   const res = await post(
     getServer().SIMPLEFIN_SERVER + '/transactions',
@@ -240,6 +246,8 @@ async function downloadSimpleFinTransactions(acctId, since) {
     balances,
     startingBalance,
   } = res;
+
+  console.log('Response:', res);
 
   return {
     transactions: all,
@@ -430,6 +438,8 @@ async function createNewPayees(payeesToCreate, addsAndUpdates) {
 }
 
 export async function reconcileExternalTransactions(acctId, transactions) {
+  console.log('Performing transaction reconciliation');
+
   const hasMatched = new Set();
   const updated = [];
   const added = [];
@@ -605,6 +615,14 @@ export async function reconcileExternalTransactions(acctId, transactions) {
 
   await createNewPayees(payeesToCreate, [...added, ...updated]);
   await batchUpdateTransactions({ added, updated });
+
+  console.log('Debug data for the operations:', {
+    transactionsStep1,
+    transactionsStep2,
+    transactionsStep3,
+    added,
+    updated,
+  });
 
   return {
     added: added.map(trans => trans.id),

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1287,6 +1287,7 @@ handlers['gocardless-accounts-sync'] = async function ({ id }) {
     const acct = accounts[i];
     if (acct.bankId) {
       try {
+        console.group('Bank Sync operation');
         const res = await bankSync.syncExternalAccount(
           userId,
           userKey,
@@ -1294,6 +1295,8 @@ handlers['gocardless-accounts-sync'] = async function ({ id }) {
           acct.account_id,
           acct.bankId,
         );
+        console.groupEnd();
+
         const { added, updated } = res;
 
         newTransactions = newTransactions.concat(added);

--- a/upcoming-release-notes/2529.md
+++ b/upcoming-release-notes/2529.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Adding extra `console.log` lines to the bank-sync operation to improve troubleshooting


### PR DESCRIPTION
We keep getting many bug reports about gocardless/simplefin. And in most cases (or ALL cases?) they are not legitimate issues in Actual, but it's hard to troubleshoot and help without some more debug information.

So this PR adds a few more console.log lines to ease the troubleshooting process.

<img width="603" alt="Screenshot 2024-03-30 at 21 03 58" src="https://github.com/actualbudget/actual/assets/886567/c5fb75c2-2fa8-467b-9864-19bf8ff635da">
