### PR TITLE
:electron: Adding retries in to the file system writes

### DIFF
--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -146,7 +146,7 @@ export const writeFile: T.WriteFile = async (filepath, contents) => {
 
     return undefined;
   } catch (err) {
-    console.error('Unable to recover from file lock', err);
+    console.error(`unable to recover from file lock on file ${filepath}`);
     throw err;
   }
 };

--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -146,7 +146,7 @@ export const writeFile: T.WriteFile = async (filepath, contents) => {
 
     return undefined;
   } catch (err) {
-    console.error(`unable to recover from file lock on file ${filepath}`);
+    console.error(`Unable to recover from file lock on file ${filepath}`);
     throw err;
   }
 };

--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -92,7 +92,6 @@ export const readFile: T.ReadFile = (
   filepath: string,
   encoding: 'utf8' | 'binary' | null = 'utf8',
 ) => {
-  console.info('reading the file');
   if (encoding === 'binary') {
     // `binary` is not actually a valid encoding, you pass `null` into node if
     // you want a buffer

--- a/upcoming-release-notes/3406.md
+++ b/upcoming-release-notes/3406.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Adding retries into filesystem calls to mitigate locking issues caused by virus scanners.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Should fix: #3390

Adds retries into file system write calls. This should mitigate errors caused by virus scanners locking the files shortly after they've been written to.

File system reads aren't affected by the lock, so I haven't touched them.

![showing err](https://github.com/user-attachments/assets/6afd629b-341a-4ae7-9c94-d44d503a52cf)

