### PR TITLE
rename electron master workflow

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -1,4 +1,4 @@
-name: Electron
+name: Electron Master
 
 defaults:
   run:

--- a/upcoming-release-notes/2620.md
+++ b/upcoming-release-notes/2620.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [youngcw]
+---
+
+Rename electron master workflow to be different thant he electron pr workflow


### PR DESCRIPTION
Rename the Electron Master workflow so that it shows up different in the actions page.

I guess Im mostly assuming that this will cause the actions page to rename the side bar name.  I just want then to not both be "Electron".
