### PR TITLE
Fix mobile navigation tabs disappearing on top bounce

### DIFF
--- a/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
@@ -138,10 +138,10 @@ export function MobileNavTabs() {
     <div key={idx} style={navTabStyle} />
   ));
 
-  useScrollListener(({ isScrolling }) => {
-    if (isScrolling('down')) {
+  useScrollListener(({ isScrolling, hasScrolledToEnd }) => {
+    if (isScrolling('down') && !hasScrolledToEnd('up')) {
       hide();
-    } else if (isScrolling('up')) {
+    } else if (isScrolling('up') && !hasScrolledToEnd('down')) {
       openDefault();
     }
   });

--- a/upcoming-release-notes/3962.md
+++ b/upcoming-release-notes/3962.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mbaeuerle]
+---
+
+Fix iOS mobile navigation tabs disappearing on bouncing top and appearing on bouncing bottom.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The mobile navigation tabs are hidden whenever you scroll down, they reappear when scrolling up. This is intended behavior.
On a bounce at the top however they disappear erroneously. I guess due to the bounce which scrolls slightly back down.
The same appears at the bottom where a bounce back up makes the tabs reappear.

This only seems to be an issue on iOS. Could not test it on Android due to not owning a device. But I could not detect this behavior in Firefox with small viewport.

This solution prevents the hiding / opening of the nav tabs by checking if it's at the top / bottom.


Issue at the top:
![bug](https://github.com/user-attachments/assets/167a320a-947e-4c6f-918e-99f24affd73c)

Issue at the bottom:
![bug2](https://github.com/user-attachments/assets/21a585e2-20cf-46c0-8634-a8223bfb4f24)

Fixed:
![fixed](https://github.com/user-attachments/assets/5d179fed-6542-4d32-98ef-5eee1351c725)