### PR TITLE
Make picking budget months easier to see

### DIFF
--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -124,6 +124,11 @@ export const MonthPicker = ({
                   borderRadius: 0,
                   cursor: 'pointer',
                 }),
+                ...(hoverId !== null &&
+                  !hovered &&
+                  selected && {
+                    filter: 'brightness(65%)',
+                  }),
                 ...(hovered &&
                   !selected && {
                     backgroundColor: theme.buttonBareBackgroundHover,

--- a/upcoming-release-notes/2797.md
+++ b/upcoming-release-notes/2797.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Make picking budget months easier to see.


### PR DESCRIPTION
I often second-guess myself when trying to select the set of months I want displayed in the budget when viewing it by more than one month at a time.  After some thought, I decided it was because I could not quickly mentally compute the full set of months I was about to select.

Here, I tweak the way the months render during a hover event so it is more obvious which set of months you will get if you click:

![brightness](https://github.com/actualbudget/actual/assets/1115390/af7c2eec-cd2e-470b-aa15-e1ea16174ad7)
