### PR TITLE
:electron: Remove unneeded logger and add reload functionality

### DIFF
--- a/packages/desktop-electron/menu.ts
+++ b/packages/desktop-electron/menu.ts
@@ -106,15 +106,15 @@ export function getMenu(
     {
       label: 'View',
       submenu: [
-        isDev
-          ? {
-              label: 'Reload',
-              accelerator: 'CmdOrCtrl+R',
-              click(_item, focusedWindow) {
-                if (focusedWindow) focusedWindow.reload();
-              },
+        {
+          label: 'Reload',
+          accelerator: 'CmdOrCtrl+R',
+          click(_item, focusedWindow) {
+            if (focusedWindow) {
+              focusedWindow.reload();
             }
-          : { label: 'hidden', visible: false },
+          },
+        },
         {
           label: 'Toggle Developer Tools',
           accelerator:

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -86,7 +86,6 @@
   },
   "dependencies": {
     "better-sqlite3": "^9.6.0",
-    "electron-log": "4.4.8",
     "fs-extra": "^11.2.0",
     "node-fetch": "^2.7.0",
     "promise-retry": "^2.0.1"

--- a/packages/loot-core/src/platform/server/log/index.api.ts
+++ b/packages/loot-core/src/platform/server/log/index.api.ts
@@ -1,6 +1,6 @@
-import type * as T from '.';
+import type { Logger } from '.';
 
-export const logger: T.Logger = {
+export const logger: Logger = {
   info: (...args) => {
     console.log(...args);
   },

--- a/packages/loot-core/src/platform/server/log/index.d.ts
+++ b/packages/loot-core/src/platform/server/log/index.d.ts
@@ -1,9 +1,6 @@
-import { type Transports } from 'electron-log';
-
 export interface Logger {
   info(...args: unknown[]): void;
   warn(...args: unknown[]): void;
-  transports?: Transports;
 }
 
 export const logger: Logger;

--- a/packages/loot-core/src/platform/server/log/index.electron.ts
+++ b/packages/loot-core/src/platform/server/log/index.electron.ts
@@ -1,12 +1,10 @@
-import electronLogger from 'electron-log';
+import type { Logger } from '.';
 
-import type * as T from '.';
-
-if (electronLogger.transports) {
-  electronLogger.transports.file.appName = 'Actual';
-  electronLogger.transports.file.level = 'info';
-  electronLogger.transports.file.maxSize = 7 * 1024 * 1024;
-  electronLogger.transports.console.level = false;
-}
-
-export const logger: T.Logger = electronLogger;
+export const logger: Logger = {
+  info: (...args) => {
+    console.log(...args);
+  },
+  warn: (...args) => {
+    console.warn(...args);
+  },
+};

--- a/packages/loot-core/src/platform/server/log/index.web.ts
+++ b/packages/loot-core/src/platform/server/log/index.web.ts
@@ -1,6 +1,6 @@
-import type * as T from '.';
+import type { Logger } from '.';
 
-export const logger: T.Logger = {
+export const logger: Logger = {
   info: (...args) => {
     console.log(...args);
   },

--- a/packages/loot-core/webpack/webpack.desktop.config.js
+++ b/packages/loot-core/webpack/webpack.desktop.config.js
@@ -28,7 +28,7 @@ module.exports = {
       'pegjs',
     ],
   },
-  externals: ['better-sqlite3', 'electron-log', 'node-fetch'],
+  externals: ['better-sqlite3', 'node-fetch'],
   plugins: [
     new webpack.IgnorePlugin({
       resourceRegExp: /original-fs/,

--- a/upcoming-release-notes/3599.md
+++ b/upcoming-release-notes/3599.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Add reload functionality into the desktop app and remove old logging package

--- a/yarn.lock
+++ b/yarn.lock
@@ -8437,7 +8437,6 @@ __metadata:
     cross-env: "npm:^7.0.3"
     electron: "npm:30.0.6"
     electron-builder: "npm:24.13.3"
-    electron-log: "npm:4.4.8"
     fs-extra: "npm:^11.2.0"
     node-fetch: "npm:^2.7.0"
     promise-retry: "npm:^2.0.1"
@@ -8759,13 +8758,6 @@ __metadata:
     electron-builder: cli.js
     install-app-deps: install-app-deps.js
   checksum: 10/d210e787cd1763c108f4600184a02860a3d00553278ef7c9d3a23b46d1646cdbcfa7514f774effb917de17f037a53773b5a6159819fc19da764ad2a3235b1c0f
-  languageName: node
-  linkType: hard
-
-"electron-log@npm:4.4.8":
-  version: 4.4.8
-  resolution: "electron-log@npm:4.4.8"
-  checksum: 10/9416e1d04395e93b6bfdd9db3815d81b39286e53aa58e21817021ae7dd5a7f03ff5878ad9edcaa2be3e1d0a2d966f785880e10f197abc2a68b8cb7f5719529e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

We don't use electron-logger for anything. The logs are buried in a hidden directory and we only log the server sync status. Instead of logging there, I've put the log messages into the console (which is what the web version does). It will be easier for users to see them there.

Someone asked for the ability to reload the app inside of electron - I've enabled it in the menu.