### PR TITLE
Fix persistent split error popover

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -1018,7 +1018,7 @@ describe('Transactions', () => {
         category: undefined,
         cleared: false,
         date: '2017-01-01',
-        error: undefined,
+        error: null,
         id: expect.any(String),
         is_parent: true,
         notes: 'Notes',

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -82,9 +82,8 @@ export function recalculateSplit(trans: TransactionEntity) {
   const { error, ...rest } = trans;
   return {
     ...rest,
-    ...(total === num(trans.amount)
-      ? {}
-      : { error: SplitTransactionError(total, trans) }),
+    error:
+      total === num(trans.amount) ? null : SplitTransactionError(total, trans),
   } satisfies TransactionEntity;
 }
 
@@ -313,9 +312,7 @@ export function splitTransaction(
     return {
       ...rest,
       is_parent: true,
-      ...(num(trans.amount) === 0
-        ? {}
-        : { error: SplitTransactionError(0, trans) }),
+      error: num(trans.amount) === 0 ? null : SplitTransactionError(0, trans),
       subtransactions: subtransactions.map(t => ({
         ...t,
         sort_order: t.sort_order || -1,

--- a/packages/loot-core/src/types/models/transaction.d.ts
+++ b/packages/loot-core/src/types/models/transaction.d.ts
@@ -31,5 +31,5 @@ export interface TransactionEntity {
     type: 'SplitTransactionError';
     version: 1;
     difference: number;
-  };
+  } | null;
 }

--- a/upcoming-release-notes/4225.md
+++ b/upcoming-release-notes/4225.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix persistent split error popover


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/4220

I'm not entirely sure this is the right fix, but it does work. The problem came because not passing an error object at all leaves the error field unchanged when the db is updated.