### PR TITLE
Update ConfirmCategoryDeleteModal.tsx

### DIFF
--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -78,8 +78,9 @@ export function ConfirmCategoryDeleteModal({
               </Block>
             ) : (
               <Block>
-                <strong>{category.name}</strong> is used by existing transactions
-                {!isIncome && 
+                <strong>{category.name}</strong> is used by existing
+                transactions
+                {!isIncome &&
                   ' or it has a positive leftover balance currently'}
                 . <strong>Are you sure you want to delete it?</strong> If so,
                 you must select another category to transfer existing

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -79,7 +79,7 @@ export function ConfirmCategoryDeleteModal({
             ) : (
               <Block>
                 <strong>{category.name}</strong> is used by existing transactions
-                {!isIncome &&
+                {!isIncome && 
                   ' or it has a positive leftover balance currently'}
                 . <strong>Are you sure you want to delete it?</strong> If so,
                 you must select another category to transfer existing

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -78,7 +78,7 @@ export function ConfirmCategoryDeleteModal({
               </Block>
             ) : (
               <Block>
-                <strong>{category.name}</strong>is used by existing transactions
+                <strong>{category.name}</strong> is used by existing transactions
                 {!isIncome &&
                   ' or it has a positive leftover balance currently'}
                 . <strong>Are you sure you want to delete it?</strong> If so,

--- a/upcoming-release-notes/4175.md
+++ b/upcoming-release-notes/4175.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [sampellino]
+---
+
+Add a missing space between the category name and "is" in the category deletion popup.


### PR DESCRIPTION
Added a missing space between the category name and "is" in the category deletion popup.

Example of bug:
![image](https://github.com/user-attachments/assets/34192996-6d58-4ae8-85c9-f837aaf942df)


<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
