### PR TITLE
[Mobile] Do not remember last entered category in mobile transaction entry

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -1015,7 +1015,7 @@ function TransactionEditUnconnected({
       setTransactions(
         makeTemporaryTransactions(
           locationState?.accountId || lastTransaction?.account || null,
-          locationState?.categoryId || lastTransaction?.category || null,
+          locationState?.categoryId || null,
           lastTransaction?.date,
         ),
       );

--- a/upcoming-release-notes/2754.md
+++ b/upcoming-release-notes/2754.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Do not remember last entered category in mobile transaction entry.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Closes #2697 