### PR TITLE
Add global feature flag state

### DIFF
--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useState } from 'react';
 
-import type { FeatureFlag } from 'loot-core/src/types/prefs';
+import type { LocalFeatureFlag } from 'loot-core/src/types/prefs';
 
 import { useFeatureFlag } from '../../hooks/useFeatureFlag';
 import { useLocalPref } from '../../hooks/useLocalPref';
@@ -13,7 +13,7 @@ import { Checkbox } from '../forms';
 import { Setting } from './UI';
 
 type FeatureToggleProps = {
-  flag: FeatureFlag;
+  flag: LocalFeatureFlag;
   disableToggle?: boolean;
   error?: ReactNode;
   children: ReactNode;

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -1,7 +1,10 @@
 import { useSelector } from 'react-redux';
 
 import { type State } from 'loot-core/src/client/state-types';
-import type { FeatureFlag } from 'loot-core/src/types/prefs';
+import {
+  type GlobalOnlyFeatureFlag,
+  type FeatureFlag,
+} from 'loot-core/src/types/prefs';
 
 const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   reportBudget: false,
@@ -9,12 +12,29 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   customReports: false,
   spendingReport: false,
   simpleFinSync: false,
+  multiUser: false,
 };
+
+const GLOBAL_ONLY_FEATURE_FLAGS = new Set('multiUser');
+
+function isGlobalOnlyFeatureFlag(
+  name: FeatureFlag,
+): name is GlobalOnlyFeatureFlag {
+  return GLOBAL_ONLY_FEATURE_FLAGS.has(name as GlobalOnlyFeatureFlag);
+}
 
 export function useFeatureFlag(name: FeatureFlag): boolean {
   return useSelector((state: State) => {
-    const value = state.prefs.local[`flags.${name}`];
+    if (!isGlobalOnlyFeatureFlag(name)) {
+      const value = state.prefs.local[`flags.${name}`];
+      if (value !== undefined) {
+        return value;
+      }
 
+      // Fall back to global prefs if local prefs don't have the flag
+    }
+
+    const value = state.prefs.global[`flags.${name}`];
     return value === undefined
       ? DEFAULT_FEATURE_FLAG_STATE[name] || false
       : value;

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -1,11 +1,14 @@
 import { type numberFormats } from '../shared/util';
 
-export type FeatureFlag =
+export type LocalFeatureFlag =
   | 'reportBudget'
   | 'goalTemplatesEnabled'
   | 'customReports'
   | 'spendingReport'
   | 'simpleFinSync';
+export type GlobalOnlyFeatureFlag = 'multiUser';
+
+export type FeatureFlag = LocalFeatureFlag | GlobalOnlyFeatureFlag;
 
 export type LocalPrefs = Partial<
   {
@@ -54,15 +57,18 @@ export type LocalPrefs = Partial<
     reportsViewSummary: boolean;
     reportsViewLabel: boolean;
     'mobile.showSpentColumn': boolean;
-  } & Record<`flags.${FeatureFlag}`, boolean>
+  } & Record<`flags.${LocalFeatureFlag}`, boolean>
 >;
 
 export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | 'development';
-export type GlobalPrefs = Partial<{
-  floatingSidebar: boolean;
-  maxMonths: number;
-  autoUpdate: boolean;
-  keyId?: string;
-  theme: Theme;
-  documentDir: string; // Electron only
-}>;
+export type GlobalPrefs = Partial<
+  {
+    floatingSidebar: boolean;
+    maxMonths: number;
+    autoUpdate: boolean;
+    keyId?: string;
+    theme: Theme;
+    documentDir: string; // Electron only
+  } & Record<`flags.${LocalFeatureFlag}`, boolean> &
+    Record<`flags.${GlobalOnlyFeatureFlag}`, boolean>
+>;

--- a/upcoming-release-notes/2835.md
+++ b/upcoming-release-notes/2835.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Add global feature flag state


### PR DESCRIPTION
As discussed on Discord, this commit adds global feature flag state in addition to the local state, to be used by the multi-user feature being built.

I didn't remove support for local flags since it would be really hard to migrate them to global state (if a flag is enabled in one budget but disabled in another, what does the global state get set to?). Instead, we'll have admin-configurable defaults (exposed in the UI via a future PR).

Since this commit doesn't add any UI exposing the new flag state, folks who want to develop on this feature should manually change the flag defaults temporarily until that UI does get built.

Open to feedback on the approach! The other approach considered was to have server-side feature flags, but we discarded that on Discord at the time due to complexity.