### PR TITLE
Handle duplicate categories/groups in nYNAB importer.

### DIFF
--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -112,12 +112,28 @@ async function importCategories(
             case 'internal': // uncategorized is ignored too, handled by actual
               break;
             default: {
-              const id = await actual.createCategory({
-                name: cat.name,
-                group_id: groupId,
-              });
-              entityIdMap.set(cat.id, id);
-              break;
+              let run = true;
+              let count = 1;
+              let origName = cat.name;
+              while(run) {
+                try{
+                  const id = await actual.createCategory({
+                    name: cat.name,
+                    group_id: groupId,
+                  });
+                  entityIdMap.set(cat.id, id);
+                  run = false;
+                  break;
+                }
+                catch(e){
+                  cat.name = origName+"-"+count.toString();
+                  count +=1;
+                  if(count>=100){
+                    run=false;
+                    throw Error(e.message)
+                  }
+                }
+              }
             }
           }
         }

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -114,9 +114,9 @@ async function importCategories(
             default: {
               let run = true;
               let count = 1;
-              let origName = cat.name;
-              while(run) {
-                try{
+              const origName = cat.name;
+              while (run) {
+                try {
                   const id = await actual.createCategory({
                     name: cat.name,
                     group_id: groupId,
@@ -124,13 +124,12 @@ async function importCategories(
                   entityIdMap.set(cat.id, id);
                   run = false;
                   break;
-                }
-                catch(e){
-                  cat.name = origName+"-"+count.toString();
-                  count +=1;
-                  if(count>=100){
-                    run=false;
-                    throw Error(e.message)
+                } catch (e) {
+                  cat.name = origName + '-' + count.toString();
+                  count += 1;
+                  if (count >= 100) {
+                    run = false;
+                    throw Error(e.message);
                   }
                 }
               }

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -113,6 +113,7 @@ async function importCategories(
               break;
             default: {
               let run = true;
+              const MAX_RETRY = 100;
               let count = 1;
               const origName = cat.name;
               while (run) {
@@ -123,11 +124,10 @@ async function importCategories(
                   });
                   entityIdMap.set(cat.id, id);
                   run = false;
-                  break;
                 } catch (e) {
                   cat.name = origName + '-' + count.toString();
                   count += 1;
-                  if (count >= 100) {
+                  if (count >= MAX_RETRY) {
                     run = false;
                     throw Error(e.message);
                   }

--- a/upcoming-release-notes/4293.md
+++ b/upcoming-release-notes/4293.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix nynab importer failing on duplicate categories


### PR DESCRIPTION
Handles the condition where nYNAB imports have duplicate categories or groups.

fixes #3069
