### PR TITLE
Fix calendar report day background colour in development theme

### DIFF
--- a/packages/desktop-client/src/style/themes/development.ts
+++ b/packages/desktop-client/src/style/themes/development.ts
@@ -214,4 +214,4 @@ export const tooltipText = colorPalette.navy900;
 export const tooltipBackground = colorPalette.navy50;
 export const tooltipBorder = colorPalette.navy150;
 
-export const calendarCellBackground = colorPalette.navy900;
+export const calendarCellBackground = colorPalette.navy100;

--- a/upcoming-release-notes/4073.md
+++ b/upcoming-release-notes/4073.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix calendar report day background color in development theme


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/70799ad8-4c7c-4237-8f40-de96b79193b4)

After:
![image](https://github.com/user-attachments/assets/e4c907ca-f152-4761-acdf-8c2faf2eb8e1)
