### PR TITLE
Search category autocomplete includes group category

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -166,6 +166,9 @@ export function CategoryAutocomplete({
   ...props
 }: CategoryAutocompleteProps) {
   const { grouped: defaultCategoryGroups = [] } = useCategories();
+  const [autocompleteCategoryMatchGroup = false] = useLocalPref(
+    'autocompleteCategoryMatchGroup',
+  );
   const categorySuggestions: CategoryAutocompleteItem[] = useMemo(
     () =>
       (categoryGroups || defaultCategoryGroups).reduce(
@@ -201,7 +204,10 @@ export function CategoryAutocomplete({
         return suggestions.filter(suggestion => {
           return (
             suggestion.id === 'split' ||
-            defaultFilterSuggestion(suggestion, value)
+            defaultFilterSuggestion(suggestion, value) ||
+            (autocompleteCategoryMatchGroup &&
+              suggestion.group &&
+              defaultFilterSuggestion(suggestion.group, value))
           );
         });
       }}

--- a/packages/desktop-client/src/components/settings/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/settings/Autocomplete.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { useLocalPref } from '../../hooks/useLocalPref';
+import { Text } from '../common/Text';
+import { Checkbox } from '../forms';
+
+import { Setting } from './UI';
+
+export function AutocompleteSettings() {
+  const [
+    autocompleteCategoryMatchGroup = false,
+    setAutocompleteCategoryMatchGroupPref,
+  ] = useLocalPref('autocompleteCategoryMatchGroup');
+
+  return (
+    <Setting
+      primaryAction={
+        <Text style={{ display: 'flex' }}>
+          <Checkbox
+            id="settings-autocompleteCategoryMatchGroup"
+            checked={!!autocompleteCategoryMatchGroup}
+            onChange={e =>
+              setAutocompleteCategoryMatchGroupPref(e.currentTarget.checked)
+            }
+          />
+          <label htmlFor="settings-autocompleteCategoryMatchGroup">
+            Category autocomplete search match on category group names
+          </label>
+        </Text>
+      }
+    >
+      <Text>
+        <strong>Autocomplete</strong> change the behavior of the autocomplete
+        dropdowns.
+      </Text>
+    </Setting>
+  );
+}

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -22,6 +22,7 @@ import { FormField, FormLabel } from '../forms';
 import { Page } from '../Page';
 import { useServerVersion } from '../ServerContext';
 
+import { AutocompleteSettings } from './Autocomplete';
 import { EncryptionSettings } from './Encryption';
 import { ExperimentalFeatures } from './Experimental';
 import { ExportBudget } from './Export';
@@ -174,6 +175,7 @@ export function Settings() {
 
         <AdvancedToggle>
           <AdvancedAbout />
+          <AutocompleteSettings />
           <ResetCache />
           <ResetSync />
           <FixSplits />

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -55,6 +55,7 @@ export type LocalPrefs = Partial<
     reportsViewSummary: boolean;
     reportsViewLabel: boolean;
     'mobile.showSpentColumn': boolean;
+    autocompleteCategoryMatchGroup: boolean;
   } & Record<`flags.${FeatureFlag}`, boolean>
 >;
 

--- a/upcoming-release-notes/2731.md
+++ b/upcoming-release-notes/2731.md
@@ -1,0 +1,5 @@
+---
+category: Enhancements
+authors: [Wizmaster]
+---
+Add option to have the Category autocomplete match on Category Group names


### PR DESCRIPTION
Resolve #2324

Reading the discussion on #1681 and #1767, I understand that people either want the category autocomplete to consider group names when searching or not. (I happen to be in the group wishing for it to match group names 😄)

I added a new option switch to have the category autocomplete match on category group names.

It can be tested on the test budget, the option is in the application settings and using the "Bills" category group name in the category autocomplete demonstrates it.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
