### PR TITLE
fix api crash - schedule upcoming length used raw

### DIFF
--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -12,6 +12,7 @@ import {
   getHasTransactionsQuery,
   getScheduledAmount,
   getStatus,
+  getUpcomingDays,
   recurConfigToRSchedule,
   getNextDate,
   getDateWithSkippedWeekend,
@@ -454,7 +455,7 @@ async function advanceSchedulesService(syncSuccess) {
       .select('value'),
   );
 
-  const upcomingLengthValue = upcomingLength[0]?.value ?? '7'; // Default to 7 days if not set
+  const upcomingLengthValue = getUpcomingDays(upcomingLength[0]?.value ?? '7');
 
   for (const schedule of schedules) {
     const status = getStatus(

--- a/upcoming-release-notes/4195.md
+++ b/upcoming-release-notes/4195.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix schedule bug crashing API


### PR DESCRIPTION
I missed a place when I updated the values for the pref