### PR TITLE
Fix crdt dependency in api publishing

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
     "clean": "rm -rf dist @types"
   },
   "dependencies": {
-    "@actual-app/crdt": "workspace:^",
+    "@actual-app/crdt": "^2.1.0",
     "better-sqlite3": "^9.6.0",
     "compare-versions": "^6.1.0",
     "node-fetch": "^3.3.2",

--- a/upcoming-release-notes/2852.md
+++ b/upcoming-release-notes/2852.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [twk3]
+---
+
+Fix crdt dependency in api publishing

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/api@workspace:packages/api"
   dependencies:
-    "@actual-app/crdt": "workspace:^"
+    "@actual-app/crdt": "npm:^2.1.0"
     "@swc/core": "npm:^1.5.3"
     "@swc/jest": "npm:^0.2.36"
     "@types/jest": "npm:^27.5.2"
@@ -38,7 +38,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@actual-app/crdt@npm:*, @actual-app/crdt@workspace:^, @actual-app/crdt@workspace:packages/crdt":
+"@actual-app/crdt@npm:*, @actual-app/crdt@npm:^2.1.0, @actual-app/crdt@workspace:packages/crdt":
   version: 0.0.0-use.local
   resolution: "@actual-app/crdt@workspace:packages/crdt"
   dependencies:


### PR DESCRIPTION
- Uses a npm valid semver

@MatissJanis alternatively we could switch to using `yarn npm publish` rather than `npm publish` which should resolve the `workspace:^` to the version specified in the crdt worspace package.json at pack time. But crdt changes infrequently, so I don't mind if we want to manually set it to keep compatibility with `npm publish`. Let me know what you think.

Fixes: https://github.com/actualbudget/actual/issues/2829
