### PR TITLE
fix: hide to budget tooltip when menu is open

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
@@ -75,7 +75,7 @@ export function ToBudget({
           prevMonthName={prevMonthName}
           style={style}
           amountStyle={amountStyle}
-          isTotalsListTooltipDisabled={!isCollapsed || asContextMenu}
+          isTotalsListTooltipDisabled={!isCollapsed || menuOpen}
           onContextMenu={handleContextMenu}
         />
       </View>

--- a/upcoming-release-notes/4246.md
+++ b/upcoming-release-notes/4246.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnderKoen]
+---
+
+Hide to budget tooltip when menu is open


### PR DESCRIPTION
Make the following impossible

![image](https://github.com/user-attachments/assets/bfe14879-d7e2-46bb-9c2f-06e6d3ad1bd6)