### PR TITLE
Category Labels Not Scaling Correctly On Small Screen

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1363,7 +1363,7 @@ const Transaction = memo(function Transaction({
                 borderRadius: 4,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
-                display: 'inline-block'
+                display: 'inline-block',
               }}
             >
               {titleFirst(categoryId)}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1361,6 +1361,9 @@ const Transaction = memo(function Transaction({
                 margin: '0 5px',
                 padding: '3px 7px',
                 borderRadius: 4,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: 'inline-block'
               }}
             >
               {titleFirst(categoryId)}

--- a/upcoming-release-notes/3906.md
+++ b/upcoming-release-notes/3906.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [annechoww]
+---
+
+Fix bug where category labels are not scaling correctly on small screens


### PR DESCRIPTION
Fixes #3849 

Category Labels should now scale alongside the background on smaller screens. See fix below:

![image](https://github.com/user-attachments/assets/23ecc329-d8ac-477b-a4aa-bff6af3e4673)