### PR TITLE
:recycle: cleanup iterableTopologicalSort feature flag

### DIFF
--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -89,9 +89,6 @@ export function ExperimentalFeatures() {
               Goal templates
             </FeatureToggle>
             <FeatureToggle flag="simpleFinSync">SimpleFIN sync</FeatureToggle>
-            <FeatureToggle flag="iterableTopologicalSort">
-              Iterable topological sort budget
-            </FeatureToggle>
           </View>
         ) : (
           <Link

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -8,7 +8,6 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesEnabled: false,
   spendingReport: false,
   simpleFinSync: false,
-  iterableTopologicalSort: true,
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts
+++ b/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts
@@ -1,5 +1,3 @@
-import { getPrefs } from '../prefs';
-
 // @ts-strict-ignore
 export function Graph() {
   const graph = {
@@ -81,40 +79,14 @@ export function Graph() {
   function topologicalSort(sourceNodes) {
     const visited = new Set();
     const sorted = [];
-    const prefs = getPrefs();
-    const iterableTopologicalSort =
-      prefs != null ? prefs['flags.iterableTopologicalSort'] : false;
 
     sourceNodes.forEach(name => {
       if (!visited.has(name)) {
-        if (iterableTopologicalSort) {
-          topologicalSortIterable(name, visited, sorted);
-        } else {
-          topologicalSortUntil(name, visited, sorted, 0);
-        }
+        topologicalSortIterable(name, visited, sorted);
       }
     });
 
     return sorted;
-  }
-
-  function topologicalSortUntil(name, visited, sorted, level) {
-    visited.add(name);
-    if (level > 2500) {
-      console.error('Limit of recursions reached while sorting budget: 2500');
-      return;
-    }
-
-    const iter = adjacent(name).values();
-    let cur = iter.next();
-    while (!cur.done) {
-      if (!visited.has(cur.value)) {
-        topologicalSortUntil(cur.value, visited, sorted, level + 1);
-      }
-      cur = iter.next();
-    }
-
-    sorted.unshift(name);
   }
 
   function topologicalSortIterable(name, visited, sorted) {

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -6,8 +6,7 @@ export type FeatureFlag =
   | 'reportBudget'
   | 'goalTemplatesEnabled'
   | 'spendingReport'
-  | 'simpleFinSync'
-  | 'iterableTopologicalSort';
+  | 'simpleFinSync';
 
 /**
  * Cross-device preferences. These sync across devices when they are changed.

--- a/upcoming-release-notes/3262.md
+++ b/upcoming-release-notes/3262.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [Matissjanis]
+---
+
+Cleanup `iterableTopologicalSort` feature flag.


### PR DESCRIPTION
We've been using the iterable solution in the last 2 releases now and no issues have been reported. So it's quite safe to say that the new solution is good and we can delete the old one.

So cleaning things up here..