### PR TITLE
[WIP] reports: Fix scrollbar colors.

### DIFF
--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -133,7 +133,7 @@ export function CategorySelector({
           paddingRight: 10,
           flexGrow: 1,
           overflowY: 'auto',
-          scrollbarColor: theme.tableHeaderBackground + ' ' + theme.tableBorder
+          scrollbarColor: theme.tableBackground + ' ' + theme.pageBackground
         }}
       >
         {categoryGroups &&

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -6,6 +6,7 @@ import {
   type CategoryGroupEntity,
 } from 'loot-core/src/types/models';
 
+import { theme } from '../../style';
 import {
   SvgCheckAll,
   SvgUncheckAll,
@@ -132,6 +133,7 @@ export function CategorySelector({
           paddingRight: 10,
           flexGrow: 1,
           overflowY: 'auto',
+          scrollbarColor: theme.tableHeaderBackground + ' ' + theme.tableBorder
         }}
       >
         {categoryGroups &&

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -6,13 +6,13 @@ import {
   type CategoryGroupEntity,
 } from 'loot-core/src/types/models';
 
-import { theme } from '../../style';
 import {
   SvgCheckAll,
   SvgUncheckAll,
   SvgViewHide,
   SvgViewShow,
 } from '../../icons/v2';
+import { theme } from '../../style';
 import { type CategoryListProps } from '../autocomplete/CategoryAutocomplete';
 import { Button } from '../common/Button';
 import { Text } from '../common/Text';
@@ -133,7 +133,7 @@ export function CategorySelector({
           paddingRight: 10,
           flexGrow: 1,
           overflowY: 'auto',
-          scrollbarColor: theme.tableBackground + ' ' + theme.pageBackground
+          scrollbarColor: theme.tableBackground + ' ' + theme.pageBackground,
         }}
       >
         {categoryGroups &&

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
@@ -74,7 +74,7 @@ export function ReportTableTotals({
           overflowX: 'auto',
           flexDirection: 'row',
           flex: 1,
-          scrollbarColor: theme.tableBorder + ' ' + theme.tableHeaderBackground
+          scrollbarColor: theme.tableBorder + ' ' + theme.tableHeaderBackground,
         }}
       >
         <Cell

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
@@ -74,6 +74,7 @@ export function ReportTableTotals({
           overflowX: 'auto',
           flexDirection: 'row',
           flex: 1,
+          scrollbarColor: theme.tableBorder + ' ' + theme.tableHeaderBackground
         }}
       >
         <Cell

--- a/upcoming-release-notes/2675.md
+++ b/upcoming-release-notes/2675.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [glowtape]
+---
+
+Fix table report scrollbar visibility.


### PR DESCRIPTION
Who knows why it doesn't show otherwise. Probably plenty of messing about with -webkit-scrollbar way up the component tree.

![image](https://github.com/actualbudget/actual/assets/4010813/5ee8e99a-9170-4da2-bc4b-30afd93eef1a)

![image](https://github.com/actualbudget/actual/assets/4010813/66dacb5e-ee72-433f-84f2-f30d479fa092)
