### PR TITLE
fix: run rules on reconciliation transaction

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -969,9 +969,16 @@ class AccountInternal extends PureComponent<
       transactions: [...reconciliationTransactions, ...this.state.transactions],
     });
 
+    // run rules on the reconciliation transaction
+    const ruledTransactions = await Promise.all(
+      reconciliationTransactions.map(transaction =>
+        send('rules-run', { transaction }),
+      ),
+    );
+
     // sync the reconciliation transaction
     await send('transactions-batch-update', {
-      added: reconciliationTransactions,
+      added: ruledTransactions,
     });
     await this.refetchTransactions();
   };

--- a/upcoming-release-notes/3625.md
+++ b/upcoming-release-notes/3625.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnderKoen]
+---
+
+Run rules on "Reconciliation balance adjustment" transactions


### PR DESCRIPTION
Run rules on reconciliated transactions