### PR TITLE
Fix app hanging when schedule moved before weekend

### DIFF
--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -176,11 +176,18 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
 
         const dates: string[] = [];
         let day = d.startOfDay(parseDate(schedule.next_date));
+        let i = 0;
         if (isRecurring) {
-          while (day <= upcomingPeriodEnd) {
+          while (day <= upcomingPeriodEnd && i < 400) {
+            i++;
             const nextDate = getNextDate(dateConditions, day);
 
             if (parseDate(nextDate) > upcomingPeriodEnd) break;
+
+            if (dates.includes(nextDate)) {
+              day = parseDate(addDays(day, 1));
+              continue;
+            }
 
             dates.push(nextDate);
             day = parseDate(addDays(nextDate, 1));

--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -176,10 +176,8 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
 
         const dates: string[] = [];
         let day = d.startOfDay(parseDate(schedule.next_date));
-        let i = 0;
         if (isRecurring) {
-          while (day <= upcomingPeriodEnd && i < 400) {
-            i++;
+          while (day <= upcomingPeriodEnd) {
             const nextDate = getNextDate(dateConditions, day);
 
             if (parseDate(nextDate) > upcomingPeriodEnd) break;

--- a/upcoming-release-notes/4196.md
+++ b/upcoming-release-notes/4196.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix app hanging when schedule moved before weekend


### PR DESCRIPTION
Keeps the loop moving if it gets "stuck" with the same nextDate twice in a row