### PR TITLE
Dim categories hidden by their groups

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -429,6 +429,7 @@ export function Modals() {
               key={name}
               modalProps={modalProps}
               categoryId={options.categoryId}
+              isHidden={options.isHidden}
               onSave={options.onSave}
               onEditNotes={options.onEditNotes}
               onDelete={options.onDelete}

--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -429,7 +429,7 @@ export function Modals() {
               key={name}
               modalProps={modalProps}
               categoryId={options.categoryId}
-              isHidden={options.isHidden}
+              categoryGroup={options.categoryGroup}
               onSave={options.onSave}
               onEditNotes={options.onEditNotes}
               onDelete={options.onDelete}

--- a/packages/desktop-client/src/components/budget/BudgetCategories.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.jsx
@@ -177,6 +177,8 @@ export const BudgetCategories = memo(
       }
     }
 
+    let catGroup = null;
+
     return (
       <View
         style={{
@@ -228,6 +230,7 @@ export const BudgetCategories = memo(
               break;
 
             case 'expense-group':
+              catGroup = item.value;
               content = (
                 <ExpenseGroup
                   group={item.value}
@@ -250,6 +253,7 @@ export const BudgetCategories = memo(
               content = (
                 <ExpenseCategory
                   cat={item.value}
+                  catGroup={catGroup}
                   editingCell={editingCell}
                   MonthComponent={dataComponents.ExpenseCategoryComponent}
                   dragState={dragState}

--- a/packages/desktop-client/src/components/budget/BudgetCategories.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.jsx
@@ -66,6 +66,7 @@ export const BudgetCategories = memo(
               cat => ({
                 type: 'expense-category',
                 value: cat,
+                group: group,
               }),
             ),
           ];
@@ -177,8 +178,6 @@ export const BudgetCategories = memo(
       }
     }
 
-    let categoryGroup = null;
-
     return (
       <View
         style={{
@@ -230,7 +229,6 @@ export const BudgetCategories = memo(
               break;
 
             case 'expense-group':
-              categoryGroup = item.value;
               content = (
                 <ExpenseGroup
                   group={item.value}
@@ -253,7 +251,7 @@ export const BudgetCategories = memo(
               content = (
                 <ExpenseCategory
                   cat={item.value}
-                  categoryGroup={categoryGroup}
+                  categoryGroup={item.group}
                   editingCell={editingCell}
                   MonthComponent={dataComponents.ExpenseCategoryComponent}
                   dragState={dragState}

--- a/packages/desktop-client/src/components/budget/BudgetCategories.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.jsx
@@ -66,7 +66,7 @@ export const BudgetCategories = memo(
               cat => ({
                 type: 'expense-category',
                 value: cat,
-                group: group,
+                group,
               }),
             ),
           ];

--- a/packages/desktop-client/src/components/budget/BudgetCategories.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.jsx
@@ -177,7 +177,7 @@ export const BudgetCategories = memo(
       }
     }
 
-    let catGroup = null;
+    let categoryGroup = null;
 
     return (
       <View
@@ -230,7 +230,7 @@ export const BudgetCategories = memo(
               break;
 
             case 'expense-group':
-              catGroup = item.value;
+              categoryGroup = item.value;
               content = (
                 <ExpenseGroup
                   group={item.value}
@@ -253,7 +253,7 @@ export const BudgetCategories = memo(
               content = (
                 <ExpenseCategory
                   cat={item.value}
-                  catGroup={catGroup}
+                  categoryGroup={categoryGroup}
                   editingCell={editingCell}
                   MonthComponent={dataComponents.ExpenseCategoryComponent}
                   dragState={dragState}

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
@@ -23,7 +23,7 @@ import { SidebarCategory } from './SidebarCategory';
 
 type ExpenseCategoryProps = {
   cat: CategoryEntity;
-  catGroup?: CategoryGroupEntity;
+  categoryGroup?: CategoryGroupEntity;
   editingCell: { id: string; cell: string } | null;
   dragState: DragState<CategoryEntity>;
   MonthComponent: ComponentProps<typeof RenderMonths>['component'];
@@ -39,7 +39,7 @@ type ExpenseCategoryProps = {
 
 export function ExpenseCategory({
   cat,
-  catGroup,
+  categoryGroup,
   editingCell,
   dragState,
   MonthComponent,
@@ -77,7 +77,7 @@ export function ExpenseCategory({
       collapsed={true}
       style={{
         backgroundColor: theme.tableBackground,
-        opacity: cat.hidden || catGroup?.hidden ? 0.5 : undefined,
+        opacity: cat.hidden || categoryGroup?.hidden ? 0.5 : undefined,
       }}
     >
       <DropHighlight pos={dropPos} offset={{ top: 1 }} />
@@ -86,7 +86,7 @@ export function ExpenseCategory({
         <SidebarCategory
           innerRef={dragRef}
           category={cat}
-          catGroup={catGroup}
+          categoryGroup={categoryGroup}
           dragPreview={dragging && dragState.preview}
           dragging={dragging && !dragState.preview}
           editing={

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
@@ -1,7 +1,10 @@
 // @ts-strict-ignore
 import React, { type ComponentProps } from 'react';
 
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import {
+  type CategoryGroupEntity,
+  type CategoryEntity,
+} from 'loot-core/src/types/models';
 
 import { theme } from '../../style';
 import { View } from '../common/View';
@@ -20,6 +23,7 @@ import { SidebarCategory } from './SidebarCategory';
 
 type ExpenseCategoryProps = {
   cat: CategoryEntity;
+  catGroup?: CategoryGroupEntity;
   editingCell: { id: string; cell: string } | null;
   dragState: DragState<CategoryEntity>;
   MonthComponent: ComponentProps<typeof RenderMonths>['component'];
@@ -35,6 +39,7 @@ type ExpenseCategoryProps = {
 
 export function ExpenseCategory({
   cat,
+  catGroup,
   editingCell,
   dragState,
   MonthComponent,
@@ -72,7 +77,7 @@ export function ExpenseCategory({
       collapsed={true}
       style={{
         backgroundColor: theme.tableBackground,
-        opacity: cat.hidden ? 0.5 : undefined,
+        opacity: cat.hidden || catGroup?.hidden ? 0.5 : undefined,
       }}
     >
       <DropHighlight pos={dropPos} offset={{ top: 1 }} />
@@ -81,6 +86,7 @@ export function ExpenseCategory({
         <SidebarCategory
           innerRef={dragRef}
           category={cat}
+          catGroup={catGroup}
           dragPreview={dragging && dragState.preview}
           dragging={dragging && !dragState.preview}
           editing={

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -1,7 +1,10 @@
 // @ts-strict-ignore
 import React, { type CSSProperties, type Ref, useState } from 'react';
 
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import {
+  type CategoryGroupEntity,
+  type CategoryEntity,
+} from 'loot-core/src/types/models';
 
 import { SvgCheveronDown } from '../../icons/v1';
 import { theme } from '../../style';
@@ -15,6 +18,7 @@ import { Tooltip } from '../tooltips';
 type SidebarCategoryProps = {
   innerRef: Ref<HTMLDivElement>;
   category: CategoryEntity;
+  catGroup?: CategoryGroupEntity;
   dragPreview?: boolean;
   dragging?: boolean;
   editing: boolean;
@@ -30,6 +34,7 @@ type SidebarCategoryProps = {
 export function SidebarCategory({
   innerRef,
   category,
+  catGroup,
   dragPreview,
   dragging,
   editing,
@@ -50,7 +55,7 @@ export function SidebarCategory({
         alignItems: 'center',
         userSelect: 'none',
         WebkitUserSelect: 'none',
-        opacity: category.hidden ? 0.33 : undefined,
+        opacity: category.hidden || catGroup?.hidden ? 0.33 : undefined,
       }}
     >
       <div
@@ -99,7 +104,7 @@ export function SidebarCategory({
                 setMenuOpen(false);
               }}
               items={[
-                {
+                !catGroup?.hidden && {
                   name: 'toggle-visibility',
                   text: category.hidden ? 'Show' : 'Hide',
                 },

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -18,7 +18,7 @@ import { Tooltip } from '../tooltips';
 type SidebarCategoryProps = {
   innerRef: Ref<HTMLDivElement>;
   category: CategoryEntity;
-  catGroup?: CategoryGroupEntity;
+  categoryGroup?: CategoryGroupEntity;
   dragPreview?: boolean;
   dragging?: boolean;
   editing: boolean;
@@ -34,7 +34,7 @@ type SidebarCategoryProps = {
 export function SidebarCategory({
   innerRef,
   category,
-  catGroup,
+  categoryGroup,
   dragPreview,
   dragging,
   editing,
@@ -55,7 +55,7 @@ export function SidebarCategory({
         alignItems: 'center',
         userSelect: 'none',
         WebkitUserSelect: 'none',
-        opacity: category.hidden || catGroup?.hidden ? 0.33 : undefined,
+        opacity: category.hidden || categoryGroup?.hidden ? 0.33 : undefined,
       }}
     >
       <div
@@ -104,7 +104,7 @@ export function SidebarCategory({
                 setMenuOpen(false);
               }}
               items={[
-                !catGroup?.hidden && {
+                !categoryGroup?.hidden && {
                   name: 'toggle-visibility',
                   text: category.hidden ? 'Show' : 'Hide',
                 },

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -227,6 +227,7 @@ function ExpenseCategoryPreview({ name, pending, style }) {
 const ExpenseCategory = memo(function ExpenseCategory({
   type,
   category,
+  isHidden,
   goal,
   budgeted,
   spent,
@@ -322,7 +323,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
         backgroundColor: 'transparent',
         borderBottomWidth: 0,
         borderTopWidth: index > 0 ? 1 : 0,
-        opacity: !!category.hidden ? 0.5 : undefined,
+        opacity: isHidden ? 0.5 : undefined,
         ...style,
       }}
       data-testid="row"
@@ -894,6 +895,7 @@ const ExpenseGroup = memo(function ExpenseGroup({
               show3Cols={show3Cols}
               type={type}
               category={category}
+              isHidden={!!category.hidden || group.hidden}
               goal={
                 type === 'report'
                   ? reportBudget.catGoal(category.id)

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -347,7 +347,7 @@ function BudgetInner(props: BudgetInnerProps) {
     dispatch(
       pushModal('category-menu', {
         categoryId: category.id,
-        isHidden: categoryGroup?.hidden,
+        categoryGroup: categoryGroup,
         onSave: onSaveCategory,
         onEditNotes: onEditCategoryNotes,
         onDelete: onDeleteCategory,

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -347,7 +347,7 @@ function BudgetInner(props: BudgetInnerProps) {
     dispatch(
       pushModal('category-menu', {
         categoryId: category.id,
-        categoryGroup: categoryGroup,
+        categoryGroup,
         onSave: onSaveCategory,
         onEditNotes: onEditCategoryNotes,
         onDelete: onDeleteCategory,

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -343,9 +343,11 @@ function BudgetInner(props: BudgetInnerProps) {
 
   const onEditCategory = id => {
     const category = categories.find(c => c.id === id);
+    const categoryGroup = categoryGroups.find(g => g.id === category.cat_group);
     dispatch(
       pushModal('category-menu', {
         categoryId: category.id,
+        isHidden: categoryGroup?.hidden,
         onSave: onSaveCategory,
         onEditNotes: onEditCategoryNotes,
         onDelete: onDeleteCategory,

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -155,7 +155,12 @@ export function CategoryMenuModal({
   );
 }
 
-function AdditionalCategoryMenu({ category, isHidden, onDelete, onToggleVisibility }) {
+function AdditionalCategoryMenu({
+  category,
+  isHidden,
+  onDelete,
+  onToggleVisibility,
+}) {
   const [menuOpen, setMenuOpen] = useState(false);
   const itemStyle: CSSProperties = {
     ...styles.mediumText,

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -23,6 +23,7 @@ import { Tooltip } from '../tooltips';
 type CategoryMenuModalProps = {
   modalProps: CommonModalProps;
   categoryId: string;
+  isHidden?: boolean;
   onSave: (category: CategoryEntity) => void;
   onEditNotes: (id: string) => void;
   onDelete: (categoryId: string) => void;
@@ -32,6 +33,7 @@ type CategoryMenuModalProps = {
 export function CategoryMenuModal({
   modalProps,
   categoryId,
+  isHidden,
   onSave,
   onEditNotes,
   onDelete,
@@ -102,6 +104,7 @@ export function CategoryMenuModal({
       leftHeaderContent={
         <AdditionalCategoryMenu
           category={category}
+          isHidden={isHidden}
           onDelete={_onDelete}
           onToggleVisibility={_onToggleVisibility}
         />
@@ -152,7 +155,7 @@ export function CategoryMenuModal({
   );
 }
 
-function AdditionalCategoryMenu({ category, onDelete, onToggleVisibility }) {
+function AdditionalCategoryMenu({ category, isHidden, onDelete, onToggleVisibility }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const itemStyle: CSSProperties = {
     ...styles.mediumText,
@@ -184,7 +187,7 @@ function AdditionalCategoryMenu({ category, onDelete, onToggleVisibility }) {
             <Menu
               getItemStyle={() => itemStyle}
               items={[
-                {
+                !isHidden && {
                   name: 'toggleVisibility',
                   text: category.hidden ? 'Show' : 'Hide',
                   icon: category.hidden ? SvgViewShow : SvgViewHide,

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -198,7 +198,7 @@ function AdditionalCategoryMenu({
                   icon: category.hidden ? SvgViewShow : SvgViewHide,
                   iconSize: 16,
                 },
-                Menu.line,
+                !isHidden && Menu.line,
                 {
                   name: 'delete',
                   text: 'Delete',

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { q } from 'loot-core/src/shared/query';
 import {
+  CategoryGroupEntity,
   type CategoryEntity,
   type NoteEntity,
 } from 'loot-core/src/types/models';
@@ -23,7 +24,7 @@ import { Tooltip } from '../tooltips';
 type CategoryMenuModalProps = {
   modalProps: CommonModalProps;
   categoryId: string;
-  isHidden?: boolean;
+  categoryGroup?: CategoryGroupEntity;
   onSave: (category: CategoryEntity) => void;
   onEditNotes: (id: string) => void;
   onDelete: (categoryId: string) => void;
@@ -33,7 +34,7 @@ type CategoryMenuModalProps = {
 export function CategoryMenuModal({
   modalProps,
   categoryId,
-  isHidden,
+  categoryGroup,
   onSave,
   onEditNotes,
   onDelete,
@@ -104,7 +105,7 @@ export function CategoryMenuModal({
       leftHeaderContent={
         <AdditionalCategoryMenu
           category={category}
-          isHidden={isHidden}
+          categoryGroup={categoryGroup}
           onDelete={_onDelete}
           onToggleVisibility={_onToggleVisibility}
         />
@@ -157,7 +158,7 @@ export function CategoryMenuModal({
 
 function AdditionalCategoryMenu({
   category,
-  isHidden,
+  categoryGroup,
   onDelete,
   onToggleVisibility,
 }) {
@@ -192,13 +193,13 @@ function AdditionalCategoryMenu({
             <Menu
               getItemStyle={() => itemStyle}
               items={[
-                !isHidden && {
+                !categoryGroup?.hidden && {
                   name: 'toggleVisibility',
                   text: category.hidden ? 'Show' : 'Hide',
                   icon: category.hidden ? SvgViewShow : SvgViewHide,
                   iconSize: 16,
                 },
-                !isHidden && Menu.line,
+                !categoryGroup?.hidden && Menu.line,
                 {
                   name: 'delete',
                   text: 'Delete',

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { useLiveQuery } from 'loot-core/src/client/query-hooks';
 import { q } from 'loot-core/src/shared/query';
 import {
-  CategoryGroupEntity,
+  type CategoryGroupEntity,
   type CategoryEntity,
   type NoteEntity,
 } from 'loot-core/src/types/models';

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -143,6 +143,7 @@ type FinanceModals = {
   };
   'category-menu': {
     categoryId: string;
+    isHidden: boolean;
     onSave: (category: CategoryEntity) => void;
     onEditNotes: (id: string) => void;
     onDelete: (categoryId: string) => void;

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -143,7 +143,7 @@ type FinanceModals = {
   };
   'category-menu': {
     categoryId: string;
-    isHidden: boolean;
+    categoryGroup?: CategoryGroupEntity;
     onSave: (category: CategoryEntity) => void;
     onEditNotes: (id: string) => void;
     onDelete: (categoryId: string) => void;

--- a/upcoming-release-notes/2582.md
+++ b/upcoming-release-notes/2582.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Dim categories in the budget view if hidden by their category group.


### PR DESCRIPTION
Closes #2578.

This dims the categories if the parent group is hidden.  It also does not show the 'hide'/'show' menu items if the category is hidden (as that would not actually change their hidden status anyway).

![dimmed-cats](https://github.com/actualbudget/actual/assets/1115390/4d6b5754-9d53-4a03-9e91-cf28ed743cd7)
