### PR TITLE
Fix barchart data sorting on barcharts split by interval

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -203,11 +203,10 @@ export function BarGraph({
 
   const leftMargin = Math.abs(largestValue) > 1000000 ? 20 : 0;
 
-  // Sort the data in the bar chart
-  const unsortedData = data[splitData];
-  const sortedData = useMemo(() => {
-    return unsortedData.sort((a, b) => a[balanceTypeOp] - b[balanceTypeOp]);
-  }, [unsortedData, balanceTypeOp]);
+  // Sort the data
+  data.data = useMemo(() => {
+    return [...data.data].sort((a, b) => a[balanceTypeOp] - b[balanceTypeOp]);
+  }, [data.data, balanceTypeOp]);
 
   return (
     <Container
@@ -225,7 +224,7 @@ export function BarGraph({
                 width={width}
                 height={height}
                 stackOffset="sign"
-                data={sortedData}
+                data={data[splitData]}
                 style={{ cursor: pointer }}
                 margin={{
                   top: labelsMargin,

--- a/upcoming-release-notes/4137.md
+++ b/upcoming-release-notes/4137.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix barchart data sorting on barcharts split by interval


### PR DESCRIPTION
I made a mistake in #4072 by allowing the interval data to be sorted too. This fixes that, and prevents the original data array from being mutated, instead sorting a copy and returning it in.

Before (notice the months on the x axis):
![image](https://github.com/user-attachments/assets/ab3b2513-f13b-4ba9-92d2-c8ceb93c6d6b)

After:
![image](https://github.com/user-attachments/assets/4640679c-ede8-481d-9ece-a1229ec65d94)

