### PR TITLE
[WIP] Enhancement: Positioning delete confirmation modal component text

### DIFF
--- a/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
@@ -33,7 +33,7 @@ export function ConfirmTransactionDeleteModal({
             rightContent={<ModalCloseButton onPress={close} />}
           />
           <View style={{ lineHeight: 1.5 }}>
-            <Paragraph>{message}</Paragraph>
+            <Paragraph style={{ textAlign: 'center' }}>{message}</Paragraph>
             <View
               style={{
                 flexDirection: 'row',


### PR DESCRIPTION
<img width="1494" alt="Screenshot 2024-11-07 at 4 32 43 PM" src="https://github.com/user-attachments/assets/a5676cab-d570-4861-ab4e-3b1a08814515">
<img width="1494" alt="Screenshot 2024-11-07 at 5 07 23 PM" src="https://github.com/user-attachments/assets/3a9bc171-1b45-4d48-8134-45e9af81ea18">

I've centered the ConfirmTransactionDeleteModal modal component paragraph.
 
The reading process of a user is easier when the text is centered because it naturally follows where the eyes are looking. 

This is my first pull request, I've read the contributing docs, if there is something I missed reading, please let me know! 
Thank you.