### PR TITLE
🐛  Fix performance when navigating between budget/accounts

### DIFF
--- a/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
@@ -30,13 +30,10 @@ export function useSheetValue<
 ): SheetValueResult<SheetName, FieldName>['value'] {
   const { sheetName, fullSheetName } = useSheetName(binding);
 
-  const bindingObj = useMemo(
-    () =>
-      typeof binding === 'string'
-        ? { name: binding, value: null, query: undefined }
-        : binding,
-    [],
-  );
+  const bindingObj =
+    typeof binding === 'string'
+      ? { name: binding, value: null, query: undefined }
+      : binding;
 
   const spreadsheet = useSpreadsheet();
   const [result, setResult] = useState<SheetValueResult<SheetName, FieldName>>({
@@ -51,6 +48,7 @@ export function useSheetValue<
   latestValue.current = result.value;
 
   useLayoutEffect(() => {
+    console.info('hello', bindingObj.query, bindingObj.name);
     if (bindingObj.query) {
       spreadsheet.createQuery(sheetName, bindingObj.name, bindingObj.query);
     }
@@ -69,7 +67,7 @@ export function useSheetValue<
         }
       },
     );
-  }, [sheetName, bindingObj.name, bindingObj.query]);
+  }, [sheetName, bindingObj.name, JSON.stringify(bindingObj.query)]);
 
   return result.value;
 }

--- a/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useLayoutEffect } from 'react';
+import { useState, useRef, useLayoutEffect, useMemo } from 'react';
 
 import { type Query } from 'loot-core/shared/query';
 import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
@@ -30,10 +30,13 @@ export function useSheetValue<
 ): SheetValueResult<SheetName, FieldName>['value'] {
   const { sheetName, fullSheetName } = useSheetName(binding);
 
-  const bindingObj =
-    typeof binding === 'string'
-      ? { name: binding, value: null, query: undefined }
-      : binding;
+  const bindingObj = useMemo(
+    () =>
+      typeof binding === 'string'
+        ? { name: binding, value: null, query: undefined }
+        : binding,
+    [],
+  );
 
   const spreadsheet = useSpreadsheet();
   const [result, setResult] = useState<SheetValueResult<SheetName, FieldName>>({
@@ -48,6 +51,7 @@ export function useSheetValue<
   latestValue.current = result.value;
 
   useLayoutEffect(() => {
+    console.info(' yo:', bindingObj.query);
     if (bindingObj.query) {
       spreadsheet.createQuery(sheetName, bindingObj.name, bindingObj.query);
     }

--- a/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
@@ -51,7 +51,6 @@ export function useSheetValue<
   latestValue.current = result.value;
 
   useLayoutEffect(() => {
-    console.info(' yo:', bindingObj.query);
     if (bindingObj.query) {
       spreadsheet.createQuery(sheetName, bindingObj.name, bindingObj.query);
     }

--- a/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useLayoutEffect, useMemo } from 'react';
+import { useState, useRef, useLayoutEffect } from 'react';
 
 import { type Query } from 'loot-core/shared/query';
 import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
@@ -48,7 +48,6 @@ export function useSheetValue<
   latestValue.current = result.value;
 
   useLayoutEffect(() => {
-    console.info('hello', bindingObj.query, bindingObj.name);
     if (bindingObj.query) {
       spreadsheet.createQuery(sheetName, bindingObj.name, bindingObj.query);
     }

--- a/upcoming-release-notes/3882.md
+++ b/upcoming-release-notes/3882.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix performance regression around accounts and budget pages


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

https://github.com/actualbudget/actual/issues/3881

This is a bit heavy handed but it works - open to other ideas. We must be passing in a new object ref with the same contents for query, so even if it's the same data it thought it was different. 

This is the only solution I can think of that doesn't involve lots of refactoring