### PR TITLE
Fix issue with Monthly Spending report not properly averaging previous three months

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -194,7 +194,11 @@ export function createSpendingSpreadsheet({
               }
               return null;
             });
-            if (month.month >= startDate && month.month < compare) {
+
+            if (
+              month.month >= monthUtils.monthFromDate(startDate) &&
+              month.month < compare
+            ) {
               if (day === '28') {
                 if (monthUtils.getMonthEnd(intervalItem) === intervalItem) {
                   averageSum += cumulativeAssets + cumulativeDebts;

--- a/upcoming-release-notes/3723.md
+++ b/upcoming-release-notes/3723.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-rich]
+---
+
+Fix issue with Monthly Spending report not properly averaging previous three months


### PR DESCRIPTION
I noticed the Monthly Spending report wasn't properly averaging the previous three months when "Average" was selected. In my tests only the previous two months were averaged.

Issue was that not all date variables were in the same format. 

`month.month` was `YYYY-MM`
`startDate` was `YYYY-MM-DD`

This caused issues when doing the string compare of `month.month >= startDate`

Changed it to call the month helper function to format startDate correctly for the comparison