### PR TITLE
[Mobile] Close modal after transferring / covering balance in mobile budget page

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -287,6 +287,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
             from: category.id,
             to: toCategoryId,
           });
+          dispatch(collapseModals(`${budgetType}-balance-menu`));
         },
         showToBeBudgeted: true,
       }),
@@ -302,6 +303,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
             to: category.id,
             from: fromCategoryId,
           });
+          dispatch(collapseModals(`${budgetType}-balance-menu`));
         },
       }),
     );

--- a/upcoming-release-notes/2572.md
+++ b/upcoming-release-notes/2572.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Close modal after transferring / covering balance in mobile budget page


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Close modal after transferring / covering balance in mobile budget page