### PR TITLE
Expose bank sync account data in AQL.

### DIFF
--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -69,6 +69,8 @@ export const schema = {
     closed: f('boolean'),
     sort_order: f('float'),
     tombstone: f('boolean'),
+    account_id: f('string'),
+    official_name: f('string'),
     account_sync_source: f('string'),
   },
   categories: {

--- a/upcoming-release-notes/3022.md
+++ b/upcoming-release-notes/3022.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Expose bank sync account data ('account_id' and 'official_name') in AQL.


### PR DESCRIPTION
These fields exist in the table, but were not exposed via AQL. So people using the API could not get this data.  This is needed for properly matching accounts to SimpleFIN (either by the ID or by the 'official' name).