### PR TITLE
[Bugfix] Remove menu from income group on mobile view

### DIFF
--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -193,63 +193,67 @@ function AdditionalCategoryGroupMenu({ group, onDelete, onToggleVisibility }) {
 
   return (
     <View>
-      <Button
-        type="bare"
-        aria-label="Menu"
-        onClick={() => {
-          setMenuOpen(true);
-        }}
-      >
-        <SvgDotsHorizontalTriple
-          width={17}
-          height={17}
-          style={{ color: 'currentColor' }}
-        />
-        {menuOpen && (
-          <Tooltip
-            position="bottom-left"
-            style={{ padding: 0 }}
-            onClose={() => {
-              setMenuOpen(false);
-            }}
-          >
-            <Menu
-              style={{
-                ...styles.mediumText,
-                color: theme.formLabelText,
-              }}
-              getItemStyle={() => itemStyle}
-              items={
-                [
-                  {
-                    name: 'toggleVisibility',
-                    text: group.hidden ? 'Show' : 'Hide',
-                    icon: group.hidden ? SvgViewShow : SvgViewHide,
-                    iconSize: 16,
-                  },
-                  ...(!group.is_income && [
-                    Menu.line,
-                    {
-                      name: 'delete',
-                      text: 'Delete',
-                      icon: SvgTrash,
-                      iconSize: 15,
-                    },
-                  ]),
-                ].filter(i => i != null) as ComponentProps<typeof Menu>['items']
-              }
-              onMenuSelect={itemName => {
+      {!group.is_income && (
+        <Button
+          type="bare"
+          aria-label="Menu"
+          onClick={() => {
+            setMenuOpen(true);
+          }}
+        >
+          <SvgDotsHorizontalTriple
+            width={17}
+            height={17}
+            style={{ color: 'currentColor' }}
+          />
+          {menuOpen && (
+            <Tooltip
+              position="bottom-left"
+              style={{ padding: 0 }}
+              onClose={() => {
                 setMenuOpen(false);
-                if (itemName === 'delete') {
-                  onDelete();
-                } else if (itemName === 'toggleVisibility') {
-                  onToggleVisibility();
-                }
               }}
-            />
-          </Tooltip>
-        )}
-      </Button>
+            >
+              <Menu
+                style={{
+                  ...styles.mediumText,
+                  color: theme.formLabelText,
+                }}
+                getItemStyle={() => itemStyle}
+                items={
+                  [
+                    {
+                      name: 'toggleVisibility',
+                      text: group.hidden ? 'Show' : 'Hide',
+                      icon: group.hidden ? SvgViewShow : SvgViewHide,
+                      iconSize: 16,
+                    },
+                    ...(!group.is_income && [
+                      Menu.line,
+                      {
+                        name: 'delete',
+                        text: 'Delete',
+                        icon: SvgTrash,
+                        iconSize: 15,
+                      },
+                    ]),
+                  ].filter(i => i != null) as ComponentProps<
+                    typeof Menu
+                  >['items']
+                }
+                onMenuSelect={itemName => {
+                  setMenuOpen(false);
+                  if (itemName === 'delete') {
+                    onDelete();
+                  } else if (itemName === 'toggleVisibility') {
+                    onToggleVisibility();
+                  }
+                }}
+              />
+            </Tooltip>
+          )}
+        </Button>
+      )}
     </View>
   );
 }

--- a/upcoming-release-notes/2570.md
+++ b/upcoming-release-notes/2570.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shall0pass]
+---
+
+Mobile: Remove menu item for income category group, which resulted in crash.


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/2565

After looking at the menu options on the desktop view and comparing them to the mobile view, there is not currently a need to show a menu option in the mobile view.  Selecting the option resulted in a crash.  The desktop view has options to rename and create categories; however, the mobile view already uses a different method to accomplish those tasks.  The remaining option of Show/Hide the Income group category has no effect on the desktop view and thus doesn't really need to be displayed in Mobile view to replicate the functionality.  This PR simply hides the menu option if, and only if, the Income Group is selected. All other groups and categories are unaffected.