### PR TITLE
:recycle: (synced-prefs) refactor ImportedTransactions usage of prefs

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactions.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactions.jsx
@@ -11,7 +11,7 @@ import {
 
 import { useActions } from '../../hooks/useActions';
 import { useDateFormat } from '../../hooks/useDateFormat';
-import { useLocalPrefs } from '../../hooks/useLocalPrefs';
+import { useSyncedPrefs } from '../../hooks/useSyncedPrefs';
 import { SvgDownAndRightArrow } from '../../icons/v2';
 import { theme, styles } from '../../style';
 import { Button, ButtonWithLoading } from '../common/Button2';
@@ -840,13 +840,12 @@ function FieldMappings({
 
 export function ImportTransactions({ options }) {
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
-  const prefs = useLocalPrefs();
+  const [prefs, savePrefs] = useSyncedPrefs();
   const {
     parseTransactions,
     importTransactions,
     importPreviewTransactions,
     getPayees,
-    savePrefs,
   } = useActions();
 
   const [multiplierAmount, setMultiplierAmount] = useState('');

--- a/packages/desktop-client/src/hooks/useSyncedPrefs.ts
+++ b/packages/desktop-client/src/hooks/useSyncedPrefs.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { savePrefs } from 'loot-core/client/actions';
+import { type SyncedPrefs } from 'loot-core/src/types/prefs';
+
+import { useLocalPrefs } from './useLocalPrefs';
+
+type SetSyncedPrefsAction = (value: Partial<SyncedPrefs>) => void;
+
+export function useSyncedPrefs(): [SyncedPrefs, SetSyncedPrefsAction] {
+  // TODO: implement real logic (follow-up PR)
+  const dispatch = useDispatch();
+  const setPrefs = useCallback<SetSyncedPrefsAction>(
+    newPrefs => {
+      dispatch(savePrefs(newPrefs));
+    },
+    [dispatch],
+  );
+
+  return [useLocalPrefs(), setPrefs];
+}

--- a/upcoming-release-notes/3408.md
+++ b/upcoming-release-notes/3408.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+SyncedPrefs: refactor `ImportTransactions` usage of prefs to use a common hook.


### PR DESCRIPTION
Refactoring SyncedPref usage in `ImportedTransaction`. This will make the migration to database-driven prefs more seamless.