### PR TITLE
Use budget name as export file name

### DIFF
--- a/packages/desktop-client/src/components/settings/Export.tsx
+++ b/packages/desktop-client/src/components/settings/Export.tsx
@@ -15,7 +15,7 @@ import { Setting } from './UI';
 export function ExportBudget() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [budgetId] = useLocalPref('id');
+  const [budgetName] = useLocalPref('budgetName');
   const [encryptKeyId] = useLocalPref('encryptKeyId');
 
   async function onExport() {
@@ -33,7 +33,7 @@ export function ExportBudget() {
 
     window.Actual?.saveFile(
       response.data,
-      `${format(new Date(), 'yyyy-MM-dd')}-${budgetId}.zip`,
+      `${format(new Date(), 'yyyy-MM-dd')}-${budgetName}.zip`,
       'Export budget',
     );
     setIsLoading(false);

--- a/upcoming-release-notes/2713.md
+++ b/upcoming-release-notes/2713.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Use budget name as export file name.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Right now, export uses the budget ID as the name of the export zip file which is always `My-Finances-xxxxxx`. This makes it hard to know which budget export is for which budget when you have multiple budget files.