### PR TITLE
Fix back button behavior after adding tx on mobile

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -559,7 +559,7 @@ const TransactionEditInner = memo(function TransactionEditInner({
         const { account: accountId } = unserializedTransaction;
         const account = accountsById?.[accountId];
         if (account) {
-          navigate(`/accounts/${account.id}`);
+          navigate(`/accounts/${account.id}`, { replace: true });
         } else {
           // Handle the case where account is undefined
           navigate(-1);

--- a/upcoming-release-notes/3825.md
+++ b/upcoming-release-notes/3825.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [JukeboxRhino]
+---
+
+Fix back button behavior after adding a new transaction on mobile


### PR DESCRIPTION
#3549 introduced a regression by removing `{ replace: true }` on the call to `navigate()` when navigating to the account page after adding a new transaction. This PR fixes the behavior so the back button works as expected again.

[Link to breaking change](https://github.com/actualbudget/actual/pull/3549/files#diff-2160422ad72c178aebbd20787701c79186591fd731cdadbd2671467c78e0470aL539)

Closes #3712