### PR TITLE
Fixes #3729: Typescript and Runtime error after previous merge

### DIFF
--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -22,9 +22,9 @@ import { useModalState } from '../../hooks/useModalState';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';
 import { SvgLogo } from '../../icons/logo';
 import { SvgDelete } from '../../icons/v0';
-import { useResponsive } from '../../ResponsiveProvider';
 import { styles, theme } from '../../style';
 import { tokens } from '../../tokens';
+import { useResponsive } from '../responsive/ResponsiveProvider';
 
 import { Button } from './Button2';
 import { Input } from './Input';

--- a/upcoming-release-notes/3794.md
+++ b/upcoming-release-notes/3794.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tlesicka]
+---
+
+Fixes typescript and runtime error from useResponsive update.


### PR DESCRIPTION
It looks like one file was missed in updating ```useResponsive```.  This corrects the reference in ```packages/desktop-client/src/components/common/Modal.tsx```