### PR TITLE
feat: [localization] Update README to mention weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To add new feature requests, open a new Issue of the "Feature Request" type.
 
 ### Translation
 
-Make Actual Budget accessible to more people by helping with translations at our [Weblate Project](https://hosted.weblate.org/projects/actualbudget/). Weblate proudly supports open-source software projects through their [Libre plan](https://weblate.org/en/hosting/#libre).
+Make Actual Budget accessible to more people by helping with the [Internationalization](https://actualbudget.org/docs/contributing/i18n/) of Actual. We are using a crowd sourcing tool to manage the translations, see our [Weblate Project](https://hosted.weblate.org/projects/actualbudget/). Weblate proudly supports open-source software projects through their [Libre plan](https://weblate.org/en/hosting/#libre). 
 
 ## Repo Activity
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Vote for your favorite requests by reacting :+1: to the top comment of the reque
 
 To add new feature requests, open a new Issue of the "Feature Request" type.
 
+### Translation
+
+Make Actual Budget accessible to more people by helping with translations at our [Weblate Project](https://hosted.weblate.org/projects/actualbudget/). Weblate proudly supports open-source software projects through their [Libre plan](https://weblate.org/en/hosting/#libre).
+
 ## Repo Activity
 
 ![Alt](https://repobeats.axiom.co/api/embed/e20537dd8b74956f86736726ccfbc6f0565bec22.svg 'Repobeats analytics image')

--- a/upcoming-release-notes/3271.md
+++ b/upcoming-release-notes/3271.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [julianwachholz]
+---
+
+Update README to add Weblate project, a crowd-sourced translation tool.


### PR DESCRIPTION
From the ongoing localization project, to get access to the Libre plan, the Weblate project which hosts the translated strings should be mentioned in the readme.

Following example from a few other projects, I put together a little blurb. Crediting Julian b/c they set up the project and this is just a single sentence.