### PR TITLE
Better account sync listing

### DIFF
--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -71,6 +71,7 @@ export function CreateAccountModal({
       name: string;
       institution: string;
       orgDomain: string;
+      balance: number;
     };
 
     for (const oldAccount of results.accounts) {
@@ -79,6 +80,7 @@ export function CreateAccountModal({
         name: oldAccount.name,
         institution: oldAccount.org.name,
         orgDomain: oldAccount.org.domain,
+        balance: oldAccount.balance,
       };
 
       newAccounts.push(newAccount);

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccounts.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccounts.jsx
@@ -7,6 +7,7 @@ import { Button } from '../common/Button';
 import { Modal } from '../common/Modal';
 import { Text } from '../common/Text';
 import { View } from '../common/View';
+import { PrivacyFilter } from '../PrivacyFilter';
 import { TableHeader, Table, Row, Field } from '../table';
 
 const addAccountOption = { id: 'new', name: 'Create new account' };
@@ -176,7 +177,9 @@ function TableRow({
   return (
     <Row style={{ backgroundColor: theme.tableBackground }}>
       <Field width={200}>{externalAccount.name}</Field>
-      <Field width={80}>{externalAccount.balance}</Field>
+      <Field width={80}>
+        <PrivacyFilter>{externalAccount.balance}</PrivacyFilter>
+      </Field>
       <Field
         width="flex"
         truncate={focusedField !== 'account'}

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccounts.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccounts.jsx
@@ -18,6 +18,7 @@ export function SelectLinkedAccounts({
   actions,
   syncSource,
 }) {
+  externalAccounts.sort((a, b) => a.name.localeCompare(b.name));
   const localAccounts = useAccounts().filter(a => a.closed === 0);
   const [chosenAccounts, setChosenAccounts] = useState(() => {
     return Object.fromEntries(
@@ -108,6 +109,7 @@ export function SelectLinkedAccounts({
             <TableHeader
               headers={[
                 { name: 'Bank Account To Sync', width: 200 },
+                { name: 'Balance', width: 80 },
                 { name: 'Account in Actual', width: 'flex' },
                 { name: 'Actions', width: 'flex' },
               ]}
@@ -174,6 +176,7 @@ function TableRow({
   return (
     <Row style={{ backgroundColor: theme.tableBackground }}>
       <Field width={200}>{externalAccount.name}</Field>
+      <Field width={80}>{externalAccount.balance}</Field>
       <Field
         width="flex"
         truncate={focusedField !== 'account'}


### PR DESCRIPTION
This sorts the accounts in the bank sync modal and adds their balance in a new column.  

This makes it much easier to find the account you are looking for.  Especially in cases where you have a lot of accounts with the same name:

<img width="804" alt="image" src="https://github.com/actualbudget/actual/assets/1115390/94d90883-c53d-4f29-a72d-55dd1e20cddd">

Knowing the balance is essential to finding the right one.