### PR TITLE
[WIP] Fix CSV import not matching category is (nothing) rules

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -941,9 +941,7 @@ export function ImportTransactions({ modalProps, options }) {
       }
 
       const category_id = parseCategoryFields(trans, categories.list);
-      if (category_id != null) {
-        trans.category = category_id;
-      }
+      trans.category = category_id;
 
       const { inflow, outflow, inOut, ...finalTransaction } = trans;
       finalTransactions.push({


### PR DESCRIPTION
Fixes #2052 

@Maxiimeeb was correct in the issue that the root cause of this is the fact that the csv import passes new transactions down the stack with `{ category: undefined }` if the category is not set in the CSV.

The `eval` function in the `Condition` class has a guard  that fails the rule if the value it's checking is strictly equal to `undefined`.

https://github.com/actualbudget/actual/blob/b803731bc52dbf3628b2129c7881cebabd24488e/packages/loot-core/src/server/accounts/rules.ts#L264-L266

This change takes one of the two possible approaches, which is to pass `null` as the category if unset instead of `undefined`. parseCategoryFields already does this so it makes sense just to use its return value.

https://github.com/actualbudget/actual/blob/b803731bc52dbf3628b2129c7881cebabd24488e/packages/desktop-client/src/components/modals/ImportTransactions.jsx#L313-L324

The other way this could be fixed is to amend the guard condition to pick up any nullish values and return accordingly straight away but I'm not sure if this approach would be in line with existing conventions throughout the project for usage of `null` and `undefined`.

```diff
-    if (fieldValue === undefined) {
-      return false;
-    }
+ if (fieldValue == null) {
+   return this.value == null && this.op === 'is';
+ }
```