### PR TITLE
Add apostrophe dot format

### DIFF
--- a/packages/loot-core/src/shared/arithmetic.test.ts
+++ b/packages/loot-core/src/shared/arithmetic.test.ts
@@ -44,5 +44,8 @@ describe('arithmetic', () => {
 
     setNumberFormat({ format: 'space-comma', hideFraction: false });
     expect(evalArithmetic('1\xa0222,45')).toEqual(1222.45);
+
+    setNumberFormat({ format: 'apostrophe-dot', hideFraction: false });
+    expect(evalArithmetic('1’222.45')).toEqual(1222.45);
   });
 });

--- a/packages/loot-core/src/shared/arithmetic.ts
+++ b/packages/loot-core/src/shared/arithmetic.ts
@@ -38,7 +38,7 @@ function parsePrimary(state) {
   }
 
   let numberStr = '';
-  while (char(state) && char(state).match(/[0-9,.\xa0 ]|\p{Sc}/u)) {
+  while (char(state) && char(state).match(/[0-9,.’\xa0 ]|\p{Sc}/u)) {
     numberStr += next(state);
   }
 

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -84,4 +84,14 @@ describe('utility functions', () => {
     formatter = getNumberFormat().formatter;
     expect(formatter.format(Number('1234.56'))).toBe('1\xa0235');
   });
+
+  test('number formatting works with apostrophe-dot format', () => {
+    setNumberFormat({ format: 'apostrophe-dot', hideFraction: false });
+    let formatter = getNumberFormat().formatter;
+    expect(formatter.format(Number('1234.56'))).toBe('1’234.56');
+
+    setNumberFormat({ format: 'apostrophe-dot', hideFraction: true });
+    formatter = getNumberFormat().formatter;
+    expect(formatter.format(Number('1234.56'))).toBe('1’235');
+  });
 });

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -217,7 +217,12 @@ export function appendDecimals(
   return amountToCurrency(currencyToAmount(result));
 }
 
-type NumberFormats = 'comma-dot' | 'dot-comma' | 'space-comma' | 'comma-dot-in';
+type NumberFormats =
+  | 'comma-dot'
+  | 'dot-comma'
+  | 'space-comma'
+  | 'apostrophe-dot'
+  | 'comma-dot-in';
 
 export const numberFormats: Array<{
   value: NumberFormats;
@@ -227,6 +232,7 @@ export const numberFormats: Array<{
   { value: 'comma-dot', label: '1,000.33', labelNoFraction: '1,000' },
   { value: 'dot-comma', label: '1.000,33', labelNoFraction: '1.000' },
   { value: 'space-comma', label: '1\xa0000,33', labelNoFraction: '1\xa0000' },
+  { value: 'apostrophe-dot', label: '1’000.33', labelNoFraction: '1’000' },
   { value: 'comma-dot-in', label: '1,00,000.33', labelNoFraction: '1,00,000' },
 ];
 
@@ -262,6 +268,12 @@ export function getNumberFormat({
       locale = 'de-DE';
       regex = /[^-0-9,]/g;
       separator = ',';
+      break;
+    case 'apostrophe-dot':
+      locale = 'de-CH';
+      regex = /[^-0-9,.]/g;
+      separator = '.';
+      separatorRegex = /[,.]/g;
       break;
     case 'comma-dot-in':
       locale = 'en-IN';

--- a/upcoming-release-notes/2982.md
+++ b/upcoming-release-notes/2982.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [julianwachholz]
+---
+
+Add apostrophe-dot (Swiss) number format


### PR DESCRIPTION
Adds a Swiss style number format option.

The Intl.NumberFormat API formats de `de-CH` locale using a fancy apostrophe (U+2019):

```
> Intl.NumberFormat('de-CH').format(1200.33)
< "1’200.33" 
```

This PR is based on #2981 