### PR TITLE
:electron: Reduce electron package size

### DIFF
--- a/packages/desktop-electron/bin/update-client
+++ b/packages/desktop-electron/bin/update-client
@@ -17,5 +17,6 @@ rm -rf ${ROOT}/build/client-build/*.map
 mkdir -p ${ROOT}/build/loot-core/lib-dist
 ls ${ROOT}/build/loot-core/lib-dist
 cp ${ROOT}/../loot-core/lib-dist/bundle.desktop.js ${ROOT}/build/loot-core/lib-dist/bundle.desktop.js
+cp ${ROOT}/../loot-core/default-db.sqlite ${ROOT}/build/loot-core/default-db.sqlite
 cp -r ${ROOT}/../loot-core/migrations ${ROOT}/build/loot-core/migrations
 

--- a/packages/desktop-electron/bin/update-client
+++ b/packages/desktop-electron/bin/update-client
@@ -12,3 +12,10 @@ rm -rf ${ROOT}/build/client-build/data
 rm -rf ${ROOT}/build/client-build/*kcab.*
 rm -rf ${ROOT}/build/client-build/*.wasm
 rm -rf ${ROOT}/build/client-build/*.map
+
+# Copy loot-core into build directory
+mkdir -p ${ROOT}/build/loot-core/lib-dist
+ls ${ROOT}/build/loot-core/lib-dist
+cp ${ROOT}/../loot-core/lib-dist/bundle.desktop.js ${ROOT}/build/loot-core/lib-dist/bundle.desktop.js
+cp -r ${ROOT}/../loot-core/migrations ${ROOT}/build/loot-core/migrations
+

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import Module from 'module';
 import path from 'path';
 
 import {

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -28,8 +28,8 @@ import {
 import './security';
 
 process.env.lootCoreScript = isDev
-  ? 'loot-core/lib-dist/bundle.desktop.js' // serve from node_modules for hot reload
-  : path.resolve(__dirname, 'loot-core/lib-dist/bundle.desktop.js'); // serve from build for production
+  ? 'loot-core/lib-dist/bundle.desktop.js' // serve from local output in development (provides hot-reloading)
+  : path.resolve(__dirname, 'loot-core/lib-dist/bundle.desktop.js'); // serve from build in production
 
 // This allows relative URLs to be resolved to app:// which makes
 // local assets load correctly

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -28,7 +28,9 @@ import {
 
 import './security';
 
-Module.globalPaths.push(__dirname + '/..');
+process.env.lootCoreScript = isDev
+  ? 'loot-core/lib-dist/bundle.desktop.js' // serve from node_modules for hot reload
+  : path.resolve(__dirname, 'loot-core/lib-dist/bundle.desktop.js'); // serve from build for production
 
 // This allows relative URLs to be resolved to app:// which makes
 // local assets load correctly
@@ -143,7 +145,9 @@ async function createWindow() {
     if (clientWin) {
       const url = clientWin.webContents.getURL();
       if (url.includes('app://') || url.includes('localhost:')) {
-        clientWin.webContents.executeJavaScript('__actionsForMenu.focused()');
+        clientWin.webContents.executeJavaScript(
+          'window.__actionsForMenu.focused()',
+        );
       }
     }
   });

--- a/packages/desktop-electron/modules.d.ts
+++ b/packages/desktop-electron/modules.d.ts
@@ -1,9 +1,3 @@
 declare module 'module' {
   const globalPaths: string[];
 }
-
-// bundles not available until we build them
-declare module 'loot-core/lib-dist/bundle.desktop.js' {
-  const initApp: (isDev: boolean) => void;
-  const lib: { getDataDir: () => string };
-}

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -57,15 +57,15 @@
     "win": {
       "target": [
         {
-          "target": "nsis",
+          "target": "appx",
           "arch": [
             "ia32",
             "x64",
-            "x64"
+            "arm64"
           ]
         },
         {
-          "target": "appx",
+          "target": "nsis",
           "arch": [
             "ia32",
             "x64",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -17,14 +17,11 @@
     "appId": "com.actualbudget.actual",
     "files": [
       "build",
-      "!node_modules/loot-core/src{,/**/*}",
-      "!node_modules/loot-core/lib-dist/{browser,bundle.mobile*}",
-      "!node_modules/absurd-sql",
       "!node_modules/better-sqlite3/{benchmark,src,bin,docs,deps,build/Release/obj,build/Release/sqlite3.a,build/Release/test_extension.node}",
       "!**/*.js.map",
       "!**/stats.json",
