### PR TITLE
Fix rounding of split rules

### DIFF
--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -677,7 +677,7 @@ describe('Rule', () => {
       );
     });
 
-    test('remainder rounds correctly', () => {
+    test('remainder rounds correctly and only if necessary', () => {
       const rule = new Rule({
         conditionsOp: 'and',
         conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],
@@ -704,6 +704,12 @@ describe('Rule', () => {
       expect(rule.exec({ imported_payee: 'James', amount: 123 })).toMatchObject(
         {
           subtransactions: [{ amount: 62 }, { amount: 61 }],
+        },
+      );
+
+      expect(rule.exec({ imported_payee: 'James', amount: 100 })).toMatchObject(
+        {
+          subtransactions: [{ amount: 50 }, { amount: 50 }],
         },
       );
     });

--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -677,6 +677,37 @@ describe('Rule', () => {
       );
     });
 
+    test('remainder rounds correctly', () => {
+      const rule = new Rule({
+        conditionsOp: 'and',
+        conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],
+        actions: [
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            options: { splitIndex: 1, method: 'remainder' },
+          },
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            options: { splitIndex: 2, method: 'remainder' },
+          },
+        ],
+      });
+
+      expect(
+        rule.exec({ imported_payee: 'James', amount: -2397 }),
+      ).toMatchObject({
+        subtransactions: [{ amount: -1198 }, { amount: -1199 }],
+      });
+
+      expect(rule.exec({ imported_payee: 'James', amount: 123 })).toMatchObject(
+        {
+          subtransactions: [{ amount: 62 }, { amount: 61 }],
+        },
+      );
+    });
+
     test('generate errors when fixed amounts exceed the total', () => {
       expect(
         fixedAmountRule.exec({ imported_payee: 'James', amount: 100 }),

--- a/packages/loot-core/src/server/accounts/rules.ts
+++ b/packages/loot-core/src/server/accounts/rules.ts
@@ -753,7 +753,7 @@ function execSplitActions(actions: Action[], transaction) {
     });
 
     // The last remainder split will be adjusted for any leftovers from rounding.
-    newTransactions[lastNonFixedTransactionIndex].amount -=
+    newTransactions[lastNonFixedTransactionIndex].amount +=
       getSplitRemainder(newTransactions);
   }
 

--- a/upcoming-release-notes/4190.md
+++ b/upcoming-release-notes/4190.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix rounding of split rules


### PR DESCRIPTION
The rounding adjustment was being applied the wrong way 😅 This PR fixes it and adds tests

Closes https://github.com/actualbudget/actual/issues/3934