### PR TITLE
Automatically close feature requests as "not planned" instead of "completed"

### DIFF
--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -32,6 +32,6 @@ jobs:
 
             <!-- feature-auto-close-comment -->
       - name: Close Issue
-        run: gh issue close "https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}"
+        run: gh issue close "https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}" --reason "not_planned"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/upcoming-release-notes/4231.md
+++ b/upcoming-release-notes/4231.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [e13h]
+---
+
+Update bot to automatically close feature request GitHub issues as "not planned" instead of "completed"


### PR DESCRIPTION
I understand that the project uses lodash issue management and immediately closes feature requests. It's a little odd though that the GitHub issues are closed as "completed" by the bot when they pretty clearly are not complete. Since GitHub supports closing an issue as "not planned", can we do that instead?

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
