### PR TITLE
Fix Parse for Date Range

### DIFF
--- a/packages/desktop-client/src/components/reports/DateRange.tsx
+++ b/packages/desktop-client/src/components/reports/DateRange.tsx
@@ -17,7 +17,7 @@ type DateRangeProps = {
 
 function checkDate(date: string) {
   const dateParsed = monthUtils.parseDate(date);
-  if (dateParsed.toString() !== 'Invalid Date') {
+  if (dateParsed) {
     return d.format(dateParsed, 'yyyy-MM-dd');
   } else {
     return null;

--- a/packages/desktop-client/src/components/reports/DateRange.tsx
+++ b/packages/desktop-client/src/components/reports/DateRange.tsx
@@ -2,6 +2,8 @@ import React, { type ReactElement } from 'react';
 
 import * as d from 'date-fns';
 
+import * as monthUtils from 'loot-core/src/shared/months';
+
 import { theme } from '../../style';
 import { styles } from '../../style/styles';
 import { Block } from '../common/Block';
@@ -14,7 +16,7 @@ type DateRangeProps = {
 };
 
 function checkDate(date: string) {
-  const dateParsed = new Date(date);
+  const dateParsed = monthUtils.parseDate(date);
   if (dateParsed.toString() !== 'Invalid Date') {
     return d.format(dateParsed, 'yyyy-MM-dd');
   } else {

--- a/upcoming-release-notes/3735.md
+++ b/upcoming-release-notes/3735.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [carkom]
+---
+
+Fix parse date in DateRange element which is causing the cards to display the wrong dates.


### PR DESCRIPTION
Fix parse date in DateRange element which is causing the cards to display the wrong dates.
