### PR TITLE
Fix "Name" field being in wrong colour in Schedules page

### DIFF
--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -283,9 +283,7 @@ export function SchedulesTable({
         <Field width="flex" name="name">
           <Text
             style={
-              schedule.name == null
-                ? { color: theme.buttonNormalDisabledText }
-                : null
+              !schedule.name ? { color: theme.buttonNormalDisabledText } : null
             }
             title={schedule.name ? schedule.name : ''}
           >

--- a/upcoming-release-notes/3739.md
+++ b/upcoming-release-notes/3739.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aappaapp]
+---
+
+Fix "Name" field being in wrong colour in Schedules page


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fixed "None" not being in the disabled colour.

<details>
<summary>Original behaviour</summary>

![image](https://github.com/user-attachments/assets/8b5cc8e9-533b-45ac-a245-03fdb48fb4e0)

</details>