### PR TITLE
Use useTranslation hook instead of directly importing the t function

### DIFF
--- a/packages/desktop-client/src/components/ManageRulesPage.tsx
+++ b/packages/desktop-client/src/components/ManageRulesPage.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { ManageRules } from './ManageRules';
 import { Page } from './Page';
 
 export function ManageRulesPage() {
+  const { t } = useTranslation();
   return (
     <Page header={t('Rules')}>
       <ManageRules isModal={false} payeeId={null} />

--- a/packages/desktop-client/src/components/Notes.tsx
+++ b/packages/desktop-client/src/components/Notes.tsx
@@ -1,9 +1,9 @@
 // @ts-strict-ignore
 import React, { useEffect, useRef, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 import remarkGfm from 'remark-gfm';
 
 import { theme } from '../style';
@@ -99,6 +99,7 @@ export function Notes({
   getStyle,
 }: NotesProps) {
   const { isNarrowWidth } = useResponsive();
+  const { t } = useTranslation();
 
   const textAreaRef = useRef<HTMLTextAreaElement>();
 

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -5,8 +5,7 @@ import React, {
   type ComponentProps,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 
@@ -36,6 +35,7 @@ export function NotesButton({
   tooltipPosition = 'bottom start',
   style,
 }: NotesButtonProps) {
+  const { t } = useTranslation();
   const triggerRef = useRef(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const note = useNotes(id) || '';

--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -6,10 +6,10 @@ import React, {
   type SetStateAction,
   type CSSProperties,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { removeNotification } from 'loot-core/client/actions';
 import { type State } from 'loot-core/src/client/state-types';
@@ -91,6 +91,7 @@ function Notification({
   notification: NotificationWithId;
   onRemove: () => void;
 }) {
+  const { t } = useTranslation();
   const {
     type,
     title,

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -1,6 +1,5 @@
 import React, { useRef, useState, type CSSProperties } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import type { Theme } from 'loot-core/src/types/prefs';
 
@@ -22,6 +21,7 @@ export function ThemeSelector({ style }: ThemeSelectorProps) {
   const triggerRef = useRef(null);
 
   const { isNarrowWidth } = useResponsive();
+  const { t } = useTranslation();
 
   const themeIcons = {
     light: SvgSun,

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, type CSSProperties } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
-import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 import { Routes, Route, useLocation } from 'react-router-dom';
 
 import { css } from '@emotion/css';

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect, type CSSProperties } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 import { Routes, Route, useLocation } from 'react-router-dom';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { sync } from 'loot-core/client/actions';
 import * as Platform from 'loot-core/src/client/platform';
@@ -108,6 +108,7 @@ type SyncButtonProps = {
   isMobile?: boolean;
 };
 function SyncButton({ style, isMobile = false }: SyncButtonProps) {
+  const { t } = useTranslation();
   const [cloudFileId] = useMetadataPref('cloudFileId');
   const dispatch = useDispatch();
   const [syncing, setSyncing] = useState(false);
@@ -267,6 +268,7 @@ type TitlebarProps = {
 };
 
 export function Titlebar({ style }: TitlebarProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const sidebar = useSidebar();

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-
-import { t } from 'i18next';
 
 import { unlinkAccount } from 'loot-core/client/actions';
 import { type AccountEntity } from 'loot-core/types/models';
@@ -17,61 +15,69 @@ import { Link } from '../common/Link';
 import { Popover } from '../common/Popover';
 import { View } from '../common/View';
 
-function getErrorMessage(type: string, code: string) {
-  switch (type.toUpperCase()) {
-    case 'ITEM_ERROR':
-      switch (code.toUpperCase()) {
-        case 'NO_ACCOUNTS':
-          return t(
-            'No open accounts could be found. Did you close the account? If so, unlink the account.',
-          );
-        case 'ITEM_LOGIN_REQUIRED':
-          return t(
-            'Your password or something else has changed with your bank and you need to login again.',
-          );
-        default:
-      }
-      break;
+function useErrorMessage() {
+  const { t } = useTranslation();
+  function getErrorMessage(type: string, code: string) {
+    switch (type.toUpperCase()) {
+      case 'ITEM_ERROR':
+        switch (code.toUpperCase()) {
+          case 'NO_ACCOUNTS':
+            return t(
+              'No open accounts could be found. Did you close the account? If so, unlink the account.',
+            );
+          case 'ITEM_LOGIN_REQUIRED':
+            return t(
+              'Your password or something else has changed with your bank and you need to login again.',
+            );
+          default:
+        }
+        break;
 
-    case 'INVALID_INPUT':
-      switch (code.toUpperCase()) {
-        case 'INVALID_ACCESS_TOKEN':
-          return t('Item is no longer authorized. You need to login again.');
-        default:
-      }
-      break;
+      case 'INVALID_INPUT':
+        switch (code.toUpperCase()) {
+          case 'INVALID_ACCESS_TOKEN':
+            return t('Item is no longer authorized. You need to login again.');
+          default:
+        }
+        break;
 
-    case 'RATE_LIMIT_EXCEEDED':
-      return t('Rate limit exceeded for this item. Please try again later.');
+      case 'RATE_LIMIT_EXCEEDED':
+        return t('Rate limit exceeded for this item. Please try again later.');
 
-    case 'INVALID_ACCESS_TOKEN':
-      return t(
-        'Your SimpleFIN Access Token is no longer valid. Please reset and generate a new token.',
-      );
+      case 'INVALID_ACCESS_TOKEN':
+        return t(
+          'Your SimpleFIN Access Token is no longer valid. Please reset and generate a new token.',
+        );
 
-    case 'ACCOUNT_NEEDS_ATTENTION':
-      return (
-        <Trans>
-          The account needs your attention at{' '}
-          <Link variant="external" to="https://bridge.simplefin.org/auth/login">
-            SimpleFIN
-          </Link>
-          .
-        </Trans>
-      );
+      case 'ACCOUNT_NEEDS_ATTENTION':
+        return (
+          <Trans>
+            The account needs your attention at{' '}
+            <Link
+              variant="external"
+              to="https://bridge.simplefin.org/auth/login"
+            >
+              SimpleFIN
+            </Link>
+            .
+          </Trans>
+        );
 
-    default:
+      default:
+    }
+
+    return (
+      <Trans>
+        An internal error occurred. Try to login again, or get{' '}
+        <Link variant="external" to="https://actualbudget.org/contact/">
+          in touch
+        </Link>{' '}
+        for support.
+      </Trans>
+    );
   }
 
-  return (
-    <Trans>
-      An internal error occurred. Try to login again, or get{' '}
-      <Link variant="external" to="https://actualbudget.org/contact/">
-        in touch
-      </Link>{' '}
-      for support.
-    </Trans>
-  );
+  return { getErrorMessage };
 }
 
 export function AccountSyncCheck() {
@@ -81,6 +87,7 @@ export function AccountSyncCheck() {
   const { id } = useParams();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef(null);
+  const { getErrorMessage } = useErrorMessage();
 
   const reauth = useCallback(
     (acc: AccountEntity) => {

--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -14,10 +14,10 @@ import {
   Dialog,
 } from 'react-aria-components';
 import { useHotkeysContext } from 'react-hotkeys-hook';
+import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 import { AutoTextSize } from 'auto-text-size';
-import { t } from 'i18next';
 
 import { useModalState } from '../../hooks/useModalState';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';
@@ -54,6 +54,7 @@ export const Modal = ({
   containerProps,
   ...props
 }: ModalProps) => {
+  const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
   const { enableScope, disableScope } = useHotkeysContext();
 
@@ -300,6 +301,7 @@ export function ModalHeader({
   title,
   rightContent,
 }: ModalHeaderProps) {
+  const { t } = useTranslation();
   return (
     <View
       role="heading"
@@ -468,6 +470,7 @@ type ModalCloseButtonProps = {
 };
 
 export function ModalCloseButton({ onPress, style }: ModalCloseButtonProps) {
+  const { t } = useTranslation();
   return (
     <Button
       variant="bare"

--- a/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
@@ -1,6 +1,5 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useNavigate } from '../../hooks/useNavigate';
 import { SvgCheveronLeft } from '../../icons/v1';
@@ -15,6 +14,7 @@ export function MobileBackButton({
   style,
   ...props
 }: MobileBackButtonProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   return (
     <Button

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
@@ -1,7 +1,6 @@
 import React, { type CSSProperties, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { t } from 'i18next';
 
 import { replaceModal, syncAndDownload } from 'loot-core/src/client/actions';
 import * as queries from 'loot-core/src/client/queries';
@@ -163,6 +162,7 @@ function AccountCard({
 }
 
 function EmptyMessage() {
+  const { t } = useTranslation();
   return (
     <View style={{ flex: 1, padding: 30 }}>
       <Text style={styles.text}>
@@ -195,6 +195,7 @@ function AccountList({
   onSelectAccount,
   onSync,
 }: AccountListProps) {
+  const { t } = useTranslation();
   const failedAccounts = useFailedAccounts();
   const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
   const onBudgetAccounts = accounts.filter(account => account.offbudget === 0);

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -1,9 +1,9 @@
 import React, { memo, useCallback, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 
 import { css } from '@emotion/css';
 import { AutoTextSize } from 'auto-text-size';
-import { t } from 'i18next';
 import memoizeOne from 'memoize-one';
 
 import { collapseModals, pushModal } from 'loot-core/client/actions';
@@ -67,6 +67,7 @@ function getColumnWidth({ show3Cols, isSidebar = false, offset = 0 } = {}) {
 }
 
 function ToBudget({ toBudget, onPress, show3Cols }) {
+  const { t } = useTranslation();
   const amount = useSheetValue(toBudget);
   const format = useFormat();
   const sidebarColumnWidth = getColumnWidth({ show3Cols, isSidebar: true });
@@ -129,6 +130,7 @@ function ToBudget({ toBudget, onPress, show3Cols }) {
 }
 
 function Saved({ projected, onPress, show3Cols }) {
+  const { t } = useTranslation();
   const binding = projected
     ? trackingBudget.totalBudgetedSaved
     : trackingBudget.totalSaved;
@@ -226,6 +228,7 @@ function BudgetCell({
   children,
   ...props
 }) {
+  const { t } = useTranslation();
   const columnWidth = getColumnWidth();
   const dispatch = useDispatch();
   const format = useFormat();
@@ -398,6 +401,7 @@ const ExpenseCategory = memo(function ExpenseCategory({
 }) {
   const opacity = blank ? 0 : 1;
 
+  const { t } = useTranslation();
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const goalTemp = useSheetValue(goal);
   const goalValue = isGoalTemplatesEnabled ? goalTemp : null;
@@ -1138,6 +1142,7 @@ const IncomeCategory = memo(function IncomeCategory({
   onEdit,
   onBudgetAction,
 }) {
+  const { t } = useTranslation();
   const listItemRef = useRef();
   const format = useFormat();
   const sidebarColumnWidth = getColumnWidth({ isSidebar: true, offset: -10 });
@@ -1413,6 +1418,7 @@ function IncomeGroup({
   collapsed,
   onToggleCollapse,
 }) {
+  const { t } = useTranslation();
   const columnWidth = getColumnWidth();
   return (
     <View>
@@ -1633,6 +1639,7 @@ export function BudgetTable({
   onOpenBudgetPageMenu,
   onOpenBudgetMonthMenu,
 }) {
+  const { t } = useTranslation();
   const { width } = useResponsive();
   const show3Cols = width >= 360;
 
@@ -1737,6 +1744,7 @@ function BudgetTableHeader({
   showSpentColumn,
   toggleSpentColumn,
 }) {
+  const { t } = useTranslation();
   const format = useFormat();
   const buttonStyle = {
     padding: 0,
@@ -1962,6 +1970,7 @@ function MonthSelector({
   onPrevMonth,
   onNextMonth,
 }) {
+  const { t } = useTranslation();
   const prevEnabled = month > monthBounds.start;
   const nextEnabled = month < monthUtils.subMonths(monthBounds.end, 1);
 

--- a/packages/desktop-client/src/components/mobile/transactions/AddTransactionButton.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/AddTransactionButton.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { SvgAdd } from '../../../icons/v1';
@@ -17,6 +16,7 @@ export function AddTransactionButton({
   accountId,
   categoryId,
 }: AddTransactionButtonProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   return (
     <Button

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   useCallback,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useParams } from 'react-router-dom';
 
@@ -16,7 +17,6 @@ import {
   parseISO,
   isValid as isValidDate,
 } from 'date-fns';
-import { t } from 'i18next';
 
 import { pushModal, setLastTransaction } from 'loot-core/client/actions';
 import { runQuery } from 'loot-core/src/client/query-helpers';
@@ -290,6 +290,7 @@ const ChildTransactionEdit = forwardRef(
     },
     ref,
   ) => {
+    const { t } = useTranslation();
     const { editingField, onRequestActiveEdit, onClearActiveEdit } =
       useSingleActiveEditForm();
     const prettyPayee = getPrettyPayee({
@@ -448,6 +449,7 @@ const TransactionEditInner = memo(function TransactionEditInner({
   onSplit,
   onAddSplit,
 }) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const transactions = useMemo(

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.jsx
@@ -65,7 +65,6 @@ export function TransactionList({
   onLoadMore,
 }) {
   const { t } = useTranslation();
-
   const sections = useMemo(() => {
     // Group by date. We can assume transactions is ordered
     const sections = [];

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { SelectedProvider, useSelected } from '../../../hooks/useSelected';
 import { SvgSearchAlternate } from '../../../icons/v2';
@@ -115,6 +114,7 @@ export function TransactionListWithBalances({
 }
 
 function BalanceWithCleared({ balanceUncleared, balanceCleared, balance }) {
+  const { t } = useTranslation();
   const unclearedAmount = useSheetValue(balanceUncleared);
 
   return (
@@ -173,6 +173,7 @@ function BalanceWithCleared({ balanceUncleared, balanceCleared, balance }) {
 }
 
 function Balance({ balance }) {
+  const { t } = useTranslation();
   return (
     <View style={{ flexBasis: '33%' }}>
       <Label title={t('Balance')} style={{ textAlign: 'center' }} />

--- a/packages/desktop-client/src/components/modals/BudgetListModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetListModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
-
-import { t } from 'i18next';
 
 import { useMetadataPref } from '../../hooks/useMetadataPref';
 import { Modal, ModalHeader, ModalCloseButton } from '../common/Modal';
@@ -10,6 +9,7 @@ import { View } from '../common/View';
 import { BudgetList } from '../manager/BudgetList';
 
 export function BudgetListModal() {
+  const { t } = useTranslation();
   const [id] = useMetadataPref('id');
   const currentFile = useSelector(state =>
     state.budgets.allFiles?.find(f => 'id' in f && f.id === id),

--- a/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
@@ -1,6 +1,5 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 
@@ -28,6 +27,7 @@ export function CategoryAutocompleteModal({
   month,
   onClose,
 }: CategoryAutocompleteModalProps) {
+  const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
 
   const defaultAutocompleteProps = {

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -5,8 +5,7 @@ import React, {
   useState,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { type CategoryGroupEntity } from 'loot-core/src/types/models';
 
@@ -47,6 +46,7 @@ export function CategoryGroupMenuModal({
   onToggleVisibility,
   onClose,
 }: CategoryGroupMenuModalProps) {
+  const { t } = useTranslation();
   const { grouped: categoryGroups } = useCategories();
   const group = categoryGroups.find(g => g.id === groupId);
   const notes = useNotes(group.id);
@@ -172,6 +172,7 @@ export function CategoryGroupMenuModal({
 }
 
 function AdditionalCategoryGroupMenu({ group, onDelete, onToggleVisibility }) {
+  const { t } = useTranslation();
   const triggerRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const itemStyle: CSSProperties = {

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import React, { useRef, useState, type CSSProperties } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { type CategoryEntity } from 'loot-core/src/types/models';
 
@@ -40,6 +39,7 @@ export function CategoryMenuModal({
   onToggleVisibility,
   onClose,
 }: CategoryMenuModalProps) {
+  const { t } = useTranslation();
   const category = useCategory(categoryId);
   const categoryGroup = useCategoryGroup(category?.cat_group);
   const originalNotes = useNotes(category.id);
@@ -158,6 +158,7 @@ function AdditionalCategoryMenu({
   onDelete,
   onToggleVisibility,
 }) {
+  const { t } = useTranslation();
   const triggerRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const itemStyle: CSSProperties = {

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -1,10 +1,10 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
 import { Form } from 'react-aria-components';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { loadAllFiles, loadGlobalPrefs, sync } from 'loot-core/client/actions';
 import { send } from 'loot-core/src/platform/client/fetch';
@@ -35,6 +35,7 @@ type CreateEncryptionKeyModalProps = {
 export function CreateEncryptionKeyModal({
   options = {},
 }: CreateEncryptionKeyModalProps) {
+  const { t } = useTranslation();
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');

--- a/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
@@ -1,9 +1,8 @@
 // @ts-strict-ignore
 import { type FormEvent, useState } from 'react';
 import { Form } from 'react-aria-components';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-
-import { t } from 'i18next';
 
 import { closeModal, createAccount } from 'loot-core/client/actions';
 import { toRelaxedNumber } from 'loot-core/src/shared/util';
@@ -30,6 +29,7 @@ import { Checkbox } from '../forms';
 import { validateAccountName } from '../util/accountValidation';
 
 export function CreateLocalAccountModal() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const accounts = useAccounts.useAccounts();

--- a/packages/desktop-client/src/components/modals/EditFieldModal.tsx
+++ b/packages/desktop-client/src/components/modals/EditFieldModal.tsx
@@ -4,9 +4,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { parseISO, format as formatDate, parse as parseDate } from 'date-fns';
-import { t } from 'i18next';
 
 import { currentDay, dayFromDate } from 'loot-core/src/shared/months';
 import { amountToInteger } from 'loot-core/src/shared/util';
@@ -45,6 +45,7 @@ export function EditFieldModal({
   onSubmit,
   onClose,
 }: EditFieldModalProps) {
+  const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const noteInputRef = useRef<HTMLInputElement | null>(null);
 

--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 import { v4 as uuid } from 'uuid';
 
 import {
@@ -304,6 +304,7 @@ function formatAmount(amount) {
 }
 
 function ScheduleDescription({ id }) {
+  const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const scheduleQuery = useMemo(
     () => q('schedules').filter({ id }).select('*'),
@@ -373,6 +374,7 @@ const splitActionFields = actionFields.filter(
 );
 const allocationMethodOptions = Object.entries(ALLOCATION_METHODS);
 function ActionEditor({ action, editorStyle, onChange, onDelete, onAdd }) {
+  const { t } = useTranslation();
   const {
     field,
     op,
@@ -762,6 +764,7 @@ const conditionFields = [
   ]);
 
 export function EditRuleModal({ defaultRule, onSave: originalOnSave }) {
+  const { t } = useTranslation();
   const [conditions, setConditions] = useState(
     defaultRule.conditions.map(parse).map(c => ({ ...c, inputKey: uuid() })),
   );

--- a/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
@@ -2,8 +2,7 @@ import React, {
   type ComponentPropsWithoutRef,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { envelopeBudget } from 'loot-core/client/queries';
 
@@ -41,6 +40,7 @@ export function EnvelopeBalanceMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
+  const { t } = useTranslation();
   const category = useCategory(categoryId);
 
   if (!category) {

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
@@ -4,8 +4,7 @@ import React, {
   useEffect,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { envelopeBudget } from 'loot-core/client/queries';
 import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
@@ -45,6 +44,7 @@ export function EnvelopeBudgetMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
+  const { t } = useTranslation();
   const budgeted = useEnvelopeSheetValue(
     envelopeBudget.catBudgeted(categoryId),
   );

--- a/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
@@ -1,8 +1,7 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
 import { Form } from 'react-aria-components';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { type FinanceModals } from 'loot-core/src/client/state-types/modals';
 import { send } from 'loot-core/src/platform/client/fetch';
@@ -33,6 +32,7 @@ export function FixEncryptionKeyModal({
 }: FixEncryptionKeyModalProps) {
   const { hasExistingKey, cloudFileId, onSuccess } = options;
 
+  const { t } = useTranslation();
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);

--- a/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
-
-import { t } from 'i18next'; // Ensure this import is correct
+import { useTranslation } from 'react-i18next';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 
@@ -27,6 +26,7 @@ type GoCardlessInitialiseProps = {
 export const GoCardlessInitialiseModal = ({
   onSuccess,
 }: GoCardlessInitialiseProps) => {
+  const { t } = useTranslation();
   const [secretId, setSecretId] = useState('');
   const [secretKey, setSecretKey] = useState('');
   const [isValid, setIsValid] = useState(true);

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 
 import deepEqual from 'deep-equal';
-import { t } from 'i18next';
 
 import {
   getPayees,
@@ -141,6 +141,7 @@ function parseCategoryFields(trans, categories) {
 }
 
 export function ImportTransactionsModal({ options }) {
+  const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [prefs, savePrefs] = useSyncedPrefs();
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
 import deepEqual from 'deep-equal';
 

--- a/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
+++ b/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
@@ -1,8 +1,7 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
-
-import { t } from 'i18next';
 
 import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
 
@@ -14,6 +13,7 @@ type ManageRulesModalProps = {
 };
 
 export function ManageRulesModal({ payeeId }: ManageRulesModalProps) {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(true);
   const location = useLocation();
   if (isNonProductionEnvironment()) {

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-
-import { t } from 'i18next';
 
 import { replaceModal } from 'loot-core/src/client/actions/modals';
 import { send } from 'loot-core/src/platform/client/fetch';
@@ -27,6 +26,7 @@ export function MergeUnusedPayeesModal({
   payeeIds,
   targetPayeeId,
 }: MergeUnusedPayeesModalProps) {
+  const { t } = useTranslation();
   const allPayees = usePayees();
   const modalStack = useSelector(state => state.modals.modalStack);
   const isEditingRule = !!modalStack.find(m => m.name === 'edit-rule');

--- a/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
@@ -1,6 +1,5 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { useNavigate } from '../../hooks/useNavigate';
@@ -24,6 +23,7 @@ export function PayeeAutocompleteModal({
   autocompleteProps,
   onClose,
 }: PayeeAutocompleteModalProps) {
+  const { t } = useTranslation();
   const payees = usePayees() || [];
   const accounts = useAccounts() || [];
   const navigate = useNavigate();

--- a/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
@@ -3,8 +3,7 @@ import React, {
   type ComponentPropsWithoutRef,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { format } from 'loot-core/shared/months';
@@ -28,6 +27,7 @@ export function ScheduledTransactionMenuModal({
   onSkip,
   onPost,
 }: ScheduledTransactionMenuModalProps) {
+  const { t } = useTranslation();
   const defaultMenuItemStyle: CSSProperties = {
     ...styles.mobileMenuItem,
     color: theme.menuItemText,
@@ -98,6 +98,7 @@ function ScheduledTransactionMenu({
   onPost,
   ...props
 }: ScheduledTransactionMenuProps) {
+  const { t } = useTranslation();
   return (
     <Menu
       {...props}

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-
-import { t } from 'i18next';
 
 import {
   closeModal,
@@ -32,6 +31,7 @@ export function SelectLinkedAccountsModal({
   syncSource,
 }) {
   externalAccounts.sort((a, b) => a.name.localeCompare(b.name));
+  const { t } = useTranslation();
   const dispatch = useDispatch();
   const localAccounts = useAccounts().filter(a => a.closed === 0);
   const [chosenAccounts, setChosenAccounts] = useState(() => {
@@ -201,6 +201,7 @@ function TableRow({
   unlinkedAccounts,
   onSetLinkedAccount,
 }) {
+  const { t } = useTranslation();
   const [focusedField, setFocusedField] = useState(null);
 
   const availableAccountOptions = [

--- a/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
@@ -2,8 +2,7 @@ import React, {
   type ComponentPropsWithoutRef,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { trackingBudget } from 'loot-core/client/queries';
 
@@ -39,6 +38,7 @@ export function TrackingBalanceMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
+  const { t } = useTranslation();
   const category = useCategory(categoryId);
 
   if (!category) {

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
@@ -4,8 +4,7 @@ import React, {
   useEffect,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { trackingBudget } from 'loot-core/client/queries';
 import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
@@ -45,6 +44,7 @@ export function TrackingBudgetMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
+  const { t } = useTranslation();
   const budgeted = useTrackingSheetValue(
     trackingBudget.catBudgeted(categoryId),
   );

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -1,7 +1,6 @@
 // @ts-strict-ignore
 import React, { Fragment, useMemo, useState } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import {
   type CategoryEntity,
@@ -34,6 +33,7 @@ export function CategorySelector({
   setSelectedCategories,
   showHiddenCategories = true,
 }: CategorySelectorProps) {
+  const { t } = useTranslation();
   const [uncheckedHidden, setUncheckedHidden] = useState(false);
   const filteredGroup = (categoryGroup: CategoryGroupEntity) => {
     return categoryGroup.categories.filter(f => {

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import { type CategoryEntity } from 'loot-core/types/models/category';
@@ -90,6 +89,7 @@ export function ReportSidebar({
   firstDayOfWeekIdx,
   isComplexCategoryCondition = false,
 }: ReportSidebarProps) {
+  const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef(null);
 

--- a/packages/desktop-client/src/components/reports/ReportTopbar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportTopbar.tsx
@@ -1,6 +1,5 @@
 import React, { type ComponentProps } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { type CustomReportEntity } from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
@@ -53,6 +52,7 @@ export function ReportTopbar({
   isItemDisabled,
   defaultItems,
 }: ReportTopbarProps) {
+  const { t } = useTranslation();
   const onChangeGraph = (cond: string) => {
     setSessionReport('graphType', cond);
     onReportChange({ type: 'modify' });

--- a/packages/desktop-client/src/components/reports/SaveReportName.tsx
+++ b/packages/desktop-client/src/components/reports/SaveReportName.tsx
@@ -1,7 +1,6 @@
 import React, { type RefObject, useEffect } from 'react';
 import { Form } from 'react-aria-components';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { type CustomReportEntity } from 'loot-core/types/models/reports';
 
@@ -38,6 +37,8 @@ export function SaveReportName({
   err,
   report,
 }: SaveReportNameProps) {
+  const { t } = useTranslation();
+
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();

--- a/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-
-import { t } from 'i18next';
 
 import { send, sendCatch } from 'loot-core/platform/client/fetch/index';
 import { addNotification } from 'loot-core/src/client/actions';
@@ -37,6 +36,8 @@ export function CustomReportListCards({
   report,
   onRemove,
 }: CustomReportListCardsProps) {
+  const { t } = useTranslation();
+
   // It's possible for a dashboard to reference a non-existing
   // custom report
   if (!report) {

--- a/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
+++ b/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import { type AccountEntity } from 'loot-core/types/models/account';
@@ -24,6 +23,7 @@ import { createGroupedSpreadsheet } from '../spreadsheets/grouped-spreadsheet';
 import { useReport } from '../useReport';
 
 function ErrorFallback() {
+  const { t } = useTranslation();
   return (
     <>
       <div>

--- a/packages/desktop-client/src/components/rules/ActionExpression.tsx
+++ b/packages/desktop-client/src/components/rules/ActionExpression.tsx
@@ -1,6 +1,5 @@
 import React, { type CSSProperties } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import {
   mapField,
@@ -68,6 +67,7 @@ function SetActionExpression({
   value,
   options,
 }: SetRuleActionEntity) {
+  const { t } = useTranslation();
   return (
     <>
       <Text>{friendlyOp(op)}</Text>{' '}

--- a/packages/desktop-client/src/components/rules/RulesHeader.tsx
+++ b/packages/desktop-client/src/components/rules/RulesHeader.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useSelectedItems, useSelectedDispatch } from '../../hooks/useSelected';
 import { SelectCell, Cell, TableHeader } from '../table';
 
 export function RulesHeader() {
+  const { t } = useTranslation();
   const selectedItems = useSelectedItems();
   const dispatchSelected = useSelectedDispatch();
 

--- a/packages/desktop-client/src/components/rules/Value.tsx
+++ b/packages/desktop-client/src/components/rules/Value.tsx
@@ -1,8 +1,8 @@
 // @ts-strict-ignore
 import React, { useState, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { format as formatDate, parseISO } from 'date-fns';
-import { t } from 'i18next';
 
 import { getMonthYearFormat } from 'loot-core/src/shared/months';
 import { getRecurringDescription } from 'loot-core/src/shared/schedules';
@@ -36,6 +36,7 @@ export function Value<T>({
   describe = x => x.name,
   style,
 }: ValueProps<T>) {
+  const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const payees = usePayees();
   const { list: categories } = useCategories();

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
@@ -6,8 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { sendCatch } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
@@ -271,6 +270,7 @@ function MonthlyPatterns({
   config: StateConfig;
   dispatch: Dispatch<ReducerAction>;
 }) {
+  const { t } = useTranslation();
   return (
     <Stack spacing={2} style={{ marginTop: 10 }}>
       {config.patterns.map((recurrence, idx) => (
@@ -351,6 +351,7 @@ function RecurringScheduleTooltip({
   onClose: () => void;
   onSave: (config: RecurConfig) => void;
 }) {
+  const { t } = useTranslation();
   const [previewDates, setPreviewDates] = useState(null);
 
   const [state, dispatch] = useReducer(reducer, {
@@ -554,6 +555,7 @@ export function RecurringSchedulePicker({
   buttonStyle,
   onChange,
 }: RecurringSchedulePickerProps) {
+  const { t } = useTranslation();
   const triggerRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';

--- a/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useSyncedPref } from '../../hooks/useSyncedPref';
 import { Button } from '../common/Button2';
@@ -10,6 +9,7 @@ import { Text } from '../common/Text';
 import { Setting } from './UI';
 
 export function BudgetTypeSettings() {
+  const { t } = useTranslation();
   const [budgetType = 'rollover', setBudgetType] = useSyncedPref('budgetType');
 
   function onSwitchType() {

--- a/packages/desktop-client/src/components/settings/Export.tsx
+++ b/packages/desktop-client/src/components/settings/Export.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { format } from 'date-fns';
-import { t } from 'i18next';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 
@@ -14,6 +14,7 @@ import { Text } from '../common/Text';
 import { Setting } from './UI';
 
 export function ExportBudget() {
+  const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [budgetName] = useMetadataPref('budgetName');

--- a/packages/desktop-client/src/components/settings/FixSplits.tsx
+++ b/packages/desktop-client/src/components/settings/FixSplits.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { send } from 'loot-core/src/platform/client/fetch';
 import { type Handlers } from 'loot-core/src/types/handlers';
@@ -55,6 +54,7 @@ function renderResults(results: Results) {
 }
 
 export function FixSplits() {
+  const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<Results | null>(null);
 

--- a/packages/desktop-client/src/components/settings/Format.tsx
+++ b/packages/desktop-client/src/components/settings/Format.tsx
@@ -1,8 +1,8 @@
 // @ts-strict-ignore
 import React, { type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { numberFormats } from 'loot-core/src/shared/util';
 import { type SyncedPrefs } from 'loot-core/src/types/prefs';
@@ -57,6 +57,7 @@ function Column({ title, children }: { title: string; children: ReactNode }) {
 }
 
 export function FormatSettings() {
+  const { t } = useTranslation();
   const sidebar = useSidebar();
   const [_firstDayOfWeekIdx, setFirstDayOfWeekIdxPref] =
     useSyncedPref('firstDayOfWeekIdx'); // Sunday;

--- a/packages/desktop-client/src/components/settings/Reset.tsx
+++ b/packages/desktop-client/src/components/settings/Reset.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { resetSync } from 'loot-core/client/actions';
 import { send } from 'loot-core/src/platform/client/fetch';
@@ -13,6 +12,7 @@ import { Text } from '../common/Text';
 import { Setting } from './UI';
 
 export function ResetCache() {
+  const { t } = useTranslation();
   const [resetting, setResetting] = useState(false);
 
   async function onResetCache() {
@@ -40,6 +40,7 @@ export function ResetCache() {
 }
 
 export function ResetSync() {
+  const { t } = useTranslation();
   const [groupId] = useMetadataPref('groupId');
   const isEnabled = !!groupId;
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/settings/Reset.tsx
+++ b/packages/desktop-client/src/components/settings/Reset.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
 import { resetSync } from 'loot-core/client/actions';
 import { send } from 'loot-core/src/platform/client/fetch';

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -1,7 +1,7 @@
 import React, { type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { type DarkTheme, type Theme } from 'loot-core/types/prefs';
 
@@ -37,6 +37,7 @@ function Column({ title, children }: { title: string; children: ReactNode }) {
 }
 
 export function ThemeSettings() {
+  const { t } = useTranslation();
   const sidebar = useSidebar();
   const [theme, switchTheme] = useTheme();
   const [darkTheme, switchDarkTheme] = usePreferredDarkTheme();

--- a/packages/desktop-client/src/components/settings/UI.tsx
+++ b/packages/desktop-client/src/components/settings/UI.tsx
@@ -1,8 +1,8 @@
 import React, { useState, type ReactNode, type CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { theme } from '../../style';
 import { tokens } from '../../tokens';
@@ -50,6 +50,7 @@ type AdvancedToggleProps = {
 };
 
 export const AdvancedToggle = ({ children }: AdvancedToggleProps) => {
+  const { t } = useTranslation();
   const location = useLocation();
   const [expanded, setExpanded] = useState(location.hash === '#advanced');
 

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
 
 import { css } from '@emotion/css';
 

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -1,8 +1,8 @@
 import React, { type ReactNode, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
-import { t } from 'i18next';
 
 import { closeBudget, loadPrefs } from 'loot-core/client/actions';
 import { isElectron } from 'loot-core/shared/environment';
@@ -36,6 +36,7 @@ import { ThemeSettings } from './Themes';
 import { AdvancedToggle, Setting } from './UI';
 
 function About() {
+  const { t } = useTranslation();
   const version = useServerVersion();
   const latestVersion = useLatestVersion();
   const isOutdated = useIsOutdated();
@@ -96,6 +97,7 @@ function IDName({ children }: { children: ReactNode }) {
 }
 
 function AdvancedAbout() {
+  const { t } = useTranslation();
   const [budgetId] = useMetadataPref('id');
   const [groupId] = useMetadataPref('groupId');
 
@@ -125,6 +127,7 @@ function AdvancedAbout() {
 }
 
 export function Settings() {
+  const { t } = useTranslation();
   const [floatingSidebar] = useGlobalPref('floatingSidebar');
   const [budgetName] = useMetadataPref('budgetName');
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.tsx
@@ -5,13 +5,13 @@ import React, {
   type CSSProperties,
   type ReactNode,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
   format as formatDate,
   isValid as isDateValid,
   parseISO,
 } from 'date-fns';
-import { t } from 'i18next';
 
 import * as monthUtils from 'loot-core/src/shared/months';
 import { integerToCurrency } from 'loot-core/src/shared/util';
@@ -165,6 +165,7 @@ export function SimpleTransactionsTable({
   fields = ['date', 'payee', 'amount'],
   style,
 }: SimpleTransactionsTableProps) {
+  const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const selectedItems = useSelectedItems();
   const dispatchSelected = useSelectedDispatch();

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -8,8 +8,7 @@ import React, {
   type KeyboardEventHandler,
   type CSSProperties,
 } from 'react';
-
-import { t } from 'i18next';
+import { useTranslation } from 'react-i18next';
 
 import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
 import { amountToInteger, appendDecimals } from 'loot-core/src/shared/util';
@@ -156,6 +155,7 @@ export function AmountInput({
 }
 
 export function BetweenAmountInput({ defaultValue, onChange }) {
+  const { t } = useTranslation();
   const [num1, setNum1] = useState(defaultValue.num1);
   const [num2, setNum2] = useState(defaultValue.num2);
 

--- a/upcoming-release-notes/3893.md
+++ b/upcoming-release-notes/3893.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Use useTranslation hook instead of directly importing t function from i18next


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
We should use `useTranslation` instead of directly import the `t` function because `useTranslation` has some functionalities that are specific to react e.g. rerendering the components when language changes

There are still some direct imports left in loot-core. We need to assess if we should translate strings at that level or we should do all translations in the desktop-client/component level.

https://github.com/actualbudget/actual/issues/3329