### PR TITLE
Explicitly disable 1Password on table inputs

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -139,7 +139,7 @@ function fireUpdate<T extends Item>(
 }
 
 function defaultRenderInput(props: ComponentProps<typeof Input>) {
-  return <Input {...props} />;
+  return <Input data-1p-ignore {...props} />;
 }
 
 function defaultRenderItems<T extends Item>(

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -139,6 +139,7 @@ function fireUpdate<T extends Item>(
 }
 
 function defaultRenderInput(props: ComponentProps<typeof Input>) {
+  // data-1p-ignore disables 1Password autofill behaviour
   return <Input data-1p-ignore {...props} />;
 }
 

--- a/upcoming-release-notes/3674.md
+++ b/upcoming-release-notes/3674.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [greggroth]
+---
+
+Fixes 1Password credit card autocomplete showing on the transactions table


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

When an account includes "Credit Card", 1Password really wants to suggest credit cards when you try to set the category or payee. This PR explicitly disables 1Password's autocomplete feature on table inputs to prevent these unwanted suggestions [using the `data-1p-ignore` property](https://developer.1password.com/docs/web/compatible-website-design/).

![Screenshot 2024-10-15 at 11 00 53 AM](https://github.com/user-attachments/assets/f8bf0e62-e2b2-436e-a64a-be22af980bfa)

I took a bit of a large-hammer/simpler approach and assumed there shouldn't be 1Password suggestions anywhere within Actual, so I added it to all `input` elements added by `Autocomplete`, but I can refactor it to push this into the properties if you'd prefer.