### PR TITLE
[Goals] fix limits

### DIFF
--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+
 import * as monthUtils from '../../shared/months';
 import { integerToCurrency, safeNumber } from '../../shared/util';
 import * as db from '../db';
@@ -11,6 +12,14 @@ export async function getSheetValue(
 ): Promise<number> {
   const node = await sheet.getCell(sheetName, cell);
   return safeNumber(typeof node.value === 'number' ? node.value : 0);
+}
+
+export async function getSheetBoolean(
+  sheetName: string,
+  cell: string,
+): Promise<boolean> {
+  const node = await sheet.getCell(sheetName, cell);
+  return typeof node.value === 'boolean' ? node.value : false;
 }
 
 // We want to only allow the positive movement of money back and

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -18,8 +18,8 @@ export class CategoryTemplate {
    *    month: the month string of the month for templates being applied
    * 2. gather needed data for external use.  ex: remainder weights, priorities, limitExcess
    * 3. run each priority level that is needed via runTemplatesForPriority
-   * 5. run the remainder templates via runRemainder()
-   * 6. finish processing by running getValues() and saving values for batch processing.
+   * 4. run the remainder templates via runRemainder()
+   * 5. finish processing by running getValues() and saving values for batch processing.
    * Alternate:
    * If the situation calls for it you can run all templates in a catagory in one go using the
    * method runAll which will run all templates and goals for reference, and can optionally be saved

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -166,6 +166,7 @@ async function processTemplate(
       try {
         const obj = await CategoryTemplate.init(templates, id, month);
         availBudget += budgeted;
+        availBudget += obj.getLimitExcess();
         const p = obj.getPriorities();
         p.forEach(pr => priorities.push(pr));
         remainderWeight += obj.getRemainderWeight();
@@ -190,13 +191,15 @@ async function processTemplate(
   if (catObjects.length === 0 && errors.length === 0) {
     return {
       type: 'message',
-      message: t('Everything is up to date'),
+      //message: t('Everything is up to date'),
+      message: 'Everything is up to date',
     };
   }
   if (errors.length > 0) {
     return {
       sticky: true,
-      message: t('There were errors interpreting some templates:'),
+      //message: t('There were errors interpreting some templates:'),
+      message: 'There were errors interpreting some templates:',
       pre: errors.join(`\n\n`),
     };
   }
@@ -221,10 +224,6 @@ async function processTemplate(
       availBudget -= ret;
     }
   }
-  // run limits
-  catObjects.forEach(o => {
-    availBudget += o.applyLimit();
-  });
   // run remainder
   if (availBudget > 0 && remainderWeight) {
     const perWeight = availBudget / remainderWeight;
@@ -247,8 +246,9 @@ async function processTemplate(
 
   return {
     type: 'message',
-    message: t('Successfully applied templates to {length} categories', {
-      length: catObjects.length,
-    }),
+    //message: t('Successfully applied templates to {length} categories', {
+    //  length: catObjects.length,
+    //}),
+    message: 'Successfully applied',
   };
 }

--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { t } from 'i18next';
+//import { t } from 'i18next';
 
 import { Notification } from '../../client/state-types/notifications';
 import * as monthUtils from '../../shared/months';
@@ -249,6 +249,6 @@ async function processTemplate(
     //message: t('Successfully applied templates to {length} categories', {
     //  length: catObjects.length,
     //}),
-    message: 'Successfully applied',
+    message: `Successfully applied templates to ${catObjects.length} categories`,
   };
 }

--- a/upcoming-release-notes/3829.md
+++ b/upcoming-release-notes/3829.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix template limits


### PR DESCRIPTION
since limits were being applied at the end of the processing chain, the funds pulled from categories because of the limit never had a chance to be used in other underfunded categories.

Ive reworked the limits to apply at the beginning, to return any excess from the previous month; and every priority pass, to not pull in unneeded funds.  Goals for the categories with limits should also set correctly now.  This also now handles rollover funds properly.

To test:
1. make a category with a limit template
2. Make a category with template that wont get fully funded with a priority level higher than the limit
3. have there be extra funds in that first category being carried from the previous month to cause the limit to already be met
4. Run templates and see that the funds removed by the limit are able to be used in the underfunded category (edge will have leftover even though the category is underfunded)
