### PR TITLE
[BugFix] Space missing on create local account copy

### DIFF
--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -204,7 +204,7 @@ export function CreateAccountModal({ upgradingAccountId }: CreateAccountProps) {
                 </InitialFocus>
                 <View style={{ lineHeight: '1.4em', fontSize: 15 }}>
                   <Text>
-                    <strong>{t('Create a local account')}</strong>
+                    <strong>{t('Create a local account')}</strong>{' '}
                     {t(
                       'if you want to add transactions manually. You can also',
                     )}{' '}

--- a/upcoming-release-notes/3985.md
+++ b/upcoming-release-notes/3985.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [talkintomato]
+---
+
+Fix space missing on create local account copy


### PR DESCRIPTION
---
category: BugFix
authors: talkintomato
---

- Add space to copy

Previously -> 
![image](https://github.com/user-attachments/assets/d09bfd71-4989-403c-bd5c-ec35452f5c30)
