### PR TITLE
:electron: Fix regex filters on electron app

### DIFF
--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -95,6 +95,10 @@ export async function asyncTransaction(
   }
 }
 
+function regexp(regex: string, text: string | null) {
+  return new RegExp(regex).test(text) ? 1 : 0;
+}
+
 export function openDatabase(pathOrBuffer: string | Buffer) {
   const db = new SQL(pathOrBuffer);
   // Define Unicode-aware LOWER and UPPER implementation.
@@ -107,6 +111,8 @@ export function openDatabase(pathOrBuffer: string | Buffer) {
   db.function('UNICODE_UPPER', { deterministic: true }, (arg: string | null) =>
     arg?.toUpperCase(),
   );
+  // @ts-expect-error @types/better-sqlite3 does not support setting strict 3rd argument
+  db.function('REGEXP', { deterministic: true }, regexp);
   return db;
 }
 

--- a/upcoming-release-notes/2929.md
+++ b/upcoming-release-notes/2929.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fixes regex filtering on the desktop app


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fixes: #2917

This PR adds in the Regex function to the DB in the same way the web client does. 

It must have been forgotten when regex functionality was added.

- Tested on WIndows

![test2](https://github.com/actualbudget/actual/assets/5285928/6544707c-ef92-4c65-b189-6ff8dca0383c)

