### PR TITLE
(transactions) show running balance with date filters

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -511,7 +511,8 @@ class AccountInternal extends PureComponent {
     return (
       account &&
       this.state.search === '' &&
-      this.state.filters.length === 0 &&
+      (this.state.filters.length === 0 ||
+        this.state.filters.every(e => e.field === 'date')) &&
       (this.state.sort.length === 0 ||
         (this.state.sort.field === 'date' &&
           this.state.sort.ascDesc === 'desc'))

--- a/upcoming-release-notes/2823.md
+++ b/upcoming-release-notes/2823.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [sidvishnoi]
+---
+
+Show running balance while filtering if only date filters are active


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

We can safely show running balance while filtering if only date filters are active.

Use case: In absence of https://github.com/actualbudget/actual/issues/2743, I created custom date-only filters to list/export transactions only in given financial year. Having ability to see running balance lets me map transactions to my bank statement easily.

I actually wanted to support running balance in exports, but that's more involved. So for now, this will do :)

