### PR TITLE
:bug: fix 's' hotkey not working in transaction table

### DIFF
--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.jsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.jsx
@@ -165,7 +165,8 @@ export function SelectedTransactionsButton({
   ]);
   useHotkeys(
     's',
-    () => (!types.trans || linked ? onViewSchedule() : onLinkSchedule()),
+    () =>
+      !types.trans || linked ? onViewSchedule() : onLinkSchedule(selectedIds),
     {
       scopes: ['app'],
     },

--- a/upcoming-release-notes/3324.md
+++ b/upcoming-release-notes/3324.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix "s" hotkey breaking in transaction table.


### PR DESCRIPTION
Closes #3321
