### PR TITLE
Fix notes icon changing size/position with long category or group names

### DIFF
--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -117,11 +117,13 @@ export function SidebarCategory({
         </Popover>
       </View>
       <View style={{ flex: 1 }} />
-      <NotesButton
-        id={category.id}
-        style={dragging && { color: 'currentColor' }}
-        defaultColor={theme.pageTextLight}
-      />
+      <View style={{ flexShrink: 0 }}>
+        <NotesButton
+          id={category.id}
+          style={dragging && { color: 'currentColor' }}
+          defaultColor={theme.pageTextLight}
+        />
+      </View>
     </View>
   );
 

--- a/packages/desktop-client/src/components/budget/SidebarGroup.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarGroup.tsx
@@ -138,11 +138,13 @@ export function SidebarGroup({
             </Popover>
           </View>
           <View style={{ flex: 1 }} />
-          <NotesButton
-            id={group.id}
-            style={dragPreview && { color: 'currentColor' }}
-            defaultColor={theme.pageTextLight}
-          />
+          <View style={{ flexShrink: 0 }}>
+            <NotesButton
+              id={group.id}
+              style={dragPreview && { color: 'currentColor' }}
+              defaultColor={theme.pageTextLight}
+            />
+          </View>
         </>
       )}
     </View>

--- a/upcoming-release-notes/2773.md
+++ b/upcoming-release-notes/2773.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jpelgrom]
+---
+
+Fix notes icon changing size/position with long category or group names.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fixes #2736 by telling the browser this icon should not be shrunk in these rows (default is 1, which means the other icons which have `flexShrink: 0` get more space).

Before/after:

|Before (demo.actualbudget.org)|After (this branch)|
|----|----|
|![image](https://github.com/actualbudget/actual/assets/8148535/04783556-facf-4117-aa0b-ce81839c9c57)|![image](https://github.com/actualbudget/actual/assets/8148535/bcf7236a-7e60-473e-b92e-75612ab5b538)|
|![image](https://github.com/actualbudget/actual/assets/8148535/fdee8ac7-f8de-4903-9bdb-84f22b98215a)|![image](https://github.com/actualbudget/actual/assets/8148535/014ac0f7-1453-497f-908f-80f26814b340)|

(first contribution, so please let me know if I missed anything)
