### PR TITLE
fix mobile header button styles

### DIFF
--- a/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
@@ -19,20 +19,22 @@ export function MobileBackButton({
   return (
     <Button
       variant="bare"
-      className={String(
-        css({
-          color: theme.mobileHeaderText,
-          justifyContent: 'center',
-          margin: 10,
-          paddingLeft: 5,
-          paddingRight: 3,
-          '&[data-hovered]': {
+      className={() =>
+        String(
+          css({
             color: theme.mobileHeaderText,
-            background: theme.mobileHeaderTextHover,
-          },
-          ...style,
-        }),
-      )}
+            justifyContent: 'center',
+            margin: 10,
+            paddingLeft: 5,
+            paddingRight: 3,
+            '&[data-hovered]': {
+              color: theme.mobileHeaderText,
+              background: theme.mobileHeaderTextHover,
+            },
+            ...style,
+          }),
+        )
+      }
       onPress={onPress || (() => navigate(-1))}
       {...props}
     >

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.jsx
@@ -172,17 +172,19 @@ function AccountList({
             <Button
               variant="bare"
               aria-label="Add account"
-              className={String(
-                css({
-                  justifyContent: 'center',
-                  color: theme.mobileHeaderText,
-                  margin: 10,
-                  ':hover': {
+              className={() =>
+                String(
+                  css({
+                    justifyContent: 'center',
                     color: theme.mobileHeaderText,
-                    background: theme.mobileHeaderTextHover,
-                  },
-                }),
-              )}
+                    margin: 10,
+                    ':hover': {
+                      color: theme.mobileHeaderText,
+                      background: theme.mobileHeaderTextHover,
+                    },
+                  }),
+                )
+              }
               onPress={onAddAccount}
             >
               <SvgAdd width={20} height={20} />

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -782,16 +782,18 @@ const ExpenseGroupHeader = memo(function ExpenseGroupHeader({
       >
         <Button
           variant="bare"
-          className={String(
-            css({
-              flexShrink: 0,
-              color: theme.pageTextSubdued,
-              ...styles.noTapHighlight,
-              '&[data-hovered], &[data-pressed]': {
-                backgroundColor: 'transparent',
-              },
-            }),
-          )}
+          className={() =>
+            String(
+              css({
+                flexShrink: 0,
+                color: theme.pageTextSubdued,
+                ...styles.noTapHighlight,
+                '&[data-hovered], &[data-pressed]': {
+                  backgroundColor: 'transparent',
+                },
+              }),
+            )
+          }
           onPress={() => onToggleCollapse?.(group.id)}
         >
           <SvgExpandArrow
@@ -978,16 +980,18 @@ const IncomeGroupHeader = memo(function IncomeGroupHeader({
       >
         <Button
           variant="bare"
-          className={String(
-            css({
-              flexShrink: 0,
-              color: theme.pageTextSubdued,
-              ...styles.noTapHighlight,
-              '&[data-hovered], &[data-pressed]': {
-                backgroundColor: 'transparent',
-              },
-            }),
-          )}
+          className={() =>
+            String(
+              css({
+                flexShrink: 0,
+                color: theme.pageTextSubdued,
+                ...styles.noTapHighlight,
+                '&[data-hovered], &[data-pressed]': {
+                  backgroundColor: 'transparent',
+                },
+              }),
+            )
+          }
           onPress={() => onToggleCollapse?.(group.id)}
         >
           <SvgExpandArrow
@@ -1606,13 +1610,15 @@ export function BudgetTable({
           leftContent={
             <Button
               variant="bare"
-              className={String(
-                css({
-                  color: theme.mobileHeaderText,
-                  margin: 10,
-                  '&[data-hovered], &[data-pressed]': noBackgroundColorStyle,
-                }),
-              )}
+              className={() =>
+                String(
+                  css({
+                    color: `${theme.mobileHeaderText} !important`,
+                    margin: 10,
+                    '&[data-hovered], &[data-pressed]': noBackgroundColorStyle,
+                  }),
+                )
+              }
               onPress={onOpenBudgetPageMenu}
             >
               <SvgLogo width="20" height="20" />
@@ -1921,18 +1927,20 @@ function MonthSelector({
             onPrevMonth();
           }
         }}
-        className={String(
-          css({
-            ...styles.noTapHighlight,
-            ...arrowButtonStyle,
-            opacity: prevEnabled ? 1 : 0.6,
-            color: theme.mobileHeaderText,
-            '&[data-hovered]': {
+        className={() =>
+          String(
+            css({
+              ...styles.noTapHighlight,
+              ...arrowButtonStyle,
+              opacity: prevEnabled ? 1 : 0.6,
               color: theme.mobileHeaderText,
-              background: theme.mobileHeaderTextHover,
-            },
-          }),
-        )}
+              '&[data-hovered]': {
+                color: theme.mobileHeaderText,
+                background: theme.mobileHeaderTextHover,
+              },
+            }),
+          )
+        }
       >
         <SvgArrowThinLeft width="15" height="15" style={{ margin: -5 }} />
       </Button>
@@ -1960,18 +1968,20 @@ function MonthSelector({
             onNextMonth();
           }
         }}
-        className={String(
-          css({
-            ...styles.noTapHighlight,
-            ...arrowButtonStyle,
-            opacity: nextEnabled ? 1 : 0.6,
-            color: theme.mobileHeaderText,
-            '&[data-hovered]': {
+        className={() =>
+          String(
+            css({
+              ...styles.noTapHighlight,
+              ...arrowButtonStyle,
+              opacity: nextEnabled ? 1 : 0.6,
               color: theme.mobileHeaderText,
-              background: theme.mobileHeaderTextHover,
-            },
-          }),
-        )}
+              '&[data-hovered]': {
+                color: theme.mobileHeaderText,
+                background: theme.mobileHeaderTextHover,
+              },
+            }),
+          )
+        }
       >
         <SvgArrowThinRight width="15" height="15" style={{ margin: -5 }} />
       </Button>

--- a/upcoming-release-notes/3488.md
+++ b/upcoming-release-notes/3488.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tim-smart]
+---
+
+Fix mobile header button styling


### PR DESCRIPTION
This change defers the generation of the css override class names,
to ensure they created *after* the base Button styles.

Fixes regression from #3453
