### PR TITLE
Exclude untranslated languages from builds

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,3 +38,7 @@ runs:
         repository: actualbudget/translations
         path: ${{ inputs.working-directory }}/packages/desktop-client/locale
       if: ${{ inputs.download-translations == 'true' }}
+    - name: Remove untranslated languages
+      run: packages/desktop-client/bin/remove-untranslated-languages
+      shell: bash
+      if: ${{ inputs.download-translations == 'true' }}

--- a/bin/package-browser
+++ b/bin/package-browser
@@ -11,6 +11,7 @@ fi
 pushd packages/desktop-client/locale > /dev/null
 git pull
 popd > /dev/null
+packages/desktop-client/bin/remove-untranslated-languages
 
 yarn workspace loot-core build:browser
 yarn workspace @actual-app/web build:browser

--- a/packages/desktop-client/bin/remove-untranslated-languages
+++ b/packages/desktop-client/bin/remove-untranslated-languages
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+// Local path to the cloned translations repository
+const localRepoPath = './packages/desktop-client/locale';
+
+// Compare JSON files and delete incomplete ones
+const processTranslations = () => {
+  try {
+    const files = fs.readdirSync(localRepoPath);
+    const enJsonPath = path.join(localRepoPath, 'en.json');
+
+    if (!fs.existsSync(enJsonPath)) {
+      throw new Error('en.json not found in the repository.');
+    }
+
+    const enJson = JSON.parse(fs.readFileSync(enJsonPath, 'utf8'));
+    const enKeysCount = Object.keys(enJson).length;
+
+    console.log(`en.json has ${enKeysCount} keys.`);
+
+    files.forEach((file) => {
+      if (file === 'en.json' || path.extname(file) !== '.json') return;
+
+      const filePath = path.join(localRepoPath, file);
+      const jsonData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      const fileKeysCount = Object.keys(jsonData).length;
+
+      // Calculate the percentage of keys present compared to en.json
+      const percentage = (fileKeysCount / enKeysCount) * 100;
+      console.log(`${file} has ${fileKeysCount} keys (${percentage.toFixed(2)}%).`);
+
+      if (percentage < 50) {
+        fs.unlinkSync(filePath);
+        console.log(`Deleted ${file} due to insufficient keys.`);
+      } else {
+        console.log(`Keeping ${file}.`);
+      }
+    });
+
+    console.log('Processing completed.');
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+  }
+};
+
+processTranslations();

--- a/upcoming-release-notes/4148.md
+++ b/upcoming-release-notes/4148.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Exclude untranslated languages from builds


### PR DESCRIPTION
As we start allowing folks to add new languages for translation, we probably don't want to show every language in the UI. Instead of hand-maintaining an allowlist of "good" languages, my idea was to use translation % as a proxy instead.