### PR TITLE
Fix payee cell overflowing when it contains an icon

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -358,14 +358,7 @@ function getPayeePretty(transaction, payee, transferAcct, numHiddenPayees = 0) {
           alignItems: 'center',
         }}
       >
-        <div
-          style={{
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {formatPayeeName(transferAcct.name)}
-        </div>
+        {formatPayeeName(transferAcct.name)}
       </View>
     );
   } else if (payee) {
@@ -706,7 +699,14 @@ function PayeeCell({
         );
 
         return (
-          <>
+          <div
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
             <PayeeIcons
               transaction={transaction}
               transferAccount={transferAccount}
@@ -732,7 +732,7 @@ function PayeeCell({
             ) : (
               payeeName
             )}
-          </>
+          </div>
         );
       }}
     >

--- a/upcoming-release-notes/4056.md
+++ b/upcoming-release-notes/4056.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix payee cell overflowing when it contains an icon


### PR DESCRIPTION
Fixes #4055 