### PR TITLE
Allow the report table columns to grow to fill available space

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableHeader.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableHeader.tsx
@@ -70,6 +70,7 @@ export function ReportTableHeader({
           style={{
             width: compact ? 80 : 125,
             flexShrink: 0,
+            flexGrow: 1,
           }}
           valueStyle={compactStyle}
           value={

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -123,6 +123,7 @@ export const ReportTableRow = memo(
             style={{
               width: compact ? 80 : 125,
               flexShrink: 0,
+              flexGrow: 1,
             }}
             valueStyle={compactStyle}
           />

--- a/upcoming-release-notes/3872.md
+++ b/upcoming-release-notes/3872.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Allow report table columns to grow to fit available space


### PR DESCRIPTION
I'll need someone with more experience here to tell me if/why this is a bad idea, but it fixes my problem of the first column being far too small for account names etc.

Before:
![image](https://github.com/user-attachments/assets/6bdda1cb-9fdc-4e6f-9080-1c768fa25fd2)

After:
![image](https://github.com/user-attachments/assets/6ec880ff-6b98-451d-8799-446bb8835ebb)
