### PR TITLE
Refine `Menu`/`Select` types to allow broader types for the `value`/`name` attribute

### DIFF
--- a/packages/desktop-client/src/components/common/Select.tsx
+++ b/packages/desktop-client/src/components/common/Select.tsx
@@ -8,15 +8,17 @@ import { Menu } from './Menu';
 import { Popover } from './Popover';
 import { View } from './View';
 
-function isValueOption<Value extends string>(
-  option: [Value, string] | typeof Menu.line,
+function isValueOption<Value>(
+  option: readonly [Value, string] | typeof Menu.line,
 ): option is [Value, string] {
   return option !== Menu.line;
 }
 
-type SelectProps<Value extends string> = {
+export type SelectOption<Value = string> = [Value, string] | typeof Menu.line;
+
+type SelectProps<Value> = {
   bare?: boolean;
-  options: Array<[Value, string] | typeof Menu.line>;
+  options: Array<readonly [Value, string] | typeof Menu.line>;
   value: Value;
   defaultLabel?: string;
   onChange?: (newValue: Value) => void;
@@ -38,7 +40,7 @@ type SelectProps<Value extends string> = {
  * // <Select options={[['1', 'Option 1'], ['2', 'Option 2']]} value="1" onChange={handleOnChange} />
  * // <Select options={[['1', 'Option 1'], ['2', 'Option 2']]} value="3" defaultLabel="Select an option"  onChange={handleOnChange} />
  */
-export function Select<Value extends string>({
+export function Select<const Value = string>({
   bare,
   options,
   value,

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState, type ComponentProps } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import { type CategoryEntity } from 'loot-core/types/models/category';
@@ -12,7 +12,7 @@ import { Information } from '../alerts';
 import { Button } from '../common/Button2';
 import { Menu } from '../common/Menu';
 import { Popover } from '../common/Popover';
-import { Select } from '../common/Select';
+import { Select, type SelectOption } from '../common/Select';
 import { Text } from '../common/Text';
 import { Tooltip } from '../common/Tooltip';
 import { View } from '../common/View';
@@ -139,10 +139,9 @@ export function ReportSidebar({
   };
 
   const rangeOptions = useMemo(() => {
-    const options: ComponentProps<typeof Select>['options'] =
-      ReportOptions.dateRange
-        .filter(f => f[customReportItems.interval as keyof dateRangeProps])
-        .map(option => [option.description, option.description]);
+    const options: SelectOption[] = ReportOptions.dateRange
+      .filter(f => f[customReportItems.interval as keyof dateRangeProps])
+      .map(option => [option.description, option.description]);
 
     // Append separator if necessary
     if (dateRangeLine > 0) {

--- a/packages/desktop-client/src/components/reports/SaveReportMenu.tsx
+++ b/packages/desktop-client/src/components/reports/SaveReportMenu.tsx
@@ -1,6 +1,6 @@
-import React, { type ComponentPropsWithoutRef } from 'react';
+import React from 'react';
 
-import { Menu } from '../common/Menu';
+import { Menu, type MenuItem } from '../common/Menu';
 
 export function SaveReportMenu({
   onMenuSelect,
@@ -11,65 +11,55 @@ export function SaveReportMenu({
   savedStatus: string;
   listReports: number;
 }) {
-  const savedMenu: ComponentPropsWithoutRef<typeof Menu> =
+  const savedMenu: MenuItem[] =
     savedStatus === 'saved'
-      ? {
-          items: [
-            { name: 'rename-report', text: 'Rename' },
-            { name: 'delete-report', text: 'Delete' },
-            Menu.line,
-          ],
-        }
-      : {
-          items: [],
-        };
+      ? [
+          { name: 'rename-report', text: 'Rename' },
+          { name: 'delete-report', text: 'Delete' },
+          Menu.line,
+        ]
+      : [];
 
-  const modifiedMenu: ComponentPropsWithoutRef<typeof Menu> =
+  const modifiedMenu: MenuItem[] =
     savedStatus === 'modified'
-      ? {
-          items: [
-            { name: 'rename-report', text: 'Rename' },
-            {
-              name: 'update-report',
-              text: 'Update report',
-            },
-            {
-              name: 'reload-report',
-              text: 'Revert changes',
-            },
-            { name: 'delete-report', text: 'Delete' },
-            Menu.line,
-          ],
-        }
-      : {
-          items: [],
-        };
+      ? [
+          { name: 'rename-report', text: 'Rename' },
+          {
+            name: 'update-report',
+            text: 'Update report',
+          },
+          {
+            name: 'reload-report',
+            text: 'Revert changes',
+          },
+          { name: 'delete-report', text: 'Delete' },
+          Menu.line,
+        ]
+      : [];
 
-  const unsavedMenu: ComponentPropsWithoutRef<typeof Menu> = {
-    items: [
-      {
-        name: 'save-report',
-        text: 'Save new report',
-      },
-      {
-        name: 'reset-report',
-        text: 'Reset to default',
-      },
-      Menu.line,
-      {
-        name: 'choose-report',
-        text: 'Choose Report',
-        disabled: listReports > 0 ? false : true,
-      },
-    ],
-  };
+  const unsavedMenu: MenuItem[] = [
+    {
+      name: 'save-report',
+      text: 'Save new report',
+    },
+    {
+      name: 'reset-report',
+      text: 'Reset to default',
+    },
+    Menu.line,
+    {
+      name: 'choose-report',
+      text: 'Choose Report',
+      disabled: listReports > 0 ? false : true,
+    },
+  ];
 
   return (
     <Menu
       onMenuSelect={item => {
         onMenuSelect(item);
       }}
-      items={[...savedMenu.items, ...modifiedMenu.items, ...unsavedMenu.items]}
+      items={[...savedMenu, ...modifiedMenu, ...unsavedMenu]}
     />
   );
 }

--- a/upcoming-release-notes/3391.md
+++ b/upcoming-release-notes/3391.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Refine Menu/Select types to allow broader types for the value/name attribute


### PR DESCRIPTION
This is useful in general but in particular for migrating some components such as `RecurringSchedulePicker` to TypeScript—these components use non-string types for values (e.g. `number`).

The non-`Select` non-`Menu` component changes are to switch those components to use the correct types instead of inferring from the props of `Select`/`Menu`. Using props doesn't play well with generics.