### PR TITLE
Make password login page more mobile responsive

### DIFF
--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -19,6 +19,7 @@ import { Link } from '../../common/Link';
 import { Select } from '../../common/Select';
 import { Text } from '../../common/Text';
 import { View } from '../../common/View';
+import { useResponsive } from '../../responsive/ResponsiveProvider';
 import { useAvailableLoginMethods, useLoginMethod } from '../../ServerContext';
 
 import { useBootstrapped, Title } from './common';
@@ -28,6 +29,7 @@ function PasswordLogin({ setError, dispatch }) {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
+  const { isNarrowWidth } = useResponsive();
 
   async function onSubmitPassword() {
     if (password === '' || loading) {
@@ -50,19 +52,25 @@ function PasswordLogin({ setError, dispatch }) {
   }
 
   return (
-    <View style={{ flexDirection: 'row', marginTop: 5 }}>
+    <View
+      style={{
+        flexDirection: isNarrowWidth ? 'column' : 'row',
+        marginTop: 5,
+        gap: '1rem',
+      }}
+    >
       <BigInput
         autoFocus={true}
         placeholder={t('Password')}
         type="password"
         onChangeValue={newValue => setPassword(newValue)}
-        style={{ flex: 1, marginRight: 10 }}
+        style={{ flex: 1 }}
         onEnter={onSubmitPassword}
       />
       <ButtonWithLoading
         variant="primary"
         isLoading={loading}
-        style={{ fontSize: 15, width: 170 }}
+        style={{ fontSize: 15, width: isNarrowWidth ? '100%' : 170 }}
         onPress={onSubmitPassword}
       >
         <Trans>Sign in</Trans>

--- a/upcoming-release-notes/4266.md
+++ b/upcoming-release-notes/4266.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Make password login page more mobile responsive


### PR DESCRIPTION
Fixes #4242

Would be nice to get into 25.2 but feel free to remove from the milestone if you disagree.

Edge:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/f2909e56-ddbe-4fcc-8ce9-91801d4b35b5" />

This PR:
<img width="549" alt="image" src="https://github.com/user-attachments/assets/9fdc3b05-59f4-4838-ba32-d14602d5eee6" />
