### PR TITLE
[Mobile] Fix comma handling in split transaction

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -313,6 +313,7 @@ const ChildTransactionEdit = forwardRef(
           >
             <FieldLabel title="Amount" style={{ padding: 0 }} />
             <AmountInput
+              mobile={true}
               disabled={
                 editingField &&
                 editingField !== getFieldName(transaction.id, 'amount')

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -8,7 +8,11 @@ import React, {
 } from 'react';
 
 import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import { amountToInteger } from 'loot-core/src/shared/util';
+import {
+  amountToInteger,
+  toRelaxedNumber,
+  getNumberFormat,
+} from 'loot-core/src/shared/util';
 
 import { useMergedRefs } from '../../hooks/useMergedRefs';
 import { SvgAdd, SvgSubtract } from '../../icons/v1';
@@ -31,6 +35,7 @@ type AmountInputProps = {
   textStyle?: CSSProperties;
   focused?: boolean;
   disabled?: boolean;
+  mobile?: boolean;
 };
 
 export function AmountInput({
@@ -46,6 +51,7 @@ export function AmountInput({
   textStyle,
   focused,
   disabled = false,
+  mobile = false,
 }: AmountInputProps) {
   const format = useFormat();
   const negative = (initialValue === 0 && zeroSign === '-') || initialValue < 0;
@@ -74,8 +80,12 @@ export function AmountInput({
   }
 
   function onInputTextChange(val) {
-    setValue(val ? val : '');
-    onChangeValue?.(val);
+    let value = val;
+    if (mobile) {
+      value = val.replace(/[,.]/, getNumberFormat().separator);
+    }
+    setValue(value ? value : '');
+    onChangeValue?.(value);
   }
 
   function fireUpdate(negate) {

--- a/upcoming-release-notes/2661.md
+++ b/upcoming-release-notes/2661.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [sierikov]
+---
+
+Fix decimal separator handling in split transaction amount field on mobile.


### PR DESCRIPTION
Attempt to solve #2629. This fix dynamically replaces a comma with a dot in "Split transaciton" mode on mobile devices.

