### PR TITLE
Update DynamicBudgetTable to fill more of the view when viewing fewer months

### DIFF
--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -45,6 +45,7 @@ const DynamicBudgetTableInner = ({
 
   const numPossible = getNumPossibleMonths(width);
   const numMonths = Math.min(numPossible, maxMonths);
+  const maxWidth = 200 + 800 * numMonths;
 
   useEffect(() => {
     setDisplayMax(numPossible);
@@ -63,7 +64,7 @@ const DynamicBudgetTableInner = ({
         opacity: width <= 0 || height <= 0 ? 0 : 1,
       }}
     >
-      <View style={{ width: '100%' }}>
+      <View style={{ width: '100%', maxWidth }}>
         <BudgetPageHeader
           startMonth={prewarmStartMonth}
           numMonths={numMonths}

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -45,7 +45,6 @@ const DynamicBudgetTableInner = ({
 
   const numPossible = getNumPossibleMonths(width);
   const numMonths = Math.min(numPossible, maxMonths);
-  const maxWidth = 200 + 500 * numMonths;
 
   useEffect(() => {
     setDisplayMax(numPossible);
@@ -64,7 +63,7 @@ const DynamicBudgetTableInner = ({
         opacity: width <= 0 || height <= 0 ? 0 : 1,
       }}
     >
-      <View style={{ width: '100%', maxWidth }}>
+      <View style={{ width: '100%' }}>
         <BudgetPageHeader
           startMonth={prewarmStartMonth}
           numMonths={numMonths}

--- a/upcoming-release-notes/2933.md
+++ b/upcoming-release-notes/2933.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jarneson33]
+---
+
+Update Budget view to allow budgeted months to span the entire view.

--- a/upcoming-release-notes/2933.md
+++ b/upcoming-release-notes/2933.md
@@ -3,4 +3,4 @@ category: Features
 authors: [jarneson33]
 ---
 
-Update Budget view to allow budgeted months to span the entire view.
+Allow budget table to fill more of the view when viewing the lesser amount of months.


### PR DESCRIPTION
Hello, new to actual and loving the project! That said I was taken aback by the budgets view when only viewing 1-2 months on a high resolution panel. So I am opening this pull request to see if this is something the maintainers would be open to or if this fixed width is a mandatory design choice.

EDIT:
Changed from allowing 100% span to just upping the original logic to allow the table to maintain original design but be less floaty island.

Thank you.

Before

![image](https://github.com/actualbudget/actual/assets/132099201/0bcc1c1c-f7da-41c8-a2df-73d66c0604f3)
![image](https://github.com/actualbudget/actual/assets/132099201/b85c55be-0e10-4137-9f93-e2ca7f7fab17)


After

![image](https://github.com/actualbudget/actual/assets/132099201/8ba72940-8f41-4d4d-93b1-c22b5330deb4)
![image](https://github.com/actualbudget/actual/assets/132099201/9aceb5b6-5a85-4089-841f-116511ba06c1)




