### PR TITLE
:bug: (bank-sync) revert bank-sync status indicator change

### DIFF
--- a/packages/loot-core/src/client/actions/account.ts
+++ b/packages/loot-core/src/client/actions/account.ts
@@ -62,10 +62,6 @@ export function linkAccount(
   offBudget?: boolean,
 ) {
   return async (dispatch: Dispatch) => {
-    if (upgradingId) {
-      await dispatch(setAccountsSyncing([upgradingId]));
-    }
-
     await send('gocardless-accounts-link', {
       requisitionId,
       account,
@@ -83,10 +79,6 @@ export function linkAccountSimpleFin(
   offBudget?: boolean,
 ) {
   return async (dispatch: Dispatch) => {
-    if (upgradingId) {
-      await dispatch(setAccountsSyncing([upgradingId]));
-    }
-
     await send('simplefin-accounts-link', {
       externalAccount,
       upgradingId,

--- a/upcoming-release-notes/3720.md
+++ b/upcoming-release-notes/3720.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Revert initial bank-sync operation status indicator change.


### PR DESCRIPTION
In https://github.com/actualbudget/actual/pull/3540 I was attempting to fix the status indicator for initial bank-sync operation. Unfortunately, this change has made things slightly worse. Sometimes the "loading" state for the initial bank-sync comes up, but then never goes away. I have not been able to figure out WHY. But arguably having no loading state is better than a forever-loading state, so reverting my original patch until I figure out a better solution.