### PR TITLE
:bug: [Goals]: Fix inconsistent schedule amounts

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -126,11 +126,12 @@ export class CategoryTemplate {
           break;
         }
         case 'schedule': {
+          const budgeted = this.fromLastMonth + toBudget;
           const ret = await goalsSchedule(
             scheduleFlag,
             t,
             this.month,
-            toBudget,
+            budgeted,
             remainder,
             this.fromLastMonth,
             toBudget,

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -126,15 +126,11 @@ export class CategoryTemplate {
           break;
         }
         case 'schedule': {
-          const budgeted = await getSheetValue(
-            monthUtils.sheetForMonth(this.month),
-            `leftover-${this.category.id}`,
-          );
           const ret = await goalsSchedule(
             scheduleFlag,
             t,
             this.month,
-            budgeted,
+            toBudget,
             remainder,
             this.fromLastMonth,
             toBudget,
@@ -146,6 +142,7 @@ export class CategoryTemplate {
           newBudget = ret.to_budget - toBudget;
           remainder = ret.remainder;
           scheduleFlag = ret.scheduleFlag;
+          first=false;
           break;
         }
         case 'average': {

--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -143,7 +143,6 @@ export class CategoryTemplate {
           newBudget = ret.to_budget - toBudget;
           remainder = ret.remainder;
           scheduleFlag = ret.scheduleFlag;
-          first=false;
           break;
         }
         case 'average': {

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -224,7 +224,7 @@ describe('checkTemplates', () => {
       expected: {
         sticky: true,
         message: 'There were errors interpreting some templates:',
-        pre: 'cat1: Schedule “Non-existent Schedule” does not exist',
+        pre: 'Category 1: Schedule “Non-existent Schedule” does not exist',
       },
     },
   ];

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -40,7 +40,7 @@ export async function checkTemplates(): Promise<Notification> {
   const scheduleNames = schedules.map(({ name }) => name);
   const errors: string[] = [];
 
-  categoryWithTemplates.forEach(({ id, name, templates }) => {
+  categoryWithTemplates.forEach(({ name, templates }) => {
     templates.forEach(template => {
       if (template.type === 'error') {
         errors.push(`${name}: ${template.line}`);

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -48,7 +48,7 @@ export async function checkTemplates(): Promise<Notification> {
         template.type === 'schedule' &&
         !scheduleNames.includes(template.name)
       ) {
-        errors.push(`${id}: Schedule “${template.name}” does not exist`);
+        errors.push(`${name}: Schedule “${template.name}” does not exist`);
       }
     });
   });

--- a/upcoming-release-notes/4265.md
+++ b/upcoming-release-notes/4265.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix schedule templates sometimes budgeting wrong amounts


### PR DESCRIPTION
The schedule templates would sometimes have inconsistent budgeted amounts. This fixes that so they should budget the same amount not matter what, in a given month.

[test.zip](https://github.com/user-attachments/files/18608378/test.zip)
To test use this file and apply the templates multiple times and see that the amount budgeted changes back and forth between two different values in edge.
