### PR TITLE
[Goals] fix how goal values are calculated

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -268,7 +268,7 @@ export class CategoryTemplate {
       this.goalAmount = amountToInteger(this.goals[0].amount);
       return;
     }
-    this.goalAmount = this.fullAmount
+    this.goalAmount = this.fullAmount;
   }
 
   //-----------------------------------------------------------------------------

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -134,18 +134,18 @@ export class CategoryTemplate {
         }
       }
 
-      // don't overbudget when using a priority
-      if (priority > 0 && toBudget > available) {
-        toBudget = available;
-      }
       available = available - toBudget;
-
-      if (priority > 0 && available <= 0) {
-        break;
-      }
     }
 
-    this.toBudgetAmount += toBudget;
+    // don't overbudget when using a priority
+    if (priority > 0 && available < 0) {
+      this.fullAmount += toBudget;
+      toBudget = Math.max(0, toBudget + available);
+      this.toBudgetAmount += toBudget;
+    } else {
+      this.fullAmount += toBudget;
+      this.toBudgetAmount += toBudget;
+    }
     return toBudget;
   }
 
@@ -155,12 +155,14 @@ export class CategoryTemplate {
     }
     if (this.limitHold && this.fromLastMonth >= this.limitAmount) {
       const orig = this.toBudgetAmount;
+      this.fullAmount = 0;
       this.toBudgetAmount = 0;
       return orig;
     }
     if (this.toBudgetAmount + this.fromLastMonth > this.limitAmount) {
       const orig = this.toBudgetAmount;
       this.toBudgetAmount = this.limitAmount - this.fromLastMonth;
+      this.fullAmount = this.toBudgetAmount;
       return orig - this.toBudgetAmount;
     }
     return 0;
@@ -200,6 +202,7 @@ export class CategoryTemplate {
   private priorities: number[] = [];
   private remainderWeight: number = 0;
   private toBudgetAmount: number = 0; // amount that will be budgeted by the templates
+  private fullAmount: number = 0; // the full requested amount
   private isLongGoal: boolean = null; //defaulting the goals to null so templates can be unset
   private goalAmount: number = null;
   private fromLastMonth = 0; // leftover from last month
@@ -265,7 +268,7 @@ export class CategoryTemplate {
       this.goalAmount = amountToInteger(this.goals[0].amount);
       return;
     }
-    this.goalAmount = this.toBudgetAmount;
+    this.goalAmount = this.fullAmount
   }
 
   //-----------------------------------------------------------------------------

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -211,16 +211,12 @@ async function processTemplate(
     const availStart = availBudget;
     const p = priorities[pi];
     for (let i = 0; i < catObjects.length; i++) {
-      if (availBudget <= 0 && p > 0) break;
       const ret = await catObjects[i].runTemplatesForPriority(
         p,
         availBudget,
         availStart,
       );
       availBudget -= ret;
-    }
-    if (availBudget <= 0) {
-      break;
     }
   }
   // run limits

--- a/upcoming-release-notes/3817.md
+++ b/upcoming-release-notes/3817.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix template goals after recent rewrite


### PR DESCRIPTION
I had messed up how the template goal values were calculated in the recent rewrite.

I had to change the following:
1. add a variable to track what the full template amount is compared to the amount that will be budgeted.
2. Remove the breaks on negative available.  That stopped the templates running early and calculating the full goal as was requested by the templates.  I was trying to be efficient, but all the processing is needed and I should have realized that.
