### PR TITLE
Fix Issue #3662 - Distribute button calculates splits one at a time

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -106,6 +106,7 @@ export function TransactionList({
 
   const onSave = useCallback(async transaction => {
     const changes = updateTransaction(transactionsLatest.current, transaction);
+    transactionsLatest.current = changes.data;
 
     if (changes.diff.updated.length > 0) {
       const dateChanged = !!changes.diff.updated[0].date;

--- a/upcoming-release-notes/3728.md
+++ b/upcoming-release-notes/3728.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix Distribute button calculates splits one at a time.


### PR DESCRIPTION
Fix #3662 