### PR TITLE
:electron: Build electron for Mac Universal arch 

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -41,6 +41,7 @@
       },
       "target": [
         {
+          "target": "default",
           "arch": ["universal"]
         }
       ]

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -38,7 +38,12 @@
       "artifactName": "${productName}-mac.${ext}",
       "notarize": {
         "teamId": "79ANZ983YF"
-      }
+      },
+      "target": [
+        {
+          "arch": ["universal"]
+        }
+      ]
     },
     "linux": {
       "target": [

--- a/upcoming-release-notes/3015.md
+++ b/upcoming-release-notes/3015.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MikesGlitch]
 ---
 
-Improve Electron build to target "Universal" for better performance on Apple Silicon
+Improve Electron Mac build to target "Universal" for better performance on Apple Silicon

--- a/upcoming-release-notes/3015.md
+++ b/upcoming-release-notes/3015.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Improve Electron build to target "Universal" for better performance on Apple Silicon


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Improve Electron Mac build to target "Universal" for better performance on Apple Silicon.

**NOTE:** this will increase the size of the Mac app from 111MB to 182MB

Tested by: [michaelhofer](https://github.com/michaelhofer) - on https://github.com/actualbudget/actual/issues/3004#issuecomment-2227006927
