### PR TITLE
Fix various split transaction edits not working

### DIFF
--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -78,12 +78,13 @@ export function recalculateSplit(trans: TransactionEntity) {
     (acc, t) => acc + num(t.amount),
     0,
   );
+
+  const { error, ...rest } = trans;
   return {
-    ...trans,
-    error:
-      total === num(trans.amount)
-        ? undefined
-        : SplitTransactionError(total, trans),
+    ...rest,
+    ...(total === num(trans.amount)
+      ? {}
+      : { error: SplitTransactionError(total, trans) }),
   } satisfies TransactionEntity;
 }
 
@@ -276,11 +277,10 @@ export function deleteTransaction(
       if (trans.id === id) {
         return null;
       } else if (trans.subtransactions?.length === 1) {
+        const { error, subtransactions, ...rest } = trans;
         return {
-          ...trans,
-          subtransactions: undefined,
+          ...rest,
           is_parent: false,
-          error: undefined,
         } satisfies TransactionEntity;
       } else {
         const sub = trans.subtransactions?.filter(t => t.id !== id);
@@ -308,11 +308,14 @@ export function splitTransaction(
       makeChild(trans),
     ];
 
+    const { error, ...rest } = trans;
+
     return {
-      ...trans,
+      ...rest,
       is_parent: true,
-      error:
-        num(trans.amount) === 0 ? undefined : SplitTransactionError(0, trans),
+      ...(num(trans.amount) === 0
+        ? {}
+        : { error: SplitTransactionError(0, trans) }),
       subtransactions: subtransactions.map(t => ({
         ...t,
         sort_order: t.sort_order || -1,

--- a/upcoming-release-notes/4186.md
+++ b/upcoming-release-notes/4186.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix various split transaction edits not working


### PR DESCRIPTION
Fixes a number of errors occurring on edge when updating split transactions. Sample repro: with an existing split, select the amount in one of the splits and hit backspace to see an error notification.

Our query engine doesn't support `undefined` for null values, only `null`; i.e., to omit a value, you either have to make it `null` or explicitly not pass it. To keep our types the same I opted for the latter.

To reviewer: this issue would have tripped the type checker if we enabled [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) in strict mode. I tried doing that though and we currently have 174 violations. How do you feel about this flag? Is it worth trying to fix the violations?