### PR TITLE
Hide Y axis values of net worth graph when privacy mode i…

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -17,6 +17,7 @@ import { type CSSProperties } from '../../../style';
 import { AlignedText } from '../../common/AlignedText';
 import { Container } from '../Container';
 import { numberFormatterTooltip } from '../numberFormatter';
+import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 
 type NetWorthGraphProps = {
   style?: CSSProperties;
@@ -29,8 +30,10 @@ export function NetWorthGraph({
   graphData,
   compact,
 }: NetWorthGraphProps) {
+  const privacyMode = usePrivacyMode();
+
   const tickFormatter = tick => {
-    return `${Math.round(tick).toLocaleString()}`; // Formats the tick values as strings with commas
+    return privacyMode ? '...' : `${Math.round(tick).toLocaleString()}`; // Formats the tick values as strings with commas
   };
 
   const gradientOffset = () => {

--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -12,12 +12,12 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
+import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 import { theme } from '../../../style';
 import { type CSSProperties } from '../../../style';
 import { AlignedText } from '../../common/AlignedText';
 import { Container } from '../Container';
 import { numberFormatterTooltip } from '../numberFormatter';
-import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 
 type NetWorthGraphProps = {
   style?: CSSProperties;

--- a/upcoming-release-notes/2594.md
+++ b/upcoming-release-notes/2594.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfix
-authors: ttlgeek
+authors: [ttlgeek]
 ---
 
 Hide Y axis values of net worth graph when privacy mode is enabled.

--- a/upcoming-release-notes/2594.md
+++ b/upcoming-release-notes/2594.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+authors: ttlgeek
+---
+
+Hide Y axis values of net worth graph when privacy mode is enabled.

--- a/upcoming-release-notes/2594.md
+++ b/upcoming-release-notes/2594.md
@@ -1,5 +1,5 @@
 ---
-category: Fixes
+category: Bugfix
 authors: ttlgeek
 ---
 


### PR DESCRIPTION
Hide Y axis values of net worth graph when privacy mode is enabled.

Closes #2563

Screenshot:

<img width="1486" alt="image" src="https://github.com/actualbudget/actual/assets/13290055/0cf7d2a5-a850-4ae2-bf2a-5495b3fef810">
