### PR TITLE
Electron: Fix load backup functionality

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -77,7 +77,7 @@ function AppInner({ budgetId, cloudFileId }: AppInnerProps) {
   }, []);
 
   useEffect(() => {
-    global.Actual.updateAppMenu(!!budgetId);
+    global.Actual.updateAppMenu(budgetId);
   }, [budgetId]);
 
   return (

--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -137,7 +137,7 @@ async function createWindow() {
 
   win.on('closed', () => {
     clientWin = null;
-    updateMenu(false);
+    updateMenu();
     unlistenToState();
   });
 
@@ -187,17 +187,22 @@ function isExternalUrl(url) {
   return !url.includes('localhost:') && !url.includes('app://');
 }
 
-function updateMenu(isBudgetOpen) {
+function updateMenu(budgetId) {
+  const isBudgetOpen = !!budgetId;
   const menu = getMenu(isDev, createWindow);
   const file = menu.items.filter(item => item.label === 'File')[0];
   const fileItems = file.submenu.items;
+  debugger;
   fileItems
     .filter(item => item.label === 'Load Backup...')
-    .map(item => (item.enabled = isBudgetOpen));
+    .forEach(item => {
+      item.enabled = isBudgetOpen;
+      item.budgetId = budgetId;
+    });
 
   const tools = menu.items.filter(item => item.label === 'Tools')[0];
   tools.submenu.items.forEach(item => {
-    item.enabled = isBudgetOpen;
+    item.enabled = !!budgetId;
   });
 
   const edit = menu.items.filter(item => item.label === 'Edit')[0];
@@ -362,8 +367,8 @@ ipcMain.on('apply-update', () => {
   updater.apply();
 });
 
-ipcMain.on('update-menu', (event, isBudgetOpen) => {
-  updateMenu(isBudgetOpen);
+ipcMain.on('update-menu', (event, budgetId) => {
+  updateMenu(budgetId);
 });
 
 ipcMain.on('set-theme', theme => {

--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -202,7 +202,7 @@ function updateMenu(budgetId) {
 
   const tools = menu.items.filter(item => item.label === 'Tools')[0];
   tools.submenu.items.forEach(item => {
-    item.enabled = !!budgetId;
+    item.enabled = isBudgetOpen;
   });
 
   const edit = menu.items.filter(item => item.label === 'Edit')[0];

--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -192,7 +192,6 @@ function updateMenu(budgetId) {
   const menu = getMenu(isDev, createWindow);
   const file = menu.items.filter(item => item.label === 'File')[0];
   const fileItems = file.submenu.items;
-  debugger;
   fileItems
     .filter(item => item.label === 'Load Backup...')
     .forEach(item => {

--- a/packages/desktop-electron/menu.js
+++ b/packages/desktop-electron/menu.js
@@ -12,7 +12,7 @@ function getMenu(isDev, createWindow) {
             if (focusedWindow) {
               if (focusedWindow.webContents.getTitle() === 'Actual') {
                 focusedWindow.webContents.executeJavaScript(
-                  "__actionsForMenu.replaceModal('load-backup')",
+                  `__actionsForMenu.replaceModal('load-backup', { budgetId: '${item.budgetId}' })`,
                 );
               }
             }

--- a/packages/desktop-electron/preload.js
+++ b/packages/desktop-electron/preload.js
@@ -49,8 +49,8 @@ contextBridge.exposeInMainWorld('Actual', {
     ipcRenderer.send('apply-update');
   },
 
-  updateAppMenu: isBudgetOpen => {
-    ipcRenderer.send('update-menu', isBudgetOpen);
+  updateAppMenu: budgetId => {
+    ipcRenderer.send('update-menu', budgetId);
   },
 
   getServerSocket: () => {

--- a/upcoming-release-notes/2580.md
+++ b/upcoming-release-notes/2580.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mikesglitch]
+---
+
+Fix "Load backup" functionality in Electron - no longer throwing fatal error


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->


The "load backup" feature isn't working in Electron - it throws a fatal error.

This is because the menu item isn't passing in the budget ID related to the backup (required parameter).

The fix is to pass the budget ID into the menu item and push the load-backup modal with it.

**Error:** 
````
TypeError: Cannot read properties of undefined (reading 'budgetId') at app://actual/static/js/index.h17Pcr58.js:202:122692 at Array.map (<anonymous>) at mxe (app://actual/static/js/index.h17Pcr58.js:202:121619) at Gx
````

![image](https://github.com/actualbudget/actual/assets/5285928/a53b0d78-ebc3-466e-8719-b3a049f6c339)

This is it working: 
![image](https://github.com/actualbudget/actual/assets/5285928/49972a84-a3d5-40cb-a1c6-fc751f2c9f7f)
