### PR TITLE
:bug: fix budget-type identification when deleting files

### DIFF
--- a/packages/desktop-client/src/components/manager/DeleteFile.tsx
+++ b/packages/desktop-client/src/components/manager/DeleteFile.tsx
@@ -20,7 +20,8 @@ export function DeleteFile({ modalProps, actions, file }: DeleteFileProps) {
   // If the state is "broken" that means it was created by another
   // user. The current user should be able to delete the local file,
   // but not the remote one
-  const isCloudFile = !!file.cloudFileId && file.state !== 'broken';
+  const isCloudFile = 'cloudFileId' in file && file.state !== 'broken';
+  console.log('file', file);
 
   const [loadingState, setLoadingState] = useState<'cloud' | 'local' | null>(
     null,

--- a/packages/desktop-client/src/components/manager/DeleteFile.tsx
+++ b/packages/desktop-client/src/components/manager/DeleteFile.tsx
@@ -21,7 +21,6 @@ export function DeleteFile({ modalProps, actions, file }: DeleteFileProps) {
   // user. The current user should be able to delete the local file,
   // but not the remote one
   const isCloudFile = 'cloudFileId' in file && file.state !== 'broken';
-  console.log('file', file);
 
   const [loadingState, setLoadingState] = useState<'cloud' | 'local' | null>(
     null,

--- a/packages/desktop-client/src/components/manager/DeleteFile.tsx
+++ b/packages/desktop-client/src/components/manager/DeleteFile.tsx
@@ -20,7 +20,7 @@ export function DeleteFile({ modalProps, actions, file }: DeleteFileProps) {
   // If the state is "broken" that means it was created by another
   // user. The current user should be able to delete the local file,
   // but not the remote one
-  const isCloudFile = 'cloudFileId' in file && file.state !== 'broken';
+  const isCloudFile = !!file.cloudFileId && file.state !== 'broken';
 
   const [loadingState, setLoadingState] = useState<'cloud' | 'local' | null>(
     null,

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -15,6 +15,7 @@ import { isNonProductionEnvironment } from '../shared/environment';
 import * as monthUtils from '../shared/months';
 import { q, Query } from '../shared/query';
 import { amountToInteger, stringToInteger } from '../shared/util';
+import { type Budget } from '../types/budget';
 import { Handlers } from '../types/handlers';
 
 import { exportToCSV, exportQueryToCSV } from './accounts/export-to-csv';
@@ -1576,10 +1577,10 @@ handlers['get-budgets'] = async function () {
           if (name !== DEMO_BUDGET_ID) {
             return {
               id: name,
-              cloudFileId: prefs.cloudFileId,
-              groupId: prefs.groupId,
+              ...(prefs.cloudFileId ? { cloudFileId: prefs.cloudFileId } : {}),
+              ...(prefs.groupId ? { groupId: prefs.groupId } : {}),
               name: prefs.budgetName || '(no name)',
-            };
+            } satisfies Budget;
           }
         }
 

--- a/upcoming-release-notes/2649.md
+++ b/upcoming-release-notes/2649.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Do not show "delete remote file" option for local budget files.


### PR DESCRIPTION
Patching how we build the file objects. `cloudFileId` should not be set for local-only files.

This leads to the "delete file" modal always showing the "delete remote file" button. Even when the button should not be there.