### PR TITLE
👷  Prep work for merging actual-server into actual repo

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableTransparentWorkspaces: false
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.3.1.cjs

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -113,6 +113,7 @@ export default [
       'packages/loot-core/**/node_modules/*',
       'packages/loot-core/**/lib-dist/*',
       'packages/loot-core/**/proto/*',
+      'packages/sync-server',
       '.yarn/*',
       '.github/*',
     ],

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -40,8 +40,8 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
-    "@actual-app/api": "*",
-    "@actual-app/crdt": "*",
+    "@actual-app/api": "workspace:^",
+    "@actual-app/crdt": "workspace:^",
     "@swc/core": "^1.5.3",
     "@swc/helpers": "^0.5.11",
     "@swc/jest": "^0.2.36",

--- a/upcoming-release-notes/4160.md
+++ b/upcoming-release-notes/4160.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Updating linting rules and disabling yarn TransparentWorkspaces in prep for merging actual-server into actual repository

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,7 +19,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@actual-app/api@npm:*, @actual-app/api@workspace:packages/api":
+"@actual-app/api@workspace:^, @actual-app/api@workspace:packages/api":
   version: 0.0.0-use.local
   resolution: "@actual-app/api@workspace:packages/api"
   dependencies:
@@ -38,7 +38,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@actual-app/crdt@npm:*, @actual-app/crdt@workspace:^, @actual-app/crdt@workspace:packages/crdt":
+"@actual-app/crdt@workspace:^, @actual-app/crdt@workspace:packages/crdt":
   version: 0.0.0-use.local
   resolution: "@actual-app/crdt@workspace:packages/crdt"
   dependencies:
@@ -13728,8 +13728,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "loot-core@workspace:packages/loot-core"
   dependencies:
-    "@actual-app/api": "npm:*"
-    "@actual-app/crdt": "npm:*"
+    "@actual-app/api": "workspace:^"
+    "@actual-app/crdt": "workspace:^"
     "@jlongster/sql.js": "npm:^1.6.7"
     "@reduxjs/toolkit": "npm:^2.5.0"
     "@rschedule/core": "npm:^1.5.0"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Laying some groundwork to make merging the repo's a bit easier. These actions came out of this POC: https://github.com/actualbudget/actual/pull/4139

- Ignore sync-server folder during lint - sync-server doesn't currently follow the linting rules
- Turning off enableTransparentWorkspaces to allow us to use the npm packages instead of the workspace package. 
  - This allows us to use the npm packages for crdt instead of being forced to build it directly in the workspace
  - If we wish to use the workspace package we have to explicitly set ```workspace:*``` in package.json