### PR TITLE
[WIP] Don't show account tooltips during VRT

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { css } from 'glamor';
 
+import * as Platform from 'loot-core/client/platform';
 import { type AccountEntity } from 'loot-core/src/types/models';
 
 import { useNotes } from '../../hooks/useNotes';
@@ -156,7 +157,7 @@ export function Account({
     </View>
   );
 
-  if (!needsTooltip) {
+  if (!needsTooltip || Platform.isPlaywright) {
     return accountRow;
   }
 

--- a/upcoming-release-notes/2838.md
+++ b/upcoming-release-notes/2838.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [psybers]
+---
+
+Don't show account tooltips during VRT.


### PR DESCRIPTION
Fixes the flakey VRT issues caused by the merge of #2796, by not showing account tooltips during VRT.