### PR TITLE
Dim hidden income category rows

### DIFF
--- a/packages/desktop-client/src/components/budget/IncomeCategory.tsx
+++ b/packages/desktop-client/src/components/budget/IncomeCategory.tsx
@@ -58,8 +58,14 @@ export function IncomeCategory({
   });
 
   return (
-    <Row innerRef={dropRef} collapsed={true}>
-      <DropHighlight pos={dropPos} offset={{ top: 1 }} />
+    <Row
+      innerRef={dropRef}
+      collapsed={true}
+      style={{
+        opacity: cat.hidden ? 0.5 : undefined,
+      }}
+    >
+    <DropHighlight pos={dropPos} offset={{ top: 1 }} />
 
       <SidebarCategory
         innerRef={dragRef}

--- a/packages/desktop-client/src/components/budget/IncomeCategory.tsx
+++ b/packages/desktop-client/src/components/budget/IncomeCategory.tsx
@@ -65,7 +65,7 @@ export function IncomeCategory({
         opacity: cat.hidden ? 0.5 : undefined,
       }}
     >
-    <DropHighlight pos={dropPos} offset={{ top: 1 }} />
+      <DropHighlight pos={dropPos} offset={{ top: 1 }} />
 
       <SidebarCategory
         innerRef={dragRef}

--- a/upcoming-release-notes/3032.md
+++ b/upcoming-release-notes/3032.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [psybers]
+---
+
+Dim hidden income category rows.


### PR DESCRIPTION
If you hide an income category, only the name of the category was dimming. This dims the entire row, similar to the expense categories being hidden.