### PR TITLE
fixes alignment of notifications on mobile to be centered

### DIFF
--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -13,6 +13,7 @@ import type { NotificationWithId } from 'loot-core/src/client/state-types/notifi
 import { useActions } from '../hooks/useActions';
 import { AnimatedLoading } from '../icons/AnimatedLoading';
 import { SvgDelete } from '../icons/v0';
+import { useResponsive } from '../ResponsiveProvider';
 import { styles, theme, type CSSProperties } from '../style';
 
 import { Button, ButtonWithLoading } from './common/Button';
@@ -245,6 +246,7 @@ function Notification({
 
 export function Notifications({ style }: { style?: CSSProperties }) {
   const { removeNotification } = useActions();
+  const { isNarrowWidth } = useResponsive();
   const notifications = useSelector(
     (state: State) => state.notifications.notifications,
   );
@@ -254,6 +256,7 @@ export function Notifications({ style }: { style?: CSSProperties }) {
         position: 'fixed',
         bottom: 20,
         right: 13,
+        left: isNarrowWidth ? 13 : undefined,
         zIndex: 10000,
         ...style,
       }}

--- a/upcoming-release-notes/3046.md
+++ b/upcoming-release-notes/3046.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [YusefOuda]
+---
+
+Fixes the alignment of notifications in mobile view


### PR DESCRIPTION
Issue: N/A

Description: Fixes alignment of notifications on mobile to be centered on the viewport.

Old | New
:---:|:---:
<img src="https://github.com/user-attachments/assets/6300932c-fa35-4eaa-bfa6-6ef766c98ac3" width="250"/> | <img src="https://github.com/user-attachments/assets/ed9f6635-fb3c-4064-9526-097bb89c0c67" width="250"/>

