### PR TITLE
:bookmark: (24.10.1) fix synced prefs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/api",
-  "version": "24.10.0",
+  "version": "24.10.1",
   "license": "MIT",
   "description": "An API for Actual",
   "engines": {

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "24.10.0",
+  "version": "24.10.1",
   "license": "MIT",
   "files": [
     "build"

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -3,7 +3,7 @@
   "author": "Actual",
   "productName": "Actual",
   "description": "A simple and powerful personal finance system",
-  "version": "24.10.0",
+  "version": "24.10.1",
   "scripts": {
     "clean": "rm -rf dist",
     "update-client": "bin/update-client",

--- a/upcoming-release-notes/3544.md
+++ b/upcoming-release-notes/3544.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-SyncedPrefs: preload in redux state and fetch from there; improved performance.

--- a/upcoming-release-notes/3566.md
+++ b/upcoming-release-notes/3566.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [MatissJanis]
----
-
-Reports: fix old reports page having empty blocks.

--- a/upcoming-release-notes/3573.md
+++ b/upcoming-release-notes/3573.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [joel-jeremy]
----
-
-[Mobile] Update Budget to Budgeted to match the column name in mobile budget table

--- a/upcoming-release-notes/3574.md
+++ b/upcoming-release-notes/3574.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [joel-jeremy]
----
-
-[Mobile] Fix budget list on mobile auto selecting a budget file under the Switch budget file menu


### PR DESCRIPTION
What commits will be included in the release?

https://github.com/actualbudget/actual/compare/v24.10.1?expand=1

---

- web: https://github.com/actualbudget/actual/pull/3596
- server: https://github.com/actualbudget/actual-server/pull/475
- docs: https://github.com/actualbudget/docs/pull/465