### PR TITLE
🐛  Fix tooltip when using touch devices

### DIFF
--- a/packages/desktop-client/src/components/common/Tooltip.tsx
+++ b/packages/desktop-client/src/components/common/Tooltip.tsx
@@ -54,8 +54,8 @@ export const Tooltip = ({
     <View
       style={{ minHeight: 'auto' }}
       ref={triggerRef}
-      onPointerEnter={handlePointerEnter}
-      onPointerLeave={handlePointerLeave}
+      onMouseEnter={handlePointerEnter}
+      onMouseLeave={handlePointerLeave}
     >
       <TooltipTrigger
         isOpen={isHovered && !triggerProps.isDisabled}

--- a/upcoming-release-notes/3342.md
+++ b/upcoming-release-notes/3342.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Prevent tooltips showing on budget notes when using touch devices


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fixes: https://github.com/actualbudget/actual-server/issues/443#issue-2499664333

https://github.com/user-attachments/assets/76ef9845-5072-425a-bd62-26ed227a32da



Touch devices like MS Surface Pro7 use touchscreens (no hover states). When touching the notes field the pointer is "entered" into the area, the timeout triggered and 300ms later the hover state showed (even though there was no hover). 

The fix was to trigger the tooltip only on mouse hover - not pointer entering.