### PR TITLE
Add goal info to the prewarm list

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -219,7 +219,7 @@ handlers['envelope-budget-month'] = async function ({ month }) {
           value(`leftover-${cat.id}`),
           value(`carryover-${cat.id}`),
           value(`goal-${cat.id}`),
-          value(`long-goal-${cat.id}`)
+          value(`long-goal-${cat.id}`),
         ]);
       }
     }
@@ -260,7 +260,7 @@ handlers['tracking-budget-month'] = async function ({ month }) {
         value(`sum-amount-${cat.id}`),
         value(`leftover-${cat.id}`),
         value(`goal-${cat.id}`),
-        value(`long-goal-${cat.id}`)
+        value(`long-goal-${cat.id}`),
       ]);
 
       if (!group.is_income) {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -218,6 +218,8 @@ handlers['envelope-budget-month'] = async function ({ month }) {
           value(`sum-amount-${cat.id}`),
           value(`leftover-${cat.id}`),
           value(`carryover-${cat.id}`),
+          value(`goal-${cat.id}`),
+          value(`long-goal-${cat.id}`)
         ]);
       }
     }

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -259,6 +259,8 @@ handlers['tracking-budget-month'] = async function ({ month }) {
         value(`budget-${cat.id}`),
         value(`sum-amount-${cat.id}`),
         value(`leftover-${cat.id}`),
+        value(`goal-${cat.id}`),
+        value(`long-goal-${cat.id}`)
       ]);
 
       if (!group.is_income) {

--- a/upcoming-release-notes/3514.md
+++ b/upcoming-release-notes/3514.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfix
+category: Maintenance
 authors: [youngcw]
 ---
 

--- a/upcoming-release-notes/3514.md
+++ b/upcoming-release-notes/3514.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Add category goal info to the budget prewarm list for faster loading of indicator colors.


### PR DESCRIPTION
I think this will speed up the loading of the goal indicators on the budget page.  I added the two cache entries to the list of values to prewarm for each month.  This doesn't totally fix the issue, but I think it helps. 

For a bit I've been seeing the category balances progressively color when opening the app(except for negative balances that are always colored correct).  Sometimes it's really slow. It is more pronounced on mobile but still noticeable on desktop.
