### PR TITLE
:bug: (tooltip) add scrollbars to tooltips that go out of bounds

### DIFF
--- a/packages/desktop-client/src/style/styles.ts
+++ b/packages/desktop-client/src/style/styles.ts
@@ -135,6 +135,7 @@ export const styles = {
     borderRadius: 4,
     backgroundColor: theme.menuBackground,
     color: theme.menuItemText,
+    overflow: 'scroll',
   },
   // Dynamically set
   lightScrollbar: null as CSSProperties | null,

--- a/upcoming-release-notes/2614.md
+++ b/upcoming-release-notes/2614.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix notes tooltip content going out of bounds.


### PR DESCRIPTION
Closes #2605

<img width="437" alt="Screenshot 2024-04-16 at 18 36 39" src="https://github.com/actualbudget/actual/assets/886567/33c52d6d-1531-4518-88cd-1f8fd1750d14">
