### PR TITLE
[Feature] Make comma's and period interchangeable when entering figures

### DIFF
--- a/packages/loot-core/src/shared/arithmetic.ts
+++ b/packages/loot-core/src/shared/arithmetic.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { getNumberFormat } from './util';
+import { currencyToAmount } from './util';
 
 function fail(state, msg) {
   throw new Error(
@@ -37,31 +37,16 @@ function parsePrimary(state) {
     next(state);
   }
 
-  if (/\p{Sc}/u.test(char(state))) {
-    next(state);
-  }
-
-  // TODO: The regex should probably respect the number format better,
-  // and we should do more strict parsing
   let numberStr = '';
-  while (char(state) && char(state).match(/[0-9,.]/)) {
-    const thousandsSep = getNumberFormat().separator === ',' ? '.' : ',';
-
-    // Don't include the thousands separator
-    if (char(state) === thousandsSep) {
-      next(state);
-    } else {
-      numberStr += next(state);
-    }
+  while (char(state) && char(state).match(/[0-9,. ]|\p{Sc}/u)) {
+    numberStr += next(state);
   }
 
   if (numberStr === '') {
     fail(state, 'Unexpected character');
   }
 
-  const number = parseFloat(
-    numberStr.replace(getNumberFormat().separator, '.'),
-  );
+  const number = currencyToAmount(numberStr);
   return isNegative ? -number : number;
 }
 

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -255,13 +255,14 @@ export function getNumberFormat({
   format?: NumberFormats;
   hideFraction: boolean;
 } = numberFormatConfig) {
-  let locale, regex, separator;
+  let locale, regex, separator, separatorRegex;
 
   switch (format) {
     case 'space-comma':
       locale = 'en-SE';
-      regex = /[^-0-9,]/g;
+      regex = /[^-0-9,.]/g;
       separator = ',';
+      separatorRegex = /[,.]/g;
       break;
     case 'dot-comma':
       locale = 'de-DE';
@@ -270,8 +271,9 @@ export function getNumberFormat({
       break;
     case 'space-dot':
       locale = 'dje';
-      regex = /[^-0-9.]/g;
+      regex = /[^-0-9,.]/g;
       separator = '.';
+      separatorRegex = /[,.]/g;
       break;
     case 'comma-dot-in':
       locale = 'en-IN';
@@ -293,6 +295,7 @@ export function getNumberFormat({
       maximumFractionDigits: hideFraction ? 0 : 2,
     }),
     regex,
+    separatorRegex,
   };
 }
 
@@ -342,11 +345,20 @@ export function amountToCurrencyNoDecimal(n) {
 }
 
 export function currencyToAmount(str: string) {
-  const amount = parseFloat(
-    str
-      .replace(getNumberFormat().regex, '')
-      .replace(getNumberFormat().separator, '.'),
-  );
+  let amount;
+  if (getNumberFormat().separatorRegex) {
+    amount = parseFloat(
+      str
+        .replace(getNumberFormat().regex, '')
+        .replace(getNumberFormat().separatorRegex, '.'),
+    );
+  } else {
+    amount = parseFloat(
+      str
+        .replace(getNumberFormat().regex, '')
+        .replace(getNumberFormat().separator, '.'),
+    );
+  }
   return isNaN(amount) ? null : amount;
 }
 

--- a/upcoming-release-notes/2672.md
+++ b/upcoming-release-notes/2672.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Wizmaster]
+---
+
+Comma and period decimal separator can both be used for number format not using those as thousand separator.


### PR DESCRIPTION
Implements #2318

It's only allowed for formats not using period or comma as a thousand separator. I don't think somebody using a format with comma and dot as decimal and thousand separator would have the issue in the first place.

I reworked the arithmetic parser to let `currencyToAmount()` handle number formatting with active format. I noticed it also made an exception for a leading currency symbol but not for a tailing one. I fixed it to allow that case. (actually in my implementation you could also put a currency symbol in the middle of a value but it would be ignored anyway, I don't think it's an issue)

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
