### PR TITLE
:test_tube: improve onboarding e2e test stability

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -35,6 +35,7 @@ import { NarrowAlternate, WideComponent } from './responsive';
 import { Settings } from './settings';
 import { FloatableSidebar } from './sidebar';
 import { Titlebar } from './Titlebar';
+import { LoadingIndicator } from './reports/LoadingIndicator';
 
 function NarrowNotSupported({
   redirectTo = '/budget',
@@ -65,19 +66,6 @@ function WideNotSupported({ children, redirectTo = '/budget' }) {
 }
 
 function RouterBehaviors() {
-  const navigate = useNavigate();
-  const accounts = useAccounts();
-  const accountsLoaded = useSelector(
-    (state: State) => state.queries.accountsLoaded,
-  );
-  useEffect(() => {
-    // If there are no accounts, we want to redirect the user to
-    // the All Accounts screen which will prompt them to add an account
-    if (accountsLoaded && accounts.length === 0) {
-      navigate('/accounts');
-    }
-  }, [accountsLoaded, accounts]);
-
   const location = useLocation();
   const href = useHref(location);
   useEffect(() => {
@@ -90,6 +78,11 @@ function RouterBehaviors() {
 export function FinancesApp() {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+
+  const accounts = useAccounts();
+  const accountsLoaded = useSelector(
+    (state: State) => state.queries.accountsLoaded,
+  );
 
   const [lastUsedVersion, setLastUsedVersion] = useLocalPref(
     'flags.updateNotificationShownForVersion',
@@ -180,7 +173,22 @@ export function FinancesApp() {
             <BankSyncStatus />
 
             <Routes>
-              <Route path="/" element={<Navigate to="/budget" replace />} />
+              <Route
+                path="/"
+                element={
+                  accountsLoaded ? (
+                    accounts.length > 0 ? (
+                      <Navigate to="/budget" replace />
+                    ) : (
+                      // If there are no accounts, we want to redirect the user to
+                      // the All Accounts screen which will prompt them to add an account
+                      <Navigate to="/accounts" replace />
+                    )
+                  ) : (
+                    <LoadingIndicator />
+                  )
+                }
+              />
 
               <Route path="/reports/*" element={<Reports />} />
 

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -31,11 +31,11 @@ import { TransactionEdit } from './mobile/transactions/TransactionEdit';
 import { Notifications } from './Notifications';
 import { ManagePayeesPage } from './payees/ManagePayeesPage';
 import { Reports } from './reports';
+import { LoadingIndicator } from './reports/LoadingIndicator';
 import { NarrowAlternate, WideComponent } from './responsive';
 import { Settings } from './settings';
 import { FloatableSidebar } from './sidebar';
 import { Titlebar } from './Titlebar';
-import { LoadingIndicator } from './reports/LoadingIndicator';
 
 function NarrowNotSupported({
   redirectTo = '/budget',

--- a/upcoming-release-notes/3503.md
+++ b/upcoming-release-notes/3503.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+e2e: improve onboarding test stability.


### PR DESCRIPTION
Improving onboarding e2e test stability.

Root cause: race condition when loading account list. If account list loads quickly - we redirect to `/account` and then back to `/budget`. If they load slower - we redirect to `/budget` and then to `/account`.

More info (failure example & trace): https://github.com/actualbudget/actual/issues/3482#issuecomment-2375104467