### PR TITLE
:test_tube: improving rules e2e test stability

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -35,7 +35,11 @@ import { RulesList } from './rules/RulesList';
 import { SchedulesQuery } from './rules/SchedulesQuery';
 import { SimpleTable } from './rules/SimpleTable';
 
-function mapValue(field, value, { payees, categories, accounts }) {
+function mapValue(
+  field,
+  value,
+  { payees = [], categories = [], accounts = [] },
+) {
   if (!value) return '';
 
   let object = null;

--- a/upcoming-release-notes/3498.md
+++ b/upcoming-release-notes/3498.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+e2e: improve rules test stability.


### PR DESCRIPTION
https://github.com/actualbudget/actual/issues/3482

I have not been able to reproduce this locally. But judging from the failing e2e test trace: the issue is that payee/category/account (one of the variables) is `undefined`. So I'm hoping this change will improve the e2e stability.

<img width="831" alt="Screenshot 2024-09-24 at 21 00 08" src="https://github.com/user-attachments/assets/560fdce2-4edc-454d-90cb-b53d00166e19">

Sample failure: https://github.com/actualbudget/actual/actions/runs/11020812113/job/30606649587?pr=3491