### PR TITLE
Cover overbudgeted action + make balance movement menus only appear on relevant conditions

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -544,6 +544,7 @@ export function Modals() {
               <RolloverToBudgetMenuModal
                 modalProps={modalProps}
                 onTransfer={options.onTransfer}
+                onCover={options.onCover}
                 onHoldBuffer={options.onHoldBuffer}
                 onResetHoldBuffer={options.onResetHoldBuffer}
               />
@@ -596,7 +597,7 @@ export function Modals() {
             <CoverModal
               key={name}
               modalProps={modalProps}
-              categoryId={options.categoryId}
+              title={options.title}
               month={options.month}
               onSubmit={options.onSubmit}
             />

--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -599,6 +599,7 @@ export function Modals() {
               modalProps={modalProps}
               title={options.title}
               month={options.month}
+              showToBeBudgeted={options.showToBeBudgeted}
               onSubmit={options.onSubmit}
             />
           );

--- a/packages/desktop-client/src/components/budget/rollover/BalanceMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BalanceMenu.tsx
@@ -43,16 +43,14 @@ export function BalanceMenu({
         }
       }}
       items={[
-        {
-          name: 'transfer',
-          text: 'Transfer to another category',
-        },
-        {
-          name: 'carryover',
-          text: carryover
-            ? 'Remove overspending rollover'
-            : 'Rollover overspending',
-        },
+        ...(balance > 0
+          ? [
+              {
+                name: 'transfer',
+                text: 'Transfer to another category',
+              },
+            ]
+          : []),
         ...(balance < 0
           ? [
               {
@@ -61,6 +59,12 @@ export function BalanceMenu({
               },
             ]
           : []),
+        {
+          name: 'carryover',
+          text: carryover
+            ? 'Remove overspending rollover'
+            : 'Rollover overspending',
+        },
       ]}
     />
   );

--- a/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
@@ -60,7 +60,7 @@ export function BalanceMovementMenu({
         <CoverMenu
           onClose={onClose}
           onSubmit={fromCategoryId => {
-            onBudgetAction(month, 'cover', {
+            onBudgetAction(month, 'cover-overspending', {
               to: categoryId,
               from: fromCategoryId,
             });

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -8,15 +8,21 @@ import { View } from '../../common/View';
 import { addToBeBudgetedGroup } from '../util';
 
 type CoverMenuProps = {
+  showToBeBudgeted?: boolean;
   onSubmit: (categoryId: string) => void;
   onClose: () => void;
 };
 
-export function CoverMenu({ onSubmit, onClose }: CoverMenuProps) {
+export function CoverMenu({
+  showToBeBudgeted = true,
+  onSubmit,
+  onClose,
+}: CoverMenuProps) {
   const { grouped: originalCategoryGroups } = useCategories();
-  const categoryGroups = addToBeBudgetedGroup(
-    originalCategoryGroups.filter(g => !g.is_income),
-  );
+  let categoryGroups = originalCategoryGroups.filter(g => !g.is_income);
+  categoryGroups = showToBeBudgeted
+    ? addToBeBudgetedGroup(categoryGroups)
+    : categoryGroups;
   const [categoryId, setCategoryId] = useState<string | null>(null);
 
   function submit() {

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudget.tsx
@@ -86,6 +86,7 @@ export function ToBudget({
         )}
         {menuOpen === 'cover' && (
           <CoverMenu
+            showToBeBudgeted={false}
             onClose={() => setMenuOpen(null)}
             onSubmit={categoryId => {
               onBudgetAction(month, 'cover-overbudgeted', {

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudget.tsx
@@ -6,6 +6,7 @@ import { type CSSProperties } from '../../../../style';
 import { Popover } from '../../../common/Popover';
 import { View } from '../../../common/View';
 import { useSheetValue } from '../../../spreadsheet/useSheetValue';
+import { CoverMenu } from '../CoverMenu';
 import { HoldMenu } from '../HoldMenu';
 import { TransferMenu } from '../TransferMenu';
 
@@ -55,6 +56,7 @@ export function ToBudget({
         {menuOpen === 'actions' && (
           <ToBudgetMenu
             onTransfer={() => setMenuOpen('transfer')}
+            onCover={() => setMenuOpen('cover')}
             onHoldBuffer={() => setMenuOpen('buffer')}
             onResetHoldBuffer={() => {
               onBudgetAction(month, 'reset-hold');
@@ -74,10 +76,20 @@ export function ToBudget({
           <TransferMenu
             initialAmount={availableValue}
             onClose={() => setMenuOpen(null)}
-            onSubmit={(amount, category) => {
+            onSubmit={(amount, categoryId) => {
               onBudgetAction(month, 'transfer-available', {
                 amount,
-                category,
+                category: categoryId,
+              });
+            }}
+          />
+        )}
+        {menuOpen === 'cover' && (
+          <CoverMenu
+            onClose={() => setMenuOpen(null)}
+            onSubmit={categoryId => {
+              onBudgetAction(month, 'cover-overbudgeted', {
+                category: categoryId,
               });
             }}
           />

--- a/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudgetMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/budgetsummary/ToBudgetMenu.tsx
@@ -1,21 +1,59 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
 
+import { rolloverBudget } from 'loot-core/client/queries';
+
 import { Menu } from '../../../common/Menu';
+import { useSheetValue } from '../../../spreadsheet/useSheetValue';
 
 type ToBudgetMenuProps = Omit<
   ComponentPropsWithoutRef<typeof Menu>,
   'onMenuSelect' | 'items'
 > & {
   onTransfer: () => void;
+  onCover: () => void;
   onHoldBuffer: () => void;
   onResetHoldBuffer: () => void;
 };
 export function ToBudgetMenu({
   onTransfer,
+  onCover,
   onHoldBuffer,
   onResetHoldBuffer,
   ...props
 }: ToBudgetMenuProps) {
+  const toBudget = useSheetValue(rolloverBudget.toBudget);
+  const forNextMonth = useSheetValue(rolloverBudget.forNextMonth);
+  const items = [
+    ...(toBudget > 0
+      ? [
+          {
+            name: 'transfer',
+            text: 'Move to a category',
+          },
+          {
+            name: 'buffer',
+            text: 'Hold for next month',
+          },
+        ]
+      : []),
+    ...(toBudget < 0
+      ? [
+          {
+            name: 'cover',
+            text: 'Cover from a category',
+          },
+        ]
+      : []),
+    ...(forNextMonth > 0
+      ? [
+          {
+            name: 'reset-buffer',
+            text: 'Reset next month’s buffer',
+          },
+        ]
+      : []),
+  ];
+
   return (
     <Menu
       {...props}
@@ -23,6 +61,9 @@ export function ToBudgetMenu({
         switch (name) {
           case 'transfer':
             onTransfer?.();
+            break;
+          case 'cover':
+            onCover?.();
             break;
           case 'buffer':
             onHoldBuffer?.();
@@ -34,20 +75,17 @@ export function ToBudgetMenu({
             throw new Error(`Unrecognized menu option: ${name}`);
         }
       }}
-      items={[
-        {
-          name: 'transfer',
-          text: 'Move to a category',
-        },
-        {
-          name: 'buffer',
-          text: 'Hold for next month',
-        },
-        {
-          name: 'reset-buffer',
-          text: 'Reset next month’s buffer',
-        },
-      ]}
+      items={
+        items.length > 0
+          ? items
+          : [
+              {
+                name: 'none',
+                text: 'No actions available',
+                disabled: true,
+              },
+            ]
+      }
     />
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -373,7 +373,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
         categoryId: category.id,
         month,
         onSubmit: fromCategoryId => {
-          onBudgetAction(month, 'cover', {
+          onBudgetAction(month, 'cover-overspending', {
             to: category.id,
             from: fromCategoryId,
           });

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -17,6 +17,7 @@ type CoverModalProps = {
   modalProps: CommonModalProps;
   title: string;
   month: string;
+  showToBeBudgeted?: boolean;
   onSubmit: (categoryId: string) => void;
 };
 
@@ -24,16 +25,18 @@ export function CoverModal({
   modalProps,
   title,
   month,
+  showToBeBudgeted = true,
   onSubmit,
 }: CoverModalProps) {
   const { grouped: originalCategoryGroups } = useCategories();
   const [categoryGroups, categories] = useMemo(() => {
-    const expenseGroups = addToBeBudgetedGroup(
-      originalCategoryGroups.filter(g => !g.is_income),
-    );
+    let expenseGroups = originalCategoryGroups.filter(g => !g.is_income);
+    expenseGroups = showToBeBudgeted
+      ? addToBeBudgetedGroup(expenseGroups)
+      : expenseGroups;
     const expenseCategories = expenseGroups.flatMap(g => g.categories || []);
     return [expenseGroups, expenseCategories];
-  }, [originalCategoryGroups]);
+  }, [originalCategoryGroups, showToBeBudgeted]);
 
   const [fromCategoryId, setFromCategoryId] = useState<string | null>(null);
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -15,14 +15,14 @@ import { type CommonModalProps } from '../Modals';
 
 type CoverModalProps = {
   modalProps: CommonModalProps;
-  categoryId: string;
+  title: string;
   month: string;
   onSubmit: (categoryId: string) => void;
 };
 
 export function CoverModal({
   modalProps,
-  categoryId,
+  title,
   month,
   onSubmit,
 }: CoverModalProps) {
@@ -67,19 +67,9 @@ export function CoverModal({
   }, [initialMount, onCategoryClick]);
 
   const fromCategory = categories.find(c => c.id === fromCategoryId);
-  const category = categories.find(c => c.id === categoryId);
-
-  if (!category) {
-    return null;
-  }
 
   return (
-    <Modal
-      title={category.name}
-      showHeader
-      focusAfterClose={false}
-      {...modalProps}
-    >
+    <Modal title={title} showHeader focusAfterClose={false} {...modalProps}>
       <View>
         <FieldLabel title="Cover from category:" />
         <TapField value={fromCategory?.name} onClick={onCategoryClick} />

--- a/packages/desktop-client/src/components/modals/RolloverBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/RolloverBudgetSummaryModal.tsx
@@ -54,6 +54,7 @@ export function RolloverBudgetSummaryModal({
       pushModal('cover', {
         title: 'Cover: Overbudgeted',
         month,
+        showToBeBudgeted: false,
         onSubmit: categoryId => {
           onBudgetAction(month, 'cover-overbudgeted', {
             category: categoryId,

--- a/packages/desktop-client/src/components/modals/RolloverBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/RolloverBudgetSummaryModal.tsx
@@ -31,19 +31,34 @@ export function RolloverBudgetSummaryModal({
     value: 0,
   });
 
-  const openTransferModal = () => {
+  const openTransferAvailableModal = () => {
     dispatch(
       pushModal('transfer', {
         title: 'Transfer: To Budget',
         month,
         amount: sheetValue,
         onSubmit: (amount, toCategoryId) => {
-          onBudgetAction?.(month, 'transfer-available', {
+          onBudgetAction(month, 'transfer-available', {
             amount,
             month,
             category: toCategoryId,
           });
           dispatch(collapseModals('transfer'));
+        },
+      }),
+    );
+  };
+
+  const openCoverOverbudgetedModal = () => {
+    dispatch(
+      pushModal('cover', {
+        title: 'Cover: Overbudgeted',
+        month,
+        onSubmit: categoryId => {
+          onBudgetAction(month, 'cover-overbudgeted', {
+            category: categoryId,
+          });
+          dispatch(collapseModals('cover'));
         },
       }),
     );
@@ -62,7 +77,7 @@ export function RolloverBudgetSummaryModal({
   };
 
   const onResetHoldBuffer = () => {
-    onBudgetAction?.(month, 'reset-hold');
+    onBudgetAction(month, 'reset-hold');
     modalProps.onClose();
   };
 
@@ -70,7 +85,8 @@ export function RolloverBudgetSummaryModal({
     dispatch(
       pushModal('rollover-summary-to-budget-menu', {
         month,
-        onTransfer: openTransferModal,
+        onTransfer: openTransferAvailableModal,
+        onCover: openCoverOverbudgetedModal,
         onResetHoldBuffer,
         onHoldBuffer,
       }),

--- a/packages/desktop-client/src/components/modals/RolloverToBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/RolloverToBudgetMenuModal.tsx
@@ -14,6 +14,7 @@ type RolloverToBudgetMenuModalProps = ComponentPropsWithoutRef<
 export function RolloverToBudgetMenuModal({
   modalProps,
   onTransfer,
+  onCover,
   onHoldBuffer,
   onResetHoldBuffer,
 }: RolloverToBudgetMenuModalProps) {
@@ -29,6 +30,7 @@ export function RolloverToBudgetMenuModal({
       <ToBudgetMenu
         getItemStyle={() => defaultMenuItemStyle}
         onTransfer={onTransfer}
+        onCover={onCover}
         onHoldBuffer={onHoldBuffer}
         onResetHoldBuffer={onResetHoldBuffer}
       />

--- a/packages/loot-core/src/client/actions/queries.ts
+++ b/packages/loot-core/src/client/actions/queries.ts
@@ -53,7 +53,7 @@ export function applyBudgetAction(month, type, args) {
       case 'reset-hold':
         await send('budget/reset-hold', { month });
         break;
-      case 'cover':
+      case 'cover-overspending':
         await send('budget/cover-overspending', {
           month,
           to: args.to,
@@ -64,6 +64,12 @@ export function applyBudgetAction(month, type, args) {
         await send('budget/transfer-available', {
           month,
           amount: args.amount,
+          category: args.category,
+        });
+        break;
+      case 'cover-overbudgeted':
+        await send('budget/cover-overbudgeted', {
+          month,
           category: args.category,
         });
         break;

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -201,6 +201,7 @@ type FinanceModals = {
   'rollover-summary-to-budget-menu': {
     month: string;
     onTransfer: () => void;
+    onCover: () => void;
     onHoldBuffer: () => void;
     onResetHoldBuffer: () => void;
   };

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -217,8 +217,9 @@ type FinanceModals = {
     showToBeBudgeted?: boolean;
   };
   cover: {
-    categoryId: string;
+    title: string;
     month: string;
+    showToBeBudgeted?: boolean;
     onSubmit: (fromCategoryId: string) => void;
   };
   'hold-buffer': {

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -373,6 +373,20 @@ export async function transferAvailable({
   await setBudget({ category, month, amount: budgeted + amount });
 }
 
+export async function coverOverbudgeted({
+  month,
+  category,
+}: {
+  month: string;
+  category: string;
+}): Promise<void> {
+  const sheetName = monthUtils.sheetForMonth(month);
+  const toBudget = await getSheetValue(sheetName, 'to-budget');
+
+  const categoryBudget = await getSheetValue(sheetName, 'budget-' + category);
+  await setBudget({ category, month, amount: categoryBudget + toBudget });
+}
+
 export async function transferCategory({
   month,
   amount,

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -55,6 +55,10 @@ app.method(
   mutator(undoable(actions.transferAvailable)),
 );
 app.method(
+  'budget/cover-overbudgeted',
+  mutator(undoable(actions.coverOverbudgeted)),
+);
+app.method(
   'budget/transfer-category',
   mutator(undoable(actions.transferCategory)),
 );

--- a/packages/loot-core/src/server/budget/types/handlers.d.ts
+++ b/packages/loot-core/src/server/budget/types/handlers.d.ts
@@ -46,6 +46,11 @@ export interface BudgetHandlers {
     category: string;
   }) => Promise<void>;
 
+  'budget/cover-overbudgeted': (arg: {
+    month: string;
+    category: string;
+  }) => Promise<void>;
+
   'budget/transfer-category': (arg: {
     month: string;
     amount: number;

--- a/upcoming-release-notes/2850.md
+++ b/upcoming-release-notes/2850.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Cover overbudgeted action + make balance movement menus only appear on relevant conditions e.g. transfer to another category menu only when there is a leftover balance.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Cover overbudgeted action + make balance movement menus only appear on relevant conditions e.g. transfer to another category menu only when there is a leftover balance.

New action can be found when clicking on an Overbudgeted amount. You can cover the Overbudgeted amount from any category same as how an overspent category can be covered from another category.