### PR TITLE
fix Tag filtering crashing app when tag has regex special character

### DIFF
--- a/packages/loot-core/src/server/accounts/transaction-rules.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.ts
@@ -468,7 +468,9 @@ export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
 
         return {
           $and: tagValues.map(v => {
-            const regex = new RegExp(`(^|\\s)${v}(\\s|$)`);
+            const regex = new RegExp(
+              `(^|\\s)${v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\s|$)`,
+            );
             return apply(field, '$regexp', regex.source);
           }),
         };

--- a/upcoming-release-notes/3725.md
+++ b/upcoming-release-notes/3725.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-rich]
+---
+
+fix Tag filtering crashing app when tag has regex special character


### PR DESCRIPTION
Actual would crash if user attempted to filter by a Tag that has regex special characters in it - see discord support thread https://discord.com/channels/937901803608096828/1297943156146311208

Fixed by escaping regex special characters in tag before doing regex tag search - used regex found here https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions#escaping