### PR TITLE
:sparkles: show the 'import transactions' button even if accounts have banksync

### DIFF
--- a/packages/desktop-client/src/components/accounts/Header.jsx
+++ b/packages/desktop-client/src/components/accounts/Header.jsx
@@ -287,38 +287,37 @@ export function AccountHeader({
           align="center"
           style={{ marginTop: 12 }}
         >
-          {((account && !account.closed) || canSync) && (
+          {canSync && (
             <Button
               variant="bare"
-              onPress={canSync ? onSync : onImport}
-              isDisabled={canSync && isServerOffline}
+              onPress={onSync}
+              isDisabled={isServerOffline}
             >
-              {canSync ? (
-                <>
-                  <AnimatedRefresh
-                    width={13}
-                    height={13}
-                    animating={
-                      account
-                        ? accountsSyncing.includes(account.id)
-                        : accountsSyncing.length > 0
-                    }
-                    style={{ marginRight: 4 }}
-                  />{' '}
-                  {isServerOffline ? t('Bank Sync Offline') : t('Bank Sync')}
-                </>
-              ) : (
-                <>
-                  <SvgDownloadThickBottom
-                    width={13}
-                    height={13}
-                    style={{ marginRight: 4 }}
-                  />{' '}
-                  <Trans>Import</Trans>
-                </>
-              )}
+              <AnimatedRefresh
+                width={13}
+                height={13}
+                animating={
+                  account
+                    ? accountsSyncing.includes(account.id)
+                    : accountsSyncing.length > 0
+                }
+                style={{ marginRight: 4 }}
+              />{' '}
+              {isServerOffline ? t('Bank Sync Offline') : t('Bank Sync')}
             </Button>
           )}
+
+          {account && !account.closed && (
+            <Button variant="bare" onPress={onImport}>
+              <SvgDownloadThickBottom
+                width={13}
+                height={13}
+                style={{ marginRight: 4 }}
+              />{' '}
+              <Trans>Import</Trans>
+            </Button>
+          )}
+
           {!showEmptyMessage && (
             <Button variant="bare" onPress={onAddTransaction}>
               <SvgAdd width={10} height={10} style={{ marginRight: 3 }} />

--- a/upcoming-release-notes/3615.md
+++ b/upcoming-release-notes/3615.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Show the "import transactions" button even if accounts have bank-sync enabled.


### PR DESCRIPTION
Tiny quality of life improvement.

<img width="477" alt="Screenshot 2024-10-09 at 18 17 56" src="https://github.com/user-attachments/assets/651c6edb-0284-4f94-9fc4-0580908c69c9">
