### PR TITLE
Github action to automatically deploy a release image to Netlify

### DIFF
--- a/.github/workflows/netlify-release.yml
+++ b/.github/workflows/netlify-release.yml
@@ -1,0 +1,46 @@
+name: Deploy Netlify Release
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CI: true
+
+on:
+  push:
+    tags:
+      - v**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Checkout
+        uses: actions/checkout@v4
+    
+      - name: Set up environment
+        uses: ./.github/actions/setup
+    
+      - name: Install Netlify
+        run: npm install netlify-cli@17.10.1 -g
+    
+      - name: Install Dependencies
+        run: npm ci
+    
+      - name: Build Actual
+        run: ./bin/package-browser
+
+      - name: Deploy to Netlify
+        id: netlify_deploy
+        run: |
+          netlify deploy \
+            --dir packages/desktop-client/build \
+            --site ${{ secrets.NETLIFY_SITE_ID }} \
+            --auth ${{ secrets.NETLIFY_API_TOKEN }} \
+            --prod \
+            > deploy_output.txt

--- a/.github/workflows/netlify-release.yml
+++ b/.github/workflows/netlify-release.yml
@@ -39,5 +39,5 @@ jobs:
             --dir packages/desktop-client/build \
             --site ${{ secrets.NETLIFY_SITE_ID }} \
             --auth ${{ secrets.NETLIFY_API_TOKEN }} \
-            --prod \
-            > deploy_output.txt
+            --filter @actual-app/web \
+            --prod

--- a/.github/workflows/netlify-release.yml
+++ b/.github/workflows/netlify-release.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install Netlify
         run: npm install netlify-cli@17.10.1 -g
     
-      - name: Install Dependencies
-        run: npm ci
-    
       - name: Build Actual
         run: ./bin/package-browser
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bundle.mobile.js.map
 
 # Misc
 .#*
+
+# Local Netlify folder
+.netlify

--- a/upcoming-release-notes/2750.md
+++ b/upcoming-release-notes/2750.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [shall0pass]
+---
+
+Add Github workflow to publish release to demo.actualbudget.org.


### PR DESCRIPTION
This is working in my fork.  Still a few things to do to tie it all together.

- [x] Github Secrets
- [x] Assign subdomain

The goal here is to have two deployments.

1.  edge.actualbudget.org  --  This will be what demo.actualbudget.org is today.  A live preview of the master branch that is updated with each new merge.
2. demo.actualbudget.org -- This will only be updated when a release is made.  This will provide a more stable preview of what to expect after installation.