### PR TITLE
fix: import meta of non custom report widgets

### DIFF
--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -194,7 +194,7 @@ async function importDashboard({ filepath }: { filepath: string }) {
             y: widget.y,
             meta: isExportedCustomReportWidget(widget)
               ? { id: widget.meta.id }
-              : null,
+              : widget.meta,
           }),
         ),
 

--- a/upcoming-release-notes/3626.md
+++ b/upcoming-release-notes/3626.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnderKoen]
+---
+
+Fix importing of non custom reports widgets on the (experimental) reports page.


### PR DESCRIPTION
When importing the exported file of the report dashboard. Names and timeframe data is lost.

Related feature: #3282 

Testing:
The following json should fail on edge to be imported (the metadata of text is required)
[dashboard (3).json](https://github.com/user-attachments/files/17330845/dashboard.3.json)

The following should be import but without custom names for networth
[dashboard (4).json](https://github.com/user-attachments/files/17330996/dashboard.4.json)

Hope it is clear!
