### PR TITLE
fix: allow child transactions to have different transfer payees

### DIFF
--- a/packages/loot-core/src/server/accounts/__snapshots__/transfer.test.ts.snap
+++ b/packages/loot-core/src/server/accounts/__snapshots__/transfer.test.ts.snap
@@ -1,5 +1,140 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Transfer split transfers are retained on child transactions 1`] = `
+Array [
+  Object {
+    "account": "one",
+    "amount": 5000,
+    "category": null,
+    "cleared": 1,
+    "date": 20170101,
+    "error": null,
+    "id": "id5",
+    "imported_id": null,
+    "imported_payee": null,
+    "is_child": 0,
+    "is_parent": 0,
+    "notes": null,
+    "parent_id": null,
+    "payee": "id3",
+    "payee_name": "",
+    "reconciled": 0,
+    "schedule": null,
+    "sort_order": 123456789,
+    "starting_balance_flag": 0,
+    "tombstone": 0,
+    "transfer_id": "id6",
+  },
+  Object {
+    "account": "two",
+    "amount": -5000,
+    "category": null,
+    "cleared": 0,
+    "date": 20170101,
+    "error": null,
+    "id": "id6",
+    "imported_id": null,
+    "imported_payee": null,
+    "is_child": 0,
+    "is_parent": 0,
+    "notes": null,
+    "parent_id": null,
+    "payee": "id2",
+    "payee_name": "",
+    "reconciled": 0,
+    "schedule": null,
+    "sort_order": 123456789,
+    "starting_balance_flag": 0,
+    "tombstone": 0,
+    "transfer_id": "id5",
+  },
+]
+`;
+
+exports[`Transfer split transfers are retained on child transactions 2`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -8,11 +8,11 @@
+      \\"error\\": null,
+      \\"id\\": \\"id5\\",
+      \\"imported_id\\": null,
+      \\"imported_payee\\": null,
+      \\"is_child\\": 0,
+-     \\"is_parent\\": 0,
++     \\"is_parent\\": 1,
+      \\"notes\\": null,
+      \\"parent_id\\": null,
+      \\"payee\\": \\"id3\\",
+      \\"payee_name\\": \\"\\",
+      \\"reconciled\\": 0,"
+`;
+
+exports[`Transfer split transfers are retained on child transactions 3`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -21,10 +21,56 @@
+      \\"starting_balance_flag\\": 0,
+      \\"tombstone\\": 0,
+      \\"transfer_id\\": \\"id6\\",
+    },
+    Object {
++     \\"account\\": \\"one\\",
++     \\"amount\\": 2000,
++     \\"category\\": null,
++     \\"cleared\\": 1,
++     \\"date\\": 20170101,
++     \\"error\\": null,
++     \\"id\\": \\"id7\\",
++     \\"imported_id\\": null,
++     \\"imported_payee\\": null,
++     \\"is_child\\": 1,
++     \\"is_parent\\": 0,
++     \\"notes\\": null,
++     \\"parent_id\\": \\"id5\\",
++     \\"payee\\": \\"id2\\",
++     \\"payee_name\\": \\"\\",
++     \\"reconciled\\": 0,
++     \\"schedule\\": null,
++     \\"sort_order\\": 123456789,
++     \\"starting_balance_flag\\": 0,
++     \\"tombstone\\": 0,
++     \\"transfer_id\\": \\"id8\\",
++   },
++   Object {
++     \\"account\\": \\"one\\",
++     \\"amount\\": -2000,
++     \\"category\\": null,
++     \\"cleared\\": 0,
++     \\"date\\": 20170101,
++     \\"error\\": null,
++     \\"id\\": \\"id8\\",
++     \\"imported_id\\": null,
++     \\"imported_payee\\": null,
++     \\"is_child\\": 0,
++     \\"is_parent\\": 0,
++     \\"notes\\": null,
++     \\"parent_id\\": null,
++     \\"payee\\": \\"id2\\",
++     \\"payee_name\\": \\"\\",
++     \\"reconciled\\": 0,
++     \\"schedule\\": null,
++     \\"sort_order\\": 123456789,
++     \\"starting_balance_flag\\": 0,
++     \\"tombstone\\": 0,
++     \\"transfer_id\\": \\"id7\\",
++   },
++   Object {
+      \\"account\\": \\"two\\",
+      \\"amount\\": -5000,
+      \\"category\\": null,
+      \\"cleared\\": 0,
+      \\"date\\": 20170101,"
+`;
+
 exports[`Transfer transfers are properly de-categorized 1`] = `
 Array [
   Object {

--- a/packages/loot-core/src/server/accounts/rules.test.ts
+++ b/packages/loot-core/src/server/accounts/rules.test.ts
@@ -524,6 +524,31 @@ describe('Rule', () => {
   });
 
   describe('split actions', () => {
+    test('splits can change the payee', () => {
+      const rule = new Rule({
+        conditionsOp: 'and',
+        conditions: [{ op: 'is', field: 'payee', value: '123' }],
+        actions: [
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            value: 100,
+            options: { splitIndex: 1, method: 'fixed-amount' },
+          },
+          {
+            op: 'set',
+            field: 'payee',
+            value: '456',
+            options: { splitIndex: 1 },
+          },
+        ],
+      });
+
+      expect(rule.exec({ payee: '123' })).toMatchObject({
+        subtransactions: [{ payee: '456' }],
+      });
+    });
+
     const fixedAmountRule = new Rule({
       conditionsOp: 'and',
       conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],

--- a/upcoming-release-notes/4255.md
+++ b/upcoming-release-notes/4255.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Allow child transactions to have different transfer payees


### PR DESCRIPTION
Fix for an issue reported on Discord. The original issue involved rules with splits, but I found a much simpler repro:
1. Create a transaction with a transfer payee but don't hit "Add."
2. Set the category to "Split" and add a single child.
3. Change the child payee to a different transfer account.
4. Click "Add."
5. Observe that the payee on the child in the added transaction is not set.

Looking for input from others with more context on the direction we're taking with payees on parent transactions, but I think this matches the approach we've taken in other places (child transactions are the source of truth, parents are generated based on the children).