### PR TITLE
fix tracking budget docs link

### DIFF
--- a/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetTypeSettings.tsx
@@ -46,7 +46,7 @@ export function BudgetTypeSettings() {
         relying on current available funds.{' '}
         <Link
           variant="external"
-          to="https://actualbudget.org/docs/experimental/tracking-budget"
+          to="https://actualbudget.org/docs/getting-started/tracking-budget"
           linkColor="purple"
         >
           {t('Learn more…')}


### PR DESCRIPTION
The link to the tracking budget docs links to the old page under experimental which no longer exists.