### PR TITLE
FIX: For Report Budget, the income categories are negative when using…

### DIFF
--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -258,8 +258,13 @@ export async function set3MonthAvg({
         'sum-amount-' + cat.id,
       );
 
-      const avg = Math.round((spent1 + spent2 + spent3) / 3);
-      setBudget({ category: cat.id, month, amount: -avg });
+      let avg = Math.round((spent1 + spent2 + spent3) / 3);
+
+      if (cat.is_income === 0) {
+        avg *= -1;
+      }
+
+      setBudget({ category: cat.id, month, amount: avg });
     }
   });
 }


### PR DESCRIPTION
I've been using Report Budget instead of Rollover Budget and it works nice. Now, I'm starting to use 'Set budgets to 3 month average' and I noticed that for Report Budget you can budget income (which is nice), but when you click 'Set budgets to 3 month average', this inverts the value of the average for all categories. I changed it to not invert for income categories.