### PR TITLE
:electron: Fix "Export" function on desktop app

### DIFF
--- a/packages/desktop-electron/index.js
+++ b/packages/desktop-electron/index.js
@@ -309,12 +309,12 @@ ipcMain.handle('open-file-dialog', (event, { filters, properties }) => {
 
 ipcMain.handle(
   'save-file-dialog',
-  (event, { title, defaultPath, fileContents }) => {
-    const fileLocation = dialog.showSaveDialogSync({ title, defaultPath });
+  async (event, { title, defaultPath, fileContents }) => {
+    const fileLocation = await dialog.showSaveDialog({ title, defaultPath });
 
     return new Promise((resolve, reject) => {
       if (fileLocation) {
-        fs.writeFile(fileLocation, fileContents, error => {
+        fs.writeFile(fileLocation.filePath, fileContents, error => {
           return reject(error);
         });
       }

--- a/upcoming-release-notes/2925.md
+++ b/upcoming-release-notes/2925.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fixes "Export data" not saving the file in Electron app on Linux


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

partial for: https://github.com/actualbudget/actual/issues/2907

The issue is due to this bug https://github.com/electron/electron/issues/42621

We're working around it by using the async version of the same function (which works)

Tested: 
- Windows
- Linux AppImage
- Linux Flatpak
