### PR TITLE
hide target category from cover overspending list

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -511,6 +511,7 @@ export function Modals() {
               title={options.title}
               month={options.month}
               showToBeBudgeted={options.showToBeBudgeted}
+              category={options.category}
               onSubmit={options.onSubmit}
             />
           );

--- a/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
@@ -59,6 +59,7 @@ export function BalanceMovementMenu({
 
       {menu === 'cover' && (
         <CoverMenu
+          targetCategory={categoryId}
           onClose={onClose}
           onSubmit={fromCategoryId => {
             onBudgetAction(month, 'cover-overspending', {

--- a/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/BalanceMovementMenu.tsx
@@ -59,7 +59,7 @@ export function BalanceMovementMenu({
 
       {menu === 'cover' && (
         <CoverMenu
-          targetCategory={categoryId}
+          category={categoryId}
           onClose={onClose}
           onSubmit={fromCategoryId => {
             onBudgetAction(month, 'cover-overspending', {

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -11,33 +11,28 @@ import { addToBeBudgetedGroup } from '../util';
 
 function removeSelectedCategory(
   categoryGroups: CategoryGroupEntity[],
-  selectedCategoryId?: string,
+  category?: string,
 ) {
-  if (!selectedCategoryId) return categoryGroups;
+  if (!category) return categoryGroups;
 
-  const newCategoryGroups: CategoryGroupEntity[] = JSON.parse(
-    JSON.stringify(categoryGroups),
-  );
-
-  newCategoryGroups.forEach(group => {
-    group.categories = group.categories?.filter(
-      category => category.id !== selectedCategoryId,
-    );
-  });
-
-  return newCategoryGroups.filter(g => g.categories?.length);
+  return categoryGroups
+    .map(group => ({
+      ...group,
+      categories: group.categories?.filter(cat => cat.id !== category),
+    }))
+    .filter(group => group.categories?.length);
 }
 
 type CoverMenuProps = {
   showToBeBudgeted?: boolean;
-  targetCategory?: string;
+  category?: string;
   onSubmit: (categoryId: string) => void;
   onClose: () => void;
 };
 
 export function CoverMenu({
   showToBeBudgeted = true,
-  targetCategory,
+  category,
   onSubmit,
   onClose,
 }: CoverMenuProps) {
@@ -63,10 +58,7 @@ export function CoverMenu({
       <InitialFocus>
         {node => (
           <CategoryAutocomplete
-            categoryGroups={removeSelectedCategory(
-              categoryGroups,
-              targetCategory,
-            )}
+            categoryGroups={removeSelectedCategory(categoryGroups, category)}
             value={categoryGroups.find(g => g.id === categoryId) ?? null}
             openOnFocus={true}
             onSelect={(id: string | undefined) => setCategoryId(id || null)}

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
-import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';
+import {
+  type CategoryGroupEntity,
+  type CategoryEntity,
+} from 'loot-core/src/types/models';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { CategoryAutocomplete } from '../../autocomplete/CategoryAutocomplete';
@@ -11,7 +14,7 @@ import { addToBeBudgetedGroup } from '../util';
 
 function removeSelectedCategory(
   categoryGroups: CategoryGroupEntity[],
-  category?: string,
+  category?: CategoryEntity['id'],
 ) {
   if (!category) return categoryGroups;
 
@@ -25,7 +28,7 @@ function removeSelectedCategory(
 
 type CoverMenuProps = {
   showToBeBudgeted?: boolean;
-  category?: string;
+  category?: CategoryEntity['id'];
   onSubmit: (categoryId: string) => void;
   onClose: () => void;
 };
@@ -45,6 +48,11 @@ export function CoverMenu({
     : filteredCategoryGroups;
   const [categoryId, setCategoryId] = useState<string | null>(null);
 
+  const filteredCategoryGroups = useMemo(
+    () => removeSelectedCategory(categoryGroups, category),
+    [categoryGroups, category],
+  );
+
   function submit() {
     if (categoryId) {
       onSubmit(categoryId);
@@ -58,8 +66,8 @@ export function CoverMenu({
       <InitialFocus>
         {node => (
           <CategoryAutocomplete
-            categoryGroups={removeSelectedCategory(categoryGroups, category)}
-            value={categoryGroups.find(g => g.id === categoryId) ?? null}
+            categoryGroups={filteredCategoryGroups}
+            value={filteredCategoryGroups.find(g => g.id === categoryId) ?? null}
             openOnFocus={true}
             onSelect={(id: string | undefined) => setCategoryId(id || null)}
             inputProps={{

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 
+import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';
+
 import { useCategories } from '../../../hooks/useCategories';
 import { CategoryAutocomplete } from '../../autocomplete/CategoryAutocomplete';
 import { Button } from '../../common/Button2';
@@ -7,14 +9,35 @@ import { InitialFocus } from '../../common/InitialFocus';
 import { View } from '../../common/View';
 import { addToBeBudgetedGroup } from '../util';
 
+function removeSelectedCategory(
+  categoryGroups: CategoryGroupEntity[],
+  selectedCategoryId?: string,
+) {
+  if (!selectedCategoryId) return categoryGroups;
+
+  const newCategoryGroups: CategoryGroupEntity[] = JSON.parse(
+    JSON.stringify(categoryGroups),
+  );
+
+  newCategoryGroups.forEach(group => {
+    group.categories = group.categories?.filter(
+      category => category.id !== selectedCategoryId,
+    );
+  });
+
+  return newCategoryGroups.filter(g => g.categories?.length);
+}
+
 type CoverMenuProps = {
   showToBeBudgeted?: boolean;
+  targetCategory?: string;
   onSubmit: (categoryId: string) => void;
   onClose: () => void;
 };
 
 export function CoverMenu({
   showToBeBudgeted = true,
+  targetCategory,
   onSubmit,
   onClose,
 }: CoverMenuProps) {
@@ -40,7 +63,10 @@ export function CoverMenu({
       <InitialFocus>
         {node => (
           <CategoryAutocomplete
-            categoryGroups={categoryGroups}
+            categoryGroups={removeSelectedCategory(
+              categoryGroups,
+              targetCategory,
+            )}
             value={categoryGroups.find(g => g.id === categoryId) ?? null}
             openOnFocus={true}
             onSelect={(id: string | undefined) => setCategoryId(id || null)}

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -40,12 +40,12 @@ export function CoverMenu({
   onClose,
 }: CoverMenuProps) {
   const { grouped: originalCategoryGroups } = useCategories();
-  const filteredCategoryGroups = originalCategoryGroups.filter(
-    g => !g.is_income,
-  );
+  const expenseGroups = originalCategoryGroups.filter(g => !g.is_income);
+
   const categoryGroups = showToBeBudgeted
-    ? addToBeBudgetedGroup(filteredCategoryGroups)
-    : filteredCategoryGroups;
+    ? addToBeBudgetedGroup(expenseGroups)
+    : expenseGroups;
+
   const [categoryId, setCategoryId] = useState<string | null>(null);
 
   const filteredCategoryGroups = useMemo(
@@ -67,7 +67,9 @@ export function CoverMenu({
         {node => (
           <CategoryAutocomplete
             categoryGroups={filteredCategoryGroups}
-            value={filteredCategoryGroups.find(g => g.id === categoryId) ?? null}
+            value={
+              filteredCategoryGroups.find(g => g.id === categoryId) ?? null
+            }
             openOnFocus={true}
             onSelect={(id: string | undefined) => setCategoryId(id || null)}
             inputProps={{

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -67,9 +67,7 @@ export function CoverMenu({
         {node => (
           <CategoryAutocomplete
             categoryGroups={filteredCategoryGroups}
-            value={
-              filteredCategoryGroups.find(g => g.id === categoryId) ?? null
-            }
+            value={categoryGroups.find(g => g.id === categoryId) ?? null}
             openOnFocus={true}
             onSelect={(id: string | undefined) => setCategoryId(id || null)}
             inputProps={{

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -391,6 +391,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
       pushModal('cover', {
         title: category.name,
         month,
+        category: category.id,
         onSubmit: fromCategoryId => {
           onBudgetAction(month, 'cover-overspending', {
             to: category.id,

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -50,9 +50,11 @@ export function CoverModal({
     const filteredCategoryGroups = originalCategoryGroups.filter(
       g => !g.is_income,
     );
+
     const expenseGroups = showToBeBudgeted
       ? addToBeBudgetedGroup(filteredCategoryGroups)
       : filteredCategoryGroups;
+
     const expenseCategories = expenseGroups.flatMap(g => g.categories || []);
     return [expenseGroups, expenseCategories];
   }, [originalCategoryGroups, showToBeBudgeted]);

--- a/upcoming-release-notes/3115.md
+++ b/upcoming-release-notes/3115.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Hide the target category from the cover overspending category list


### PR DESCRIPTION
When using the cover overspending menu, it allows you to select the target category as the cover source. This doesn't cause a problem but doesn't make much sense or do anything.