### PR TITLE
🔖 (25.2.1) fix desktop apps and reports page

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/api",
-  "version": "25.2.0",
+  "version": "25.2.1",
   "license": "MIT",
   "description": "An API for Actual",
   "engines": {

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "25.2.0",
+  "version": "25.2.1",
   "license": "MIT",
   "files": [
     "build"

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -3,7 +3,7 @@
   "author": "Actual",
   "productName": "Actual",
   "description": "A simple and powerful personal finance system",
-  "version": "25.2.0",
+  "version": "25.2.1",
   "scripts": {
     "clean": "rm -rf dist",
     "update-client": "bin/update-client",

--- a/upcoming-release-notes/4303.md
+++ b/upcoming-release-notes/4303.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [jfdoming]
----
-
-Fix crashes on reports page with translations enabled

--- a/upcoming-release-notes/4312.md
+++ b/upcoming-release-notes/4312.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [matt-fidd]
----
-
-Fix broken Weblate URL in settings if the language option has never been set

--- a/upcoming-release-notes/4317.md
+++ b/upcoming-release-notes/4317.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [MikesGlitch]
----
-
-Fix Electron language support


### PR DESCRIPTION
What commits will be included in the release?

https://github.com/actualbudget/actual/compare/v25.2.1?expand=1

---

- web: https://github.com/actualbudget/actual/pull/4319
- server: https://github.com/actualbudget/actual-server/pull/565
- docs: https://github.com/actualbudget/docs/pull/628