### PR TITLE
Fixes #3682 - Fix $ne filters incorrectly excluding null values

### DIFF
--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -706,8 +706,8 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
         state.namedParameters = [].concat.apply([], orders);
 
         return `CASE
-          WHEN ${left} IS NULL THEN ${right} IS NULL
-          ELSE ${left} != ${right}
+          WHEN ${left} IS NULL THEN ${right} IS NOT NULL
+          ELSE ${left} IS NOT ${right}
         END`;
       }
 

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -711,7 +711,7 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
         END`;
       }
 
-      return `${left} != ${right}`;
+      return `(${left} != ${right} OR ${left} IS NULL)`;
     }
     case '$oneof': {
       const [left, right] = valArray(state, [lhs, rhs], [null, 'array']);

--- a/packages/loot-core/src/server/aql/exec.test.ts
+++ b/packages/loot-core/src/server/aql/exec.test.ts
@@ -167,7 +167,7 @@ describe('runQuery', () => {
   it('allows null as a parameter', async () => {
     await db.insertCategoryGroup({ id: 'group', name: 'group' });
     await db.insertCategory({ id: 'cat', name: 'cat', cat_group: 'group' });
-    await db.insertCategory({ id: 'different', name: 'different', cat_group: 'group' });
+    await db.insertCategory({ id: 'cat2', name: 'cat2', cat_group: 'group' });
     const transNoCat = await db.insertTransaction({
       account: 'acct',
       date: '2020-01-01',
@@ -184,7 +184,7 @@ describe('runQuery', () => {
       account: 'acct',
       date: '2020-01-02',
       amount: -5001,
-      category: 'different',
+      category: 'cat2',
     });
 
     const queryState = q('transactions')
@@ -200,29 +200,40 @@ describe('runQuery', () => {
 
     data = (
       await runQuery(
-
         q('transactions')
           .filter({ category: { $ne: ':category' } })
           .select('category')
           .serialize(),
 
-        { params: { category: 'different' } }
+        { params: { category: 'cat2' } },
       )
     ).data;
-    expect(data.length).toBe(2);
+    expect(data).toHaveLength(2);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: transNoCat }),
+        expect.objectContaining({ id: transCat }),
+        expect.not.objectContaining({ id: transCat2 }),
+      ]),
+    );
 
     data = (
       await runQuery(
-
         q('transactions')
           .filter({ category: { $ne: ':category' } })
           .select('category')
           .serialize(),
-        { params: { category: null } }
+        { params: { category: null } },
       )
     ).data;
-    expect(data.length).toBe(2);
-
+    expect(data).toHaveLength(2);
+    expect(data).toEqual(
+      expect.arrayContaining([
+        expect.not.objectContaining({ id: transNoCat }),
+        expect.objectContaining({ id: transCat }),
+        expect.objectContaining({ id: transCat2 }),
+      ]),
+    );
   });
 
   it('parameters have the correct order', async () => {


### PR DESCRIPTION
Fixes #3682 

As described in the ticket, any "is not" or "not one of" filters currently exclude the specified value(s) and also exclude null values.

Reproduce by filtering All Transactions to exclude any category - all off-budget or categorized transactions also get filtered out.

Given, example list dataset of Items (name, colour)
```
"Banana", "Yellow"
"Lime", "Yellow"
"Air", null
"Car", "Red"
```

And query of `select * from Items where colour != "Yellow"`,

Old result set (incorrectly excluding both null and "Yellow" Items):
`"Car", "Red"`

After my change, the new result set returns all Items which aren't yellow:
```
"Air", null
"Car", "Red"
```

-----

I wrote a couple tests for namedParameter queries and no existing tests are failing, but even still I'm not overly confident in the changes on lines 709-710 due to it being a weird bit of sql and I'm not a sql expert. I would appreciate it if someone with more sql knowledge confirms it won't have any weird edge-cases I didn't think to test for.
