### PR TITLE
Fix the position of the separator in the operator menu when editing a rule

### DIFF
--- a/packages/desktop-client/src/components/modals/EditRule.jsx
+++ b/packages/desktop-client/src/components/modals/EditRule.jsx
@@ -122,7 +122,7 @@ export function OpSelect({
       .map(op => [op, formatOp(op, type)]);
 
     if (type === 'string' || type === 'id') {
-      options.splice(options.length / 2, 0, Menu.line);
+      options.splice(Math.ceil(options.length / 2), 0, Menu.line);
     }
 
     return options;

--- a/upcoming-release-notes/3037.md
+++ b/upcoming-release-notes/3037.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ctozlowski]
+---
+
+Fix the position of the separator in the operator menu when editing a rule


### PR DESCRIPTION
Noticed the separator line was in the wrong position when I was editing a rule. This should fix it.

Before:
<img width="341" alt="unfixed" src="https://github.com/user-attachments/assets/feaa85a6-fe0b-49dc-9679-3dd4d3b9fb64">

After:
<img width="341" alt="fixed" src="https://github.com/user-attachments/assets/6d6e75dd-58f3-44ab-8974-f667017a85b2">

