### PR TITLE
Fix OFX import with non-unique FITID

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -352,7 +352,7 @@ describe('API CRUD operations', () => {
 
     let newTransaction = [
       { date: '2023-11-03', imported_id: '11', amount: 100 },
-      { date: '2023-11-03', imported_id: '11', amount: 100 },
+      { date: '2023-11-03', imported_id: '12', amount: 100 },
     ];
 
     const addResult = await api.addTransactions(accountId, newTransaction, {

--- a/upcoming-release-notes/2646.md
+++ b/upcoming-release-notes/2646.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Wizmaster]
+---
+
+Fix OFX import with non-unique FITID


### PR DESCRIPTION
Fix #608

When importing, only merge transaction found with same imported_id if the imported_payee and amount also match, and if a single transaction was found. Else let the fuzzy matching try to find a transaction match.

In the comment https://github.com/actualbudget/actual/issues/608#issuecomment-2067322290 I thought using the date to match the transaction but decided against it, the user could change the date to their liking and matching on it would becomes unreliable.

Testing with the OFX files provided in #608 was conclusive. Only 3 transactions were mistakenly merged:
- 1 due to issue #2420, the dates where close enough and the amounts the same
- 2 due to fitid, amounts and payee info being the same (the issue arose because the payee used were "Generic Transaction #xx" with xx being the fitid, something I believe unlikely with real data)

Testing with my own data was also ok.