### PR TITLE
Fix Calendar Widget tracking transfers as income and expense

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -203,6 +203,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
             $and: [
               { date: { $gte: monthUtils.firstDayOfMonth(start) } },
               { date: { $lte: monthUtils.lastDayOfMonth(end) } },
+              { transfer_id: { $eq: null } },
             ],
           })
           .select('*');

--- a/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
@@ -80,6 +80,7 @@ export function calendarSpreadsheet(
           $and: [
             { date: { $gte: d.format(startDay, 'yyyy-MM-dd') } },
             { date: { $lte: d.format(endDay, 'yyyy-MM-dd') } },
+            { transfer_id: { $eq: null } },
           ],
         })
         .filter({

--- a/upcoming-release-notes/4143.md
+++ b/upcoming-release-notes/4143.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [AntoineTA]
+---
+
+Fix calendar widget tracking transfers as income and expense


### PR DESCRIPTION
Fixes #4136

When fetching transactions for the calendar widget, ignore transactions that are transfers by only getting transactions whose `transfer_id` is null.