### PR TITLE
:bug: (bank-sync) fix initial sync - close modal stack, show loading indicators

### DIFF
--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import {
+  closeModal,
   linkAccount,
   linkAccountSimpleFin,
   unlinkAccount,
@@ -90,6 +91,8 @@ export function SelectLinkedAccountsModal({
         }
       },
     );
+
+    dispatch(closeModal());
   }
 
   const unlinkedAccounts = localAccounts.filter(
@@ -176,10 +179,7 @@ export function SelectLinkedAccountsModal({
           >
             <Button
               variant="primary"
-              onPress={() => {
-                onNext();
-                close();
-              }}
+              onPress={onNext}
               isDisabled={!Object.keys(chosenAccounts).length}
             >
               Link accounts

--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -55,8 +55,17 @@ export function unlinkAccount(id: string) {
   };
 }
 
-export function linkAccount(requisitionId, account, upgradingId, offBudget) {
+export function linkAccount(
+  requisitionId: string,
+  account: unknown,
+  upgradingId?: string,
+  offBudget?: boolean,
+) {
   return async (dispatch: Dispatch) => {
+    if (upgradingId) {
+      await dispatch(setAccountsSyncing([upgradingId]));
+    }
+
     await send('gocardless-accounts-link', {
       requisitionId,
       account,
@@ -68,8 +77,16 @@ export function linkAccount(requisitionId, account, upgradingId, offBudget) {
   };
 }
 
-export function linkAccountSimpleFin(externalAccount, upgradingId, offBudget) {
+export function linkAccountSimpleFin(
+  externalAccount: unknown,
+  upgradingId?: string,
+  offBudget?: boolean,
+) {
   return async (dispatch: Dispatch) => {
+    if (upgradingId) {
+      await dispatch(setAccountsSyncing([upgradingId]));
+    }
+
     await send('simplefin-accounts-link', {
       externalAccount,
       upgradingId,

--- a/upcoming-release-notes/3540.md
+++ b/upcoming-release-notes/3540.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+BankSync: fix showing sync status after linking and close all modal stack.


### PR DESCRIPTION
Two fixes here for the initial bank sync:

1. close all the modal windows after successfully linking
2. show a loading indicator besides accounts after linking