### PR TITLE
:wrench: improve unit test stability while using uuid

### DIFF
--- a/packages/loot-core/src/mocks/setup.ts
+++ b/packages/loot-core/src/mocks/setup.ts
@@ -58,6 +58,17 @@ jest.mock('uuid', () => ({
     return 'id' + _id++;
   },
 }));
+jest.mock('../server/migrate/migrations', () => {
+  const realMigrations = jest.requireActual('../server/migrate/migrations');
+  return {
+    ...realMigrations,
+    migrate: async db => {
+      _id = 100_000_000;
+      await realMigrations.migrate(db);
+      _id = 1;
+    },
+  };
+});
 
 global.getDatabaseDump = async function (tables) {
   if (!tables) {

--- a/upcoming-release-notes/3144.md
+++ b/upcoming-release-notes/3144.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Unit tests: improve the reliability of unique ids.


### PR DESCRIPTION
We use uuid package throughout the codebase to generate unique ids. In unit tests - we have mocked it (here https://github.com/actualbudget/actual/blob/master/packages/loot-core/src/mocks/setup.ts#L55-L60). For tests it generates a sequential ID. This works fine for the most part.

Until we add a new migration that also wants to use uuid. Migrations run before all other code. So a new migration using uuid messes up all test snapshots. Suddenly id5 becomes id6.

This solves the problem. No matter how many new migrations will be added - they will not mess up the snapshots that rely on `uuid`.