### PR TITLE
🐛 Fix validation issue for invalid server URLs in /config-server page

### DIFF
--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -63,23 +63,16 @@ export function ConfigServer() {
 
     setError(null);
     setLoading(true);
-    const { error } = await setServerUrl(url);
 
-    if (
-      ['network-failure', 'get-server-failure'].includes(error) &&
-      !url.startsWith('http://') &&
-      !url.startsWith('https://')
-    ) {
-      const { error } = await setServerUrl('https://' + url);
-      if (error) {
-        setUrl('https://' + url);
-        setError(error);
-      } else {
-        await signOut();
-        navigate('/');
-      }
-      setLoading(false);
-    } else if (error) {
+    let httpUrl = url;
+    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+      httpUrl = 'https://' + url;
+    }
+
+    const { error } = await setServerUrl(httpUrl);
+    setUrl(httpUrl);
+
+    if (error) {
       setLoading(false);
       setError(error);
     } else {

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1513,7 +1513,7 @@ handlers['get-did-bootstrap'] = async function () {
 handlers['subscribe-needs-bootstrap'] = async function ({
   url,
 }: { url? } = {}) {
-  if (!isValidBaseURL(url)) {
+  if (url && !isValidBaseURL(url)) {
     return { error: 'get-server-failure' };
   }
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -56,7 +56,7 @@ import * as prefs from './prefs';
 import { app as reportsApp } from './reports/app';
 import { app as rulesApp } from './rules/app';
 import { app as schedulesApp } from './schedules/app';
-import { getServer, setServer } from './server-config';
+import { getServer, isValidBaseURL, setServer } from './server-config';
 import * as sheet from './sheet';
 import { resolveName, unresolveName } from './spreadsheet/util';
 import {
@@ -1513,6 +1513,10 @@ handlers['get-did-bootstrap'] = async function () {
 handlers['subscribe-needs-bootstrap'] = async function ({
   url,
 }: { url? } = {}) {
+  if (!isValidBaseURL(url)) {
+    return { error: 'get-server-failure' };
+  }
+
   try {
     if (!getServer(url)) {
       return { bootstrapped: true, hasServer: false };

--- a/packages/loot-core/src/server/server-config.ts
+++ b/packages/loot-core/src/server/server-config.ts
@@ -16,6 +16,14 @@ function joinURL(base: string | URL, ...paths: string[]): string {
   return url.toString();
 }
 
+export function isValidBaseURL(base: string): boolean {
+  try {
+    return Boolean(new URL(base));
+  } catch (error) {
+    return false;
+  }
+}
+
 export function setServer(url: string): void {
   if (url == null) {
     config = null;

--- a/upcoming-release-notes/3837.md
+++ b/upcoming-release-notes/3837.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [shb9019]
+---
+
+Fix validation issue for invalid server URLs in /config-server page


### PR DESCRIPTION
Fixes #3784.

**Issue**
Passing an invalid URL such as "wrong.server.here" does not throw a validation error, but it redirects to the login page without any password input box. See #3784 for details.

**Cause**
In a recent change, the validation logic returns the global server config if the URL cannot be parsed. This fails if there is no existing server config.

**Changes**
1. Append "https://" (if absent) to server URL in `ConfigServer.tsx` before validating the URL.
2. Before validating in "subscribe-needs-bootstrap" handler, check if the passed base URL can be used to construct `URL()`.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
