### PR TITLE
[Goals] fix remainder goal

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -202,7 +202,7 @@ export class CategoryTemplate {
   private priorities: number[] = [];
   private remainderWeight: number = 0;
   private toBudgetAmount: number = 0; // amount that will be budgeted by the templates
-  private fullAmount: number = 0; // the full requested amount
+  private fullAmount: number = null; // the full requested amount, start null for remainder only cats
   private isLongGoal: boolean = null; //defaulting the goals to null so templates can be unset
   private goalAmount: number = null;
   private fromLastMonth = 0; // leftover from last month


### PR DESCRIPTION
Fix the case that there is only a remainder template and no other templates.  Remainders shouldn't set or affect goals.  Edge currently will show 0 as the goal for remainder only templates, but categories with other template lines work fine.

To test:
1. Add a remainder template to a category
2. Add a template and a remainder template to a category
3. Run templates
4. See that the remainder only category has no goal set (no tooltip will show on hover of balance), and that the category with two templates will show the expected goal excluding the remainder additions

Ill skip the release note since I just merged in a PR that talked about fixing goals.
