### PR TITLE
Use amount input on rules page instead of plain text field

### DIFF
--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -381,22 +381,14 @@ function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
           />
 
           <View style={{ flex: 1 }}>
-            {options.method === 'fixed-amount' && (
+            {options.method !== 'remainder' && (
               <GenericInput
                 key={inputKey}
                 field={field}
                 type="number"
-                numberFormatType="currency"
-                value={amountToInteger(value)}
-                onChange={v => onChange('value', integerToAmount(v))}
-              />
-            )}
-            {options.method === 'fixed-percent' && (
-              <GenericInput
-                key={inputKey}
-                field={field}
-                type="number"
-                numberFormatType="percentage"
+                numberFormatType={
+                  options.method === 'fixed-percent' ? 'percentage' : 'currency'
+                }
                 value={value}
                 onChange={v => onChange('value', v)}
               />

--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -235,6 +235,7 @@ function ConditionEditor({
         value={value}
         multi={op === 'oneOf' || op === 'notOneOf'}
         onChange={v => onChange('value', v)}
+        numberFormatType="currency"
       />
     );
   }
@@ -365,6 +366,7 @@ function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
               op={op}
               value={value}
               onChange={v => onChange('value', v)}
+              numberFormatType="currency"
             />
           </View>
         </>

--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -386,6 +386,9 @@ function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
                 key={inputKey}
                 field={field}
                 type="number"
+                numberFormatType={
+                  options.method === 'fixed-percent' ? 'percentage' : 'currency'
+                }
                 value={value}
                 onChange={v => onChange('value', v)}
               />

--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -381,14 +381,22 @@ function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
           />
 
           <View style={{ flex: 1 }}>
-            {options.method !== 'remainder' && (
+            {options.method === 'fixed-amount' && (
               <GenericInput
                 key={inputKey}
                 field={field}
                 type="number"
-                numberFormatType={
-                  options.method === 'fixed-percent' ? 'percentage' : 'currency'
-                }
+                numberFormatType="currency"
+                value={amountToInteger(value)}
+                onChange={v => onChange('value', integerToAmount(v))}
+              />
+            )}
+            {options.method === 'fixed-percent' && (
+              <GenericInput
+                key={inputKey}
+                field={field}
+                type="number"
+                numberFormatType="percentage"
                 value={value}
                 onChange={v => onChange('value', v)}
               />

--- a/packages/desktop-client/src/components/spreadsheet/useFormat.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useFormat.ts
@@ -7,6 +7,7 @@ import { integerToCurrency } from 'loot-core/src/shared/util';
 export type FormatType =
   | 'string'
   | 'number'
+  | 'percentage'
   | 'financial'
   | 'financial-with-sign';
 
@@ -25,6 +26,8 @@ function format(
       return val;
     case 'number':
       return '' + value;
+    case 'percentage':
+      return value + '%';
     case 'financial-with-sign':
       const formatted = format(value, 'financial', formatter);
       if (typeof value === 'number' && value >= 0) {

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
+import { integerToAmount, amountToInteger } from 'loot-core/src/shared/util';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useDateFormat } from '../../hooks/useDateFormat';
@@ -41,7 +42,11 @@ export function GenericInput({
     switch (numberFormatType) {
       case 'currency':
         return (
-          <AmountInput inputRef={inputRef} value={value} onUpdate={onChange} />
+          <AmountInput
+            inputRef={inputRef}
+            value={amountToInteger(value)}
+            onUpdate={v => onChange(integerToAmount(v))}
+          />
         );
       case 'percentage':
         return (

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
-import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
 
 import { useCategories } from '../../hooks/useCategories';

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -50,7 +50,11 @@ export function GenericInput({
         );
       case 'percentage':
         return (
-          <PercentInput inputRef={inputRef} value={value} onUpdate={onChange} />
+          <PercentInput
+            inputRef={inputRef}
+            value={value}
+            onUpdatePercent={onChange}
+          />
         );
       default:
         return (

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -218,9 +218,6 @@ export function GenericInput({
               <AmountInput
                 inputRef={inputRef}
                 value={amountToInteger(value)}
-                placeholder="0.00"
-                onEnter={e => onChange(e.target.value)}
-                onBlur={e => onChange(e.target.value)}
                 onUpdate={newValue => onChange(integerToAmount(newValue))}
               />
             );

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -20,11 +20,13 @@ import { DateSelect } from '../select/DateSelect';
 import { RecurringSchedulePicker } from '../select/RecurringSchedulePicker';
 
 import { AmountInput } from './AmountInput';
+import { PercentInput } from './PercentInput';
 
 export function GenericInput({
   field,
   subfield,
   type,
+  numberFormatType = 'currency',
   multi,
   value,
   inputRef,
@@ -35,6 +37,29 @@ export function GenericInput({
   const savedReports = useReports();
   const saved = useSelector(state => state.queries.saved);
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+
+  const getNumberInputByFormatType = numberFormatType => {
+    switch (numberFormatType) {
+      case 'currency':
+        return (
+          <AmountInput inputRef={inputRef} value={value} onUpdate={onChange} />
+        );
+      case 'percentage':
+        return (
+          <PercentInput inputRef={inputRef} value={value} onUpdate={onChange} />
+        );
+      default:
+        return (
+          <Input
+            inputRef={inputRef}
+            defaultValue={value || ''}
+            placeholder="nothing"
+            onEnter={e => onChange(e.target.value)}
+            onBlur={e => onChange(e.target.value)}
+          />
+        );
+    }
+  };
 
   // This makes the UI more resilient in case of faulty data
   if (multi && !Array.isArray(value)) {
@@ -214,13 +239,7 @@ export function GenericInput({
       } else {
         switch (type) {
           case 'number':
-            content = (
-              <AmountInput
-                inputRef={inputRef}
-                value={amountToInteger(value)}
-                onUpdate={newValue => onChange(integerToAmount(newValue))}
-              />
-            );
+            content = getNumberInputByFormatType(numberFormatType);
             break;
           default:
             content = (

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -26,7 +26,7 @@ export function GenericInput({
   field,
   subfield,
   type,
-  numberFormatType = 'currency',
+  numberFormatType = undefined,
   multi,
   value,
   inputRef,

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -244,22 +244,18 @@ export function GenericInput({
             onSelect={onChange}
           />
         );
+      } else if (type === 'number') {
+        content = getNumberInputByFormatType(numberFormatType);
       } else {
-        switch (type) {
-          case 'number':
-            content = getNumberInputByFormatType(numberFormatType);
-            break;
-          default:
-            content = (
-              <Input
-                inputRef={inputRef}
-                defaultValue={value || ''}
-                placeholder="nothing"
-                onEnter={e => onChange(e.target.value)}
-                onBlur={e => onChange(e.target.value)}
-              />
-            );
-        }
+        content = (
+          <Input
+            inputRef={inputRef}
+            defaultValue={value || ''}
+            placeholder="nothing"
+            onEnter={e => onChange(e.target.value)}
+            onBlur={e => onChange(e.target.value)}
+          />
+        );
       }
       break;
   }

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
+import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
 
 import { useCategories } from '../../hooks/useCategories';
@@ -17,6 +18,8 @@ import { View } from '../common/View';
 import { Checkbox } from '../forms';
 import { DateSelect } from '../select/DateSelect';
 import { RecurringSchedulePicker } from '../select/RecurringSchedulePicker';
+
+import { AmountInput } from './AmountInput';
 
 export function GenericInput({
   field,
@@ -209,15 +212,30 @@ export function GenericInput({
           />
         );
       } else {
-        content = (
-          <Input
-            inputRef={inputRef}
-            defaultValue={value || ''}
-            placeholder="nothing"
-            onEnter={e => onChange(e.target.value)}
-            onBlur={e => onChange(e.target.value)}
-          />
-        );
+        switch (type) {
+          case 'number':
+            content = (
+              <AmountInput
+                inputRef={inputRef}
+                value={amountToInteger(value)}
+                placeholder="0.00"
+                onEnter={e => onChange(e.target.value)}
+                onBlur={e => onChange(e.target.value)}
+                onUpdate={newValue => onChange(integerToAmount(newValue))}
+              />
+            );
+            break;
+          default:
+            content = (
+              <Input
+                inputRef={inputRef}
+                defaultValue={value || ''}
+                placeholder="nothing"
+                onEnter={e => onChange(e.target.value)}
+                onBlur={e => onChange(e.target.value)}
+              />
+            );
+        }
       }
       break;
   }

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -4,6 +4,7 @@ import React, {
   useState,
   useEffect,
   type FocusEventHandler,
+  type FocusEvent,
 } from 'react';
 
 import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
@@ -53,34 +54,29 @@ export function PercentInput({
     }
   }, [focused]);
 
-  function onSelectionChange(e) {
-    const selectionStart = e.target.selectionStart;
-    const selectionEnd = e.target.selectionEnd;
+  function onSelectionChange() {
+    if (!ref.current) {
+      return;
+    }
+
+    const selectionStart = ref.current.selectionStart;
+    const selectionEnd = ref.current.selectionEnd;
     if (
       selectionStart === selectionEnd &&
-      selectionStart >= e.target.value.length
+      selectionStart !== null &&
+      selectionStart >= ref.current.value.length
     ) {
-      e.target.setSelectionRange(
-        e.target.value.length - 1,
-        e.target.value.length - 1,
+      ref.current.setSelectionRange(
+        ref.current.value.length - 1,
+        ref.current.value.length - 1,
       );
     }
   }
 
-  function onInputTextChange(val) {
+  function onInputTextChange(val: string) {
     const number = val.replace(/[^0-9.]/g, '');
-    console.log(val);
-
     setValue(number ? format(number, 'percentage') : '');
     onChangeValue?.(number);
-
-    const selectionStart = ref.current?.selectionStart;
-    const selectionEnd = ref.current?.selectionEnd;
-    console.log(selectionStart, selectionEnd, val.length);
-    if (selectionStart === selectionEnd && selectionStart >= val.length) {
-      console.log('set range to', val.length - 1, val.length - 1);
-      ref.current?.setSelectionRange(val.length - 1, val.length - 1);
-    }
   }
 
   function fireUpdate() {
@@ -91,7 +87,7 @@ export function PercentInput({
     onUpdate?.(valueOrInitial);
   }
 
-  function onInputAmountBlur(e) {
+  function onInputAmountBlur(e: FocusEvent<HTMLInputElement>) {
     if (!ref.current?.contains(e.relatedTarget)) {
       fireUpdate();
     }

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -17,11 +17,10 @@ import { useFormat } from '../spreadsheet/useFormat';
 type PercentInputProps = {
   id?: string;
   inputRef?: Ref<HTMLInputElement>;
-  value: number;
-  defaultValue?: number;
-  onChangeValue?: (value: string) => void;
+  value?: number;
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
+  onChangeValue?: (value: string) => void;
   onUpdatePercent?: (percent: number) => void;
   style?: CSSProperties;
   focused?: boolean;

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -18,6 +18,7 @@ type PercentInputProps = {
   id?: string;
   inputRef?: Ref<HTMLInputElement>;
   value: number;
+  defaultValue?: number;
   onChangeValue?: (value: string) => void;
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
@@ -27,10 +28,13 @@ type PercentInputProps = {
   disabled?: boolean;
 };
 
+const clampToPercent = (value: number) => Math.max(Math.min(value, 100), 0);
+
 export function PercentInput({
   id,
   inputRef,
-  value: initialValue,
+  value: initialValue = 0,
+  defaultValue = 100,
   onFocus,
   onBlur,
   onChangeValue,
@@ -42,15 +46,15 @@ export function PercentInput({
   const format = useFormat();
 
   const [value, setValue] = useState(() =>
-    format(Math.abs(initialValue || 0), 'percentage'),
+    format(clampToPercent(defaultValue), 'percentage'),
   );
   useEffect(() => {
-    const initialValueAbsolute = Math.abs(initialValue || 0);
-    if (initialValueAbsolute !== initialValue) {
-      setValue(format(initialValueAbsolute, 'percentage'));
-      onUpdatePercent?.(initialValueAbsolute);
+    const clampedDefaultValue = clampToPercent(defaultValue);
+    if (clampedDefaultValue !== initialValue) {
+      setValue(format(clampedDefaultValue, 'percentage'));
+      onUpdatePercent?.(clampedDefaultValue);
     }
-  }, [initialValue, onUpdatePercent, value, format]);
+  }, [initialValue, onUpdatePercent, format, defaultValue]);
 
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -1,0 +1,121 @@
+import React, {
+  type Ref,
+  useRef,
+  useState,
+  useEffect,
+  type FocusEventHandler,
+} from 'react';
+
+import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
+
+import { useMergedRefs } from '../../hooks/useMergedRefs';
+import { type CSSProperties } from '../../style';
+import { Input } from '../common/Input';
+import { useFormat } from '../spreadsheet/useFormat';
+
+type AmountInputProps = {
+  id?: string;
+  inputRef?: Ref<HTMLInputElement>;
+  value: number;
+  onChangeValue?: (value: string) => void;
+  onFocus?: FocusEventHandler<HTMLInputElement>;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onUpdate?: (amount: number) => void;
+  style?: CSSProperties;
+  focused?: boolean;
+  disabled?: boolean;
+};
+
+export function PercentInput({
+  id,
+  inputRef,
+  value: initialValue,
+  onFocus,
+  onBlur,
+  onChangeValue,
+  onUpdate,
+  style,
+  focused,
+  disabled = false,
+}: AmountInputProps) {
+  const format = useFormat();
+
+  const initialValueAbsolute = format(initialValue || 0, 'percentage');
+  const [value, setValue] = useState(initialValueAbsolute);
+  useEffect(() => setValue(initialValueAbsolute), [initialValueAbsolute]);
+
+  const ref = useRef<HTMLInputElement>(null);
+  const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
+
+  useEffect(() => {
+    if (focused) {
+      ref.current?.focus();
+    }
+  }, [focused]);
+
+  function onSelectionChange(e) {
+    const selectionStart = e.target.selectionStart;
+    const selectionEnd = e.target.selectionEnd;
+    if (
+      selectionStart === selectionEnd &&
+      selectionStart >= e.target.value.length
+    ) {
+      e.target.setSelectionRange(
+        e.target.value.length - 1,
+        e.target.value.length - 1,
+      );
+    }
+  }
+
+  function onInputTextChange(val) {
+    const number = val.replace(/[^0-9.]/g, '');
+    console.log(val);
+
+    setValue(number ? format(number, 'percentage') : '');
+    onChangeValue?.(number);
+
+    const selectionStart = ref.current?.selectionStart;
+    const selectionEnd = ref.current?.selectionEnd;
+    console.log(selectionStart, selectionEnd, val.length);
+    if (selectionStart === selectionEnd && selectionStart >= val.length) {
+      console.log('set range to', val.length - 1, val.length - 1);
+      ref.current?.setSelectionRange(val.length - 1, val.length - 1);
+    }
+  }
+
+  function fireUpdate() {
+    const valueOrInitial = Math.max(
+      Math.min(evalArithmetic(value.replace('%', '')), 100),
+      0,
+    );
+    onUpdate?.(valueOrInitial);
+  }
+
+  function onInputAmountBlur(e) {
+    if (!ref.current?.contains(e.relatedTarget)) {
+      fireUpdate();
+    }
+    onBlur?.(e);
+  }
+
+  return (
+    <Input
+      id={id}
+      inputRef={mergedRef}
+      inputMode="decimal"
+      value={value}
+      disabled={disabled}
+      focused={focused}
+      style={{ flex: 1, alignItems: 'stretch', ...style }}
+      onKeyUp={e => {
+        if (e.key === 'Enter') {
+          fireUpdate();
+        }
+      }}
+      onChangeValue={onInputTextChange}
+      onBlur={onInputAmountBlur}
+      onFocus={onFocus}
+      onSelect={onSelectionChange}
+    />
+  );
+}

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -14,14 +14,14 @@ import { type CSSProperties } from '../../style';
 import { Input } from '../common/Input';
 import { useFormat } from '../spreadsheet/useFormat';
 
-type AmountInputProps = {
+type PercentInputProps = {
   id?: string;
   inputRef?: Ref<HTMLInputElement>;
   value: number;
   onChangeValue?: (value: string) => void;
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
-  onUpdate?: (amount: number) => void;
+  onUpdatePercent?: (percent: number) => void;
   style?: CSSProperties;
   focused?: boolean;
   disabled?: boolean;
@@ -34,11 +34,11 @@ export function PercentInput({
   onFocus,
   onBlur,
   onChangeValue,
-  onUpdate,
+  onUpdatePercent,
   style,
   focused,
   disabled = false,
-}: AmountInputProps) {
+}: PercentInputProps) {
   const format = useFormat();
 
   const initialValueAbsolute = format(initialValue || 0, 'percentage');
@@ -84,7 +84,7 @@ export function PercentInput({
       Math.min(evalArithmetic(value.replace('%', '')), 100),
       0,
     );
-    onUpdate?.(valueOrInitial);
+    onUpdatePercent?.(valueOrInitial);
   }
 
   function onInputAmountBlur(e: FocusEvent<HTMLInputElement>) {

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -34,7 +34,6 @@ export function PercentInput({
   id,
   inputRef,
   value: initialValue = 0,
-  defaultValue = 100,
   onFocus,
   onBlur,
   onChangeValue,
@@ -46,15 +45,15 @@ export function PercentInput({
   const format = useFormat();
 
   const [value, setValue] = useState(() =>
-    format(clampToPercent(defaultValue), 'percentage'),
+    format(clampToPercent(initialValue), 'percentage'),
   );
   useEffect(() => {
-    const clampedDefaultValue = clampToPercent(defaultValue);
-    if (clampedDefaultValue !== initialValue) {
-      setValue(format(clampedDefaultValue, 'percentage'));
-      onUpdatePercent?.(clampedDefaultValue);
+    const clampedInitialValue = clampToPercent(initialValue);
+    if (clampedInitialValue !== initialValue) {
+      setValue(format(clampedInitialValue, 'percentage'));
+      onUpdatePercent?.(clampedInitialValue);
     }
-  }, [initialValue, onUpdatePercent, format, defaultValue]);
+  }, [initialValue, onUpdatePercent, format]);
 
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
@@ -91,11 +90,9 @@ export function PercentInput({
   }
 
   function fireUpdate() {
-    const valueOrInitial = Math.max(
-      Math.min(evalArithmetic(value.replace('%', '')), 100),
-      0,
-    );
-    onUpdatePercent?.(valueOrInitial);
+    const clampedValue = clampToPercent(evalArithmetic(value.replace('%', '')));
+    onUpdatePercent?.(clampedValue);
+    onInputTextChange(String(clampedValue));
   }
 
   function onInputAmountBlur(e: FocusEvent<HTMLInputElement>) {

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -41,9 +41,16 @@ export function PercentInput({
 }: PercentInputProps) {
   const format = useFormat();
 
-  const initialValueAbsolute = format(initialValue || 0, 'percentage');
-  const [value, setValue] = useState(initialValueAbsolute);
-  useEffect(() => setValue(initialValueAbsolute), [initialValueAbsolute]);
+  const [value, setValue] = useState(() =>
+    format(Math.abs(initialValue || 0), 'percentage'),
+  );
+  useEffect(() => {
+    const initialValueAbsolute = Math.abs(initialValue || 0);
+    if (initialValueAbsolute !== initialValue) {
+      setValue(format(initialValueAbsolute, 'percentage'));
+      onUpdatePercent?.(initialValueAbsolute);
+    }
+  }, [initialValue, onUpdatePercent, value, format]);
 
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);

--- a/upcoming-release-notes/2566.md
+++ b/upcoming-release-notes/2566.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Use `AmountInput` on rules page to get formatting/sign toggle button


### PR DESCRIPTION
There was feedback on the original rules-with-splits PR that amount inputs could use the featureful amount input instead of a plain text field. This PR updates that page to use the `AmountInput` component.