### PR TITLE
Revert #2643

### DIFF
--- a/packages/loot-core/src/server/accounts/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.test.ts
@@ -420,23 +420,7 @@ describe('Transaction rules', () => {
       account,
       payee: lowesId,
       notes: '',
-      amount: 102,
-    });
-    await db.insertTransaction({
-      id: '6',
-      date: '2020-10-17',
-      account,
-      payee: krogerId,
-      notes: 'baz',
-      amount: -102,
-    });
-    await db.insertTransaction({
-      id: '7',
-      date: '2020-10-17',
-      account,
-      payee: krogerId,
-      notes: 'zaz',
-      amount: -101,
+      amount: 124,
     });
 
     let transactions = await getMatchingTransactions([
@@ -453,36 +437,6 @@ describe('Transaction rules', () => {
       { field: 'amount', op: 'is', value: 353 },
     ]);
     expect(transactions.map(t => t.id)).toEqual(['1']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'is', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['6', '5']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'isapprox', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['6', '7', '4', '5']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'gt', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['2', '3', '1']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'lt', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['7', '4']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'gte', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['6', '5', '2', '3', '1']);
-
-    transactions = await getMatchingTransactions([
-      { field: 'amount', op: 'lte', value: 102 },
-    ]);
-    expect(transactions.map(t => t.id)).toEqual(['6', '7', '4', '5']);
 
     transactions = await getMatchingTransactions([
       { field: 'notes', op: 'is', value: 'FooO' },
@@ -507,7 +461,7 @@ describe('Transaction rules', () => {
     transactions = await getMatchingTransactions([
       { field: 'amount', op: 'gt', value: 300 },
     ]);
-    expect(transactions.map(t => t.id)).toEqual(['2', '3', '1']);
+    expect(transactions.map(t => t.id)).toEqual(['2', '1']);
 
     transactions = await getMatchingTransactions([
       { field: 'amount', op: 'gt', value: 400 },
@@ -536,7 +490,7 @@ describe('Transaction rules', () => {
     transactions = await getMatchingTransactions([
       { field: 'date', op: 'gt', value: '2020-10-10' },
     ]);
-    expect(transactions.map(t => t.id)).toEqual(['6', '7', '4', '5', '2', '3']);
+    expect(transactions.map(t => t.id)).toEqual(['4', '5', '2', '3']);
 
     // todo: isapprox
   });

--- a/packages/loot-core/src/server/accounts/transaction-rules.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.ts
@@ -335,25 +335,22 @@ export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
 
     const apply = (field, op, value) => {
       if (type === 'number') {
-        const outflowQuery = {
-          $and: [
-            { amount: { $lt: 0 } },
-            { [field]: { $transform: '$neg', [op]: value } },
-          ],
-        };
-        const inflowQuery = {
-          $and: [{ amount: { $gt: 0 } }, { [field]: { [op]: value } }],
-        };
         if (options) {
           if (options.outflow) {
-            return outflowQuery;
+            return {
+              $and: [
+                { amount: { $lt: 0 } },
+                { [field]: { $transform: '$neg', [op]: value } },
+              ],
+            };
           } else if (options.inflow) {
-            return inflowQuery;
+            return {
+              $and: [{ amount: { $gt: 0 } }, { [field]: { [op]: value } }],
+            };
           }
         }
-        return {
-          $or: [outflowQuery, inflowQuery],
-        };
+
+        return { amount: { [op]: value } };
       } else if (type === 'string') {
         return { [field]: { $transform: '$lower', [op]: value } };
       } else if (type === 'date') {

--- a/upcoming-release-notes/2643.md
+++ b/upcoming-release-notes/2643.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mirdaki]
+---
+
+Fix amount filter to include both incoming and outgoing amounts.

--- a/upcoming-release-notes/2643.md
+++ b/upcoming-release-notes/2643.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [mirdaki]
----
-
-Fix amount filter to include both incoming and outgoing amounts.

--- a/upcoming-release-notes/2803.md
+++ b/upcoming-release-notes/2803.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Revert amount filter chnage


### PR DESCRIPTION
#2643 is a nice change, but there are multiple things that use the amount filter, like schedules, that would need changed to match the update.  We could return to this after the release if desired and have time to fix the internal amount filter uses.

Also, maybe instead of changing how the filter works we would instead use the amountInput component when creating the filter to be more clear what the amount is.  That way the filter uses don't have to be changed to match then new filter.
