### PR TITLE
:electron: Replace deprecated file protocol registration

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -60,13 +60,13 @@ function createBackgroundProcess() {
     isDev ? { execArgv: ['--inspect'], stdio: 'pipe' } : { stdio: 'pipe' },
   );
 
-  serverProcess.stdout.on('data', (chunk: Buffer) => {
+  serverProcess.stdout?.on('data', (chunk: Buffer) => {
     // Send the Server console.log messages to the main browser window
     clientWin?.webContents.executeJavaScript(`
       console.info('Server Log:', ${JSON.stringify(chunk.toString('utf8'))})`);
   });
 
-  serverProcess.stderr.on('data', (chunk: Buffer) => {
+  serverProcess.stderr?.on('data', (chunk: Buffer) => {
     // Send the Server console.error messages out to the main browser window
     clientWin?.webContents.executeJavaScript(`
       console.error('Server Log:', ${JSON.stringify(chunk.toString('utf8'))})`);

--- a/upcoming-release-notes/3475.md
+++ b/upcoming-release-notes/3475.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Replacing the deprecated Electron file handler protocol with the new version


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Replaced the registerFileProtocol with the new version. This should make upgrading Electron easier.

https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-250