### PR TITLE
Fix yearly schedule templates

### DIFF
--- a/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goals/goalsSchedule.ts
@@ -166,7 +166,11 @@ async function getSinkingBaseContributionTotal(t) {
   //return only the base contribution of each schedule
   let total = 0;
   for (let ll = 0; ll < t.length; ll++) {
-    total += t[ll].target / t[ll].target_interval;
+    let monthlyAmount = t[ll].target / t[ll].target_interval;
+    if (t[ll].target_frequency === 'yearly') {
+      monthlyAmount /= 12;
+    }
+    total += monthlyAmount;
   }
   return total;
 }

--- a/upcoming-release-notes/3511.md
+++ b/upcoming-release-notes/3511.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [JukeboxRhino]
+---
+
+Fix yearly schedule templates not behaving correctly when budgeting ahead of the transaction date


### PR DESCRIPTION
Current behavior of template goals set to a schedule with frequency `yearly` are broken once the category is fully funded. This means budgeting into future months does not work as expected, in this case the full yearly amount is budgeted in the month following the transaction (instead of 1/12 the amount). The function that handles calculating the base savings amount has been updated to take yearly schedules into account.

Example of **previous broken** behavior:
![image](https://github.com/user-attachments/assets/f786b907-7917-4273-8cc7-b5e747b979a1)
![image](https://github.com/user-attachments/assets/76ba9a06-bed3-463e-b687-88741240fa3d)

The same budget file with the fix applied and templates re-ran:
![image](https://github.com/user-attachments/assets/630c6cc2-a2f9-4435-a195-063ac5d98b95)
