### PR TITLE
Allow 5 decimal places in file import parser

### DIFF
--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -2,19 +2,20 @@ import { looselyParseAmount, getNumberFormat, setNumberFormat } from './util';
 
 describe('utility functions', () => {
   test('looseParseAmount works with basic numbers', () => {
+    // Parsing is currently limited to 1,2 decimal places or 5.
+    // Ignoring 3 places removes the possibility of improper parse
+    //  of amounts without decimal amounts included.
     expect(looselyParseAmount('3')).toBe(3);
+    expect(looselyParseAmount('3.4')).toBe(3.40);
     expect(looselyParseAmount('3.45')).toBe(3.45);
-
-    // Parsing is currently limited to 2 decimal places.
-    // Only <. ,> and 2 other chars counts as decimal places
-    // Proper parsing would include format settings,
-    // but currently we are format agnostic
     expect(looselyParseAmount('3.456')).toBe(3456);
+    expect(looselyParseAmount('3.45000')).toBe(3.45);
   });
 
   test('looseParseAmount works with alternate formats', () => {
     expect(looselyParseAmount('3,45')).toBe(3.45);
     expect(looselyParseAmount('3,456')).toBe(3456);
+    expect(looselyParseAmount('3,45000')).toBe(3.45);
   });
 
   test('looseParseAmount works with negative numbers', () => {

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -6,7 +6,7 @@ describe('utility functions', () => {
     // Ignoring 3 places removes the possibility of improper parse
     //  of amounts without decimal amounts included.
     expect(looselyParseAmount('3')).toBe(3);
-    expect(looselyParseAmount('3.4')).toBe(3.40);
+    expect(looselyParseAmount('3.4')).toBe(3.4);
     expect(looselyParseAmount('3.45')).toBe(3.45);
     expect(looselyParseAmount('3.456')).toBe(3456);
     expect(looselyParseAmount('3.45000')).toBe(3.45);

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -379,7 +379,9 @@ export function looselyParseAmount(amount: string) {
     amount = amount.replace('(', '-').replace(')', '');
   }
 
-  const m = amount.match(/[.,][^.,]{1,2}$/);
+  //look for a decimal marker, then look for either 5 or 1-2 decimal places.
+  // This avoids matching against 3 places which may not actually be decimal
+  const m = amount.match(/[.,]([^.,]{5}|[^.,]{1,2})$/);
   if (!m || m.index === undefined || m.index === 0) {
     return safeNumber(parseFloat(extractNumbers(amount)));
   }

--- a/upcoming-release-notes/2588.md
+++ b/upcoming-release-notes/2588.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Allow 5 decimal places in csv files without matching on 3 or 4


### PR DESCRIPTION
I updated the file import amount parser a bit ago to only allow 2 decimal places. The point of that was to not accidentally set something as decimal when a number didn't include any decimal amount. 

This PR adjusts the parser to allow 5 or 1-2 digits after the decimal marker. This way files that use the finance-y format of 5 decimal places work.
