### PR TITLE
fix paid schedules showing as upcoming in the account

### DIFF
--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -371,3 +371,10 @@ export function getUpcomingDays(upcomingLength = '7') {
       return parseInt(upcomingLength, 10);
   }
 }
+
+export function scheduleIsRecurring(dateCond) {
+  const cond = new Condition(dateCond.op, 'date', dateCond.value, null);
+  const value = cond.getValue();
+
+  return value.type === 'recur';
+}

--- a/upcoming-release-notes/4188.md
+++ b/upcoming-release-notes/4188.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix paid schedules showing as upcoming in the account


### PR DESCRIPTION
I found an issue where if a schedule posts early the upcoming one will still show even if the schedule is "paid".

This adds the same helper function as https://github.com/actualbudget/actual/pull/4180 whichever is merged first will probably cause a conflict with the other, I'll fix it.