-      "!node_modules/@jlongster/sql.js/**/*",
-      "!build/client-build/sql-wasm.wasm"
+      "!build/client-build/sql-wasm.wasm",
+      "!build/loot-core/lib-dist/{browser,bundle.mobile*}"
     ],
     "beforePack": "./build/beforePackHook.js",
     "mac": {
@@ -60,19 +57,9 @@
     "win": {
       "target": [
         {
-          "target": "appx",
-          "arch": [
-            "ia32",
-            "x64",
-            "arm64"
-          ]
-        },
-        {
           "target": "nsis",
           "arch": [
-            "ia32",
-            "x64",
-            "arm64"
+            "x64"
           ]
         }
       ],
@@ -88,9 +75,9 @@
     "npmRebuild": false
   },
   "dependencies": {
+    "better-sqlite3": "^9.6.0",
     "electron-is-dev": "2.0.0",
     "electron-log": "4.4.8",
-    "loot-core": "*",
     "node-fetch": "^2.7.0",
     "promise-retry": "^2.0.1"
   },

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -59,7 +59,17 @@
         {
           "target": "nsis",
           "arch": [
+            "ia32",
+            "x64",
             "x64"
+          ]
+        },
+        {
+          "target": "appx",
+          "arch": [
+            "ia32",
+            "x64",
+            "arm64"
           ]
         }
       ],

--- a/packages/desktop-electron/server.ts
+++ b/packages/desktop-electron/server.ts
@@ -4,8 +4,13 @@ import fetch from 'node-fetch';
 global.fetch = fetch;
 
 const lazyLoadBackend = async (isDev: boolean) => {
-  const bundle = await import(process.env.lootCoreScript);
-  bundle.initApp(isDev);
+  try {
+    const bundle = await import(process.env.lootCoreScript);
+    bundle.initApp(isDev);
+  } catch (error) {
+    console.error('Failed to init the server bundle:', error);
+    throw new Error(`Failed to init the server bundle: ${error.message}`);
+  }
 };
 
 const isDev = false;

--- a/packages/desktop-electron/server.ts
+++ b/packages/desktop-electron/server.ts
@@ -1,14 +1,10 @@
-import Module from 'module';
-
 // @ts-strict-ignore
 import fetch from 'node-fetch';
 
-Module.globalPaths.push(__dirname + '/..');
 global.fetch = fetch;
 
 const lazyLoadBackend = async (isDev: boolean) => {
-  // eslint-disable-next-line import/extensions
-  const bundle = await import('loot-core/lib-dist/bundle.desktop.js');
+  const bundle = await import(process.env.lootCoreScript);
   bundle.initApp(isDev);
 };
 

--- a/packages/desktop-electron/window-state.ts
+++ b/packages/desktop-electron/window-state.ts
@@ -3,15 +3,6 @@ import path from 'path';
 
 import electron, { BrowserWindow } from 'electron';
 
