### PR TITLE
remove version from electron build names

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -35,6 +35,7 @@
       "icon": "icons/icon.icns",
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
+      "artifactName": "${productName}-mac.${ext}",
       "notarize": {
         "teamId": "79ANZ983YF"
       }
@@ -44,7 +45,7 @@
         "flatpak",
         "AppImage"
       ],
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-linux.${ext}"
     },
     "flatpak": {
       "runtimeVersion": "23.08",
@@ -52,7 +53,8 @@
     },
     "win": {
       "target": "nsis",
-      "icon": "icons/icon.ico"
+      "icon": "icons/icon.ico",
+      "artifactName": "${productName}-windows.${ext}"
     }
   },
   "dependencies": {

--- a/upcoming-release-notes/3000.md
+++ b/upcoming-release-notes/3000.md
@@ -1,0 +1,6 @@
+---
+category: Maintinance
+authors: [youngcw]
+---
+
+Cleanup desktop app filenames to prep for download page

--- a/upcoming-release-notes/3000.md
+++ b/upcoming-release-notes/3000.md
@@ -1,5 +1,5 @@
 ---
-category: Maintinance
+category: Maintenance
 authors: [youngcw]
 ---
 


### PR DESCRIPTION
This will make it so the desktop app filename is always the same in the release and we can point the download page to the release page without having to update the page every month


Do I get a prize for being PR 3000?
