### PR TITLE
Force transaction cleared checkboxes to show on reconcile view

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -754,7 +754,11 @@ class AccountInternal extends PureComponent {
   };
 
   onReconcile = async balance => {
-    this.setState({ reconcileAmount: balance });
+    this.setState(({ showCleared }) => ({
+      reconcileAmount: balance,
+      showCleared: true,
+      prevShowCleared: showCleared,
+    }));
   };
 
   onDoneReconciling = async () => {
@@ -783,7 +787,10 @@ class AccountInternal extends PureComponent {
       await this.lockTransactions();
     }
 
-    this.setState({ reconcileAmount: null });
+    this.setState({
+      reconcileAmount: null,
+      showCleared: this.state.prevShowCleared,
+    });
   };
 
   onCreateReconciliationTransaction = async diff => {

--- a/upcoming-release-notes/2589.md
+++ b/upcoming-release-notes/2589.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Force transaction cleared checkboxes to show on reconcile view


### PR DESCRIPTION
This PR fixes #1013 

This is my first change in Actual and I've only got limited React experience so if there is a better way to do this, or to recall previous state values, please shout and I'll amend.