### PR TITLE
[WIP] Spending Report: Fix budget category filtering

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -45,6 +45,11 @@ export function createSpendingSpreadsheet({
     const { filters } = await send('make-filters-from-conditions', {
       conditions: conditions.filter(cond => !cond.customName),
     });
+
+    const {filters: budgetFilters} = await send('make-filters-from-conditions', {
+      conditions: conditions.filter(cond => !cond.customName && cond.field == "category"),
+    });
+
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
     const [assets, debts] = await Promise.all([
@@ -109,7 +114,7 @@ export function createSpendingSpreadsheet({
             $and: [{ month: { $eq: budgetMonth } }],
           })
           .filter({
-            [conditionsOpKey]: filters.filter(filter => filter['category']),
+            [conditionsOpKey]: budgetFilters,
           })
           .groupBy([{ $id: '$category' }])
           .select([


### PR DESCRIPTION
Fixes up the Spending Report category filters when comparing to the budget. Previously only worked for the category *is* filter. Now added support for all category filters (one of, not in, etc.)

Fixes #4044 

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
