### PR TITLE
:zap: extra error handling in case backend failed loading

### DIFF
--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -12,15 +12,15 @@ let hasInitialized = false;
 const importScriptsWithRetry = async (script, { maxRetries = 5 } = {}) => {
   try {
     importScripts(script);
-  } catch (e) {
+  } catch (error) {
     // Break if maxRetries has exceeded
     if (maxRetries <= 0) {
-      throw e;
+      throw error;
     } else {
       console.groupCollapsed(
         `Failed to load backend, will retry ${maxRetries} more time(s)`,
       );
-      console.log(e);
+      console.log(error);
       console.groupEnd();
     }
 
@@ -36,10 +36,10 @@ const importScriptsWithRetry = async (script, { maxRetries = 5 } = {}) => {
   }
 };
 
-self.addEventListener('message', async e => {
+self.addEventListener('message', async event => {
   try {
     if (!hasInitialized) {
-      const msg = e.data;
+      const msg = event.data;
 
       if (msg.type === 'init') {
         hasInitialized = true;
@@ -75,8 +75,8 @@ self.addEventListener('message', async e => {
         });
       }
     }
-  } catch (e) {
-    console.log('Failed initializing backend:', e);
+  } catch (error) {
+    console.log('Failed initializing backend:', error);
     self.postMessage({
       type: 'app-init-failure',
       BackendInitFailure: true,

--- a/packages/desktop-client/src/components/FatalError.tsx
+++ b/packages/desktop-client/src/components/FatalError.tsx
@@ -15,6 +15,7 @@ type AppError = Error & {
   type?: string;
   IDBFailure?: boolean;
   SharedArrayBufferMissing?: boolean;
+  BackendInitFailure?: boolean;
 };
 
 type FatalErrorProps = {
@@ -64,18 +65,7 @@ function RenderSimple({ error }: RenderSimpleProps) {
     // user something at least so they aren't looking at a blank
     // screen
     msg = (
-      <Text>
-        There was a problem loading the app in this browser version. If this
-        continues to be a problem, you can{' '}
-        <Link
-          variant="external"
-          linkColor="muted"
-          to="https://github.com/actualbudget/releases"
-        >
-          download the desktop app
-        </Link>
-        .
-      </Text>
+      <Text>There was a problem loading the app in this browser version.</Text>
     );
   }
 

--- a/upcoming-release-notes/2601.md
+++ b/upcoming-release-notes/2601.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Improved fatal-error handling in case backend failed loading: show error message.


### PR DESCRIPTION
Adding a bit of extra error handling in case the backend has failed loading (fatal error).

It seems at some point we have lost the fatal error handling logic. Meaning that in case of fatal errors (backend totally failed loading) - we would show an endless spinning bar instead of an error message.

So this _slightly_ improves the situation.. the user will now see an error message.

---

Also renamed `e` vars to something else. This _might_ fix https://github.com/actualbudget/actual/issues/1766 , but since I've not been able to reproduce the issue locally - it's mostly a shot in the dark.