### PR TITLE
 :sparkles: (dashboards) making "all widget" button always visible

### DIFF
--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -341,7 +341,7 @@ export function Overview() {
             >
               {currentBreakpoint === 'desktop' && (
                 <>
-                  {isEditing ? (
+                  {isDashboardsFeatureEnabled && (
                     <>
                       <Button
                         ref={triggerRef}
@@ -350,12 +350,6 @@ export function Overview() {
                         onPress={() => setMenuOpen(true)}
                       >
                         <Trans>Add new widget</Trans>
-                      </Button>
-                      <Button
-                        isDisabled={isImporting}
-                        onPress={() => setIsEditing(false)}
-                      >
-                        <Trans>Finish editing dashboard</Trans>
                       </Button>
 
                       <Popover
@@ -430,24 +424,30 @@ export function Overview() {
                         />
                       </Popover>
                     </>
+                  )}
+
+                  {isEditing ? (
+                    <Button
+                      isDisabled={isImporting}
+                      onPress={() => setIsEditing(false)}
+                    >
+                      <Trans>Finish editing dashboard</Trans>
+                    </Button>
+                  ) : isDashboardsFeatureEnabled ? (
+                    <Button
+                      isDisabled={isImporting}
+                      onPress={() => setIsEditing(true)}
+                    >
+                      <Trans>Edit dashboard</Trans>
+                    </Button>
                   ) : (
-                    <>
-                      <Button
-                        variant="primary"
-                        isDisabled={isImporting}
-                        onPress={() => navigate('/reports/custom')}
-                      >
-                        <Trans>Create new custom report</Trans>
-                      </Button>
-                      {isDashboardsFeatureEnabled && (
-                        <Button
-                          isDisabled={isImporting}
-                          onPress={() => setIsEditing(true)}
-                        >
-                          <Trans>Edit dashboard</Trans>
-                        </Button>
-                      )}
-                    </>
+                    <Button
+                      variant="primary"
+                      isDisabled={isImporting}
+                      onPress={() => navigate('/reports/custom')}
+                    >
+                      <Trans>Create new custom report</Trans>
+                    </Button>
                   )}
 
                   {isDashboardsFeatureEnabled && (

--- a/upcoming-release-notes/3588.md
+++ b/upcoming-release-notes/3588.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Dashboards: make "add widgets" button always visible.


### PR DESCRIPTION
Feedback item here: https://github.com/actualbudget/actual/issues/3282#issuecomment-2357762546

---

Before: "add widget" button was visible only in edit mode; "create custom report" button was visible only in non-edit mode

After: "add widget" button is always visible (both edit and non-edit mode); "create custom report" has been removed

---

These changes are under feature flag. Experience WITHOUT the feature flag has no changes (there is still a "create custom report" button)