### PR TITLE
fix: creating new payee with 'one of'-condition broken

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -1,14 +1,14 @@
 // @ts-strict-ignore
 import React, {
-  useState,
-  useRef,
-  useEffect,
-  useMemo,
+  type ChangeEvent,
   type ComponentProps,
   type HTMLProps,
-  type ReactNode,
   type KeyboardEvent,
-  type ChangeEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from 'react';
 
 import { css, cx } from '@emotion/css';
@@ -17,7 +17,7 @@ import Downshift, { type StateChangeTypes } from 'downshift';
 import { getNormalisedString } from 'loot-core/src/shared/normalisation';
 
 import { SvgRemove } from '../../icons/v2';
-import { theme, styles } from '../../style';
+import { styles, theme } from '../../style';
 import { Button } from '../common/Button';
 import { Input } from '../common/Input';
 import { Popover } from '../common/Popover';
@@ -649,10 +649,10 @@ function MultiAutocomplete<T extends Item>({
     onSelect(items);
   }
 
-  function onAddItem(id: T['id']) {
+  function onAddItem(id: T['id'], value: string) {
     if (id) {
       id = id.trim();
-      onSelect([...selectedItemIds, id], id);
+      onSelect([...selectedItemIds, id], value);
     }
   }
 
@@ -738,6 +738,7 @@ type AutocompleteFooterProps = {
   embedded?: boolean;
   children: ReactNode;
 };
+
 export function AutocompleteFooter({
   show = true,
   embedded,

--- a/upcoming-release-notes/4099.md
+++ b/upcoming-release-notes/4099.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ jfdoming ]
+---
+
+Fix incorrect behavior when creating a new payee in a new rule with the condition set to "one of"

--- a/upcoming-release-notes/4099.md
+++ b/upcoming-release-notes/4099.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfix
-authors: [ jfdoming ]
+authors: [sveselinovic]
 ---
 
-Fix incorrect behavior when creating a new payee in a new rule with the condition set to "one of"
+Fix resulting wrong name when creating a new payee in rule with the condition set to "one of"


### PR DESCRIPTION
Fixes #4026 

I don't think there is anything else necessary and it seems like creating a new payee with the 'one of'-operator works just fine now. I will look into it again to make sure and learn a bit more about the project. 

Should I extend/create a test for this? 