### PR TITLE
Add run-vrt script to run vrt inside docker

### DIFF
--- a/bin/run-vrt
+++ b/bin/run-vrt
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# See here for more information: https://github.com/actualbudget/actual/tree/master/packages/desktop-client#visual-regression
+
+if [ ! -d "node_modules" ] || [ "$(ls -A node_modules)" = "" ]; then
+    yarn
+fi
+
+E2E_START_URL="https://localhost:3001"
+VRT_ARGS=""
+
+# Loop through all arguments
+while [ $# -gt 0 ]; do
+    key="$1"
+    case $key in
+        --e2e-start-url)
+            E2E_START_URL="$2"
+            shift
+            ;;
+        *)
+            VRT_ARGS="$VRT_ARGS $1"
+            ;;
+    esac
+    shift
+done
+
+echo "Running VRT tests with the following parameters:"
+echo "E2E_START_URL: $E2E_START_URL"
+echo "VRT_ARGS: $VRT_ARGS"
+
+docker run --rm --network host -v "$(pwd)":/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.41.1-jammy /bin/bash \
+  -c "E2E_START_URL=$E2E_START_URL yarn vrt $VRT_ARGS"

--- a/bin/run-vrt
+++ b/bin/run-vrt
@@ -6,7 +6,7 @@ if [ ! -d "node_modules" ] || [ "$(ls -A node_modules)" = "" ]; then
     yarn
 fi
 
-E2E_START_URL="https://localhost:3001"
+E2E_START_URL="${E2E_START_URL:-https://localhost:3001}"
 VRT_ARGS=""
 
 # Loop through all arguments

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:debug": "yarn workspaces foreach --all --verbose run test",
     "e2e": "yarn workspaces foreach --all --parallel --verbose run e2e",
     "vrt": "yarn workspaces foreach --all --parallel --verbose run vrt",
+    "vrt:docker": "./bin/run-vrt",
     "rebuild-electron": "./node_modules/.bin/electron-rebuild -f -m ./packages/loot-core",
     "rebuild-node": "yarn workspace loot-core rebuild",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -83,7 +83,10 @@ You can also run the tests against a remote server by passing the URL:
 
 Run via yarn:
 ```sh
-yarn vrt:docker --e2e-start-url https://my-remote-server.com
+E2E_START_URL=https://my-remote-server.com yarn vrt:docker
+
+    # Or pass in server URL as argument
+    yarn vrt:docker --e2e-start-url https://my-remote-server.com
 ```
 
 Run manually:

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -45,7 +45,7 @@ HTTPS=true docker compose up --build
 
 Note the network IP address and port the dev instance is listening on.
 
-Next, navigate to the root of your project folder, run the standartised docker container, and launch the visual regression tests from within it.
+Next, navigate to the root of your project folder, run the standardized docker container, and launch the visual regression tests from within it.
 
 Run via yarn:
 
@@ -81,7 +81,7 @@ E2E_START_URL=https://ip:port yarn vrt
 
 You can also run the tests against a remote server by passing the URL:
 
-Run via yarn:
+Run in standardized docker container:
 ```sh
 E2E_START_URL=https://my-remote-server.com yarn vrt:docker
 
@@ -89,7 +89,7 @@ E2E_START_URL=https://my-remote-server.com yarn vrt:docker
     yarn vrt:docker --e2e-start-url https://my-remote-server.com
 ```
 
-Run manually:
+Run locally:
 ```sh
 E2E_START_URL=https://my-remote-server.com yarn vrt
 ```

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -69,7 +69,8 @@ docker run --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/
     # If you receive an error such as "docker: invalid reference format", please instead use the following command:
     docker run --rm --network host -v ${pwd}:/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.41.1-jammy /bin/bash
 
-# Run the VRT tests: important - they MUST be ran against a HTTPS server.  Use the ip and port noted earlier
+# Once inside the docker container, run the VRT tests: important - they MUST be ran against a HTTPS server.
+# Use the ip and port noted earlier
 E2E_START_URL=https://ip:port yarn vrt
 
     # To update snapshots, use the following command:

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -47,6 +47,21 @@ Note the network IP address and port the dev instance is listening on.
 
 Next, navigate to the root of your project folder, run the standartised docker container, and launch the visual regression tests from within it.
 
+Run via yarn:
+
+```sh
+# By default, this connects to https://localhost:3001
+yarn vrt:docker
+
+    # To use a different ip and port:
+    yarn vrt:docker --e2e-start-url https://ip:port
+
+    # To update snapshots, use the following command:
+    yarn vrt:docker --e2e-start-url https://ip:port --update-snapshots
+```
+
+Run manually:
+
 ```sh
 # Run docker container
 docker run --rm --network host -v $(pwd):/work/ -w /work/ -it mcr.microsoft.com/playwright:v1.41.1-jammy /bin/bash
@@ -65,6 +80,12 @@ E2E_START_URL=https://ip:port yarn vrt
 
 You can also run the tests against a remote server by passing the URL:
 
+Run via yarn:
+```sh
+yarn vrt:docker --e2e-start-url https://my-remote-server.com
+```
+
+Run manually:
 ```sh
 E2E_START_URL=https://my-remote-server.com yarn vrt
 ```

--- a/upcoming-release-notes/2762.md
+++ b/upcoming-release-notes/2762.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Add run-vrt script to run vrt inside docker via yarn.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Run vrt tests in the standardized docker container by simply running:
```sh
yarn vrt:docker

# to update snapshots
yarn vrt:docker --update-snapshots
```