### PR TITLE
[Goals]add template to set x month average

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -22,8 +22,8 @@ expr
     { return { type: 'schedule', name, priority: +priority, full } }
   / priority: priority? _? remainder: remainder
     { return { type: 'remainder', priority: null, weight: remainder } }
-  / priority: priority? _? 'average'i _ amount: amount _ 'months'i?
-    { return { type: 'average', amount, priority: +priority }}
+  / priority: priority? _? 'average'i _ amount: positive _ 'months'i?
+    { return { type: 'average', amount: +amount, priority: +priority }}
 
 
 repeat 'repeat interval'

--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -22,6 +22,8 @@ expr
     { return { type: 'schedule', name, priority: +priority, full } }
   / priority: priority? _? remainder: remainder
     { return { type: 'remainder', priority: null, weight: remainder } }
+  / priority: priority? _? 'average'i _ amount: amount _ 'months'i?
+    { return { type: 'average', amount, priority: +priority }}
 
 
 repeat 'repeat interval'

--- a/packages/loot-core/src/server/budget/goals/goalsAverage.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsAverage.ts
@@ -16,16 +16,16 @@ export async function goalsAverage(
     let sum = 0;
     for (let i = 1; i <= template.amount; i++) {
       // add up other months
-      let sheetName = monthUtils.sheetForMonth(
+      const sheetName = monthUtils.sheetForMonth(
         monthUtils.subMonths(month, i),
       );
       sum += await getSheetValue(sheetName, `sum-amount-${category.id}`);
     }
-    increment = sum/template.amount;
+    increment = sum / template.amount;
   } else {
     errors.push('Number of months to average is not valid');
-    return {to_budget, errors}
+    return { to_budget, errors };
   }
   to_budget += -Math.round(increment);
-  return { to_budget, errors};
+  return { to_budget, errors };
 }

--- a/packages/loot-core/src/server/budget/goals/goalsAverage.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsAverage.ts
@@ -1,0 +1,31 @@
+// @ts-strict-ignore
+
+import * as monthUtils from '../../../shared/months';
+import { getSheetValue } from '../actions';
+
+export async function goalsAverage(
+  template,
+  month,
+  category,
+  errors,
+  to_budget,
+) {
+  // simple has an 'amount' param
+  let increment = 0;
+  if (template.amount) {
+    let sum = 0;
+    for (let i = 1; i <= template.amount; i++) {
+      // add up other months
+      let sheetName = monthUtils.sheetForMonth(
+        monthUtils.subMonths(month, i),
+      );
+      sum += await getSheetValue(sheetName, `sum-amount-${category.id}`);
+    }
+    increment = sum/template.amount;
+  } else {
+    errors.push('Number of months to average is not valid');
+    return {to_budget, errors}
+  }
+  to_budget += -Math.round(increment);
+  return { to_budget, errors};
+}

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -14,6 +14,7 @@ import { goalsSchedule } from './goals/goalsSchedule';
 import { goalsSimple } from './goals/goalsSimple';
 import { goalsSpend } from './goals/goalsSpend';
 import { goalsWeek } from './goals/goalsWeek';
+import { goalsAverage } from './goals/goalsAverage';
 
 export async function applyTemplate({ month }) {
   await storeTemplates();
@@ -607,6 +608,18 @@ async function applyCategoryTemplate(
           to_budget,
         );
         to_budget = goalsReturn.to_budget;
+        break;
+      }
+      case 'average': {
+        const goalsReturn = await goalsAverage(
+          template,
+          current_month,
+          category,
+          errors,
+          to_budget
+        );
+        to_budget = goalsReturn.to_budget;
+        errors = goalsReturn.errors;
         break;
       }
       case 'error':

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -7,6 +7,7 @@ import { batchMessages } from '../sync';
 
 import { setBudget, getSheetValue, isReflectBudget, setGoal } from './actions';
 import { parse } from './goal-template.pegjs';
+import { goalsAverage } from './goals/goalsAverage';
 import { goalsBy } from './goals/goalsBy';
 import { goalsPercentage } from './goals/goalsPercentage';
 import { findRemainder, goalsRemainder } from './goals/goalsRemainder';
@@ -14,7 +15,6 @@ import { goalsSchedule } from './goals/goalsSchedule';
 import { goalsSimple } from './goals/goalsSimple';
 import { goalsSpend } from './goals/goalsSpend';
 import { goalsWeek } from './goals/goalsWeek';
-import { goalsAverage } from './goals/goalsAverage';
 
 export async function applyTemplate({ month }) {
   await storeTemplates();
@@ -616,7 +616,7 @@ async function applyCategoryTemplate(
           current_month,
           category,
           errors,
-          to_budget
+          to_budget,
         );
         to_budget = goalsReturn.to_budget;
         errors = goalsReturn.errors;

--- a/upcoming-release-notes/2688.md
+++ b/upcoming-release-notes/2688.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Goals: Add template to budget X months average spending.  Matches the funcion of the existing budget page button.


### PR DESCRIPTION
Adds a new template to automatically run a "Set X month average" like is possible in the budget page.  This way if a user likes those they can run them with other templates.  This matches the function of the existing button by reading the spent amount of the previous months and averages it.

Fixes #2587

docs: actualbudget/docs#351
