### PR TITLE
Privacy mode: instead of blurring, use an illegible font (#3376)

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -6,6 +6,7 @@
     "build"
   ],
   "devDependencies": {
+    "@fontsource/redacted-script": "^5.0.21",
     "@juggle/resize-observer": "^3.4.0",
     "@playwright/test": "1.41.1",
     "@rollup/plugin-inject": "^5.0.5",

--- a/packages/desktop-client/src/components/PrivacyFilter.tsx
+++ b/packages/desktop-client/src/components/PrivacyFilter.tsx
@@ -1,7 +1,5 @@
 // @ts-strict-ignore
 import React, {
-  useState,
-  useCallback,
   Children,
   type ComponentPropsWithRef,
   type ReactNode,
@@ -79,12 +77,13 @@ function PrivacyOverlay({ children, ...props }) {
         [
           {
             display: 'inline-flex',
+            flexGrow: 1,
             position: 'relative',
             ' > div:first-child': {
               opacity: 0,
             },
             ' > div:nth-child(2)': {
-              display: 'block',
+              display: 'flex',
             },
             '&:hover': {
               ' > div:first-child': {
@@ -100,22 +99,31 @@ function PrivacyOverlay({ children, ...props }) {
       )}`}
       {...restProps}
     >
-      <div>
-        <View>{children}</View>
+      <div
+        className={`${css([
+          {
+            display: 'flex',
+            flexGrow: 1,
+          },
+        ])}`}
+      >
+        {children}
       </div>
 
       <div
         aria-hidden="true"
         className={`${css({
+          flexDirection: 'column',
           fontFamily: 'Redacted Script',
           height: '100%',
           inset: 0,
+          justifyContent: 'center',
           pointerEvents: 'none',
           position: 'absolute',
           width: '100%',
         })}`}
       >
-        <View>{children}</View>
+        {children}
       </div>
     </View>
   );

--- a/packages/desktop-client/src/components/PrivacyFilter.tsx
+++ b/packages/desktop-client/src/components/PrivacyFilter.tsx
@@ -71,10 +71,6 @@ export function PrivacyFilter({
 }
 
 function PrivacyOverlay({ children, ...props }) {
-  const [hovered, setHovered] = useState(false);
-  const onHover = useCallback(() => setHovered(true), [setHovered]);
-  const onHoverEnd = useCallback(() => setHovered(false), [setHovered]);
-
   const { style, ...restProps } = props;
 
   return (
@@ -85,17 +81,23 @@ function PrivacyOverlay({ children, ...props }) {
             display: 'inline-flex',
             position: 'relative',
             ' > div:first-child': {
-              opacity: hovered ? 1 : 0,
+              opacity: 0,
             },
             ' > div:nth-child(2)': {
-              display: hovered ? 'none' : 'block',
+              display: 'block',
+            },
+            '&:hover': {
+              ' > div:first-child': {
+                opacity: 1,
+              },
+              ' > div:nth-child(2)': {
+                display: 'none',
+              },
             },
           },
         ],
         style,
       )}`}
-      onPointerEnter={onHover}
-      onPointerLeave={onHoverEnd}
       {...restProps}
     >
       <div>

--- a/packages/desktop-client/src/components/PrivacyFilter.tsx
+++ b/packages/desktop-client/src/components/PrivacyFilter.tsx
@@ -7,6 +7,8 @@ import React, {
   type ReactNode,
 } from 'react';
 
+import { css } from 'glamor';
+
 import { usePrivacyMode } from '../hooks/usePrivacyMode';
 import { useResponsive } from '../ResponsiveProvider';
 
@@ -44,11 +46,9 @@ export function ConditionalPrivacyFilter({
 
 type PrivacyFilterProps = ComponentPropsWithRef<typeof View> & {
   activationFilters?: (boolean | (() => boolean))[];
-  lineHeight?: number;
 };
 export function PrivacyFilter({
   activationFilters,
-  lineHeight,
   children,
   ...props
 }: PrivacyFilterProps) {
@@ -63,43 +63,58 @@ export function PrivacyFilter({
         typeof value === 'boolean' ? value : value(),
       ));
 
-  const privacyLineHeight = lineHeight != null ? lineHeight : 'inherit';
-
   return !activate ? (
     <>{Children.toArray(children)}</>
   ) : (
-    <PrivacyOverlay lineHeight={privacyLineHeight} {...props}>
-      {children}
-    </PrivacyOverlay>
+    <PrivacyOverlay {...props}>{children}</PrivacyOverlay>
   );
 }
 
-function PrivacyOverlay({ lineHeight, children, ...props }) {
+function PrivacyOverlay({ children, ...props }) {
   const [hovered, setHovered] = useState(false);
   const onHover = useCallback(() => setHovered(true), [setHovered]);
   const onHoverEnd = useCallback(() => setHovered(false), [setHovered]);
-
-  const privacyStyle = {
-    ...(!hovered && {
-      fontFamily: 'Redacted Script',
-      lineHeight,
-    }),
-  };
 
   const { style, ...restProps } = props;
 
   return (
     <View
-      style={{
-        display: style?.display ? style.display : 'inline-flex',
-        ...privacyStyle,
-        ...style,
-      }}
+      className={`${css(
+        [
+          {
+            display: 'inline-flex',
+            position: 'relative',
+            ' > div:first-child': {
+              opacity: hovered ? 1 : 0,
+            },
+            ' > div:nth-child(2)': {
+              display: hovered ? 'none' : 'block',
+            },
+          },
+        ],
+        style,
+      )}`}
       onPointerEnter={onHover}
       onPointerLeave={onHoverEnd}
       {...restProps}
     >
-      {children}
+      <div>
+        <View>{children}</View>
+      </div>
+
+      <div
+        aria-hidden="true"
+        className={`${css({
+          fontFamily: 'Redacted Script',
+          height: '100%',
+          inset: 0,
+          pointerEvents: 'none',
+          position: 'absolute',
+          width: '100%',
+        })}`}
+      >
+        <View>{children}</View>
+      </div>
     </View>
   );
 }

--- a/packages/desktop-client/src/components/PrivacyFilter.tsx
+++ b/packages/desktop-client/src/components/PrivacyFilter.tsx
@@ -44,11 +44,11 @@ export function ConditionalPrivacyFilter({
 
 type PrivacyFilterProps = ComponentPropsWithRef<typeof View> & {
   activationFilters?: (boolean | (() => boolean))[];
-  blurIntensity?: number;
+  lineHeight?: number;
 };
 export function PrivacyFilter({
   activationFilters,
-  blurIntensity,
+  lineHeight,
   children,
   ...props
 }: PrivacyFilterProps) {
@@ -63,29 +63,26 @@ export function PrivacyFilter({
         typeof value === 'boolean' ? value : value(),
       ));
 
-  const blurAmount = blurIntensity != null ? `${blurIntensity}px` : '3px';
+  const privacyLineHeight = lineHeight != null ? lineHeight : 'inherit';
 
   return !activate ? (
     <>{Children.toArray(children)}</>
   ) : (
-    <BlurredOverlay blurIntensity={blurAmount} {...props}>
+    <PrivacyOverlay lineHeight={privacyLineHeight} {...props}>
       {children}
-    </BlurredOverlay>
+    </PrivacyOverlay>
   );
 }
 
-function BlurredOverlay({ blurIntensity, children, ...props }) {
+function PrivacyOverlay({ lineHeight, children, ...props }) {
   const [hovered, setHovered] = useState(false);
   const onHover = useCallback(() => setHovered(true), [setHovered]);
   const onHoverEnd = useCallback(() => setHovered(false), [setHovered]);
 
-  const blurStyle = {
+  const privacyStyle = {
     ...(!hovered && {
-      filter: `blur(${blurIntensity})`,
-      WebkitFilter: `blur(${blurIntensity})`,
-      // To fix blur performance issue in Safari.
-      // https://graffino.com/til/CjT2jrcLHP-how-to-fix-filter-blur-performance-issue-in-safari
-      transform: `translate3d(0, 0, 0)`,
+      fontFamily: 'Redacted Script',
+      lineHeight,
     }),
   };
 
@@ -95,7 +92,7 @@ function BlurredOverlay({ blurIntensity, children, ...props }) {
     <View
       style={{
         display: style?.display ? style.display : 'inline-flex',
-        ...blurStyle,
+        ...privacyStyle,
         ...style,
       }}
       onPointerEnter={onHover}

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -169,11 +169,6 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
         valueProps={{
           binding: envelopeBudget.groupBalance(id),
           type: 'financial',
-          privacyFilter: {
-            style: {
-              paddingRight: styles.monthRightPadding,
-            },
-          },
         }}
       />
     </View>
@@ -431,11 +426,6 @@ export function IncomeGroupMonth({ month }: IncomeGroupMonthProps) {
         valueProps={{
           binding: envelopeBudget.groupIncomeReceived,
           type: 'financial',
-          privacyFilter: {
-            style: {
-              paddingRight: styles.monthRightPadding,
-            },
-          },
         }}
       />
     </View>

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
@@ -64,7 +64,11 @@ export function ToBudgetAmount({
           offset={3}
           triggerProps={{ isDisabled: isTotalsListTooltipDisabled }}
         >
-          <PrivacyFilter lineHeight={1.2}>
+          <PrivacyFilter
+            style={{
+              textAlign: 'center',
+            }}
+          >
             <Block
               onClick={onClick}
               data-cellname={sheetName}

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
@@ -64,7 +64,7 @@ export function ToBudgetAmount({
           offset={3}
           triggerProps={{ isDisabled: isTotalsListTooltipDisabled }}
         >
-          <PrivacyFilter blurIntensity={7}>
+          <PrivacyFilter lineHeight={1.2}>
             <Block
               onClick={onClick}
               data-cellname={sheetName}

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -178,12 +178,6 @@ export const GroupMonth = memo(function GroupMonth({
           valueProps={{
             binding: trackingBudget.groupBalance(id),
             type: 'financial',
-            // TODO: may no longer be unnecessary
-            privacyFilter: {
-              style: {
-                paddingRight: styles.monthRightPadding,
-              },
-            },
           }}
         />
       )}

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -178,6 +178,7 @@ export const GroupMonth = memo(function GroupMonth({
           valueProps={{
             binding: trackingBudget.groupBalance(id),
             type: 'financial',
+            // TODO: may no longer be unnecessary
             privacyFilter: {
               style: {
                 paddingRight: styles.monthRightPadding,

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/Saved.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/Saved.tsx
@@ -85,9 +85,7 @@ export function Saved({ projected, style }: SavedProps) {
             },
           ])}`}
         >
-          <PrivacyFilter blurIntensity={7}>
-            {format(saved, 'financial')}
-          </PrivacyFilter>
+          <PrivacyFilter>{format(saved, 'financial')}</PrivacyFilter>
         </View>
       </Tooltip>
     </View>

--- a/packages/desktop-client/src/components/reports/ReportSummary.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSummary.tsx
@@ -117,9 +117,7 @@ export function ReportSummary({
             fontWeight: 800,
           }}
         >
-          <PrivacyFilter blurIntensity={7}>
-            {amountToCurrency(data[balanceTypeOp])}
-          </PrivacyFilter>
+          <PrivacyFilter>{amountToCurrency(data[balanceTypeOp])}</PrivacyFilter>
         </Text>
         <Text style={{ fontWeight: 600 }}>For this time period</Text>
       </View>
@@ -154,7 +152,7 @@ export function ReportSummary({
             fontWeight: 800,
           }}
         >
-          <PrivacyFilter blurIntensity={7}>
+          <PrivacyFilter>
             {!isNaN(average) && integerToCurrency(Math.round(average))}
           </PrivacyFilter>
         </Text>

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -804,7 +804,7 @@ export function CustomReport() {
                       left={<Block>{balanceType}:</Block>}
                       right={
                         <Text>
-                          <PrivacyFilter blurIntensity={5}>
+                          <PrivacyFilter>
                             {amountToCurrency(data[balanceTypeOp])}
                           </PrivacyFilter>
                         </Text>

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.jsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.jsx
@@ -195,9 +195,7 @@ function NetWorthInner({ widget }) {
           <View
             style={{ ...styles.largeText, fontWeight: 400, marginBottom: 5 }}
           >
-            <PrivacyFilter blurIntensity={5}>
-              {integerToCurrency(data.netWorth)}
-            </PrivacyFilter>
+            <PrivacyFilter>{integerToCurrency(data.netWorth)}</PrivacyFilter>
           </View>
           <PrivacyFilter>
             <Change amount={data.totalChange} />

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -515,7 +515,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       }
                       right={
                         <Text style={{ fontWeight: 600 }}>
-                          <PrivacyFilter blurIntensity={5}>
+                          <PrivacyFilter>
                             {amountToCurrency(
                               Math.abs(data.intervalData[todayDay].budget),
                             )}

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -474,7 +474,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                         }
                         right={
                           <Text style={{ fontWeight: 600 }}>
-                            <PrivacyFilter blurIntensity={5}>
+                            <PrivacyFilter>
                               {amountToCurrency(
                                 Math.abs(data.intervalData[todayDay].compare),
                               )}
@@ -494,7 +494,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                         }
                         right={
                           <Text style={{ fontWeight: 600 }}>
-                            <PrivacyFilter blurIntensity={5}>
+                            <PrivacyFilter>
                               {amountToCurrency(
                                 Math.abs(data.intervalData[todayDay].compareTo),
                               )}
@@ -535,7 +535,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       }
                       right={
                         <Text style={{ fontWeight: 600 }}>
-                          <PrivacyFilter blurIntensity={5}>
+                          <PrivacyFilter>
                             {amountToCurrency(
                               Math.abs(data.intervalData[todayDay].average),
                             )}

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -197,11 +197,6 @@ export function Cell({
         privacyFilter={mergeConditionalPrivacyFilterProps(
           {
             activationFilters: [!focused, !exposed],
-            style: {
-              position: 'absolute',
-              width: '100%',
-              height: '100%',
-            },
           },
           privacyFilter,
         )}

--- a/packages/desktop-client/src/fonts.scss
+++ b/packages/desktop-client/src/fonts.scss
@@ -2,3 +2,5 @@
   $inter-font-path: '../../../node_modules/inter-ui/Inter (web)'
 );
 @include variable.default;
+
+@import "@fontsource/redacted-script";

--- a/upcoming-release-notes/3377.md
+++ b/upcoming-release-notes/3377.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [olets]
+---
+
+Privacy mode: instead of blurring, use an illegible font (#3376)

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,6 +59,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/web@workspace:packages/desktop-client"
   dependencies:
+    "@fontsource/redacted-script": "npm:^5.0.21"
     "@juggle/resize-observer": "npm:^3.4.0"
     "@playwright/test": "npm:1.41.1"
     "@rollup/plugin-inject": "npm:^5.0.5"
@@ -1843,6 +1844,13 @@ __metadata:
   version: 8.57.0
   resolution: "@eslint/js@npm:8.57.0"
   checksum: 10/3c501ce8a997cf6cbbaf4ed358af5492875e3550c19b9621413b82caa9ae5382c584b0efa79835639e6e0ddaa568caf3499318e5bdab68643ef4199dce5eb0a0
+  languageName: node
+  linkType: hard
+
+"@fontsource/redacted-script@npm:^5.0.21":
+  version: 5.0.21
+  resolution: "@fontsource/redacted-script@npm:5.0.21"
+  checksum: 10/93f506c9e8df827ab1872d433a09079c592f3a20a1c36b9a168e68377967d3d1d282fffd51bee973c2ecb253316ff4641d244f8f05242e4aa968a1eb14d065eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- For #3376

Instead of blurring, uses the font Redacted Script https://github.com/christiannaths/redacted-font#redacted-script.

The good: much more private

Edit: the following limitation no longer applies (see https://github.com/actualbudget/actual/pull/3377#pullrequestreview-2287013488)

~The touchy: this font's sizing isn't identical to the non-private font. In some cases there's a minor layout shift on hover, and/or when toggling between modes.~

~The implementation support per-element `line-height` customization, and could easily be extended to support per-element `letter-spacing`. I haven't gone deep down that rabbit hole, only customizing line height on the two large font size numbers, where the difference is more significant.~

<details><summary>screenshot</summary><img width="1145" alt="image" src="https://github.com/user-attachments/assets/417e6046-c1dc-4a0c-8052-1be366b5bc84">
</details>

<details><summary> screencap, updated</summary>

https://github.com/user-attachments/assets/0be1ffdb-4371-4994-b5f4-76374b39b3d3

</details>

<details><summary>OLD outdated screencapture, for posterity</summary>

https://github.com/user-attachments/assets/7752efe8-0f6b-4f65-9805-f1db82c56fdd

</details>

