### PR TITLE
Ignore transactions with empty date & amount

### DIFF
--- a/packages/loot-core/src/server/accounts/parse-file.ts
+++ b/packages/loot-core/src/server/accounts/parse-file.ts
@@ -96,13 +96,15 @@ async function parseQIF(filepath: string): Promise<ParseFileResult> {
 
   return {
     errors: [],
-    transactions: data.transactions.map(trans => ({
-      amount: trans.amount != null ? looselyParseAmount(trans.amount) : null,
-      date: trans.date,
-      payee_name: trans.payee,
-      imported_payee: trans.payee,
-      notes: trans.memo || null,
-    })),
+    transactions: data.transactions
+      .map(trans => ({
+        amount: trans.amount != null ? looselyParseAmount(trans.amount) : null,
+        date: trans.date,
+        payee_name: trans.payee,
+        imported_payee: trans.payee,
+        notes: trans.memo || null,
+      }))
+      .filter(trans => trans.date != null && trans.amount != null),
   };
 }
 

--- a/upcoming-release-notes/2653.md
+++ b/upcoming-release-notes/2653.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kyangk]
+---
+
+Ignore transactions with empty date & amount


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

fixes: #2647

My bank always generates an empty record for qif. This shows up as an empty line when importing. This prevents it from being imported successfully. Right now, I am manually editing the qif file before importing each time.

With this change, transactions with empty date and amount are ignored.

<img width="595" alt="Screen Shot 2024-04-20 at 8 30 30 AM" src="https://github.com/actualbudget/actual/assets/947525/8f05d996-1112-4ddf-bd9f-5f965fe898b7">


```
!Type:CCard
D04/10/2024
N1111111
PABC
A
T123
^
^
```