### PR TITLE
Fix `send` types in a number of places (1/2)

### DIFF
--- a/packages/desktop-client/src/components/ServerContext.tsx
+++ b/packages/desktop-client/src/components/ServerContext.tsx
@@ -93,7 +93,11 @@ export function ServerProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     async function run() {
-      setServerURL(await send('get-server-url'));
+      const serverURL = await send('get-server-url');
+      if (!serverURL) {
+        return;
+      }
+      setServerURL(serverURL);
       setVersion(await getServerVersion());
     }
     run();
@@ -135,7 +139,8 @@ export function ServerProvider({ children }: { children: ReactNode }) {
     async (url: string, opts: { validate?: boolean } = {}) => {
       const { error } = await send('set-server-url', { ...opts, url });
       if (!error) {
-        setServerURL(await send('get-server-url'));
+        const serverURL = await send('get-server-url');
+        setServerURL(serverURL!);
         setVersion(await getServerVersion());
       }
       return { error };

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
@@ -106,8 +106,9 @@ function UserAccessContent({
   }, [cloudFileId, setLoading, t]);
 
   const loadOwner = useCallback(async () => {
-    const file: Awaited<ReturnType<Handlers['get-user-file-info']>> =
-      (await send('get-user-file-info', cloudFileId as string)) ?? {};
+    const file = (await send('get-user-file-info', cloudFileId as string)) ?? {
+      usersWithAccess: [],
+    };
     const owner = file?.usersWithAccess.filter(user => user.owner);
 
     if (owner.length > 0) {

--- a/packages/desktop-client/src/components/filters/SavedFilterMenuButton.tsx
+++ b/packages/desktop-client/src/components/filters/SavedFilterMenuButton.tsx
@@ -42,7 +42,7 @@ export function SavedFilterMenuButton({
   const [adding, setAdding] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef(null);
-  const [err, setErr] = useState(null);
+  const [err, setErr] = useState<string | null>(null);
   const [menuItem, setMenuItem] = useState('');
   const [name, setName] = useState(filterId?.name ?? '');
   const id = filterId?.id;

--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -88,7 +88,7 @@ export function CreateAccountModal({ upgradingAccountId }: CreateAccountProps) {
         balance: number;
       };
 
-      for (const oldAccount of results.accounts) {
+      for (const oldAccount of results.accounts ?? []) {
         const newAccount: NormalizedAccount = {
           account_id: oldAccount.id,
           name: oldAccount.name,

--- a/packages/desktop-client/src/components/modals/EditUser.tsx
+++ b/packages/desktop-client/src/components/modals/EditUser.tsx
@@ -83,12 +83,14 @@ function useSaveUser() {
     user: User,
     setError: (error: string) => void,
   ): Promise<boolean> {
-    const { error, id: newId } = (await send(method, user)) || {};
-    if (!error) {
+    const res = (await send(method, user)) || {};
+    if (!res['error']) {
+      const newId = res['id'];
       if (newId) {
         user.id = newId;
       }
     } else {
+      const error = res['error'];
       setError(getUserDirectoryErrors(error));
       if (error === 'token-expired') {
         dispatch(

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -35,9 +35,9 @@ export function ManagePayeesWithData({
   }, []);
 
   const refetchRuleCounts = useCallback(async () => {
-    let counts = await send('payees-get-rule-counts');
-    counts = new Map(Object.entries(counts));
-    setRuleCounts({ value: counts });
+    const counts = await send('payees-get-rule-counts');
+    const countsMap = new Map(Object.entries(counts));
+    setRuleCounts({ value: countsMap });
   }, []);
 
   useEffect(() => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
@@ -34,7 +34,7 @@ export function calendarSpreadsheet(
       }[];
     }) => void,
   ) => {
-    let filters;
+    let filters: unknown[];
 
     try {
       const { filters: filtersLocal } = await send(

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -109,7 +109,7 @@ export function createSpendingSpreadsheet({
             $and: [{ month: { $eq: budgetMonth } }],
           })
           .filter({
-            [conditionsOpKey]: filters.filter(filter => filter.category),
+            [conditionsOpKey]: filters.filter(filter => filter['category']),
           })
           .groupBy([{ $id: '$category' }])
           .select([

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -27,7 +27,7 @@ export function summarySpreadsheet(
       toRange: string;
     }) => void,
   ) => {
-    let filters = [];
+    let filters: unknown[] = [];
     try {
       const response = await send('make-filters-from-conditions', {
         conditions: conditions.filter(cond => !cond.customName),

--- a/upcoming-release-notes/4146.md
+++ b/upcoming-release-notes/4146.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Fix `send` types in a number of places (1/2)


### PR DESCRIPTION
In https://github.com/actualbudget/actual/pull/4145 I'm attempting to remove `any` types from the `send` function. In doing so I uncovered a bunch of places where types were set incorrectly. This PR cleans up those types (split into 2 for readability).