### PR TITLE
Release 'Splits in rules' feature

### DIFF
--- a/packages/desktop-client/e2e/rules.test.js
+++ b/packages/desktop-client/e2e/rules.test.js
@@ -69,11 +69,6 @@ test.describe('Rules', () => {
   });
 
   test('creates a split transaction rule and makes sure it is applied when creating a transaction', async () => {
-    const settingsPage = await navigation.goToSettingsPage();
-    await settingsPage.enableExperimentalFeature('splits in rules');
-
-    await expect(settingsPage.page.getByLabel('splits in rules')).toBeChecked();
-
     rulesPage = await navigation.goToRulesPage();
 
     await rulesPage.createRule({

--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -30,7 +30,6 @@ import {
 } from 'loot-core/src/shared/util';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
-import { useFeatureFlag } from '../../hooks/useFeatureFlag';
 import { useSelected, SelectedProvider } from '../../hooks/useSelected';
 import { SvgDelete, SvgAdd, SvgSubtract } from '../../icons/v0';
 import { SvgInformationOutline } from '../../icons/v1';
@@ -659,7 +658,6 @@ const conditionFields = [
   ]);
 
 export function EditRule({ modalProps, defaultRule, onSave: originalOnSave }) {
-  const splitsEnabled = useFeatureFlag('splitsInRules');
   const [conditions, setConditions] = useState(
     defaultRule.conditions.map(parse),
   );
@@ -887,9 +885,7 @@ export function EditRule({ modalProps, defaultRule, onSave: originalOnSave }) {
   };
 
   // Enable editing existing split rules even if the feature has since been disabled.
-  const showSplitButton = splitsEnabled
-    ? actionSplits.length > 0
-    : actionSplits.length > 1;
+  const showSplitButton = actionSplits.length > 0;
 
   return (
     <Modal

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -90,7 +90,6 @@ export function ExperimentalFeatures() {
               Goal templates
             </FeatureToggle>
             <FeatureToggle flag="simpleFinSync">SimpleFIN sync</FeatureToggle>
-            <FeatureToggle flag="splitsInRules">Splits in rules</FeatureToggle>
           </View>
         ) : (
           <Link

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -9,7 +9,6 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   customReports: false,
   spendingReport: false,
   simpleFinSync: false,
-  splitsInRules: false,
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -21,7 +21,6 @@ import {
 import { fastSetMerge } from '../../shared/util';
 import { RuleConditionEntity } from '../../types/models';
 import { RuleError } from '../errors';
-import * as prefs from '../prefs';
 import { Schedule as RSchedule } from '../util/rschedule';
 
 function assert(test, type, msg) {

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -510,7 +510,7 @@ export function execActions(actions: Action[], transaction) {
 
   let update = execNonSplitActions(parentActions, transaction);
   if (totalSplitCount === 1) {
-    //
+    // No splits, no need to do anything else.
     return update;
   }
 

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -509,7 +509,8 @@ export function execActions(actions: Action[], transaction) {
     ) + 1;
 
   let update = execNonSplitActions(parentActions, transaction);
-  if (!prefs.getPrefs()?.['flags.splitsInRules'] || totalSplitCount === 1) {
+  if (totalSplitCount === 1) {
+    //
     return update;
   }
 

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -5,8 +5,7 @@ export type FeatureFlag =
   | 'goalTemplatesEnabled'
   | 'customReports'
   | 'spendingReport'
-  | 'simpleFinSync'
-  | 'splitsInRules';
+  | 'simpleFinSync';
 
 export type LocalPrefs = Partial<
   {

--- a/upcoming-release-notes/2789.md
+++ b/upcoming-release-notes/2789.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jfdoming]
+---
+
+Release 'Splits in rules' feature


### PR DESCRIPTION
As it says on the tin. There are further UX improvements that could still be made (e.g., recomputing percent-based splits during manual transaction entry) but by and large this is feature complete and stable.