### PR TITLE
[Mobile] Fix "Category budget has been updated to ..." notification even when the budget was not updated

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -97,9 +97,12 @@ const AmountInput = memo(function AmountInput({
   };
 
   const onUpdate = (value: string) => {
-    props.onUpdate?.(value);
+    const originalAmount = Math.abs(props.value);
     const amount = applyText();
-    props.onUpdateAmount?.(amount);
+    if (amount !== originalAmount) {
+      props.onUpdate?.(value);
+      props.onUpdateAmount?.(amount);
+    }
   };
 
   const onBlur: HTMLProps<HTMLInputElement>['onBlur'] = e => {

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -584,11 +584,9 @@ const TransactionEditInner = memo(function TransactionEditInner({
     value => {
       if (transaction.amount !== value) {
         onUpdateInner(transaction, 'amount', value.toString());
-      } else {
-        onClearActiveEdit();
       }
     },
-    [onClearActiveEdit, onUpdateInner, transaction],
+    [onUpdateInner, transaction],
   );
 
   const onEditFieldInner = useCallback(
@@ -788,6 +786,7 @@ const TransactionEditInner = memo(function TransactionEditInner({
             zeroSign="-"
             focused={totalAmountFocused}
             onFocus={onTotalAmountEdit}
+            onBlur={onClearActiveEdit}
             onUpdateAmount={onTotalAmountUpdate}
             focusedStyle={{
               width: 'auto',

--- a/upcoming-release-notes/4200.md
+++ b/upcoming-release-notes/4200.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix FocusableAmountInput's onUpdate to only fire when amount was updated


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
In edge, there is an issue in mobile where if you open the category budget modal and close it the "{Category} budget has been updated..." notification pops up even if the amount was not changed.

This PR is to fix FocusableAmountInput's onUpdate to only fire when amount was updated

Steps to reproduce:
1. Open mobile budget page
2. Click on a category's budget amount
3. Close the budget modal
4. (The notification shows up)