### PR TITLE
Enable compress to avoid minified scripts from throwing SyntaxError in safari16

### DIFF
--- a/packages/loot-core/webpack/webpack.browser.config.js
+++ b/packages/loot-core/webpack/webpack.browser.config.js
@@ -73,7 +73,9 @@ module.exports = {
         // `terserOptions` options will be passed to `swc` (`@swc/core`)
         // Link to options - https://swc.rs/docs/config-js-minify
         terserOptions: {
-          compress: false,
+          compress: {
+            drop_debugger: false,
+          },
           mangle: true,
         },
       }),

--- a/upcoming-release-notes/2825.md
+++ b/upcoming-release-notes/2825.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [chinalichen]
+---
+
+Enable compress to avoid minified scripts from throwing SyntaxError in safari16


### PR DESCRIPTION
Fixes #1766 

The worker script `kcab.worker.$HASH.js` which minified by swcMinify includes functions like `function e(e,t=0){}`. Run this function in safari 16 will throw SyntaxError
![image](https://github.com/actualbudget/actual/assets/2139908/fd47c07c-6de0-4f3d-8263-27bb18aaa8db)

Enable compress for swcMinify will remove useless function name `e` in `function e(e,t=0){}`. You can try compress flags in [this swc playground](https://play.swc.rs/?version=1.5.24&code=H4sIAAAAAAAAAytKTc8sLkkt0kgrzUsuyczPU0gpLcjJTE4sSY0HCWkguAWJRYm5Ogr5aWnFqSUKtgoGmgrVtZpcACgasG1CAAAA&config=H4sIAAAAAAAAA1WPSwrDMAxE9zmF0bqLttAueocewrhKcPAPS4GGkLvH33521sw8j7QNQsBMCh5iS880BBkJ42dOCq2O5TspgMpKUlEHhlN3Z8rWKA1hkfbqAMs4IReKrufLrRFgvCfsRNOsdnpcfzuVtyEi0X8wR6WbTOY5Lq1waKVg%2FWspXjuF14B1gTt8Q70rf1AUTc8O1jP2A%2BC7qlwWAQAA).