### PR TITLE
[Maintenance] Update TransactionEdit conponent onEdit function to use serialized transactions

### DIFF
--- a/upcoming-release-notes/2555.md
+++ b/upcoming-release-notes/2555.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Update TransactionEdit component onEdit function to use serialized transactions.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Removed need to serialize transaction and remove the old comment saying we don't have access to serialized transactions. Also renamed some `transaction` variables to `unserializedTransaction` to avoid confusion with the other serialized `transaction` variables