### PR TITLE
Hide "try demo" on login page (fixes #2106)

### DIFF
--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -171,21 +171,21 @@ export function Login() {
         </View>
       )}
       {shouldDisplayDemo() && (
-              <View
-              style={{
-                flexDirection: 'row',
-                justifyContent: 'center',
-                marginTop: 15,
-              }}
-            >
-              <Button
-                variant="bare"
-                style={{ fontSize: 15, color: theme.pageTextLink, marginLeft: 10 }}
-                onPress={onDemo}
-              >
-                <Trans>Try Demo &rarr;</Trans>
-              </Button>
-            </View>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'center',
+            marginTop: 15,
+          }}
+        >
+          <Button
+            variant="bare"
+            style={{ fontSize: 15, color: theme.pageTextLink, marginLeft: 10 }}
+            onPress={onDemo}
+          >
+            <Trans>Try Demo &rarr;</Trans>
+          </Button>
+        </View>
       )}
     </View>
   );

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -17,6 +17,7 @@ import { Text } from '../../common/Text';
 import { View } from '../../common/View';
 
 import { useBootstrapped, Title } from './common';
+import { shouldDisplayDemo } from 'loot-core/src/shared/environment';
 
 export function Login() {
   const { t } = useTranslation();
@@ -169,21 +170,23 @@ export function Login() {
           )}
         </View>
       )}
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'center',
-          marginTop: 15,
-        }}
-      >
-        <Button
-          variant="bare"
-          style={{ fontSize: 15, color: theme.pageTextLink, marginLeft: 10 }}
-          onPress={onDemo}
-        >
-          <Trans>Try Demo &rarr;</Trans>
-        </Button>
-      </View>
+      {shouldDisplayDemo() && (
+              <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'center',
+                marginTop: 15,
+              }}
+            >
+              <Button
+                variant="bare"
+                style={{ fontSize: 15, color: theme.pageTextLink, marginLeft: 10 }}
+                onPress={onDemo}
+              >
+                <Trans>Try Demo &rarr;</Trans>
+              </Button>
+            </View>
+      )}
     </View>
   );
 }

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -7,6 +7,7 @@ import { useParams, useSearchParams } from 'react-router-dom';
 import { createBudget } from 'loot-core/src/client/actions/budgets';
 import { loggedIn } from 'loot-core/src/client/actions/user';
 import { send } from 'loot-core/src/platform/client/fetch';
+import { shouldDisplayLoginDemo } from 'loot-core/src/shared/environment';
 
 import { AnimatedLoading } from '../../../icons/AnimatedLoading';
 import { theme } from '../../../style';
@@ -17,7 +18,6 @@ import { Text } from '../../common/Text';
 import { View } from '../../common/View';
 
 import { useBootstrapped, Title } from './common';
-import { shouldDisplayLoginDemo } from 'loot-core/src/shared/environment';
 
 export function Login() {
   const { t } = useTranslation();

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -17,7 +17,7 @@ import { Text } from '../../common/Text';
 import { View } from '../../common/View';
 
 import { useBootstrapped, Title } from './common';
-import { shouldDisplayDemo } from 'loot-core/src/shared/environment';
+import { shouldDisplayLoginDemo } from 'loot-core/src/shared/environment';
 
 export function Login() {
   const { t } = useTranslation();
@@ -170,7 +170,7 @@ export function Login() {
           )}
         </View>
       )}
-      {shouldDisplayDemo() && (
+      {shouldDisplayLoginDemo() && (
         <View
           style={{
             flexDirection: 'row',

--- a/packages/loot-core/src/shared/environment.ts
+++ b/packages/loot-core/src/shared/environment.ts
@@ -18,3 +18,7 @@ export function isElectron() {
   }
   return false;
 }
+
+export function shouldDisplayDemo() {
+  return process.env.REACT_APP_HIDE_DEMO === undefined;
+}

--- a/packages/loot-core/src/shared/environment.ts
+++ b/packages/loot-core/src/shared/environment.ts
@@ -19,6 +19,6 @@ export function isElectron() {
   return false;
 }
 
-export function shouldDisplayDemo() {
-  return process.env.REACT_APP_HIDE_DEMO === undefined;
+export function shouldDisplayLoginDemo() {
+  return process.env.REACT_APP_HIDE_LOGIN_DEMO === undefined;
 }

--- a/upcoming-release-notes/3889.md
+++ b/upcoming-release-notes/3889.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [sammichaels]
+---
+
+Adds environment variable to remove "try demo" link on login page.


### PR DESCRIPTION
Fixes #2106.  Setting the environment variable REACT_APP_HIDE_LOGIN_DEMO to anything will prevent the "Try Demo" link from displaying on the login page.