### PR TITLE
fix: use Unicode-aware SQLite LIKE filtering

### DIFF
--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { removeFile, readFile } from '../fs';
 
+import { UnicodeLike } from './unicodeLike';
+
 function verifyParamTypes(sql, arr) {
   arr.forEach(val => {
     if (typeof val !== 'string' && typeof val !== 'number' && val !== null) {
@@ -101,7 +103,7 @@ function regexp(regex: string, text: string | null) {
 
 export function openDatabase(pathOrBuffer: string | Buffer) {
   const db = new SQL(pathOrBuffer);
-  // Define Unicode-aware LOWER and UPPER implementation.
+  // Define Unicode-aware LOWER, UPPER, and LIKE implementation.
   // This is necessary because better-sqlite3 uses SQLite build without ICU support.
   // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
   db.function('UNICODE_LOWER', { deterministic: true }, (arg: string | null) =>
@@ -111,6 +113,8 @@ export function openDatabase(pathOrBuffer: string | Buffer) {
   db.function('UNICODE_UPPER', { deterministic: true }, (arg: string | null) =>
     arg?.toUpperCase(),
   );
+  // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
+  db.function('UNICODE_LIKE', { deterministic: true }, UnicodeLike);
   // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
   db.function('REGEXP', { deterministic: true }, regexp);
   return db;

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { removeFile, readFile } from '../fs';
 
-import { UnicodeLike } from './unicodeLike';
+import { unicodeLike } from './unicodeLike';
 
 function verifyParamTypes(sql, arr) {
   arr.forEach(val => {
@@ -114,7 +114,7 @@ export function openDatabase(pathOrBuffer: string | Buffer) {
     arg?.toUpperCase(),
   );
   // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
-  db.function('UNICODE_LIKE', { deterministic: true }, UnicodeLike);
+  db.function('UNICODE_LIKE', { deterministic: true }, unicodeLike);
   // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
   db.function('REGEXP', { deterministic: true }, regexp);
   return db;

--- a/packages/loot-core/src/platform/server/sqlite/index.web.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.web.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import initSqlJS, { type SqlJsStatic, type Database } from '@jlongster/sql.js';
 
-import { UnicodeLike } from './unicodeLike';
+import { unicodeLike } from './unicodeLike';
 
 let SQL: SqlJsStatic | null = null;
 
@@ -203,7 +203,7 @@ export async function openDatabase(pathOrBuffer?: string | Buffer) {
   // but SQL.js does not support this: https://github.com/sql-js/sql.js/issues/551
   db.create_function('UNICODE_LOWER', arg => arg?.toLowerCase());
   db.create_function('UNICODE_UPPER', arg => arg?.toUpperCase());
-  db.create_function('UNICODE_LIKE', UnicodeLike);
+  db.create_function('UNICODE_LIKE', unicodeLike);
   db.create_function('REGEXP', regexp);
   return db;
 }

--- a/packages/loot-core/src/platform/server/sqlite/index.web.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.web.ts
@@ -1,6 +1,8 @@
 // @ts-strict-ignore
 import initSqlJS, { type SqlJsStatic, type Database } from '@jlongster/sql.js';
 
+import { UnicodeLike } from './unicodeLike';
+
 let SQL: SqlJsStatic | null = null;
 
 export async function init() {
@@ -193,7 +195,7 @@ export async function openDatabase(pathOrBuffer?: string | Buffer) {
     db = new SQL.Database();
   }
 
-  // Define Unicode-aware LOWER and UPPER implementation.
+  // Define Unicode-aware LOWER, UPPER, and LIKE implementation.
   // This is necessary because sql.js uses SQLite build without ICU support.
   //
   // Note that this function should ideally be created with a deterministic flag
@@ -201,6 +203,7 @@ export async function openDatabase(pathOrBuffer?: string | Buffer) {
   // but SQL.js does not support this: https://github.com/sql-js/sql.js/issues/551
   db.create_function('UNICODE_LOWER', arg => arg?.toLowerCase());
   db.create_function('UNICODE_UPPER', arg => arg?.toUpperCase());
+  db.create_function('UNICODE_LIKE', UnicodeLike);
   db.create_function('REGEXP', regexp);
   return db;
 }

--- a/packages/loot-core/src/platform/server/sqlite/unicodeLike.test.ts
+++ b/packages/loot-core/src/platform/server/sqlite/unicodeLike.test.ts
@@ -1,0 +1,57 @@
+import { UnicodeLike } from './unicodeLike';
+
+describe('unicode LIKE functionality', () => {
+  it('empty pattern should not match to a value', () => {
+    const result = UnicodeLike(null, 'value');
+
+    expect(result).toBe(0);
+  });
+
+  it('empty pattern should not match to null', () => {
+    const result = UnicodeLike(null, null);
+
+    expect(result).toBe(0);
+  });
+
+  it('should match special characters', () => {
+    const result = UnicodeLike('.*+^${}()|[]\\', '.*+^${}()|[]\\');
+
+    expect(result).toBe(1);
+  });
+
+  it('should use ? as the single character placeholder', () => {
+    const result = UnicodeLike('t?st', 'test');
+
+    expect(result).toBe(1);
+  });
+
+  it('should use % as the zero-or-more characters placeholder', () => {
+    const result = UnicodeLike('t%st', 'te123st');
+
+    expect(result).toBe(1);
+  });
+
+  it('should ignore case for unicode', () => {
+    const result = UnicodeLike('á', 'Ábcdefg');
+
+    expect(result).toBe(1);
+  });
+
+  it('should ignore case for ascii', () => {
+    const result = UnicodeLike('a', 'Abcdefg');
+
+    expect(result).toBe(1);
+  });
+
+  it('should treat null value as empty string', () => {
+    const result = UnicodeLike('%', null);
+
+    expect(result).toBe(1);
+  });
+
+  it('should not match null value to the string “null”', () => {
+    const result = UnicodeLike('null', null);
+
+    expect(result).toBe(0);
+  });
+});

--- a/packages/loot-core/src/platform/server/sqlite/unicodeLike.test.ts
+++ b/packages/loot-core/src/platform/server/sqlite/unicodeLike.test.ts
@@ -1,56 +1,56 @@
-import { UnicodeLike } from './unicodeLike';
+import { unicodeLike } from './unicodeLike';
 
 describe('unicode LIKE functionality', () => {
   it('empty pattern should not match to a value', () => {
-    const result = UnicodeLike(null, 'value');
+    const result = unicodeLike(null, 'value');
 
     expect(result).toBe(0);
   });
 
   it('empty pattern should not match to null', () => {
-    const result = UnicodeLike(null, null);
+    const result = unicodeLike(null, null);
 
     expect(result).toBe(0);
   });
 
   it('should match special characters', () => {
-    const result = UnicodeLike('.*+^${}()|[]\\', '.*+^${}()|[]\\');
+    const result = unicodeLike('.*+^${}()|[]\\', '.*+^${}()|[]\\');
 
     expect(result).toBe(1);
   });
 
   it('should use ? as the single character placeholder', () => {
-    const result = UnicodeLike('t?st', 'test');
+    const result = unicodeLike('t?st', 'test');
 
     expect(result).toBe(1);
   });
 
   it('should use % as the zero-or-more characters placeholder', () => {
-    const result = UnicodeLike('t%st', 'te123st');
+    const result = unicodeLike('t%st', 'te123st');
 
     expect(result).toBe(1);
   });
 
   it('should ignore case for unicode', () => {
-    const result = UnicodeLike('á', 'Ábcdefg');
+    const result = unicodeLike('á', 'Ábcdefg');
 
     expect(result).toBe(1);
   });
 
   it('should ignore case for ascii', () => {
-    const result = UnicodeLike('a', 'Abcdefg');
+    const result = unicodeLike('a', 'Abcdefg');
 
     expect(result).toBe(1);
   });
 
   it('should treat null value as empty string', () => {
-    const result = UnicodeLike('%', null);
+    const result = unicodeLike('%', null);
 
     expect(result).toBe(1);
   });
 
   it('should not match null value to the string “null”', () => {
-    const result = UnicodeLike('null', null);
+    const result = unicodeLike('null', null);
 
     expect(result).toBe(0);
   });

--- a/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
+++ b/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import LRU from 'lru-cache';
 
 const likePatternCache = new LRU({ max: 500 });
@@ -10,7 +11,7 @@ export function UnicodeLike(
     return 0;
   }
 
-  if (!value){
+  if (!value) {
     value = '';
   }
 

--- a/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
+++ b/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
@@ -1,0 +1,31 @@
+import LRU from 'lru-cache';
+
+const likePatternCache = new LRU({ max: 500 });
+
+export function UnicodeLike(
+  pattern: string | null,
+  value: string | null,
+): number {
+  if (!pattern) {
+    return 0;
+  }
+
+  if (!value){
+    value = '';
+  }
+
+  let cachedRegExp = likePatternCache.get(pattern);
+  if (!cachedRegExp) {
+    // we don't escape ? and % because we don't know
+    // whether they originate from the user input or from our query compiler.
+    // Maybe improve the query compiler to correctly process these characters?
+    const processedPattern = pattern
+      .replace(/[.*+^${}()|[\]\\]/g, '\\$&')
+      .replaceAll('?', '.')
+      .replaceAll('%', '.*');
+    cachedRegExp = new RegExp(processedPattern, 'i');
+    likePatternCache.set(pattern, cachedRegExp);
+  }
+
+  return cachedRegExp.test(value) ? 1 : 0;
+}

--- a/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
+++ b/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts
@@ -3,7 +3,7 @@ import LRU from 'lru-cache';
 
 const likePatternCache = new LRU({ max: 500 });
 
-export function UnicodeLike(
+export function unicodeLike(
   pattern: string | null,
   value: string | null,
 ): number {

--- a/packages/loot-core/src/server/aql/compiler.test.ts
+++ b/packages/loot-core/src/server/aql/compiler.test.ts
@@ -123,6 +123,28 @@ describe('sheet language', () => {
     );
   });
 
+  it('`like` should use unicode function', () => {
+    const result = generateSQLWithState(
+      q('transactions')
+        .select('payee')
+        .filter({ 'payee.name': { $like: `%TEST%` } })
+        .serialize(),
+      schemaWithRefs,
+    );
+    expect(result.sql).toMatch(`UNICODE_LIKE('%TEST%', payees1.name)`);
+  });
+
+  it('`notlike` should use unicode function', () => {
+    const result = generateSQLWithState(
+      q('transactions')
+        .select('payee')
+        .filter({ 'payee.name': { $notlike: `%TEST%` } })
+        .serialize(),
+      schemaWithRefs,
+    );
+    expect(result.sql).toMatch(`NOT UNICODE_LIKE('%TEST%', payees1.name)`);
+  });
+
   it('`select` allows nested functions', () => {
     const result = generateSQLWithState(
       q('transactions')

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -720,7 +720,7 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
     }
     case '$like': {
       const [left, right] = valArray(state, [lhs, rhs], ['string', 'string']);
-      return `${left} LIKE ${right}`;
+      return `UNICODE_LIKE(${right}, ${left})`;
     }
     case '$regexp': {
       const [left, right] = valArray(state, [lhs, rhs], ['string', 'string']);
@@ -728,7 +728,7 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
     }
     case '$notlike': {
       const [left, right] = valArray(state, [lhs, rhs], ['string', 'string']);
-      return `(${left} NOT LIKE ${right}\n OR ${left} IS NULL)`;
+      return `(NOT UNICODE_LIKE(${right}, ${left})\n OR ${left} IS NULL)`;
     }
     default:
       throw new CompileError(`Unknown operator: ${op}`);

--- a/upcoming-release-notes/2903.md
+++ b/upcoming-release-notes/2903.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [dymanoid]
+---
+
+Use Unicode-aware database queries for filtering and searching.


### PR DESCRIPTION
Fixes: #2755, #2347

This PR changes the behavior of the `LIKE` SQLite queries. Instead of using the built-in implementation that can run in case-insensitive mode only for ASCII characters (and thus performs case-sensitive comparison for all other, like Cyrillic, diacritic, accents etc), the new implementation is based on JS regex that handles all characters in Unicode.