### PR TITLE
🐛 Fix iphone 13 unable to use regex lookbehinds

### DIFF
--- a/packages/loot-core/src/server/accounts/transaction-rules.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.ts
@@ -475,10 +475,6 @@ export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
             tagValues.push(word);
           }
         });
-        // const tagValues = value.split(' ').filter(tag => tag.startsWith('#'));
-        // const tagValues = value
-        //   .split(/(?<!#)(#[\w\d\p{Emoji}-]+)(?=\s|$)/gu)
-        //   .filter(tag => tag.startsWith('#'));
 
         return {
           $and: tagValues.map(v => {

--- a/packages/loot-core/src/server/accounts/transaction-rules.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.ts
@@ -462,9 +462,23 @@ export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
         return { $or: values.map(v => apply(field, '$eq', v)) };
 
       case 'hasTags':
-        const tagValues = value
-          .split(/(?<!#)(#[\w\d\p{Emoji}-]+)(?=\s|$)/gu)
-          .filter(tag => tag.startsWith('#'));
+        const words = value.split(/\s+/);
+        const tagValues = [];
+        words.forEach(word => {
+          const startsWithHash = word.startsWith('#');
+          const containsMultipleHash = word.slice(1).includes('#');
+          const correctlyFormatted = word.match(/#[\w\d\p{Emoji}-]+/gu);
+          const validHashtag =
+            startsWithHash && !containsMultipleHash && correctlyFormatted;
+
+          if (validHashtag) {
+            tagValues.push(word);
+          }
+        });
+        // const tagValues = value.split(' ').filter(tag => tag.startsWith('#'));
+        // const tagValues = value
+        //   .split(/(?<!#)(#[\w\d\p{Emoji}-]+)(?=\s|$)/gu)
+        //   .filter(tag => tag.startsWith('#'));
 
         return {
           $and: tagValues.map(v => {

--- a/upcoming-release-notes/3823.md
+++ b/upcoming-release-notes/3823.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix Iphone 13 error when attempting to view budget.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Support post: https://discord.com/channels/937901803608096828/1304951796715884644

Iphone 13 cannot use Regex lookbehinds.  https://caniuse.com/?search=Lookbehind

This was stopping users from opening the app on Iphone 13. 