### PR TITLE
allow 4 decimal places in file imports

### DIFF
--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -10,7 +10,8 @@ describe('utility functions', () => {
     expect(looselyParseAmount('3.45')).toBe(3.45);
     // cant tell if this next case should be decimal or different format
     // so we set as full numbers
-    expect(looselyParseAmount('3.456')).toBe(3456);
+    expect(looselyParseAmount('3.456')).toBe(3456); // the expected failing case
+    expect(looselyParseAmount('3.4500')).toBe(3.45);
     expect(looselyParseAmount('3.45000')).toBe(3.45);
     expect(looselyParseAmount('3.450000')).toBe(3.45);
     expect(looselyParseAmount('3.4500000')).toBe(3.45);
@@ -20,7 +21,8 @@ describe('utility functions', () => {
 
   test('looseParseAmount works with alternate formats', () => {
     expect(looselyParseAmount('3,45')).toBe(3.45);
-    expect(looselyParseAmount('3,456')).toBe(3456);
+    expect(looselyParseAmount('3,456')).toBe(3456); //expected failing case
+    expect(looselyParseAmount('3,4500')).toBe(3.45);
     expect(looselyParseAmount('3,45000')).toBe(3.45);
     expect(looselyParseAmount('3,450000')).toBe(3.45);
     expect(looselyParseAmount('3,4500000')).toBe(3.45);

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -429,7 +429,7 @@ export function looselyParseAmount(amount: string) {
 
   // Look for a decimal marker, then look for either 1-2 or 5-9 decimal places.
   // This avoids matching against 3 places which may not actually be decimal
-  const m = amount.match(/[.,]([^.,]{5,9}|[^.,]{1,2})$/);
+  const m = amount.match(/[.,]([^.,]{4,9}|[^.,]{1,2})$/);
   if (!m || m.index === undefined) {
     return safeNumber(parseFloat(extractNumbers(amount)));
   }

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -427,7 +427,7 @@ export function looselyParseAmount(amount: string) {
     amount = amount.replace('(', '-').replace(')', '');
   }
 
-  // Look for a decimal marker, then look for either 1-2 or 5-9 decimal places.
+  // Look for a decimal marker, then look for either 1-2 or 4-9 decimal places.
   // This avoids matching against 3 places which may not actually be decimal
   const m = amount.match(/[.,]([^.,]{4,9}|[^.,]{1,2})$/);
   if (!m || m.index === undefined) {

--- a/upcoming-release-notes/3676.md
+++ b/upcoming-release-notes/3676.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Allow 4 decimal places in file import.


### PR DESCRIPTION
fixes #3638 

Still ignores 3 decimal places since that would break things for lots of people.
I should have allowed this before, but I didn't know if any banks actually exported 4 places.  I guess we know now.
