### PR TITLE
Support splits in create-rule option on account page

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1056,18 +1056,24 @@ class AccountInternal extends PureComponent {
         .select('*')
         .options({ splits: 'grouped' }),
     );
+
     const transactions = ungroupTransactions(data);
-    const payeeCondition = transactions[0].imported_payee
+    const ruleTransaction = transactions[0];
+    const childTransactions = transactions.filter(
+      t => t.parent_id === ruleTransaction.id,
+    );
+
+    const payeeCondition = ruleTransaction.imported_payee
       ? {
           field: 'imported_payee',
           op: 'is',
-          value: transactions[0].imported_payee,
+          value: ruleTransaction.imported_payee,
           type: 'string',
         }
       : {
           field: 'payee',
           op: 'is',
-          value: transactions[0].payee,
+          value: ruleTransaction.payee,
           type: 'id',
         };
 
@@ -1076,12 +1082,38 @@ class AccountInternal extends PureComponent {
       conditionsOp: 'and',
       conditions: [payeeCondition],
       actions: [
-        {
-          op: 'set',
-          field: 'category',
-          value: transactions[0].category,
-          type: 'id',
-        },
+        ...(childTransactions.length === 0
+          ? [
+              {
+                op: 'set',
+                field: 'category',
+                value: ruleTransaction.category,
+                type: 'id',
+                options: {
+                  splitIndex: 0,
+                },
+              },
+            ]
+          : []),
+        ...childTransactions.flatMap((sub, index) => [
+          {
+            op: 'set-split-amount',
+            value: sub.amount,
+            options: {
+              splitIndex: index + 1,
+              method: 'fixed-amount',
+            },
+          },
+          {
+            op: 'set',
+            field: 'category',
+            value: sub.category,
+            type: 'id',
+            options: {
+              splitIndex: index + 1,
+            },
+          },
+        ]),
       ],
     };
 

--- a/upcoming-release-notes/2569.md
+++ b/upcoming-release-notes/2569.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Support creating rules from split transactions on the accounts page


### PR DESCRIPTION
Feedback: support creating rules from split transactions on the accounts page.