### PR TITLE
Move reproduction block as a separate text block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -23,8 +23,6 @@ body:
       options:
         - label: 'I have searched and found no existing issue'
           required: true
-        - label: 'I will be providing steps how to reproduce the bug (in most cases this will also mean uploading a demo budget file)'
-          required: true
     validations:
       required: true
   - type: textarea
@@ -34,6 +32,14 @@ body:
       description: Also tell us, what did you expect to happen? If you’re reporting an issue with imports, please attach a (redacted) version of the file you’re having trouble importing. You may need to zip it before uploading.
       placeholder: Tell us what you see!
       value: 'A bug happened!'
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: How can we reproduce the issue?
+      description: Please give step-by-step instructions on how to reproduce the issue. In most cases this might also require uploading a sample budget/import file.
+      value: ''
     validations:
       required: true
   - type: markdown


### PR DESCRIPTION
People seem to be reporting bugs without giving us the reproduction steps.. Hopefully this will improve the situation.