### PR TITLE
Fix incorrect cumulative totals for Days 28+ on the Spending Report

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -223,7 +223,7 @@ export function createSpendingSpreadsheet({
           return arr;
         }, []);
         const maxCumulative = data.reduce((a, b) =>
-          a.cumulative < b.cumulative ? a : b,
+          b.cumulative === null ? a : b,
         ).cumulative;
 
         const totalDaily = data.reduce((a, v) => (a = a + v.totalTotals), 0);

--- a/upcoming-release-notes/3679.md
+++ b/upcoming-release-notes/3679.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-rich]
+---
+
+Fix incorrect cumulative totals for Days 28+ on the Spending Report


### PR DESCRIPTION
Hey, this is my first pull request and I'm not very familiar with contributing to projects in general, so let me know if this is the correct process or if I should do anything in a different way.

This change fixes incorrect cumulative totals on days 28+ in the Spending Report that can occur when there are deposit transactions.

Brief summary of code's purpose:
Loops through an array with objects for days 28 to 30/31. Objects have a "cumulative total" already calculated. We want to use the latest "real" value (ie: if it's the 29th of the current month, the 30th's value doesn't exist, so use the 29th's cumulative total).

Explanation of issue:
The old code seemed to assume each "real" day's cumulative total would always decrease (larger negative value). It checked each day's value against the next day's and kept the smaller number. Presumably, it assumed the larger number would be 0 or null due to the day not having happened yet, but this isn't the always the case when there are deposit transactions. This caused the largest negative and [possibly] incorrect cumulative total to show up on the graph.

eg:
If we had these totals in a 31-day month
```
Day, Daily Total, Cumulative Total
...
28, -500, -2000
29, 500, -1500
30, -300, -1800
31, -150, -1950
```
2000 would show up on the graph rather than 1950 since 2000 is the largest negative value and would be checked against the rest.

If the 31st day had a Daily Total of 250 instead, the correct Cumulative Total of 2050 would show up on the graph since 2050 is now the largest negative cumulative total.

Fix:
I noticed the Cumulative total for days that haven't happened yet is null, so I just changed it to use the last non-null cumulative total. If applicable, days that have passed will have a cumulative total of 0 rather than null, so checking against null should only impact future days.

I wrote this comment about it, but I hadn't looked at the code so was off on some details at the time. https://github.com/actualbudget/actual/issues/2820#issuecomment-2408100582