### PR TITLE
Filter Balance fix

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -315,7 +315,7 @@ class AccountInternal extends PureComponent {
 
   fetchTransactions = filters => {
     const query = this.makeRootQuery();
-    this.rootQuery = this.currentQuery = query;
+    this.rootQuery = this.currentQuery = this.filterQuery = query;
     if (filters) this.applyFilters(filters);
     else this.updateQuery(query);
 
@@ -677,6 +677,17 @@ class AccountInternal extends PureComponent {
     return {
       name: `balance-query-${id}`,
       query: this.makeRootQuery().calculate({ $sum: '$amount' }),
+    };
+  }
+
+  getFilterQuery(filters, conditionsOpKey) {
+    return {
+      name: `filtered-query`,
+      query: this.makeRootQuery()
+        .filter({
+          [conditionsOpKey]: [...filters],
+        })
+        .calculate({ $sum: '$amount' }),
     };
   }
 
@@ -1301,6 +1312,7 @@ class AccountInternal extends PureComponent {
         conditions: conditions.filter(cond => !cond.customName),
       });
       const conditionsOpKey = this.state.conditionsOp === 'or' ? '$or' : '$and';
+      this.filterQuery = this.getFilterQuery(filters, conditionsOpKey);
       this.currentQuery = this.rootQuery.filter({
         [conditionsOpKey]: [...filters, ...customFilters],
       });
@@ -1518,6 +1530,7 @@ class AccountInternal extends PureComponent {
           >
             <View style={styles.page}>
               <AccountHeader
+                filterQuery={this.filterQuery}
                 tableRef={this.table}
                 editingName={editingName}
                 isNameEditable={isNameEditable}

--- a/packages/desktop-client/src/components/accounts/Balance.jsx
+++ b/packages/desktop-client/src/components/accounts/Balance.jsx
@@ -104,10 +104,11 @@ function SelectedBalance({ selectedItems, account }) {
   );
 }
 
-function FilteredBalance({ selectedItems }) {
-  const balance = selectedItems
-    .filter(item => !item._unmatched && !item.is_parent)
-    .reduce((sum, product) => sum + product.amount, 0);
+function FilteredBalance({ filterQuery }) {
+  const balance = useSheetValue({
+    name: filterQuery ? filterQuery.name : '',
+    query: filterQuery ? filterQuery.query : null,
+  });
 
   return (
     <DetailedBalance
@@ -142,7 +143,7 @@ export function Balances({
   onToggleExtraBalances,
   account,
   filteredItems,
-  transactions,
+  filterQuery,
 }) {
   const selectedItems = useSelectedItems();
 
@@ -201,7 +202,7 @@ export function Balances({
         <SelectedBalance selectedItems={selectedItems} account={account} />
       )}
       {filteredItems.length > 0 && (
-        <FilteredBalance selectedItems={transactions} />
+        <FilteredBalance filterQuery={filterQuery} />
       )}
     </View>
   );

--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -32,6 +32,7 @@ import { Balances } from './Balance';
 import { ReconcilingMessage, ReconcileTooltip } from './Reconcile';
 
 export function AccountHeader({
+  filterQuery,
   tableRef,
   editingName,
   isNameEditable,
@@ -242,7 +243,7 @@ export function AccountHeader({
           onToggleExtraBalances={onToggleExtraBalances}
           account={account}
           filteredItems={filters}
-          transactions={transactions}
+          filterQuery={filterQuery}
         />
 
         <Stack


### PR DESCRIPTION
On the accounts page - filter balance only adds up transactions that are showing. If your filter has more than one page it won't be added to the balance unless you scroll to the bottom and reveal all transactions. This fixes that.
