### PR TITLE
🔧 Prevent sidebar from saving to metadata until resize is complete

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Sidebar.tsx
+++ b/packages/desktop-client/src/components/sidebar/Sidebar.tsx
@@ -50,14 +50,25 @@ export function Sidebar() {
   const [isFloating = false, setFloatingSidebarPref] =
     useGlobalPref('floatingSidebar');
 
-  const [_sidebarWidth, setSidebarWidth] = useLocalPref('sidebarWidth');
+  const [sidebarWidthLocalPref, setSidebarWidthLocalPref] =
+    useLocalPref('sidebarWidth');
   const DEFAULT_SIDEBAR_WIDTH = 240;
   const MAX_SIDEBAR_WIDTH = width / 3;
   const MIN_SIDEBAR_WIDTH = 200;
-  const sidebarWidth = Math.min(
-    MAX_SIDEBAR_WIDTH,
-    Math.max(MIN_SIDEBAR_WIDTH, _sidebarWidth || DEFAULT_SIDEBAR_WIDTH),
+
+  const [sidebarWidth, setSidebarWidth] = useState(
+    Math.min(
+      MAX_SIDEBAR_WIDTH,
+      Math.max(
+        MIN_SIDEBAR_WIDTH,
+        sidebarWidthLocalPref || DEFAULT_SIDEBAR_WIDTH,
+      ),
+    ),
   );
+
+  const onResizeStop = () => {
+    setSidebarWidthLocalPref(sidebarWidth);
+  };
 
   async function onReorder(
     id: string,
@@ -95,6 +106,7 @@ export function Sidebar() {
         width: sidebarWidth,
         height: '100%',
       }}
+      onResizeStop={onResizeStop}
       maxWidth={MAX_SIDEBAR_WIDTH}
       minWidth={MIN_SIDEBAR_WIDTH}
       enable={{

--- a/upcoming-release-notes/3393.md
+++ b/upcoming-release-notes/3393.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Prevent sidebar from saving to metadata.json unnecessarily


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The sidebar is saving to metadata.json every time the window is resized and on every movement while being dragged.
![Recording 2024-09-08 at 10 27 32](https://github.com/user-attachments/assets/fd38b999-14be-4aaa-80f6-64d816ea06ba)

This fix makes it save when the drag has ended.

I looked into this due to this bug: https://github.com/actualbudget/actual/issues/3390 . I'm doubtful that it will fix it, but it's the only thing I can see that's saving to metadata.json a lot.