### PR TITLE
Make `Account.tsx` compatible with `exactOptionalPropertyTypes`

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -153,11 +153,11 @@ function EmptyMessage({ onAdd }: EmptyMessageProps) {
 }
 
 type AllTransactionsProps = {
-  account?: AccountEntity;
+  account?: AccountEntity | undefined;
   transactions: TransactionEntity[];
   balances: Record<string, { balance: number }> | null;
-  showBalances?: boolean;
-  filtered?: boolean;
+  showBalances?: boolean | undefined;
+  filtered?: boolean | undefined;
   children: (
     transactions: TransactionEntity[],
     balances: Record<string, { balance: number }> | null,
@@ -265,7 +265,12 @@ function getField(field?: string) {
 }
 
 type AccountInternalProps = {
-  accountId?: AccountEntity['id'] | 'onbudget' | 'offbudget' | 'uncategorized';
+  accountId?:
+    | AccountEntity['id']
+    | 'onbudget'
+    | 'offbudget'
+    | 'uncategorized'
+    | undefined;
   filterConditions: RuleConditionEntity[];
   showBalances?: boolean;
   setShowBalances: (newValue: boolean) => void;
@@ -280,7 +285,7 @@ type AccountInternalProps = {
   newTransactions: Array<TransactionEntity['id']>;
   matchedTransactions: Array<TransactionEntity['id']>;
   splitsExpandedDispatch: ReturnType<typeof useSplitsExpanded>['dispatch'];
-  expandSplits?: boolean;
+  expandSplits?: boolean | undefined;
   savedFilters: TransactionFilterEntity[];
   onBatchEdit: ReturnType<typeof useTransactionBatchActions>['onBatchEdit'];
   onBatchDuplicate: ReturnType<
@@ -306,7 +311,7 @@ type AccountInternalProps = {
 type AccountInternalState = {
   search: string;
   filterConditions: ConditionEntity[];
-  filterId?: SavedFilter;
+  filterId?: SavedFilter | undefined;
   filterConditionsOp: 'and' | 'or';
   loading: boolean;
   workingHard: boolean;
@@ -314,10 +319,10 @@ type AccountInternalState = {
   transactions: TransactionEntity[];
   transactionCount: number;
   transactionsFiltered?: boolean;
-  showBalances?: boolean;
+  showBalances?: boolean | undefined;
   balances: Record<string, { balance: number }> | null;
-  showCleared?: boolean;
-  prevShowCleared?: boolean;
+  showCleared?: boolean | undefined;
+  prevShowCleared?: boolean | undefined;
   showReconciled: boolean;
   editingName: boolean;
   nameError: string;
@@ -326,8 +331,8 @@ type AccountInternalState = {
   sort: {
     ascDesc: 'asc' | 'desc';
     field: string;
-    prevField?: string;
-    prevAscDesc?: 'asc' | 'desc';
+    prevField?: string | undefined;
+    prevAscDesc?: 'asc' | 'desc' | undefined;
   } | null;
   filteredAmount: null | number;
 };

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -11,7 +11,7 @@ import { useAccounts } from './useAccounts';
 import { usePayees } from './usePayees';
 
 type UseAccountPreviewTransactionsProps = {
-  accountId?: AccountEntity['id'];
+  accountId?: AccountEntity['id'] | undefined;
 };
 
 type UseAccountPreviewTransactionsResult = {
@@ -73,25 +73,26 @@ function accountPreview({
 }: AccountPreviewProps): TransactionEntity[] {
   return transactions.map(transaction => {
     const inverse = transaction.account !== accountId;
+    const subtransactions = transaction.subtransactions?.map(st => ({
+      ...st,
+      amount: inverse ? -st.amount : st.amount,
+      payee:
+        (inverse ? getPayeeByTransferAccount(st.account)?.id : st.payee) || '',
+      account: inverse
+        ? getTransferAccountByPayee(st.payee)?.id || ''
+        : st.account,
+    }));
     return {
       ...transaction,
       amount: inverse ? -transaction.amount : transaction.amount,
-      payee: inverse
-        ? getPayeeByTransferAccount(transaction.account)?.id || ''
-        : transaction.payee,
+      payee:
+        (inverse
+          ? getPayeeByTransferAccount(transaction.account)?.id
+          : transaction.payee) || '',
       account: inverse
         ? getTransferAccountByPayee(transaction.payee)?.id || ''
         : transaction.account,
-      subtransactions: transaction.subtransactions?.map(st => ({
-        ...st,
-        amount: inverse ? -st.amount : st.amount,
-        payee: inverse
-          ? getPayeeByTransferAccount(st.account)?.id || ''
-          : st.payee,
-        account: inverse
-          ? getTransferAccountByPayee(st.payee)?.id || ''
-          : st.account,
-      })),
+      ...(subtransactions && { subtransactions }),
     };
   });
 }

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -42,7 +42,7 @@ type BatchDeleteProps = {
 
 type BatchLinkScheduleProps = {
   ids: Array<TransactionEntity['id']>;
-  account?: AccountEntity;
+  account?: AccountEntity | undefined;
   onSuccess?: (
     ids: Array<TransactionEntity['id']>,
     schedule: ScheduleEntity,

--- a/packages/loot-core/src/client/state-types/modals.d.ts
+++ b/packages/loot-core/src/client/state-types/modals.d.ts
@@ -148,7 +148,7 @@ type FinanceModals = {
   'category-autocomplete': {
     categoryGroups?: CategoryGroupEntity[];
     onSelect: (categoryId: string, categoryName: string) => void;
-    month?: string;
+    month?: string | undefined;
     showHiddenCategories?: boolean;
     onClose?: () => void;
   };
@@ -313,7 +313,7 @@ type FinanceModals = {
     confirmReason: string;
   };
   'confirm-transaction-delete': {
-    message?: string;
+    message?: string | undefined;
     onConfirm: () => void;
   };
   'edit-user': {

--- a/upcoming-release-notes/4189.md
+++ b/upcoming-release-notes/4189.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Make `Account.tsx` compatible with `exactOptionalPropertyTypes`


### PR DESCRIPTION
From https://github.com/actualbudget/actual/pull/4186, I discovered it would be useful to enable `exactOptionalPropertyTypes` to prevent similar issues in the future. However, doing so requires updates in quite a few places, and interacts weirdly with the following pattern in React:

```tsx
type ComponentProps = {
  ...
  prop?: string;
}

...

<Component
  ...
  prop={cond ? "abc" : undefined}
/>
```

The easiest fix for conditional props is to change the prop type to:
```tsx
type ComponentProps = {
  ...
  prop?: string | undefined;
}
```

Opening this PR to get feedback on whether we can accept this slight degradation in dev experience in exchange for better type safety.