### PR TITLE
[Fix] "Enter" key should save on "Cover Overspending" popup 

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -546,8 +546,8 @@ function SingleAutocomplete<T extends Item>({
                   }
 
                   if (!isOpen) {
-                    // When autocomplete dropdown is closed, allow any unhandled keydown events to be passed back to the parent
-                    // E.g. When user selects item (closing the dropdown), then presses "Enter" to confirm the selection
+                    // When autocomplete dropdown is closed, allow any keydown events to be passed back to the parent
+                    // E.g. When user selects an item, then presses "Enter" to confirm the selection
                     onKeyDown?.(e);
                   }
                 },

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -544,12 +544,6 @@ function SingleAutocomplete<T extends Item>({
                       close();
                     }
                   }
-
-                  if (!isOpen) {
-                    // When autocomplete dropdown is closed, allow any keydown events to be passed back to the parent
-                    // E.g. When user selects an item, then presses "Enter" to confirm the selection
-                    onKeyDown?.(e);
-                  }
                 },
                 onChange: (e: ChangeEvent<HTMLInputElement>) => {
                   const { onChange } = inputProps || {};

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -544,6 +544,12 @@ function SingleAutocomplete<T extends Item>({
                       close();
                     }
                   }
+
+                  if (!isOpen) {
+                    // When autocomplete dropdown is closed, allow any unhandled keydown events to be passed back to the parent
+                    // E.g. When user selects item (closing the dropdown), then presses "Enter" to confirm the selection
+                    onKeyDown?.(e);
+                  }
                 },
                 onChange: (e: ChangeEvent<HTMLInputElement>) => {
                   const { onChange } = inputProps || {};

--- a/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/rollover/CoverMenu.tsx
@@ -44,11 +44,7 @@ export function CoverMenu({
             onSelect={(id: string | undefined) => setCategoryId(id || null)}
             inputProps={{
               inputRef: node,
-              onKeyDown: e => {
-                if (e.key === 'Enter') {
-                  submit();
-                }
-              },
+              onEnter: event => !event.defaultPrevented && submit(),
               placeholder: '(none)',
             }}
             showHiddenCategories={false}

--- a/upcoming-release-notes/3153.md
+++ b/upcoming-release-notes/3153.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [MikesGlitch]
 ---
 
-Fix the "Enter" shortcut not firing after selecting item in an autocomplete
+Fix the "Enter" shortcut not saving on "Cover Overspending" popup

--- a/upcoming-release-notes/3153.md
+++ b/upcoming-release-notes/3153.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix the "Enter" shortcut not firing after selecting item in an autocomplete


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fixes: #3150
