### PR TITLE
recalculateSplit one last time to clear any erroneous errors

### DIFF
--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -789,7 +789,7 @@ export function execActions(actions: Action[], transaction) {
   // Remove that entry from the subtransactions.
   update.subtransactions = update.subtransactions.slice(1);
 
-  return update;
+  return recalculateSplit(update);
 }
 
 export class Rule {

--- a/upcoming-release-notes/3624.md
+++ b/upcoming-release-notes/3624.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Sjones512]
+---
+
+Fix rules for scheduled transactions incorrectly showing a split error when the all splits are "fixed-amount".


### PR DESCRIPTION
Call recalculateSplit one last time to clear any erroneous errors

Fixes #3353 
