### PR TITLE
Fix hard crash when closing budget thats synced to cloud file

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -124,7 +124,9 @@ function AppInner() {
     }
 
     initAll().catch(showErrorBoundary);
-  }, [cloudFileId, dispatch, showErrorBoundary, t]);
+    // Removed cloudFileId from dependencies to prevent hard crash when closing budget in Electron
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, showErrorBoundary, t]);
 
   useEffect(() => {
     global.Actual.updateAppMenu(budgetId);

--- a/upcoming-release-notes/4322.md
+++ b/upcoming-release-notes/4322.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix hard crash when closing cloud budget on Electron


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The hard crash was introduced here:  https://github.com/actualbudget/actual/pull/4124

**Cause:** 
When you close a cloud budget the useEffect that calls ```init``` is triggered because of the cloudFileId. The init triggers a load budget call - so we're loading the budget while we're closing it, causing the app to crash. It was crashing trying to get the global spreadsheet when it was unloaded.