### PR TITLE
Identify Payee and Notes fields by name if they exist in CSV import

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -201,20 +201,22 @@ function getInitialMappings(transactions) {
   );
 
   const payeeField = key(
-    fields.find(([name]) => name.toLowerCase().includes('payee')) ?? fields.find(
-      ([name]) =>
-        name !== dateField && name !== amountField && name !== categoryField,
-    ),
+    fields.find(([name]) => name.toLowerCase().includes('payee')) ??
+      fields.find(
+        ([name]) =>
+          name !== dateField && name !== amountField && name !== categoryField,
+      ),
   );
 
   const notesField = key(
-    fields.find(([name]) => name.toLowerCase().includes('notes')) ?? fields.find(
-      ([name]) =>
-        name !== dateField &&
-        name !== amountField &&
-        name !== categoryField &&
-        name !== payeeField,
-    ),
+    fields.find(([name]) => name.toLowerCase().includes('notes')) ??
+      fields.find(
+        ([name]) =>
+          name !== dateField &&
+          name !== amountField &&
+          name !== categoryField &&
+          name !== payeeField,
+      ),
   );
 
   const inOutField = key(

--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -201,14 +201,14 @@ function getInitialMappings(transactions) {
   );
 
   const payeeField = key(
-    fields.find(
+    fields.find(([name]) => name.toLowerCase().includes('payee')) ?? fields.find(
       ([name]) =>
         name !== dateField && name !== amountField && name !== categoryField,
     ),
   );
 
   const notesField = key(
-    fields.find(
+    fields.find(([name]) => name.toLowerCase().includes('notes')) ?? fields.find(
       ([name]) =>
         name !== dateField &&
         name !== amountField &&

--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -201,7 +201,7 @@ function getInitialMappings(transactions) {
   );
 
   const payeeField = key(
-    fields.find(([name]) => name.toLowerCase().includes('payee')) ??
+    fields.find(([name]) => name.toLowerCase().includes('payee')) ||
       fields.find(
         ([name]) =>
           name !== dateField && name !== amountField && name !== categoryField,
@@ -209,7 +209,7 @@ function getInitialMappings(transactions) {
   );
 
   const notesField = key(
-    fields.find(([name]) => name.toLowerCase().includes('notes')) ??
+    fields.find(([name]) => name.toLowerCase().includes('notes')) ||
       fields.find(
         ([name]) =>
           name !== dateField &&

--- a/upcoming-release-notes/3203.md
+++ b/upcoming-release-notes/3203.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [spalmurray]
+---
+
+Identify Payee and Notes fields by name if they exist in CSV import


### PR DESCRIPTION
Use CSV fields with name "payee" or "notes" as defaults for Payee/Notes in getInitialMappings. Falls back to the first unused field if none exists with matching name (which is the current behavior).

Fixes #3154