### PR TITLE
Changing the autocomplete search to accept text without accents to match options with accents

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -92,10 +92,16 @@ export function defaultFilterSuggestion<T extends Item>(
   suggestion: T,
   value: string,
 ) {
-  return getItemName(suggestion).toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "")
-            .includes(
-                        value.toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "")
-                     );
+  return getItemName(suggestion)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .includes(
+      value
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/\p{Diacritic}/gu, ''),
+    );
 }
 
 function defaultFilterSuggestions<T extends Item>(

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -92,7 +92,10 @@ export function defaultFilterSuggestion<T extends Item>(
   suggestion: T,
   value: string,
 ) {
-  return getItemName(suggestion).toLowerCase().includes(value.toLowerCase());
+  return getItemName(suggestion).toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "")
+            .includes(
+                        value.toLowerCase().normalize("NFD").replace(/\p{Diacritic}/gu, "")
+                     );
 }
 
 function defaultFilterSuggestions<T extends Item>(

--- a/upcoming-release-notes/2842.md
+++ b/upcoming-release-notes/2842.md
@@ -1,0 +1,9 @@
+---
+category: Enhancements
+authors: lelemm
+---
+
+This enhances the capability to use autocomplete for languages that use accents like Portuguese.
+For example, you may have a category that has accents, but currently it will match only when you type the accent in the search string. That seems minimal, but it gets frustrating at some point.
+
+This PR address this quality of life. When searching, it will match if you do not type the accent, and vice-versa.

--- a/upcoming-release-notes/2842.md
+++ b/upcoming-release-notes/2842.md
@@ -1,6 +1,6 @@
 ---
 category: Enhancements
-authors: lelemm
+authors: [lelemm]
 ---
 
 This enhances the capability to use autocomplete for languages that use accents like Portuguese.

--- a/upcoming-release-notes/2842.md
+++ b/upcoming-release-notes/2842.md
@@ -3,7 +3,4 @@ category: Enhancements
 authors: [lelemm]
 ---
 
-This enhances the capability to use autocomplete for languages that use accents like Portuguese.
-For example, you may have a category that has accents, but currently it will match only when you type the accent in the search string. That seems minimal, but it gets frustrating at some point.
-
-This PR address this quality of life. When searching, it will match if you do not type the accent, and vice-versa.
+Enhancement in autocomplete for languages that use accents like Portuguese. This change address this quality of life. When searching, it will match even if you do not type the accent, and vice-versa.

--- a/upcoming-release-notes/2842.md
+++ b/upcoming-release-notes/2842.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [lelemm]
 ---
 
-Enhancement in autocomplete for languages that use accents like Portuguese. This change address this quality of life. When searching, it will match even if you do not type the accent, and vice-versa.
+Enhanced autocomplete for languages with accents like Portuguese. Matches search queries regardless of accents.


### PR DESCRIPTION
category: Enhancements
authors: [lelemm]

This enhances the capability to use autocomplete for languages that use accents like Portuguese.
For example, you may have a category that has accents, but currently it will match only when you type the accent in the search string. That seems minimal, but it gets frustrating at some point.

This PR address this quality of life. When searching, it will match if you do not type the accent, and vice-versa. Check the vid bellow:

https://github.com/actualbudget/actual/assets/15043428/e478a7fa-ebc5-48c2-830c-5812786ef697

