### PR TITLE
CAMT.053: Handle missing ValDt on entries with Sts Book

### DIFF
--- a/packages/loot-core/src/mocks/files/camt/camt.053.xml
+++ b/packages/loot-core/src/mocks/files/camt/camt.053.xml
@@ -129,9 +129,7 @@
                 <BookgDt>
                     <Dt>2013-12-30</Dt>
                 </BookgDt>
-                <ValDt>
-                    <Dt>2013-12-30</Dt>
-                </ValDt>
+                <!-- ValDt deliberately omitted -->
                 <AcctSvcrRef>2013123001153870001</AcctSvcrRef>
                 <BkTxCd />
                 <NtryDtls>

--- a/packages/loot-core/src/server/accounts/xmlcamt2json.ts
+++ b/packages/loot-core/src/server/accounts/xmlcamt2json.ts
@@ -86,6 +86,9 @@ function convertToNumberOrNull(value: string): number | null {
 }
 
 function getDtOrDtTm(Date: DateRef | null): string | null {
+  if (!Date) {
+    return null;
+  }
   if ('DtTm' in Date) {
     return Date.DtTm.slice(0, 10);
   }

--- a/upcoming-release-notes/3086.md
+++ b/upcoming-release-notes/3086.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [simonschmidt]
+---
+
+Fix crash on CAMT.053 imports with missing ValDt


### PR DESCRIPTION
In the XML export from [LHV](https://lhv.ee) entries only have date information in `BookgDt` but there is no `ValDt`.

For reference, this is the schema declared in the export I get:

```
<Document
  xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd"
  >
```

---

The error I got was in `getDtOrDtTm`:

> TypeError: right-hand side of 'in' should be an object, got undefined

This handles that by explicitly checking for falsy input. The code seems to have already been expecting
this situation as it already falls back to `BookgDt` in:

```javascript
const date = getDtOrDtTm(entry.ValDt) || getDtOrDtTm(entry.BookgDt);
```

Glancing over the xsd spec this seems to make sense as both `ValDt` and `BookgDt` have `minOccurs="0" maxOccurs="1"`