### PR TITLE
[WIP] Implement balance colorization

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/accounts/Account.jsx
@@ -1706,6 +1706,7 @@ export function Account() {
   const failedAccounts = useFailedAccounts();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [hideFraction = false] = useLocalPref('hideFraction');
+  const [colorizeBalances = true] = useLocalPref('colorizeBalances');
   const [expandSplits] = useLocalPref('expand-splits');
   const [showBalances] = useLocalPref(`show-balances-${params.id}`);
   const [hideCleared] = useLocalPref(`hide-cleared-${params.id}`);
@@ -1728,6 +1729,7 @@ export function Account() {
     failedAccounts,
     dateFormat,
     hideFraction,
+    colorizeBalances,
     expandSplits,
     showBalances,
     showCleared: !hideCleared,

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -23,11 +23,14 @@ import { useLocalPref } from '../../hooks/useLocalPref';
 import { SvgSplit } from '../../icons/v0';
 import { useResponsive } from '../../ResponsiveProvider';
 import { type CSSProperties, theme, styles } from '../../style';
-import { makeAmountFullStyle } from '../budget/util';
 import { Text } from '../common/Text';
 import { TextOneLine } from '../common/TextOneLine';
 import { View } from '../common/View';
 import { useSheetValue } from '../spreadsheet/useSheetValue';
+import {
+  makeAmountFullStyle,
+  useBalanceValueColorization,
+} from '../spreadsheet/valueColorization';
 
 import { Autocomplete, defaultFilterSuggestion } from './Autocomplete';
 import { ItemHeader } from './ItemHeader';
@@ -342,6 +345,7 @@ function CategoryItem({
 
   const isToBeBudgetedItem = item.id === 'to-be-budgeted';
   const toBudget = useSheetValue(rolloverBudget.toBudget);
+  const colorizeBalanceValues = useBalanceValueColorization();
 
   return (
     <div
@@ -376,10 +380,14 @@ function CategoryItem({
             display: !showBalances ? 'none' : undefined,
             marginLeft: 5,
             flexShrink: 0,
-            ...makeAmountFullStyle(isToBeBudgetedItem ? toBudget : balance, {
-              positiveColor: theme.noticeTextMenu,
-              negativeColor: theme.errorTextMenu,
-            }),
+            ...makeAmountFullStyle(
+              colorizeBalanceValues,
+              isToBeBudgetedItem ? toBudget : balance,
+              {
+                positiveColor: theme.noticeTextMenu,
+                negativeColor: theme.errorTextMenu,
+              },
+            ),
           }}
         >
           {isToBeBudgetedItem

--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -9,8 +9,10 @@ import { View } from '../common/View';
 import { type Binding } from '../spreadsheet';
 import { CellValue } from '../spreadsheet/CellValue';
 import { useSheetValue } from '../spreadsheet/useSheetValue';
-
-import { makeBalanceAmountStyle } from './util';
+import {
+  makeBalanceAmountStyle,
+  useBalanceValueColorization,
+} from '../spreadsheet/valueColorization';
 
 type BalanceWithCarryoverProps = Omit<
   ComponentPropsWithoutRef<typeof CellValue>,
@@ -37,6 +39,7 @@ export function BalanceWithCarryover({
   const goalValue = useSheetValue(goal);
   const budgetedValue = useSheetValue(budgeted);
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  const colorizeValues = useBalanceValueColorization();
 
   const { isNarrowWidth } = useResponsive();
 
@@ -48,6 +51,7 @@ export function BalanceWithCarryover({
         type="financial"
         getStyle={value =>
           makeBalanceAmountStyle(
+            colorizeValues,
             value,
             isGoalTemplatesEnabled ? goalValue : null,
             budgetedValue,
@@ -78,6 +82,7 @@ export function BalanceWithCarryover({
             width={carryoverStyle?.width || 7}
             height={carryoverStyle?.height || 7}
             style={makeBalanceAmountStyle(
+              colorizeValues,
               balanceValue,
               goalValue,
               budgetedValue,

--- a/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
+++ b/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
@@ -13,9 +13,13 @@ import { Text } from '../../common/Text';
 import { View } from '../../common/View';
 import { CellValue } from '../../spreadsheet/CellValue';
 import { useFormat } from '../../spreadsheet/useFormat';
+import {
+  makeAmountGrey,
+  useBalanceValueColorization,
+  makeAmountFullStyle,
+} from '../../spreadsheet/valueColorization';
 import { Field, SheetCell } from '../../table';
 import { BalanceWithCarryover } from '../BalanceWithCarryover';
-import { makeAmountGrey } from '../util';
 
 import { BalanceMenu } from './BalanceMenu';
 import { BudgetMenu } from './BudgetMenu';
@@ -27,6 +31,7 @@ const headerLabelStyle: CSSProperties = {
 };
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
   const format = useFormat();
+  const colorizeBalanceValues = useBalanceValueColorization();
   return (
     <View
       style={{
@@ -61,7 +66,10 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
         <CellValue
           binding={reportBudget.totalLeftover}
           type="financial"
-          style={{ color: theme.pageTextLight, fontWeight: 600 }}
+          style={{ fontWeight: 600 }}
+          getStyle={(value: number) =>
+            makeAmountFullStyle(colorizeBalanceValues, value)
+          }
         />
       </View>
     </View>
@@ -92,6 +100,7 @@ type GroupMonthProps = {
 };
 export const GroupMonth = memo(function GroupMonth({ group }: GroupMonthProps) {
   const { id } = group;
+  const colorizeBalanceValues = useBalanceValueColorization();
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>
@@ -128,6 +137,8 @@ export const GroupMonth = memo(function GroupMonth({ group }: GroupMonthProps) {
           valueProps={{
             binding: reportBudget.groupBalance(id),
             type: 'financial',
+            getValueStyle: value =>
+              makeAmountFullStyle(colorizeBalanceValues, value),
             privacyFilter: {
               style: {
                 paddingRight: styles.monthRightPadding,

--- a/packages/desktop-client/src/components/budget/report/budgetsummary/Saved.tsx
+++ b/packages/desktop-client/src/components/budget/report/budgetsummary/Saved.tsx
@@ -12,7 +12,7 @@ import { View } from '../../../common/View';
 import { PrivacyFilter } from '../../../PrivacyFilter';
 import { useFormat } from '../../../spreadsheet/useFormat';
 import { useSheetValue } from '../../../spreadsheet/useSheetValue';
-import { makeAmountFullStyle } from '../../util';
+import { makeAmountFullStyle } from '../../../spreadsheet/valueColorization';
 
 type SavedProps = {
   projected: boolean;
@@ -45,7 +45,7 @@ export function Saved({ projected, style }: SavedProps) {
               right={
                 <Text
                   style={{
-                    ...makeAmountFullStyle(budgetedSaved),
+                    ...makeAmountFullStyle(true, budgetedSaved),
                     ...styles.tnum,
                   }}
                 >
@@ -56,7 +56,9 @@ export function Saved({ projected, style }: SavedProps) {
             <AlignedText
               left="Difference:"
               right={
-                <Text style={{ ...makeAmountFullStyle(diff), ...styles.tnum }}>
+                <Text
+                  style={{ ...makeAmountFullStyle(true, diff), ...styles.tnum }}
+                >
                   {format(diff, 'financial-with-sign')}
                 </Text>
               }

--- a/packages/desktop-client/src/components/budget/rollover/RolloverComponents.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/RolloverComponents.tsx
@@ -13,9 +13,13 @@ import { Text } from '../../common/Text';
 import { View } from '../../common/View';
 import { CellValue } from '../../spreadsheet/CellValue';
 import { useFormat } from '../../spreadsheet/useFormat';
+import {
+  makeAmountGrey,
+  useBalanceValueColorization,
+  makeAmountFullStyle,
+} from '../../spreadsheet/valueColorization';
 import { Row, Field, SheetCell } from '../../table';
 import { BalanceWithCarryover } from '../BalanceWithCarryover';
-import { makeAmountGrey } from '../util';
 
 import { BalanceMovementMenu } from './BalanceMovementMenu';
 import { BudgetMenu } from './BudgetMenu';
@@ -28,6 +32,7 @@ const headerLabelStyle: CSSProperties = {
 
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
   const format = useFormat();
+  const colorizeBalanceValues = useBalanceValueColorization();
   return (
     <View
       style={{
@@ -62,7 +67,10 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
         <CellValue
           binding={rolloverBudget.totalBalance}
           type="financial"
-          style={{ color: theme.tableHeaderText, fontWeight: 600 }}
+          style={{ fontWeight: 600 }}
+          getStyle={(value: number) =>
+            makeAmountFullStyle(colorizeBalanceValues, value)
+          }
         />
       </View>
     </View>
@@ -90,6 +98,7 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
   group,
 }: ExpenseGroupMonthProps) {
   const { id } = group;
+  const colorizeBalanceValues = useBalanceValueColorization();
 
   return (
     <View style={{ flex: 1, flexDirection: 'row' }}>
@@ -125,6 +134,8 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
         valueProps={{
           binding: rolloverBudget.groupBalance(id),
           type: 'financial',
+          getValueStyle: value =>
+            makeAmountFullStyle(colorizeBalanceValues, value),
           privacyFilter: {
             style: {
               paddingRight: styles.monthRightPadding,

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -6,7 +6,7 @@ import { type Handlers } from 'loot-core/src/types/handlers';
 import { type CategoryGroupEntity } from 'loot-core/src/types/models';
 import { type LocalPrefs } from 'loot-core/src/types/prefs';
 
-import { type CSSProperties, styles, theme } from '../../style';
+import { styles } from '../../style';
 import { type DropPosition } from '../sort';
 
 import { getValidMonthBounds } from './MonthsContext';
@@ -37,55 +37,6 @@ export function separateGroups(categoryGroups: CategoryGroupEntity[]) {
     categoryGroups.filter(g => !g.is_income),
     categoryGroups.find(g => g.is_income),
   ];
-}
-
-export function makeAmountGrey(value: number | string): CSSProperties {
-  return value === 0 || value === '0' || value === '' || value == null
-    ? { color: theme.tableTextSubdued }
-    : null;
-}
-
-export function makeBalanceAmountStyle(
-  value: number,
-  goalValue?: number,
-  budgetedValue?: number,
-) {
-  if (value < 0) {
-    return { color: theme.errorText };
-  }
-
-  if (goalValue == null) {
-    const greyed = makeAmountGrey(value);
-    if (greyed) {
-      return greyed;
-    }
-  } else {
-    if (budgetedValue < goalValue) {
-      return { color: theme.warningText };
-    }
-    return { color: theme.noticeText };
-  }
-}
-
-export function makeAmountFullStyle(
-  value: number,
-  colors?: {
-    positiveColor?: string;
-    negativeColor?: string;
-    zeroColor?: string;
-  },
-) {
-  const positiveColorToUse = colors?.positiveColor || theme.noticeText;
-  const negativeColorToUse = colors?.negativeColor || theme.errorText;
-  const zeroColorToUse = colors?.zeroColor || theme.tableTextSubdued;
-  return {
-    color:
-      value < 0
-        ? negativeColorToUse
-        : value === 0
-          ? zeroColorToUse
-          : positiveColorToUse,
-  };
 }
 
 export function findSortDown(

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -11,17 +11,21 @@ import { useNavigate } from '../../../hooks/useNavigate';
 import { useSetThemeColor } from '../../../hooks/useSetThemeColor';
 import { SvgAdd } from '../../../icons/v1';
 import { theme, styles } from '../../../style';
-import { makeAmountFullStyle } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Text } from '../../common/Text';
 import { TextOneLine } from '../../common/TextOneLine';
 import { View } from '../../common/View';
 import { MobilePageHeader, Page } from '../../Page';
 import { CellValue } from '../../spreadsheet/CellValue';
+import {
+  makeAmountFullStyle,
+  useBalanceValueColorization,
+} from '../../spreadsheet/valueColorization';
 import { MOBILE_NAV_HEIGHT } from '../MobileNavTabs';
 import { PullToRefresh } from '../PullToRefresh';
 
 function AccountHeader({ name, amount, style = {} }) {
+  const colorizeBalances = useBalanceValueColorization();
   return (
     <View
       style={{
@@ -49,6 +53,7 @@ function AccountHeader({ name, amount, style = {} }) {
         binding={amount}
         style={{ ...styles.text, fontSize: 14 }}
         type="financial"
+        getStyle={value => makeAmountFullStyle(colorizeBalances, value)}
       />
     </View>
   );
@@ -63,6 +68,8 @@ function AccountCard({
   getBalanceQuery,
   onSelect,
 }) {
+  const colorizeBalances = useBalanceValueColorization();
+
   return (
     <View
       style={{
@@ -136,7 +143,7 @@ function AccountCard({
           binding={getBalanceQuery(account)}
           type="financial"
           style={{ fontSize: 16, color: 'inherit' }}
-          getStyle={makeAmountFullStyle}
+          getStyle={value => makeAmountFullStyle(colorizeBalances, value)}
           data-testid="account-balance"
         />
       </Button>
@@ -252,6 +259,7 @@ export function Accounts() {
   const [_numberFormat] = useLocalPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
   const [hideFraction = false] = useLocalPref('hideFraction');
+  const [colorizeBalances = true] = useLocalPref('colorizeBalances');
 
   const navigate = useNavigate();
 
@@ -274,7 +282,7 @@ export function Accounts() {
       <AccountList
         // This key forces the whole table rerender when the number
         // format changes
-        key={numberFormat + hideFraction}
+        key={numberFormat + hideFraction + colorizeBalances}
         accounts={accounts.filter(account => !account.closed)}
         updatedAccounts={updatedAccounts}
         getBalanceQuery={queries.accountBalance}

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -21,7 +21,6 @@ import { SvgViewShow } from '../../../icons/v2';
 import { useResponsive } from '../../../ResponsiveProvider';
 import { theme, styles } from '../../../style';
 import { BalanceWithCarryover } from '../../budget/BalanceWithCarryover';
-import { makeAmountFullStyle, makeAmountGrey } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Card } from '../../common/Card';
 import { Label } from '../../common/Label';
@@ -31,6 +30,11 @@ import { MobilePageHeader, Page } from '../../Page';
 import { CellValue } from '../../spreadsheet/CellValue';
 import { useFormat } from '../../spreadsheet/useFormat';
 import { useSheetValue } from '../../spreadsheet/useSheetValue';
+import {
+  makeAmountFullStyle,
+  makeAmountGrey,
+  useBalanceValueColorization,
+} from '../../spreadsheet/valueColorization';
 import { MOBILE_NAV_HEIGHT } from '../MobileNavTabs';
 import { PullToRefresh } from '../PullToRefresh';
 
@@ -397,6 +401,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
   const listItemRef = useRef();
   const format = useFormat();
   const navigate = useNavigate();
+  const colorizeValues = useBalanceValueColorization();
   const onShowActivity = () => {
     navigate(`/categories/${category.id}?month=${month}`);
   };
@@ -574,7 +579,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
                     mode="oneline"
                     style={{
                       maxWidth: columnWidth,
-                      ...makeAmountFullStyle(value, {
+                      ...makeAmountFullStyle(colorizeValues, value, {
                         zeroColor: theme.pillTextSubdued,
                       }),
                       textAlign: 'right',
@@ -642,6 +647,7 @@ const ExpenseGroupHeader = memo(function ExpenseGroupHeader({
   const opacity = blank ? 0 : 1;
   const listItemRef = useRef();
   const format = useFormat();
+  const colorizeValues = useBalanceValueColorization();
   const sidebarColumnWidth = getColumnWidth({
     show3Cols,
     isSidebar: true,
@@ -822,6 +828,9 @@ const ExpenseGroupHeader = memo(function ExpenseGroupHeader({
                   fontWeight: '500',
                   paddingLeft: 5,
                   textAlign: 'right',
+                  ...makeAmountFullStyle(colorizeValues, value, {
+                    zeroColor: theme.pillTextSubdued,
+                  }),
                 }}
               >
                 {format(value, 'financial')}
@@ -1663,6 +1672,7 @@ function BudgetTableHeader({
   toggleSpentColumn,
 }) {
   const format = useFormat();
+  const colorizeValues = useBalanceValueColorization();
   const buttonStyle = {
     padding: 0,
     backgroundColor: 'transparent',
@@ -1855,11 +1865,11 @@ function BudgetTableHeader({
                 mode="oneline"
                 style={{
                   maxWidth: columnWidth,
-                  color: theme.formInputText,
                   paddingLeft: 5,
                   textAlign: 'right',
                   fontSize: 12,
                   fontWeight: '500',
+                  ...makeAmountFullStyle(colorizeValues, value),
                 }}
               >
                 {format(value, 'financial')}

--- a/packages/desktop-client/src/components/mobile/budget/Category.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/Category.tsx
@@ -15,6 +15,7 @@ export function Category() {
   const [_numberFormat] = useLocalPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
   const [hideFraction = false] = useLocalPref('hideFraction');
+  const [colorizeBalances = true] = useLocalPref('colorizeBalances');
 
   const { id: categoryId } = useParams();
   const [searchParams] = useSearchParams();
@@ -30,7 +31,7 @@ export function Category() {
     <CategoryTransactions
       // This key forces the whole table rerender when the number
       // format changes
-      key={numberFormat + hideFraction}
+      key={numberFormat + hideFraction + colorizeBalances}
       category={category}
       month={month}
     />

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -61,6 +61,7 @@ function BudgetInner(props: BudgetInnerProps) {
   const [_numberFormat] = useLocalPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
   const [hideFraction = false] = useLocalPref('hideFraction');
+  const [colorizeBalances = true] = useLocalPref('colorizeBalances');
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -440,7 +441,7 @@ function BudgetInner(props: BudgetInnerProps) {
           <BudgetTable
             // This key forces the whole table rerender when the number
             // format changes
-            key={`${numberFormat}${hideFraction}`}
+            key={`${numberFormat}${hideFraction}${colorizeBalances}`}
             categoryGroups={categoryGroups}
             type={budgetType}
             month={startMonth}

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -17,10 +17,10 @@ import {
 import { useLocalPref } from '../../../hooks/useLocalPref';
 import { useMergedRefs } from '../../../hooks/useMergedRefs';
 import { type CSSProperties, theme } from '../../../style';
-import { makeAmountFullStyle } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Text } from '../../common/Text';
 import { View } from '../../common/View';
+import { makeAmountFullStyle } from '../../spreadsheet/valueColorization';
 
 type AmountInputProps = {
   value: number;
@@ -218,7 +218,7 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
         onUpdateAmount={amount => onUpdateAmount(amount, isNegative)}
         focused={focused && !disabled}
         style={{
-          ...makeAmountFullStyle(value, {
+          ...makeAmountFullStyle(true, value, {
             zeroColor: isNegative ? theme.errorText : theme.noticeText,
           }),
           width: 80,
@@ -269,7 +269,7 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
           >
             <Text
               style={{
-                ...makeAmountFullStyle(value),
+                ...makeAmountFullStyle(true, value),
                 fontSize: 15,
                 userSelect: 'none',
                 ...textStyle,

--- a/packages/desktop-client/src/components/mobile/transactions/Transaction.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/Transaction.jsx
@@ -14,11 +14,11 @@ import {
   SvgLockClosed,
 } from '../../../icons/v2';
 import { styles, theme } from '../../../style';
-import { makeAmountFullStyle } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Text } from '../../common/Text';
 import { TextOneLine } from '../../common/TextOneLine';
 import { View } from '../../common/View';
+import { makeAmountFullStyle } from '../../spreadsheet/valueColorization';
 
 import { lookupName, getDescriptionPretty, Status } from './TransactionEdit';
 
@@ -209,7 +209,7 @@ export const Transaction = memo(function Transaction({
             marginLeft: 25,
             marginRight: 5,
             fontSize: 14,
-            ...makeAmountFullStyle(amount),
+            ...makeAmountFullStyle(true, amount),
           }}
         >
           {integerToCurrency(amount)}

--- a/packages/desktop-client/src/components/settings/Format.tsx
+++ b/packages/desktop-client/src/components/settings/Format.tsx
@@ -14,7 +14,7 @@ import { View } from '../common/View';
 import { Checkbox } from '../forms';
 import { useSidebar } from '../sidebar/SidebarProvider';
 
-import { Setting } from './UI';
+import { Column, Setting } from './UI';
 
 // Follows Pikaday 'firstDay' numbering
 // https://github.com/Pikaday/Pikaday
@@ -36,22 +36,6 @@ const dateFormats: { value: LocalPrefs['dateFormat']; label: string }[] = [
   { value: 'MM.dd.yyyy', label: 'MM.DD.YYYY' },
   { value: 'dd.MM.yyyy', label: 'DD.MM.YYYY' },
 ];
-
-function Column({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <View
-      style={{
-        alignItems: 'flex-start',
-        flexGrow: 1,
-        gap: '0.5em',
-        width: '100%',
-      }}
-    >
-      <Text style={{ fontWeight: 500 }}>{title}</Text>
-      <View style={{ alignItems: 'flex-start', gap: '1em' }}>{children}</View>
-    </View>
-  );
-}
 
 export function FormatSettings() {
   const sidebar = useSidebar();

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -2,30 +2,65 @@ import React from 'react';
 
 import { type Theme } from 'loot-core/types/prefs';
 
+import { useLocalPref } from '../../hooks/useLocalPref';
 import { themeOptions, useTheme } from '../../style';
+import { tokens } from '../../tokens';
 import { Button } from '../common/Button';
 import { Select } from '../common/Select';
 import { Text } from '../common/Text';
+import { View } from '../common/View';
+import { Checkbox } from '../forms';
+import { useSidebar } from '../sidebar/SidebarProvider';
 
-import { Setting } from './UI';
+import { Column, Setting } from './UI';
 
 export function ThemeSettings() {
   const [theme, switchTheme] = useTheme();
+  const sidebar = useSidebar();
+  const [colorizeBalances = true, setColorizeBalancesPref] =
+    useLocalPref('colorizeBalances');
 
   return (
     <Setting
       primaryAction={
-        <Button bounce={false} style={{ padding: 0 }}>
-          <Select<Theme>
-            bare
-            onChange={value => {
-              switchTheme(value);
-            }}
-            value={theme}
-            options={themeOptions}
-            style={{ padding: '2px 10px', fontSize: 15 }}
-          />
-        </Button>
+        <View
+          style={{
+            flexDirection: 'column',
+            gap: '1em',
+            width: '100%',
+            [`@media (min-width: ${
+              sidebar.floating
+                ? tokens.breakpoint_small
+                : tokens.breakpoint_medium
+            })`]: {
+              flexDirection: 'row',
+            },
+          }}
+        >
+          <Column>
+            <Button bounce={false} style={{ padding: 0 }}>
+              <Select<Theme>
+                bare
+                onChange={value => {
+                  switchTheme(value);
+                }}
+                value={theme}
+                options={themeOptions}
+                style={{ padding: '2px 10px', fontSize: 15 }}
+              />
+            </Button>
+            <Text style={{ display: 'flex' }}>
+              <Checkbox
+                id="settings-textColorizeBalances"
+                checked={!!colorizeBalances}
+                onChange={e => setColorizeBalancesPref(e.currentTarget.checked)}
+              />
+              <label htmlFor="settings-textColorizeBalances">
+                Colorize Budget and Account balances
+              </label>
+            </Text>
+          </Column>
+        </View>
       }
     >
       <Text>

--- a/packages/desktop-client/src/components/settings/UI.tsx
+++ b/packages/desktop-client/src/components/settings/UI.tsx
@@ -6,6 +6,7 @@ import { css, media } from 'glamor';
 import { type CSSProperties, theme } from '../../style';
 import { tokens } from '../../tokens';
 import { Link } from '../common/Link';
+import { Text } from '../common/Text';
 import { View } from '../common/View';
 
 type SettingProps = {
@@ -91,3 +92,25 @@ export const AdvancedToggle = ({ children }: AdvancedToggleProps) => {
     </Link>
   );
 };
+
+export function Column({
+  title,
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <View
+      style={{
+        alignItems: 'flex-start',
+        flexGrow: 1,
+        gap: '0.5em',
+        width: '100%',
+      }}
+    >
+      {title && <Text style={{ fontWeight: 500 }}>{title}</Text>}
+      <View style={{ alignItems: 'flex-start', gap: '1em' }}>{children}</View>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -23,6 +23,10 @@ import {
 } from '../sort';
 import { type Binding } from '../spreadsheet';
 import { CellValue } from '../spreadsheet/CellValue';
+import {
+  makeBalanceAmountStyle,
+  useBalanceValueColorization,
+} from '../spreadsheet/valueColorization';
 
 export const accountNameStyle: CSSProperties = {
   marginTop: -2,
@@ -89,6 +93,7 @@ export function Account({
 
   const accountNote = useNotes(`account-${account?.id}`);
   const needsTooltip = !!account?.id;
+  const colorizeBalanceValues = useBalanceValueColorization();
 
   const accountRow = (
     <View innerRef={dropRef} style={{ flexShrink: 0, ...outerStyle }}>
@@ -155,7 +160,15 @@ export function Account({
                 }
               }
               left={name}
-              right={<CellValue binding={query} type="financial" />}
+              right={
+                <CellValue
+                  binding={query}
+                  type="financial"
+                  getStyle={(value: number) =>
+                    makeBalanceAmountStyle(colorizeBalanceValues, value)
+                  }
+                />
+              }
             />
           </Link>
         </View>

--- a/packages/desktop-client/src/components/spreadsheet/valueColorization.ts
+++ b/packages/desktop-client/src/components/spreadsheet/valueColorization.ts
@@ -1,0 +1,61 @@
+import { useSelector } from 'react-redux';
+
+import { selectValueColorization } from 'loot-core/client/selectors';
+
+import { type CSSProperties, theme } from '../../style';
+
+export function useBalanceValueColorization() {
+  return useSelector(selectValueColorization);
+}
+
+export function makeAmountGrey(value: number | string): CSSProperties {
+  return value === 0 || value === '0' || value === '' || value == null
+    ? { color: theme.tableTextSubdued }
+    : null;
+}
+
+export function makeBalanceAmountStyle(
+  colorize: boolean,
+  value: number,
+  goalValue?: number,
+  budgetedValue?: number,
+): CSSProperties {
+  if (value < 0) {
+    return colorize ? { color: theme.errorText } : null;
+  }
+
+  if (goalValue == null) {
+    const greyed = makeAmountGrey(value);
+    return greyed ?? (colorize ? { color: theme.noticeText } : null);
+  } else {
+    if (budgetedValue < goalValue) {
+      return { color: theme.warningText };
+    }
+    return { color: theme.noticeText };
+  }
+}
+
+export function makeAmountFullStyle(
+  colorize: boolean,
+  value: number | string,
+  colors?: {
+    positiveColor?: string;
+    negativeColor?: string;
+    zeroColor?: string;
+  },
+): CSSProperties {
+  const zeroColorToUse = colors?.zeroColor || theme.tableTextSubdued;
+  if (typeof value === 'string' || value === 0) {
+    return { color: zeroColorToUse };
+  }
+
+  if (!colorize) {
+    return null;
+  }
+
+  const positiveColorToUse = colors?.positiveColor || theme.noticeText;
+  const negativeColorToUse = colors?.negativeColor || theme.errorText;
+  return {
+    color: value < 0 ? negativeColorToUse : positiveColorToUse,
+  };
+}

--- a/packages/desktop-client/src/components/spreadsheet/valueColorization.ts
+++ b/packages/desktop-client/src/components/spreadsheet/valueColorization.ts
@@ -1,11 +1,14 @@
+// @ts-strict-ignore
 import { useSelector } from 'react-redux';
 
-import { selectValueColorization } from 'loot-core/client/selectors';
+import { type State } from 'loot-core/src/client/state-types';
 
 import { type CSSProperties, theme } from '../../style';
 
 export function useBalanceValueColorization() {
-  return useSelector(selectValueColorization);
+  return useSelector(
+    (state: State) => state.prefs.local?.colorizeBalances ?? true,
+  );
 }
 
 export function makeAmountGrey(value: number | string): CSSProperties {

--- a/packages/loot-core/src/client/selectors.ts
+++ b/packages/loot-core/src/client/selectors.ts
@@ -16,8 +16,3 @@ export const selectNumberFormat = createSelector(getLocalPrefsState, prefs =>
     hideFraction: prefs.hideFraction,
   }),
 );
-
-export const selectValueColorization = createSelector(
-  getLocalPrefsState,
-  prefs => prefs.colorizeBalances,
-);

--- a/packages/loot-core/src/client/selectors.ts
+++ b/packages/loot-core/src/client/selectors.ts
@@ -16,3 +16,8 @@ export const selectNumberFormat = createSelector(getLocalPrefsState, prefs =>
     hideFraction: prefs.hideFraction,
   }),
 );
+
+export const selectValueColorization = createSelector(
+  getLocalPrefsState,
+  prefs => prefs.colorizeBalances,
+);

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -18,6 +18,7 @@ export type LocalPrefs = Partial<
       | 'dd.MM.yyyy';
     numberFormat: (typeof numberFormats)[number]['value'];
     hideFraction: boolean;
+    colorizeBalances: boolean;
     hideClosedAccounts: boolean;
     hideMobileMessage: boolean;
     isPrivacyEnabled: boolean;

--- a/upcoming-release-notes/2894.md
+++ b/upcoming-release-notes/2894.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [dymanoid]
+---
+
+Accounts and Balance values colorization, can be activated in Settings.


### PR DESCRIPTION
This PR is a pure UI modification.
The current value colorization is somewhat inconsistent: e.g. the category balance values get colorized while the group balances don't. Also, the account balances aren't colorized, while this might be helpful to users because it gives a better overview of the current financial stats (e.g. debts and credit cards could be displayed red).

The PR introduces a new option 'Colorize Account and Balance values' which changes the way the balances for accounts, groups, and categories are displayed.

Here are two screenshots to compare:
**Colorizing ON**
![colored](https://github.com/actualbudget/actual/assets/9433345/0b0b9f40-8316-4524-b826-67c9077bad49)

**Colorizing OFF**
![flat](https://github.com/actualbudget/actual/assets/9433345/9814582f-d8ba-4236-b8fd-f02c2f0c0fb0)
