### PR TITLE
fix: pushModal not dispatched in GoCardless linking

### DIFF
--- a/packages/desktop-client/src/gocardless.ts
+++ b/packages/desktop-client/src/gocardless.ts
@@ -45,12 +45,14 @@ export async function authorizeBank(
 ) {
   _authorize(dispatch, upgradingAccountId, {
     onSuccess: async data => {
-      pushModal('select-linked-accounts', {
-        accounts: data.accounts,
-        requisitionId: data.id,
-        upgradingAccountId,
-        syncSource: 'goCardless',
-      });
+      dispatch(
+        pushModal('select-linked-accounts', {
+          accounts: data.accounts,
+          requisitionId: data.id,
+          upgradingAccountId,
+          syncSource: 'goCardless',
+        }),
+      );
     },
   });
 }

--- a/upcoming-release-notes/3515.md
+++ b/upcoming-release-notes/3515.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [EtaoinWu]
+---
+
+Fix GoCardless linking (account selection window not appearing)


### PR DESCRIPTION
### Background

Multiple reports in Discord shows that the current master branch has issues with gocardless linking: [mine](https://discord.com/channels/937901803608096828/1288271251810422857), [valerio's](https://discord.com/channels/937901803608096828/1288418544739942452), [aaarzan's](https://discord.com/channels/937901803608096828/1285223872022712353), [ROuGGy's](https://discord.com/channels/937901803608096828/1286541192191938570) among others. The symptom seems to be that, after a successful callback from GoCardless, Actual refuses to pop up the next step in the linking process, which is to select accounts to sync from. Server logs and browser console logs shows no anomaly.

### Contribution

I tracked down the issue, and found that in [gocardless.ts](https://github.com/actualbudget/actual/blob/686ce5b504e40646a0d7b92114ef4f07f1f8992a/packages/desktop-client/src/gocardless.ts#L47-L54), the callback `onSuccess` only generates a `pushModal` action without sending it to dispatch:

```typescript
_authorize(dispatch, upgradingAccountId, {
  onSuccess: async data => {
    pushModal('select-linked-accounts', {
      accounts: data.accounts,
      requisitionId: data.id,
      upgradingAccountId,
      syncSource: 'goCardless',
    });
  },
});
```

Therefore a `SelectLinkedAccountsModal` was never generated.

This was introduced in 420aad0 (#3413) two weeks ago. Latest release (v24.9.0) was not affected.

### Next steps & help needed

I am unfortunately not a React dev, and lacks the environment or tool to build and test it. I hope that other contributors in this community can help verify my fix and resolve this issue.