### PR TITLE
Consider account sort order in autocomplete

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.tsx
@@ -122,13 +122,12 @@ export function AccountAutocomplete({
     .filter(item => {
       return includeClosedAccounts ? item : !item.closed;
     })
-    .sort((a, b) => {
-      if (a.closed === b.closed) {
-        return a.offbudget === b.offbudget ? 0 : a.offbudget ? 1 : -1;
-      } else {
-        return a.closed ? 1 : -1;
-      }
-    });
+    .sort(
+      (a, b) =>
+        a.closed - b.closed ||
+        a.offbudget - b.offbudget ||
+        a.sort_order - b.sort_order,
+    );
 
   return (
     <Autocomplete

--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -243,5 +243,6 @@ export function moveAccount(id, targetId) {
   return async (dispatch: Dispatch) => {
     await send('account-move', { id, targetId });
     dispatch(getAccounts());
+    dispatch(getPayees());
   };
 }

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -536,7 +536,7 @@ export function getPayees() {
     SELECT p.*, COALESCE(a.name, p.name) AS name FROM payees p
     LEFT JOIN accounts a ON (p.transfer_acct = a.id AND a.tombstone = 0)
     WHERE p.tombstone = 0 AND (p.transfer_acct IS NULL OR a.id IS NOT NULL)
-    ORDER BY p.transfer_acct IS NULL DESC, p.name COLLATE NOCASE
+    ORDER BY p.transfer_acct IS NULL DESC, p.name COLLATE NOCASE, a.offbudget, a.sort_order
   `);
 }
 

--- a/upcoming-release-notes/2896.md
+++ b/upcoming-release-notes/2896.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [dymanoid]
+---
+
+Respect the user-defined account sort order in all autocomplete lists.


### PR DESCRIPTION
This PR enables the user-defined account sort order in all account lists displayed in the autocomplete dropdowns (account and payee autocomplete).
Currently, the category autocomplete does respect the user-defined sort order while it's not the case for accounts. This little improvement makes the app behavior consistent.