### PR TITLE
Fix bugs in payee table

### DIFF
--- a/packages/desktop-client/src/components/payees/PayeeTable.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTable.tsx
@@ -12,7 +12,7 @@ import { type PayeeEntity } from 'loot-core/src/types/models';
 
 import { useSelectedItems } from '../../hooks/useSelected';
 import { View } from '../common/View';
-import { Table } from '../table';
+import { useTableNavigator, Table } from '../table';
 
 import { PayeeTableRow } from './PayeeTableRow';
 
@@ -46,9 +46,16 @@ export const PayeeTable = forwardRef<
     setHovered(id);
   }, []);
 
+  const tableNavigator = useTableNavigator(payees, item =>
+    item.transfer_acct == null
+      ? ['select', 'name', 'rule-count']
+      : ['rule-count'],
+  );
+
   return (
     <View style={{ flex: 1 }} onMouseLeave={() => setHovered(null)}>
       <Table
+        navigator={tableNavigator}
         ref={ref}
         items={payees}
         renderItem={({ item, editing, focusedField, onEdit }) => {

--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -133,6 +133,9 @@ export const PayeeTableRow = memo(
           focused={focusedField === 'select'}
           selected={selected}
           onSelect={e => {
+            if (payee.transfer_acct != null) {
+              return;
+            }
             dispatchSelected({
               type: 'select',
               id: payee.id,

--- a/upcoming-release-notes/3768.md
+++ b/upcoming-release-notes/3768.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix bugs on payee management page


### PR DESCRIPTION
Two bugs:
1. #3767 
2. In edge, you can select transfer payees even though the checkbox is invisible.

Ideally we'd have tests for these features. Not feeling super well right now so if someone wants to take a stab at it in the future, I'll make an issue.