### PR TITLE
Fix budget type toggle not working the first time

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -375,7 +375,7 @@ function CategoryItem({
         borderTop: `1px solid ${theme.pillBorder}`,
       }
     : {};
-  const [budgetType] = useLocalPref('budgetType');
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
 
   const balance = useSheetValue(
     budgetType === 'rollover'

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -75,8 +75,7 @@ function BudgetInner(props: BudgetInnerProps) {
     start: startMonth,
     end: startMonth,
   });
-  const [budgetTypePref] = useLocalPref('budgetType');
-  const budgetType = budgetTypePref || 'rollover';
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const [maxMonthsPref] = useGlobalPref('maxMonths');
   const maxMonths = maxMonthsPref || 1;
   const [initialized, setInitialized] = useState(false);

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -461,8 +461,7 @@ function BudgetInner(props: BudgetInnerProps) {
 
 export function Budget() {
   const { list: categories, grouped: categoryGroups } = useCategories();
-  const [_budgetType] = useLocalPref('budgetType');
-  const budgetType = _budgetType || 'rollover';
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const spreadsheet = useSpreadsheet();
   useSetThemeColor(theme.mobileViewTheme);
   return (

--- a/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
@@ -15,7 +15,7 @@ import { Setting } from './UI';
 
 export function BudgetTypeSettings() {
   const dispatch = useDispatch();
-  const [budgetType] = useLocalPref('budgetType');
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const [loading, setLoading] = useState(false);
 
   const currentMonth = monthUtils.currentMonth();

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -57,7 +57,7 @@ function FeatureToggle({
 }
 
 function ReportBudgetFeature() {
-  const [budgetType] = useLocalPref('budgetType');
+  const [budgetType = 'rollover'] = useLocalPref('budgetType');
   const enabled = useFeatureFlag('reportBudget');
   const blockToggleOff = budgetType === 'report' && enabled;
   return (

--- a/upcoming-release-notes/3169.md
+++ b/upcoming-release-notes/3169.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [YusefOuda]
+---
+
+Fix budget type toggle not working the first time


### PR DESCRIPTION
**Issue**: When switching from "rollover" budget to "report" budget for the first time, the toggle doesn't actually work. This is because the localPref `budgetType` does not have a value initially, and the logic did not handle that so it attempts to toggle to a "rollover" budget (when it is already by default a "rollover")


`const newBudgetType = budgetType === 'rollover' ? 'report' : 'rollover';`

This PR fixes that issue by defaulting the localPref to "rollover" (also fixed it in other files where we use that localPref.