### PR TITLE
[WIP] modify fly.io url to point to correct documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Want to say thanks? Click the ⭐ at the top of the page.
 There are four ways to deploy Actual:
 
 1. One-click deployment [via PikaPods](https://www.pikapods.com/pods?run=actual) (~1.40 $/month) - recommended for non-technical users
-1. Managed hosting [via Fly.io](https://actualbudget.org/docs/install/docker) (~1.50 $/month)
+1. Managed hosting [via Fly.io](https://actualbudget.org/docs/install/fly) (~1.50 $/month)
 1. Self-hosted by using [a Docker image](https://actualbudget.org/docs/install/docker)
 1. Local-only apps - [downloadable Windows, Mac and Linux apps](https://actualbudget.org/download/) you can run on your device
 

--- a/upcoming-release-notes/3113.md
+++ b/upcoming-release-notes/3113.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [reecerunnells]
+---
+
+Updated Fly.io link in README to point to correct section of documentation.


### PR DESCRIPTION
- README: noticed fly.io points to docker, updated the url

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
