### PR TITLE
Fix off-by-one error when placing category into 2nd-to-last place

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.jsx
@@ -9,7 +9,12 @@ import { BudgetCategories } from './BudgetCategories';
 import { BudgetSummaries } from './BudgetSummaries';
 import { BudgetTotals } from './BudgetTotals';
 import { MonthsProvider } from './MonthsContext';
-import { findSortDown, findSortUp, getScrollbarWidth } from './util';
+import {
+  findSortDown,
+  findSortUp,
+  getScrollbarWidth,
+  separateGroups,
+} from './util';
 
 export function BudgetTable(props) {
   const {
@@ -86,9 +91,10 @@ export function BudgetTable(props) {
   };
 
   const _onReorderGroup = (id, dropPos, targetId) => {
+    const [expenseGroups] = separateGroups(categoryGroups); // exclude Income group from sortable groups to fix off-by-one error
     onReorderGroup({
       id,
-      ...findSortDown(categoryGroups, dropPos, targetId),
+      ...findSortDown(expenseGroups, dropPos, targetId),
     });
   };
 

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -103,7 +103,7 @@ export function findSortDown(
     }
 
     const newIdx = idx + 1;
-    if (newIdx < arr.length - 1) {
+    if (newIdx < arr.length) {
       return { targetId: arr[newIdx].id };
     } else {
       // Move to the end

--- a/upcoming-release-notes/3241.md
+++ b/upcoming-release-notes/3241.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [JL102]
+---
+
+Fixed category appearing in last slot when you drag it to the second-to-last slot


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

There was a typo in `findSortDown` which led to categories being dropped in the last place when it should be in the second-to-last place. However, fixing the typo broke the sorting of groups, because `findSortDown` was passed _every_ group, including the non-sortable income group, so before the typo fix, there were two off-by-one errors that cancelled each other out. This was fixed by pulling out the Income group before passing it to `findSortDown`.