### PR TITLE
:electron: Fix backup time format in electron

### DIFF
--- a/packages/loot-core/src/server/backups.ts
+++ b/packages/loot-core/src/server/backups.ts
@@ -73,7 +73,7 @@ export async function getAvailableBackups(id: string): Promise<Backup[]> {
 
   return backups.map(backup => ({
     ...backup,
-    date: backup.date ? dateFns.format(backup.date, 'yyyy-MM-dd h:mm') : null,
+    date: backup.date ? dateFns.format(backup.date, 'yyyy-MM-dd H:mm') : null,
   }));
 }
 

--- a/upcoming-release-notes/2960.md
+++ b/upcoming-release-notes/2960.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Fix time display of backup on Electrons "Load Backup" modal

--- a/upcoming-release-notes/2960.md
+++ b/upcoming-release-notes/2960.md
@@ -1,5 +1,5 @@
 ---
-category: Maintenance
+category: Bugfix
 authors: [MikesGlitch]
 ---
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Previously we were showing 12 hour format for both AM and PM without showing the fact it was AM or PM. 

I've changed it to 24h format so the time is always shown correctly.

**Old (incorrectly appears like "4:41" - people would assume AM)** 
![image](https://github.com/actualbudget/actual/assets/5285928/4e244a23-cc73-4c8c-9548-a345d2ea84af)

**New (shows 24H format)**
![image](https://github.com/actualbudget/actual/assets/5285928/f6f99b34-87c4-406b-94cb-7c10e36782eb)
