### PR TITLE
[WIP] :wrench: downgrade the backend build target to es2020

### DIFF
--- a/packages/api/tsconfig.dist.json
+++ b/packages/api/tsconfig.dist.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     // Using ES2021 because that’s the newest version where
     // the latest Node 16.x release supports all of the features
-    "target": "ES2021",
+    "target": "ES2020",
     "module": "CommonJS",
     "noEmit": false,
     "declaration": true,
@@ -11,7 +11,7 @@
     "declarationDir": "@types",
     "paths": {
       "loot-core/src/*": ["./loot-core/*"],
-      "loot-core/*": ["./@types/loot-core/*"],
+      "loot-core/*": ["./@types/loot-core/*"]
     }
   },
   "include": ["."],


### PR DESCRIPTION
Potential fix for https://github.com/actualbudget/actual/issues/1766