### PR TITLE
Fix reconcileTransactions Invokation To Use strictIdChecking

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1157,6 +1157,7 @@ handlers['transactions-import'] = mutator(function ({
         accountId,
         transactions,
         false,
+        true,
         isPreview,
       );
     } catch (err) {

--- a/upcoming-release-notes/3232.md
+++ b/upcoming-release-notes/3232.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [pmoon00]
+---
+
+Fix import transaction issue introduced by strict id checking feature


### PR DESCRIPTION
# Overview

This PR fixes the issue described in issue #3227. This bug was caused by an oversight when merging the `strictIdChecking` feature with the `isPreview` feature that was implemented into the same `reconcileTransactions` function.

I've deliberately not hoisted the `strictIdChecking` parameter through to the API layer because I figured that having it set to true as default is sensible. If not, we can hoist it up.

