### PR TITLE
Clarify logic to generate splits from rules

### DIFF
--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -675,6 +675,32 @@ describe('Rule', () => {
         },
       );
     });
+
+    test('generate errors on fixed amounts less than total', () => {
+      expect(
+        fixedAmountRule.exec({ imported_payee: 'James', amount: 100 }),
+      ).toMatchObject({
+        error: {
+          difference: -100,
+          type: 'SplitTransactionError',
+          version: 1,
+        },
+        subtransactions: [{ amount: 100 }, { amount: 100 }],
+      });
+    });
+
+    test('generate errors on fixed amounts more than total', () => {
+      expect(
+        fixedAmountRule.exec({ imported_payee: 'James', amount: 300 }),
+      ).toMatchObject({
+        error: {
+          difference: 100,
+          type: 'SplitTransactionError',
+          version: 1,
+        },
+        subtransactions: [{ amount: 100 }, { amount: 100 }],
+      });
+    });
   });
 
   test('rules are deterministically ranked', () => {

--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -676,7 +676,7 @@ describe('Rule', () => {
       );
     });
 
-    test('generate errors on fixed amounts less than total', () => {
+    test('generate errors when fixed amounts exceed the total', () => {
       expect(
         fixedAmountRule.exec({ imported_payee: 'James', amount: 100 }),
       ).toMatchObject({
@@ -689,7 +689,7 @@ describe('Rule', () => {
       });
     });
 
-    test('generate errors on fixed amounts more than total', () => {
+    test('generate errors when fixed amounts undershoot the total', () => {
       expect(
         fixedAmountRule.exec({ imported_payee: 'James', amount: 300 }),
       ).toMatchObject({

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -22,6 +22,7 @@ import {
 import { recurConfigToRSchedule } from '../../shared/schedules';
 import {
   addSplitTransaction,
+  groupTransaction,
   recalculateSplit,
   splitTransaction,
   ungroupTransaction,
@@ -667,6 +668,75 @@ function execNonSplitActions(actions: Action[], transaction) {
   return update;
 }
 
+function getSplitRemainder(transactions) {
+  const { error } = recalculateSplit(groupTransaction(transactions));
+  return error ? error.difference : 0;
+}
+
+function execSplitActions(actions: Action[], transaction) {
+  const splitAmountActions = actions.filter(
+    action => action.op === 'set-split-amount',
+  );
+
+  // Convert the transaction to a split transaction.
+  const { data } = splitTransaction(
+    ungroupTransaction(transaction),
+    transaction.id,
+  );
+  let newTransactions = data;
+
+  // Add empty splits, and apply non-set-amount actions.
+  // This also populates any fixed-amount splits.
+  actions.forEach(action => {
+    const splitTransactionIndex = (action.options?.splitIndex ?? 0) + 1;
+    if (splitTransactionIndex >= newTransactions.length) {
+      const { data } = addSplitTransaction(newTransactions, transaction.id);
+      newTransactions = data;
+    }
+    action.exec(newTransactions[splitTransactionIndex]);
+  });
+
+  // Distribute to fixed-percent splits.
+  const remainingAfterFixedAmounts = getSplitRemainder(newTransactions);
+  splitAmountActions
+    .filter(action => action.options.method === 'fixed-percent')
+    .forEach(action => {
+      const splitTransactionIndex = (action.options?.splitIndex ?? 0) + 1;
+      const percent = action.value / 100;
+      const amount = Math.round(remainingAfterFixedAmounts * percent);
+      newTransactions[splitTransactionIndex].amount = amount;
+    });
+
+  // Distribute to remainder splits.
+  const remainderActions = splitAmountActions.filter(
+    action => action.options.method === 'remainder',
+  );
+  const remainingAfterFixedPercents = getSplitRemainder(newTransactions);
+  if (remainderActions.length !== 0) {
+    const amountPerRemainderSplit = Math.round(
+      remainingAfterFixedPercents / remainderActions.length,
+    );
+    let lastNonFixedTransactionIndex = -1;
+    remainderActions.forEach(action => {
+      const splitTransactionIndex = (action.options?.splitIndex ?? 0) + 1;
+      newTransactions[splitTransactionIndex].amount = amountPerRemainderSplit;
+      lastNonFixedTransactionIndex = Math.max(
+        lastNonFixedTransactionIndex,
+        splitTransactionIndex,
+      );
+    });
+
+    // The last remainder split will be adjusted for any leftovers from rounding.
+    newTransactions[lastNonFixedTransactionIndex].amount -=
+      getSplitRemainder(newTransactions);
+  }
+
+  // The split index 0 (transaction index 1) is reserved for "Apply to all" actions.
+  // Remove that entry from the transaction list.
+  newTransactions.splice(1, 1);
+  return recalculateSplit(groupTransaction(newTransactions));
+}
+
 export function execActions(actions: Action[], transaction) {
   const parentActions = actions.filter(action => !action.options?.splitIndex);
   const childActions = actions.filter(action => action.options?.splitIndex);
@@ -676,126 +746,18 @@ export function execActions(actions: Action[], transaction) {
       0,
     ) + 1;
 
-  let update = execNonSplitActions(parentActions, transaction);
+  const nonSplitResult = execNonSplitActions(parentActions, transaction);
   if (totalSplitCount === 1) {
     // No splits, no need to do anything else.
-    return update;
+    return nonSplitResult;
   }
 
-  if (update.is_child) {
+  if (nonSplitResult.is_child) {
     // Rules with splits can't be applied to child transactions.
-    return update;
+    return nonSplitResult;
   }
 
-  const splitAmountActions = childActions.filter(
-    action => action.op === 'set-split-amount',
-  );
-  const fixedSplitAmountActions = splitAmountActions.filter(
-    action => action.options.method === 'fixed-amount',
-  );
-  const fixedAmountsBySplit: Record<number, number> = {};
-  fixedSplitAmountActions.forEach(action => {
-    const splitIndex = action.options.splitIndex ?? 0;
-    fixedAmountsBySplit[splitIndex] = action.value;
-  });
-  const fixedAmountSplitCount = Object.keys(fixedAmountsBySplit).length;
-  const totalFixedAmount = Object.values(fixedAmountsBySplit).reduce<number>(
-    (prev, cur: number) => prev + cur,
-    0,
-  );
-  if (
-    fixedAmountSplitCount === totalSplitCount &&
-    totalFixedAmount !== (transaction.amount ?? totalFixedAmount)
-  ) {
-    // Not all value would be distributed to a split.
-    return transaction;
-  }
-
-  const { data, newTransaction } = splitTransaction(
-    ungroupTransaction(update),
-    transaction.id,
-  );
-  update = recalculateSplit(newTransaction);
-  data[0] = update;
-  let newTransactions = data;
-
-  for (const action of childActions) {
-    const splitIndex = action.options?.splitIndex ?? 0;
-    if (splitIndex >= update.subtransactions.length) {
-      const { data, newTransaction } = addSplitTransaction(
-        newTransactions,
-        transaction.id,
-      );
-      update = recalculateSplit(newTransaction);
-      data[0] = update;
-      newTransactions = data;
-    }
-    action.exec(update.subtransactions[splitIndex]);
-  }
-
-  // Make sure every transaction has an amount.
-  if (fixedAmountSplitCount !== totalSplitCount) {
-    // This is the amount that will be distributed to the splits that
-    // don't have a fixed amount. The last split will get the remainder.
-    // The amount will be zero if the parent transaction has no amount.
-    const amountToDistribute =
-      (transaction.amount ?? totalFixedAmount) - totalFixedAmount;
-    let remainingAmount = amountToDistribute;
-
-    // First distribute the fixed percentages.
-    splitAmountActions
-      .filter(action => action.options.method === 'fixed-percent')
-      .forEach(action => {
-        const splitIndex = action.options.splitIndex;
-        const percent = action.value / 100;
-        const amount = Math.round(amountToDistribute * percent);
-        update.subtransactions[splitIndex].amount = amount;
-        remainingAmount -= amount;
-      });
-
-    // Then distribute the remainder.
-    const remainderSplitAmountActions = splitAmountActions.filter(
-      action => action.options.method === 'remainder',
-    );
-
-    // Check if there is any value left to distribute after all fixed
-    // (percentage and amount) splits have been distributed.
-    if (remainingAmount !== 0) {
-      // If there are no remainder splits explicitly added by the user,
-      // distribute the remainder to a virtual split that will be
-      // adjusted for the remainder.
-      if (remainderSplitAmountActions.length === 0) {
-        const splitIndex = totalSplitCount;
-        const { newTransaction } = addSplitTransaction(
-          newTransactions,
-          transaction.id,
-        );
-        update = recalculateSplit(newTransaction);
-        update.subtransactions[splitIndex].amount = remainingAmount;
-      } else {
-        const amountPerRemainderSplit = Math.round(
-          remainingAmount / remainderSplitAmountActions.length,
-        );
-        let lastNonFixedIndex = -1;
-        remainderSplitAmountActions.forEach(action => {
-          const splitIndex = action.options.splitIndex;
-          update.subtransactions[splitIndex].amount = amountPerRemainderSplit;
-          remainingAmount -= amountPerRemainderSplit;
-          lastNonFixedIndex = Math.max(lastNonFixedIndex, splitIndex);
-        });
-
-        // The last non-fixed split will be adjusted for the remainder.
-        update.subtransactions[lastNonFixedIndex].amount -= remainingAmount;
-      }
-      update = recalculateSplit(update);
-    }
-  }
-
-  // The split index 0 is reserved for "Apply to all" actions.
-  // Remove that entry from the subtransactions.
-  update.subtransactions = update.subtransactions.slice(1);
-
-  return recalculateSplit(update);
+  return execSplitActions(childActions, nonSplitResult);
 }
 
 export class Rule {

--- a/upcoming-release-notes/3641.md
+++ b/upcoming-release-notes/3641.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix visual glitches with scheduled split transactions


### PR DESCRIPTION
Closes #3353 and fixes another bug I found in the process (if you add amounts that _don't_ add up to the total, previously there _was no error_). Process I used to test this:
1. Add unit tests for #3353 and validate the specific test fails.
2. Add tests for the other bug and validate they fail.
3. Refactor and simplify the split generation logic. All tests now pass, and some basic testing in the UI looks good.

The straightforward fix for this issue is in https://github.com/actualbudget/actual/pull/3624. However, from revisiting this logic, it was pretty messy and hard to reason about before. Hopefully the refactor I'm landing here along with the tests will give increased confidence.