### PR TITLE
Goals: Up To Template calculation with negative category balance

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSimple.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSimple.ts
@@ -8,7 +8,7 @@ export async function goalsSimple(
   limit,
   hold,
   to_budget,
-  balance,
+  last_month_balance,
 ) {
   // simple has 'monthly' and/or 'limit' params
   if (template.limit != null) {
@@ -26,7 +26,7 @@ export async function goalsSimple(
     const monthly = amountToInteger(template.monthly);
     increment = monthly;
   } else {
-    increment = limit - balance;
+    increment = limit - last_month_balance;
   }
   to_budget += increment;
   return { to_budget, errors, limit, limitCheck, hold };

--- a/packages/loot-core/src/server/budget/goals/goalsSimple.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSimple.ts
@@ -8,6 +8,7 @@ export async function goalsSimple(
   limit,
   hold,
   to_budget,
+  balance,
 ) {
   // simple has 'monthly' and/or 'limit' params
   if (template.limit != null) {
@@ -25,7 +26,7 @@ export async function goalsSimple(
     const monthly = amountToInteger(template.monthly);
     increment = monthly;
   } else {
-    increment = limit;
+    increment = limit - balance;
   }
   to_budget += increment;
   return { to_budget, errors, limit, limitCheck, hold };

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -513,7 +513,7 @@ async function applyCategoryTemplate(
           limit,
           hold,
           to_budget,
-          balance,
+          last_month_balance,
         );
         to_budget = goalsReturn.to_budget;
         errors = goalsReturn.errors;

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -513,6 +513,7 @@ async function applyCategoryTemplate(
           limit,
           hold,
           to_budget,
+          balance,
         );
         to_budget = goalsReturn.to_budget;
         errors = goalsReturn.errors;

--- a/upcoming-release-notes/2535.md
+++ b/upcoming-release-notes/2535.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Goal templates: Allow budgeting to a full category balance when using 'up to' and a negative category rollover balance.


### PR DESCRIPTION
If using a template such as #template up to 1000, the budgeted amount would not reach 1000 if a negative balance was rolled over from the previous month. This change allows for rolling over a negative balance from a previous month.

I've tested 3 scenarios:
Category balance of -500. Budgeted amount is 1500.
Category balance of 0. Budgeted amount is 1000.
Category balance of 500. Budgeted amount is 500.

All scenarios result in a final category balance of 1000, which I believe is the expected behavior of 'up to'.

Discord report: https://discord.com/channels/937901803608096828/1223925566583865354/1223925566583865354