### PR TITLE
Fix calendar interaction when editing reports dashboard

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/CalendarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CalendarGraph.tsx
@@ -31,12 +31,14 @@ type CalendarGraphProps = {
   }[];
   start: Date;
   firstDayOfWeekIdx?: SyncedPrefs['firstDayOfWeekIdx'];
+  isEditing?: boolean;
   onDayClick: (date: Date | null) => void;
 };
 export function CalendarGraph({
   data,
   start,
   firstDayOfWeekIdx,
+  isEditing,
   onDayClick,
 }: CalendarGraphProps) {
   const startingDate = startOfWeek(new Date(), {
@@ -97,6 +99,7 @@ export function CalendarGraph({
           gap: 2,
           width: '100%',
           height: '100%',
+          zIndex: isEditing ? -1 : 'auto', // Prevents interaction with calendar buttons when editing dashboard.
         }}
       >
         {data.map((day, index) =>

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -302,6 +302,7 @@ export function CalendarCard({
                   selectedMonthNameFormat={selectedMonthNameFormat}
                   index={index}
                   widgetId={widgetId}
+                  isEditing={isEditing}
                 />
               ))
             ) : (
@@ -327,6 +328,7 @@ type CalendarCardInnerProps = {
   selectedMonthNameFormat: string;
   index: number;
   widgetId: string;
+  isEditing?: boolean;
 };
 function CalendarCardInner({
   calendar,
@@ -335,6 +337,7 @@ function CalendarCardInner({
   selectedMonthNameFormat,
   index,
   widgetId,
+  isEditing,
 }: CalendarCardInnerProps) {
   const [monthNameVisible, setMonthNameVisible] = useState(true);
   const monthFormatSizeContainers = useRef<(HTMLSpanElement | null)[]>(
@@ -513,6 +516,7 @@ function CalendarCardInner({
         data={calendar.data}
         start={calendar.start}
         firstDayOfWeekIdx={firstDayOfWeekIdx}
+        isEditing={isEditing}
         onDayClick={date => {
           if (date) {
             navigate(


### PR DESCRIPTION
### Bug
As of v25.2.1 and before, the buttons (day boxes) on calendar reports remain clickable when when editing the reports dashboard. This presents a problem where the calendar is invertedly clicked on when drag-n-dropping to move it.

### How to reproduce
1. Add calendar report.
2. Edit dashboard.
3. Click from anywhere in the middle of the calendar (not the edges) and drag the card to a new position.
4. Upon letting go, you will be taken to the calendar report when you should have stayed at the dashboard for further editing.

### Proposed solution
This code solves the issue by sending the calendar day buttons to the background while editing the dashboard. I originally tried just disabling the buttons, but when hovering, the cursor is set to `default` rather than `move` which it should be when dragging the card.