### PR TITLE
Disable typography linter in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,3 @@
-/* eslint-disable rulesdir/typography */
 const path = require('path');
 
 const rulesDirPlugin = require('eslint-plugin-rulesdir');
@@ -330,6 +329,18 @@ module.exports = {
       ],
       rules: {
         'react-hooks/exhaustive-deps': 'off',
+      },
+    },
+    {
+      files: [
+        '.eslintrc.js',
+        '*.test.js',
+        '*.test.ts',
+        '*.test.jsx',
+        '*.test.tsx',
+      ],
+      rules: {
+        'rulesdir/typography': 'off',
       },
     },
   ],

--- a/packages/loot-core/src/server/aql/views.test.ts
+++ b/packages/loot-core/src/server/aql/views.test.ts
@@ -30,7 +30,6 @@ const schemaConfig = {
 
       v_transactions2: (_, publicFields) => {
         const fields = publicFields({
-          // eslint-disable-next-line rulesdir/typography
           transfer_id: 'COERCE(transfer_id, "foo")',
         });
 

--- a/upcoming-release-notes/3114.md
+++ b/upcoming-release-notes/3114.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Disable typography linter in tests


### PR DESCRIPTION
In https://github.com/actualbudget/actual/pull/3044 the `typography` linter rule is applying to test files. Strings in test files aren't user-facing, so it doesn't make sense to apply this rule there.