### PR TITLE
fix: date handlebar functions

### DIFF
--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -406,6 +406,10 @@ describe('Action', () => {
       testHelper('{{month "2002-07-25"}}', '7');
       testHelper('{{year "2002-07-25"}}', '2002');
       testHelper('{{format "2002-07-25" "MM yyyy d"}}', '07 2002 25');
+      testHelper('{{day undefined}}', '');
+      testHelper('{{month undefined}}', '');
+      testHelper('{{year undefined}}', '');
+      testHelper('{{format undefined undefined}}', '');
     });
 
     test('{{debug}} should log the item', () => {

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -76,10 +76,10 @@ function registerHandlebarsHelpers() {
     min: mathHelper((a, b) => Math.min(a, b)),
     max: mathHelper((a, b) => Math.max(a, b)),
     fixed: (a: unknown, digits: unknown) => Number(a).toFixed(Number(digits)),
-    day: (date: string) => format(date, 'd'),
-    month: (date: string) => format(date, 'M'),
-    year: (date: string) => format(date, 'yyyy'),
-    format: (date: string, f: string) => format(date, f),
+    day: (date?: string) => date && format(date, 'd'),
+    month: (date?: string) => date && format(date, 'M'),
+    year: (date?: string) => date && format(date, 'yyyy'),
+    format: (date?: string, f?: string) => date && f && format(date, f),
     debug: (value: unknown) => {
       console.log(value);
     },

--- a/upcoming-release-notes/3749.md
+++ b/upcoming-release-notes/3749.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnderKoen]
+---
+
+Fix usage of date functions in action rule templating.


### PR DESCRIPTION
Fixxes an issue that `{{day today}}` wasn't working. As reported in #3606 by @IsThisThingStillOn