### PR TITLE
Fix crashes on reports page with translations enabled

### DIFF
--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -36,33 +36,43 @@ export const defaultReport: CustomReportEntity = {
 };
 
 const balanceTypeOptions = [
-  { description: t('Payment'), format: 'totalDebts' as const },
-  { description: t('Deposit'), format: 'totalAssets' as const },
-  { description: t('Net'), format: 'totalTotals' as const },
-  { description: t('Net Payment'), format: 'netDebts' as const },
-  { description: t('Net Deposit'), format: 'netAssets' as const },
+  { description: t('Payment'), key: 'Payment', format: 'totalDebts' as const },
+  { description: t('Deposit'), key: 'Deposit', format: 'totalAssets' as const },
+  { description: t('Net'), key: 'Net', format: 'totalTotals' as const },
+  {
+    description: t('Net Payment'),
+    key: 'Net Payment',
+    format: 'netDebts' as const,
+  },
+  {
+    description: t('Net Deposit'),
+    key: 'Net Deposit',
+    format: 'netAssets' as const,
+  },
 ];
 
 const groupByOptions = [
-  { description: 'Category' },
-  { description: 'Group' },
-  { description: 'Payee' },
-  { description: 'Account' },
-  { description: 'Interval' },
+  { description: t('Category'), key: 'Category' },
+  { description: t('Group'), key: 'Group' },
+  { description: t('Payee'), key: 'Payee' },
+  { description: t('Account'), key: 'Account' },
+  { description: t('Interval'), key: 'Interval' },
 ];
 
 const sortByOptions: {
   description: string;
+  key: string;
   format: sortByOpType;
 }[] = [
-  { description: t('Ascending'), format: 'asc' as const },
-  { description: t('Descending'), format: 'desc' as const },
-  { description: t('Name'), format: 'name' as const },
-  { description: t('Budget'), format: 'budget' as const },
+  { description: t('Ascending'), key: 'Ascending', format: 'asc' as const },
+  { description: t('Descending'), key: 'Descending', format: 'desc' as const },
+  { description: t('Name'), key: 'Name', format: 'name' as const },
+  { description: t('Budget'), key: 'Budget', format: 'budget' as const },
 ];
 
 export type dateRangeProps = {
   description: string;
+  key: string;
   name: number | string;
   type?: string;
   Daily: boolean;
@@ -74,6 +84,7 @@ export type dateRangeProps = {
 const dateRangeOptions: dateRangeProps[] = [
   {
     description: t('This week'),
+    key: 'This week',
     name: 0,
     type: 'Week',
     Daily: true,
@@ -83,6 +94,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last week'),
+    key: 'Last week',
     name: 1,
     type: 'Week',
     Daily: true,
@@ -92,6 +104,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('This month'),
+    key: 'This month',
     name: 0,
     type: 'Month',
     Daily: true,
@@ -101,6 +114,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last month'),
+    key: 'Last month',
     name: 1,
     type: 'Month',
     Daily: true,
@@ -110,6 +124,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last 3 months'),
+    key: 'Last 3 months',
     name: 3,
     type: 'Month',
     Daily: true,
@@ -119,6 +134,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last 6 months'),
+    key: 'Last 6 months',
     name: 6,
     type: 'Month',
     Daily: false,
@@ -128,6 +144,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last 12 months'),
+    key: 'Last 12 months',
     name: 12,
     type: 'Month',
     Daily: false,
@@ -137,6 +154,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Year to date'),
+    key: 'Year to date',
     name: 'yearToDate',
     type: 'Month',
     Daily: false,
@@ -146,6 +164,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('Last year'),
+    key: 'Last year',
     name: 'lastYear',
     type: 'Month',
     Daily: false,
@@ -155,6 +174,7 @@ const dateRangeOptions: dateRangeProps[] = [
   },
   {
     description: t('All time'),
+    key: 'All time',
     name: 'allTime',
     type: 'Month',
     Daily: false,
@@ -166,6 +186,7 @@ const dateRangeOptions: dateRangeProps[] = [
 
 type intervalOptionsProps = {
   description: string;
+  key: string;
   name: 'Day' | 'Week' | 'Month' | 'Year';
   format: string;
   range:
@@ -178,12 +199,14 @@ type intervalOptionsProps = {
 const intervalOptions: intervalOptionsProps[] = [
   {
     description: t('Daily'),
+    key: 'Daily',
     name: 'Day',
     format: 'yy-MM-dd',
     range: 'dayRangeInclusive',
   },
   {
     description: t('Weekly'),
+    key: 'Weekly',
     name: 'Week',
     format: 'yy-MM-dd',
     range: 'weekRangeInclusive',
@@ -191,6 +214,7 @@ const intervalOptions: intervalOptionsProps[] = [
   //{ value: 3, description: 'Fortnightly', name: 3},
   {
     description: t('Monthly'),
+    key: 'Monthly',
     name: 'Month',
     // eslint-disable-next-line rulesdir/typography
     format: "MMM ''yy",
@@ -198,6 +222,7 @@ const intervalOptions: intervalOptionsProps[] = [
   },
   {
     description: t('Yearly'),
+    key: 'Yearly',
     name: 'Year',
     format: 'yyyy',
     range: 'yearRangeInclusive',
@@ -205,36 +230,29 @@ const intervalOptions: intervalOptionsProps[] = [
 ];
 
 export const ReportOptions = {
-  groupBy: groupByOptions.map(item => item.description),
+  groupBy: groupByOptions,
+  groupByItems: new Set(groupByOptions.map(item => item.key)),
   balanceType: balanceTypeOptions,
   balanceTypeMap: new Map(
-    balanceTypeOptions.map(item => [item.description, item.format]),
+    balanceTypeOptions.map(item => [item.key, item.format]),
   ),
   sortBy: sortByOptions,
-  sortByMap: new Map(
-    sortByOptions.map(item => [item.description, item.format]),
-  ),
+  sortByMap: new Map(sortByOptions.map(item => [item.key, item.format])),
   dateRange: dateRangeOptions,
-  dateRangeMap: new Map(
-    dateRangeOptions.map(item => [item.description, item.name]),
-  ),
-  dateRangeType: new Map(
-    dateRangeOptions.map(item => [item.description, item.type]),
-  ),
+  dateRangeMap: new Map(dateRangeOptions.map(item => [item.key, item.name])),
+  dateRangeType: new Map(dateRangeOptions.map(item => [item.key, item.type])),
   interval: intervalOptions,
   intervalMap: new Map<string, 'Day' | 'Week' | 'Month' | 'Year'>(
-    intervalOptions.map(item => [item.description, item.name]),
+    intervalOptions.map(item => [item.key, item.name]),
   ),
-  intervalFormat: new Map(
-    intervalOptions.map(item => [item.description, item.format]),
-  ),
+  intervalFormat: new Map(intervalOptions.map(item => [item.key, item.format])),
   intervalRange: new Map<
     string,
     | 'dayRangeInclusive'
     | 'weekRangeInclusive'
     | 'rangeInclusive'
     | 'yearRangeInclusive'
-  >(intervalOptions.map(item => [item.description, item.range])),
+  >(intervalOptions.map(item => [item.key, item.range])),
 };
 
 export type QueryDataEntity = {

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -156,7 +156,7 @@ export function ReportSidebar({
   const rangeOptions = useMemo(() => {
     const options: SelectOption[] = ReportOptions.dateRange
       .filter(f => f[customReportItems.interval as keyof dateRangeProps])
-      .map(option => [option.description, option.description]);
+      .map(option => [option.key, option.description]);
 
     // Append separator if necessary
     if (dateRangeLine > 0) {
@@ -230,7 +230,10 @@ export function ReportSidebar({
           <Select
             value={customReportItems.groupBy}
             onChange={e => onChangeSplit(e)}
-            options={ReportOptions.groupBy.map(option => [option, option])}
+            options={ReportOptions.groupBy.map(option => [
+              option.key,
+              option.description,
+            ])}
             disabledKeys={disabledItems('split')}
           />
         </View>
@@ -249,7 +252,7 @@ export function ReportSidebar({
             value={customReportItems.balanceType}
             onChange={e => onChangeBalanceType(e)}
             options={ReportOptions.balanceType.map(option => [
-              option.description,
+              option.key,
               option.description,
             ])}
             disabledKeys={disabledItems('type')}
@@ -274,14 +277,14 @@ export function ReportSidebar({
               if (
                 ReportOptions.dateRange
                   .filter(d => !d[e as keyof dateRangeProps])
-                  .map(int => int.description)
+                  .map(int => int.key)
                   .includes(customReportItems.dateRange)
               ) {
                 onSelectRange(defaultsList.intervalRange.get(e) || '');
               }
             }}
             options={ReportOptions.interval.map(option => [
-              option.description,
+              option.key,
               option.description,
             ])}
             disabledKeys={[]}

--- a/packages/desktop-client/src/components/reports/disabledList.ts
+++ b/packages/desktop-client/src/components/reports/disabledList.ts
@@ -5,18 +5,22 @@ import { type sortByOpType } from 'loot-core/types/models';
 const intervalOptions = [
   {
     description: t('Daily'),
+    key: 'Daily',
     defaultRange: 'This month',
   },
   {
     description: t('Weekly'),
+    key: 'Weekly',
     defaultRange: 'Last 3 months',
   },
   {
     description: t('Monthly'),
+    key: 'Monthly',
     defaultRange: 'Last 6 months',
   },
   {
     description: t('Yearly'),
+    key: 'Yearly',
     defaultRange: 'Year to date',
   },
 ];
@@ -215,6 +219,6 @@ export const defaultsList = {
     modeOptions.map(item => [item.description, item.defaultGraph]),
   ),
   intervalRange: new Map(
-    intervalOptions.map(item => [item.description, item.defaultRange]),
+    intervalOptions.map(item => [item.key, item.defaultRange]),
   ),
 };

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -524,7 +524,7 @@ function CustomReportInner({ report: initialReport }: CustomReportInnerProps) {
   };
 
   const defaultItems = (item: string) => {
-    const chooseGraph = ReportOptions.groupBy.includes(item) ? graphType : item;
+    const chooseGraph = ReportOptions.groupByItems.has(item) ? graphType : item;
     if (
       (disabledGraphList(mode, chooseGraph, 'disabledSplit') || []).includes(
         groupBy,

--- a/upcoming-release-notes/4303.md
+++ b/upcoming-release-notes/4303.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix crashes on reports page with translations enabled


### PR DESCRIPTION
As it says on the tin.

Steps to repro (in the latest release):
1. Pick a language other than English.
2. Reload the page.
3. Navigate to the Reports page.
4. Add a custom report.
5. Observe crashes.

Testing this PR involves all of the above, but fixing the original crash uncovered many other crashes of the same shape. It's worth just clicking around the custom reports UI to verify the issue is eliminated (I did as much as I could, but it's possible I missed something).

Note to reviewers: Most of the options I added a "key" to have another value we could have already used as a "key"; for example, `intervalOptions` has `.name`. However, there are a _ton_ of places in the reports code that hard-code string checks, and in most of these places, the `interval` (or other attribute) is passed as a plain string rather than a union of possible values. Fixing this is a huge pain—we'd need to add strict string types throughout the entire codebase, then fix all errors, and then add a migration to the new key attribute—so after trying that approach it seemed easier in the short term to just add a 'key' attribute instead with the exact same value as the previously-used `description`.

Also worth noting: `mode`, despite having a `description` attribute, doesn't use that attribute anywhere that's displayed/translated—hence I didn't add a `key`.