### PR TITLE
🔧 Summary Card: Change the font size implementation to be simpler & fix import dashboard

### DIFF
--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -34,8 +34,8 @@ export function SummaryNumber({
 }: SummaryNumberProps) {
   const [fontSize, setFontSize] = useState<number>(initialFontSize);
   const refDiv = useRef<HTMLDivElement>(null);
+  const displayAmount = amountToCurrency(Math.abs(value)) + suffix;
 
-  const displayAmount = amountToCurrency(Math.abs(value));
   const handleResize = debounce(() => {
     if (!refDiv.current) return;
 
@@ -65,7 +65,7 @@ export function SummaryNumber({
         <View
           ref={mergedRef as Ref<HTMLDivElement>}
           role="text"
-          aria-label={`${value < 0 ? 'Negative' : 'Positive'} amount: ${displayAmount}${suffix}`}
+          aria-label={`${value < 0 ? 'Negative' : 'Positive'} amount: ${displayAmount}`}
           style={{
             alignItems: 'center',
             flexGrow: 1,
@@ -82,10 +82,7 @@ export function SummaryNumber({
           }}
         >
           <span aria-hidden="true">
-            <PrivacyFilter>
-              {displayAmount}
-              {suffix}
-            </PrivacyFilter>
+            <PrivacyFilter>{displayAmount}</PrivacyFilter>
           </span>
         </View>
       )}

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -37,6 +37,8 @@ export function SummaryNumber({
 
   const displayAmount = amountToCurrency(Math.abs(value));
   const handleResize = debounce(() => {
+    if (!refDiv.current) return;
+
     const { clientWidth, clientHeight } = refDiv.current;
     const width = clientWidth - CONTAINER_MARGIN * 2; // margin left and right
     const height = clientHeight - CONTAINER_MARGIN * 2; // margin top and bottom

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -47,7 +47,10 @@ export function SummaryNumber({
     );
 
     setFontSize(calculatedFontSize);
-    fontSizeChanged(calculatedFontSize);
+
+    if (calculatedFontSize !== initialFontSize) {
+      fontSizeChanged(calculatedFontSize);
+    }
   }, 100);
 
   const ref = useResizeObserver(handleResize);

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -13,7 +13,7 @@ import { chartTheme } from './chart-theme';
 import { LoadingIndicator } from './LoadingIndicator';
 
 const FONT_SIZE_SCALE_FACTOR = 1.6;
-const FONT_PADDING = 8;
+const CONTAINER_MARGIN = 8;
 
 type SummaryNumberProps = {
   value: number;
@@ -38,13 +38,12 @@ export function SummaryNumber({
   const displayAmount = amountToCurrency(Math.abs(value));
   const handleResize = debounce(() => {
     const { clientWidth, clientHeight } = refDiv.current;
-    const widthWithPadding = clientWidth - FONT_PADDING * 2; // padding left and right
-    const heightWithPadding = clientHeight - FONT_PADDING * 2; // padding top and bottom
+    const width = clientWidth - CONTAINER_MARGIN * 2; // margin left and right
+    const height = clientHeight - CONTAINER_MARGIN * 2; // margin top and bottom
 
     const calculatedFontSize = Math.min(
-      (widthWithPadding * FONT_SIZE_SCALE_FACTOR) /
-        displayAmount.toString().length,
-      heightWithPadding, // Ensure the text fits vertically by using the height as the limiting factor
+      (width * FONT_SIZE_SCALE_FACTOR) / displayAmount.toString().length,
+      height, // Ensure the text fits vertically by using the height as the limiting factor
     );
 
     setFontSize(calculatedFontSize);
@@ -71,7 +70,7 @@ export function SummaryNumber({
             maxWidth: '100%',
             fontSize,
             lineHeight: 1,
-            margin: FONT_PADDING,
+            margin: CONTAINER_MARGIN,
             justifyContent: 'center',
             transition: animate ? 'font-size 0.3s ease' : '',
             color: value < 0 ? chartTheme.colors.red : chartTheme.colors.blue,

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -40,7 +40,7 @@ export function SummaryNumber({
     if (!refDiv.current) return;
 
     const { clientWidth, clientHeight } = refDiv.current;
-    const width = clientWidth - CONTAINER_MARGIN * 2; // account for margin left and right
+    const width = clientWidth; // no margin required on left and right
     const height = clientHeight - CONTAINER_MARGIN * 2; // account for margin top and bottom
 
     const calculatedFontSize = Math.min(
@@ -75,7 +75,7 @@ export function SummaryNumber({
             maxWidth: '100%',
             fontSize,
             lineHeight: 1,
-            margin: CONTAINER_MARGIN,
+            margin: `${CONTAINER_MARGIN}px 0`,
             justifyContent: 'center',
             transition: animate ? 'font-size 0.3s ease' : '',
             color: value < 0 ? chartTheme.colors.red : chartTheme.colors.blue,

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -12,8 +12,8 @@ import { PrivacyFilter } from '../PrivacyFilter';
 import { chartTheme } from './chart-theme';
 import { LoadingIndicator } from './LoadingIndicator';
 
-const FONT_SIZE_SCALE_FACTOR = 0.9;
-const MAX_RECURSION_DEPTH = 10;
+const FONT_SIZE_SCALE_FACTOR = 1.6;
+const FONT_PADDING = 8;
 
 type SummaryNumberProps = {
   value: number;
@@ -32,61 +32,24 @@ export function SummaryNumber({
   initialFontSize = 14,
   fontSizeChanged,
 }: SummaryNumberProps) {
-  const [fontSize, setFontSize] = useState<number>(0);
+  const [fontSize, setFontSize] = useState<number>(initialFontSize);
   const refDiv = useRef<HTMLDivElement>(null);
-  const offScreenRef = useRef<HTMLDivElement>(null);
 
-  const adjustFontSizeBinary = (minFontSize: number, maxFontSize: number) => {
-    if (!offScreenRef.current || !refDiv.current) return;
-
-    const offScreenDiv = offScreenRef.current;
-    const refDivCurrent = refDiv.current;
-
-    const binarySearchFontSize = (
-      min: number,
-      max: number,
-      depth: number = 0,
-    ) => {
-      if (depth >= MAX_RECURSION_DEPTH) {
-        setFontSize(min);
-        return;
-      }
-
-      const testFontSize = (min + max) / 2;
-      offScreenDiv.style.fontSize = `${testFontSize}px`;
-
-      requestAnimationFrame(() => {
-        const isOverflowing =
-          offScreenDiv.scrollWidth > refDivCurrent.clientWidth ||
-          offScreenDiv.scrollHeight > refDivCurrent.clientHeight;
-
-        if (isOverflowing) {
-          binarySearchFontSize(min, testFontSize, depth + 1);
-        } else {
-          const isUnderflowing =
-            offScreenDiv.scrollWidth <=
-              refDivCurrent.clientWidth * FONT_SIZE_SCALE_FACTOR ||
-            offScreenDiv.scrollHeight <=
-              refDivCurrent.clientHeight * FONT_SIZE_SCALE_FACTOR;
-
-          if (isUnderflowing && testFontSize < max) {
-            binarySearchFontSize(testFontSize, max, depth + 1);
-          } else {
-            setFontSize(testFontSize);
-            if (initialFontSize !== testFontSize && fontSizeChanged) {
-              fontSizeChanged(testFontSize);
-            }
-          }
-        }
-      });
-    };
-
-    binarySearchFontSize(minFontSize, maxFontSize);
-  };
-
+  const displayAmount = amountToCurrency(Math.abs(value));
   const handleResize = debounce(() => {
-    adjustFontSizeBinary(14, 200);
-  }, 250);
+    const { clientWidth, clientHeight } = refDiv.current;
+    const widthWithPadding = clientWidth - FONT_PADDING * 2; // padding left and right
+    const heightWithPadding = clientHeight - FONT_PADDING * 2; // padding top and bottom
+
+    const calculatedFontSize = Math.min(
+      (widthWithPadding * FONT_SIZE_SCALE_FACTOR) /
+        displayAmount.toString().length,
+      heightWithPadding, // Ensure the text fits vertically by using the height as the limiting factor
+    );
+
+    setFontSize(calculatedFontSize);
+    fontSizeChanged(calculatedFontSize);
+  }, 100);
 
   const ref = useResizeObserver(handleResize);
   const mergedRef = useMergedRefs(ref, refDiv);
@@ -95,53 +58,32 @@ export function SummaryNumber({
     <>
       {loading && <LoadingIndicator />}
       {!loading && (
-        <>
-          <div
-            ref={offScreenRef}
-            style={{
-              position: 'fixed',
-              left: '-999px',
-              top: '-999px',
-              fontSize: `${initialFontSize}px`,
-              lineHeight: 1,
-              visibility: 'hidden',
-              whiteSpace: 'nowrap',
-              padding: 8,
-            }}
-          >
+        <View
+          ref={mergedRef as Ref<HTMLDivElement>}
+          role="text"
+          aria-label={`${value < 0 ? 'Negative' : 'Positive'} amount: ${displayAmount}${suffix}`}
+          style={{
+            alignItems: 'center',
+            flexGrow: 1,
+            flexShrink: 1,
+            width: '100%',
+            height: '100%',
+            maxWidth: '100%',
+            fontSize,
+            lineHeight: 0.85,
+            margin: FONT_PADDING,
+            justifyContent: 'center',
+            transition: animate ? 'font-size 0.3s ease' : '',
+            color: value < 0 ? chartTheme.colors.red : chartTheme.colors.blue,
+          }}
+        >
+          <span aria-hidden="true">
             <PrivacyFilter>
-              {amountToCurrency(Math.abs(value))}
+              {displayAmount}
               {suffix}
             </PrivacyFilter>
-          </div>
-
-          <View
-            ref={mergedRef as Ref<HTMLDivElement>}
-            role="text"
-            aria-label={`${value < 0 ? 'Negative' : 'Positive'} amount: ${amountToCurrency(Math.abs(value))}${suffix}`}
-            style={{
-              alignItems: 'center',
-              flexGrow: 1,
-              flexShrink: 1,
-              width: '100%',
-              height: '100%',
-              maxWidth: '100%',
-              fontSize: `${fontSize}px`,
-              lineHeight: 1,
-              padding: 8,
-              justifyContent: 'center',
-              transition: animate ? 'font-size 0.3s ease' : '',
-              color: value < 0 ? chartTheme.colors.red : chartTheme.colors.blue,
-            }}
-          >
-            <span aria-hidden="true">
-              <PrivacyFilter>
-                {amountToCurrency(Math.abs(value))}
-                {suffix}
-              </PrivacyFilter>
-            </span>
-          </View>
-        </>
+          </span>
+        </View>
       )}
     </>
   );

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -40,8 +40,8 @@ export function SummaryNumber({
     if (!refDiv.current) return;
 
     const { clientWidth, clientHeight } = refDiv.current;
-    const width = clientWidth - CONTAINER_MARGIN * 2; // margin left and right
-    const height = clientHeight - CONTAINER_MARGIN * 2; // margin top and bottom
+    const width = clientWidth - CONTAINER_MARGIN * 2; // account for margin left and right
+    const height = clientHeight - CONTAINER_MARGIN * 2; // account for margin top and bottom
 
     const calculatedFontSize = Math.min(
       (width * FONT_SIZE_SCALE_FACTOR) / displayAmount.toString().length,

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -70,7 +70,7 @@ export function SummaryNumber({
             height: '100%',
             maxWidth: '100%',
             fontSize,
-            lineHeight: 0.85,
+            lineHeight: 1,
             margin: FONT_PADDING,
             justifyContent: 'center',
             transition: animate ? 'font-size 0.3s ease' : '',

--- a/packages/desktop-client/src/components/reports/SummaryNumber.tsx
+++ b/packages/desktop-client/src/components/reports/SummaryNumber.tsx
@@ -50,7 +50,7 @@ export function SummaryNumber({
 
     setFontSize(calculatedFontSize);
 
-    if (calculatedFontSize !== initialFontSize) {
+    if (calculatedFontSize !== initialFontSize && fontSizeChanged) {
       fontSizeChanged(calculatedFontSize);
     }
   }, 100);

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -81,6 +81,7 @@ const exportModel = {
           'spending-card',
           'custom-report',
           'markdown-card',
+          'summary-card',
         ].includes(widget.type)
       ) {
         throw new ValidationError(

--- a/upcoming-release-notes/3871.md
+++ b/upcoming-release-notes/3871.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Summary Report: Update font size implementation to be simpler


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

I've simplified the font sizing - it should have quicker performance and it's easier to understand. There's a slight spacing adjustment too - It should look less tight but still fill out the space. 

Will need a thorough check to ensure It has the same output depending on the value.

**This also fixes the Import dashboard** when a summary card is being imported. _summary-card_ has been added into the importable report types.
