### PR TITLE
Fix mobile payee creation display for long payee names

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -420,7 +420,7 @@ export function CreatePayeeButton({
       data-testid="create-payee-button"
       style={{
         display: 'block',
-        flexShrink: 0,
+        flex: '1 0',
         color: highlighted
           ? theme.menuAutoCompleteTextHover
           : theme.noticeTextMenu,

--- a/upcoming-release-notes/3019.md
+++ b/upcoming-release-notes/3019.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [JukeboxRhino]
+---
+
+Fix payee creation for long names on narrow screens


### PR DESCRIPTION
The button to create a new payee when entering a transaction on mobile does not currently expand when text wraps. This PR allows the button to expand in the same way it does on desktop.

## Before:
![Screenshot from 2024-07-09 15-54-49](https://github.com/actualbudget/actual/assets/12942439/344d5b7b-de19-42c9-b32a-1adbecdd1a08)

## After:
![Screenshot from 2024-07-09 16-28-04](https://github.com/actualbudget/actual/assets/12942439/d7ba6d22-b92f-47a2-a135-29e2e2899eb2)
![Screenshot from 2024-07-09 16-28-52](https://github.com/actualbudget/actual/assets/12942439/f5ac99fc-49cb-42f0-8143-c1803b5debf0)
![Screenshot from 2024-07-09 16-27-07](https://github.com/actualbudget/actual/assets/12942439/3f7d6993-f84d-4145-897c-040957526ea3)
