### PR TITLE
add goal tooltip to balance in budget table

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -83,13 +83,15 @@ export function BalanceWithCarryover({
   const budgetedValue = useSheetValue(budgeted);
   const longGoalValue = useSheetValue(longGoal);
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
-  const differenceToGoal = budgetedValue - goalValue;
   const valueStyle = makeBalanceAmountStyle(
     balanceValue,
     isGoalTemplatesEnabled ? goalValue : null,
     longGoalValue === 1 ? balanceValue : budgetedValue,
   );
   const format = useFormat();
+
+  const differenceToGoal =
+    longGoalValue === 1 ? balanceValue - goalValue : budgetedValue - goalValue;
 
   const balanceCellValue = (
     <CellValue
@@ -150,8 +152,17 @@ export function BalanceWithCarryover({
                 <div>{format(goalValue, 'financial')}</div>
               </GoalTooltipRow>
               <GoalTooltipRow>
-                <div>Budgeted:</div>
-                <div>{format(budgetedValue, 'financial')}</div>
+                {longGoalValue !== 1 ? (
+                  <>
+                    <div>Budgeted:</div>
+                    <div>{format(budgetedValue, 'financial')}</div>
+                  </>
+                ) : (
+                  <>
+                    <div>Balance:</div>
+                    <div>{format(balanceValue, 'financial')}</div>
+                  </>
+                )}
               </GoalTooltipRow>
             </View>
           }

--- a/upcoming-release-notes/3123.md
+++ b/upcoming-release-notes/3123.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Add a goal information tooltip to the balance on the budget table


### PR DESCRIPTION
I saw a suggestion along these lines in the discord some time ago (can't pinpoint exactly but somewhere around the 2 month mark probably)

What do people think? I've gone through a good few designs so if anyone has any suggestions I'm more than open to them!

To test you'll need to enable goal templates, apply them, and hover over the balance in the final column of the budget table. I'm not sure if this would want a dashed underline to make it more obvious or if it's best left discovered organically to keep the table clearer.

![image](https://github.com/user-attachments/assets/16239070-6e82-4e1c-911e-6eb50a930ac6)

