### PR TITLE
:electron: Option to launch Actual on startup

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -154,6 +154,7 @@ global.Actual = {
     window.open(url, '_blank');
   },
   onEventFromMain: () => {},
+  setStartupOptions: () => {},
   isUpdateReadyForDownload: () => isUpdateReadyForDownload,
   waitForUpdateReadyForDownload: () => isUpdateReadyForDownloadPromise,
   applyAppUpdate: async () => {

--- a/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
@@ -10,6 +10,7 @@ import { theme, styles } from '../../../style';
 import { Button } from '../../common/Button2';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 import { Text } from '../../common/Text';
+import { Toggle } from '../../common/Toggle';
 import { View } from '../../common/View';
 
 function FileLocationSettings() {
@@ -141,6 +142,62 @@ function SelfSignedCertLocationSettings() {
   );
 }
 
+function StartupOptions() {
+  const [startupOptionsPref, setStartupOptionsPref] =
+    useGlobalPref('startupOptions');
+
+  const { t } = useTranslation();
+
+  const onToggleOpenAtLogin = (openAtLogin: boolean) => {
+    setStartupOptionsPref({ openAtLogin });
+    globalThis.window.Actual.setStartupOptions({ openAtLogin });
+  };
+
+  return (
+    <View
+      style={{
+        gap: 15,
+        backgroundColor: theme.pillBackground,
+        alignSelf: 'flex-start',
+        alignItems: 'flex-start',
+        padding: 15,
+        borderRadius: 4,
+        border: '1px solid ' + theme.pillBorderDark,
+        width: '100%',
+      }}
+    >
+      <Text>
+        <strong>
+          <Trans>Startup options</Trans>
+        </strong>{' '}
+        <small style={{ marginLeft: '0.5rem' }}>
+          <i>
+            <Trans>system startup behaviour</Trans>
+          </i>
+        </small>
+      </Text>
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: '0.5rem',
+          width: '100%',
+          alignItems: 'center',
+        }}
+      >
+        <label htmlFor="startupOptions" title={t('Startup options')}>
+          <Trans>Open Actual when your computer starts up</Trans>
+        </label>
+        <Toggle
+          id="startupOptions"
+          isOn={startupOptionsPref?.openAtLogin || false}
+          style={{ marginLeft: 5 }}
+          onToggle={onToggleOpenAtLogin}
+        />
+      </View>
+    </View>
+  );
+}
+
 export function FilesSettingsModal() {
   const dispatch = useDispatch();
 
@@ -171,6 +228,7 @@ export function FilesSettingsModal() {
           >
             <FileLocationSettings />
             <SelfSignedCertLocationSettings />
+            <StartupOptions />
             <Button
               variant="primary"
               style={{

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -341,6 +341,16 @@ app.on('activate', () => {
   }
 });
 
+ipcMain.handle(
+  'set-startup-options',
+  (_event, payload: { openAtLogin?: boolean }) => {
+    const openAtLogin = payload.openAtLogin;
+    app.setLoginItemSettings({
+      openAtLogin,
+    });
+  },
+);
+
 export type GetBootstrapDataPayload = {
   version: string;
   isDev: boolean;

--- a/packages/desktop-electron/preload.ts
+++ b/packages/desktop-electron/preload.ts
@@ -66,6 +66,10 @@ contextBridge.exposeInMainWorld('Actual', {
     ipcRenderer.send('update-menu', budgetId);
   },
 
+  setStartupOptions: (options: { openAtLogin?: boolean }) => {
+    ipcRenderer.send('set-startup-options', options);
+  },
+
   // No auto-updates in the desktop app
   isUpdateReadyForDownload: () => false,
   waitForUpdateReadyForDownload: () => new Promise<void>(() => {}),

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1345,6 +1345,15 @@ handlers['save-global-prefs'] = async function (prefs) {
       prefs.serverSelfSignedCert,
     );
   }
+<<<<<<< Updated upstream
+=======
+  if ('startupOptions' in prefs) {
+    await asyncStorage.setItem('startupOptions', prefs.startupOptions);
+  }
+  if ('ngrokConfig' in prefs) {
+    await asyncStorage.setItem('ngrokConfig', prefs.ngrokConfig);
+  }
+>>>>>>> Stashed changes
   return 'ok';
 };
 
@@ -1357,6 +1366,11 @@ handlers['load-global-prefs'] = async function () {
     [, theme],
     [, preferredDarkTheme],
     [, serverSelfSignedCert],
+<<<<<<< Updated upstream
+=======
+    [, startupOptions],
+    [, ngrokConfig],
+>>>>>>> Stashed changes
   ] = await asyncStorage.multiGet([
     'floating-sidebar',
     'max-months',
@@ -1365,6 +1379,11 @@ handlers['load-global-prefs'] = async function () {
     'theme',
     'preferred-dark-theme',
     'server-self-signed-cert',
+<<<<<<< Updated upstream
+=======
+    'startupOptions',
+    'ngrokConfig',
+>>>>>>> Stashed changes
   ]);
   return {
     floatingSidebar: floatingSidebar === 'true' ? true : false,
@@ -1384,6 +1403,11 @@ handlers['load-global-prefs'] = async function () {
         ? preferredDarkTheme
         : 'dark',
     serverSelfSignedCert: serverSelfSignedCert || undefined,
+<<<<<<< Updated upstream
+=======
+    startupOptions: startupOptions || undefined,
+    ngrokConfig: ngrokConfig || undefined,
+>>>>>>> Stashed changes
   };
 };
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1345,15 +1345,9 @@ handlers['save-global-prefs'] = async function (prefs) {
       prefs.serverSelfSignedCert,
     );
   }
-<<<<<<< Updated upstream
-=======
   if ('startupOptions' in prefs) {
     await asyncStorage.setItem('startupOptions', prefs.startupOptions);
   }
-  if ('ngrokConfig' in prefs) {
-    await asyncStorage.setItem('ngrokConfig', prefs.ngrokConfig);
-  }
->>>>>>> Stashed changes
   return 'ok';
 };
 
@@ -1366,11 +1360,7 @@ handlers['load-global-prefs'] = async function () {
     [, theme],
     [, preferredDarkTheme],
     [, serverSelfSignedCert],
-<<<<<<< Updated upstream
-=======
     [, startupOptions],
-    [, ngrokConfig],
->>>>>>> Stashed changes
   ] = await asyncStorage.multiGet([
     'floating-sidebar',
     'max-months',
@@ -1379,11 +1369,7 @@ handlers['load-global-prefs'] = async function () {
     'theme',
     'preferred-dark-theme',
     'server-self-signed-cert',
-<<<<<<< Updated upstream
-=======
     'startupOptions',
-    'ngrokConfig',
->>>>>>> Stashed changes
   ]);
   return {
     floatingSidebar: floatingSidebar === 'true' ? true : false,
@@ -1403,11 +1389,7 @@ handlers['load-global-prefs'] = async function () {
         ? preferredDarkTheme
         : 'dark',
     serverSelfSignedCert: serverSelfSignedCert || undefined,
-<<<<<<< Updated upstream
-=======
     startupOptions: startupOptions || undefined,
-    ngrokConfig: ngrokConfig || undefined,
->>>>>>> Stashed changes
   };
 };
 

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -82,4 +82,18 @@ export type GlobalPrefs = Partial<{
   preferredDarkTheme: DarkTheme;
   documentDir: string; // Electron only
   serverSelfSignedCert: string; // Electron only
+<<<<<<< Updated upstream
+=======
+  startupOptions?: {
+    // Electron only
+    openAtLogin?: boolean;
+  };
+  ngrokConfig?: {
+    // Electron only
+    autoStart?: boolean;
+    authToken?: string;
+    port?: number;
+    domain?: string;
+  };
+>>>>>>> Stashed changes
 }>;

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -82,18 +82,8 @@ export type GlobalPrefs = Partial<{
   preferredDarkTheme: DarkTheme;
   documentDir: string; // Electron only
   serverSelfSignedCert: string; // Electron only
-<<<<<<< Updated upstream
-=======
   startupOptions?: {
     // Electron only
     openAtLogin?: boolean;
   };
-  ngrokConfig?: {
-    // Electron only
-    autoStart?: boolean;
-    authToken?: string;
-    port?: number;
-    domain?: string;
-  };
->>>>>>> Stashed changes
 }>;

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -6,6 +6,15 @@ declare global {
       IS_FAKE_WEB: boolean;
       ACTUAL_VERSION: string;
       openURLInBrowser: (url: string) => void;
+<<<<<<< Updated upstream
+=======
+      downloadActualServer: (releaseVersion: string) => Promise<void>;
+      startActualServer: (releaseVersion: string) => Promise<void>;
+      exposeActualServer: (
+        settings: GlobalPrefs['ngrokConfig'],
+      ) => Promise<{ url?: string; error?: string } | undefined>;
+      setStartupOptions: (options: { openAtLogin?: boolean }) => void;
+>>>>>>> Stashed changes
       saveFile: (
         contents: string | Buffer,
         filename: string,

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -6,15 +6,8 @@ declare global {
       IS_FAKE_WEB: boolean;
       ACTUAL_VERSION: string;
       openURLInBrowser: (url: string) => void;
-<<<<<<< Updated upstream
-=======
       downloadActualServer: (releaseVersion: string) => Promise<void>;
-      startActualServer: (releaseVersion: string) => Promise<void>;
-      exposeActualServer: (
-        settings: GlobalPrefs['ngrokConfig'],
-      ) => Promise<{ url?: string; error?: string } | undefined>;
       setStartupOptions: (options: { openAtLogin?: boolean }) => void;
->>>>>>> Stashed changes
       saveFile: (
         contents: string | Buffer,
         filename: string,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Providing an option to launch Actual on computer startup.

This will be a follow up feature if the desktop app ever hosts the electron-sync server.  

- [ ] Provide an option to start actual-server when the computer starts up
- [ ] Allow the app to start _silently_ in the app tray. This will allow the sync server to run without the Actual app getting in the way.

Will be useful for: #3631 - it will enable us to start the sync server when the computer starts. Ideally we'd find a way to start it in a background process.

Tested on: 
- [ ] Windows
- [ ] Mac
- [ ] Linux