-const backend = undefined;
-const getBackend = async () => {
-  if (!process.env.lootCoreScript) {
-    throw new Error('lootCoreScript not set');
-  }
-
-  return backend || (await import(process.env.lootCoreScript));
-};
-
 type WindowState = Electron.Rectangle & {
   isMaximized?: boolean;
   isFullScreen?: boolean;
@@ -20,11 +11,10 @@ type WindowState = Electron.Rectangle & {
 
 async function loadState() {
   let state: WindowState | undefined = undefined;
-  const backend = await getBackend();
   try {
     state = JSON.parse(
       fs.readFileSync(
-        path.join(backend.lib.getDataDir(), 'window.json'),
+        path.join(process.env.ACTUAL_DATA_DIR, 'window.json'),
         'utf8',
       ),
     );
@@ -51,10 +41,9 @@ function updateState(win: BrowserWindow, state: WindowState) {
 }
 
 async function saveState(win: BrowserWindow, state: WindowState) {
-  const backend = await getBackend();
   updateState(win, state);
   fs.writeFileSync(
-    path.join(backend.lib.getDataDir(), 'window.json'),
+    path.join(process.env.ACTUAL_DATA_DIR, 'window.json'),
     JSON.stringify(state),
     'utf8',
   );

--- a/packages/desktop-electron/window-state.ts
+++ b/packages/desktop-electron/window-state.ts
@@ -9,14 +9,19 @@ type WindowState = Electron.Rectangle & {
   displayBounds?: Electron.Rectangle;
 };
 
+const getDataDir = () => {
+  if (!process.env.ACTUAL_DATA_DIR) {
+    throw new Error('ACTUAL_DATA_DIR is not set');
+  }
+
+  return process.env.ACTUAL_DATA_DIR;
+};
+
 async function loadState() {
   let state: WindowState | undefined = undefined;
   try {
     state = JSON.parse(
-      fs.readFileSync(
-        path.join(process.env.ACTUAL_DATA_DIR, 'window.json'),
-        'utf8',
-      ),
+      fs.readFileSync(path.join(getDataDir(), 'window.json'), 'utf8'),
     );
   } catch (e) {
     console.log('Could not load window state');
@@ -43,7 +48,7 @@ function updateState(win: BrowserWindow, state: WindowState) {
 async function saveState(win: BrowserWindow, state: WindowState) {
   updateState(win, state);
   fs.writeFileSync(
-    path.join(process.env.ACTUAL_DATA_DIR, 'window.json'),
+    path.join(getDataDir(), 'window.json'),
     JSON.stringify(state),
     'utf8',
   );

--- a/packages/desktop-electron/window-state.ts
+++ b/packages/desktop-electron/window-state.ts
@@ -4,8 +4,13 @@ import path from 'path';
 import electron, { BrowserWindow } from 'electron';
 
 const backend = undefined;
-const getBackend = async () =>
-  backend || (await import(process.env.lootCoreScript));
+const getBackend = async () => {
+  if (!process.env.lootCoreScript) {
+    throw new Error('lootCoreScript not set');
+  }
+
+  return backend || (await import(process.env.lootCoreScript));
+};
 
 type WindowState = Electron.Rectangle & {
   isMaximized?: boolean;

--- a/packages/desktop-electron/window-state.ts
+++ b/packages/desktop-electron/window-state.ts
@@ -5,8 +5,7 @@ import electron, { BrowserWindow } from 'electron';
 
 const backend = undefined;
 const getBackend = async () =>
-  // eslint-disable-next-line import/extensions
-  backend || (await import('loot-core/lib-dist/bundle.desktop.js'));
+  backend || (await import(process.env.lootCoreScript));
 
 type WindowState = Electron.Rectangle & {
   isMaximized?: boolean;

--- a/upcoming-release-notes/3553.md
+++ b/upcoming-release-notes/3553.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Reducing Desktop app package size

--- a/yarn.lock
+++ b/yarn.lock
@@ -8412,13 +8412,13 @@ __metadata:
     "@electron/notarize": "npm:2.4.0"
     "@electron/rebuild": "npm:3.6.0"
     "@types/copyfiles": "npm:^2"
+    better-sqlite3: "npm:^9.6.0"
     copyfiles: "npm:^2.4.1"
     cross-env: "npm:^7.0.3"
     electron: "npm:30.0.6"
     electron-builder: "npm:24.13.3"
     electron-is-dev: "npm:2.0.0"
     electron-log: "npm:4.4.8"
-    loot-core: "npm:*"
     node-fetch: "npm:^2.7.0"
     promise-retry: "npm:^2.0.1"
     typescript: "npm:^5.5.4"
@@ -13111,7 +13111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loot-core@npm:*, loot-core@workspace:packages/loot-core":
+"loot-core@workspace:packages/loot-core":
   version: 0.0.0-use.local
   resolution: "loot-core@workspace:packages/loot-core"
   dependencies:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

We currently include all of loot-core's dependencies in the electron app. This may have been the root cause of the better-sqlite x64/arm64 issues we had a while ago. We don't need to include these modules because we bundle loot-core into bundle.desktop.js. 

This change makes it much easier to see what the Electron app _really_ depends on.

**Difference in size:** 

**Old :** 
![image](https://github.com/user-attachments/assets/c7fa7b0a-2265-407b-bdfa-fa5c72a4bcd5)

**New:** 
![image](https://github.com/user-attachments/assets/f4cb2f00-adb7-4de3-b5ff-64b30de14ad8)


**Tested on:**
- [x] Windows
- [x] Linux
- [x] Mac

