### PR TITLE
:electron: Removing electron-is-dev dependency

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -16,7 +16,6 @@ import {
   OpenDialogSyncOptions,
   SaveDialogOptions,
 } from 'electron';
-import isDev from 'electron-is-dev';
 import promiseRetry from 'promise-retry';
 
 import { getMenu } from './menu';
@@ -26,6 +25,8 @@ import {
 } from './window-state';
 
 import './security';
+
+const isDev = !app.isPackaged; // dev mode if not packaged
 
 process.env.lootCoreScript = isDev
   ? 'loot-core/lib-dist/bundle.desktop.js' // serve from local output in development (provides hot-reloading)

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -86,7 +86,6 @@
   },
   "dependencies": {
     "better-sqlite3": "^9.6.0",
-    "electron-is-dev": "2.0.0",
     "electron-log": "4.4.8",
     "node-fetch": "^2.7.0",
     "promise-retry": "^2.0.1"

--- a/upcoming-release-notes/3580.md
+++ b/upcoming-release-notes/3580.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Remove is-dev dependency from the Desktop App

--- a/upcoming-release-notes/3580.md
+++ b/upcoming-release-notes/3580.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MikesGlitch]
 ---
 
-Remove is-dev dependency from the Desktop App
+Remove electron-is-dev dependency from the Desktop App

--- a/yarn.lock
+++ b/yarn.lock
@@ -8417,7 +8417,6 @@ __metadata:
     cross-env: "npm:^7.0.3"
     electron: "npm:30.0.6"
     electron-builder: "npm:24.13.3"
-    electron-is-dev: "npm:2.0.0"
     electron-log: "npm:4.4.8"
     node-fetch: "npm:^2.7.0"
     promise-retry: "npm:^2.0.1"
@@ -8739,13 +8738,6 @@ __metadata:
     electron-builder: cli.js
     install-app-deps: install-app-deps.js
   checksum: 10/d210e787cd1763c108f4600184a02860a3d00553278ef7c9d3a23b46d1646cdbcfa7514f774effb917de17f037a53773b5a6159819fc19da764ad2a3235b1c0f
-  languageName: node
-  linkType: hard
-
-"electron-is-dev@npm:2.0.0":
-  version: 2.0.0
-  resolution: "electron-is-dev@npm:2.0.0"
-  checksum: 10/7393f46f06153d70a427ea904c60a092e50fbf1015c26c342cebb8324ada8c9e0c0f1f02867af56d9cc76f47be17da8cb311ea6bdc83343e7ebd2323ec4014c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

```electron-is-dev``` is no longer required now that Electron has a an ```isPackaged``` property. 

The ```isPackaged``` property is the recommended way to know if we're in dev mode or not. 