### PR TITLE
Perform bank sync in same order as accounts shown in sidebar.

### DIFF
--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -96,7 +96,7 @@ export function syncAccounts(id?: string) {
             ({ bank, closed, tombstone }) => !!bank && !closed && !tombstone,
           )
           .sort((a, b) =>
-            a.offbudget == b.offbudget
+            a.offbudget === b.offbudget
               ? a.sort_order - b.sort_order
               : a.offbudget - b.offbudget,
           )

--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -95,6 +95,11 @@ export function syncAccounts(id?: string) {
           .queries.accounts.filter(
             ({ bank, closed, tombstone }) => !!bank && !closed && !tombstone,
           )
+          .sort((a, b) =>
+            a.offbudget == b.offbudget
+              ? a.sort_order - b.sort_order
+              : a.offbudget - b.offbudget,
+          )
           .map(({ id }) => id);
 
     dispatch(setAccountsSyncing(accountIdsToSync));

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1062,7 +1062,8 @@ handlers['accounts-bank-sync'] = async function ({ id }) {
   const accounts = await db.runQuery(
     `SELECT a.*, b.bank_id as bankId FROM accounts a
          LEFT JOIN banks b ON a.bank = b.id
-         WHERE a.tombstone = 0 AND a.closed = 0 ${id ? 'AND a.id = ?' : ''}`,
+         WHERE a.tombstone = 0 AND a.closed = 0 ${id ? 'AND a.id = ?' : ''}
+         ORDER BY a.offbudget, a.sort_order`,
     id ? [id] : [],
     true,
   );

--- a/upcoming-release-notes/3029.md
+++ b/upcoming-release-notes/3029.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Perform bank sync in same order as accounts shown in sidebar.


### PR DESCRIPTION
Right now bank sync syncs one bank at a time, based on the default sort order returned by the SQL query.  This makes them sync in the same order they show in the left sidebar.