### PR TITLE
Add autocapitalize to payee autocomplete

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -288,6 +288,7 @@ export function PayeeAutocomplete({
       focused={payeeFieldFocused}
       inputProps={{
         ...inputProps,
+        autoCapitalize: 'words',
         onBlur: () => {
           setRawPayee('');
           setPayeeFieldFocused(false);

--- a/upcoming-release-notes/3056.md
+++ b/upcoming-release-notes/3056.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [JukeboxRhino]
+---
+
+Add payee autocapitalization when creating on mobile


### PR DESCRIPTION
Having your words be automatically capitalized while typing in payee names is a nice QoL feature that we can add for very little effort on our part. Existing search functionality is maintained because the search is case-insensitive. Only mobile browsers are affected.

Before:
[Screen_Recording_20240714_203146_Firefox.webm](https://github.com/user-attachments/assets/a696c864-bc3e-473d-bf62-5ffde724c307)

After:
[Screen_Recording_20240714_203019_Firefox.webm](https://github.com/user-attachments/assets/46fd422e-83d1-4dcc-84cd-bc6894f0bdf1)

Reference:
[autocapitalize="words"](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize#words)

