### PR TITLE
[Goals]: fix repeating spend templates

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -450,11 +450,14 @@ export class CategoryTemplate {
     let firstMonth = true;
 
     //update months if needed
+    const repeat = template.annual
+      ? (template.repeat || 1) * 12
+      : template.repeat;
     let m = monthUtils.differenceInCalendarMonths(toMonth, this.month);
-    if (template.annual && m < 0) {
+    if (repeat && m < 0) {
       while (m < 0) {
-        toMonth = monthUtils.addMonths(toMonth, 12);
-        fromMonth = monthUtils.addMonths(fromMonth, 12);
+        toMonth = monthUtils.addMonths(toMonth, repeat);
+        fromMonth = monthUtils.addMonths(fromMonth, repeat);
         m = monthUtils.differenceInCalendarMonths(toMonth, this.month);
       }
     }

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -444,10 +444,20 @@ export class CategoryTemplate {
   }
 
   private async runSpend(template): Promise<number> {
-    const fromMonth = `${template.from}`;
-    const toMonth = `${template.month}`;
+    let fromMonth = `${template.from}`;
+    let toMonth = `${template.month}`;
     let alreadyBudgeted = this.fromLastMonth;
     let firstMonth = true;
+
+    //update months if needed
+    let m = monthUtils.differenceInCalendarMonths(toMonth, this.month);
+    if (template.annual && m < 0) {
+      while (m < 0) {
+        toMonth = monthUtils.addMonths(toMonth, 12);
+        fromMonth = monthUtils.addMonths(fromMonth, 12);
+        m = monthUtils.differenceInCalendarMonths(toMonth, this.month);
+      }
+    }
 
     for (
       let m = fromMonth;

--- a/upcoming-release-notes/4066.md
+++ b/upcoming-release-notes/4066.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix spend template not repeating


### PR DESCRIPTION
The logic to update the dates on repeated spend templates got missed.  Fixes #4065
