### PR TITLE
:bug: (reports) deleting custom report should remove it from the dashboard

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
@@ -9,6 +9,7 @@ import { type CustomReportEntity } from 'loot-core/types/models/reports';
 
 import { useAccounts } from '../../../hooks/useAccounts';
 import { useCategories } from '../../../hooks/useCategories';
+import { useFeatureFlag } from '../../../hooks/useFeatureFlag';
 import { usePayees } from '../../../hooks/usePayees';
 import { useSyncedPref } from '../../../hooks/useSyncedPref';
 import { SvgExclamationSolid } from '../../../icons/v1';
@@ -35,9 +36,15 @@ export function CustomReportListCards({
   report,
   onRemove,
 }: CustomReportListCardsProps) {
+  const isDashboardsFeatureEnabled = useFeatureFlag('dashboards');
+
   // It's possible for a dashboard to reference a non-existing
   // custom report
   if (!report) {
+    if (!isDashboardsFeatureEnabled) {
+      return null;
+    }
+
     return (
       <MissingReportCard isEditing={isEditing} onRemove={onRemove}>
         This custom report has been deleted.

--- a/upcoming-release-notes/3469.md
+++ b/upcoming-release-notes/3469.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Reports - deleting custom reports should remove the widget from the dashboard.


### PR DESCRIPTION

Closes #3354


Reproduction (do not enable any feature flag):

1. create a custom report widget
2. observe it in the main "reports" page
3. delete it from the inner custom reports page
4. observe that it is no longer visible in the "reports" page