### PR TITLE
fix first occurrence of some schedules moved after the weekend not showing in preview

### DIFF
--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -190,8 +190,6 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
             dates.push(nextDate);
             day = parseDate(addDays(nextDate, 1));
           }
-        } else {
-          dates.push(getNextDate(dateConditions, day));
         }
 
         if (status === 'paid') {
@@ -215,7 +213,7 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
             amount: getScheduledAmount(schedule._amount),
             date,
             schedule: schedule.id,
-            forceUpcoming: schedules.length > 0 || status === 'paid',
+            forceUpcoming: date !== schedule.next_date || status === 'paid',
           });
         });
 

--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -175,7 +175,7 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
         const isRecurring = scheduleIsRecurring(dateConditions);
 
         const dates: string[] = [];
-        let day = d.startOfDay(parseDate(schedule.next_date));
+        let day = today;
         if (isRecurring) {
           while (day <= upcomingPeriodEnd) {
             const nextDate = getNextDate(dateConditions, day);

--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -174,8 +174,8 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
         const status = statuses.get(schedule.id);
         const isRecurring = scheduleIsRecurring(dateConditions);
 
-        const dates: string[] = [];
-        let day = today;
+        const dates: string[] = [schedule.next_date];
+        let day = d.startOfDay(parseDate(schedule.next_date));
         if (isRecurring) {
           while (day <= upcomingPeriodEnd) {
             const nextDate = getNextDate(dateConditions, day);

--- a/upcoming-release-notes/4256.md
+++ b/upcoming-release-notes/4256.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix first occurrence of some schedules moved after the weekend not showing in preview


### PR DESCRIPTION
Testing:
If you upload this to edge you'll see the schedule preview doesn't show in the account, but it does in the preview build.

[schedules_test.zip](https://github.com/user-attachments/files/18609280/schedules_test.zip)