### PR TITLE
[WIP] [Proof of Concept] Virtual calculator keyboard on mobile transaction edit page

### DIFF
--- a/packages/component-library/src/theme.ts
+++ b/packages/component-library/src/theme.ts
@@ -201,4 +201,10 @@ export const theme = {
   tooltipBackground: 'var(--color-tooltipBackground)',
   tooltipBorder: 'var(--color-tooltipBorder)',
   calendarCellBackground: 'var(--color-calendarCellBackground)',
+  keyboardBackground: 'var(--color-keyboardBackground)',
+  keyboardBorder: 'var(--color-keyboardBorder)',
+  keyboardText: 'var(--color-keyboardText)',
+  keyboardButtonBackground: 'var(--color-keyboardButtonBackground)',
+  keyboardButtonShadow: 'var(--color-keyboardButtonShadow)',
+  keyboardButtonSecondaryBackground: 'var(--color-keyboardButtonSecondaryBackground)',
 };

--- a/packages/component-library/src/theme.ts
+++ b/packages/component-library/src/theme.ts
@@ -206,5 +206,6 @@ export const theme = {
   keyboardText: 'var(--color-keyboardText)',
   keyboardButtonBackground: 'var(--color-keyboardButtonBackground)',
   keyboardButtonShadow: 'var(--color-keyboardButtonShadow)',
-  keyboardButtonSecondaryBackground: 'var(--color-keyboardButtonSecondaryBackground)',
+  keyboardButtonSecondaryBackground:
+    'var(--color-keyboardButtonSecondaryBackground)',
 };

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -65,6 +65,7 @@
     "react-modal": "3.16.3",
     "react-redux": "^9.2.0",
     "react-router": "7.6.2",
+    "react-simple-keyboard": "^3.7.134",
     "react-simple-pull-to-refresh": "^1.3.3",
     "react-spring": "^10.0.0",
     "react-stately": "^3.37.0",

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -65,7 +65,7 @@
     "react-modal": "3.16.3",
     "react-redux": "^9.2.0",
     "react-router": "7.6.2",
