### PR TITLE
[Mobile] Change transaction to positive when Income-type category is selected

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -601,8 +601,20 @@ const TransactionEditInner = memo(function TransactionEditInner({
       if (name === 'account') {
         hasAccountChanged.current = serializedTransaction.account !== value;
       }
+      if (newTransaction.amount < 0 && name === 'category') {
+        const selectedCategory = categories.find(c => c.id === value);
+        if (selectedCategory['is_income'] === 1) {
+          const newTransaction = {
+            ...serializedTransaction,
+            [name]: value,
+            amount: serializedTransaction.amount * -1,
+          };
+          await onUpdate(newTransaction);
+          onClearActiveEdit();
+        }
+      }
     },
-    [onClearActiveEdit, onUpdate],
+    [onClearActiveEdit, onUpdate, categories],
   );
 
   const onTotalAmountUpdate = useCallback(


### PR DESCRIPTION
I've had an 'issue' where I forgot to set the new transactions balance to be positive after inputting income and I'd realise it only after selecting the category. This fixes that. 