### PR TITLE
Check gocardless bank data type before setting state

### DIFF
--- a/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
@@ -42,7 +42,7 @@ function useAvailableBanks(country: string) {
 
       const { data, error } = await sendCatch('gocardless-get-banks', country);
 
-      if (error) {
+      if (error || !Array.isArray(data)) {
         setIsError(true);
         setBanks([]);
       } else {

--- a/upcoming-release-notes/3793.md
+++ b/upcoming-release-notes/3793.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [thraizz]
+---
+
+Handle unexpected response from GoCardless when getting banks.


### PR DESCRIPTION
Hey, thanks for the great work on actual. I had a smaller issue and could fix it myself, so I'm raising this PR.
I had the issue that I deleted my token in GoCardless and then GoCardless would give back an error object instead of an array in the `useAvailableBanks` hook. This would cause errors down the line, for example when giving this as  `sugggestions` to the `Autocomplete` component.
Checking if the response is an array prevents the app from crashing and also displays the correct "Failed loading available banks: GoCardless access credentials might be misconfigured. Please set them up again." error message.