### PR TITLE
Mark release as draft initially

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Add to Release
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: |
             packages/desktop-electron/dist/*.dmg
             packages/desktop-electron/dist/*.exe

--- a/upcoming-release-notes/4105.md
+++ b/upcoming-release-notes/4105.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Mark releases as draft by default


### PR DESCRIPTION
Feedback from latest release: mark GitHub release as draft initially

Also see Action docs https://github.com/softprops/action-gh-release?tab=readme-ov-file#-customizing and our docs https://github.com/actualbudget/docs/pull/605