### PR TITLE
fix: i18n: Use 'en' as default language

### DIFF
--- a/packages/desktop-client/src/i18n.ts
+++ b/packages/desktop-client/src/i18n.ts
@@ -13,7 +13,8 @@ i18n
   .init({
     // While we mark all strings for translations, one can test
     // it by setting the language in localStorage to their choice.
-    lng: localStorage.getItem('language') || 'cimode',
+    // Set this to 'cimode' to see the exact keys without interpolation.
+    lng: localStorage.getItem('language') || 'en',
 
     // allow keys to be phrases having `:`, `.`
     nsSeparator: false,

--- a/upcoming-release-notes/3242.md
+++ b/upcoming-release-notes/3242.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [julianwachholz]
+---
+
+Fixed translation keys being shown verbatim without interpolation


### PR DESCRIPTION
Using 'cimode' as default language code will return the translation keys verbatim without doing interpolation. This is unwanted unless working directly on localization.

Fixes #3240
