### PR TITLE
[Mobile] Fix report budget income budgeted input

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -679,10 +679,17 @@ const IncomeCategory = memo(function IncomeCategory({
   style,
   onEdit,
   onBudgetAction,
-  isEditingBudget,
-  onEditBudget,
 }) {
   const listItemRef = useRef();
+  const [isEditingBudget, setIsEditingBudget] = useState(false);
+  const { onRequestActiveEdit, onClearActiveEdit } = useSingleActiveEditForm();
+
+  const onEditBudget = () => {
+    onRequestActiveEdit(`${category.id}-budget`, () => {
+      setIsEditingBudget(true);
+      return () => setIsEditingBudget(false);
+    });
+  };
 
   return (
     <ListItem
@@ -740,15 +747,8 @@ const IncomeCategory = memo(function IncomeCategory({
             onBudgetAction={onBudgetAction}
             isEditing={isEditingBudget}
             onEdit={onEditBudget}
+            onBlur={onClearActiveEdit}
           />
-          {/* <CellValue
-            binding={budget}
-            style={{
-              ...styles.smallText,
-              textAlign: 'right',
-            }}
-            type="financial"
-          /> */}
         </View>
       )}
       <View
@@ -949,8 +949,6 @@ function IncomeGroup({
   editMode,
   onEditGroup,
   onEditCategory,
-  editingBudgetCategoryId,
-  onEditCategoryBudget,
   onBudgetAction,
 }) {
   return (
@@ -1014,8 +1012,6 @@ function IncomeGroup({
                 editMode={editMode}
                 onEdit={onEditCategory}
                 onBudgetAction={onBudgetAction}
-                isEditingBudget={editingBudgetCategoryId === category.id}
-                onEditBudget={onEditCategoryBudget}
               />
             );
           })}

--- a/upcoming-release-notes/2573.md
+++ b/upcoming-release-notes/2573.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix mobile report budget bug where you can't click on an income category's budgeted input.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fix mobile report budget bug where you can't click on an income category's budgeted input