### PR TITLE
[Mobile] Auto create 2 child transactions on split

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -28,6 +28,7 @@ import {
   splitTransaction,
   addSplitTransaction,
   deleteTransaction,
+  makeChild,
 } from 'loot-core/src/shared/transactions';
 import {
   titleFirst,
@@ -284,6 +285,7 @@ const ChildTransactionEdit = forwardRef(
   (
     {
       transaction,
+      amountFocused,
       amountSign,
       getCategory,
       getPrettyPayee,
@@ -336,7 +338,7 @@ const ChildTransactionEdit = forwardRef(
                 editingField &&
                 editingField !== getFieldName(transaction.id, 'amount')
               }
-              focused={transaction.amount === 0}
+              focused={amountFocused}
               value={amountToInteger(transaction.amount)}
               zeroSign={amountSign}
               style={{ marginRight: 8 }}
@@ -795,10 +797,11 @@ const TransactionEditInner = memo(function TransactionEditInner({
           </View>
         )}
 
-        {childTransactions.map(childTrans => (
+        {childTransactions.map((childTrans, i, arr) => (
           <ChildTransactionEdit
             key={childTrans.id}
             transaction={childTrans}
+            amountFocused={arr.findIndex(c => c.amount === 0) === i}
             amountSign={childAmountSign}
             ref={r => {
               childTransactionElementRefMap.current = {
@@ -1136,7 +1139,11 @@ function TransactionEditUnconnected({
   };
 
   const onSplit = id => {
-    const changes = splitTransaction(transactions, id);
+    const changes = splitTransaction(transactions, id, parent => [
+      makeChild(parent),
+      makeChild(parent),
+    ]);
+
     setTransactions(changes.data);
   };
 

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -42,7 +42,7 @@ type GenericTransactionEntity =
 
 export function makeChild<T extends GenericTransactionEntity>(
   parent: T,
-  data: T = {},
+  data: object = {},
 ) {
   const prefix = parent.id === 'temp' ? 'temp' : '';
 

--- a/upcoming-release-notes/2821.md
+++ b/upcoming-release-notes/2821.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Auto create two child transactions on mobile instead of one when splitting a transactions.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Two child transactions created instead of one:
![image](https://github.com/actualbudget/actual/assets/20313680/9bc9ddc2-692f-47b0-943b-7a5d8b6a6b8a)
