### PR TITLE
[Mobile] Use budget start month pref on mobile to match desktop behavior

### DIFF
--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -75,22 +75,18 @@ function BudgetInner(props: BudgetInnerProps) {
   const spreadsheet = useSpreadsheet();
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [_startMonth, setBudgetStartMonthPref] =
-    useLocalPref('budget.startMonth');
-  const startMonth = _startMonth || currentMonth;
   const [summaryCollapsed, setSummaryCollapsedPref] = useLocalPref(
     'budget.summaryCollapsed',
   );
-  const [_budgetType] = useLocalPref('budgetType');
-  const budgetType = _budgetType || 'rollover';
-  const [_maxMonths] = useGlobalPref('maxMonths');
-  const maxMonths = _maxMonths || 1;
-
-  const [initialized, setInitialized] = useState(false);
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
+  const [maxMonths = 1] = useGlobalPref('maxMonths');
+  const [startMonth = currentMonth, setStartMonthPref] =
+    useLocalPref('budget.startMonth');
   const [bounds, setBounds] = useState({
-    start: currentMonth,
-    end: currentMonth,
+    start: startMonth,
+    end: startMonth,
   });
+  const [initialized, setInitialized] = useState(false);
   const { grouped: categoryGroups } = useCategories();
 
   function loadCategories() {
@@ -153,7 +149,7 @@ function BudgetInner(props: BudgetInnerProps) {
   }, [props.accountId]);
 
   const onMonthSelect = async (month, numDisplayed) => {
-    setBudgetStartMonthPref(month);
+    setStartMonthPref(month);
 
     const warmingMonth = month;
 
@@ -180,7 +176,7 @@ function BudgetInner(props: BudgetInnerProps) {
     }
 
     if (warmingMonth === month) {
-      setBudgetStartMonthPref(month);
+      setStartMonthPref(month);
     }
   };
 

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -78,14 +78,16 @@ function BudgetInner(props: BudgetInnerProps) {
   const [summaryCollapsed, setSummaryCollapsedPref] = useLocalPref(
     'budget.summaryCollapsed',
   );
-  const [budgetType = 'rollover'] = useLocalPref('budgetType');
-  const [maxMonths = 1] = useGlobalPref('maxMonths');
-  const [startMonth = currentMonth, setStartMonthPref] =
-    useLocalPref('budget.startMonth');
+  const [startMonthPref, setStartMonthPref] = useLocalPref('budget.startMonth');
+  const startMonth = startMonthPref || currentMonth;
   const [bounds, setBounds] = useState({
     start: startMonth,
     end: startMonth,
   });
+  const [budgetTypePref] = useLocalPref('budgetType');
+  const budgetType = budgetTypePref || 'rollover';
+  const [maxMonthsPref] = useGlobalPref('maxMonths');
+  const maxMonths = maxMonthsPref || 1;
   const [initialized, setInitialized] = useState(false);
   const { grouped: categoryGroups } = useCategories();
 

--- a/upcoming-release-notes/2613.md
+++ b/upcoming-release-notes/2613.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Honor the budget.startMonth pref to open the last month the user was working on before closing the app.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Honor the `budget.startMonth` pref to open the last month the user was working on before closing the app (similar to how it is on desktop) 