### PR TITLE
:bug: (dashboards) remove faulty dashboard widgets

### DIFF
--- a/packages/loot-core/migrations/1730744182000_fix_dashboard_table.sql
+++ b/packages/loot-core/migrations/1730744182000_fix_dashboard_table.sql
@@ -2,6 +2,6 @@ BEGIN TRANSACTION;
 
 UPDATE dashboard
 SET tombstone = 1
-WHERE type = NULL;
+WHERE type is NULL;
 
 COMMIT;

--- a/packages/loot-core/migrations/1730744182000_fix_dashboard_table.sql
+++ b/packages/loot-core/migrations/1730744182000_fix_dashboard_table.sql
@@ -1,0 +1,7 @@
+BEGIN TRANSACTION;
+
+UPDATE dashboard
+SET tombstone = 1
+WHERE type = NULL;
+
+COMMIT;

--- a/upcoming-release-notes/3785.md
+++ b/upcoming-release-notes/3785.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Dashboards: add migration that will remove faulty 'blank' widgets.


### PR DESCRIPTION
Created a migration that removes faulty widgets. I suspect a SyncedPrefs issue (which has been patched) might have been the root cause of these being created in the first place.

But we should still clean them up even if the root cause might be patched.