### PR TITLE
Make /login show descriptive error when an incorrect password is submitted

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1483,16 +1483,18 @@ handlers['subscribe-change-password'] = async function ({ password }) {
 };
 
 handlers['subscribe-sign-in'] = async function ({ password }) {
-  const res = await post(getServer().SIGNUP_SERVER + '/login', {
-    password,
-  });
+  try {
+    const res = await post(getServer().SIGNUP_SERVER + '/login', {
+      password,
+    });
 
-  if (res.token) {
-    await asyncStorage.setItem('user-token', res.token);
-    return {};
+    if (res.token) {
+      await asyncStorage.setItem('user-token', res.token);
+      return {};
+    }
+  } catch (e) {
+    return { error: 'invalid-password' };
   }
-
-  return { error: 'invalid-password' };
 };
 
 handlers['subscribe-sign-out'] = async function () {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1483,18 +1483,22 @@ handlers['subscribe-change-password'] = async function ({ password }) {
 };
 
 handlers['subscribe-sign-in'] = async function ({ password }) {
+  let res;
+
   try {
-    const res = await post(getServer().SIGNUP_SERVER + '/login', {
+    res = await post(getServer().SIGNUP_SERVER + '/login', {
       password,
     });
-
-    if (res.token) {
-      await asyncStorage.setItem('user-token', res.token);
-      return {};
-    }
-  } catch (e) {
-    return { error: 'invalid-password' };
+  } catch (err) {
+    return { error: err.reason || 'network-failure' };
   }
+
+  if (!res.token) {
+    throw new Error('login: User token not set');
+  }
+
+  await asyncStorage.setItem('user-token', res.token);
+  return {};
 };
 
 handlers['subscribe-sign-out'] = async function () {

--- a/upcoming-release-notes/2641.md
+++ b/upcoming-release-notes/2641.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mattfidd]
+---
+
+Make /login show descriptive error when an incorrect password is submitted


### PR DESCRIPTION
Fixes #2640 

Before:
![image](https://github.com/actualbudget/actual/assets/81489167/710406bd-9378-4b54-b6a1-1e5279340113)

After:
![image](https://github.com/actualbudget/actual/assets/81489167/588be372-2c26-4971-b654-9e8b6dabce60)
