### PR TITLE
keep all English translations regardless of translated %

### DIFF
--- a/packages/desktop-client/bin/remove-untranslated-languages
+++ b/packages/desktop-client/bin/remove-untranslated-languages
@@ -23,6 +23,11 @@ const processTranslations = () => {
     files.forEach((file) => {
       if (file === 'en.json' || path.extname(file) !== '.json') return;
 
+      if (file.startsWith('en-')) {
+        console.log(`Keeping ${file} as it's an English language.`);
+        return;
+      }
+
       const filePath = path.join(localRepoPath, file);
       const jsonData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       const fileKeysCount = Object.keys(jsonData).length;

--- a/upcoming-release-notes/4232.md
+++ b/upcoming-release-notes/4232.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Keep all English translations regardless of translated percentage


### PR DESCRIPTION
English localisations (en-GB for example) only need a few strings changing, the rest we can allow to fall back as they're common between the US original and GB localisation.

This prevents every string having to be copied over to any en translations and allowing only the differences to be added.