### PR TITLE
fix: Account names in side nav squashed

### DIFF
--- a/packages/desktop-client/src/components/common/Tooltip.tsx
+++ b/packages/desktop-client/src/components/common/Tooltip.tsx
@@ -52,7 +52,7 @@ export const Tooltip = ({
 
   return (
     <View
-      style={{minHeight: 'auto'}}
+      style={{ minHeight: 'auto' }}
       ref={triggerRef}
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}

--- a/packages/desktop-client/src/components/common/Tooltip.tsx
+++ b/packages/desktop-client/src/components/common/Tooltip.tsx
@@ -52,6 +52,7 @@ export const Tooltip = ({
 
   return (
     <View
+      style={{minHeight: 'auto'}}
       ref={triggerRef}
       onPointerEnter={handlePointerEnter}
       onPointerLeave={handlePointerLeave}

--- a/upcoming-release-notes/2866.md
+++ b/upcoming-release-notes/2866.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix: Account names in side nav squashed


### PR DESCRIPTION
fix #2843 