### PR TITLE
[e2e] Account page tests - wait for transaction table to be visible

### DIFF
--- a/packages/desktop-client/e2e/onboarding.test.js
+++ b/packages/desktop-client/e2e/onboarding.test.js
@@ -93,7 +93,9 @@ test.describe('Onboarding', () => {
 
   test('navigates back to start page by clicking on “no server” in an empty budget file', async () => {
     await configurationPage.clickOnNoServer();
-    await configurationPage.startFresh();
+    const accountPage = await configurationPage.startFresh();
+
+    await expect(accountPage.transactionTable).toBeVisible();
 
     await navigation.clickOnNoServer();
     await page.getByRole('button', { name: 'Start using a server' }).click();

--- a/packages/desktop-client/e2e/page-models/configuration-page.js
+++ b/packages/desktop-client/e2e/page-models/configuration-page.js
@@ -1,3 +1,4 @@
+import { AccountPage } from './account-page';
 import { BudgetPage } from './budget-page';
 
 export class ConfigurationPage {
@@ -18,6 +19,8 @@ export class ConfigurationPage {
 
   async startFresh() {
     await this.page.getByRole('button', { name: 'Start fresh' }).click();
+
+    return new AccountPage(this.page);
   }
 
   async importBudget(type, file) {

--- a/upcoming-release-notes/3530.md
+++ b/upcoming-release-notes/3530.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+[e2e] Fix the flaky "navigates back to start page by clicking on “no server” in an empty budget file test" from onboarding.test.js


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fix the flaky `navigates back to start page by clicking on “no server” in an empty budget file` test from onboarding.test.js