### PR TITLE
[Goals]: Fix applying templates in tracking budget

### DIFF
--- a/packages/loot-core/src/server/budget/goaltemplates.ts
+++ b/packages/loot-core/src/server/budget/goaltemplates.ts
@@ -130,7 +130,7 @@ async function processTemplate(
     const isReflect = isReflectBudget();
     const categoriesLong = await getCategories();
     categoriesLong.forEach(c => {
-      if (!isReflect && !c.is_income) {
+      if (isReflect || !c.is_income) {
         categories.push(c);
       }
     });

--- a/upcoming-release-notes/4010.md
+++ b/upcoming-release-notes/4010.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix goal templates not applying in tracking budget


### PR DESCRIPTION
my logic was wrong and made templates not apply to the tracking budget.  Fixes #4006 

To test:
Add any template to a tracking budget and try to apply it.  It won't do anything in current edge.
