### PR TITLE
Fix theme "flickering" from light to dark on load of the page

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
@@ -128,7 +128,7 @@ export function App() {
   );
   const dispatch = useDispatch();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     function checkScrollbars() {
       if (hiddenScrollbars !== hasHiddenScrollbars()) {
         setHiddenScrollbars(hasHiddenScrollbars());

--- a/packages/desktop-client/src/style/theme.tsx
+++ b/packages/desktop-client/src/style/theme.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
 import type { DarkTheme, Theme } from 'loot-core/src/types/prefs';
@@ -52,7 +52,7 @@ export function ThemeStyle() {
     | undefined
   >(undefined);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (theme === 'auto') {
       const darkTheme = themes[darkThemePreference];
 

--- a/packages/desktop-client/src/style/theme.tsx
+++ b/packages/desktop-client/src/style/theme.tsx
@@ -52,9 +52,9 @@ export function ThemeStyle() {
     | undefined
   >(undefined);
 
-  const darkThemeMediaQueryListener = useCallback(
-    (event: MediaQueryListEvent) => {
-      if (event.matches) {
+  const setAutoThemeColors = useCallback(
+    (isDarkMode: boolean) => {
+      if (isDarkMode) {
         setThemeColors(themes[darkThemePreference].colors);
       } else {
         setThemeColors(themes['light'].colors);
@@ -65,36 +65,31 @@ export function ThemeStyle() {
 
   useLayoutEffect(() => {
     if (theme === 'auto') {
-      const darkThemeMediaQuery = window.matchMedia(
+      const isDarkMode = window.matchMedia(
         '(prefers-color-scheme: dark)',
-      );
-      if (darkThemeMediaQuery.matches) {
-        setThemeColors(themes[darkThemePreference].colors);
-      } else {
-        setThemeColors(themes['light'].colors);
-      }
+      ).matches;
+      setAutoThemeColors(isDarkMode);
     } else {
       setThemeColors(themes[theme].colors);
     }
-  }, [theme, darkThemePreference]);
+  }, [theme, darkThemePreference, setAutoThemeColors]);
 
   useEffect(() => {
     if (theme === 'auto') {
       const darkThemeMediaQuery = window.matchMedia(
         '(prefers-color-scheme: dark)',
       );
-      darkThemeMediaQuery.addEventListener(
-        'change',
-        darkThemeMediaQueryListener,
-      );
+
+      const changeListener = (event: MediaQueryListEvent) => {
+        setAutoThemeColors(event.matches);
+      };
+
+      darkThemeMediaQuery.addEventListener('change', changeListener);
       return () => {
-        darkThemeMediaQuery.removeEventListener(
-          'change',
-          darkThemeMediaQueryListener,
-        );
+        darkThemeMediaQuery.removeEventListener('change', changeListener);
       };
     }
-  }, [theme, darkThemeMediaQueryListener]);
+  }, [setAutoThemeColors, theme]);
 
   if (!themeColors) return null;
 

--- a/packages/desktop-client/src/style/theme.tsx
+++ b/packages/desktop-client/src/style/theme.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { useLayoutEffect, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
 
 import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
 import type { DarkTheme, Theme } from 'loot-core/src/types/prefs';
@@ -52,42 +52,49 @@ export function ThemeStyle() {
     | undefined
   >(undefined);
 
+  const darkThemeMediaQueryListener = useCallback(
+    (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setThemeColors(themes[darkThemePreference].colors);
+      } else {
+        setThemeColors(themes['light'].colors);
+      }
+    },
+    [darkThemePreference],
+  );
+
   useLayoutEffect(() => {
     if (theme === 'auto') {
-      const darkTheme = themes[darkThemePreference];
-
-      function darkThemeMediaQueryListener(event: MediaQueryListEvent) {
-        if (event.matches) {
-          setThemeColors(darkTheme.colors);
-        } else {
-          setThemeColors(themes['light'].colors);
-        }
-      }
       const darkThemeMediaQuery = window.matchMedia(
         '(prefers-color-scheme: dark)',
       );
+      if (darkThemeMediaQuery.matches) {
+        setThemeColors(themes[darkThemePreference].colors);
+      } else {
+        setThemeColors(themes['light'].colors);
+      }
+    } else {
+      setThemeColors(themes[theme].colors);
+    }
+  }, [theme, darkThemePreference]);
 
+  useEffect(() => {
+    if (theme === 'auto') {
+      const darkThemeMediaQuery = window.matchMedia(
+        '(prefers-color-scheme: dark)',
+      );
       darkThemeMediaQuery.addEventListener(
         'change',
         darkThemeMediaQueryListener,
       );
-
-      if (darkThemeMediaQuery.matches) {
-        setThemeColors(darkTheme.colors);
-      } else {
-        setThemeColors(themes['light'].colors);
-      }
-
       return () => {
         darkThemeMediaQuery.removeEventListener(
           'change',
           darkThemeMediaQueryListener,
         );
       };
-    } else {
-      setThemeColors(themes[theme].colors);
     }
-  }, [theme, darkThemePreference]);
+  }, [theme, darkThemeMediaQueryListener]);
 
   if (!themeColors) return null;
 

--- a/upcoming-release-notes/3520.md
+++ b/upcoming-release-notes/3520.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix the theme color change that happens when initially loading the page where initially it's set to light mode and then switches to the configured theme.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fixes the theme color change (from light theme to configured theme) that happens when initially loading the page.

Switching to `useLayoutEffect` so that the proper theme colors are set before the page is painted on screen