### PR TITLE
:bug: (dashboards) save cash flow balance setting

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -90,7 +90,9 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
   const [start, setStart] = useState(initialStart);
   const [end, setEnd] = useState(initialEnd);
   const [mode, setMode] = useState(initialMode);
-  const [showBalance, setShowBalance] = useState(true);
+  const [showBalance, setShowBalance] = useState(
+    widget?.meta?.showBalance ?? true,
+  );
 
   const [isConcise, setIsConcise] = useState(() => {
     const numDays = d.differenceInCalendarDays(
@@ -158,6 +160,7 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
           end,
           mode,
         },
+        showBalance,
       },
     });
     dispatch(

--- a/packages/loot-core/src/types/models/dashboard.d.ts
+++ b/packages/loot-core/src/types/models/dashboard.d.ts
@@ -37,6 +37,7 @@ export type CashFlowWidget = AbstractWidget<
     conditions?: RuleConditionEntity[];
     conditionsOp?: 'and' | 'or';
     timeFrame?: TimeFrame;
+    showBalance?: boolean;
   } | null
 >;
 export type SpendingWidget = AbstractWidget<

--- a/upcoming-release-notes/3745.md
+++ b/upcoming-release-notes/3745.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Dashboards: save cash-flow balance setting with the widget.


### PR DESCRIPTION
Closes #3671

It doesn't actually affect the widget in the dashboard page though... but now the state of it will be saved in the "inner" pages.