### PR TITLE
[Goals]: fix stacked templates

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -95,31 +95,32 @@ export class CategoryTemplate {
     let scheduleFlag = false;
     // switch on template type and calculate the amount for the line
     for (let i = 0; i < t.length; i++) {
+      let newBudget = 0;
       switch (t[i].type) {
         case 'simple': {
-          toBudget += this.runSimple(t[i], this.limitAmount);
+          newBudget = this.runSimple(t[i], this.limitAmount);
           break;
         }
         case 'copy': {
-          toBudget += await this.runCopy(t[i]);
+          newBudget = await this.runCopy(t[i]);
           break;
         }
         case 'week': {
-          toBudget += this.runWeek(t[i]);
+          newBudget = this.runWeek(t[i]);
           break;
         }
         case 'spend': {
-          toBudget += await this.runSpend(t[i]);
+          newBudget = await this.runSpend(t[i]);
           break;
         }
         case 'percentage': {
-          toBudget += await this.runPercentage(t[i], availStart);
+          newBudget = await this.runPercentage(t[i], availStart);
           break;
         }
         case 'by': {
           //TODO add the logic to run all of these at once or whatever is needed
           const ret = this.runBy(t[i], first, remainder);
-          toBudget += ret.ret;
+          newBudget = ret.ret;
           remainder = ret.remainder;
           first = false;
           break;
@@ -140,18 +141,21 @@ export class CategoryTemplate {
             [],
             this.category,
           );
-          toBudget = ret.to_budget;
+          // Schedules assume that its to budget value is the whole thing so this
+          // needs to remove the previous funds so they aren't double counted
+          newBudget = ret.to_budget-toBudget;
           remainder = ret.remainder;
           scheduleFlag = ret.scheduleFlag;
           break;
         }
         case 'average': {
-          toBudget += await this.runAverage(t[i]);
+          newBudget += await this.runAverage(t[i]);
           break;
         }
       }
 
-      available = available - toBudget;
+      available = available - newBudget;
+      toBudget += newBudget;
     }
 
     //check limit

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -143,13 +143,13 @@ export class CategoryTemplate {
           );
           // Schedules assume that its to budget value is the whole thing so this
           // needs to remove the previous funds so they aren't double counted
-          newBudget = ret.to_budget-toBudget;
+          newBudget = ret.to_budget - toBudget;
           remainder = ret.remainder;
           scheduleFlag = ret.scheduleFlag;
           break;
         }
         case 'average': {
-          newBudget += await this.runAverage(t[i]);
+          newBudget = await this.runAverage(t[i]);
           break;
         }
       }

--- a/upcoming-release-notes/4120.md
+++ b/upcoming-release-notes/4120.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fixed stacked templates with priorities


### PR DESCRIPTION
Bug discussed here https://discord.com/channels/937901803608096828/1326945284722524170

Multiple templates in a category/priority level would double/triple/etc count the amounts requested by the early templates causing the amount check to think it had overbudgeted and remove funds.
