### PR TITLE
Include translations in builds

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,6 +28,6 @@ runs:
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Update translations
-      run: git submodule update --remote
+      run: git config --global --add safe.directory "$PWD" && git submodule update --remote
       shell: bash
       if: ${{ inputs.edge }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,5 +1,11 @@
 name: Setup
 
+inputs:
+  edge:
+    description: 'Whether this is an edge build (vs release)'
+    required: true
+    type: boolean
+
 runs:
   using: composite
   steps:
@@ -21,3 +27,7 @@ runs:
       run: yarn --immutable
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
+    - name: Update translations
+      run: git submodule update --remote
+      shell: bash
+      if: ${{ inputs.edge }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Build API
         run: cd packages/api && yarn build
       - name: Create package tgz
@@ -38,8 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Build CRDT
         run: cd packages/crdt && yarn build
       - name: Create package tgz
@@ -54,8 +62,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Build Web
         run: ./bin/package-browser
       - name: Upload Build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,24 +15,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Lint
         run: yarn lint
   typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Typecheck
         run: yarn typecheck
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Test
         run: yarn test
 
@@ -41,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: actions/setup-node@v4
         with:
           node-version: '19'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,8 +17,12 @@ jobs:
       netlify_url: ${{ steps.netlify.outputs.url }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Wait for Netlify build to finish
         id: netlify
         env:
@@ -34,8 +38,12 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.41.1-jammy
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Run E2E Tests on Netlify URL
         run: yarn e2e
         env:
@@ -55,8 +63,12 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.41.1-jammy
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Run VRT Tests on Netlify URL
         run: yarn vrt
         env:

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
@@ -49,6 +51,8 @@ jobs:
           sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: false
       - name: Build Electron for Mac
         if: ${{ startsWith(matrix.os, 'macos') }}
         run: ./bin/package-electron

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
@@ -44,6 +46,8 @@ jobs:
           sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Build Electron
         run: ./bin/package-electron
       - name: Upload Build

--- a/.github/workflows/netlify-release.yml
+++ b/.github/workflows/netlify-release.yml
@@ -22,9 +22,13 @@ jobs:
     steps:
       - name: Repository Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
     
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: false
     
       - name: Install Netlify
         run: npm install netlify-cli@17.10.1 -g

--- a/.github/workflows/update-vrt.yml
+++ b/.github/workflows/update-vrt.yml
@@ -29,8 +29,11 @@ jobs:
         with:
           repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
           ref: ${{ steps.comment-branch.outputs.head_ref }}
+          submodules: true
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          edge: true
       - name: Wait for Netlify build to finish
         id: netlify
         env:

--- a/.github/workflows/update-vrt.yml
+++ b/.github/workflows/update-vrt.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-          submodules: true
+          submodules: recursive
       - name: Set up environment
         uses: ./.github/actions/setup
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/desktop-client/locale"]
+	path = packages/desktop-client/locale
+	url = ../translations

--- a/upcoming-release-notes/4035.md
+++ b/upcoming-release-notes/4035.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Include translations in all builds


### PR DESCRIPTION
This is the final step in getting translations rolled out! We're using [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) here, which allow us to keep the https://github.com/actualbudget/translations logically inside a `locale/` directory on checkouts. Note that anyone who wants to contribute translations will need to run `git submodule update --init` before they will see the translations locally, and anyone with a local web-only install (not `actual-server`) will need to do the same in order to see the translations.

Also see [this PR](https://github.com/actualbudget/docs/pull/586/files) for a small update to the release process.