### PR TITLE
:speech_balloon: (bank-sync) update sync button label to improve discoverability

### DIFF
--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -271,7 +271,7 @@ export function AccountHeader({
                     }
                     style={{ marginRight: 4 }}
                   />{' '}
-                  {isServerOffline ? 'Sync offline' : 'Sync'}
+                  {isServerOffline ? 'Bank Sync Offline' : 'Bank Sync'}
                 </>
               ) : (
                 <>

--- a/upcoming-release-notes/2899.md
+++ b/upcoming-release-notes/2899.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Bank Sync: update bank-sync button label to "Bank Sync" to improve discoverability for new users


### PR DESCRIPTION
We are getting a few confused folks on Discord that confuse the "sync" button at the top of the page with the "sync" button in account view.

Updating the label of this button to clear the confusion a bit.