### PR TITLE
fix(#2495): fix GoCardless transaction ID to fallback to it's own generated ID on sync

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -364,7 +364,10 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
         date: trans.date,
         notes: notes.trim().replace('#', '##'),
         category: trans.category ?? null,
-        imported_id: trans.transactionId,
+        imported_id:
+          !trans.cleared || trans.transactionId
+            ? trans.transactionId
+            : `${trans.account}-${trans.internalTransactionId}`,
         imported_payee: trans.imported_payee,
         cleared: trans.cleared,
       },

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -365,9 +365,9 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
         notes: notes.trim().replace('#', '##'),
         category: trans.category ?? null,
         imported_id:
-          !trans.cleared || trans.transactionId
-            ? trans.transactionId
-            : `${trans.account}-${trans.internalTransactionId}`,
+          trans.cleared && !trans.transactionId
+            ? `${trans.account}-${trans.internalTransactionId}`
+            : trans.transactionId,
         imported_payee: trans.imported_payee,
         cleared: trans.cleared,
       },

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -365,9 +365,9 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
         notes: notes.trim().replace('#', '##'),
         category: trans.category ?? null,
         imported_id:
-          trans.cleared && !trans.transactionId
-            ? `${trans.account}-${trans.internalTransactionId}`
-            : trans.transactionId,
+          !trans.cleared || trans.transactionId
+            ? trans.transactionId
+            : `${trans.account}-${trans.internalTransactionId}`,
         imported_payee: trans.imported_payee,
         cleared: trans.cleared,
       },

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -351,6 +351,12 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
 
     trans.cleared = Boolean(trans.booked);
 
+    let imported_id = trans.transactionId;
+
+    if (trans.cleared && !trans.transactionId && trans.internalTransactionId) {
+      imported_id = `${trans.account}-${trans.internalTransactionId}`;
+    }
+
     const notes =
       trans.remittanceInformationUnstructured ||
       (trans.remittanceInformationUnstructuredArray || []).join(', ');
@@ -364,10 +370,7 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
         date: trans.date,
         notes: notes.trim().replace('#', '##'),
         category: trans.category ?? null,
-        imported_id:
-          !trans.cleared || trans.transactionId
-            ? trans.transactionId
-            : `${trans.account}-${trans.internalTransactionId}`,
+        imported_id,
         imported_payee: trans.imported_payee,
         cleared: trans.cleared,
       },

--- a/upcoming-release-notes/4241.md
+++ b/upcoming-release-notes/4241.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [NullScope]
 ---
 
-Fix GoCardless transaction ID to fallback to it's own generated ID
+Fix GoCardless transaction ID to fallback to it's own generated ID on sync

--- a/upcoming-release-notes/4241.md
+++ b/upcoming-release-notes/4241.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [NullScope]
+---
+
+Fix GoCardless transaction ID to fallback to it's own generated ID


### PR DESCRIPTION
Some bank accounts have no `transactionId` in GoCardless, meaning that any changes (e.g setting to 0 for duplicated transactions) to any such imported transaction will cause Actual to re-import the transaction instead of updating or ignoring it.

GoCardless has an `internalTransactionId` for cases like these as described here: https://bankaccountdata.zendesk.com/hc/en-gb/articles/11529646897820-internalTransactionId-a-unique-transaction-ID-now-generated-by-GoCardless

There are some caveats though:
- It does NOT exist in pending transactions
- It is ONLY guaranteed to be unique inside the same bank account

As such, this PR falls back to `{acctId}-{internalTransactionId}` in case `transactionId` does not exist AND the transaction has been cleared.

Fixes #2495