### PR TITLE
fix: don't clobber server pathname

### DIFF
--- a/packages/loot-core/src/server/server-config.ts
+++ b/packages/loot-core/src/server/server-config.ts
@@ -12,7 +12,7 @@ let config: ServerConfig | null = null;
 
 function joinURL(base: string | URL, ...paths: string[]): string {
   const url = new URL(base);
-  url.pathname = fs.join(...paths);
+  url.pathname += fs.join(...paths);
   return url.toString();
 }
 

--- a/packages/loot-core/src/server/server-config.ts
+++ b/packages/loot-core/src/server/server-config.ts
@@ -12,7 +12,7 @@ let config: ServerConfig | null = null;
 
 function joinURL(base: string | URL, ...paths: string[]): string {
   const url = new URL(base);
-  url.pathname += fs.join(...paths);
+  url.pathname = fs.join(url.pathname, ...paths);
   return url.toString();
 }
 

--- a/upcoming-release-notes/3815.md
+++ b/upcoming-release-notes/3815.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joshyrobot]
+---
+
+Allow server URLs to contain pathnames.


### PR DESCRIPTION
The provided server URL may already include a pathname, so all further segments need to be appended. This also more closely matches the name `joinURL`. Currently if `https://example.com/actual` is passed in to `getServer`, it will return URLs derived from `https://example.com` only.

While this doesn't implement #672, it would allow for any existing Actual client to access a server that's proxied behind a pathname.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
