### PR TITLE
[TypeScript] Make `db.first` generic to make it easy to type DB query results

### DIFF
--- a/packages/loot-core/src/mocks/budget.ts
+++ b/packages/loot-core/src/mocks/budget.ts
@@ -461,13 +461,13 @@ async function fillOther(handlers, account, payees, groups) {
 async function createBudget(accounts, payees, groups) {
   const primaryAccount = accounts.find(a => (a.name = 'Bank of America'));
   const earliestDate = (
-    await db.first<db.DbViewTransaction>(
+    await db.first<Pick<db.DbViewTransaction, 'date'>>(
       `SELECT t.date FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
        WHERE a.offbudget = 0 AND t.is_child = 0 ORDER BY date ASC LIMIT 1`,
     )
   ).date;
   const earliestPrimaryDate = (
-    await db.first<db.DbViewTransaction>(
+    await db.first<Pick<db.DbViewTransaction, 'date'>>(
       `SELECT t.date FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
        WHERE a.id = ? AND a.offbudget = 0 AND t.is_child = 0 ORDER BY date ASC LIMIT 1`,
       [primaryAccount.id],

--- a/packages/loot-core/src/mocks/budget.ts
+++ b/packages/loot-core/src/mocks/budget.ts
@@ -461,14 +461,14 @@ async function fillOther(handlers, account, payees, groups) {
 async function createBudget(accounts, payees, groups) {
   const primaryAccount = accounts.find(a => (a.name = 'Bank of America'));
   const earliestDate = (
-    await db.first(
-      `SELECT * FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
+    await db.first<db.DbViewTransaction>(
+      `SELECT t.date FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
        WHERE a.offbudget = 0 AND t.is_child = 0 ORDER BY date ASC LIMIT 1`,
     )
   ).date;
   const earliestPrimaryDate = (
-    await db.first(
-      `SELECT * FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
+    await db.first<db.DbViewTransaction>(
+      `SELECT t.date FROM v_transactions t LEFT JOIN accounts a ON t.account = a.id
        WHERE a.id = ? AND a.offbudget = 0 AND t.is_child = 0 ORDER BY date ASC LIMIT 1`,
       [primaryAccount.id],
     )

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -11,11 +11,9 @@ import {
   AccountEntity,
   CategoryEntity,
   SyncServerGoCardlessAccount,
-  PayeeEntity,
   TransactionEntity,
   SyncServerSimpleFinAccount,
 } from '../../types/models';
-import { BankEntity } from '../../types/models/bank';
 import { createApp } from '../app';
 import * as db from '../db';
 import {
@@ -77,7 +75,7 @@ async function getAccountBalance({
   id: string;
   cutoff: string | Date;
 }) {
-  const { balance }: { balance: number } = await db.first(
+  const { balance } = await db.first<{ balance: number }>(
     'SELECT sum(amount) as balance FROM transactions WHERE acct = ? AND isParent = 0 AND tombstone = 0 AND date <= ?',
     [id, db.toDateRepr(dayFromDate(cutoff))],
   );
@@ -85,11 +83,11 @@ async function getAccountBalance({
 }
 
 async function getAccountProperties({ id }: { id: AccountEntity['id'] }) {
-  const { balance }: { balance: number } = await db.first(
+  const { balance } = await db.first<{ balance: number }>(
     'SELECT sum(amount) as balance FROM transactions WHERE acct = ? AND isParent = 0 AND tombstone = 0',
     [id],
   );
-  const { count }: { count: number } = await db.first(
+  const { count } = await db.first<{ count: number }>(
     'SELECT count(id) as count FROM transactions WHERE acct = ? AND tombstone = 0',
     [id],
   );
@@ -112,7 +110,7 @@ async function linkGoCardlessAccount({
   const bank = await link.findOrCreateBank(account.institution, requisitionId);
 
   if (upgradingId) {
-    const accRow: AccountEntity = await db.first(
+    const accRow = await db.first<db.DbAccount>(
       'SELECT * FROM accounts WHERE id = ?',
       [upgradingId],
     );
@@ -178,7 +176,7 @@ async function linkSimpleFinAccount({
   );
 
   if (upgradingId) {
-    const accRow: AccountEntity = await db.first(
+    const accRow = await db.first<db.DbAccount>(
       'SELECT * FROM accounts WHERE id = ?',
       [upgradingId],
     );
@@ -278,7 +276,7 @@ async function closeAccount({
   await unlinkAccount({ id });
 
   return withUndo(async () => {
-    const account: AccountEntity = await db.first(
+    const account = await db.first<db.DbAccount>(
       'SELECT * FROM accounts WHERE id = ? AND tombstone = 0',
       [id],
     );
@@ -303,7 +301,7 @@ async function closeAccount({
         true,
       );
 
-      const { id: payeeId }: Pick<PayeeEntity, 'id'> = await db.first(
+      const { id: payeeId } = await db.first<Pick<db.DbPayee, 'id'>>(
         'SELECT id FROM payees WHERE transfer_acct = ?',
         [id],
       );
@@ -340,7 +338,7 @@ async function closeAccount({
       // If there is a balance we need to transfer it to the specified
       // account (and possibly categorize it)
       if (balance !== 0 && transferAccountId) {
-        const { id: payeeId }: Pick<PayeeEntity, 'id'> = await db.first(
+        const { id: payeeId } = await db.first<Pick<db.DbPayee, 'id'>>(
           'SELECT id FROM payees WHERE transfer_acct = ?',
           [transferAccountId],
         );
@@ -948,7 +946,7 @@ async function importTransactions({
 }
 
 async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
-  const { bank: bankId }: Pick<AccountEntity, 'bank'> = await db.first(
+  const { bank: bankId } = await db.first<Pick<db.DbAccount, 'bank'>>(
     'SELECT bank FROM accounts WHERE id = ?',
     [id],
   );
@@ -957,7 +955,7 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
     return 'ok';
   }
 
-  const accRow: AccountEntity = await db.first(
+  const accRow = await db.first<db.DbAccount>(
     'SELECT * FROM accounts WHERE id = ?',
     [id],
   );
@@ -978,7 +976,7 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
     return;
   }
 
-  const { count }: { count: number } = await db.first(
+  const { count } = await db.first<{ count: number }>(
     'SELECT COUNT(*) as count FROM accounts WHERE bank = ?',
     [bankId],
   );
@@ -991,8 +989,9 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
   }
 
   if (count === 0) {
-    const { bank_id: requisitionId }: Pick<BankEntity, 'bank_id'> =
-      await db.first('SELECT bank_id FROM banks WHERE id = ?', [bankId]);
+    const { bank_id: requisitionId } = await db.first<
+      Pick<db.DbBank, 'bank_id'>
+    >('SELECT bank_id FROM banks WHERE id = ?', [bankId]);
 
     const serverConfig = getServer();
     if (!serverConfig) {

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -75,24 +75,27 @@ async function getAccountBalance({
   id: string;
   cutoff: string | Date;
 }) {
-  const { balance } = await db.first<{ balance: number }>(
+  const result = await db.first<{ balance: number }>(
     'SELECT sum(amount) as balance FROM transactions WHERE acct = ? AND isParent = 0 AND tombstone = 0 AND date <= ?',
     [id, db.toDateRepr(dayFromDate(cutoff))],
   );
-  return balance ? balance : 0;
+  return result?.balance ? result.balance : 0;
 }
 
 async function getAccountProperties({ id }: { id: AccountEntity['id'] }) {
-  const { balance } = await db.first<{ balance: number }>(
+  const balanceResult = await db.first<{ balance: number }>(
     'SELECT sum(amount) as balance FROM transactions WHERE acct = ? AND isParent = 0 AND tombstone = 0',
     [id],
   );
-  const { count } = await db.first<{ count: number }>(
+  const countResult = await db.first<{ count: number }>(
     'SELECT count(id) as count FROM transactions WHERE acct = ? AND tombstone = 0',
     [id],
   );
 
-  return { balance: balance || 0, numTransactions: count };
+  return {
+    balance: balanceResult?.balance || 0,
+    numTransactions: countResult?.count || 0,
+  };
 }
 
 async function linkGoCardlessAccount({
@@ -114,6 +117,11 @@ async function linkGoCardlessAccount({
       'SELECT * FROM accounts WHERE id = ?',
       [upgradingId],
     );
+
+    if (!accRow) {
+      throw new Error(`Account with ID ${upgradingId} not found.`);
+    }
+
     id = accRow.id;
     await db.update('accounts', {
       id,
@@ -180,6 +188,11 @@ async function linkSimpleFinAccount({
       'SELECT * FROM accounts WHERE id = ?',
       [upgradingId],
     );
+
+    if (!accRow) {
+      throw new Error(`Account with ID ${upgradingId} not found.`);
+    }
+
     id = accRow.id;
     await db.update('accounts', {
       id,
@@ -301,10 +314,14 @@ async function closeAccount({
         true,
       );
 
-      const { id: payeeId } = await db.first<Pick<db.DbPayee, 'id'>>(
+      const transferPayee = await db.first<Pick<db.DbPayee, 'id'>>(
         'SELECT id FROM payees WHERE transfer_acct = ?',
         [id],
       );
+
+      if (!transferPayee) {
+        throw new Error(`Transfer payee with account ID ${id} not found.`);
+      }
 
       await batchMessages(async () => {
         // TODO: what this should really do is send a special message that
@@ -326,7 +343,7 @@ async function closeAccount({
         });
 
         db.deleteAccount({ id });
-        db.deleteTransferPayee({ id: payeeId });
+        db.deleteTransferPayee({ id: transferPayee.id });
       });
     } else {
       if (balance !== 0 && transferAccountId == null) {
@@ -338,14 +355,20 @@ async function closeAccount({
       // If there is a balance we need to transfer it to the specified
       // account (and possibly categorize it)
       if (balance !== 0 && transferAccountId) {
-        const { id: payeeId } = await db.first<Pick<db.DbPayee, 'id'>>(
+        const transferPayee = await db.first<Pick<db.DbPayee, 'id'>>(
           'SELECT id FROM payees WHERE transfer_acct = ?',
           [transferAccountId],
         );
 
+        if (!transferPayee) {
+          throw new Error(
+            `Transfer payee with account ID ${transferAccountId} not found.`,
+          );
+        }
+
         await mainApp.handlers['transaction-add']({
           id: uuidv4(),
-          payee: payeeId,
+          payee: transferPayee.id,
           amount: -balance,
           account: id,
           date: monthUtils.currentDay(),
@@ -946,19 +969,20 @@ async function importTransactions({
 }
 
 async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
-  const { bank: bankId } = await db.first<Pick<db.DbAccount, 'bank'>>(
-    'SELECT bank FROM accounts WHERE id = ?',
-    [id],
-  );
-
-  if (!bankId) {
-    return 'ok';
-  }
-
   const accRow = await db.first<db.DbAccount>(
     'SELECT * FROM accounts WHERE id = ?',
     [id],
   );
+
+  if (!accRow) {
+    throw new Error(`Account with ID ${id} not found.`);
+  }
+
+  const bankId = accRow.bank;
+
+  if (!bankId) {
+    return 'ok';
+  }
 
   const isGoCardless = accRow.account_sync_source === 'goCardless';
 
@@ -976,7 +1000,7 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
     return;
   }
 
-  const { count } = await db.first<{ count: number }>(
+  const accountWithBankResult = await db.first<{ count: number }>(
     'SELECT COUNT(*) as count FROM accounts WHERE bank = ?',
     [bankId],
   );
@@ -988,15 +1012,22 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
     return 'ok';
   }
 
-  if (count === 0) {
-    const { bank_id: requisitionId } = await db.first<
-      Pick<db.DbBank, 'bank_id'>
-    >('SELECT bank_id FROM banks WHERE id = ?', [bankId]);
+  if (!accountWithBankResult || accountWithBankResult.count === 0) {
+    const bank = await db.first<Pick<db.DbBank, 'bank_id'>>(
+      'SELECT bank_id FROM banks WHERE id = ?',
+      [bankId],
+    );
+
+    if (!bank) {
+      throw new Error(`Bank with ID ${bankId} not found.`);
+    }
 
     const serverConfig = getServer();
     if (!serverConfig) {
       throw new Error('Failed to get server config.');
     }
+
+    const requisitionId = bank.bank_id;
 
     try {
       await post(

--- a/packages/loot-core/src/server/accounts/link.ts
+++ b/packages/loot-core/src/server/accounts/link.ts
@@ -5,7 +5,7 @@ import * as db from '../db';
 
 export async function findOrCreateBank(institution, requisitionId) {
   const bank = await db.first<Pick<db.DbBank, 'id' | 'bank_id'>>(
-    'SELECT id, bank_id, name FROM banks WHERE bank_id = ?',
+    'SELECT id, bank_id FROM banks WHERE bank_id = ?',
     [requisitionId],
   );
 

--- a/packages/loot-core/src/server/accounts/link.ts
+++ b/packages/loot-core/src/server/accounts/link.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as db from '../db';
 
 export async function findOrCreateBank(institution, requisitionId) {
-  const bank = await db.first(
+  const bank = await db.first<Pick<db.DbBank, 'id' | 'bank_id'>>(
     'SELECT id, bank_id, name FROM banks WHERE bank_id = ?',
     [requisitionId],
   );

--- a/packages/loot-core/src/server/accounts/payees.ts
+++ b/packages/loot-core/src/server/accounts/payees.ts
@@ -1,11 +1,10 @@
 // @ts-strict-ignore
-import { CategoryEntity, PayeeEntity } from '../../types/models';
 import * as db from '../db';
 
 export async function createPayee(description) {
   // Check to make sure no payee already exists with exactly the same
   // name
-  const row: Pick<PayeeEntity, 'id'> = await db.first(
+  const row = await db.first<Pick<db.DbPayee, 'id'>>(
     `SELECT id FROM payees WHERE UNICODE_LOWER(name) = ? AND tombstone = 0`,
     [description.toLowerCase()],
   );
@@ -13,19 +12,19 @@ export async function createPayee(description) {
   if (row) {
     return row.id;
   } else {
-    return (await db.insertPayee({ name: description })) as PayeeEntity['id'];
+    return (await db.insertPayee({ name: description })) as db.DbPayee['id'];
   }
 }
 
 export async function getStartingBalancePayee() {
-  let category: CategoryEntity = await db.first(`
+  let category = await db.first<db.DbCategory>(`
     SELECT * FROM categories
       WHERE is_income = 1 AND
       LOWER(name) = 'starting balances' AND
       tombstone = 0
   `);
   if (category === null) {
-    category = await db.first(
+    category = await db.first<db.DbCategory>(
       'SELECT * FROM categories WHERE is_income = 1 AND tombstone = 0',
     );
   }

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -584,7 +584,7 @@ export async function matchTransactions(
   );
 
   // The first pass runs the rules, and preps data for fuzzy matching
-  const accounts: AccountEntity[] = await db.getAccounts();
+  const accounts: db.DbAccount[] = await db.getAccounts();
   const accountsMap = new Map(accounts.map(account => [account.id, account]));
 
   const transactionsStep1 = [];
@@ -603,7 +603,7 @@ export async function matchTransactions(
     // is the highest fidelity match and should always be attempted
     // first.
     if (trans.imported_id) {
-      match = await db.first(
+      match = await db.first<db.DbViewTransaction>(
         'SELECT * FROM v_transactions WHERE imported_id = ? AND account = ?',
         [trans.imported_id, acctId],
       );
@@ -737,7 +737,7 @@ export async function addTransactions(
     { rawPayeeName: true },
   );
 
-  const accounts: AccountEntity[] = await db.getAccounts();
+  const accounts: db.DbAccount[] = await db.getAccounts();
   const accountsMap = new Map(accounts.map(account => [account.id, account]));
 
   for (const { trans: originalTrans, subtransactions } of normalized) {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -94,9 +94,10 @@ async function validateExpenseCategory(debug, id) {
     throw APIError(`${debug}: category id is required`);
   }
 
-  const row = await db.first('SELECT is_income FROM categories WHERE id = ?', [
-    id,
-  ]);
+  const row = await db.first<Pick<db.DbCategory, 'is_income'>>(
+    'SELECT is_income FROM categories WHERE id = ?',
+    [id],
+  );
 
   if (!row) {
     throw APIError(`${debug}: category “${id}” does not exist`);

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -329,7 +329,7 @@ export async function setNMonthAvg({
   N: number;
   category: string;
 }): Promise<void> {
-  const categoryFromDb = await db.first(
+  const categoryFromDb = await db.first<Pick<db.DbViewCategory, 'is_income'>>(
     'SELECT is_income FROM v_categories WHERE id = ?',
     [category],
   );
@@ -361,7 +361,7 @@ export async function holdForNextMonth({
   month: string;
   amount: number;
 }): Promise<boolean> {
-  const row = await db.first(
+  const row = await db.first<Pick<db.DbZeroBudgetMonth, 'buffered'>>(
     'SELECT buffered FROM zero_budget_months WHERE id = ?',
     [month],
   );

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -442,7 +442,7 @@ export async function createBudget(months) {
 }
 
 export async function createAllBudgets() {
-  const earliestTransaction = await db.first(
+  const earliestTransaction = await db.first<db.DbTransaction>(
     'SELECT * FROM transactions WHERE isChild=0 AND date IS NOT NULL ORDER BY date ASC LIMIT 1',
   );
   const earliestDate =

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -64,7 +64,7 @@ async function applyGroupCleanups(
         );
         const to_budget = budgeted + Math.abs(balance);
         const categoryId = generalGroup[ii].category;
-        let carryover = await db.first(
+        let carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
           `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
           [db_month, categoryId],
         );
@@ -220,7 +220,7 @@ async function processCleanup(month: string): Promise<Notification> {
         } else {
           warnings.push(category.name + ' does not have available funds.');
         }
-        const carryover = await db.first(
+        const carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
           `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
           [db_month, category.id],
         );
@@ -249,7 +249,7 @@ async function processCleanup(month: string): Promise<Notification> {
     const budgeted = await getSheetValue(sheetName, `budget-${category.id}`);
     const to_budget = budgeted + Math.abs(balance);
     const categoryId = category.id;
-    let carryover = await db.first(
+    let carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
       `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
       [db_month, categoryId],
     );

--- a/packages/loot-core/src/server/budget/goalsSchedule.ts
+++ b/packages/loot-core/src/server/budget/goalsSchedule.ts
@@ -21,8 +21,10 @@ async function createScheduleList(
   const errors = [];
 
   for (let ll = 0; ll < template.length; ll++) {
-    const { id: sid, completed: complete } = await db.first(
-      'SELECT * FROM schedules WHERE TRIM(name) = ? AND tombstone = 0',
+    const { id: sid, completed: complete } = await db.first<
+      Pick<db.DbSchedule, 'id' | 'completed'>
+    >(
+      'SELECT id, completed FROM schedules WHERE TRIM(name) = ? AND tombstone = 0',
       [template[ll].name.trim()],
     );
     const rule = await getRuleForSchedule(sid);

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -144,7 +144,9 @@ async function addDashboardWidget(
   // If no x & y was provided - calculate it dynamically
   // The new widget should be the very last one in the list of all widgets
   if (!('x' in widget) && !('y' in widget)) {
-    const data = await db.first(
+    const data = await db.first<
+      Pick<db.DbDashboard, 'x' | 'y' | 'width' | 'height'>
+    >(
       'SELECT x, y, width, height FROM dashboard WHERE tombstone = 0 ORDER BY y DESC, x DESC',
     );
 

--- a/packages/loot-core/src/server/filters/app.ts
+++ b/packages/loot-core/src/server/filters/app.ts
@@ -42,7 +42,7 @@ const filterModel = {
 };
 
 async function filterNameExists(name, filterId, newItem) {
-  const idForName = await db.first(
+  const idForName = await db.first<Pick<db.DbTransactionFilter, 'id'>>(
     'SELECT id from transaction_filters WHERE tombstone = 0 AND name = ?',
     [name],
   );

--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -68,7 +68,9 @@ describe('Budgets', () => {
 
     // Grab the clock to compare later
     await db.openDatabase('test-budget');
-    const row = await db.first('SELECT * FROM messages_clock');
+    const row = await db.first<db.DbClockMessage>(
+      'SELECT * FROM messages_clock',
+    );
 
     const { error } = await runHandler(handlers['load-budget'], {
       id: 'test-budget',

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -258,7 +258,7 @@ handlers['category-delete'] = mutator(async function ({ id, transferId }) {
   return withUndo(async () => {
     let result = {};
     await batchMessages(async () => {
-      const row = await db.first(
+      const row = await db.first<Pick<db.DbCategory, 'is_income'>>(
         'SELECT is_income FROM categories WHERE id = ?',
         [id],
       );
@@ -269,9 +269,10 @@ handlers['category-delete'] = mutator(async function ({ id, transferId }) {
 
       const transfer =
         transferId &&
-        (await db.first('SELECT is_income FROM categories WHERE id = ?', [
-          transferId,
-        ]));
+        (await db.first<Pick<db.DbCategory, 'is_income'>>(
+          'SELECT is_income FROM categories WHERE id = ?',
+          [transferId],
+        ));
 
       if (!row || (transferId && !transfer)) {
         result = { error: 'no-categories' };
@@ -1406,9 +1407,10 @@ async function loadBudget(id: string) {
 
   // This is a bit leaky, but we need to set the initial budget type
   const { value: budgetType = 'rollover' } =
-    (await db.first('SELECT value from preferences WHERE id = ?', [
-      'budgetType',
-    ])) ?? {};
+    (await db.first<Pick<db.DbPreference, 'value'>>(
+      'SELECT value from preferences WHERE id = ?',
+      ['budgetType'],
+    )) ?? {};
   sheet.get().meta().budgetType = budgetType;
   await budget.createAllBudgets();
 

--- a/packages/loot-core/src/server/migrate/migrations.test.ts
+++ b/packages/loot-core/src/server/migrate/migrations.test.ts
@@ -62,14 +62,14 @@ describe('Migrations', () => {
     return withMigrationsDir(
       __dirname + '/../../mocks/migrations',
       async () => {
-        let desc = await db.first(
+        let desc = await db.first<{ sql: string }>(
           "SELECT * FROM sqlite_master WHERE name = 'poop'",
         );
         expect(desc).toBe(null);
 
         await migrate(db.getDatabase());
 
-        desc = await db.first(
+        desc = await db.first<{ sql: string }>(
           "SELECT * FROM sqlite_master WHERE name = 'poop'",
         );
         expect(desc).toBeDefined();

--- a/packages/loot-core/src/server/reports/app.ts
+++ b/packages/loot-core/src/server/reports/app.ts
@@ -85,7 +85,7 @@ async function reportNameExists(
   reportId: string,
   newItem: boolean,
 ) {
-  const idForName: { id: string } = await db.first(
+  const idForName = await db.first<Pick<db.DbCustomReport, 'id'>>(
     'SELECT id from custom_reports WHERE tombstone = 0 AND name = ?',
     [name],
   );

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -140,7 +140,9 @@ export async function setNextDate({
     if (newNextDate !== nextDate) {
       // Our `update` functon requires the id of the item and we don't
       // have it, so we need to query it
-      const nd = await db.first(
+      const nd = await db.first<
+        Pick<db.DbScheduleNextDate, 'id' | 'base_next_date_ts'>
+      >(
         'SELECT id, base_next_date_ts FROM schedules_next_date WHERE schedule_id = ?',
         [id],
       );
@@ -166,7 +168,7 @@ export async function setNextDate({
 // Methods
 
 async function checkIfScheduleExists(name, scheduleId) {
-  const idForName = await db.first(
+  const idForName = await db.first<Pick<db.DbSchedule, 'id'>>(
     'SELECT id from schedules WHERE tombstone = 0 AND name = ?',
     [name],
   );

--- a/packages/loot-core/src/server/schedules/find-schedules.ts
+++ b/packages/loot-core/src/server/schedules/find-schedules.ts
@@ -337,8 +337,8 @@ export async function findSchedules() {
 
   for (const account of accounts) {
     // Find latest transaction-ish to start with
-    const latestTrans = await db.first<db.DbViewTransaction>(
-      'SELECT * FROM v_transactions WHERE account = ? AND parent_id IS NULL ORDER BY date DESC LIMIT 1',
+    const latestTrans = await db.first<Pick<db.DbViewTransaction, 'date'>>(
+      'SELECT data FROM v_transactions WHERE account = ? AND parent_id IS NULL ORDER BY date DESC LIMIT 1',
       [account.id],
     );
 

--- a/packages/loot-core/src/server/schedules/find-schedules.ts
+++ b/packages/loot-core/src/server/schedules/find-schedules.ts
@@ -338,7 +338,7 @@ export async function findSchedules() {
   for (const account of accounts) {
     // Find latest transaction-ish to start with
     const latestTrans = await db.first<Pick<db.DbViewTransaction, 'date'>>(
-      'SELECT data FROM v_transactions WHERE account = ? AND parent_id IS NULL ORDER BY date DESC LIMIT 1',
+      'SELECT date FROM v_transactions WHERE account = ? AND parent_id IS NULL ORDER BY date DESC LIMIT 1',
       [account.id],
     );
 

--- a/packages/loot-core/src/server/schedules/find-schedules.ts
+++ b/packages/loot-core/src/server/schedules/find-schedules.ts
@@ -337,7 +337,7 @@ export async function findSchedules() {
 
   for (const account of accounts) {
     // Find latest transaction-ish to start with
-    const latestTrans = await db.first(
+    const latestTrans = await db.first<db.DbViewTransaction>(
       'SELECT * FROM v_transactions WHERE account = ? AND parent_id IS NULL ORDER BY date DESC LIMIT 1',
       [account.id],
     );

--- a/packages/loot-core/src/server/sheet.ts
+++ b/packages/loot-core/src/server/sheet.ts
@@ -5,6 +5,7 @@ import { captureBreadcrumb } from '../platform/exceptions';
 import * as sqlite from '../platform/server/sqlite';
 import { sheetForMonth } from '../shared/months';
 
+import { DbPreference } from './db';
 import * as Platform from './platform';
 import { Spreadsheet } from './spreadsheet/spreadsheet';
 import { resolveName } from './spreadsheet/util';
@@ -189,16 +190,19 @@ export async function reloadSpreadsheet(db): Promise<Spreadsheet> {
   }
 }
 
-export async function loadUserBudgets(db): Promise<void> {
+export async function loadUserBudgets(
+  db: typeof import('./db'),
+): Promise<void> {
   const sheet = globalSheet;
 
   // TODO: Clear out the cache here so make sure future loads of the app
   // don't load any extra values that aren't set here
 
   const { value: budgetType = 'rollover' } =
-    (await db.first('SELECT value from preferences WHERE id = ?', [
-      'budgetType',
-    ])) ?? {};
+    (await db.first<Pick<DbPreference, 'value'>>(
+      'SELECT value from preferences WHERE id = ?',
+      ['budgetType'],
+    )) ?? {};
 
   const table = budgetType === 'report' ? 'reflect_budgets' : 'zero_budgets';
   const budgets = await db.all(`

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -943,11 +943,14 @@ describe('Learning categories', () => {
 
     // Internally, it should still be stored with the internal names
     // so that it's backwards compatible
-    const rawRule = await db.first('SELECT * FROM rules');
-    rawRule.conditions = JSON.parse(rawRule.conditions);
-    rawRule.actions = JSON.parse(rawRule.actions);
-    expect(rawRule.conditions[0].field).toBe('imported_description');
-    expect(rawRule.actions[0].field).toBe('description');
+    const rawRule = await db.first<db.DbRule>('SELECT * FROM rules');
+    const parsedRule = {
+      ...rawRule,
+      conditions: JSON.parse(rawRule.conditions),
+      actions: JSON.parse(rawRule.actions),
+    };
+    expect(parsedRule.conditions[0].field).toBe('imported_description');
+    expect(parsedRule.actions[0].field).toBe('description');
 
     await loadRules();
 
@@ -973,11 +976,14 @@ describe('Learning categories', () => {
     // This rule internally has been stored with the public names.
     // Making this work now allows us to switch to it by default in
     // the future
-    const rawRule = await db.first('SELECT * FROM rules');
-    rawRule.conditions = JSON.parse(rawRule.conditions);
-    rawRule.actions = JSON.parse(rawRule.actions);
-    expect(rawRule.conditions[0].field).toBe('imported_payee');
-    expect(rawRule.actions[0].field).toBe('payee');
+    const rawRule = await db.first<db.DbRule>('SELECT * FROM rules');
+    const parsedRule = {
+      ...rawRule,
+      conditions: JSON.parse(rawRule.conditions),
+      actions: JSON.parse(rawRule.actions),
+    };
+    expect(parsedRule.conditions[0].field).toBe('imported_payee');
+    expect(parsedRule.actions[0].field).toBe('payee');
 
     const [rule] = getRules();
     expect(rule.conditions[0].field).toBe('imported_payee');

--- a/packages/loot-core/src/server/transactions/transfer.test.ts
+++ b/packages/loot-core/src/server/transactions/transfer.test.ts
@@ -179,8 +179,8 @@ describe('Transfer', () => {
     await prepareDatabase();
 
     const [transferOne, transferTwo] = await Promise.all([
-      db.first("SELECT * FROM payees WHERE transfer_acct = 'one'"),
-      db.first("SELECT * FROM payees WHERE transfer_acct = 'two'"),
+      db.first<db.DbPayee>("SELECT * FROM payees WHERE transfer_acct = 'one'"),
+      db.first<db.DbPayee>("SELECT * FROM payees WHERE transfer_acct = 'two'"),
     ]);
 
     let parent: Transaction = {

--- a/packages/loot-core/src/server/transactions/transfer.test.ts
+++ b/packages/loot-core/src/server/transactions/transfer.test.ts
@@ -64,10 +64,10 @@ describe('Transfer', () => {
 
     const differ = expectSnapshotWithDiffer(await getAllTransactions());
 
-    const transferTwo = await db.first(
+    const transferTwo = await db.first<db.DbPayee>(
       "SELECT * FROM payees WHERE transfer_acct = 'two'",
     );
-    const transferThree = await db.first(
+    const transferThree = await db.first<db.DbPayee>(
       "SELECT * FROM payees WHERE transfer_acct = 'three'",
     );
 
@@ -134,10 +134,10 @@ describe('Transfer', () => {
   test('transfers are properly de-categorized', async () => {
     await prepareDatabase();
 
-    const transferTwo = await db.first(
+    const transferTwo = await db.first<db.DbPayee>(
       "SELECT * FROM payees WHERE transfer_acct = 'two'",
     );
-    const transferThree = await db.first(
+    const transferThree = await db.first<db.DbPayee>(
       "SELECT * FROM payees WHERE transfer_acct = 'three'",
     );
 

--- a/packages/loot-core/src/server/update.ts
+++ b/packages/loot-core/src/server/update.ts
@@ -13,9 +13,10 @@ async function runMigrations() {
 
 async function updateViews() {
   const hashKey = 'view-hash';
-  const row = await db.first('SELECT value FROM __meta__ WHERE key = ?', [
-    hashKey,
-  ]);
+  const row = await db.first<{ value: string }>(
+    'SELECT value FROM __meta__ WHERE key = ?',
+    [hashKey],
+  );
   const { value: hash } = row || {};
 
   const views = makeViews(schema, schemaConfig);

--- a/packages/loot-core/src/types/models/index.d.ts
+++ b/packages/loot-core/src/types/models/index.d.ts
@@ -13,3 +13,4 @@ export type * from './schedule';
 export type * from './transaction';
 export type * from './transaction-filter';
 export type * from './user';
+export type * from './bank';

--- a/upcoming-release-notes/4248.md
+++ b/upcoming-release-notes/4248.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+[TypeScript] Make `db.first` generic to make it easy to type DB query results.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Follow up to https://github.com/actualbudget/actual/pull/4247

- [x] `db.runQuery`
- [x] `db.first`
- [ ] `db.firstSync`
- [ ] `db.all`
- [ ] `db.select`
- [ ] `db.selectWithSchema`
- [ ] `db.selectFirstWithSchema`