### PR TITLE
Custom Reports show activity fixes

### DIFF
--- a/packages/desktop-client/src/components/reports/ChooseGraph.tsx
+++ b/packages/desktop-client/src/components/reports/ChooseGraph.tsx
@@ -147,6 +147,7 @@ export function ChooseGraph({
         balanceTypeOp={balanceTypeOp}
         showHiddenCategories={showHiddenCategories}
         showOffBudget={showOffBudget}
+        interval={interval}
       />
     );
   }
@@ -162,6 +163,7 @@ export function ChooseGraph({
         groupBy={groupBy}
         showHiddenCategories={showHiddenCategories}
         showOffBudget={showOffBudget}
+        interval={interval}
       />
     );
   }

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -121,7 +121,7 @@ const dateRangeOptions: dateRangeProps[] = [
   {
     description: 'Year to date',
     name: 'yearToDate',
-    Daily: true,
+    Daily: false,
     Weekly: true,
     Monthly: true,
     Yearly: true,
@@ -129,7 +129,7 @@ const dateRangeOptions: dateRangeProps[] = [
   {
     description: 'Last year',
     name: 'lastYear',
-    Daily: true,
+    Daily: false,
     Weekly: true,
     Monthly: true,
     Yearly: true,
@@ -137,7 +137,7 @@ const dateRangeOptions: dateRangeProps[] = [
   {
     description: 'All time',
     name: 'allTime',
-    Daily: true,
+    Daily: false,
     Weekly: true,
     Monthly: true,
     Yearly: true,

--- a/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
@@ -206,7 +206,7 @@ export function AreaGraph({
                   top: 0,
                   right: labelsMargin,
                   left: leftMargin,
-                  bottom: 0,
+                  bottom: 10,
                 }}
               >
                 {compact ? null : (

--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -36,6 +36,7 @@ import { numberFormatterTooltip } from '../numberFormatter';
 
 import { adjustTextSize } from './adjustTextSize';
 import { renderCustomLabel } from './renderCustomLabel';
+import { showActivity } from './showActivity';
 
 type PayloadChild = {
   props: {
@@ -183,61 +184,6 @@ export function BarGraph({
 
   const leftMargin = Math.abs(largestValue) > 1000000 ? 20 : 0;
 
-  const onShowActivity = item => {
-    const amount = balanceTypeOp === 'totalDebts' ? 'lte' : 'gte';
-    const field = groupBy === 'Interval' ? null : groupBy.toLowerCase();
-    const hiddenCategories = categories.list
-      .filter(f => f.hidden)
-      .map(e => e.id);
-    const offBudgetAccounts = accounts.filter(f => f.offbudget).map(e => e.id);
-
-    const conditions = [
-      ...filters,
-      { field, op: 'is', value: item.id, type: 'id' },
-      {
-        field: 'date',
-        op: 'gte',
-        value: data.startDate,
-        options: { date: true },
-        type: 'date',
-      },
-      {
-        field: 'date',
-        op: 'lte',
-        value: data.endDate,
-        options: { date: true },
-        type: 'date',
-      },
-      balanceTypeOp !== 'totalTotals' && {
-        field: 'amount',
-        op: amount,
-        value: 0,
-        type: 'number',
-      },
-      hiddenCategories.length > 0 &&
-        !showHiddenCategories && {
-          field: 'category',
-          op: 'notOneOf',
-          value: hiddenCategories,
-          type: 'id',
-        },
-      offBudgetAccounts.length > 0 &&
-        !showOffBudget && {
-          field: 'account',
-          op: 'notOneOf',
-          value: offBudgetAccounts,
-          type: 'id',
-        },
-    ].filter(f => f);
-    navigate('/accounts', {
-      state: {
-        goBack: true,
-        conditions,
-        categoryId: item.id,
-      },
-    });
-  };
-
   return (
     <Container
       style={{
@@ -309,10 +255,23 @@ export function BarGraph({
                     !['Group', 'Interval'].includes(groupBy) &&
                     setPointer('pointer')
                   }
-                  onClick={
+                  onClick={item =>
                     !isNarrowWidth &&
                     !['Group', 'Interval'].includes(groupBy) &&
-                    onShowActivity
+                    showActivity({
+                      navigate,
+                      categories,
+                      accounts,
+                      balanceTypeOp,
+                      filters,
+                      showHiddenCategories,
+                      showOffBudget,
+                      type: 'totals',
+                      startDate: data.startDate,
+                      endDate: data.endDate,
+                      field: groupBy.toLowerCase(),
+                      id: item.id,
+                    })
                   }
                 >
                   {viewLabels && !compact && (

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -17,6 +17,7 @@ import { Container } from '../Container';
 
 import { adjustTextSize } from './adjustTextSize';
 import { renderCustomLabel } from './renderCustomLabel';
+import { showActivity } from './showActivity';
 
 const RADIAN = Math.PI / 180;
 
@@ -207,61 +208,6 @@ export function DonutGraph({
   const { isNarrowWidth } = useResponsive();
   const [pointer, setPointer] = useState('');
 
-  const onShowActivity = item => {
-    const amount = balanceTypeOp === 'totalDebts' ? 'lte' : 'gte';
-    const field = groupBy === 'Interval' ? null : groupBy.toLowerCase();
-    const hiddenCategories = categories.list
-      .filter(f => f.hidden)
-      .map(e => e.id);
-    const offBudgetAccounts = accounts.filter(f => f.offbudget).map(e => e.id);
-
-    const conditions = [
-      ...filters,
-      { field, op: 'is', value: item.id, type: 'id' },
-      {
-        field: 'date',
-        op: 'gte',
-        value: data.startDate,
-        options: { date: true },
-        type: 'date',
-      },
-      {
-        field: 'date',
-        op: 'lte',
-        value: data.endDate,
-        options: { date: true },
-        type: 'date',
-      },
-      balanceTypeOp !== 'totalTotals' && {
-        field: 'amount',
-        op: amount,
-        value: 0,
-        type: 'number',
-      },
-      hiddenCategories.length > 0 &&
-        !showHiddenCategories && {
-          field: 'category',
-          op: 'notOneOf',
-          value: hiddenCategories,
-          type: 'id',
-        },
-      offBudgetAccounts.length > 0 &&
-        !showOffBudget && {
-          field: 'account',
-          op: 'notOneOf',
-          value: offBudgetAccounts,
-          type: 'id',
-        },
-    ].filter(f => f);
-    navigate('/accounts', {
-      state: {
-        goBack: true,
-        conditions,
-        categoryId: item.id,
-      },
-    });
-  };
-
   const getVal = obj => {
     if (balanceTypeOp === 'totalDebts') {
       return -1 * obj[balanceTypeOp];
@@ -309,10 +255,23 @@ export function DonutGraph({
                       setPointer('pointer');
                     }
                   }}
-                  onClick={
+                  onClick={item =>
                     !isNarrowWidth &&
                     !['Group', 'Interval'].includes(groupBy) &&
-                    onShowActivity
+                    showActivity({
+                      navigate,
+                      categories,
+                      accounts,
+                      balanceTypeOp,
+                      filters,
+                      showHiddenCategories,
+                      showOffBudget,
+                      type: 'totals',
+                      startDate: data.startDate,
+                      endDate: data.endDate,
+                      field: groupBy.toLowerCase(),
+                      id: item.id,
+                    })
                   }
                 >
                   {data.legend.map((entry, index) => (

--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -31,6 +31,8 @@ import { Container } from '../Container';
 import { getCustomTick } from '../getCustomTick';
 import { numberFormatterTooltip } from '../numberFormatter';
 
+import { showActivity } from './showActivity';
+
 type PayloadItem = {
   dataKey: string;
   value: number;
@@ -116,6 +118,7 @@ type LineGraphProps = {
   balanceTypeOp: 'totalAssets' | 'totalDebts' | 'totalTotals';
   showHiddenCategories?: boolean;
   showOffBudget?: boolean;
+  interval?: string;
 };
 
 export function LineGraph({
@@ -127,6 +130,7 @@ export function LineGraph({
   balanceTypeOp,
   showHiddenCategories,
   showOffBudget,
+  interval,
 }: LineGraphProps) {
   const navigate = useNavigate();
   const categories = useCategories();
@@ -143,49 +147,20 @@ export function LineGraph({
   const leftMargin = Math.abs(largestValue) > 1000000 ? 20 : 5;
 
   const onShowActivity = (item, id, payload) => {
-    const amount = balanceTypeOp === 'totalDebts' ? 'lte' : 'gte';
-    const field = groupBy === 'Interval' ? null : groupBy.toLowerCase();
-    const hiddenCategories = categories.list
-      .filter(f => f.hidden)
-      .map(e => e.id);
-    const offBudgetAccounts = accounts.filter(f => f.offbudget).map(e => e.id);
-
-    const conditions = [
-      ...filters,
-      { field, op: 'is', value: id, type: 'id' },
-      {
-        field: 'date',
-        op: 'is',
-        value: payload.payload.dateStart,
-        options: { date: true },
-      },
-      balanceTypeOp !== 'totalTotals' && {
-        field: 'amount',
-        op: amount,
-        value: 0,
-        type: 'number',
-      },
-      hiddenCategories.length > 0 &&
-        !showHiddenCategories && {
-          field: 'category',
-          op: 'notOneOf',
-          value: hiddenCategories,
-          type: 'id',
-        },
-      offBudgetAccounts.length > 0 &&
-        !showOffBudget && {
-          field: 'account',
-          op: 'notOneOf',
-          value: offBudgetAccounts,
-          type: 'id',
-        },
-    ].filter(f => f);
-    navigate('/accounts', {
-      state: {
-        goBack: true,
-        conditions,
-        categoryId: item.id,
-      },
+    showActivity({
+      navigate,
+      categories,
+      accounts,
+      balanceTypeOp,
+      filters,
+      showHiddenCategories,
+      showOffBudget,
+      type: 'time',
+      startDate: payload.payload.intervalStartDate,
+      endDate: payload.payload.intervalEndDate,
+      field: groupBy.toLowerCase(),
+      id,
+      interval,
     });
   };
 

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.ts
@@ -1,9 +1,12 @@
 import { type NavigateFunction } from 'react-router-dom';
 
+import * as monthUtils from 'loot-core/src/shared/months';
 import { type AccountEntity } from 'loot-core/types/models/account';
 import { type CategoryEntity } from 'loot-core/types/models/category';
 import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
+
+import { ReportOptions } from '../ReportOptions';
 
 type showActivityProps = {
   navigate: NavigateFunction;
@@ -18,6 +21,7 @@ type showActivityProps = {
   endDate?: string;
   field?: string;
   id?: string;
+  interval?: string;
 };
 
 export function showActivity({
@@ -33,22 +37,32 @@ export function showActivity({
   endDate,
   field,
   id,
+  interval = 'Day',
 }: showActivityProps) {
   const amount =
-    balanceTypeOp === 'totalDebts' || type === 'debts' ? 'lte' : 'gte';
+    balanceTypeOp === 'totalDebts' || type === 'debts' ? true : false;
   const hiddenCategories = categories.list.filter(f => f.hidden).map(e => e.id);
   const offBudgetAccounts = accounts.filter(f => f.offbudget).map(e => e.id);
+  const fromDate =
+    interval === 'Weekly'
+      ? 'dayFromDate'
+      : (((ReportOptions.intervalMap.get(interval) || 'Day').toLowerCase() +
+          'FromDate') as 'dayFromDate' | 'monthFromDate' | 'yearFromDate');
+  let isDateOp = false;
+  if (interval === 'Weekly' || type !== 'time') {
+    isDateOp = true;
+  }
 
   const conditions = [
     ...filters,
     id && { field, op: 'is', value: id, type: 'id' },
     {
       field: 'date',
-      op: type === 'time' ? 'is' : 'gte',
-      value: startDate,
-      options: { date: true },
+      op: isDateOp ? 'gte' : 'is',
+      value: isDateOp ? startDate : monthUtils[fromDate](startDate),
+      type: 'date',
     },
-    type !== 'time' && {
+    isDateOp && {
       field: 'date',
       op: 'lte',
       value: endDate,
@@ -59,9 +73,13 @@ export function showActivity({
       (type === 'totals' || type === 'time')
     ) && {
       field: 'amount',
-      op: amount,
+      op: 'gte',
       value: 0,
-      type: 'number',
+      options: {
+        type: 'number',
+        inflow: !amount,
+        outflow: amount,
+      },
     },
     hiddenCategories.length > 0 &&
       !showHiddenCategories && {

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
@@ -98,6 +98,7 @@ export function ReportTable({
         compactStyle={compactStyle}
         showHiddenCategories={showHiddenCategories}
         showOffBudget={showOffBudget}
+        interval={interval}
       />
     );
   }, []);
@@ -129,6 +130,7 @@ export function ReportTable({
           totalScrollRef={totalScrollRef}
           handleScroll={handleScroll}
           height={32 + scrollWidthTotals}
+          interval={interval}
         />
       );
     },

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -32,6 +32,7 @@ type ReportTableRowProps = {
   totalStyle?: CSSProperties;
   showHiddenCategories?: boolean;
   showOffBudget?: boolean;
+  interval: string;
   totalScrollRef?: RefObject<HTMLDivElement>;
   handleScroll?: UIEventHandler<HTMLDivElement>;
   height?: number;
@@ -56,6 +57,7 @@ export const ReportTableRow = memo(
     totalScrollRef,
     handleScroll,
     height,
+    interval,
   }: ReportTableRowProps) => {
     const average = amountToInteger(item[balanceTypeOp]) / intervalsCount;
     const groupByItem = groupBy === 'Interval' ? 'date' : 'name';
@@ -68,6 +70,7 @@ export const ReportTableRow = memo(
     const pointer =
       !isNarrowWidth &&
       !['Group', 'Interval'].includes(groupBy) &&
+      !compact &&
       !categories.grouped.map(g => g.id).includes(item.id)
         ? 'pointer'
         : 'inherit';
@@ -75,6 +78,7 @@ export const ReportTableRow = memo(
     const hoverUnderline =
       !isNarrowWidth &&
       !['Group', 'Interval'].includes(groupBy) &&
+      !compact &&
       !categories.grouped.map(g => g.id).includes(item.id)
         ? {
             cursor: pointer,
@@ -132,6 +136,7 @@ export const ReportTableRow = memo(
                     onClick={() =>
                       !isNarrowWidth &&
                       !['Group', 'Interval'].includes(groupBy) &&
+                      !compact &&
                       !categories.grouped.map(g => g.id).includes(item.id) &&
                       showActivity({
                         navigate,
@@ -143,8 +148,10 @@ export const ReportTableRow = memo(
                         showOffBudget,
                         type: 'time',
                         startDate: intervalItem.intervalStartDate || '',
+                        endDate: intervalItem.intervalEndDate || '',
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        interval,
                       })
                     }
                     width="flex"
@@ -171,6 +178,7 @@ export const ReportTableRow = memo(
                     onClick={() =>
                       !isNarrowWidth &&
                       !['Group', 'Interval'].includes(groupBy) &&
+                      !compact &&
                       !categories.grouped.map(g => g.id).includes(item.id) &&
                       showActivity({
                         navigate,
@@ -205,6 +213,7 @@ export const ReportTableRow = memo(
                     onClick={() =>
                       !isNarrowWidth &&
                       !['Group', 'Interval'].includes(groupBy) &&
+                      !compact &&
                       !categories.grouped.map(g => g.id).includes(item.id) &&
                       showActivity({
                         navigate,
@@ -240,6 +249,7 @@ export const ReportTableRow = memo(
             onClick={() =>
               !isNarrowWidth &&
               !['Group', 'Interval'].includes(groupBy) &&
+              !compact &&
               !categories.grouped.map(g => g.id).includes(item.id) &&
               showActivity({
                 navigate,

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -124,8 +124,10 @@ export function CustomReport() {
   const [dateRange, setDateRange] = useState(loadReport.dateRange);
   const [dataCheck, setDataCheck] = useState(false);
   const dateRangeLine =
-    ReportOptions.dateRange.filter(f => f[interval as keyof dateRangeProps])
-      .length - 3;
+    interval === 'Daily'
+      ? 0
+      : ReportOptions.dateRange.filter(f => f[interval as keyof dateRangeProps])
+          .length - 3;
 
   const [intervals, setIntervals] = useState(
     monthUtils.rangeInclusive(startDate, endDate),

--- a/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
@@ -155,7 +155,7 @@ export function createCustomSpreadsheet({
     let totalDebts = 0;
 
     const intervalData = intervals.reduce(
-      (arr: IntervalEntity[], intervalItem) => {
+      (arr: IntervalEntity[], intervalItem, index) => {
         let perIntervalAssets = 0;
         let perIntervalDebts = 0;
         const stacked: Record<string, number> = {};
@@ -214,7 +214,11 @@ export function createCustomSpreadsheet({
             ReportOptions.intervalFormat.get(interval) || '',
           ),
           ...stacked,
-          intervalStartDate: intervalItem,
+          intervalStartDate: index === 0 ? startDate : intervalItem,
+          intervalEndDate:
+            index + 1 === intervals.length
+              ? endDate
+              : monthUtils.subDays(intervals[index + 1], 1),
           totalDebts: integerToAmount(perIntervalDebts),
           totalAssets: integerToAmount(perIntervalAssets),
           totalTotals: integerToAmount(perIntervalDebts + perIntervalAssets),
@@ -235,6 +239,8 @@ export function createCustomSpreadsheet({
         showOffBudget,
         showHiddenCategories,
         showUncategorized,
+        startDate,
+        endDate,
       });
       return { ...calc };
     });

--- a/packages/desktop-client/src/components/reports/spreadsheets/grouped-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/grouped-spreadsheet.ts
@@ -180,6 +180,8 @@ export function createGroupedSpreadsheet({
               showOffBudget,
               showHiddenCategories,
               showUncategorized,
+              startDate,
+              endDate,
             });
             return { ...calc };
           });

--- a/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
@@ -1,3 +1,4 @@
+import * as monthUtils from 'loot-core/src/shared/months';
 import { amountToInteger, integerToAmount } from 'loot-core/src/shared/util';
 import {
   type GroupedEntity,
@@ -20,6 +21,8 @@ type recalculateProps = {
   showOffBudget?: boolean;
   showHiddenCategories?: boolean;
   showUncategorized?: boolean;
+  startDate: string;
+  endDate: string;
 };
 
 export function recalculate({
@@ -31,11 +34,13 @@ export function recalculate({
   showOffBudget,
   showHiddenCategories,
   showUncategorized,
+  startDate,
+  endDate,
 }: recalculateProps): GroupedEntity {
   let totalAssets = 0;
   let totalDebts = 0;
   const intervalData = intervals.reduce(
-    (arr: IntervalEntity[], intervalItem) => {
+    (arr: IntervalEntity[], intervalItem, index) => {
       const last = arr.length === 0 ? null : arr[arr.length - 1];
 
       const intervalAssets = filterHiddenItems(
@@ -77,7 +82,11 @@ export function recalculate({
         totalDebts: integerToAmount(intervalDebts),
         totalTotals: integerToAmount(intervalAssets + intervalDebts),
         change,
-        intervalStartDate: intervalItem,
+        intervalStartDate: index === 0 ? startDate : intervalItem,
+        intervalEndDate:
+          index + 1 === intervals.length
+            ? endDate
+            : monthUtils.subDays(intervals[index + 1], 1),
       });
 
       return arr;

--- a/packages/loot-core/src/types/models/reports.d.ts
+++ b/packages/loot-core/src/types/models/reports.d.ts
@@ -79,6 +79,7 @@ export type IntervalEntity = {
   date?: string;
   change?: number;
   intervalStartDate?: string;
+  intervalEndDate?: string;
   totalAssets: number;
   totalDebts: number;
   totalTotals: number;


### PR DESCRIPTION
There was a regression created with #2643 which broke the "showActivity" elements of custom reports since they were using negative numbers for the filters. Easy fix, just switched to "inflow/outflow"

Also had an issue with weekly show activity clicks not filtering dates correctly. To duplicate on edge Open new custom report, click table graph, click time, change interval to weekly, click any cell, notice the "filtered balance" doesn't match the cell you clicked. Can also be seen on weekly stacked bar graph and weekly line graph.
