### PR TITLE
pass causes along in failed-to-load exceptions

### DIFF
--- a/packages/desktop-client/src/components/util/LoadComponent.tsx
+++ b/packages/desktop-client/src/components/util/LoadComponent.tsx
@@ -34,6 +34,7 @@ function LoadComponentInner<K extends string>({
     localModuleCache.get(name) ?? null,
   );
   const [failedToLoad, setFailedToLoad] = useState(false);
+  const [failedToLoadException, setFailedToLoadException] = useState(null);
 
   useEffect(() => {
     if (localModuleCache.has(name)) {
@@ -55,13 +56,14 @@ function LoadComponentInner<K extends string>({
       {
         retries: 5,
       },
-    ).catch(() => {
+    ).catch((e) => {
       setFailedToLoad(true);
+      setFailedToLoadException(e);
     });
   }, [name, importer]);
 
   if (failedToLoad) {
-    throw new LazyLoadFailedError(name);
+    throw new LazyLoadFailedError(name, failedToLoadException);
   }
 
   if (!Component) {

--- a/packages/desktop-client/src/components/util/LoadComponent.tsx
+++ b/packages/desktop-client/src/components/util/LoadComponent.tsx
@@ -56,7 +56,7 @@ function LoadComponentInner<K extends string>({
       {
         retries: 5,
       },
-    ).catch((e) => {
+    ).catch(e => {
       setFailedToLoad(true);
       setFailedToLoadException(e);
     });

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -100,8 +100,9 @@ export class LazyLoadFailedError extends Error {
   type = 'app-init-failure';
   meta = {};
 
-  constructor(name: string) {
+  constructor(name: string, cause: unknown) {
     super(`Error: failed loading lazy-loaded module ${name}`);
     this.meta = { name };
+    this.cause = cause;
   }
 }

--- a/upcoming-release-notes/3525.md
+++ b/upcoming-release-notes/3525.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [qedi-r]
+---
+
+Expose underlying exception source when a module fails to load.


### PR DESCRIPTION
When developing, especially deep in a component, the original error will get swallowed on the error screen. You can often get a generic error like this:

![image](https://github.com/user-attachments/assets/7cf6f42c-df48-4823-91b8-dfd811b0eb4e)

the root cause though, doesn't get passed on the exception chain, so the console will just report the generic error:

![image](https://github.com/user-attachments/assets/92ca071a-b801-438e-ba5d-c7116a14643d)

this captures the original exception to show as the cause:

![image](https://github.com/user-attachments/assets/ebec8753-ac6f-4c5f-8ea5-14da838fc59b)