-    "react-simple-keyboard": "^3.7.134",
+    "react-simple-keyboard": "^3.8.106",
     "react-simple-pull-to-refresh": "^1.3.3",
     "react-spring": "^10.0.0",
     "react-stately": "^3.37.0",

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -94,9 +94,9 @@ const AmountInput = memo(function AmountInput({
   };
 
   const applyText = () => {
-    const parsed = hasArithmeticOperator(text)
+    const parsed = (hasArithmeticOperator(text)
       ? evalArithmetic(text)
-      : currencyToAmount(text) || 0;
+      : currencyToAmount(text)) ?? 0;
 
     const newValue = editing ? parsed : value;
 
@@ -150,7 +150,7 @@ const AmountInput = memo(function AmountInput({
         } else {
           // Evaluate the left side of the expression whenever an operator is added
           const left = text.slice(0, lastOperatorIndex);
-          const leftEvaluated = evalArithmetic(left);
+          const leftEvaluated = evalArithmetic(left) ?? 0;
           const leftEvaluatedWithDecimal = appendDecimals(
             reapplyThousandSeparators(String(amountToInteger(leftEvaluated))),
             hideFraction,

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -23,6 +23,10 @@ import {
 } from 'loot-core/shared/util';
 
 import { makeAmountFullStyle } from '@desktop-client/components/budget/util';
+import {
+  AmountKeyboard,
+  type AmountKeyboardRef,
+} from '@desktop-client/components/util/AmountKeyboard';
 import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 
@@ -58,6 +62,7 @@ const AmountInput = memo(function AmountInput({
   );
 
   const initialValue = Math.abs(props.value);
+  const keyboardRef = useRef<AmountKeyboardRef | null>(null);
 
   useEffect(() => {
     if (focused) {
@@ -119,6 +124,7 @@ const AmountInput = memo(function AmountInput({
     setEditing(true);
     setText(text);
     props.onChangeValue?.(text);
+    keyboardRef.current?.setInput(text);
   };
 
   const input = (
@@ -126,11 +132,17 @@ const AmountInput = memo(function AmountInput({
       type="text"
       ref={mergedInputRef}
       value={text}
-      inputMode="decimal"
+      inputMode="none"
       autoCapitalize="none"
       onChange={e => onChangeText(e.target.value)}
       onFocus={onFocus}
-      onBlur={onBlur}
+      onBlur={e => {
+        // Do not blur when clicking on the keyboard elements
+        if (keyboardRef.current?.keyboardDOM.contains(e.relatedTarget)) {
+          return;
+        }
+        onBlur(e);
+      }}
       onKeyUp={onKeyUp}
       data-testid="amount-input"
       style={{ flex: 1, textAlign: 'center', position: 'absolute' }}
@@ -160,6 +172,13 @@ const AmountInput = memo(function AmountInput({
       >
         {editing ? text : amountToCurrency(value)}
       </Text>
+      {focused && (
+        <AmountKeyboard
+          keyboardRef={(r: AmountKeyboardRef) => (keyboardRef.current = r)}
+          onChange={onChangeText}
+          onBlur={onBlur}
+        />
+      )}
     </View>
   );
 });

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -94,9 +94,10 @@ const AmountInput = memo(function AmountInput({
   };
 
   const applyText = () => {
-    const parsed = (hasArithmeticOperator(text)
-      ? evalArithmetic(text)
-      : currencyToAmount(text)) ?? 0;
+    const parsed =
+      (hasArithmeticOperator(text)
+        ? evalArithmetic(text)
+        : currencyToAmount(text)) ?? 0;
 
     const newValue = editing ? parsed : value;
 

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -84,8 +84,8 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
           default: [
             '+ 1 2 3',
             '- 4 5 6',
-            '* 7 8 9',
-            '/ . 0 {bksp}',
+            '× 7 8 9',
+            '÷ . 0 {bksp}',
           ],
         }}
         display={{

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -27,6 +27,7 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
       },
       '& .hg-button': {
         ...styles.noTapHighlight,
+        ...styles.mediumText,
         display: 'flex',
         height: '60px',
         flex: 1,
@@ -34,7 +35,6 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         justifyContent: 'center',
         borderRadius: 16,
         cursor: 'pointer',
-        fontSize: 'inherit',
         backgroundColor: theme.buttonNormalBackground,
         color: theme.buttonNormalText,
         border: `1px solid ${theme.buttonNormalBorder}`,
@@ -70,7 +70,7 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         padding: 5,
       }}
       onBlur={e => {
-        if (keyboardRef.current?.keyboardDOM?.contains(e.relatedTarget)) {
+        if (keyboardRef.current?.keyboardDOM.contains(e.relatedTarget)) {
           return;
         }
 

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -17,6 +17,7 @@ export type AmountKeyboardRef = SimpleKeyboard;
 
 type AmountKeyboardProps = ComponentPropsWithoutRef<typeof Keyboard> & {
   onBlur?: FocusEventHandler<HTMLDivElement>;
+  onEnter?: (text: string) => void;
 };
 
 export function AmountKeyboard(props: AmountKeyboardProps) {
@@ -50,10 +51,18 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         },
       },
       // eslint-disable-next-line rulesdir/typography
-      '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="×"], & [data-skbtn="÷"], & [data-skbtn="{bksp}"]':
+      '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="×"], & [data-skbtn="÷"]':
         {
           backgroundColor: theme.keyboardButtonSecondaryBackground,
         },
+      // eslint-disable-next-line rulesdir/typography
+      '& [data-skbtn="{bksp}"], & [data-skbtn="{clear}"]': {
+        backgroundColor: theme.keyboardButtonSecondaryBackground,
+      },
+      // eslint-disable-next-line rulesdir/typography
+      '& [data-skbtn="{enter}"]': {
+        backgroundColor: theme.buttonPrimaryBackground,
+      },
     }),
     props.theme,
   ]);
@@ -81,24 +90,37 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
       }}
     >
       <Keyboard
-        layoutName="default"
         layout={{
-          // eslint-disable-next-line prettier/prettier
           default: [
             '+ 1 2 3',
             '- 4 5 6',
             '× 7 8 9',
-            '÷ . 0 {bksp}',
+            '÷ {clear} 0 {bksp}',
+            '{space} , . {enter}',
           ],
         }}
         display={{
           '{bksp}': '⌫',
+          '{enter}': '↵',
+          '{space}': '␣',
+          '{clear}': 'C',
         }}
         useButtonTag
+        stopMouseUpPropagation
+        stopMouseDownPropagation
+        autoUseTouchEvents
         {...props}
         keyboardRef={r => {
           keyboardRef.current = r;
           props.keyboardRef?.(r);
+        }}
+        onKeyPress={key => {
+          if (key === '{clear}') {
+            props.onChange?.('');
+          } else if (key === '{enter}') {
+            props.onEnter?.(keyboardRef.current?.getInput() || '');
+          }
+          props.onKeyPress?.(key);
         }}
         theme={layoutClassName}
       />

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -1,0 +1,104 @@
+import React, {
+  type FocusEventHandler,
+  type ComponentPropsWithoutRef,
+  useRef,
+} from 'react';
+import {
+  default as Keyboard,
+  type SimpleKeyboard,
+} from 'react-simple-keyboard';
+
+import { css, cx } from '@emotion/css';
+
+import { styles, theme } from '../../style';
+import { View } from '../common/View';
+
+export type AmountKeyboardRef = SimpleKeyboard;
+
+type AmountKeyboardProps = ComponentPropsWithoutRef<typeof Keyboard> & {
+  onBlur?: FocusEventHandler<HTMLDivElement>;
+};
+
+export function AmountKeyboard(props: AmountKeyboardProps) {
+  const layoutClassName = cx([
+    css({
+      '& .hg-row': {
+        display: 'flex',
+      },
+      '& .hg-button': {
+        ...styles.noTapHighlight,
+        display: 'flex',
+        height: '60px',
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 16,
+        cursor: 'pointer',
+        fontSize: 'inherit',
+        backgroundColor: theme.buttonNormalBackground,
+        color: theme.buttonNormalText,
+        border: `1px solid ${theme.buttonNormalBorder}`,
+        padding: '5px 10px',
+        margin: 2,
+        ':active': {
+          transform: 'translateY(1px)',
+          boxShadow: `0 1px 4px 0 ${theme.buttonNormalShadow}`,
+          transition: 'none',
+        },
+      },
+      // eslint-disable-next-line rulesdir/typography
+      '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="*"], & [data-skbtn="/"], & [data-skbtn="{bksp}"]':
+        {
+          backgroundColor: theme.pageTextSubdued,
+        },
+    }),
+    props.theme,
+  ]);
+
+  const keyboardRef = useRef<SimpleKeyboard | null>(null);
+
+  return (
+    <View
+      style={{
+        position: 'fixed',
+        left: 0,
+        bottom: 0,
+        right: 0,
+        zIndex: 999,
+        backgroundColor: theme.tableBackground,
+        borderTop: `1px solid ${theme.tableBorder}`,
+        padding: 5,
+      }}
+      onBlur={e => {
+        if (keyboardRef.current?.keyboardDOM?.contains(e.relatedTarget)) {
+          return;
+        }
+
+        props.onBlur?.(e);
+      }}
+    >
+      <Keyboard
+        layoutName="default"
+        layout={{
+          // eslint-disable-next-line prettier/prettier
+          default: [
+            '+ 1 2 3',
+            '- 4 5 6',
+            '* 7 8 9',
+            '/ . 0 {bksp}',
+          ],
+        }}
+        display={{
+          '{bksp}': '⌫',
+        }}
+        useButtonTag
+        {...props}
+        keyboardRef={r => {
+          keyboardRef.current = r;
+          props.keyboardRef?.(r);
+        }}
+        theme={layoutClassName}
+      />
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -47,7 +47,7 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         },
       },
       // eslint-disable-next-line rulesdir/typography
-      '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="*"], & [data-skbtn="/"], & [data-skbtn="{bksp}"]':
+      '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="×"], & [data-skbtn="÷"], & [data-skbtn="{bksp}"]':
         {
           backgroundColor: theme.pageTextSubdued,
         },

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -68,7 +68,7 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
   const keyboardRefProp = props.keyboardRef;
 
   const mergedRef = useCallback(
-    r => {
+    (r: SimpleKeyboard) => {
       keyboardRef.current = r;
       keyboardRefProp?.(r);
     },

--- a/packages/desktop-client/src/components/util/AmountKeyboard.tsx
+++ b/packages/desktop-client/src/components/util/AmountKeyboard.tsx
@@ -8,10 +8,10 @@ import {
   type SimpleKeyboard,
 } from 'react-simple-keyboard';
 
+import { styles } from '@actual-app/components/styles';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
-
-import { styles, theme } from '../../style';
-import { View } from '../common/View';
 
 export type AmountKeyboardRef = SimpleKeyboard;
 
@@ -27,7 +27,8 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
       },
       '& .hg-button': {
         ...styles.noTapHighlight,
-        ...styles.mediumText,
+        ...styles.largeText,
+        fontWeight: 500,
         display: 'flex',
         height: '60px',
         flex: 1,
@@ -35,21 +36,23 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         justifyContent: 'center',
         borderRadius: 16,
         cursor: 'pointer',
-        backgroundColor: theme.buttonNormalBackground,
-        color: theme.buttonNormalText,
-        border: `1px solid ${theme.buttonNormalBorder}`,
+        backgroundColor: theme.keyboardButtonBackground,
+        color: theme.keyboardText,
         padding: '5px 10px',
         margin: 2,
+        borderWidth: 0,
+        outline: 0,
+        boxSizing: 'border-box',
         ':active': {
           transform: 'translateY(1px)',
-          boxShadow: `0 1px 4px 0 ${theme.buttonNormalShadow}`,
+          boxShadow: `0 1px 4px 0 ${theme.keyboardButtonShadow}`,
           transition: 'none',
         },
       },
       // eslint-disable-next-line rulesdir/typography
       '& [data-skbtn="+"], & [data-skbtn="-"], & [data-skbtn="×"], & [data-skbtn="÷"], & [data-skbtn="{bksp}"]':
         {
-          backgroundColor: theme.pageTextSubdued,
+          backgroundColor: theme.keyboardButtonSecondaryBackground,
         },
     }),
     props.theme,
@@ -65,8 +68,8 @@ export function AmountKeyboard(props: AmountKeyboardProps) {
         bottom: 0,
         right: 0,
         zIndex: 999,
-        backgroundColor: theme.tableBackground,
-        borderTop: `1px solid ${theme.tableBorder}`,
+        backgroundColor: theme.keyboardBackground,
+        borderTop: `1px solid ${theme.keyboardBorder}`,
         padding: 5,
       }}
       onBlur={e => {

--- a/packages/desktop-client/src/style/themes/dark.ts
+++ b/packages/desktop-client/src/style/themes/dark.ts
@@ -217,3 +217,9 @@ export const tooltipBackground = colorPalette.navy800;
 export const tooltipBorder = colorPalette.navy700;
 
 export const calendarCellBackground = colorPalette.navy900;
+export const keyboardBackground = colorPalette.navy900;
+export const keyboardBorder = colorPalette.navy600;
+export const keyboardText = buttonNormalText;
+export const keyboardButtonBackground = buttonNormalBackground;
+export const keyboardButtonShadow = 'rgba(0, 0, 0, 0.4)';
+export const keyboardButtonSecondaryBackground = colorPalette.navy500;

--- a/packages/desktop-client/src/style/themes/development.ts
+++ b/packages/desktop-client/src/style/themes/development.ts
@@ -217,3 +217,9 @@ export const tooltipBackground = colorPalette.navy50;
 export const tooltipBorder = colorPalette.navy150;
 
 export const calendarCellBackground = colorPalette.navy100;
+export const keyboardBackground = colorPalette.navy100;
+export const keyboardBorder = colorPalette.navy150;
+export const keyboardText = buttonNormalText;
+export const keyboardButtonBackground = buttonNormalBackground;
+export const keyboardButtonShadow = 'rgba(0, 0, 0, 0.2)';
+export const keyboardButtonSecondaryBackground = colorPalette.navy200;

--- a/packages/desktop-client/src/style/themes/light.ts
+++ b/packages/desktop-client/src/style/themes/light.ts
@@ -219,3 +219,9 @@ export const tooltipBackground = colorPalette.white;
 export const tooltipBorder = colorPalette.navy150;
 
 export const calendarCellBackground = colorPalette.navy100;
+export const keyboardBackground = colorPalette.navy100;
+export const keyboardBorder = colorPalette.navy150;
+export const keyboardText = buttonNormalText;
+export const keyboardButtonBackground = buttonNormalBackground;
+export const keyboardButtonShadow = 'rgba(0, 0, 0, 0.2)';
+export const keyboardButtonSecondaryBackground = colorPalette.navy200;

--- a/packages/desktop-client/src/style/themes/midnight.ts
+++ b/packages/desktop-client/src/style/themes/midnight.ts
@@ -219,3 +219,9 @@ export const tooltipBackground = colorPalette.gray800;
 export const tooltipBorder = colorPalette.gray600;
 
 export const calendarCellBackground = colorPalette.navy900;
+export const keyboardBackground = colorPalette.gray900;
+export const keyboardBorder = colorPalette.gray600;
+export const keyboardText = buttonNormalText;
+export const keyboardButtonBackground = buttonNormalBackground;
+export const keyboardButtonShadow = 'rgba(0, 0, 0, 0.4)';
+export const keyboardButtonSecondaryBackground = colorPalette.gray400;

--- a/packages/loot-core/src/shared/arithmetic.ts
+++ b/packages/loot-core/src/shared/arithmetic.ts
@@ -1,17 +1,29 @@
 // @ts-strict-ignore
 import { currencyToAmount } from './util';
 
-function fail(state, msg) {
+// These operators go from high to low order of precedence
+const operators = ['^', '/', '÷', '*', '×', '-', '+'] as const;
+type ArithmeticOp = (typeof operators)[number];
+
+type ArithmeticAst =
+  | number
+  | { op: ArithmeticOp; left: ArithmeticAst; right: ArithmeticAst };
+
+type ArithmeticState = { str: string; index: number };
+
+const parseOperator = makeOperatorParser(...operators);
+
+function fail(state: ArithmeticState, msg: string) {
   throw new Error(
     msg + ': ' + JSON.stringify(state.str.slice(state.index, 10)),
   );
 }
 
-function char(state) {
+function char(state: ArithmeticState): string {
   return state.str[state.index];
 }
 
-function next(state) {
+function next(state: ArithmeticState): string {
   if (state.index >= state.str.length) {
     return null;
   }
@@ -21,7 +33,7 @@ function next(state) {
   return ch;
 }
 
-function nextOperator(state, op) {
+function nextOperator(state: ArithmeticState, op: ArithmeticOp) {
   if (char(state) === op) {
     next(state);
     return true;
@@ -30,7 +42,7 @@ function nextOperator(state, op) {
   return false;
 }
 
-function parsePrimary(state) {
+function parsePrimary(state: ArithmeticState): number {
   // We only support numbers
   const isNegative = char(state) === '-';
   if (isNegative) {
@@ -50,7 +62,7 @@ function parsePrimary(state) {
   return isNegative ? -number : number;
 }
 
-function parseParens(state) {
+function parseParens(state: ArithmeticState): ArithmeticAst {
   if (char(state) === '(') {
     next(state);
     const expr = parseOperator(state);
@@ -66,7 +78,7 @@ function parseParens(state) {
   return parsePrimary(state);
 }
 
-function makeOperatorParser(...ops) {
+function makeOperatorParser(...ops: ArithmeticOp[]) {
   return ops.reduce((prevParser, op) => {
     return state => {
       let node = prevParser(state);
@@ -78,15 +90,15 @@ function makeOperatorParser(...ops) {
   }, parseParens);
 }
 
-// These operators go from high to low order of precedence
-const parseOperator = makeOperatorParser('^', '/', '*', '-', '+');
-
-function parse(expression: string) {
-  const state = { str: expression.replace(/\s/g, ''), index: 0 };
+function parse(expression: string): ArithmeticAst {
+  const state: ArithmeticState = {
+    str: expression.replace(/\s/g, ''),
+    index: 0,
+  };
   return parseOperator(state);
 }
 
-function evaluate(ast): number {
+function evaluate(ast: ArithmeticAst): number {
   if (typeof ast === 'number') {
     return ast;
   }
@@ -99,8 +111,10 @@ function evaluate(ast): number {
     case '-':
       return evaluate(left) - evaluate(right);
     case '*':
+    case '×':
       return evaluate(left) * evaluate(right);
     case '/':
+    case '÷':
       return evaluate(left) / evaluate(right);
     case '^':
       return Math.pow(evaluate(left), evaluate(right));
@@ -128,4 +142,15 @@ export function evalArithmetic(
 
   // Never return NaN
   return isNaN(result) ? defaultValue : result;
+}
+
+export function hasArithmeticOperator(expression: string): boolean {
+  return operators.some(op => expression.includes(op));
+}
+
+export function lastIndexOfArithmeticOperator(expression: string): number {
+  return operators.reduce((max, op) => {
+    const index = expression.lastIndexOf(op);
+    return index > max ? index : max;
+  }, -1);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,6 +185,7 @@ __metadata:
     react-modal: "npm:3.16.3"
     react-redux: "npm:^9.2.0"
     react-router: "npm:7.6.2"
+    react-simple-keyboard: "npm:^3.7.134"
     react-simple-pull-to-refresh: "npm:^1.3.3"
     react-spring: "npm:^10.0.0"
     react-stately: "npm:^3.37.0"
@@ -17077,6 +17078,16 @@ __metadata:
     react-dom:
       optional: true
   checksum: 10/38a8473c7358d873eb60cc6660deae16a629701b8867ee00e67871ff61009b90f73853235ef3b0f2e43ebedee697389afc7bf170df069823dc872be79798965b
+  languageName: node
+  linkType: hard
+
+"react-simple-keyboard@npm:^3.7.134":
+  version: 3.7.134
+  resolution: "react-simple-keyboard@npm:3.7.134"
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 10/b98cce161003b8ddf777fcaa1d2e02a34011dcb913f1360c34301633ebe18ff659fcc57e6f0115e1c4101ca8b225447a948c6d94052104a3e31bf2b4deac73a6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -185,7 +185,7 @@ __metadata:
     react-modal: "npm:3.16.3"
     react-redux: "npm:^9.2.0"
     react-router: "npm:7.6.2"
-    react-simple-keyboard: "npm:^3.7.134"
+    react-simple-keyboard: "npm:^3.8.106"
     react-simple-pull-to-refresh: "npm:^1.3.3"
     react-spring: "npm:^10.0.0"
     react-stately: "npm:^3.37.0"
@@ -17081,13 +17081,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-simple-keyboard@npm:^3.7.134":
-  version: 3.7.134
-  resolution: "react-simple-keyboard@npm:3.7.134"
+"react-simple-keyboard@npm:^3.8.106":
+  version: 3.8.106
+  resolution: "react-simple-keyboard@npm:3.8.106"
   peerDependencies:
-    react: ^16.0.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-  checksum: 10/b98cce161003b8ddf777fcaa1d2e02a34011dcb913f1360c34301633ebe18ff659fcc57e6f0115e1c4101ca8b225447a948c6d94052104a3e31bf2b4deac73a6
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/69b75d1de7fc604c2fe8b614765a0e2f7d8a61dfbb5ad7e969531ba0fcf3ab0f2e92abc9e08528fa3d190d381b531c8a1d42f929173e882d5ce3fd3441713885
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

POC for implementing a virtual keyboard on mobile which contains math operators (+, -, ×, ÷) to possibly support doing some calculations on the amount inputs (similar to how we can use math operators in desktop transactions page's amount fields).

Feedback or ideas are welcome!

https://github.com/actualbudget/actual/issues/1556