### PR TITLE
🔧 Prevent metadata.json update if the sync time value is the same 

### DIFF
--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -768,11 +768,15 @@ async function _fullSync(
       ),
     );
   } else {
-    // All synced up, store the current time as a simple optimization
-    // for the next sync
-    await prefs.savePrefs({
-      lastSyncedTimestamp: getClock().timestamp.toString(),
-    });
+    // All synced up, store the current time as a simple optimization for the next sync
+    const requiresUpdate =
+      getClock().timestamp.toString() !== lastSyncedTimestamp;
+
+    if (requiresUpdate) {
+      await prefs.savePrefs({
+        lastSyncedTimestamp: getClock().timestamp.toString(),
+      });
+    }
   }
 
   return receivedMessages;

--- a/upcoming-release-notes/3398.md
+++ b/upcoming-release-notes/3398.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Prevent sync from saving to metadata.json unnecessarily


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The sync gets fired when the user changes focus to the Actual app - this can cause unnecessary updates to metadata.json. 

This change checks the current sync time and skips updating the metadata.json if the value is the same.

Evidence: 
![metadata json #2](https://github.com/user-attachments/assets/b86a8289-d6ac-4f5e-8acf-1a68fe4826a2)

This may help with #3390
