### PR TITLE
Fix string upload if new changes are present

### DIFF
--- a/.github/workflows/i18n-string-extract-master.yml
+++ b/.github/workflows/i18n-string-extract-master.yml
@@ -41,7 +41,7 @@ jobs:
           wlc \
             --url https://hosted.weblate.org/api/ \
             --key "${{ secrets.WEBLATE_API_KEY_CI_STRINGS }}" \
-            pull \
+            push \
             actualbudget/actual
       - name: Check out updated translations
         uses: actions/checkout@v4
@@ -69,6 +69,13 @@ jobs:
           else
             echo "No changes to commit"
           fi
+      - name: Update Weblate with latest translations
+        run: |
+          wlc \
+            --url https://hosted.weblate.org/api/ \
+            --key "${{ secrets.WEBLATE_API_KEY_CI_STRINGS }}" \
+            pull \
+            actualbudget/actual
 
       - name: Unlock translations
         if: always()  # Clean up even on failure

--- a/upcoming-release-notes/4149.md
+++ b/upcoming-release-notes/4149.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix string upload if new changes are present


### PR DESCRIPTION
The previous iteration of this GitHub action had a small error in that `wlc pull` is for pulling translations _from_ Git _to_ Weblate, rather than from Weblate to Git. This PR updates the action to use the correct verb, and also adds logic to pull new strings back into Weblate right away.

Should fix [this](https://github.com/actualbudget/actual/actions/runs/12760920680/job/35567137047) failed run