### PR TITLE
Fix wording of slit rule.

### DIFF
--- a/packages/desktop-client/e2e/rules.test.js
+++ b/packages/desktop-client/e2e/rules.test.js
@@ -89,7 +89,7 @@ test.describe('Rules', () => {
         splitActions: [
           [
             {
-              field: 'a fixed percent',
+              field: 'a fixed percent of the remainder',
               value: '90',
             },
             {

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -65,7 +65,7 @@ export const FIELD_TYPES = new Map(
 
 export const ALLOCATION_METHODS = {
   'fixed-amount': 'a fixed amount',
-  'fixed-percent': 'a fixed percent',
+  'fixed-percent': 'a fixed percent of the remainder',
   remainder: 'an equal portion of the remainder',
 };
 


### PR DESCRIPTION
One of the split rules is labeled "A fixed percentage" but the way it operates it is more like a percent of "the remainder". This clarifies that, by updating the text to state so.