### PR TITLE
:recycle: (synced-prefs) refactor some SyncedPrefs to string type

### DIFF
--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -60,15 +60,16 @@ type PrivacyButtonProps = {
 };
 
 function PrivacyButton({ style }: PrivacyButtonProps) {
-  const [isPrivacyEnabled, setPrivacyEnabledPref] =
+  const [isPrivacyEnabledPref, setPrivacyEnabledPref] =
     useSyncedPref('isPrivacyEnabled');
+  const isPrivacyEnabled = String(isPrivacyEnabledPref) === 'true';
 
   const privacyIconStyle = { width: 15, height: 15 };
 
   useHotkeys(
     'shift+ctrl+p, shift+cmd+p, shift+meta+p',
     () => {
-      setPrivacyEnabledPref(!isPrivacyEnabled);
+      setPrivacyEnabledPref(String(!isPrivacyEnabled));
     },
     {
       preventDefault: true,
@@ -81,7 +82,7 @@ function PrivacyButton({ style }: PrivacyButtonProps) {
     <Button
       variant="bare"
       aria-label={`${isPrivacyEnabled ? 'Disable' : 'Enable'} privacy mode`}
-      onPress={() => setPrivacyEnabledPref(!isPrivacyEnabled)}
+      onPress={() => setPrivacyEnabledPref(String(!isPrivacyEnabled))}
       style={style}
     >
       {isPrivacyEnabled ? (

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1836,7 +1836,7 @@ export function Account() {
   const payees = usePayees();
   const failedAccounts = useFailedAccounts();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
   const [expandSplits] = useLocalPref('expand-splits');
   const [showBalances, setShowBalances] = useSyncedPref(
     `show-balances-${params.id}`,
@@ -1871,16 +1871,20 @@ export function Account() {
           accounts={accounts}
           failedAccounts={failedAccounts}
           dateFormat={dateFormat}
-          hideFraction={hideFraction}
+          hideFraction={String(hideFraction) === 'true'}
           expandSplits={expandSplits}
-          showBalances={showBalances}
-          setShowBalances={setShowBalances}
-          showCleared={!hideCleared}
-          setShowCleared={val => setHideCleared(!val)}
-          showReconciled={!hideReconciled}
-          setShowReconciled={val => setHideReconciled(!val)}
-          showExtraBalances={showExtraBalances}
-          setShowExtraBalances={setShowExtraBalances}
+          showBalances={String(showBalances) === 'true'}
+          setShowBalances={showBalances =>
+            setShowBalances(String(showBalances))
+          }
+          showCleared={String(hideCleared) !== 'true'}
+          setShowCleared={val => setHideCleared(String(!val))}
+          showReconciled={String(hideReconciled) !== 'true'}
+          setShowReconciled={val => setHideReconciled(String(!val))}
+          showExtraBalances={String(showExtraBalances) === 'true'}
+          setShowExtraBalances={extraBalances =>
+            setShowExtraBalances(String(extraBalances))
+          }
           payees={payees}
           modalShowing={modalShowing}
           accountsSyncing={accountsSyncing}

--- a/packages/desktop-client/src/components/mobile/accounts/Account.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Account.jsx
@@ -22,7 +22,7 @@ export function Account() {
 
   const [_numberFormat] = useSyncedPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const { id: accountId } = useParams();
 

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.jsx
@@ -31,7 +31,6 @@ import { isPreviewId } from 'loot-core/shared/transactions';
 import { useDateFormat } from '../../../hooks/useDateFormat';
 import { useNavigate } from '../../../hooks/useNavigate';
 import { usePreviewTransactions } from '../../../hooks/usePreviewTransactions';
-import { useSyncedPref } from '../../../hooks/useSyncedPref';
 import { styles, theme } from '../../../style';
 import { Text } from '../../common/Text';
 import { View } from '../../common/View';
@@ -153,7 +152,6 @@ function TransactionListWithPreviews({ account }) {
   );
 
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
-  const [_numberFormat] = useSyncedPref('numberFormat');
   const dispatch = useDispatch();
   const navigate = useNavigate();
 

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -251,7 +251,7 @@ export function Accounts() {
   const updatedAccounts = useSelector(state => state.queries.updatedAccounts);
   const [_numberFormat] = useSyncedPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const navigate = useNavigate();
 

--- a/packages/desktop-client/src/components/mobile/budget/Category.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/Category.tsx
@@ -14,7 +14,7 @@ export function Category() {
   useSetThemeColor(theme.mobileViewTheme);
   const [_numberFormat] = useSyncedPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const { id: categoryId } = useParams();
   const [searchParams] = useSearchParams();

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.jsx
@@ -13,7 +13,6 @@ import { isPreviewId } from 'loot-core/shared/transactions';
 
 import { useDateFormat } from '../../../hooks/useDateFormat';
 import { useNavigate } from '../../../hooks/useNavigate';
-import { useSyncedPref } from '../../../hooks/useSyncedPref';
 import { TextOneLine } from '../../common/TextOneLine';
 import { View } from '../../common/View';
 import { MobilePageHeader, Page } from '../../Page';
@@ -29,7 +28,6 @@ export function CategoryTransactions({ category, month }) {
   const [transactions, setTransactions] = useState([]);
 
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
-  const [_numberFormat] = useSyncedPref('numberFormat');
 
   const makeRootQuery = useCallback(
     () =>

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -38,6 +38,10 @@ import { SyncRefresh } from '../../SyncRefresh';
 
 import { BudgetTable } from './BudgetTable';
 
+function isBudgetType(input?: string): input is 'rollover' | 'report' {
+  return ['rollover', 'report'].includes(input);
+}
+
 type BudgetInnerProps = {
   categories: CategoryEntity[];
   categoryGroups: CategoryGroupEntity[];
@@ -462,14 +466,14 @@ function BudgetInner(props: BudgetInnerProps) {
 
 export function Budget() {
   const { list: categories, grouped: categoryGroups } = useCategories();
-  const [budgetType = 'rollover'] = useSyncedPref('budgetType');
+  const [budgetType] = useSyncedPref('budgetType');
   const spreadsheet = useSpreadsheet();
   useSetThemeColor(theme.mobileViewTheme);
   return (
     <BudgetInner
       categoryGroups={categoryGroups}
       categories={categories}
-      budgetType={budgetType}
+      budgetType={isBudgetType(budgetType) ? budgetType : 'rollover'}
       spreadsheet={spreadsheet}
     />
   );

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -64,7 +64,7 @@ function BudgetInner(props: BudgetInnerProps) {
 
   const [_numberFormat] = useSyncedPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -46,7 +46,7 @@ const AmountInput = memo(function AmountInput({
   const [text, setText] = useState('');
   const [value, setValue] = useState(0);
   const inputRef = useRef<HTMLInputElement>();
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const mergedInputRef = useMergedRefs<HTMLInputElement>(
     props.inputRef,
@@ -107,7 +107,7 @@ const AmountInput = memo(function AmountInput({
   };
 
   const onChangeText = (text: string) => {
-    text = appendDecimals(text, hideFraction);
+    text = appendDecimals(text, String(hideFraction) === 'true');
     setEditing(true);
     setText(text);
     props.onChangeValue?.(text);

--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -875,13 +875,13 @@ export function ImportTransactions({ options }) {
       (filename.endsWith('.tsv') ? '\t' : ','),
   );
   const [skipLines, setSkipLines] = useState(
-    prefs[`csv-skip-lines-${accountId}`] ?? 0,
+    parseInt(prefs[`csv-skip-lines-${accountId}`], 10) || 0,
   );
   const [hasHeaderRow, setHasHeaderRow] = useState(
-    prefs[`csv-has-header-${accountId}`] ?? true,
+    String(prefs[`csv-has-header-${accountId}`]) !== 'false',
   );
   const [fallbackMissingPayeeToMemo, setFallbackMissingPayeeToMemo] = useState(
-    prefs[`ofx-fallback-missing-payee-${accountId}`] ?? true,
+    String(prefs[`ofx-fallback-missing-payee-${accountId}`]) !== 'false',
   );
 
   const [parseDateFormat, setParseDateFormat] = useState(null);
@@ -923,7 +923,8 @@ export function ImportTransactions({ options }) {
       let parseDateFormat = null;
 
       if (filetype === 'csv' || filetype === 'qif') {
-        flipAmount = prefs[`flip-amount-${accountId}-${filetype}`] || false;
+        flipAmount =
+          String(prefs[`flip-amount-${accountId}-${filetype}`]) === 'true';
         setFlipAmount(flipAmount);
       }
 
@@ -1186,7 +1187,9 @@ export function ImportTransactions({ options }) {
 
     if (isOfxFile(filetype)) {
       savePrefs({
-        [`ofx-fallback-missing-payee-${accountId}`]: fallbackMissingPayeeToMemo,
+        [`ofx-fallback-missing-payee-${accountId}`]: String(
+          fallbackMissingPayeeToMemo,
+        ),
       });
     }
 
@@ -1195,12 +1198,14 @@ export function ImportTransactions({ options }) {
         [`csv-mappings-${accountId}`]: JSON.stringify(fieldMappings),
       });
       savePrefs({ [`csv-delimiter-${accountId}`]: delimiter });
-      savePrefs({ [`csv-has-header-${accountId}`]: hasHeaderRow });
-      savePrefs({ [`csv-skip-lines-${accountId}`]: skipLines });
+      savePrefs({ [`csv-has-header-${accountId}`]: String(hasHeaderRow) });
+      savePrefs({ [`csv-skip-lines-${accountId}`]: String(skipLines) });
     }
 
     if (filetype === 'csv' || filetype === 'qif') {
-      savePrefs({ [`flip-amount-${accountId}-${filetype}`]: flipAmount });
+      savePrefs({
+        [`flip-amount-${accountId}-${filetype}`]: String(flipAmount),
+      });
     }
 
     const didChange = await importTransactions(

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -36,7 +36,7 @@ function FeatureToggle({
       <Checkbox
         checked={enabled}
         onChange={() => {
-          setFlagPref(!enabled);
+          setFlagPref(String(!enabled));
         }}
         disabled={disableToggle}
       />

--- a/packages/desktop-client/src/components/settings/Format.tsx
+++ b/packages/desktop-client/src/components/settings/Format.tsx
@@ -62,8 +62,7 @@ export function FormatSettings() {
   const [, setDateFormatPref] = useSyncedPref('dateFormat');
   const [_numberFormat, setNumberFormatPref] = useSyncedPref('numberFormat');
   const numberFormat = _numberFormat || 'comma-dot';
-  const [hideFraction = false, setHideFractionPref] =
-    useSyncedPref('hideFraction');
+  const [hideFraction, setHideFractionPref] = useSyncedPref('hideFraction');
 
   const selectButtonStyle: CSSProperties = {
     ':hover': {
@@ -95,7 +94,7 @@ export function FormatSettings() {
               onChange={format => setNumberFormatPref(format)}
               options={numberFormats.map(f => [
                 f.value,
-                hideFraction ? f.labelNoFraction : f.label,
+                String(hideFraction) === 'true' ? f.labelNoFraction : f.label,
               ])}
               buttonStyle={selectButtonStyle}
             />
@@ -103,8 +102,10 @@ export function FormatSettings() {
             <Text style={{ display: 'flex' }}>
               <Checkbox
                 id="settings-textDecimal"
-                checked={!!hideFraction}
-                onChange={e => setHideFractionPref(e.currentTarget.checked)}
+                checked={String(hideFraction) === 'true'}
+                onChange={e =>
+                  setHideFractionPref(String(e.currentTarget.checked))
+                }
               />
               <label htmlFor="settings-textDecimal">Hide decimal places</label>
             </Text>

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -63,7 +63,7 @@ export function AmountInput({
   const buttonRef = useRef();
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
-  const [hideFraction = false] = useSyncedPref('hideFraction');
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   useEffect(() => {
     if (focused) {
@@ -81,7 +81,9 @@ export function AmountInput({
   }
 
   function onInputTextChange(val) {
-    val = autoDecimals ? appendDecimals(val, hideFraction) : val;
+    val = autoDecimals
+      ? appendDecimals(val, String(hideFraction) === 'true')
+      : val;
     setValue(val ? val : '');
     onChangeValue?.(val);
   }

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -17,6 +17,6 @@ export function useFeatureFlag(name: FeatureFlag): boolean {
 
     return value === undefined
       ? DEFAULT_FEATURE_FLAG_STATE[name] || false
-      : value;
+      : String(value) === 'true';
   });
 }

--- a/packages/desktop-client/src/hooks/usePrivacyMode.ts
+++ b/packages/desktop-client/src/hooks/usePrivacyMode.ts
@@ -4,6 +4,6 @@ import { type State } from 'loot-core/src/client/state-types';
 
 export function usePrivacyMode() {
   return useSelector(
-    (state: State) => state.prefs.local?.isPrivacyEnabled ?? false,
+    (state: State) => String(state.prefs.local?.isPrivacyEnabled) === 'true',
   );
 }

--- a/packages/desktop-client/src/hooks/usePrivacyMode.ts
+++ b/packages/desktop-client/src/hooks/usePrivacyMode.ts
@@ -1,9 +1,6 @@
-import { useSelector } from 'react-redux';
-
-import { type State } from 'loot-core/src/client/state-types';
+import { useSyncedPref } from './useSyncedPref';
 
 export function usePrivacyMode() {
-  return useSelector(
-    (state: State) => String(state.prefs.local?.isPrivacyEnabled) === 'true',
-  );
+  const [isPrivacyEnabled] = useSyncedPref('isPrivacyEnabled');
+  return String(isPrivacyEnabled) === 'true';
 }

--- a/packages/loot-core/src/client/reducers/prefs.ts
+++ b/packages/loot-core/src/client/reducers/prefs.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { setNumberFormat } from '../../shared/util';
+import { isNumberFormat, setNumberFormat } from '../../shared/util';
 import * as constants from '../constants';
 import type { Action } from '../state-types';
 import type { PrefsState } from '../state-types/prefs';
@@ -14,7 +14,9 @@ export function update(state = initialState, action: Action): PrefsState {
     case constants.SET_PREFS:
       if (action.prefs) {
         setNumberFormat({
-          format: action.prefs.numberFormat || 'comma-dot',
+          format: isNumberFormat(action.prefs.numberFormat)
+            ? action.prefs.numberFormat
+            : 'comma-dot',
           hideFraction: action.prefs.hideFraction,
         });
       }
@@ -22,7 +24,11 @@ export function update(state = initialState, action: Action): PrefsState {
     case constants.MERGE_LOCAL_PREFS:
       if (action.prefs.numberFormat || action.prefs.hideFraction != null) {
         setNumberFormat({
-          format: action.prefs.numberFormat || state.local.numberFormat,
+          format: isNumberFormat(action.prefs.numberFormat)
+            ? action.prefs.numberFormat
+            : isNumberFormat(state.local.numberFormat)
+              ? state.local.numberFormat
+              : 'comma-dot',
           hideFraction:
             action.prefs.hideFraction != null
               ? action.prefs.hideFraction

--- a/packages/loot-core/src/client/reducers/prefs.ts
+++ b/packages/loot-core/src/client/reducers/prefs.ts
@@ -17,7 +17,7 @@ export function update(state = initialState, action: Action): PrefsState {
           format: isNumberFormat(action.prefs.numberFormat)
             ? action.prefs.numberFormat
             : 'comma-dot',
-          hideFraction: action.prefs.hideFraction,
+          hideFraction: String(action.prefs.hideFraction) === 'true',
         });
       }
       return { local: action.prefs, global: action.globalPrefs };
@@ -30,9 +30,11 @@ export function update(state = initialState, action: Action): PrefsState {
               ? state.local.numberFormat
               : 'comma-dot',
           hideFraction:
-            action.prefs.hideFraction != null
-              ? action.prefs.hideFraction
-              : state.local.hideFraction,
+            String(
+              action.prefs.hideFraction != null
+                ? action.prefs.hideFraction
+                : state.local.hideFraction,
+            ) === 'true',
         });
       }
 

--- a/packages/loot-core/src/client/selectors.ts
+++ b/packages/loot-core/src/client/selectors.ts
@@ -13,6 +13,6 @@ const getLocalPrefsState = createSelector(getPrefsState, prefs => prefs.local);
 export const selectNumberFormat = createSelector(getLocalPrefsState, prefs =>
   getNumberFormat({
     format: isNumberFormat(prefs.numberFormat) ? prefs.numberFormat : undefined,
-    hideFraction: prefs.hideFraction,
+    hideFraction: String(prefs.hideFraction) === 'true',
   }),
 );

--- a/packages/loot-core/src/client/selectors.ts
+++ b/packages/loot-core/src/client/selectors.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { createSelector } from 'reselect';
 
-import { getNumberFormat } from '../shared/util';
+import { getNumberFormat, isNumberFormat } from '../shared/util';
 
 import type { State } from './state-types';
 
@@ -12,7 +12,7 @@ const getLocalPrefsState = createSelector(getPrefsState, prefs => prefs.local);
 
 export const selectNumberFormat = createSelector(getLocalPrefsState, prefs =>
   getNumberFormat({
-    format: prefs.numberFormat,
+    format: isNumberFormat(prefs.numberFormat) ? prefs.numberFormat : undefined,
     hideFraction: prefs.hideFraction,
   }),
 );

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -222,12 +222,20 @@ export function appendDecimals(
   return amountToCurrency(currencyToAmount(result));
 }
 
-type NumberFormats =
-  | 'comma-dot'
-  | 'dot-comma'
-  | 'space-comma'
-  | 'apostrophe-dot'
-  | 'comma-dot-in';
+const NUMBER_FORMATS = [
+  'comma-dot',
+  'dot-comma',
+  'space-comma',
+  'apostrophe-dot',
+  'comma-dot',
+  'comma-dot-in',
+] as const;
+
+type NumberFormats = (typeof NUMBER_FORMATS)[number];
+
+export function isNumberFormat(input: string): input is NumberFormats {
+  return (NUMBER_FORMATS as readonly string[]).includes(input);
+}
 
 export const numberFormats: Array<{
   value: NumberFormats;

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -14,14 +14,9 @@ export type FeatureFlag =
  */
 export type SyncedPrefs = Partial<
   {
-    firstDayOfWeekIdx: `${0 | 1 | 2 | 3 | 4 | 5 | 6}`;
-    dateFormat:
-      | 'MM/dd/yyyy'
-      | 'dd/MM/yyyy'
-      | 'yyyy-MM-dd'
-      | 'MM.dd.yyyy'
-      | 'dd.MM.yyyy';
-    numberFormat: (typeof numberFormats)[number]['value'];
+    firstDayOfWeekIdx: string;
+    dateFormat: string;
+    numberFormat: string;
     hideFraction: boolean;
     isPrivacyEnabled: boolean;
     [key: `show-balances-${string}`]: boolean;
@@ -31,13 +26,13 @@ export type SyncedPrefs = Partial<
     // TODO: pull from src/components/modals/ImportTransactions.js
     [key: `parse-date-${string}-${'csv' | 'qif'}`]: string;
     [key: `csv-mappings-${string}`]: string;
-    [key: `csv-delimiter-${string}`]: ',' | ';' | '\t';
+    [key: `csv-delimiter-${string}`]: string;
     [key: `csv-skip-lines-${string}`]: number;
     [key: `csv-has-header-${string}`]: boolean;
     [key: `ofx-fallback-missing-payee-${string}`]: boolean;
     [key: `flip-amount-${string}-${'csv' | 'qif'}`]: boolean;
-    budgetType: 'report' | 'rollover';
-  } & Record<`flags.${FeatureFlag}`, boolean>
+    budgetType: string;
+  } & Record<`flags.${FeatureFlag}`, string>
 >;
 
 /**

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -1,5 +1,3 @@
-import { type numberFormats } from '../shared/util';
-
 import { spendingReportTimeType } from './models/reports';
 
 export type FeatureFlag =

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -11,26 +11,28 @@ export type FeatureFlag =
  * Cross-device preferences. These sync across devices when they are changed.
  */
 export type SyncedPrefs = Partial<
-  {
-    firstDayOfWeekIdx: string;
-    dateFormat: string;
-    numberFormat: string;
-    hideFraction: boolean;
-    isPrivacyEnabled: boolean;
-    [key: `show-balances-${string}`]: boolean;
-    [key: `show-extra-balances-${string}`]: boolean;
-    [key: `hide-cleared-${string}`]: boolean;
-    [key: `hide-reconciled-${string}`]: boolean;
+  Record<
+    | 'firstDayOfWeekIdx'
+    | 'dateFormat'
+    | 'numberFormat'
+    | 'hideFraction'
+    | 'isPrivacyEnabled'
+    | `show-balances-${string}`
+    | `show-extra-balances-${string}`
+    | `hide-cleared-${string}`
+    | `hide-reconciled-${string}`
     // TODO: pull from src/components/modals/ImportTransactions.js
-    [key: `parse-date-${string}-${'csv' | 'qif'}`]: string;
-    [key: `csv-mappings-${string}`]: string;
-    [key: `csv-delimiter-${string}`]: string;
-    [key: `csv-skip-lines-${string}`]: number;
-    [key: `csv-has-header-${string}`]: boolean;
-    [key: `ofx-fallback-missing-payee-${string}`]: boolean;
-    [key: `flip-amount-${string}-${'csv' | 'qif'}`]: boolean;
-    budgetType: string;
-  } & Record<`flags.${FeatureFlag}`, string>
+    | `parse-date-${string}-${'csv' | 'qif'}`
+    | `csv-mappings-${string}`
+    | `csv-delimiter-${string}`
+    | `csv-skip-lines-${string}`
+    | `csv-has-header-${string}`
+    | `ofx-fallback-missing-payee-${string}`
+    | `flip-amount-${string}-${'csv' | 'qif'}`
+    | 'budgetType'
+    | `flags.${FeatureFlag}`,
+    string
+  >
 >;
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,14 +31,14 @@
     "noEmit": true,
     "paths": {
       // until we turn on composite/references
-      "loot-core/*": ["./packages/loot-core/src/*"],
+      "loot-core/*": ["./packages/loot-core/src/*"]
     },
     "plugins": [
       {
         "name": "typescript-strict-plugin",
-        "path": ["./packages"],
-      },
-    ],
+        "path": ["./packages"]
+      }
+    ]
   },
   "include": ["packages/**/*"],
   "exclude": [
@@ -48,10 +48,11 @@
     "**/client-build/*",
     "**/dist/*",
     "**/lib-dist/*",
+    "**/test-results/*"
   ],
   "ts-node": {
     "compilerOptions": {
-      "module": "CommonJS",
-    },
-  },
+      "module": "CommonJS"
+    }
+  }
 }

--- a/upcoming-release-notes/3395.md
+++ b/upcoming-release-notes/3395.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+SyncedPrefs: refactor pref values from explicit types to `string` (pt.1)

--- a/upcoming-release-notes/3395.md
+++ b/upcoming-release-notes/3395.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MatissJanis]
 ---
 
-SyncedPrefs: refactor pref values from explicit types to `string` (pt.1)
+SyncedPrefs: refactor pref values from explicit types to `string`.


### PR DESCRIPTION
We discussed this in private among the maintainers, but here's the TLDR:

SyncedPrefs are getting moved to the database. The database for synced prefs no notion of data types of the values (i.e. number, boolean, enum). All the values there are treated as `string`.

Which means we need to decide between:

1. using `string` for all the values in the UI code as well or
2. implement conversion/type-guard logic inside the `useSyncedPrefs`

We decided to go with (1) because that's generally the more simple solution. (2) would require implementation of lots of logic which would make the seemingly simple hook very verbose.

This PR converts the SyncedPrefs to `string` type.