### PR TITLE
Remove the trafico pr review triggers

### DIFF
--- a/.github/workflows/trafico.yml
+++ b/.github/workflows/trafico.yml
@@ -21,8 +21,6 @@ on:
      - edited
      - review_requested
      - review_request_removed
-  pull_request_review:
-    types: [submitted, edited, dismissed]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
These triggers were causing errors on forks, due to lack of permissions on these actions

- We loose triggers for Approved and Changes Requested

This at least stops the errors. As far as I can tell, we will need a hosted bot if we want to enable triggering on review changes.

