### PR TITLE
Update global event listeners to handle sync server and DB update sync events

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -662,6 +662,12 @@ export default [
               message:
                 "Please import Actual's useSelector() hook from `src/redux` instead.",
             },
+            {
+              name: 'react-redux',
+              importNames: ['useStore'],
+              message:
+                "Please import Actual's useStore() hook from `src/redux` instead.",
+            },
           ],
         },
       ],

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -26,9 +26,10 @@ import {
   send,
 } from 'loot-core/src/platform/client/fetch';
 
+import { handleGlobalEvents } from '../global-events';
 import { useMetadataPref } from '../hooks/useMetadataPref';
 import { installPolyfills } from '../polyfills';
-import { useDispatch, useSelector } from '../redux';
+import { useDispatch, useSelector, useStore } from '../redux';
 import { styles, hasHiddenScrollbars, ThemeStyle, useTheme } from '../style';
 import { ExposeNavigate } from '../util/router-tools';
 
@@ -160,6 +161,10 @@ function ErrorFallback({ error }: FallbackProps) {
 }
 
 export function App() {
+  const store = useStore();
+
+  useEffect(() => handleGlobalEvents(store), [store]);
+
   const [hiddenScrollbars, setHiddenScrollbars] = useState(
     hasHiddenScrollbars(),
   );

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -16,7 +16,7 @@ import {
 } from 'loot-core/client/queries/queriesSlice';
 import { addNotification, pushModal } from 'loot-core/src/client/actions';
 import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send, listen } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 
 import { useCategories } from '../../hooks/useCategories';
@@ -83,13 +83,9 @@ function BudgetInner(props: BudgetInnerProps) {
   const [initialized, setInitialized] = useState(false);
   const { grouped: categoryGroups } = useCategories();
 
-  function loadCategories() {
-    dispatch(getCategories());
-  }
-
   useEffect(() => {
     async function run() {
-      loadCategories();
+      await dispatch(getCategories());
 
       const { start, end } = await send('get-budget-bounds');
       setBounds({ start, end });
@@ -105,31 +101,6 @@ function BudgetInner(props: BudgetInnerProps) {
     }
 
     run();
-
-    const unlistens = [
-      listen('sync-event', event => {
-        if (event.type === 'success') {
-          const tables = event.tables;
-          if (
-            tables.includes('categories') ||
-            tables.includes('category_mapping') ||
-            tables.includes('category_groups')
-          ) {
-            loadCategories();
-          }
-        }
-      }),
-
-      listen('undo-event', ({ tables }) => {
-        if (tables.includes('categories')) {
-          loadCategories();
-        }
-      }),
-    ];
-
-    return () => {
-      unlistens.forEach(unlisten => unlisten());
-    };
   }, []);
 
   useEffect(() => {

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -22,7 +22,6 @@ import {
 } from 'loot-core/client/data-hooks/transactions';
 import * as queries from 'loot-core/client/queries';
 import {
-  getPayees,
   markAccountRead,
   reopenAccount,
   updateAccount,

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -279,10 +279,6 @@ function TransactionListWithPreviews({
         ) {
           reloadTransactions();
         }
-
-        if (tables.includes('payees') || tables.includes('payee_mapping')) {
-          dispatch(getPayees());
-        }
       }
     });
   }, [dispatch, reloadTransactions]);

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -72,10 +72,6 @@ export function CategoryTransactions({
         ) {
           reloadTransactions();
         }
-
-        if (tables.includes('payees') || tables.includes('payee_mapping')) {
-          dispatch(getPayees());
-        }
       }
     });
   }, [dispatch, reloadTransactions]);

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -5,7 +5,6 @@ import {
   useTransactionsSearch,
 } from 'loot-core/client/data-hooks/transactions';
 import * as queries from 'loot-core/client/queries';
-import { getPayees } from 'loot-core/client/queries/queriesSlice';
 import { listen } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -9,14 +9,13 @@ import {
   createGroup,
   deleteCategory,
   deleteGroup,
-  getCategories,
   moveCategory,
   moveCategoryGroup,
   updateCategory,
   updateGroup,
 } from 'loot-core/client/queries/queriesSlice';
 import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send, listen } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/src/platform/client/fetch';
 import * as monthUtils from 'loot-core/src/shared/months';
 
 import { useCategories } from '../../../hooks/useCategories';
@@ -67,22 +66,6 @@ export function Budget() {
     }
 
     init();
-
-    const unlisten = listen('sync-event', event => {
-      if (event.type === 'success') {
-        const tables = event.tables;
-        if (
-          tables.includes('categories') ||
-          tables.includes('category_mapping') ||
-          tables.includes('category_groups')
-        ) {
-          // TODO: is this loading every time?
-          dispatch(getCategories());
-        }
-      }
-    });
-
-    return () => unlisten();
   }, [budgetType, startMonth, dispatch, spreadsheet]);
 
   const onBudgetAction = useCallback(

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -67,7 +67,6 @@ export function ManagePayeesWithData({
         return;
       }
 
-      await dispatch(getPayees());
       await refetchOrphanedPayees();
 
       const targetId =

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -26,7 +26,6 @@ import { q } from 'loot-core/src/shared/query';
 import { AuthProvider } from './auth/AuthProvider';
 import { App } from './components/App';
 import { ServerProvider } from './components/ServerContext';
-import { handleGlobalEvents } from './global-events';
 
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
@@ -41,9 +40,6 @@ const boundActions = bindActionCreators(
   },
   store.dispatch,
 );
-
-// Listen for global events from the server or main process
-handleGlobalEvents(store);
 
 async function appFocused() {
   await send('app-focused');

--- a/packages/desktop-client/src/redux/index.ts
+++ b/packages/desktop-client/src/redux/index.ts
@@ -1,9 +1,15 @@
 import {
   useDispatch as useReduxDispatch,
   useSelector as useReduxSelector,
+  useStore as useReduxStore,
 } from 'react-redux';
 
-import { type AppDispatch, type RootState } from 'loot-core/client/store';
+import {
+  type AppStore,
+  type AppDispatch,
+  type RootState,
+} from 'loot-core/client/store';
 
+export const useStore = useReduxStore.withTypes<AppStore>();
 export const useDispatch = useReduxDispatch.withTypes<AppDispatch>();
 export const useSelector = useReduxSelector.withTypes<RootState>();

--- a/upcoming-release-notes/4161.md
+++ b/upcoming-release-notes/4161.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix payees autocomplete not reflecting new name of a renamed account (under the Transfer To/From section)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
Fixes https://github.com/actualbudget/actual/issues/4082

The `global-listeners` file listens to a bunch of events from the backend (i.e. service worker). One of these events is the `sync-event` this event is emitted whenever new messages are received from the sync server (`type: 'success'`) or whenever a DB update is made (`type: 'applied'`). This change updates the `sync-event` handler so that it handles both `success` and `applied` sync event types - what this means is that whenever Actual received sync messages from the sync server or whenever a DB update is made, the payees, categories, and accounts in the redux state are automatically updated.

This will also help with performance by removing some of the duplicate `sync-event` listeners resulting in less DB calls