### PR TITLE
fix: schedules are missing highlight color

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -824,7 +824,6 @@ const Transaction = memo(function Transaction(props) {
         ...style,
         ...(isPreview && {
           color: theme.tableTextInactive,
-          backgroundColor: !selected ? theme.tableBackground : undefined,
           fontStyle: 'italic',
         }),
         ...(_unmatched && { opacity: 0.5 }),

--- a/upcoming-release-notes/2864.md
+++ b/upcoming-release-notes/2864.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aaimio]
+---
+
+Fix an issue where selected cheduled transactions did not have a correct background colour

--- a/upcoming-release-notes/2864.md
+++ b/upcoming-release-notes/2864.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [aaimio]
 ---
 
-Fix an issue where selected cheduled transactions did not have a correct background colour
+Fix an issue where selected scheduled transactions did not have a correct background colour


### PR DESCRIPTION
## Changelog

- Removes a redundant style declaration overriding scheduled transaction's background colour
  - https://github.com/actualbudget/actual/issues/2856 

Background colour is already set here:
- https://github.com/actualbudget/actual/pull/2864/files#diff-3087d39fd07c36984e71c4d00f499b77d68a797730f84f042b0cf659cc6e7cf4R807-R811