### PR TITLE
:fire: remove unused permissions prop from Button components

### DIFF
--- a/packages/desktop-client/src/components/common/Button.tsx
+++ b/packages/desktop-client/src/components/common/Button.tsx
@@ -7,8 +7,6 @@ import React, {
 
 import { css } from '@emotion/css';
 
-import { useAuth } from '../../auth/AuthProvider';
-import { type Permissions } from '../../auth/types';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';
 import { styles, theme } from '../../style';
 
@@ -27,7 +25,6 @@ type ButtonProps = HTMLProps<HTMLButtonElement> & {
   textStyle?: CSSProperties;
   bounce?: boolean;
   as?: ElementType;
-  permission?: Permissions;
 };
 
 type ButtonType = 'normal' | 'primary' | 'bare' | 'menu' | 'menuSelected';
@@ -141,13 +138,10 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       activeStyle,
       bounce = true,
       as = 'button',
-      permission,
       ...nativeProps
     }: ButtonProps,
     ref,
   ) => {
-    const { hasPermission } = useAuth();
-
     const typeWithDisabled: ButtonType | `${ButtonType}Disabled` = disabled
       ? `${type}Disabled`
       : type;
@@ -192,7 +186,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...(typeof as === 'string'
           ? { className: css(buttonStyle) }
           : { style: buttonStyle })}
-        disabled={disabled ? disabled : !hasPermission(permission)}
+        disabled={disabled}
         type={isSubmit ? 'submit' : 'button'}
         {...nativeProps}
       >

--- a/packages/desktop-client/src/components/common/Button2.tsx
+++ b/packages/desktop-client/src/components/common/Button2.tsx
@@ -9,8 +9,6 @@ import { Button as ReactAriaButton } from 'react-aria-components';
 
 import { css } from '@emotion/css';
 
-import { useAuth } from '../../auth/AuthProvider';
-import { type Permissions } from '../../auth/types';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';
 import { styles, theme } from '../../style';
 
@@ -134,22 +132,13 @@ type ButtonProps = ComponentPropsWithoutRef<typeof ReactAriaButton> & {
   variant?: ButtonVariant;
   bounce?: boolean;
   children?: ReactNode;
-  permission?: Permissions;
 };
 
 type ButtonVariant = 'normal' | 'primary' | 'bare' | 'menu' | 'menuSelected';
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (props, ref) => {
-    const {
-      permission,
-      children,
-      variant = 'normal',
-      bounce = true,
-      ...restProps
-    } = props;
-
-    const { hasPermission } = useAuth();
+    const { children, variant = 'normal', bounce = true, ...restProps } = props;
 
     const variantWithDisabled: ButtonVariant | `${ButtonVariant}Disabled` =
       props.isDisabled ? `${variant}Disabled` : variant;
@@ -184,7 +173,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <ReactAriaButton
         ref={ref}
-        isDisabled={restProps.isDisabled || !hasPermission(permission)}
         {...restProps}
         className={
           typeof className === 'function'

--- a/upcoming-release-notes/4085.md
+++ b/upcoming-release-notes/4085.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove unused `permission` prop from `Button` component.


### PR DESCRIPTION
If we wish to add this functionality back - please add it on the consumer level instead of the `Button` component.

i.e. 

```
<Button isDisabled={hasPermission("something")} />
```