### PR TITLE
Fix preview transactions not detecting schedule as paid when a child transaction is linked.

### DIFF
--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -36,14 +36,14 @@ export function getHasTransactionsQuery(schedules) {
           $gte:
             dateCond && dateCond.op === 'is'
               ? schedule.next_date
-              : monthUtils.subDays(schedule.next_date, 2),
+              : monthUtils.subDays(schedule.next_date, 7),
         },
       },
     };
   });
 
   return q('transactions')
-    .options({ splits: 'grouped' })
+    .options({ splits: 'all' })
     .filter({ $or: filters })
     .orderBy({ date: 'desc' })
     .select(['schedule', 'date']);

--- a/upcoming-release-notes/2712.md
+++ b/upcoming-release-notes/2712.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix preview transactions not detecting schedule as paid when a child transaction is linked.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Steps to reproduce:
1. Create a schedule that is upcoming (appears as preview transactions)
2. Create a split transaction
3. Link a child transaction to the schedule
4. Preview transaction doesn't disappear

If you do the same with non-split transactions, the preview transaction will disappear as expected

