### PR TITLE
Change Actual default theme to System Default

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1502,7 +1502,7 @@ handlers['load-global-prefs'] = async function () {
       theme === 'development' ||
       theme === 'midnight'
         ? theme
-        : 'light',
+        : 'auto',
   };
 };
 


### PR DESCRIPTION
This PR is to change the default visual theme from light to the system default. 

At the moment, light theme is always default. There is already functionality built-in to Actual for using the system theme, so this change will just set the system theme be the default for Actual. Users can still override the theme manually like before, but now Actual will obey the user's set preference right away. This change only comes into play when the theme is not set.

I tried to test with the playwright module, but the test `Schedules › creates a new schedule, posts the transaction and later completes it` failed saying that the `Target page, context, or browser has been closed` and then it timed out. Might be a local issue, so submitting the PR to see if the automated build passes.