### PR TITLE
fix size comparison workflow

### DIFF
--- a/.github/workflows/size-compare.yml
+++ b/.github/workflows/size-compare.yml
@@ -61,6 +61,7 @@ jobs:
           workflow: build.yml
           name: build-stats
           path: head
+          allow_forks: true
 
       - name: Strip content hashes from stats files
         run: |

--- a/upcoming-release-notes/3594.md
+++ b/upcoming-release-notes/3594.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix regression in size comparison workflow


### PR DESCRIPTION
This fixes the errors we're seeing with the size comparison workflow

eg.
https://github.com/actualbudget/actual/actions/runs/11219565964/job/31185802750?pr=3581

new default value for `allow_forks` is `false` as of dawidd6/action-download-artifact v4
https://github.com/dawidd6/action-download-artifact/releases/tag/v4