### PR TITLE
Fix rollover arrow display for mobile and desktop

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -1,8 +1,6 @@
 // @ts-strict-ignore
 import React, { type ReactNode, type ComponentPropsWithoutRef } from 'react';
 
-import { type Property as CSSProperty } from 'csstype';
-
 import { useFeatureFlag } from '../../hooks/useFeatureFlag';
 import { SvgArrowThinRight } from '../../icons/v1';
 import { type CSSProperties } from '../../style';
@@ -13,6 +11,10 @@ import { useSheetValue } from '../spreadsheet/useSheetValue';
 
 import { makeBalanceAmountStyle } from './util';
 
+type CarryoverIndicatorProps = {
+  style?: CSSProperties;
+};
+
 type BalanceWithCarryoverProps = Omit<
   ComponentPropsWithoutRef<typeof CellValue>,
   'binding'
@@ -22,17 +24,38 @@ type BalanceWithCarryoverProps = Omit<
   goal: Binding;
   budgeted: Binding;
   disabled?: boolean;
-  carryoverStyle?: CSSProperties;
-  carryoverView?: (valueColor: CSSProperty.Color | undefined) => ReactNode;
+  carryoverIndicator?: ({ style }: CarryoverIndicatorProps) => JSX.Element;
 };
+
+export function DefaultCarryoverIndicator({ style }: CarryoverIndicatorProps) {
+  return (
+    <View
+      style={{
+        marginLeft: 2,
+        position: 'absolute',
+        right: '-4px',
+        alignSelf: 'center',
+        top: 0,
+        bottom: 0,
+        ...style,
+      }}
+    >
+      <SvgArrowThinRight
+        width={style?.width || 7}
+        height={style?.height || 7}
+        style={style}
+      />
+    </View>
+  );
+}
+
 export function BalanceWithCarryover({
   carryover,
   balance,
   goal,
   budgeted,
   disabled,
-  carryoverStyle,
-  carryoverView,
+  carryoverIndicator = DefaultCarryoverIndicator,
   ...props
 }: BalanceWithCarryoverProps) {
   const carryoverValue = useSheetValue(carryover);
@@ -76,28 +99,7 @@ export function BalanceWithCarryover({
           ...props.style,
         }}
       />
-      {carryoverValue &&
-        (carryoverView ? (
-          carryoverView(valueStyle?.color)
-        ) : (
-          <View
-            style={{
-              marginLeft: 2,
-              position: 'absolute',
-              right: '-4px',
-              alignSelf: 'center',
-              top: 0,
-              bottom: 0,
-              ...carryoverStyle,
-            }}
-          >
-            <SvgArrowThinRight
-              width={carryoverStyle?.width || 7}
-              height={carryoverStyle?.height || 7}
-              style={valueStyle}
-            />
-          </View>
-        ))}
+      {carryoverValue && carryoverIndicator({ style: valueStyle })}
     </span>
   );
 }

--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { type ReactNode, type ComponentPropsWithoutRef } from 'react';
+import React, { type ComponentPropsWithoutRef } from 'react';
 
 import { useFeatureFlag } from '../../hooks/useFeatureFlag';
 import { SvgArrowThinRight } from '../../icons/v1';

