### PR TITLE
Ignore deleted categories when running templates

### DIFF
--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -34,6 +34,7 @@ export async function getCategoriesWithTemplateNotes(): Promise<
       FROM notes n
              JOIN categories c ON n.id = c.id
       WHERE c.id = n.id
+        AND c.tombstone = 0
         AND (lower(note) LIKE '%${TEMPLATE_PREFIX}%'
         OR lower(note) LIKE '%${GOAL_PREFIX}%')
     `,


### PR DESCRIPTION
An issue came up on discord where the syntax checker was looking at deleted categories.  The templates were probably running on deleted categories too, but the budget math ignores them so it went unnoticed. 
