### PR TITLE
Show/hide reconciled transactions in the account view

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -362,7 +362,7 @@ class AccountInternal extends PureComponent {
 
     // Filter out reconciled transactions if necessary.
     if (!this.state.showReconciled) {
-      query = query.filter({ reconciled: { $eq: false } })
+      query = query.filter({ reconciled: { $eq: false } });
     }
 
     this.paged = pagedQuery(

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -659,20 +659,16 @@ class AccountInternal extends PureComponent {
         }
         break;
       case 'toggle-reconciled':
-        const refilterTransactions = () => {
-          const filters = this.state.filters;
-          if (filters.length > 0) {
-            this.applyFilters([...filters]);
-          } else {
-            this.fetchTransactions();
-          }
-        };
         if (this.state.showReconciled) {
           this.props.savePrefs({ ['hide-reconciled-' + accountId]: true });
-          this.setState({ showReconciled: false }, refilterTransactions);
+          this.setState({ showReconciled: false }, () =>
+            this.fetchTransactions(this.state.filters),
+          );
         } else {
           this.props.savePrefs({ ['hide-reconciled-' + accountId]: false });
-          this.setState({ showReconciled: true }, refilterTransactions);
+          this.setState({ showReconciled: true }, () =>
+            this.fetchTransactions(this.state.filters),
+          );
         }
         break;
       default:

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -659,16 +659,20 @@ class AccountInternal extends PureComponent {
         }
         break;
       case 'toggle-reconciled':
+        const refilterTransactions = () => {
+          const filters = this.state.filters;
+          if (filters.length > 0) {
+            this.applyFilters([...filters]);
+          } else {
+            this.fetchTransactions();
+          }
+        };
         if (this.state.showReconciled) {
           this.props.savePrefs({ ['hide-reconciled-' + accountId]: true });
-          this.setState({ showReconciled: false }, () => {
-            this.fetchTransactions();
-          });
+          this.setState({ showReconciled: false }, refilterTransactions);
         } else {
           this.props.savePrefs({ ['hide-reconciled-' + accountId]: false });
-          this.setState({ showReconciled: true }, () => {
-            this.fetchTransactions();
-          });
+          this.setState({ showReconciled: true }, refilterTransactions);
         }
         break;
       default:

--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -213,6 +213,7 @@ class AccountInternal extends PureComponent {
       showBalances: props.showBalances,
       balances: null,
       showCleared: props.showCleared,
+      showReconciled: props.showReconciled,
       editingName: false,
       isAdding: false,
       latestDate: null,
@@ -359,6 +360,11 @@ class AccountInternal extends PureComponent {
       this.paged.unsubscribe();
     }
 
+    // Filter out reconciled transactions if necessary.
+    if (!this.state.showReconciled) {
+      query = query.filter({ reconciled: { $eq: false } })
+    }
+
     this.paged = pagedQuery(
       query.select('*'),
       async (data, prevData) => {
@@ -420,6 +426,7 @@ class AccountInternal extends PureComponent {
           showBalances: nextProps.showBalances,
           balances: null,
           showCleared: nextProps.showCleared,
+          showReconciled: nextProps.showReconciled,
           reconcileAmount: null,
         },
         () => {
@@ -649,6 +656,19 @@ class AccountInternal extends PureComponent {
         } else {
           this.props.savePrefs({ ['hide-cleared-' + accountId]: false });
           this.setState({ showCleared: true });
+        }
+        break;
+      case 'toggle-reconciled':
+        if (this.state.showReconciled) {
+          this.props.savePrefs({ ['hide-reconciled-' + accountId]: true });
+          this.setState({ showReconciled: false }, () => {
+            this.fetchTransactions();
+          });
+        } else {
+          this.props.savePrefs({ ['hide-reconciled-' + accountId]: false });
+          this.setState({ showReconciled: true }, () => {
+            this.fetchTransactions();
+          });
         }
         break;
       default:
@@ -1392,6 +1412,7 @@ class AccountInternal extends PureComponent {
       showBalances,
       balances,
       showCleared,
+      showReconciled,
     } = this.state;
 
     const account = accounts.find(account => account.id === accountId);
@@ -1450,6 +1471,7 @@ class AccountInternal extends PureComponent {
                 showBalances={showBalances}
                 showExtraBalances={showExtraBalances}
                 showCleared={showCleared}
+                showReconciled={showReconciled}
                 showEmptyMessage={showEmptyMessage}
                 balanceQuery={balanceQuery}
                 canCalculateBalance={this.canCalculateBalance}
@@ -1593,6 +1615,7 @@ export function Account() {
   const [expandSplits] = useLocalPref('expand-splits');
   const [showBalances] = useLocalPref(`show-balances-${params.id}`);
   const [hideCleared] = useLocalPref(`hide-cleared-${params.id}`);
+  const [hideReconciled] = useLocalPref(`hide-reconciled-${params.id}`);
   const [showExtraBalances] = useLocalPref(
     `show-extra-balances-${params.id || 'all-accounts'}`,
   );
@@ -1614,6 +1637,7 @@ export function Account() {
     expandSplits,
     showBalances,
     showCleared: !hideCleared,
+    showReconciled: !hideReconciled,
     showExtraBalances,
     payees,
     modalShowing,

--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -46,6 +46,7 @@ export function AccountHeader({
   showBalances,
   showExtraBalances,
   showCleared,
+  showReconciled,
   showEmptyMessage,
   balanceQuery,
   reconcileAmount,
@@ -323,6 +324,7 @@ export function AccountHeader({
                   isSorted={isSorted}
                   showBalances={showBalances}
                   showCleared={showCleared}
+                  showReconciled={showReconciled}
                   onMenuSelect={item => {
                     setMenuOpen(false);
                     onMenuSelect(item);
@@ -382,6 +384,7 @@ function AccountMenu({
   showBalances,
   canShowBalances,
   showCleared,
+  showReconciled,
   onClose,
   isSorted,
   onReconcile,
@@ -418,6 +421,10 @@ function AccountMenu({
           {
             name: 'toggle-cleared',
             text: (showCleared ? 'Hide' : 'Show') + ' “cleared” checkboxes',
+          },
+          {
+            name: 'toggle-reconciled',
+            text: (showReconciled ? 'Hide' : 'Show') + ' reconciled transactions',
           },
           { name: 'export', text: 'Export' },
           { name: 'reconcile', text: 'Reconcile' },

--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -424,7 +424,8 @@ function AccountMenu({
           },
           {
             name: 'toggle-reconciled',
-            text: (showReconciled ? 'Hide' : 'Show') + ' reconciled transactions',
+            text:
+              (showReconciled ? 'Hide' : 'Show') + ' reconciled transactions',
           },
           { name: 'export', text: 'Export' },
           { name: 'reconcile', text: 'Reconcile' },

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -26,6 +26,7 @@ export type LocalPrefs = Partial<
     'expand-splits': boolean;
     [key: `show-extra-balances-${string}`]: boolean;
     [key: `hide-cleared-${string}`]: boolean;
+    [key: `hide-reconciled-${string}`]: boolean;
     'budget.collapsed': string[];
     'budget.summaryCollapsed': boolean;
     'budget.showHiddenCategories': boolean;

--- a/upcoming-release-notes/2542.md
+++ b/upcoming-release-notes/2542.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [davidkus]
+---
+
+Adding menu item to show/hide reconciled transactions in the account view.


### PR DESCRIPTION
Adds toggle to show/hide reconciled transactions in the account view.
This functions similar to how it works in YNAB:
1. Setting is stored in local prefs (persisted between refresh)
2. Setting is per-account

edit:
Just some more context on this:

I had previously added a filter for reconciled transactions in #2108. But this doesn't really work as I'd want it (and other people have requested). Really what we want is for this to persist, and behave like the YNAB "view" for hiding reconciled transactions (e.g. still show scheduled transactions).


https://github.com/actualbudget/actual/assets/5488094/72b60afd-51d4-49f8-b8d3-ee9618de8ec6

