### PR TITLE
change the mobile budget balance colors to be the same as desktop

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -18,8 +18,8 @@ type BalanceWithCarryoverProps = Omit<
 > & {
   carryover: Binding;
   balance: Binding;
-  goal?: Binding;
-  budgeted?: Binding;
+  goal: Binding;
+  budgeted: Binding;
   disabled?: boolean;
   carryoverStyle?: CSSProperties;
 };
@@ -79,7 +79,7 @@ export function BalanceWithCarryover({
             height={carryoverStyle?.height || 7}
             style={makeBalanceAmountStyle(
               balanceValue,
-              goalValue,
+              isGoalTemplatesEnabled? goalValue : null,
               budgetedValue,
             )}
           />

--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -79,7 +79,7 @@ export function BalanceWithCarryover({
             height={carryoverStyle?.height || 7}
             style={makeBalanceAmountStyle(
               balanceValue,
-              isGoalTemplatesEnabled? goalValue : null,
+              isGoalTemplatesEnabled ? goalValue : null,
               budgetedValue,
             )}
           />

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -337,6 +337,8 @@ const ExpenseCategory = memo(function ExpenseCategory({
   const opacity = blank ? 0 : 1;
 
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  const goalValue = isGoalTemplatesEnabled ? useSheetValue(goal) : null;
+  const budgetedValue = isGoalTemplatesEnabled ? useSheetValue(budgeted) : null;
 
   const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const dispatch = useDispatch();
@@ -583,8 +585,8 @@ const ExpenseCategory = memo(function ExpenseCategory({
                       maxWidth: columnWidth,
                       ...makeBalanceAmountStyle(
                         value,
-                        isGoalTemplatesEnabled ? useSheetValue(goal) : null,
-                        isGoalTemplatesEnabled ? useSheetValue(budgeted) : null,
+                        goalValue,
+                        budgetedValue,
                       ),
                       textAlign: 'right',
                       fontSize: 12,

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -22,11 +22,7 @@ import { SvgViewShow } from '../../../icons/v2';
 import { useResponsive } from '../../../ResponsiveProvider';
 import { theme, styles } from '../../../style';
 import { BalanceWithCarryover } from '../../budget/BalanceWithCarryover';
-import {
-  makeAmountFullStyle,
-  makeAmountGrey,
-  makeBalanceAmountStyle,
-} from '../../budget/util';
+import { makeAmountGrey, makeBalanceAmountStyle } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Card } from '../../common/Card';
 import { Label } from '../../common/Label';
@@ -337,8 +333,10 @@ const ExpenseCategory = memo(function ExpenseCategory({
   const opacity = blank ? 0 : 1;
 
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
-  const goalValue = isGoalTemplatesEnabled ? useSheetValue(goal) : null;
-  const budgetedValue = isGoalTemplatesEnabled ? useSheetValue(budgeted) : null;
+  const goalTemp = useSheetValue(goal);
+  const goalValue = isGoalTemplatesEnabled ? goalTemp : null;
+  const budgetedTemp = useSheetValue(budgeted);
+  const budgetedValue = isGoalTemplatesEnabled ? budgetedTemp : null;
 
   const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -8,6 +8,7 @@ import { collapseModals, pushModal } from 'loot-core/client/actions';
 import { rolloverBudget, reportBudget } from 'loot-core/src/client/queries';
 import * as monthUtils from 'loot-core/src/shared/months';
 
+import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
 import { useLocalPref } from '../../../hooks/useLocalPref';
 import { useNavigate } from '../../../hooks/useNavigate';
 import { SvgLogo } from '../../../icons/logo';
@@ -21,7 +22,11 @@ import { SvgViewShow } from '../../../icons/v2';
 import { useResponsive } from '../../../ResponsiveProvider';
 import { theme, styles } from '../../../style';
 import { BalanceWithCarryover } from '../../budget/BalanceWithCarryover';
-import { makeAmountFullStyle, makeAmountGrey,makeBalanceAmountStyle } from '../../budget/util';
+import {
+  makeAmountFullStyle,
+  makeAmountGrey,
+  makeBalanceAmountStyle,
+} from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Card } from '../../common/Card';
 import { Label } from '../../common/Label';
@@ -33,8 +38,6 @@ import { useFormat } from '../../spreadsheet/useFormat';
 import { useSheetValue } from '../../spreadsheet/useSheetValue';
 import { MOBILE_NAV_HEIGHT } from '../MobileNavTabs';
 import { PullToRefresh } from '../PullToRefresh';
-
-import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
 
 import { ListItem } from './ListItem';
 
@@ -580,8 +583,8 @@ const ExpenseCategory = memo(function ExpenseCategory({
                       maxWidth: columnWidth,
                       ...makeBalanceAmountStyle(
                         value,
-                        isGoalTemplatesEnabled? useSheetValue(goal): null,
-                        isGoalTemplatesEnabled? useSheetValue(budgeted): null,
+                        isGoalTemplatesEnabled ? useSheetValue(goal) : null,
+                        isGoalTemplatesEnabled ? useSheetValue(budgeted) : null,
                       ),
                       textAlign: 'right',
                       fontSize: 12,

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -21,7 +21,7 @@ import { SvgViewShow } from '../../../icons/v2';
 import { useResponsive } from '../../../ResponsiveProvider';
 import { theme, styles } from '../../../style';
 import { BalanceWithCarryover } from '../../budget/BalanceWithCarryover';
-import { makeAmountFullStyle, makeAmountGrey } from '../../budget/util';
+import { makeAmountFullStyle, makeAmountGrey,makeBalanceAmountStyle } from '../../budget/util';
 import { Button } from '../../common/Button';
 import { Card } from '../../common/Card';
 import { Label } from '../../common/Label';
@@ -574,9 +574,11 @@ const ExpenseCategory = memo(function ExpenseCategory({
                     mode="oneline"
                     style={{
                       maxWidth: columnWidth,
-                      ...makeAmountFullStyle(value, {
-                        zeroColor: theme.pillTextSubdued,
-                      }),
+                      ...makeBalanceAmountStyle(
+                        value,
+                        useSheetValue(goal),
+                        useSheetValue(budgeted)
+                      ),
                       textAlign: 'right',
                       fontSize: 12,
                     }}

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -34,6 +34,8 @@ import { useSheetValue } from '../../spreadsheet/useSheetValue';
 import { MOBILE_NAV_HEIGHT } from '../MobileNavTabs';
 import { PullToRefresh } from '../PullToRefresh';
 
+import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
+
 import { ListItem } from './ListItem';
 
 const PILL_STYLE = {
@@ -331,6 +333,8 @@ const ExpenseCategory = memo(function ExpenseCategory({
 }) {
   const opacity = blank ? 0 : 1;
 
+  const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+
   const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const dispatch = useDispatch();
 
@@ -576,8 +580,8 @@ const ExpenseCategory = memo(function ExpenseCategory({
                       maxWidth: columnWidth,
                       ...makeBalanceAmountStyle(
                         value,
-                        useSheetValue(goal),
-                        useSheetValue(budgeted)
+                        isGoalTemplatesEnabled? useSheetValue(goal): null,
+                        isGoalTemplatesEnabled? useSheetValue(budgeted): null,
                       ),
                       textAlign: 'right',
                       fontSize: 12,

--- a/upcoming-release-notes/2940.md
+++ b/upcoming-release-notes/2940.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix mobile budget coloring to show template colors


### PR DESCRIPTION
fix: #2938

The makes it so the mobile category balance acts the same on mobile as it does on desktop.  Templates will cause colors for balance, otherwise only white, gray, or red.

This also fixes a small bug where the carryover arrow would always show the template color even with templates disabled.