--- a/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
+++ b/packages/desktop-client/src/components/budget/report/ReportComponents.tsx
@@ -321,7 +321,6 @@ export const CategoryMonth = memo(function CategoryMonth({
       {!category.is_income && (
         <Field
           name="balance"
-          truncate={false}
           width="flex"
           style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
         >

--- a/packages/desktop-client/src/components/budget/rollover/RolloverComponents.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/RolloverComponents.tsx
@@ -310,7 +310,6 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
       </Field>
       <Field
         name="balance"
-        truncate={false}
         width="flex"
         style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
       >

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -16,6 +16,7 @@ import { SvgExpandArrow } from '../../../icons/v0';
 import {
   SvgArrowThinLeft,
   SvgArrowThinRight,
+  SvgArrowThickRight,
   SvgCheveronRight,
 } from '../../../icons/v1';
 import { SvgViewShow } from '../../../icons/v2';
@@ -593,6 +594,23 @@ const ExpenseCategory = memo(function ExpenseCategory({
                     {format(value, 'financial')}
                   </AutoTextSize>
                 </Button>
+              )}
+              carryoverView={valueColor => (
+                <View
+                  style={{
+                    position: 'absolute',
+                    right: '-3px',
+                    top: '-5px',
+                    borderRadius: '50%',
+                    backgroundColor: valueColor,
+                  }}
+                >
+                  <SvgArrowThickRight
+                    width={11}
+                    height={11}
+                    style={{ color: theme.pillBackgroundLight }}
+                  />
+                </View>
               )}
             />
           </span>

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -595,14 +595,14 @@ const ExpenseCategory = memo(function ExpenseCategory({
                   </AutoTextSize>
                 </Button>
               )}
-              carryoverView={valueColor => (
+              carryoverIndicator={({ style }) => (
                 <View
                   style={{
                     position: 'absolute',
                     right: '-3px',
                     top: '-5px',
                     borderRadius: '50%',
-                    backgroundColor: valueColor,
+                    backgroundColor: style?.color,
                   }}
                 >
                   <SvgArrowThickRight

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -602,7 +602,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
                     right: '-3px',
                     top: '-5px',
                     borderRadius: '50%',
-                    backgroundColor: style?.color,
+                    backgroundColor: style?.color ?? theme.pillText,
                   }}
                 >
                   <SvgArrowThickRight

--- a/packages/desktop-client/src/components/modals/ReportBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ReportBalanceMenuModal.tsx
@@ -4,7 +4,10 @@ import { reportBudget } from 'loot-core/client/queries';
 
 import { useCategory } from '../../hooks/useCategory';
 import { type CSSProperties, theme, styles } from '../../style';
-import { BalanceWithCarryover } from '../budget/BalanceWithCarryover';
+import {
+  BalanceWithCarryover,
+  DefaultCarryoverIndicator,
+} from '../budget/BalanceWithCarryover';
 import { BalanceMenu } from '../budget/report/BalanceMenu';
 import { Modal, ModalTitle } from '../common/Modal';
 import { Text } from '../common/Text';
@@ -63,16 +66,21 @@ export function ReportBalanceMenuModal({
             textAlign: 'center',
             ...styles.veryLargeText,
           }}
-          carryoverStyle={{
-            width: 15,
-            height: 15,
-            display: 'inline-flex',
-            position: 'relative',
-          }}
           carryover={reportBudget.catCarryover(categoryId)}
           balance={reportBudget.catBalance(categoryId)}
           goal={reportBudget.catGoal(categoryId)}
           budgeted={reportBudget.catBudgeted(categoryId)}
+          carryoverIndicator={({ style }) =>
+            DefaultCarryoverIndicator({
+              style: {
+                width: 15,
+                height: 15,
+                display: 'inline-flex',
+                position: 'relative',
+                ...style,
+              },
+            })
+          }
         />
       </View>
       <BalanceMenu

--- a/packages/desktop-client/src/components/modals/ReportBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ReportBalanceMenuModal.tsx
@@ -63,7 +63,12 @@ export function ReportBalanceMenuModal({
             textAlign: 'center',
             ...styles.veryLargeText,
           }}
-          carryoverStyle={{ right: -20, width: 15, height: 15 }}
+          carryoverStyle={{
+            width: 15,
+            height: 15,
+            display: 'inline-flex',
+            position: 'relative',
+          }}
           carryover={reportBudget.catCarryover(categoryId)}
           balance={reportBudget.catBalance(categoryId)}
           goal={reportBudget.catGoal(categoryId)}

--- a/packages/desktop-client/src/components/modals/RolloverBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/RolloverBalanceMenuModal.tsx
@@ -4,7 +4,10 @@ import { rolloverBudget } from 'loot-core/client/queries';
 
 import { useCategory } from '../../hooks/useCategory';
 import { type CSSProperties, theme, styles } from '../../style';
-import { BalanceWithCarryover } from '../budget/BalanceWithCarryover';
+import {
+  BalanceWithCarryover,
+  DefaultCarryoverIndicator,
+} from '../budget/BalanceWithCarryover';
 import { BalanceMenu } from '../budget/rollover/BalanceMenu';
 import { Modal, ModalTitle } from '../common/Modal';
 import { Text } from '../common/Text';
@@ -65,16 +68,21 @@ export function RolloverBalanceMenuModal({
             textAlign: 'center',
             ...styles.veryLargeText,
           }}
-          carryoverStyle={{
-            width: 15,
-            height: 15,
-            display: 'inline-flex',
-            position: 'relative',
-          }}
           carryover={rolloverBudget.catCarryover(categoryId)}
           balance={rolloverBudget.catBalance(categoryId)}
           goal={rolloverBudget.catGoal(categoryId)}
           budgeted={rolloverBudget.catBudgeted(categoryId)}
+          carryoverIndicator={({ style }) =>
+            DefaultCarryoverIndicator({
+              style: {
+                width: 15,
+                height: 15,
+                display: 'inline-flex',
+                position: 'relative',
+                ...style,
+              },
+            })
+          }
         />
       </View>
       <BalanceMenu

--- a/packages/desktop-client/src/components/modals/RolloverBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/RolloverBalanceMenuModal.tsx
@@ -65,7 +65,12 @@ export function RolloverBalanceMenuModal({
             textAlign: 'center',
             ...styles.veryLargeText,
           }}
-          carryoverStyle={{ right: -20, width: 15, height: 15 }}
+          carryoverStyle={{
+            width: 15,
+            height: 15,
+            display: 'inline-flex',
+            position: 'relative',
+          }}
           carryover={rolloverBudget.catCarryover(categoryId)}
           balance={rolloverBudget.catBalance(categoryId)}
           goal={rolloverBudget.catGoal(categoryId)}

--- a/upcoming-release-notes/2943.md
+++ b/upcoming-release-notes/2943.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [dymanoid]
+---
+
+Fix the carryover arrow display for mobile and desktop views.


### PR DESCRIPTION
Fixes: #2879 

This PR implements a new look for the mobile carryover indicator (arrow) in the budget view. The arrow looks similar to notification badges on mobile apps.
This PR also fixes the issues when showing this arrow display in the desktop view (narrow window widths).
Additionally, the arrow display is also improved in the balance modals.
