### PR TITLE
Handling tunnel errors as network failure

### DIFF
--- a/packages/loot-core/src/server/post.ts
+++ b/packages/loot-core/src/server/post.ts
@@ -18,8 +18,6 @@ function throwIfNot200(res, text) {
 
     // Actual Sync Server may be exposed via a tunnel (e.g. ngrok). Tunnel errors should be treated as network errors.
     const tunnelErrorHeaders = ['ngrok-error-code'];
-
-    // const headerKeys = res.headers.keys().toArray();
     const tunnelError = tunnelErrorHeaders.some(header =>
       res.headers.has(header),
     );

--- a/packages/loot-core/src/server/post.ts
+++ b/packages/loot-core/src/server/post.ts
@@ -15,6 +15,21 @@ function throwIfNot200(res, text) {
       const json = JSON.parse(text);
       throw new PostError(json.reason);
     }
+
+    // Actual Sync Server may be exposed via a tunnel (e.g. ngrok). Tunnel errors should be treated as network errors.
+    const tunnelErrorHeaders = ['ngrok-error-code'];
+
+    const headerKeys = res.headers.keys().toArray();
+    const tunnelError = tunnelErrorHeaders.some(tunnelErrorHeader =>
+      headerKeys.includes(tunnelErrorHeader),
+    );
+
+    if (tunnelError) {
+      // Tunnel errors are present when the tunnel is active and the server is not reachable e.g. server is offline
+      // When we experience a tunnel error we treat it as a network failure
+      throw new PostError('network-failure');
+    }
+
     throw new PostError(text);
   }
 }

--- a/packages/loot-core/src/server/post.ts
+++ b/packages/loot-core/src/server/post.ts
@@ -19,9 +19,9 @@ function throwIfNot200(res, text) {
     // Actual Sync Server may be exposed via a tunnel (e.g. ngrok). Tunnel errors should be treated as network errors.
     const tunnelErrorHeaders = ['ngrok-error-code'];
 
-    const headerKeys = res.headers.keys().toArray();
-    const tunnelError = tunnelErrorHeaders.some(tunnelErrorHeader =>
-      headerKeys.includes(tunnelErrorHeader),
+    // const headerKeys = res.headers.keys().toArray();
+    const tunnelError = tunnelErrorHeaders.some(header =>
+      res.headers.has(header),
     );
 
     if (tunnelError) {

--- a/upcoming-release-notes/3697.md
+++ b/upcoming-release-notes/3697.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Supporting the use of an ngrok tunnel when used to tunnel into actual-sync server


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

## Why?

If the sync server is behind an active tunnel but the server is offline we get a error message like: 

```
We had problems syncing your changes. Please report this as a bug by [opening a Github issue]
```

We get the error because the tunnel service says it can't connect to the server and we're not handling it.

This could be a common situation when the user wants to run the sync server on a computer in their house, but expose it to the internet for mobile use. Tunneling services like ngrok stay online forever, but If they turn their computer off the sync server goes offline. 

This fix detects known tunnels (ngrok for now) and if the tunnel is telling us the server is offline we handle it as normal - we tell the user it's offline.

This was found while working on the desktop app server sync: https://github.com/actualbudget/actual/pull/3631
