### PR TITLE
Add more logging for GoCardless rate limit information

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -32,7 +32,7 @@ import { title } from './title';
 import { runRules } from './transaction-rules';
 import { batchUpdateTransactions } from './transactions';
 
-function BankSyncError(type: string, code: string, details?: Object) {
+function BankSyncError(type: string, code: string, details?: object) {
   return { type: 'BankSyncError', category: type, code, details };
 }
 

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -32,8 +32,8 @@ import { title } from './title';
 import { runRules } from './transaction-rules';
 import { batchUpdateTransactions } from './transactions';
 
-function BankSyncError(type: string, code: string) {
-  return { type: 'BankSyncError', category: type, code };
+function BankSyncError(type: string, code: string, details?: Object) {
+  return { type: 'BankSyncError', category: type, code, details };
 }
 
 function makeSplitTransaction(trans, subtransactions) {
@@ -152,7 +152,11 @@ async function downloadGoCardlessTransactions(
   );
 
   if (res.error_code) {
-    throw BankSyncError(res.error_type, res.error_code);
+    const errorDetails = {
+      rateLimitHeaders: res.rateLimitHeaders,
+    };
+
+    throw BankSyncError(res.error_type, res.error_code, errorDetails);
   }
 
   if (includeBalance) {

--- a/upcoming-release-notes/3895.md
+++ b/upcoming-release-notes/3895.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Add more logging for GoCardless rate limit information


### PR DESCRIPTION
Adds a little more information to the error printed in the console when the GoCardless rate limit is reached. I'd love to work this into the UI at some point but this is an improvement.

Complimentary server PR: https://github.com/actualbudget/actual-server/pull/509

Fixes https://github.com/actualbudget/actual-server/issues/488