### PR TITLE
Don't update transaction date when importing manually

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -351,8 +351,8 @@ describe('API CRUD operations', () => {
     const accountId = await api.createAccount({ name: 'test-account' }, 0);
 
     let newTransaction = [
-      { date: '2023-11-03', imported_id: '11', amount: 100 },
-      { date: '2023-11-03', imported_id: '11', amount: 100 },
+      { date: '2023-11-03', imported_id: '11', amount: 100, notes: 'notes' },
+      { date: '2023-11-03', imported_id: '12', amount: 100, notes: '' },
     ];
 
     const addResult = await api.addTransactions(accountId, newTransaction, {
@@ -375,8 +375,9 @@ describe('API CRUD operations', () => {
     expect(transactions).toHaveLength(2);
 
     newTransaction = [
-      { date: '2023-12-03', imported_id: '11', amount: 100 },
-      { date: '2023-12-03', imported_id: '22', amount: 200 },
+      { date: '2023-12-03', imported_id: '11', amount: 100, notes: 'notes' },
+      { date: '2023-12-03', imported_id: '12', amount: 100, notes: 'notes' },
+      { date: '2023-12-03', imported_id: '22', amount: 200, notes: '' },
     ];
 
     const reconciled = await api.importTransactions(accountId, newTransaction);
@@ -392,9 +393,22 @@ describe('API CRUD operations', () => {
       '2023-12-31',
     );
     expect(transactions).toEqual(
-      expect.arrayContaining(
-        newTransaction.map(trans => expect.objectContaining(trans)),
-      ),
+      expect.arrayContaining([
+        expect.objectContaining({ imported_id: '22', amount: 200 }),
+      ]),
+    );
+    expect(transactions).toHaveLength(1);
+
+    // confirm imported transactions update perfomed
+    transactions = await api.getTransactions(
+      accountId,
+      '2023-11-01',
+      '2023-11-30',
+    );
+    expect(transactions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ notes: 'notes', amount: 100 }),
+      ]),
     );
     expect(transactions).toHaveLength(2);
 

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -490,7 +490,6 @@ export async function reconcileTransactions(
 
       // Update the transaction
       const updates = {
-        ...(isBankSyncAccount ? {} : { date: trans.date }),
         imported_id: trans.imported_id || null,
         payee: existing.payee || trans.payee || null,
         category: existing.category || trans.category || null,

--- a/upcoming-release-notes/2648.md
+++ b/upcoming-release-notes/2648.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Wizmaster]
+---
+
+Don't update transaction date when importing manually


### PR DESCRIPTION
Following work done in #1559 and update in #2534 (discussion https://github.com/actualbudget/actual/pull/2534#discussion_r1545649961), I think manual import should not override the transaction date as is done with bank account sync.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
