### PR TITLE
Update the budget page to be printable

### DIFF
--- a/packages/desktop-client/index.html
+++ b/packages/desktop-client/index.html
@@ -112,6 +112,12 @@
       .js-focus-visible :focus:not(.focus-visible) {
         outline: 0;
       }
+
+      @media print {
+        body {
+          overflow: visible;
+        }
+      }
     </style>
   </head>
   <body>

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -197,6 +197,9 @@ export function App() {
                           flexGrow: 1,
                           overflow: 'hidden',
                           ...styles.lightScrollbar,
+                          '@media print': {
+                            overflow: 'visible',
+                          },
                         }}
                       >
                         <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -177,6 +177,9 @@ export function FinancesApp() {
             flex: 1,
             overflow: 'hidden',
             width: '100%',
+            '@media print': {
+              overflow: 'visible',
+            },
           }}
         >
           <View
@@ -184,6 +187,9 @@ export function FinancesApp() {
               flex: 1,
               overflow: 'auto',
               position: 'relative',
+              '@media print': {
+                overflow: 'visible',
+              },
             }}
           >
             <Titlebar

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -286,6 +286,9 @@ export function Titlebar({ style }: TitlebarProps) {
           Platform.OS === 'mac' &&
           floatingSidebar && { paddingLeft: 80 }),
         ...style,
+        '@media print': {
+          display: 'none',
+        },
       }}
     >
       {(floatingSidebar || sidebar.alwaysFloats) && (

--- a/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
@@ -47,7 +47,7 @@ export function BudgetSummaries({ SummaryComponent }: BudgetSummariesProps) {
   const allMonths = [...months];
   allMonths.unshift(subMonths(months[0], 1));
   allMonths.push(addMonths(months[months.length - 1], 1));
-  const totalWidth = isPrinting ? measure.width() : widthState;
+  const totalWidth = isPrinting ? (measure.width() ?? widthState) : widthState;
   const monthWidth = totalWidth / months.length;
 
   useLayoutEffect(() => {

--- a/packages/desktop-client/src/components/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.jsx
@@ -213,6 +213,9 @@ export function BudgetTable(props) {
             flex: 1,
             paddingLeft: 5,
             paddingRight: 5,
+            '@media print': {
+              overflowY: 'visible',
+            },
           }}
         >
           <View

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useEffect, useRef, type ComponentProps } from 'react';
+import React, { useEffect, type ComponentProps } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -8,7 +8,6 @@ import { useMediaQuery } from 'usehooks-ts';
 import * as monthUtils from 'loot-core/src/shared/months';
 
 import { useSpaceMeasure } from '../../hooks/useSpaceMeasure';
-import { useResponsive } from '../../ResponsiveProvider';
 import { View } from '../common/View';
 
 import { useBudgetMonthCount } from './BudgetMonthCountContext';

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -428,6 +428,9 @@ export function Budget() {
         paddingLeft: 8,
         paddingRight: 8,
         overflow: 'hidden',
+        '@media print': {
+          overflow: 'visible',
+        },
       }}
     >
       <BudgetInner

--- a/packages/desktop-client/src/components/sidebar/Sidebar.tsx
+++ b/packages/desktop-client/src/components/sidebar/Sidebar.tsx
@@ -75,6 +75,11 @@ export function Sidebar() {
 
   return (
     <Resizable
+      className={css({
+        '@media print': {
+          display: 'none',
+        },
+      })}
       defaultSize={{
         width: sidebarWidth,
         height: '100%',

--- a/packages/desktop-client/src/hooks/useSpaceMeasure.tsx
+++ b/packages/desktop-client/src/hooks/useSpaceMeasure.tsx
@@ -1,0 +1,35 @@
+import { useRef } from 'react';
+
+import { View } from '../components/common/View';
+
+export const useSpaceMeasure = () => {
+  const widthRef = useRef<HTMLDivElement>(null);
+  const heightRef = useRef<HTMLDivElement>(null);
+
+  const measuringElements = (
+    <>
+      <View
+        ref={widthRef}
+        style={{
+          width: '100%',
+          height: 0,
+          position: 'absolute',
+        }}
+      />
+      <View
+        ref={heightRef}
+        style={{
+          width: 0,
+          height: '100%',
+          position: 'absolute',
+        }}
+      />
+    </>
+  );
+
+  return {
+    width: () => widthRef.current?.offsetWidth,
+    height: () => heightRef.current?.offsetHeight,
+    elements: measuringElements,
+  };
+};

--- a/upcoming-release-notes/3780.md
+++ b/upcoming-release-notes/3780.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Update the budget page to be printable


### PR DESCRIPTION
I've seen this request a few times and got curious what it'd take. Originally I tried the Reports page which seems more difficult, but the Budget page seems doable. Feedback welcome! I've only tested this in Chrome—would appreciate help testing in other browsers.

Suggested testing steps:
1. Add a bunch of categories to the budget.
2. Hit Ctrl-P to print the page and see what it looks like on various configurations.