### PR TITLE
Update splash background to match theming

### DIFF
--- a/packages/desktop-client/public/site.webmanifest
+++ b/packages/desktop-client/public/site.webmanifest
@@ -1,89 +1,89 @@
 {
-    "name": "Actual",
-    "short_name": "Actual",
-    "description": "A local-first personal finance tool",
-    "icons": [
+  "name": "Actual",
+  "short_name": "Actual",
+  "description": "A local-first personal finance tool",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/maskable-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/maskable-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "Add Transaction",
+      "short_name": "Add Transaction",
+      "description": "Add a new transaction",
+      "url": "/transactions/new",
+      "icons": [
         {
-            "src": "/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png",
-            "purpose": "any"
-        },
-        {
-            "src": "/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png",
-            "purpose": "any"
-        },
-        {
-            "src": "/maskable-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png",
-            "purpose": "maskable"
-        },
-        {
-            "src": "/maskable-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png",
-            "purpose": "maskable"
+          "src": "/shortcut-transaction.svg",
+          "sizes": "150x150"
         }
-    ],
-    "shortcuts": [
+      ]
+    },
+    {
+      "name": "Accounts",
+      "short_name": "Accounts",
+      "description": "View all accounts",
+      "url": "/accounts",
+      "icons": [
         {
-            "name": "Add Transaction",
-            "short_name": "Add Transaction",
-            "description": "Add a new transaction",
-            "url": "/transactions/new",
-            "icons": [
-                {
-                    "src": "/shortcut-transaction.svg",
-                    "sizes": "150x150"
-                }
-            ]
-        },
-        {
-            "name": "Accounts",
-            "short_name": "Accounts",
-            "description": "View all accounts",
-            "url": "/accounts",
-            "icons": [
-                {
-                    "src": "/shortcut-accounts.svg",
-                    "sizes": "150x150"
-                }
-            ]
-        },
-        {
-            "name": "Reports",
-            "short_name": "Reports",
-            "description": "View reports",
-            "url": "/reports",
-            "icons": [
-                {
-                    "src": "/shortcut-reports.svg",
-                    "sizes": "150x150"
-                }
-            ]
+          "src": "/shortcut-accounts.svg",
+          "sizes": "150x150"
         }
-    ],
-    "screenshots": [
+      ]
+    },
+    {
+      "name": "Reports",
+      "short_name": "Reports",
+      "description": "View reports",
+      "url": "/reports",
+      "icons": [
         {
-            "src": "/screenshot_wide.png",
-            "form_factor": "wide",
-            "label": "Actual Budget Homepage",
-            "type": "image/png",
-            "sizes": "1280x720"
-        },
-        {
-            "src": "/screenshot_narrow.png",
-            "form_factor": "narrow",
-            "label": "Actual Budget Mobile Homepage",
-            "type": "image/png",
-            "sizes": "350x600"
+          "src": "/shortcut-reports.svg",
+          "sizes": "150x150"
         }
-    ],
-    "theme_color": "#8812E1",
-    "background_color": "#ffffff",
-    "display": "standalone",
-    "start_url": "./"
+      ]
+    }
+  ],
+  "screenshots": [
+    {
+      "src": "/screenshot_wide.png",
+      "form_factor": "wide",
+      "label": "Actual Budget Homepage",
+      "type": "image/png",
+      "sizes": "1280x720"
+    },
+    {
+      "src": "/screenshot_narrow.png",
+      "form_factor": "narrow",
+      "label": "Actual Budget Mobile Homepage",
+      "type": "image/png",
+      "sizes": "350x600"
+    }
+  ],
+  "theme_color": "#8812E1",
+  "background_color": "#8812E1",
+  "display": "standalone",
+  "start_url": "./"
 }

--- a/upcoming-release-notes/3400.md
+++ b/upcoming-release-notes/3400.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Update splash background to match theming


### PR DESCRIPTION
I noticed that (at least on Android) the PWA looks weird when launching: the background is fully white, which makes it look like we didn't bother to theme the app. This PR updates the background color to match the theme, which I think is reasonable (e.g., my bank's app has a splash-screen background color that matches the icon). I think we could still do better (e.g., having a higher-resolution image—the current icon looks a little blurry in the screenshot below) but IMO this is an improvement.

Thoughts? If this is something we want to add, having someone test on iOS would be great (I don't have a device handy).

Recommend reviewing with whitespace diff off (my editor auto-formatted 😞).

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8f864d9b-9447-4932-a492-254f70d1bd53) | ![image](https://github.com/user-attachments/assets/4b41cba2-10ec-419c-a996-3901235d55e5) |