### PR TITLE
Mobile auto decimal

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.jsx
@@ -69,6 +69,14 @@ const AmountInput = memo(function AmountInput({
   };
 
   const onChangeText = text => {
+    if (text.slice(-1) == '.') {
+        text = text.slice(0, -1);
+    }
+    text = text.replaceAll(/[,.]/g, "");
+    text = text.replace(/^0+(?!$)/, "");
+    text = text.padStart(3, '0');
+    text = text.slice(0, -2) + '.' + text.slice(-2);
+
     setEditing(true);
     setText(text);
     props.onChange?.(text);
@@ -108,7 +116,7 @@ const AmountInput = memo(function AmountInput({
         data-testid="amount-fake-input"
         pointerEvents="none"
       >
-        {editing ? text : amountToCurrency(value)}
+        {editing ? amountToCurrency(text) : amountToCurrency(value)}
       </Text>
     </View>
   );

--- a/upcoming-release-notes/2536.md
+++ b/upcoming-release-notes/2536.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ilar]
+---
+
+When adding a transaction in mobile view, periods and commas are displayed while editing to keep values easier to read and prevent typos. Additionally, the decimal spot is automatically populated as you type, preventing typos like "5326" instead of "53.26" and speeding/easing input.


### PR DESCRIPTION
This PR is to add the functionality from #1509 for mobile transactions, as well as display formatting while in the process of editing to improve readability.

The functionality from 1509 is intended to prevent typos and speed up/ease input on phones by pre-populating the decimal in the third position from the right, much as other budget software does like YNAB does.

As I am unfamiliar with the codebase, I am unsure how well this internationalizes and welcome feedback- I don't know what I don't know, in this case.