### PR TITLE
:electron: Removing node-fetch and updating root ca impl for more support

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -21,6 +21,8 @@ import {
 import { copy, exists, remove } from 'fs-extra';
 import promiseRetry from 'promise-retry';
 
+import { GlobalPrefs } from 'loot-core/types/prefs';
+
 import { getMenu } from './menu';
 import {
   get as getWindowState,
@@ -28,7 +30,6 @@ import {
 } from './window-state';
 
 import './security';
-import { GlobalPrefs } from 'loot-core/types/prefs';
 
 const isDev = !app.isPackaged; // dev mode if not packaged
 
@@ -60,11 +61,11 @@ if (isDev) {
 }
 
 async function loadGlobalPrefs() {
-  let state: GlobalPrefs | undefined = undefined;
+  let state: { [key: string]: unknown } | undefined = undefined;
   try {
     state = JSON.parse(
       fs.readFileSync(
-        path.join(process.env.ACTUAL_DATA_DIR, 'global-store.json'),
+        path.join(process.env.ACTUAL_DATA_DIR!, 'global-store.json'),
         'utf8',
       ),
     );

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -15,6 +15,8 @@ import {
   UtilityProcess,
   OpenDialogSyncOptions,
   SaveDialogOptions,
+  Env,
+  ForkOptions,
 } from 'electron';
 import { copy, exists, remove } from 'fs-extra';
 import promiseRetry from 'promise-retry';
@@ -26,6 +28,7 @@ import {
 } from './window-state';
 
 import './security';
+import { GlobalPrefs } from 'loot-core/types/prefs';
 
 const isDev = !app.isPackaged; // dev mode if not packaged
 
@@ -56,11 +59,49 @@ if (isDev) {
   process.traceProcessWarnings = true;
 }
 
-function createBackgroundProcess() {
+async function loadGlobalPrefs() {
+  let state: GlobalPrefs | undefined = undefined;
+  try {
+    state = JSON.parse(
+      fs.readFileSync(
+        path.join(process.env.ACTUAL_DATA_DIR, 'global-store.json'),
+        'utf8',
+      ),
+    );
+  } catch (e) {
+    console.info('Could not load global state - using defaults'); // This could be the first time running the app - no global-store.json
+    state = {};
+  }
+
+  return state;
+}
+
+async function createBackgroundProcess() {
+  const globalPrefs = await loadGlobalPrefs(); // ensures we have the latest settings - even when restarting the server
+  let envVariables: Env = {
+    ...process.env, // required
+  };
+
+  if (globalPrefs?.['server-self-signed-cert']) {
+    envVariables = {
+      ...envVariables,
+      NODE_EXTRA_CA_CERTS: globalPrefs?.['server-self-signed-cert'], // add self signed cert to env - fetch can pick it up
+    };
+  }
+
+  let forkOptions: ForkOptions = {
+    stdio: 'pipe',
+    env: envVariables,
+  };
+
+  if (isDev) {
+    forkOptions = { ...forkOptions, execArgv: ['--inspect'] };
+  }
+
   serverProcess = utilityProcess.fork(
     __dirname + '/server.js',
     ['--subprocess', app.getVersion()],
-    isDev ? { execArgv: ['--inspect'], stdio: 'pipe' } : { stdio: 'pipe' },
+    forkOptions,
   );
 
   serverProcess.stdout?.on('data', (chunk: Buffer) => {

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -21,8 +21,6 @@ import {
 import { copy, exists, remove } from 'fs-extra';
 import promiseRetry from 'promise-retry';
 
-import { GlobalPrefs } from 'loot-core/types/prefs';
-
 import { getMenu } from './menu';
 import {
   get as getWindowState,

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -87,7 +87,6 @@
   "dependencies": {
     "better-sqlite3": "^9.6.0",
     "fs-extra": "^11.2.0",
-    "node-fetch": "^2.7.0",
     "promise-retry": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/desktop-electron/server.ts
+++ b/packages/desktop-electron/server.ts
@@ -1,10 +1,16 @@
 const lazyLoadBackend = async (isDev: boolean) => {
+  if (process.env.lootCoreScript === undefined) {
+    throw new Error(
+      'The environment variable `lootCoreScript` is not defined. Please define it to point to the server bundle.',
+    );
+  }
+
   try {
     const bundle = await import(process.env.lootCoreScript);
     bundle.initApp(isDev);
   } catch (error) {
     console.error('Failed to init the server bundle:', error);
-    throw new Error(`Failed to init the server bundle: ${error.message}`);
+    throw new Error(`Failed to init the server bundle: ${error?.message}`);
   }
 };
 

--- a/packages/desktop-electron/server.ts
+++ b/packages/desktop-electron/server.ts
@@ -1,8 +1,3 @@
-// @ts-strict-ignore
-import fetch from 'node-fetch';
-
-global.fetch = fetch;
-
 const lazyLoadBackend = async (isDev: boolean) => {
   try {
     const bundle = await import(process.env.lootCoreScript);

--- a/packages/desktop-electron/server.ts
+++ b/packages/desktop-electron/server.ts
@@ -10,7 +10,7 @@ const lazyLoadBackend = async (isDev: boolean) => {
     bundle.initApp(isDev);
   } catch (error) {
     console.error('Failed to init the server bundle:', error);
-    throw new Error(`Failed to init the server bundle: ${error?.message}`);
+    throw new Error(`Failed to init the server bundle: ${error}`);
   }
 };
 

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -33,7 +33,6 @@
     "md5": "^2.3.0",
     "memoize-one": "^6.0.0",
     "mitt": "^3.0.1",
-    "node-fetch": "^2.7.0",
     "reselect": "^4.1.8",
     "slash": "3.0.0",
     "throttleit": "^1.0.1",

--- a/packages/loot-core/src/platform/server/fetch/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fetch/index.electron.ts
@@ -1,12 +1,9 @@
-// @ts-strict-ignore
-import nodeFetch from 'node-fetch';
-
 export const fetch = async (
   input: RequestInfo | URL,
   options?: RequestInit,
 ) => {
   try {
-    return await nodeFetch(input, {
+    return await globalThis.fetch(input, {
       ...options,
       headers: {
         ...options?.headers,

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -2149,23 +2149,6 @@ export async function initApp(isDev, socketName) {
     }
   }
 
-  const selfSignedCertPath = await asyncStorage.getItem(
-    'server-self-signed-cert',
-  );
-
-  if (selfSignedCertPath) {
-    try {
-      const selfSignedCert = await fs.readFile(selfSignedCertPath);
-      https.globalAgent.options.ca = [...tls.rootCertificates, selfSignedCert];
-    } catch (error) {
-      console.error(
-        'Unable to add the self signed certificate, removing its reference',
-        error,
-      );
-      await asyncStorage.removeItem('server-self-signed-cert');
-    }
-  }
-
   const url = await asyncStorage.getItem('server-url');
 
   if (!url) {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1,7 +1,5 @@
 // @ts-strict-ignore
 import './polyfills';
-import https from 'https';
-import tls from 'tls';
 
 import * as injectAPI from '@actual-app/api/injected';
 import * as CRDT from '@actual-app/crdt';

--- a/packages/loot-core/webpack/webpack.desktop.config.js
+++ b/packages/loot-core/webpack/webpack.desktop.config.js
@@ -28,7 +28,7 @@ module.exports = {
       'pegjs',
     ],
   },
-  externals: ['better-sqlite3', 'node-fetch'],
+  externals: ['better-sqlite3'],
   plugins: [
     new webpack.IgnorePlugin({
       resourceRegExp: /original-fs/,

--- a/upcoming-release-notes/3782.md
+++ b/upcoming-release-notes/3782.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MikesGlitch]
 ---
 
-Updating the Desktop app self signed certificate implementation for greater support
+Removing node-fetch from the Desktop app and updating self signed certificate implementation

--- a/upcoming-release-notes/3782.md
+++ b/upcoming-release-notes/3782.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Updating the Desktop app self signed certificate implementation for greater support

--- a/yarn.lock
+++ b/yarn.lock
@@ -8633,7 +8633,6 @@ __metadata:
     electron: "npm:30.0.6"
     electron-builder: "npm:24.13.3"
     fs-extra: "npm:^11.2.0"
-    node-fetch: "npm:^2.7.0"
     promise-retry: "npm:^2.0.1"
     typescript: "npm:^5.5.4"
   languageName: unknown
@@ -13336,7 +13335,6 @@ __metadata:
     memoize-one: "npm:^6.0.0"
     mitt: "npm:^3.0.1"
     mockdate: "npm:^3.0.5"
-    node-fetch: "npm:^2.7.0"
     npm-run-all: "npm:^4.1.5"
     path-browserify: "npm:^1.0.1"
     peggy: "npm:3.0.2"
@@ -14539,20 +14537,6 @@ __metadata:
   bin:
     ndh: bin/ndh
   checksum: 10/c25f23a5a8b6c1be61b7b3fa8b075bc3e4bdd2a6bf9cc7927e7813942cf503614fcf7cd23025a334152b1a84b086b7c90fbf0f7af161929a1d61d3e51de3c337
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "node-fetch@npm:2.7.0"
-  dependencies:
-    whatwg-url: "npm:^5.0.0"
-  peerDependencies:
-    encoding: ^0.1.0
-  peerDependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
   languageName: node
   linkType: hard
 
@@ -18233,13 +18217,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tr46@npm:~0.0.3":
-  version: 0.0.3
-  resolution: "tr46@npm:0.0.3"
-  checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
-  languageName: node
-  linkType: hard
-
 "trampa@npm:^1.0.0":
   version: 1.0.1
   resolution: "trampa@npm:1.0.1"
@@ -19357,13 +19334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "webidl-conversions@npm:3.0.1"
-  checksum: 10/b65b9f8d6854572a84a5c69615152b63371395f0c5dcd6729c45789052296df54314db2bc3e977df41705eacb8bc79c247cee139a63fa695192f95816ed528ad
-  languageName: node
-  linkType: hard
-
 "webidl-conversions@npm:^4.0.2":
   version: 4.0.2
   resolution: "webidl-conversions@npm:4.0.2"
@@ -19506,16 +19476,6 @@ __metadata:
   version: 2.3.0
   resolution: "whatwg-mimetype@npm:2.3.0"
   checksum: 10/3582c1d74d708716013433bbab45cb9b31ef52d276adfbe2205d948be1ec9bb1a4ac05ce6d9045f3acc4104489e1344c857b14700002385a4b997a5673ff6416
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-url@npm:5.0.0"
-  dependencies:
-    tr46: "npm:~0.0.3"
-    webidl-conversions: "npm:^3.0.0"
-  checksum: 10/f95adbc1e80820828b45cc671d97da7cd5e4ef9deb426c31bcd5ab00dc7103042291613b3ef3caec0a2335ed09e0d5ed026c940755dbb6d404e2b27f940fdf07
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

# Why
- The less Electron specific dependencies the better
- Electron supports Fetch out of the box nowadays so there's no reason to have node-fetch in Electron. Fetch supports the env variable but not the https.agent implementation - that's why that's updated.
- I'd like us to start moving Electron specific functionality out of loot-core and into Electrons main process to make the system more rebust. This should prevent any issues in the event that loot-core bundle crashes (this has caused issues in the past)
- It will reduce our electron bundle size a little bit

Found while working on this: #3631 

**Tested on:** 
- [x] Windows
- [x] Linux

Didn't test Mac but should be fine.