### PR TITLE
:electron: Restart server silently when adding self signed cert and add some logs

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -51,6 +51,8 @@ global.Actual = {
     window.location.reload();
   },
 
+  restartElectronServer: () => {},
+
   openFileDialog: async ({ filters = [] }) => {
     return new Promise(resolve => {
       let createdElement = false;

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import {
@@ -101,9 +101,22 @@ export function ConfigServer() {
 
     if (selfSignedCertificateLocation) {
       setServerSelfSignedCert(selfSignedCertificateLocation[0]);
-      globalThis.window.Actual.relaunch(); // relaunch to use the certificate
     }
   }
+
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    // When self signed cert has changed, restart the server
+    if (isMounted.current) {
+      setLoading(true);
+      globalThis.window.Actual.restartServer(); // restart the server process to use the new certificate
+      setError(null);
+      setLoading(false);
+    } else {
+      isMounted.current = true;
+    }
+  }, [_serverSelfSignedCert]);
 
   async function onSkip() {
     await setServerUrl(null);

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -110,7 +110,7 @@ export function ConfigServer() {
     // When self signed cert has changed, restart the server
     if (isMounted.current) {
       setLoading(true);
-      globalThis.window.Actual.restartServer();
+      globalThis.window.Actual.restartElectronServer();
       setError(null);
       setLoading(false);
     } else {

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import {
@@ -34,8 +34,15 @@ export function ConfigServer() {
   }, [currentUrl]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [serverSelfSignedCert, setServerSelfSignedCert] = useGlobalPref(
+
+  const restartElectronServer = useCallback(() => {
+    globalThis.window.Actual.restartElectronServer();
+    setError(null);
+  }, []);
+
+  const [_serverSelfSignedCert, setServerSelfSignedCert] = useGlobalPref(
     'serverSelfSignedCert',
+    restartElectronServer,
   );
 
   function getErrorMessage(error: string) {
@@ -103,18 +110,6 @@ export function ConfigServer() {
       setServerSelfSignedCert(selfSignedCertificateLocation[0]);
     }
   }
-
-  const isMounted = useRef(false);
-
-  useEffect(() => {
-    // When self signed cert has changed, restart the server
-    if (isMounted.current) {
-      globalThis.window.Actual.restartElectronServer();
-      setError(null);
-    } else {
-      isMounted.current = true;
-    }
-  }, [serverSelfSignedCert]);
 
   async function onSkip() {
     await setServerUrl(null);

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -34,7 +34,7 @@ export function ConfigServer() {
   }, [currentUrl]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [_serverSelfSignedCert, setServerSelfSignedCert] = useGlobalPref(
+  const [serverSelfSignedCert, setServerSelfSignedCert] = useGlobalPref(
     'serverSelfSignedCert',
   );
 
@@ -110,13 +110,13 @@ export function ConfigServer() {
     // When self signed cert has changed, restart the server
     if (isMounted.current) {
       setLoading(true);
-      globalThis.window.Actual.restartServer(); // restart the server process to use the new certificate
+      globalThis.window.Actual.restartServer();
       setError(null);
       setLoading(false);
     } else {
       isMounted.current = true;
     }
-  }, [_serverSelfSignedCert]);
+  }, [serverSelfSignedCert]);
 
   async function onSkip() {
     await setServerUrl(null);

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -109,10 +109,8 @@ export function ConfigServer() {
   useEffect(() => {
     // When self signed cert has changed, restart the server
     if (isMounted.current) {
-      setLoading(true);
       globalThis.window.Actual.restartElectronServer();
       setError(null);
-      setLoading(false);
     } else {
       isMounted.current = true;
     }

--- a/packages/desktop-client/src/hooks/useGlobalPref.ts
+++ b/packages/desktop-client/src/hooks/useGlobalPref.ts
@@ -11,13 +11,21 @@ type SetGlobalPrefAction<K extends keyof GlobalPrefs> = (
 
 export function useGlobalPref<K extends keyof GlobalPrefs>(
   prefName: K,
+  onSaveGlobalPrefs?: () => void,
 ): [GlobalPrefs[K], SetGlobalPrefAction<K>] {
   const dispatch = useDispatch();
   const setGlobalPref = useCallback<SetGlobalPrefAction<K>>(
     value => {
-      dispatch(saveGlobalPrefs({ [prefName]: value } as GlobalPrefs));
+      dispatch(
+        saveGlobalPrefs(
+          {
+            [prefName]: value,
+          } as GlobalPrefs,
+          onSaveGlobalPrefs,
+        ),
+      );
     },
-    [prefName, dispatch],
+    [prefName, dispatch, onSaveGlobalPrefs],
   );
   const globalPref = useSelector(
     (state: State) => state.prefs.global?.[prefName] as GlobalPrefs[K],

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -297,6 +297,12 @@ ipcMain.on('get-bootstrap-data', event => {
   event.returnValue = payload;
 });
 
+ipcMain.handle('restart-server', () => {
+  serverProcess.kill();
+  serverProcess = null;
+  createBackgroundProcess();
+});
+
 ipcMain.handle('relaunch', () => {
   app.relaunch();
   app.exit();

--- a/packages/desktop-electron/preload.ts
+++ b/packages/desktop-electron/preload.ts
@@ -34,6 +34,10 @@ contextBridge.exposeInMainWorld('Actual', {
     ipcRenderer.invoke('relaunch');
   },
 
+  restartServer: () => {
+    ipcRenderer.invoke('restart-server');
+  },
+
   openFileDialog: (opts: OpenFileDialogPayload) => {
     return ipcRenderer.invoke('open-file-dialog', opts);
   },

--- a/packages/desktop-electron/preload.ts
+++ b/packages/desktop-electron/preload.ts
@@ -34,7 +34,7 @@ contextBridge.exposeInMainWorld('Actual', {
     ipcRenderer.invoke('relaunch');
   },
 
-  restartServer: () => {
+  restartElectronServer: () => {
     ipcRenderer.invoke('restart-server');
   },
 

--- a/packages/loot-core/src/client/actions/prefs.ts
+++ b/packages/loot-core/src/client/actions/prefs.ts
@@ -48,12 +48,16 @@ export function loadGlobalPrefs() {
   };
 }
 
-export function saveGlobalPrefs(prefs: prefs.GlobalPrefs) {
+export function saveGlobalPrefs(
+  prefs: prefs.GlobalPrefs,
+  onSaveGlobalPrefs?: () => void,
+) {
   return async (dispatch: Dispatch) => {
     await send('save-global-prefs', prefs);
     dispatch({
       type: constants.MERGE_GLOBAL_PREFS,
       globalPrefs: prefs,
     });
+    onSaveGlobalPrefs?.();
   };
 }

--- a/packages/loot-core/src/platform/server/fetch/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fetch/index.electron.ts
@@ -1,12 +1,20 @@
 // @ts-strict-ignore
 import nodeFetch from 'node-fetch';
 
-export const fetch = (input: RequestInfo | URL, options?: RequestInit) => {
-  return nodeFetch(input, {
-    ...options,
-    headers: {
-      ...options?.headers,
-      origin: 'app://actual',
-    },
-  });
+export const fetch = async (
+  input: RequestInfo | URL,
+  options?: RequestInit,
+) => {
+  try {
+    return await nodeFetch(input, {
+      ...options,
+      headers: {
+        ...options?.headers,
+        origin: 'app://actual',
+      },
+    });
+  } catch (error) {
+    console.error(error); // log error
+    throw error;
+  }
 };

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -15,7 +15,7 @@ declare global {
         opts: Parameters<import('electron').Dialog['showOpenDialogSync']>[0],
       ) => Promise<string[]>;
       relaunch: () => void;
-      restartServer: () => void;
+      restartElectronServer: () => void;
     };
 
     __navigate?: import('react-router').NavigateFunction;

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -15,6 +15,7 @@ declare global {
         opts: Parameters<import('electron').Dialog['showOpenDialogSync']>[0],
       ) => Promise<string[]>;
       relaunch: () => void;
+      restartServer: () => void;
     };
 
     __navigate?: import('react-router').NavigateFunction;

--- a/upcoming-release-notes/3431.md
+++ b/upcoming-release-notes/3431.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Restart server silently when adding self signed cert and add some logs


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Selecting a self signed certificate no longer restarts the app. Instead we restart the server process silently. The user shouldn't notice.

I've also added some logging for errors given by nodeFetch. That should help people diagnose cert/network related erros.

![showing err](https://github.com/user-attachments/assets/6615f5a8-49b8-4a74-a261-b0bd8173e2b4)

