### PR TITLE
Fixes #2703 - Fixes inaccurate running balance when hiding reconciled transactions

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -488,7 +488,10 @@ class AccountInternal extends PureComponent<
 
     // Filter out reconciled transactions if they are hidden
     // and we're not showing balances.
-    if (!this.state.showReconciled && (!this.state.showBalances || !this.canCalculateBalance())) {
+    if (
+      !this.state.showReconciled &&
+      (!this.state.showBalances || !this.canCalculateBalance())
+    ) {
       query = query.filter({ reconciled: { $eq: false } });
     }
 

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -486,8 +486,9 @@ class AccountInternal extends PureComponent<
       this.paged.unsubscribe();
     }
 
-    // Filter out reconciled transactions if necessary.
-    if (!this.state.showReconciled) {
+    // Filter out reconciled transactions if they are hidden
+    // and we're not showing balances.
+    if (!this.state.showReconciled && (!this.state.showBalances || !this.canCalculateBalance())) {
       query = query.filter({ reconciled: { $eq: false } });
     }
 
@@ -1746,6 +1747,7 @@ class AccountInternal extends PureComponent<
                   payees={payees}
                   balances={allBalances}
                   showBalances={!!allBalances}
+                  showReconciled={showReconciled}
                   showCleared={showCleared}
                   showAccount={
                     !accountId ||

--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -68,6 +68,7 @@ export function TransactionList({
   payees,
   balances,
   showBalances,
+  showReconciled,
   showCleared,
   showAccount,
   headerContent,
@@ -203,8 +204,9 @@ export function TransactionList({
       accounts={accounts}
       categoryGroups={categoryGroups}
       payees={payees}
-      showBalances={showBalances}
       balances={balances}
+      showBalances={showBalances}
+      showReconciled={showReconciled}
       showCleared={showCleared}
       showAccount={showAccount}
       showCategory={true}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1809,6 +1809,12 @@ function TransactionTableInner({
     }
   }, [isAddingPrev, props.isAdding, newNavigator]);
 
+  // Don't render reconciled transactions if we're hiding them.
+  const transactionsToRender = useMemo(
+    () => props.showReconciled ? props.transactions : props.transactions.filter(t => !t.reconciled),
+    [props.transactions, props.showReconciled]
+  );
+
   const renderRow = ({ item, index, editing }) => {
     const {
       transactions,
@@ -1982,7 +1988,7 @@ function TransactionTableInner({
           navigator={tableNavigator}
           ref={tableRef}
           listContainerRef={listContainerRef}
-          items={props.transactions}
+          items={transactionsToRender}
           renderItem={renderRow}
           renderEmpty={renderEmpty}
           loadMore={props.loadMoreTransactions}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1811,8 +1811,11 @@ function TransactionTableInner({
 
   // Don't render reconciled transactions if we're hiding them.
   const transactionsToRender = useMemo(
-    () => props.showReconciled ? props.transactions : props.transactions.filter(t => !t.reconciled),
-    [props.transactions, props.showReconciled]
+    () =>
+      props.showReconciled
+        ? props.transactions
+        : props.transactions.filter(t => !t.reconciled),
+    [props.transactions, props.showReconciled],
   );
 
   const renderRow = ({ item, index, editing }) => {

--- a/upcoming-release-notes/3603.md
+++ b/upcoming-release-notes/3603.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [wysinder]
+---
+
+Fixes inaccurate running balance when hiding reconciled transactions


### PR DESCRIPTION
Fixes #2703 to show an account's running balance accurately when hiding its reconciled transactions. This addresses the use case of wanting to hide reconciled transactions (to keep them off of mind) and still showing the account's running balance.

### Implementation notes:
* This fix changes `updateQuery` to _not_ filter out reconciled transactions, but defers the filtering downstream to `TransactionsTable` instead (which now takes the `showReconciled` prop accordingly).
* This allows us to call `calculateBalances` on the full set of account transactions. Previously, `calculateBalances` would be executed on only the rendered transactions, which meant the calculation would not reflect the account's actual balance.
* This does not break the existing behaviour that hides running balances when searching, filtering, or sorting (`canCalculateBalance` is respected).

### Preview build screenshots:
Show running balance + Show reconciled transactions:
![image](https://github.com/user-attachments/assets/75ac4739-2918-4bf5-bd5a-b5ad68f6fee4)

[PREVIOUS TO THIS FIX] Show running balance + Hide reconciled transactions (inaccurate running balance):
![image](https://github.com/user-attachments/assets/d6e35ac5-7132-41f5-ad78-271508b361de)

[WITH THIS FIX] Show running balance + Hide reconciled transactions (running balance is now accurate):
![image](https://github.com/user-attachments/assets/e5f07cc3-0a37-4044-ba1d-70aceb383a85)

Show running balance + Hide reconciled transactions + Reconciled transaction in between two other transactions (shows accurate running balance on that day):
![image](https://github.com/user-attachments/assets/6369e1fa-b751-405d-84d4-b8378114de77)

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
