### PR TITLE
Show account notes in tooltip on sidebar

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -51,20 +51,20 @@ type AccountProps = {
   onDrop?: OnDropCallback;
 };
 
-export function Account({
-  name,
+function AccountRow(
   account,
-  connected,
-  pending = false,
-  failed,
-  updated,
-  to,
-  query,
-  style,
-  outerStyle,
+  outerStyle: CSSProperties,
   onDragChange,
   onDrop,
-}: AccountProps) {
+  to: string,
+  style: CSSProperties,
+  updated: boolean,
+  pending: boolean,
+  failed: boolean,
+  connected: boolean,
+  name: string,
+  query: Binding,
+) {
   const type = account
     ? account.closed
       ? 'account-closed'
@@ -85,8 +85,6 @@ export function Account({
     id: account && account.id,
     onDrop,
   });
-
-  const accountNote = useNotes(`account-${account?.id}`);
 
   return (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>
@@ -145,47 +143,97 @@ export function Account({
               />
             </View>
 
-            {!!account?.id ? (
-              <Tooltip
-                content={
-                  <View
-                    style={{
-                      padding: 3,
-                      paddingBottom: accountNote ? 0 : 3,
-                    }}
-                  >
-                    <Text
-                      style={{
-                        fontWeight: 'bold',
-                        borderBottom: accountNote
-                          ? `1px solid ${theme.tableBorder}`
-                          : 0,
-                      }}
-                    >
-                      {name}
-                    </Text>
-                    {accountNote && <Notes notes={accountNote} />}
-                  </View>
-                }
-                placement="right top"
-                triggerProps={{
-                  delay: 1000,
-                }}
-              >
-                <AlignedText
-                  left={name}
-                  right={<CellValue binding={query} type="financial" />}
-                />
-              </Tooltip>
-            ) : (
-              <AlignedText
-                left={name}
-                right={<CellValue binding={query} type="financial" />}
-              />
-            )}
+            <AlignedText
+              left={name}
+              right={<CellValue binding={query} type="financial" />}
+            />
           </Link>
         </View>
       </View>
     </View>
+  );
+}
+
+export function Account({
+  name,
+  account,
+  connected,
+  pending = false,
+  failed,
+  updated,
+  to,
+  query,
+  style,
+  outerStyle,
+  onDragChange,
+  onDrop,
+}: AccountProps) {
+  const accountNote = useNotes(`account-${account?.id}`);
+  const needsTooltip = !!account?.id;
+
+  return needsTooltip ? (
+    <Tooltip
+      content={
+        <View
+          style={{
+            padding: 3,
+          }}
+        >
+          <Text
+            style={{
+              fontWeight: 'bold',
+              borderBottom: accountNote ? `1px solid ${theme.tableBorder}` : 0,
+            }}
+          >
+            {name}
+          </Text>
+          {accountNote && (
+            <Notes
+              getStyle={value => ({
+                padding: 0,
+              })}
+              notes={accountNote}
+            />
+          )}
+        </View>
+      }
+      className={`${css({
+        borderRadius: '0px 5px 5px 0px ! important',
+      })}`}
+      placement="right top"
+      triggerProps={{
+        delay: 1000,
+      }}
+    >
+      {AccountRow(
+        account,
+        outerStyle,
+        onDragChange,
+        onDrop,
+        to,
+        style,
+        updated,
+        pending,
+        failed,
+        connected,
+        name,
+        query,
+      )}
+    </Tooltip>
+  ) : (
+    AccountRow(
+      account,
+      outerStyle,
+      onDragChange,
+      onDrop,
+      to,
+      style,
+      updated,
+      pending,
+      failed,
+      connected,
+      name,
+      query,
+    )
   );
 }

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -5,10 +5,13 @@ import { css } from 'glamor';
 
 import { type AccountEntity } from 'loot-core/src/types/models';
 
+import { useNotes } from '../../hooks/useNotes';
 import { styles, theme, type CSSProperties } from '../../style';
 import { AlignedText } from '../common/AlignedText';
 import { Link } from '../common/Link';
+import { Tooltip } from '../common/Tooltip';
 import { View } from '../common/View';
+import { Notes } from '../Notes';
 import {
   useDraggable,
   useDroppable,
@@ -82,6 +85,9 @@ export function Account({
     onDrop,
   });
 
+  const accountNote = useNotes(`account-${account?.id}`);
+  const note = `**${name}**` + (accountNote ? `\n\n${accountNote}` : '');
+
   return (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>
       <View>
@@ -140,7 +146,17 @@ export function Account({
             </View>
 
             <AlignedText
-              left={name}
+              left={
+                <Tooltip
+                  content={<Notes notes={note} />}
+                  placement="bottom left"
+                  triggerProps={{
+                    delay: 1000,
+                  }}
+                >
+                  {name}
+                </Tooltip>
+              }
               right={<CellValue binding={query} type="financial" />}
             />
           </Link>

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -189,7 +189,7 @@ export function Account({
           </Text>
           {accountNote && (
             <Notes
-              getStyle={value => ({
+              getStyle={() => ({
                 padding: 0,
               })}
               notes={accountNote}

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -51,20 +51,20 @@ type AccountProps = {
   onDrop?: OnDropCallback;
 };
 
-function AccountRow(
+export function Account({
+  name,
   account,
-  outerStyle: CSSProperties,
+  connected,
+  pending = false,
+  failed,
+  updated,
+  to,
+  query,
+  style,
+  outerStyle,
   onDragChange,
   onDrop,
-  to: string,
-  style: CSSProperties,
-  updated: boolean,
-  pending: boolean,
-  failed: boolean,
-  connected: boolean,
-  name: string,
-  query: Binding,
-) {
+}: AccountProps) {
   const type = account
     ? account.closed
       ? 'account-closed'
@@ -86,7 +86,10 @@ function AccountRow(
     onDrop,
   });
 
-  return (
+  const accountNote = useNotes(`account-${account?.id}`);
+  const needsTooltip = !!account?.id;
+
+  const accountRow = (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>
       <View>
         <DropHighlight pos={dropPos} />
@@ -152,26 +155,12 @@ function AccountRow(
       </View>
     </View>
   );
-}
 
-export function Account({
-  name,
-  account,
-  connected,
-  pending = false,
-  failed,
-  updated,
-  to,
-  query,
-  style,
-  outerStyle,
-  onDragChange,
-  onDrop,
-}: AccountProps) {
-  const accountNote = useNotes(`account-${account?.id}`);
-  const needsTooltip = !!account?.id;
+  if (!needsTooltip) {
+    return accountRow;
+  }
 
-  return needsTooltip ? (
+  return (
     <Tooltip
       content={
         <View
@@ -198,41 +187,13 @@ export function Account({
           )}
         </View>
       }
-      style={{ ...styles.tooltip,  borderRadius: '0px 5px 5px 0px', }}
+      style={{ ...styles.tooltip, borderRadius: '0px 5px 5px 0px' }}
       placement="right top"
       triggerProps={{
         delay: 1000,
       }}
     >
-      {AccountRow(
-        account,
-        outerStyle,
-        onDragChange,
-        onDrop,
-        to,
-        style,
-        updated,
-        pending,
-        failed,
-        connected,
-        name,
-        query,
-      )}
+      {accountRow}
     </Tooltip>
-  ) : (
-    AccountRow(
-      account,
-      outerStyle,
-      onDragChange,
-      onDrop,
-      to,
-      style,
-      updated,
-      pending,
-      failed,
-      connected,
-      name,
-      query,
-    )
   );
 }

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -151,7 +151,12 @@ export function Account({
                 !!account?.id ? (
                   <Tooltip
                     content={
-                      <View>
+                      <View
+                        style={{
+                          padding: 3,
+                          paddingBottom: accountNote ? 0 : 3,
+                        }}
+                      >
                         <Text
                           style={{
                             fontWeight: 'bold',

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -146,40 +146,44 @@ export function Account({
               />
             </View>
 
-            <AlignedText
-              left={
-                !!account?.id ? (
-                  <Tooltip
-                    content={
-                      <View
-                        style={{
-                          padding: 3,
-                          paddingBottom: accountNote ? 0 : 3,
-                        }}
-                      >
-                        <Text
-                          style={{
-                            fontWeight: 'bold',
-                          }}
-                        >
-                          {name}
-                        </Text>
-                        {accountNote && <Notes notes={accountNote} />}
-                      </View>
-                    }
-                    placement="bottom left"
-                    triggerProps={{
-                      delay: 1000,
+            {!!account?.id ? (
+              <Tooltip
+                content={
+                  <View
+                    style={{
+                      padding: 3,
+                      paddingBottom: accountNote ? 0 : 3,
                     }}
                   >
-                    {name}
-                  </Tooltip>
-                ) : (
-                  name
-                )
-              }
-              right={<CellValue binding={query} type="financial" />}
-            />
+                    <Text
+                      style={{
+                        fontWeight: 'bold',
+                        borderBottom: accountNote
+                          ? `1px solid ${theme.tableBorder}`
+                          : 0,
+                      }}
+                    >
+                      {name}
+                    </Text>
+                    {accountNote && <Notes notes={accountNote} />}
+                  </View>
+                }
+                placement="right top"
+                triggerProps={{
+                  delay: 1000,
+                }}
+              >
+                <AlignedText
+                  left={name}
+                  right={<CellValue binding={query} type="financial" />}
+                />
+              </Tooltip>
+            ) : (
+              <AlignedText
+                left={name}
+                right={<CellValue binding={query} type="financial" />}
+              />
+            )}
           </Link>
         </View>
       </View>

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -9,6 +9,7 @@ import { useNotes } from '../../hooks/useNotes';
 import { styles, theme, type CSSProperties } from '../../style';
 import { AlignedText } from '../common/AlignedText';
 import { Link } from '../common/Link';
+import { Text } from '../common/Text';
 import { Tooltip } from '../common/Tooltip';
 import { View } from '../common/View';
 import { Notes } from '../Notes';
@@ -86,7 +87,7 @@ export function Account({
   });
 
   const accountNote = useNotes(`account-${account?.id}`);
-  const note = `**${name}**` + (accountNote ? `\n\n${accountNote}` : '');
+  // const note = `**${name}**` + (accountNote ? `\n\n${accountNote}` : '');
 
   return (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>
@@ -149,7 +150,18 @@ export function Account({
               left={
                 !!account?.id ? (
                   <Tooltip
-                    content={<Notes notes={note} />}
+                    content={
+                      <View>
+                        <Text
+                          style={{
+                            fontWeight: 'bold',
+                          }}
+                        >
+                          {name}
+                        </Text>
+                        {accountNote && <Notes notes={accountNote} />}
+                      </View>
+                    }
                     placement="bottom left"
                     triggerProps={{
                       delay: 1000,

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -198,9 +198,7 @@ export function Account({
           )}
         </View>
       }
-      className={`${css({
-        borderRadius: '0px 5px 5px 0px ! important',
-      })}`}
+      style={{ ...styles.tooltip,  borderRadius: '0px 5px 5px 0px', }}
       placement="right top"
       triggerProps={{
         delay: 1000,

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -87,7 +87,6 @@ export function Account({
   });
 
   const accountNote = useNotes(`account-${account?.id}`);
-  // const note = `**${name}**` + (accountNote ? `\n\n${accountNote}` : '');
 
   return (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -176,13 +176,14 @@ export function Account({
       content={
         <View
           style={{
-            padding: 3,
+            padding: 10,
           }}
         >
           <Text
             style={{
               fontWeight: 'bold',
               borderBottom: accountNote ? `1px solid ${theme.tableBorder}` : 0,
+              marginBottom: accountNote ? '0.5rem' : 0,
             }}
           >
             {name}

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -147,15 +147,19 @@ export function Account({
 
             <AlignedText
               left={
-                <Tooltip
-                  content={<Notes notes={note} />}
-                  placement="bottom left"
-                  triggerProps={{
-                    delay: 1000,
-                  }}
-                >
-                  {name}
-                </Tooltip>
+                !!account?.id ? (
+                  <Tooltip
+                    content={<Notes notes={note} />}
+                    placement="bottom left"
+                    triggerProps={{
+                      delay: 1000,
+                    }}
+                  >
+                    {name}
+                  </Tooltip>
+                ) : (
+                  name
+                )
               }
               right={<CellValue binding={query} type="financial" />}
             />

--- a/upcoming-release-notes/2796.md
+++ b/upcoming-release-notes/2796.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Show account notes in tooltip on sidebar.


### PR DESCRIPTION
Shows the account's notes when hovering the account in the sidebar:

![image](https://github.com/actualbudget/actual/assets/1115390/dc7ba28b-a2bb-4280-9d32-e0f9f860bb3b)

If the account has no notes, just the full name shows (which can be very useful when long names are cut off):

![image](https://github.com/actualbudget/actual/assets/1115390/1829bad6-eafa-45e9-b29f-7fea6d59e1b8)
