### PR TITLE
Fixing import of reconciled split transactions

### DIFF
--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -54,6 +54,7 @@ export function makeChild<T extends GenericTransactionEntity>(
     account: parent.account,
     date: parent.date,
     cleared: parent.cleared != null ? parent.cleared : null,
+    reconciled: 'reconciled' in data ? data.reconciled : parent.reconciled,
     starting_balance_flag:
       parent.starting_balance_flag != null
         ? parent.starting_balance_flag


### PR DESCRIPTION
When importing transactions from nYNAB, I noticed that for reconciled split transactions, the "child" transactions were not being marked as reconciled after import.