### PR TITLE
:bug: (reports) fix reports page having empty blocks

### DIFF
--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -82,16 +82,26 @@ export function Overview() {
   const isDashboardsFeatureEnabled = useFeatureFlag('dashboards');
   const spendingReportFeatureFlag = useFeatureFlag('spendingReport');
 
-  const baseLayout = widgets.map(widget => ({
-    i: widget.id,
-    w: widget.width,
-    h: widget.height,
-    minW:
-      isCustomReportWidget(widget) || widget.type === 'markdown-card' ? 2 : 3,
-    minH:
-      isCustomReportWidget(widget) || widget.type === 'markdown-card' ? 1 : 2,
-    ...widget,
-  }));
+  const baseLayout = widgets
+    .map(widget => ({
+      i: widget.id,
+      w: widget.width,
+      h: widget.height,
+      minW:
+        isCustomReportWidget(widget) || widget.type === 'markdown-card' ? 2 : 3,
+      minH:
+        isCustomReportWidget(widget) || widget.type === 'markdown-card' ? 1 : 2,
+      ...widget,
+    }))
+    .filter(item => {
+      if (isDashboardsFeatureEnabled) {
+        return true;
+      }
+      if (item.type === 'custom-report' && !customReportMap.has(item.meta.id)) {
+        return false;
+      }
+      return true;
+    });
 
   const layout =
     spendingReportFeatureFlag &&

--- a/upcoming-release-notes/3566.md
+++ b/upcoming-release-notes/3566.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Reports: fix old reports page having empty blocks.


### PR DESCRIPTION
Fixes #3559

Not exactly a _perfect_ patch, but a workable short-term solution until I get the dashboards feature finished off.