### PR TITLE
Fix loading of number format on initial app startup

### DIFF
--- a/packages/desktop-client/src/components/spreadsheet/useFormat.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useFormat.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import {
   getNumberFormat,
   integerToCurrency,
-  isNumberFormat,
+  parseNumberFormat,
   setNumberFormat,
 } from 'loot-core/src/shared/util';
 
@@ -64,10 +64,7 @@ export function useFormat() {
   const [hideFraction] = useSyncedPref('hideFraction');
 
   const config = useMemo(
-    () => ({
-      format: isNumberFormat(numberFormat) ? numberFormat : 'comma-dot',
-      hideFraction: String(hideFraction) === 'true',
-    }),
+    () => parseNumberFormat({ format: numberFormat, hideFraction }),
     [numberFormat, hideFraction],
   );
 

--- a/packages/loot-core/src/client/actions/prefs.ts
+++ b/packages/loot-core/src/client/actions/prefs.ts
@@ -1,4 +1,5 @@
 import { send } from '../../platform/client/fetch';
+import { parseNumberFormat, setNumberFormat } from '../../shared/util';
 import {
   type GlobalPrefs,
   type MetadataPrefs,
@@ -19,12 +20,25 @@ export function loadPrefs() {
       dispatch(closeModal());
     }
 
+    const [globalPrefs, syncedPrefs] = await Promise.all([
+      send('load-global-prefs'),
+      send('preferences/get'),
+    ]);
+
     dispatch({
       type: constants.SET_PREFS,
       prefs,
-      globalPrefs: await send('load-global-prefs'),
-      syncedPrefs: await send('preferences/get'),
+      globalPrefs,
+      syncedPrefs,
     });
+
+    // Certain loot-core utils depend on state outside of the React tree, update them
+    setNumberFormat(
+      parseNumberFormat({
+        format: syncedPrefs.numberFormat,
+        hideFraction: syncedPrefs.hideFraction,
+      }),
+    );
 
     return prefs;
   };

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -235,7 +235,7 @@ const NUMBER_FORMATS = [
 
 type NumberFormats = (typeof NUMBER_FORMATS)[number];
 
-export function isNumberFormat(input: string = ''): input is NumberFormats {
+function isNumberFormat(input: string = ''): input is NumberFormats {
   return (NUMBER_FORMATS as readonly string[]).includes(input);
 }
 
@@ -258,6 +258,19 @@ let numberFormatConfig: {
   format: 'comma-dot',
   hideFraction: false,
 };
+
+export function parseNumberFormat({
+  format,
+  hideFraction,
+}: {
+  format?: string;
+  hideFraction?: string | boolean;
+}) {
+  return {
+    format: isNumberFormat(format) ? format : 'comma-dot',
+    hideFraction: String(hideFraction) === 'true',
+  };
+}
 
 export function setNumberFormat(config: typeof numberFormatConfig) {
   numberFormatConfig = config;

--- a/upcoming-release-notes/4038.md
+++ b/upcoming-release-notes/4038.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix loading of number format preferences at app startup


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/4037. The bug occurs because the React component renders without using `useFormat` at all. An easy fix would be to just call that hook inside the component, but then we risk this bug cropping up on other pages. Instead I changed the logic at preference load time so it's valid for all components

Requesting Matiss since this relates to https://github.com/actualbudget/actual/pull/3397 but feel free to request someone else instead