### PR TITLE
:bug: Fix flicker when saving transaction on account page when transactions are scheduled

### DIFF
--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -32,10 +32,6 @@ export function useAccountPreviewTransactions({
   const payees = usePayees();
 
   const previewTransactions = useMemo(() => {
-    if (isLoading) {
-      return [];
-    }
-
     if (!accountId) {
       return originalPreviewTransactions;
     }
@@ -50,9 +46,12 @@ export function useAccountPreviewTransactions({
           a => a.id === payees.find(p => p.id === payeeId)?.transfer_acct,
         ),
     });
-  }, [accountId, accounts, isLoading, originalPreviewTransactions, payees]);
+  }, [accountId, accounts, originalPreviewTransactions, payees]);
 
-  return { isLoading, previewTransactions };
+  return {
+    isLoading,
+    previewTransactions,
+  };
 }
 
 type AccountPreviewProps = {

--- a/upcoming-release-notes/3920.md
+++ b/upcoming-release-notes/3920.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix flickering when saving a transaction when there are transactions scheduled


### PR DESCRIPTION
Info: #3916

Fixes: 
![test](https://github.com/user-attachments/assets/2f705f82-6e28-498f-8c14-635251e074c4)