### PR TITLE
Fix `send` types in a number of places (2/2)

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -480,7 +480,11 @@ class AccountInternal extends PureComponent<
   }
 
   fetchAllIds = async () => {
-    const { data } = await runQuery(this.paged?.query.select('id'));
+    if (!this.paged) {
+      return [];
+    }
+
+    const { data } = await runQuery(this.paged.query.select('id'));
     // Remember, this is the `grouped` split type so we need to deal
     // with the `subtransactions` property
     return data.reduce((arr: string[], t: TransactionEntity) => {
@@ -709,7 +713,7 @@ class AccountInternal extends PureComponent<
   };
 
   async calculateBalances() {
-    if (!this.canCalculateBalance()) {
+    if (!this.canCalculateBalance() || !this.paged) {
       return null;
     }
 
@@ -930,6 +934,10 @@ class AccountInternal extends PureComponent<
   }
 
   getFilteredAmount = async () => {
+    if (!this.paged) {
+      return 0;
+    }
+
     const { data: amount } = await runQuery(
       this.paged?.query.calculate({ $sum: '$amount' }),
     );

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -718,7 +718,7 @@ class AccountInternal extends PureComponent<
     }
 
     const { data } = await runQuery(
-      this.paged?.query
+      this.paged.query
         .options({ splits: 'none' })
         .select([{ balance: { $sumOver: '$amount' } }]),
     );
@@ -939,7 +939,7 @@ class AccountInternal extends PureComponent<
     }
 
     const { data: amount } = await runQuery(
-      this.paged?.query.calculate({ $sum: '$amount' }),
+      this.paged.query.calculate({ $sum: '$amount' }),
     );
     return amount;
   };

--- a/packages/desktop-client/src/components/modals/EditUser.tsx
+++ b/packages/desktop-client/src/components/modals/EditUser.tsx
@@ -83,14 +83,14 @@ function useSaveUser() {
     user: User,
     setError: (error: string) => void,
   ): Promise<boolean> {
-    const res = (await send(method, user)) || {};
-    if (!res['error']) {
-      const newId = res['id'];
+    const res = await send(method, user);
+    if (!('error' in res)) {
+      const newId = res.id;
       if (newId) {
         user.id = newId;
       }
     } else {
-      const error = res['error'];
+      const error = res.error;
       setError(getUserDirectoryErrors(error));
       if (error === 'token-expired') {
         dispatch(

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -247,7 +247,7 @@ export function Overview() {
     const res = await send('dashboard-import', { filepath });
     setIsImporting(false);
 
-    if (res.error) {
+    if ('error' in res) {
       switch (res.error) {
         case 'json-parse-error':
           dispatch(

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
@@ -234,7 +234,11 @@ function reducer(state: ReducerState, action: ReducerAction): ReducerState {
   }
 }
 
-function SchedulePreview({ previewDates }: { previewDates: Date[] }) {
+function SchedulePreview({
+  previewDates,
+}: {
+  previewDates: string[] | string;
+}) {
   const dateFormat = (useDateFormat() || 'MM/dd/yyyy')
     .replace('MM', 'M')
     .replace('dd', 'd');
@@ -369,7 +373,9 @@ function RecurringScheduleTooltip({
   onSave: (config: RecurConfig) => void;
 }) {
   const { t } = useTranslation();
-  const [previewDates, setPreviewDates] = useState(null);
+  const [previewDates, setPreviewDates] = useState<string[] | string | null>(
+    null,
+  );
 
   const { FREQUENCY_OPTIONS } = useFrequencyOptions();
 

--- a/packages/loot-core/src/client/actions/budgets.ts
+++ b/packages/loot-core/src/client/actions/budgets.ts
@@ -148,14 +148,11 @@ export function createBudget({ testMode = false, demoMode = false } = {}) {
   };
 }
 
-export function validateBudgetName(name: string): {
-  valid: boolean;
-  message?: string;
-} {
+export function validateBudgetName(name: string) {
   return send('validate-budget-name', { name });
 }
 
-export function uniqueBudgetName(name: string): string {
+export function uniqueBudgetName(name: string) {
   return send('unique-budget-name', { name });
 }
 

--- a/packages/loot-core/src/client/actions/prefs.ts
+++ b/packages/loot-core/src/client/actions/prefs.ts
@@ -43,7 +43,7 @@ export function loadPrefs() {
     );
 
     // We need to load translations before the app renders
-    setI18NextLanguage(globalPrefs.language);
+    setI18NextLanguage(globalPrefs.language ?? '');
 
     return prefs;
   };

--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -239,7 +239,7 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
         if (!isUnmounted) {
           const withDefaults = newTrans.map(t => ({
             ...t,
-            category: statuses.get(t.schedule),
+            category: t.schedule != null ? statuses.get(t.schedule) : undefined,
             schedule: t.schedule,
             subtransactions: t.subtransactions?.map(
               (st: TransactionEntity) => ({

--- a/packages/loot-core/src/client/query-helpers.ts
+++ b/packages/loot-core/src/client/query-helpers.ts
@@ -3,7 +3,7 @@ import { listen, send } from '../platform/client/fetch';
 import { once } from '../shared/async';
 import { getPrimaryOrderBy, type Query } from '../shared/query';
 
-export async function runQuery(query) {
+export async function runQuery(query: Query) {
   return send('query', query.serialize());
 }
 
@@ -207,7 +207,7 @@ export class LiveQuery<TResponse = unknown> {
   protected fetchData = async (
     runQuery: () => Promise<{
       data: Data<TResponse>;
-      dependencies: Set<string>;
+      dependencies: string[];
     }>,
   ) => {
     // TODO: precompile queries, or cache compilation results on the

--- a/packages/loot-core/src/platform/client/fetch/index.d.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.d.ts
@@ -41,7 +41,8 @@ export type Unlisten = typeof unlisten;
 /** Mock functions */
 export function initServer(handlers: {
   query: (query: { table: string; selectExpressions: unknown }) => Promise<{
-    data: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data: any;
     dependencies: string[];
   }>;
   getCell?: () => { value: number };

--- a/packages/loot-core/src/server/admin/types/handlers.ts
+++ b/packages/loot-core/src/server/admin/types/handlers.ts
@@ -6,15 +6,21 @@ export interface AdminHandlers {
 
   'user-delete-all': (
     ids: string[],
-  ) => Promise<{ someDeletionsFailed: boolean; ids?: number[] }>;
+  ) => Promise<
+    { someDeletionsFailed: boolean; ids?: number[] } | { error: string }
+  >;
 
   'user-add': (
     user: Omit<UserEntity, 'id'>,
-  ) => Promise<{ error?: string } | { id: string }>;
+  ) => Promise<
+    { error?: string; id?: undefined } | { error?: undefined; id: string }
+  >;
 
   'user-update': (
     user: Omit<UserEntity, 'id'>,
-  ) => Promise<{ error?: string } | { id: string }>;
+  ) => Promise<
+    { error?: string; id?: undefined } | { error?: undefined; id: string }
+  >;
 
   'access-add': (
     user: NewUserAccessEntity,

--- a/packages/loot-core/src/server/admin/types/handlers.ts
+++ b/packages/loot-core/src/server/admin/types/handlers.ts
@@ -12,15 +12,11 @@ export interface AdminHandlers {
 
   'user-add': (
     user: Omit<UserEntity, 'id'>,
-  ) => Promise<
-    { error?: string; id?: undefined } | { error?: undefined; id: string }
-  >;
+  ) => Promise<{ error: string } | { id: string }>;
 
   'user-update': (
     user: Omit<UserEntity, 'id'>,
-  ) => Promise<
-    { error?: string; id?: undefined } | { error?: undefined; id: string }
-  >;
+  ) => Promise<{ error: string } | { id: string }>;
 
   'access-add': (
     user: NewUserAccessEntity,

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -1005,7 +1005,9 @@ export type SchemaConfig = {
     | Record<string, unknown>
     | ((name: string, config: { withDead; isJoin; tableOptions }) => unknown);
   tableFilters?: (name: string) => unknown[];
-  customizeQuery?: <T extends { table: string; orderExpressions: unknown[] }>(
+  customizeQuery?: <
+    T extends { table: string; orderExpressions: readonly unknown[] },
+  >(
     queryString: T,
   ) => T;
   views?: Record<

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -1,4 +1,5 @@
 import { getNormalisedString } from '../../shared/normalisation';
+import { QueryState } from '../../shared/query';
 
 // @ts-strict-ignore
 let _uid = 0;
@@ -1005,11 +1006,7 @@ export type SchemaConfig = {
     | Record<string, unknown>
     | ((name: string, config: { withDead; isJoin; tableOptions }) => unknown);
   tableFilters?: (name: string) => unknown[];
-  customizeQuery?: <
-    T extends { table: string; orderExpressions: readonly unknown[] },
-  >(
-    queryString: T,
-  ) => T;
+  customizeQuery?: (queryString: QueryState) => QueryState;
   views?: Record<
     string,
     {

--- a/packages/loot-core/src/server/dashboard/types/handlers.d.ts
+++ b/packages/loot-core/src/server/dashboard/types/handlers.d.ts
@@ -17,8 +17,8 @@ export interface DashboardHandlers {
   'dashboard-import': (args: {
     filepath: string;
   }) => Promise<
-    | { status: 'ok' }
-    | { error: 'json-parse-error' | 'internal-error' }
+    | { error?: undefined; message?: undefined; status: 'ok' }
+    | { error: 'json-parse-error' | 'internal-error'; message?: undefined }
     | { error: 'validation-error'; message: string }
   >;
 }

--- a/packages/loot-core/src/server/dashboard/types/handlers.d.ts
+++ b/packages/loot-core/src/server/dashboard/types/handlers.d.ts
@@ -17,8 +17,8 @@ export interface DashboardHandlers {
   'dashboard-import': (args: {
     filepath: string;
   }) => Promise<
-    | { error?: undefined; message?: undefined; status: 'ok' }
-    | { error: 'json-parse-error' | 'internal-error'; message?: undefined }
+    | { status: 'ok' }
+    | { error: 'json-parse-error' | 'internal-error' }
     | { error: 'validation-error'; message: string }
   >;
 }

--- a/packages/loot-core/src/server/rules/types/handlers.ts
+++ b/packages/loot-core/src/server/rules/types/handlers.ts
@@ -45,7 +45,7 @@ export interface RulesHandlers {
 
   'rules-get': () => Promise<RuleEntity[]>;
 
-  'rule-get': (arg: { id: string }) => Promise<RuleEntity>;
+  'rule-get': (arg: { id: RuleEntity['id'] }) => Promise<RuleEntity>;
 
   'rules-run': (arg: {
     transaction: TransactionEntity;

--- a/packages/loot-core/src/server/rules/types/handlers.ts
+++ b/packages/loot-core/src/server/rules/types/handlers.ts
@@ -45,9 +45,9 @@ export interface RulesHandlers {
 
   'rules-get': () => Promise<RuleEntity[]>;
 
-  // TODO: change return value to `RuleEntity`
-  'rule-get': (arg: { id: string }) => Promise<unknown>;
+  'rule-get': (arg: { id: string }) => Promise<RuleEntity>;
 
-  // TODO: change types to `TransactionEntity`
-  'rules-run': (arg: { transaction }) => Promise<unknown>;
+  'rules-run': (arg: {
+    transaction: TransactionEntity;
+  }) => Promise<TransactionEntity>;
 }

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -306,6 +306,8 @@ export async function updateSchedule({
 
     await db.updateWithSchema('schedules', schedule);
   });
+
+  return schedule.id;
 }
 
 export async function deleteSchedule({ id }) {

--- a/packages/loot-core/src/server/schedules/types/handlers.ts
+++ b/packages/loot-core/src/server/schedules/types/handlers.ts
@@ -15,7 +15,7 @@ export interface SchedulesHandlers {
     schedule;
     conditions?;
     resetNextDate?: boolean;
-  }) => Promise<void>;
+  }) => Promise<string>;
 
   'schedule/delete': (arg: { id: string }) => Promise<void>;
 

--- a/packages/loot-core/src/server/schedules/types/handlers.ts
+++ b/packages/loot-core/src/server/schedules/types/handlers.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import { DiscoverScheduleEntity } from '../../../types/models';
+import { DiscoverScheduleEntity, ScheduleEntity } from '../../../types/models';
 
 export interface SchedulesHandlers {
   'schedule/create': (arg: {
@@ -15,13 +15,17 @@ export interface SchedulesHandlers {
     schedule;
     conditions?;
     resetNextDate?: boolean;
-  }) => Promise<string>;
+  }) => Promise<ScheduleEntity['id']>;
 
-  'schedule/delete': (arg: { id: string }) => Promise<void>;
+  'schedule/delete': (arg: { id: ScheduleEntity['id'] }) => Promise<void>;
 
-  'schedule/skip-next-date': (arg: { id: string }) => Promise<void>;
+  'schedule/skip-next-date': (arg: {
+    id: ScheduleEntity['id'];
+  }) => Promise<void>;
 
-  'schedule/post-transaction': (arg: { id: string }) => Promise<void>;
+  'schedule/post-transaction': (arg: {
+    id: ScheduleEntity['id'];
+  }) => Promise<void>;
 
   'schedule/force-run-service': () => Promise<unknown>;
 

--- a/packages/loot-core/src/types/models/simplefin.d.ts
+++ b/packages/loot-core/src/types/models/simplefin.d.ts
@@ -2,6 +2,7 @@ import { AccountEntity } from './account';
 import { BankSyncResponse } from './bank-sync';
 
 export type SimpleFinOrganization = {
+  id: string;
   name: string;
   domain: string;
 };
@@ -9,6 +10,7 @@ export type SimpleFinOrganization = {
 export type SimpleFinAccount = {
   id: string;
   name: string;
+  balance: number;
   org: SimpleFinOrganization;
 };
 

--- a/packages/loot-core/src/types/server-handlers.d.ts
+++ b/packages/loot-core/src/types/server-handlers.d.ts
@@ -52,7 +52,7 @@ export interface ServerHandlers {
     payees;
   }) => Promise<unknown>;
 
-  'transactions-export-query': (arg: { query: QueryState }) => Promise<unknown>;
+  'transactions-export-query': (arg: { query: QueryState }) => Promise<string>;
 
   'get-categories': () => Promise<{
     grouped: Array<CategoryGroupEntity>;
@@ -109,7 +109,7 @@ export interface ServerHandlers {
 
   'payees-get': () => Promise<PayeeEntity[]>;
 
-  'payees-get-rule-counts': () => Promise<unknown>;
+  'payees-get-rule-counts': () => Promise<Record<string, number>>;
 
   'payees-merge': (arg: { targetId; mergeIds }) => Promise<void>;
 
@@ -141,7 +141,7 @@ export interface ServerHandlers {
 
   'create-query': (arg: { sheetName; name; query }) => Promise<unknown>;
 
-  query: (query: Query) => Promise<{ data: unknown; dependencies }>;
+  query: (query: Query) => Promise<{ data: unknown; dependencies: string[] }>;
 
   'account-update': (arg: { id; name }) => Promise<unknown>;
 
@@ -182,7 +182,10 @@ export interface ServerHandlers {
 
   'account-move': (arg: { id; targetId }) => Promise<unknown>;
 
-  'secret-set': (arg: { name: string; value: string | null }) => Promise<null>;
+  'secret-set': (arg: {
+    name: string;
+    value: string | null;
+  }) => Promise<{ error?: string; reason?: string }>;
   'secret-check': (arg: string) => Promise<string | { error?: string }>;
 
   'gocardless-poll-web-token': (arg: {
@@ -196,7 +199,11 @@ export interface ServerHandlers {
 
   'simplefin-status': () => Promise<{ configured: boolean }>;
 
-  'simplefin-accounts': () => Promise<{ accounts: SimpleFinAccount[] }>;
+  'simplefin-accounts': () => Promise<{
+    accounts?: SimpleFinAccount[];
+    error_code?: string;
+    reason?: string;
+  }>;
 
   'simplefin-batch-sync': ({ ids }: { ids: string[] }) => Promise<
     {
@@ -326,7 +333,7 @@ export interface ServerHandlers {
           return_url;
           loginMethod?: 'openid';
         },
-  ) => Promise<{ error?: string }>;
+  ) => Promise<{ error?: string; redirect_url?: string }>;
 
   'subscribe-sign-out': () => Promise<'ok'>;
 

--- a/packages/loot-core/src/types/server-handlers.d.ts
+++ b/packages/loot-core/src/types/server-handlers.d.ts
@@ -109,7 +109,7 @@ export interface ServerHandlers {
 
   'payees-get': () => Promise<PayeeEntity[]>;
 
-  'payees-get-rule-counts': () => Promise<Record<string, number>>;
+  'payees-get-rule-counts': () => Promise<Record<PayeeEntity['id'], number>>;
 
   'payees-merge': (arg: { targetId; mergeIds }) => Promise<void>;
 
@@ -141,7 +141,8 @@ export interface ServerHandlers {
 
   'create-query': (arg: { sheetName; name; query }) => Promise<unknown>;
 
-  query: (query: Query) => Promise<{ data: unknown; dependencies: string[] }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  query: (query: Query) => Promise<{ data: any; dependencies: string[] }>;
 
   'account-update': (arg: { id; name }) => Promise<unknown>;
 

--- a/upcoming-release-notes/4147.md
+++ b/upcoming-release-notes/4147.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Fix `send` types in a number of places (2/2)


### PR DESCRIPTION
In https://github.com/actualbudget/actual/pull/4145 I'm attempting to remove `any` types from the `send` function. In doing so I uncovered a bunch of places where types were set incorrectly. This PR cleans up those types (split into 2 for readability).