### PR TITLE
:recycle: replace loot-core/src imports with loot-core

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import type { Handlers } from 'loot-core/src/types/handlers';
+import type { Handlers } from 'loot-core/types/handlers';
 
 import * as injected from './injected';
 

--- a/packages/api/tsconfig.dist.json
+++ b/packages/api/tsconfig.dist.json
@@ -11,7 +11,6 @@
     "outDir": "dist",
     "declarationDir": "@types",
     "paths": {
-      "loot-core/src/*": ["./loot-core/*"],
       "loot-core/*": ["./@types/loot-core/*"]
     }
   },

--- a/packages/desktop-client/e2e/budget.mobile.test.ts
+++ b/packages/desktop-client/e2e/budget.mobile.test.ts
@@ -1,7 +1,7 @@
 import { type Page } from '@playwright/test';
 
+import * as monthUtils from 'loot-core/shared/months';
 import { amountToCurrency, currencyToAmount } from 'loot-core/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
 
 import { expect, test } from './fixtures';
 import { ConfigurationPage } from './page-models/configuration-page';

--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -2,7 +2,7 @@ import { initBackend as initSQLBackend } from 'absurd-sql/dist/indexeddb-main-th
 // eslint-disable-next-line import/no-unresolved
 import { registerSW } from 'virtual:pwa-register';
 
-import * as Platform from 'loot-core/src/client/platform';
+import * as Platform from 'loot-core/client/platform';
 
 import packageJson from '../package.json';
 

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -19,12 +19,9 @@ import {
   signOut,
 } from 'loot-core/client/actions';
 import { setAppState, sync } from 'loot-core/client/app/appSlice';
+import * as Platform from 'loot-core/client/platform';
 import { SpreadsheetProvider } from 'loot-core/client/SpreadsheetProvider';
-import * as Platform from 'loot-core/src/client/platform';
-import {
-  init as initConnection,
-  send,
-} from 'loot-core/src/platform/client/fetch';
+import { init as initConnection, send } from 'loot-core/platform/client/fetch';
 
 import { handleGlobalEvents } from '../global-events';
 import { useMetadataPref } from '../hooks/useMetadataPref';

--- a/packages/desktop-client/src/components/FatalError.tsx
+++ b/packages/desktop-client/src/components/FatalError.tsx
@@ -4,7 +4,7 @@ import { useTranslation, Trans } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { View } from '@actual-app/components/view';
 
-import { LazyLoadFailedError } from 'loot-core/src/shared/errors';
+import { LazyLoadFailedError } from 'loot-core/shared/errors';
 
 import { Block } from './common/Block';
 import { Link } from './common/Link';

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -11,7 +11,7 @@ import {
 
 import { addNotification } from 'loot-core/client/actions';
 import { sync } from 'loot-core/client/app/appSlice';
-import * as undo from 'loot-core/src/platform/client/undo';
+import * as undo from 'loot-core/platform/client/undo';
 
 import { ProtectedRoute } from '../auth/ProtectedRoute';
 import { Permissions } from '../auth/types';

--- a/packages/desktop-client/src/components/GlobalKeys.ts
+++ b/packages/desktop-client/src/components/GlobalKeys.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import * as Platform from 'loot-core/src/client/platform';
+import * as Platform from 'loot-core/client/platform';
 
 import { useNavigate } from '../hooks/useNavigate';
 

--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import { closeBudget, getUserData, signOut } from 'loot-core/client/actions';
-import { listen } from 'loot-core/src/platform/client/fetch';
+import { listen } from 'loot-core/platform/client/fetch';
 import { type RemoteFile, type SyncedLocalFile } from 'loot-core/types/file';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 

--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -9,19 +9,16 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { pushModal } from 'loot-core/client/actions/modals';
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { initiallyLoadPayees } from 'loot-core/client/queries/queriesSlice';
+import { send } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { q } from 'loot-core/shared/query';
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
-import { mapField, friendlyOp } from 'loot-core/src/shared/rules';
-import { describeSchedule } from 'loot-core/src/shared/schedules';
-import {
-  type RuleEntity,
-  type NewRuleEntity,
-} from 'loot-core/src/types/models';
+import { mapField, friendlyOp } from 'loot-core/shared/rules';
+import { describeSchedule } from 'loot-core/shared/schedules';
+import { type RuleEntity, type NewRuleEntity } from 'loot-core/types/models';
 
 import { useAccounts } from '../hooks/useAccounts';
 import { useCategories } from '../hooks/useCategories';

--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import { closeModal } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useMetadataPref } from '../hooks/useMetadataPref';
 import { useModalState } from '../hooks/useModalState';

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useNotes } from '../hooks/useNotes';
 import { SvgCustomNotesPaper } from '../icons/v2';

--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { css } from '@emotion/css';
 
 import { removeNotification } from 'loot-core/client/actions';
-import type { NotificationWithId } from 'loot-core/src/client/state-types/notifications';
+import type { NotificationWithId } from 'loot-core/client/state-types/notifications';
 
 import { AnimatedLoading } from '../icons/AnimatedLoading';
 import { SvgDelete } from '../icons/v0';

--- a/packages/desktop-client/src/components/ServerContext.tsx
+++ b/packages/desktop-client/src/components/ServerContext.tsx
@@ -10,7 +10,7 @@ import React, {
 import { t } from 'i18next';
 
 import { addNotification } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 import { type Handlers } from 'loot-core/types/handlers';
 
 type LoginMethods = {

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import type { Theme } from 'loot-core/src/types/prefs';
+import type { Theme } from 'loot-core/types/prefs';
 
 import { SvgMoonStars, SvgSun, SvgSystem } from '../icons/v2';
 import { themeOptions, useTheme } from '../style';

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -6,13 +6,13 @@ import { Routes, Route, useLocation } from 'react-router-dom';
 import { css } from '@emotion/css';
 
 import { sync } from 'loot-core/client/app/appSlice';
-import * as Platform from 'loot-core/src/client/platform';
-import * as queries from 'loot-core/src/client/queries';
-import { listen } from 'loot-core/src/platform/client/fetch';
+import * as Platform from 'loot-core/client/platform';
+import * as queries from 'loot-core/client/queries';
+import { listen } from 'loot-core/platform/client/fetch';
 import {
   isDevelopmentEnvironment,
   isElectron,
-} from 'loot-core/src/shared/environment';
+} from 'loot-core/shared/environment';
 
 import { useGlobalPref } from '../hooks/useGlobalPref';
 import { useMetadataPref } from '../hooks/useMetadataPref';

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -21,6 +21,12 @@ import {
   replaceModal,
 } from 'loot-core/client/actions';
 import { syncAndDownload } from 'loot-core/client/app/appSlice';
+import { useFilters } from 'loot-core/client/data-hooks/filters';
+import {
+  SchedulesProvider,
+  accountSchedulesQuery,
+} from 'loot-core/client/data-hooks/schedules';
+import * as queries from 'loot-core/client/queries';
 import {
   createPayee,
   initiallyLoadPayees,
@@ -29,24 +35,18 @@ import {
   updateAccount,
   updateNewTransactions,
 } from 'loot-core/client/queries/queriesSlice';
-import { type AppDispatch } from 'loot-core/client/store';
-import { validForTransfer } from 'loot-core/client/transfer';
-import { type UndoState } from 'loot-core/server/undo';
-import { useFilters } from 'loot-core/src/client/data-hooks/filters';
-import {
-  SchedulesProvider,
-  accountSchedulesQuery,
-} from 'loot-core/src/client/data-hooks/schedules';
-import * as queries from 'loot-core/src/client/queries';
 import {
   runQuery,
   pagedQuery,
   type PagedQuery,
-} from 'loot-core/src/client/query-helpers';
-import { send, listen } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
-import { currentDay } from 'loot-core/src/shared/months';
-import { q, type Query } from 'loot-core/src/shared/query';
+} from 'loot-core/client/query-helpers';
+import { type AppDispatch } from 'loot-core/client/store';
+import { validForTransfer } from 'loot-core/client/transfer';
+import { send, listen } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
+import { type UndoState } from 'loot-core/server/undo';
+import { currentDay } from 'loot-core/shared/months';
+import { q, type Query } from 'loot-core/shared/query';
 import {
   updateTransaction,
   realizeTempTransactions,
@@ -54,8 +54,8 @@ import {
   ungroupTransactions,
   makeChild,
   makeAsNonChildTransactions,
-} from 'loot-core/src/shared/transactions';
-import { applyChanges, groupById } from 'loot-core/src/shared/util';
+} from 'loot-core/shared/transactions';
+import { applyChanges, groupById } from 'loot-core/shared/util';
 import {
   type NewRuleEntity,
   type RuleActionEntity,
@@ -63,7 +63,7 @@ import {
   type RuleConditionEntity,
   type TransactionEntity,
   type TransactionFilterEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { useAccountPreviewTransactions } from '../../hooks/useAccountPreviewTransactions';
 import { useAccounts } from '../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 
 import { useHover } from 'usehooks-ts';
 
+import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
+import { q, type Query } from 'loot-core/shared/query';
+import { getScheduledAmount } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
-import { useCachedSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { q, type Query } from 'loot-core/src/shared/query';
-import { getScheduledAmount } from 'loot-core/src/shared/schedules';
 import { type AccountEntity } from 'loot-core/types/models';
 
 import { useSelectedItems } from '../../hooks/useSelected';

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Trans } from 'react-i18next';
 
-import * as queries from 'loot-core/src/client/queries';
-import { type Query } from 'loot-core/src/shared/query';
-import { currencyToInteger } from 'loot-core/src/shared/util';
+import * as queries from 'loot-core/client/queries';
+import { type Query } from 'loot-core/shared/query';
+import { currencyToInteger } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
@@ -11,8 +11,8 @@ import React, {
 import { Trans, useTranslation } from 'react-i18next';
 
 import { addNotification, pushModal } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
+import { send } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
 import { type Handlers } from 'loot-core/types/handlers';
 import { type UserAvailable } from 'loot-core/types/models';
 import { type UserAccessEntity } from 'loot-core/types/models/userAccess';

--- a/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
+++ b/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
@@ -11,9 +11,9 @@ import {
 import { Trans, useTranslation } from 'react-i18next';
 
 import { addNotification, signOut } from 'loot-core/client/actions';
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
+import { pushModal } from 'loot-core/client/actions/modals';
+import { send } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
 import {
   type NewUserEntity,
   type UserEntity,

--- a/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/AccountAutocomplete.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import { css, cx } from '@emotion/css';
 
-import { type AccountEntity } from 'loot-core/src/types/models';
+import { type AccountEntity } from 'loot-core/types/models';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { theme, styles } from '../../style';

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -14,7 +14,7 @@ import React, {
 import { css, cx } from '@emotion/css';
 import Downshift, { type StateChangeTypes } from 'downshift';
 
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
 
 import { SvgRemove } from '../../icons/v2';
 import { styles, theme } from '../../style';

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -15,12 +15,12 @@ import { Trans, useTranslation } from 'react-i18next';
 import { css, cx } from '@emotion/css';
 
 import { trackingBudget, envelopeBudget } from 'loot-core/client/queries';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { integerToCurrency } from 'loot-core/shared/util';
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
 import {
   type CategoryEntity,
   type CategoryGroupEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useSyncedPref } from '../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/autocomplete/FilterAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/FilterAutocomplete.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentProps } from 'react';
 
-import { useFilters } from 'loot-core/src/client/data-hooks/filters';
+import { useFilters } from 'loot-core/client/data-hooks/filters';
 import { type TransactionFilterEntity } from 'loot-core/types/models/transaction-filter';
 
 import { Autocomplete } from './Autocomplete';

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.test.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.test.tsx
@@ -2,7 +2,7 @@ import { render, type Screen, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
-import { generateAccount } from 'loot-core/src/mocks';
+import { generateAccount } from 'loot-core/mocks';
 import type { AccountEntity, PayeeEntity } from 'loot-core/types/models';
 
 import { AuthProvider } from '../../auth/AuthProvider';

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -19,11 +19,8 @@ import {
   createPayee,
   getActivePayees,
 } from 'loot-core/client/queries/queriesSlice';
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
-import {
-  type AccountEntity,
-  type PayeeEntity,
-} from 'loot-core/src/types/models';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
+import { type AccountEntity, type PayeeEntity } from 'loot-core/types/models';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { useCommonPayees, usePayees } from '../../hooks/usePayees';

--- a/packages/desktop-client/src/components/autocomplete/ReportAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/ReportAutocomplete.tsx
@@ -1,7 +1,7 @@
 import React, { type ComponentProps } from 'react';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
-import { type CustomReportEntity } from 'loot-core/src/types/models/reports';
+import { type CustomReportEntity } from 'loot-core/types/models/reports';
 
 import { Autocomplete } from './Autocomplete';
 import { ReportList } from './ReportList';

--- a/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
@@ -9,7 +9,7 @@ import { useSpring, animated } from 'react-spring';
 
 import { css } from '@emotion/css';
 
-import { addMonths, subMonths } from 'loot-core/src/shared/months';
+import { addMonths, subMonths } from 'loot-core/shared/months';
 
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import { View } from '../common/View';

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, type ComponentProps } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { View } from '../common/View';
 

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
@@ -4,7 +4,7 @@ import React, { type ComponentProps } from 'react';
 import {
   type CategoryGroupEntity,
   type CategoryEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { theme } from '../../style';
 import { View } from '../common/View';

--- a/packages/desktop-client/src/components/budget/IncomeCategory.tsx
+++ b/packages/desktop-client/src/components/budget/IncomeCategory.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import React, { type ComponentProps } from 'react';
 
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import { type CategoryEntity } from 'loot-core/types/models';
 
 import {
   useDraggable,

--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -2,7 +2,7 @@
 import React, { type CSSProperties, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import { SvgCalendar } from '../../icons/v2';

--- a/packages/desktop-client/src/components/budget/MonthsContext.tsx
+++ b/packages/desktop-client/src/components/budget/MonthsContext.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import React, { createContext, type ReactNode } from 'react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 export type MonthBounds = {
   start: string;

--- a/packages/desktop-client/src/components/budget/RenderMonths.tsx
+++ b/packages/desktop-client/src/components/budget/RenderMonths.tsx
@@ -5,7 +5,7 @@ import React, {
   type ComponentType,
 } from 'react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { theme } from '../../style';
 import { View } from '../common/View';

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import {
   type CategoryGroupEntity,
   type CategoryEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { SvgCheveronDown } from '../../icons/v1';

--- a/packages/desktop-client/src/components/budget/envelope/BalanceMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/BalanceMenu.tsx
@@ -1,7 +1,7 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
+import { envelopeBudget } from 'loot-core/client/queries';
 
 import { Menu } from '../../common/Menu';
 

--- a/packages/desktop-client/src/components/budget/envelope/BalanceMovementMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/BalanceMovementMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
+import { envelopeBudget } from 'loot-core/client/queries';
 
 import { BalanceMenu } from './BalanceMenu';
 import { CoverMenu } from './CoverMenu';

--- a/packages/desktop-client/src/components/budget/envelope/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/CoverMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import { type CategoryEntity } from 'loot-core/types/models';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { CategoryAutocomplete } from '../../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -8,10 +8,10 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
+import { envelopeBudget } from 'loot-core/client/queries';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
 
 import { useContextMenu } from '../../../hooks/useContextMenu';
 import { useUndo } from '../../../hooks/useUndo';

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetContext.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetContext.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode, createContext, useContext } from 'react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 type EnvelopeBudgetContextDefinition = {
   summaryCollapsed: boolean;

--- a/packages/desktop-client/src/components/budget/envelope/HoldMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/HoldMenu.tsx
@@ -6,9 +6,9 @@ import React, {
 } from 'react';
 import { Trans } from 'react-i18next';
 
-import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
 
 import { Button } from '../../common/Button2';
 import { InitialFocus } from '../../common/InitialFocus';

--- a/packages/desktop-client/src/components/budget/envelope/TransferMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/TransferMenu.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
 import { type CategoryEntity } from 'loot-core/types/models';
 
 import { useCategories } from '../../../hooks/useCategories';

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/BudgetSummary.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useUndo } from '../../../../hooks/useUndo';
 import { SvgDotsHorizontalTriple } from '../../../../icons/v1';

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
 } from 'react';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
+import { envelopeBudget } from 'loot-core/client/queries';
 
 import { useContextMenu } from '../../../../hooks/useContextMenu';
 import { Popover } from '../../../common/Popover';

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
@@ -2,7 +2,7 @@ import React, { type CSSProperties, type MouseEventHandler } from 'react';
 
 import { css } from '@emotion/css';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
+import { envelopeBudget } from 'loot-core/client/queries';
 
 import { theme, styles } from '../../../../style';
 import { Block } from '../../../common/Block';

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
@@ -1,6 +1,6 @@
 import React, { type CSSProperties } from 'react';
 
-import { envelopeBudget } from 'loot-core/src/client/queries';
+import { envelopeBudget } from 'loot-core/client/queries';
 
 import { styles } from '../../../../style';
 import { AlignedText } from '../../../common/AlignedText';

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -2,6 +2,7 @@
 import React, { memo, useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { addNotification, pushModal } from 'loot-core/client/actions';
 import {
   applyBudgetAction,
   createCategory,
@@ -14,10 +15,9 @@ import {
   updateCategory,
   updateGroup,
 } from 'loot-core/client/queries/queriesSlice';
-import { addNotification, pushModal } from 'loot-core/src/client/actions';
-import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useGlobalPref } from '../../hooks/useGlobalPref';

--- a/packages/desktop-client/src/components/budget/tracking/BalanceMenu.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/BalanceMenu.tsx
@@ -1,7 +1,7 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trackingBudget } from 'loot-core/src/client/queries';
+import { trackingBudget } from 'loot-core/client/queries';
 
 import { Menu } from '../../common/Menu';
 

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -10,10 +10,10 @@ import { Trans } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import { trackingBudget } from 'loot-core/src/client/queries';
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency, amountToInteger } from 'loot-core/src/shared/util';
+import { trackingBudget } from 'loot-core/client/queries';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency, amountToInteger } from 'loot-core/shared/util';
 
 import { useUndo } from '../../../hooks/useUndo';
 import { SvgCheveronDown } from '../../../icons/v1';

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetContext.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetContext.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import React, { type ReactNode, createContext, useContext } from 'react';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 const Context = createContext(null);
 

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/BudgetSummary.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/BudgetSummary.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useUndo } from '../../../../hooks/useUndo';
 import { SvgDotsHorizontalTriple } from '../../../../icons/v1';

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/ExpenseTotal.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/ExpenseTotal.tsx
@@ -1,7 +1,7 @@
 import React, { type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trackingBudget } from 'loot-core/src/client/queries';
+import { trackingBudget } from 'loot-core/client/queries';
 
 import { BudgetTotal } from './BudgetTotal';
 import { ExpenseProgress } from './ExpenseProgress';

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/IncomeTotal.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/IncomeTotal.tsx
@@ -1,7 +1,7 @@
 import React, { type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { trackingBudget } from 'loot-core/src/client/queries';
+import { trackingBudget } from 'loot-core/client/queries';
 
 import { BudgetTotal } from './BudgetTotal';
 import { IncomeProgress } from './IncomeProgress';

--- a/packages/desktop-client/src/components/budget/tracking/budgetsummary/Saved.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/budgetsummary/Saved.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import { trackingBudget } from 'loot-core/src/client/queries';
+import { trackingBudget } from 'loot-core/client/queries';
 
 import { theme, styles } from '../../../../style';
 import { AlignedText } from '../../../common/AlignedText';

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -3,15 +3,15 @@ import { type CSSProperties } from 'react';
 
 import { t } from 'i18next';
 
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { type Handlers } from 'loot-core/src/types/handlers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { type Handlers } from 'loot-core/types/handlers';
 import {
   type CategoryEntity,
   type CategoryGroupEntity,
-} from 'loot-core/src/types/models';
-import { type SyncedPrefs } from 'loot-core/src/types/prefs';
+} from 'loot-core/types/models';
+import { type SyncedPrefs } from 'loot-core/types/prefs';
 
 import { styles, theme } from '../../style';
 import { type DropPosition } from '../sort';

--- a/packages/desktop-client/src/components/filters/AppliedFilters.tsx
+++ b/packages/desktop-client/src/components/filters/AppliedFilters.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 
 import { View } from '../common/View';
 

--- a/packages/desktop-client/src/components/filters/FilterExpression.tsx
+++ b/packages/desktop-client/src/components/filters/FilterExpression.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { mapField, friendlyOp } from 'loot-core/src/shared/rules';
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { mapField, friendlyOp } from 'loot-core/shared/rules';
+import { integerToCurrency } from 'loot-core/shared/util';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 
 import { SvgDelete } from '../../icons/v0';
 import { theme } from '../../style';

--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -10,9 +10,9 @@ import {
   isValid as isDateValid,
 } from 'date-fns';
 
-import { useFilters } from 'loot-core/src/client/data-hooks/filters';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { getMonthYearFormat } from 'loot-core/src/shared/months';
+import { useFilters } from 'loot-core/client/data-hooks/filters';
+import { send } from 'loot-core/platform/client/fetch';
+import { getMonthYearFormat } from 'loot-core/shared/months';
 import {
   mapField,
   deserializeField,
@@ -20,8 +20,8 @@ import {
   unparse,
   FIELD_TYPES,
   getValidOps,
-} from 'loot-core/src/shared/rules';
-import { titleFirst } from 'loot-core/src/shared/util';
+} from 'loot-core/shared/rules';
+import { titleFirst } from 'loot-core/shared/util';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
 import { styles, theme } from '../../style';

--- a/packages/desktop-client/src/components/filters/OpButton.tsx
+++ b/packages/desktop-client/src/components/filters/OpButton.tsx
@@ -2,7 +2,7 @@ import React, { type CSSProperties } from 'react';
 
 import { css } from '@emotion/css';
 
-import { friendlyOp } from 'loot-core/src/shared/rules';
+import { friendlyOp } from 'loot-core/shared/rules';
 
 import { theme } from '../../style';
 import { Button } from '../common/Button2';

--- a/packages/desktop-client/src/components/filters/SavedFilterMenuButton.tsx
+++ b/packages/desktop-client/src/components/filters/SavedFilterMenuButton.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
+import { send, sendCatch } from 'loot-core/platform/client/fetch';
 import { type TransactionFilterEntity } from 'loot-core/types/models';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 

--- a/packages/desktop-client/src/components/filters/subfieldFromFilter.ts
+++ b/packages/desktop-client/src/components/filters/subfieldFromFilter.ts
@@ -1,4 +1,4 @@
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 
 export function subfieldFromFilter({
   field,

--- a/packages/desktop-client/src/components/filters/subfieldToOptions.ts
+++ b/packages/desktop-client/src/components/filters/subfieldToOptions.ts
@@ -1,4 +1,4 @@
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 
 export function subfieldToOptions(field: string, subfield: string) {
   let setOptions: RuleConditionEntity['options'];

--- a/packages/desktop-client/src/components/filters/updateFilterReducer.ts
+++ b/packages/desktop-client/src/components/filters/updateFilterReducer.ts
@@ -1,5 +1,5 @@
-import { makeValue, FIELD_TYPES } from 'loot-core/src/shared/rules';
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { makeValue, FIELD_TYPES } from 'loot-core/shared/rules';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 
 export function updateFilterReducer(
   state: Pick<RuleConditionEntity, 'op' | 'field' | 'value'>,

--- a/packages/desktop-client/src/components/manager/BudgetList.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetList.tsx
@@ -20,7 +20,7 @@ import {
 import {
   isElectron,
   isNonProductionEnvironment,
-} from 'loot-core/src/shared/environment';
+} from 'loot-core/shared/environment';
 import {
   type RemoteFile,
   type File,

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -6,7 +6,7 @@ import { createBudget, loggedIn, signOut } from 'loot-core/client/actions';
 import {
   isNonProductionEnvironment,
   isElectron,
-} from 'loot-core/src/shared/environment';
+} from 'loot-core/shared/environment';
 
 import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useNavigate } from '../../hooks/useNavigate';

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
@@ -2,8 +2,8 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { createBudget } from 'loot-core/src/client/actions/budgets';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { createBudget } from 'loot-core/client/actions/budgets';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useDispatch } from '../../../redux';

--- a/packages/desktop-client/src/components/manager/subscribe/ChangePassword.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/ChangePassword.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -3,9 +3,9 @@ import React, { useState, useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
+import { loggedIn } from 'loot-core/client/actions/user';
+import { send } from 'loot-core/platform/client/fetch';
 import { isElectron } from 'loot-core/shared/environment';
-import { loggedIn } from 'loot-core/src/client/actions/user';
-import { send } from 'loot-core/src/platform/client/fetch';
 import { type OpenIdConfig } from 'loot-core/types/models/openid';
 
 import { useNavigate } from '../../../hooks/useNavigate';

--- a/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
+++ b/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
-import { loggedIn } from 'loot-core/src/client/actions/user';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { loggedIn } from 'loot-core/client/actions/user';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useDispatch } from '../../../redux';
 

--- a/packages/desktop-client/src/components/manager/subscribe/common.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/common.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 import { type Handlers } from 'loot-core/types/handlers';
 
 import { useNavigate } from '../../../hooks/useNavigate';

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
@@ -3,9 +3,9 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
+import { replaceModal } from 'loot-core/client/actions';
 import { syncAndDownload } from 'loot-core/client/app/appSlice';
-import { replaceModal } from 'loot-core/src/client/actions';
-import * as queries from 'loot-core/src/client/queries';
+import * as queries from 'loot-core/client/queries';
 import { type AccountEntity } from 'loot-core/types/models';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -6,13 +6,13 @@ import { AutoTextSize } from 'auto-text-size';
 import memoizeOne from 'memoize-one';
 
 import { collapseModals, pushModal } from 'loot-core/client/actions';
-import { groupById, integerToCurrency } from 'loot-core/shared/util';
 import {
   envelopeBudget,
   trackingBudget,
   uncategorizedCount,
-} from 'loot-core/src/client/queries';
-import * as monthUtils from 'loot-core/src/shared/months';
+} from 'loot-core/client/queries';
+import * as monthUtils from 'loot-core/shared/months';
+import { groupById, integerToCurrency } from 'loot-core/shared/util';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { useFeatureFlag } from '../../../hooks/useFeatureFlag';

--- a/packages/desktop-client/src/components/mobile/budget/Category.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/Category.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { useSyncedPref } from '../../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -14,9 +14,9 @@ import {
   updateCategory,
   updateGroup,
 } from 'loot-core/client/queries/queriesSlice';
-import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { useLocalPref } from '../../../hooks/useLocalPref';

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -15,7 +15,7 @@ import {
   amountToCurrency,
   appendDecimals,
   currencyToAmount,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 
 import { useMergedRefs } from '../../../hooks/useMergedRefs';
 import { useSyncedPref } from '../../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -10,9 +10,9 @@ import { ListBox, Section, Header, Collection } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 
 import { setNotificationInset } from 'loot-core/client/actions';
+import * as monthUtils from 'loot-core/shared/months';
+import { isPreviewId } from 'loot-core/shared/transactions';
 import { groupById, integerToCurrency } from 'loot-core/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { isPreviewId } from 'loot-core/src/shared/transactions';
 import { type TransactionEntity } from 'loot-core/types/models/transaction';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
@@ -11,8 +11,8 @@ import {
   useLongPress,
 } from '@react-aria/interactions';
 
-import { isPreviewId } from 'loot-core/src/shared/transactions';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { isPreviewId } from 'loot-core/shared/transactions';
+import { integerToCurrency } from 'loot-core/shared/util';
 import { type TransactionEntity } from 'loot-core/types/models';
 
 import { useAccount } from '../../../hooks/useAccount';

--- a/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
@@ -1,7 +1,7 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { theme } from '../../style';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { type CategoryGroupEntity } from 'loot-core/src/types/models';
+import { type CategoryGroupEntity } from 'loot-core/types/models';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useNotes } from '../../hooks/useNotes';

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -2,7 +2,7 @@
 import React, { useRef, useState, type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import { type CategoryEntity } from 'loot-core/types/models';
 
 import { useCategory } from '../../hooks/useCategory';
 import { useCategoryGroup } from '../../hooks/useCategoryGroup';

--- a/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
@@ -5,8 +5,8 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
 import { closeAccount } from 'loot-core/client/queries/queriesSlice';
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { type AccountEntity } from 'loot-core/src/types/models';
+import { integerToCurrency } from 'loot-core/shared/util';
+import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 
 import { useAccounts } from '../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import { type CategoryEntity } from 'loot-core/types/models';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useDispatch } from '../../redux';

--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -3,7 +3,7 @@ import { DialogTrigger } from 'react-aria-components';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useAuth } from '../../auth/AuthProvider';
 import { Permissions } from '../../auth/types';

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -7,8 +7,8 @@ import { css } from '@emotion/css';
 
 import { loadAllFiles, loadGlobalPrefs } from 'loot-core/client/actions';
 import { sync } from 'loot-core/client/app/appSlice';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { getCreateKeyError } from 'loot-core/src/shared/errors';
+import { send } from 'loot-core/platform/client/fetch';
+import { getCreateKeyError } from 'loot-core/shared/errors';
 
 import { useDispatch } from '../../redux';
 import { styles, theme } from '../../style';

--- a/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { closeModal } from 'loot-core/client/actions';
 import { createAccount } from 'loot-core/client/queries/queriesSlice';
-import { toRelaxedNumber } from 'loot-core/src/shared/util';
+import { toRelaxedNumber } from 'loot-core/shared/util';
 
 import * as useAccounts from '../../hooks/useAccounts';
 import { useNavigate } from '../../hooks/useNavigate';

--- a/packages/desktop-client/src/components/modals/EditFieldModal.tsx
+++ b/packages/desktop-client/src/components/modals/EditFieldModal.tsx
@@ -8,8 +8,8 @@ import { useTranslation } from 'react-i18next';
 
 import { parseISO, format as formatDate, parse as parseDate } from 'date-fns';
 
-import { currentDay, dayFromDate } from 'loot-core/src/shared/months';
-import { amountToInteger } from 'loot-core/src/shared/util';
+import { currentDay, dayFromDate } from 'loot-core/shared/months';
+import { amountToInteger } from 'loot-core/shared/util';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
 import { theme } from '../../style';

--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -4,13 +4,13 @@ import { useTranslation, Trans } from 'react-i18next';
 import { css } from '@emotion/css';
 import { v4 as uuid } from 'uuid';
 
+import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { initiallyLoadPayees } from 'loot-core/client/queries/queriesSlice';
+import { runQuery } from 'loot-core/client/query-helpers';
 import { enableUndo, disableUndo } from 'loot-core/client/undo';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
 import {
   mapField,
   friendlyOp,
@@ -22,12 +22,12 @@ import {
   ALLOCATION_METHODS,
   isValidOp,
   getValidOps,
-} from 'loot-core/src/shared/rules';
+} from 'loot-core/shared/rules';
 import {
   integerToCurrency,
   integerToAmount,
   amountToInteger,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
 import { useFeatureFlag } from '../../hooks/useFeatureFlag';

--- a/packages/desktop-client/src/components/modals/EditUser.tsx
+++ b/packages/desktop-client/src/components/modals/EditUser.tsx
@@ -3,10 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { addNotification, popModal, signOut } from 'loot-core/client/actions';
 import { send } from 'loot-core/platform/client/fetch';
-import {
-  PossibleRoles,
-  type UserEntity,
-} from 'loot-core/src/types/models/user';
+import { PossibleRoles, type UserEntity } from 'loot-core/types/models/user';
 
 import { useDispatch } from '../../redux';
 import { styles, theme } from '../../style';

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useNotes } from '../../hooks/useNotes';
 import { useUndo } from '../../hooks/useUndo';

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 
 import { collapseModals, pushModal } from 'loot-core/client/actions';
 import { envelopeBudget } from 'loot-core/client/queries';
+import { format, sheetForMonth, prevMonth } from 'loot-core/shared/months';
 import { groupById, integerToCurrency } from 'loot-core/shared/util';
-import { format, sheetForMonth, prevMonth } from 'loot-core/src/shared/months';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useUndo } from '../../hooks/useUndo';

--- a/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import { Form } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 
-import { type FinanceModals } from 'loot-core/src/client/state-types/modals';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { getTestKeyError } from 'loot-core/src/shared/errors';
+import { type FinanceModals } from 'loot-core/client/state-types/modals';
+import { send } from 'loot-core/platform/client/fetch';
+import { getTestKeyError } from 'loot-core/shared/errors';
 
 import { styles, theme } from '../../style';
 import { Button, ButtonWithLoading } from '../common/Button2';

--- a/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
@@ -2,12 +2,12 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { sendCatch } from 'loot-core/src/platform/client/fetch';
+import { pushModal } from 'loot-core/client/actions/modals';
+import { sendCatch } from 'loot-core/platform/client/fetch';
 import {
   type GoCardlessInstitution,
   type GoCardlessToken,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { useGoCardlessStatus } from '../../hooks/useGoCardlessStatus';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';

--- a/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
@@ -2,8 +2,8 @@
 import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
+import { send } from 'loot-core/platform/client/fetch';
 import { getSecretsError } from 'loot-core/shared/errors';
-import { send } from 'loot-core/src/platform/client/fetch';
 
 import { Error } from '../alerts';
 import { ButtonWithLoading } from '../common/Button2';

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -9,7 +9,7 @@ import {
   importTransactions,
 } from 'loot-core/client/queries/queriesSlice';
 import { send } from 'loot-core/platform/client/fetch';
-import { amountToInteger } from 'loot-core/src/shared/util';
+import { amountToInteger } from 'loot-core/shared/util';
 
 import { useCategories } from '../../../hooks/useCategories';
 import { useDateFormat } from '../../../hooks/useDateFormat';

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/Transaction.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/Transaction.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentProps, useMemo } from 'react';
 
-import { amountToCurrency } from 'loot-core/src/shared/util';
+import { amountToCurrency } from 'loot-core/shared/util';
 import { type CategoryEntity } from 'loot-core/types/models';
 
 import { SvgDownAndRightArrow } from '../../../icons/v2';

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
@@ -1,7 +1,7 @@
 import * as d from 'date-fns';
 
-import { format as formatDate_ } from 'loot-core/src/shared/months';
-import { looselyParseAmount } from 'loot-core/src/shared/util';
+import { format as formatDate_ } from 'loot-core/shared/months';
+import { looselyParseAmount } from 'loot-core/shared/util';
 
 export const dateFormats = [
   { format: 'yyyy mm dd', label: 'YYYY MM DD' },

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -2,7 +2,7 @@ import { type CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import * as Platform from 'loot-core/src/client/platform';
+import * as Platform from 'loot-core/client/platform';
 
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Text } from '../common/Text';

--- a/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
+++ b/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { loadBackup, makeBackup } from 'loot-core/client/actions';
+import { send, listen, unlisten } from 'loot-core/platform/client/fetch';
 import { type Backup } from 'loot-core/server/backups';
-import { send, listen, unlisten } from 'loot-core/src/platform/client/fetch';
 
 import { useMetadataPref } from '../../hooks/useMetadataPref';
 import { useDispatch } from '../../redux';

--- a/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
+++ b/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
+import { isNonProductionEnvironment } from 'loot-core/shared/environment';
 
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { ManageRules } from '../ManageRules';

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { replaceModal } from 'loot-core/src/client/actions/modals';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { replaceModal } from 'loot-core/client/actions/modals';
+import { send } from 'loot-core/platform/client/fetch';
 import { type PayeeEntity } from 'loot-core/types/models';
 
 import { usePayees } from '../../hooks/usePayees';

--- a/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { closeBudget, popModal } from 'loot-core/client/actions';
 import { send } from 'loot-core/platform/client/fetch';
-import * as asyncStorage from 'loot-core/src/platform/server/asyncStorage';
+import * as asyncStorage from 'loot-core/platform/server/asyncStorage';
 
 import { useDispatch } from '../../redux';
 import { theme, styles } from '../../style';

--- a/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
@@ -2,8 +2,8 @@
 import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
+import { send } from 'loot-core/platform/client/fetch';
 import { getSecretsError } from 'loot-core/shared/errors';
-import { send } from 'loot-core/src/platform/client/fetch';
 
 import { Error } from '../alerts';
 import { ButtonWithLoading } from '../common/Button2';

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { useNotes } from '../../hooks/useNotes';
 import { useUndo } from '../../hooks/useUndo';

--- a/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { sheetForMonth } from 'loot-core/src/shared/months';
-import * as monthUtils from 'loot-core/src/shared/months';
+import { sheetForMonth } from 'loot-core/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { styles } from '../../style';
 import { ExpenseTotal } from '../budget/tracking/budgetsummary/ExpenseTotal';

--- a/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { deleteBudget } from 'loot-core/client/actions';
-import { type File } from 'loot-core/src/types/file';
+import { type File } from 'loot-core/types/file';
 
 import { useDispatch } from '../../../redux';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
@@ -7,7 +7,7 @@ import {
   uniqueBudgetName,
   validateBudgetName,
 } from 'loot-core/client/actions';
-import { type File } from 'loot-core/src/types/file';
+import { type File } from 'loot-core/types/file';
 
 import { useDispatch } from '../../../redux';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/modals/manager/ImportActualModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportActualModal.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { importBudget } from 'loot-core/src/client/actions/budgets';
+import { importBudget } from 'loot-core/client/actions/budgets';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useDispatch } from '../../../redux';

--- a/packages/desktop-client/src/components/modals/manager/ImportYNAB4Modal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportYNAB4Modal.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { importBudget } from 'loot-core/src/client/actions/budgets';
+import { importBudget } from 'loot-core/client/actions/budgets';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useDispatch } from '../../../redux';

--- a/packages/desktop-client/src/components/modals/manager/ImportYNAB5Modal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportYNAB5Modal.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { importBudget } from 'loot-core/src/client/actions/budgets';
+import { importBudget } from 'loot-core/client/actions/budgets';
 
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useDispatch } from '../../../redux';

--- a/packages/desktop-client/src/components/payees/ManagePayees.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayees.tsx
@@ -10,8 +10,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import memoizeOne from 'memoize-one';
 
 import { pushModal } from 'loot-core/client/actions';
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
-import { type Diff, groupById } from 'loot-core/src/shared/util';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
+import { type Diff, groupById } from 'loot-core/shared/util';
 import { type PayeeEntity } from 'loot-core/types/models';
 
 import {

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -5,10 +5,10 @@ import {
   getPayees,
   initiallyLoadPayees,
 } from 'loot-core/client/queries/queriesSlice';
+import { send, listen } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
 import { type UndoState } from 'loot-core/server/undo';
-import { send, listen } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
-import { applyChanges, type Diff } from 'loot-core/src/shared/util';
+import { applyChanges, type Diff } from 'loot-core/shared/util';
 import { type NewRuleEntity, type PayeeEntity } from 'loot-core/types/models';
 
 import { usePayees } from '../../hooks/usePayees';

--- a/packages/desktop-client/src/components/payees/PayeeMenu.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeMenu.tsx
@@ -1,6 +1,6 @@
 import { useTranslation, Trans } from 'react-i18next';
 
-import { type PayeeEntity } from 'loot-core/src/types/models';
+import { type PayeeEntity } from 'loot-core/types/models';
 
 import { useSyncedPref } from '../../hooks/useSyncedPref';
 import { SvgDelete, SvgMerge } from '../../icons/v0';

--- a/packages/desktop-client/src/components/payees/PayeeTable.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTable.tsx
@@ -8,7 +8,7 @@ import {
   type ComponentRef,
 } from 'react';
 
-import { type PayeeEntity } from 'loot-core/src/types/models';
+import { type PayeeEntity } from 'loot-core/types/models';
 
 import { useSelectedItems } from '../../hooks/useSelected';
 import { View } from '../common/View';

--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -2,7 +2,7 @@
 import { memo, useRef, type CSSProperties } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { type PayeeEntity } from 'loot-core/src/types/models';
+import { type PayeeEntity } from 'loot-core/types/models';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useSelectedDispatch } from '../../hooks/useSelected';

--- a/packages/desktop-client/src/components/reports/CategorySelector.tsx
+++ b/packages/desktop-client/src/components/reports/CategorySelector.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import {
   type CategoryEntity,
   type CategoryGroupEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import {
   SvgCheckAll,

--- a/packages/desktop-client/src/components/reports/Change.tsx
+++ b/packages/desktop-client/src/components/reports/Change.tsx
@@ -1,6 +1,6 @@
 import React, { type CSSProperties } from 'react';
 
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { integerToCurrency } from 'loot-core/shared/util';
 
 import { styles } from '../../style/styles';
 import { theme } from '../../style/theme';

--- a/packages/desktop-client/src/components/reports/ChooseGraph.tsx
+++ b/packages/desktop-client/src/components/reports/ChooseGraph.tsx
@@ -1,6 +1,6 @@
 import React, { type UIEvent, useRef, type CSSProperties } from 'react';
 
-import { type DataEntity } from 'loot-core/src/types/models/reports';
+import { type DataEntity } from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 
 import { styles } from '../../style/styles';

--- a/packages/desktop-client/src/components/reports/DateRange.tsx
+++ b/packages/desktop-client/src/components/reports/DateRange.tsx
@@ -3,7 +3,7 @@ import { Trans } from 'react-i18next';
 
 import * as d from 'date-fns';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 
 import { theme } from '../../style';
 import { styles } from '../../style/styles';

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -1,7 +1,7 @@
 import { type ComponentProps, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   type RuleConditionEntity,
   type TimeFrame,

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -4,19 +4,16 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import {
-  addNotification,
-  removeNotification,
-} from 'loot-core/src/client/actions';
-import { useDashboard } from 'loot-core/src/client/data-hooks/dashboard';
-import { useReports } from 'loot-core/src/client/data-hooks/reports';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { addNotification, removeNotification } from 'loot-core/client/actions';
+import { useDashboard } from 'loot-core/client/data-hooks/dashboard';
+import { useReports } from 'loot-core/client/data-hooks/reports';
+import { send } from 'loot-core/platform/client/fetch';
 import {
   type CustomReportWidget,
   type ExportImportDashboard,
   type MarkdownWidget,
   type Widget,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { useNavigate } from '../../hooks/useNavigate';

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -1,6 +1,6 @@
 import { t } from 'i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   type CustomReportEntity,
   type AccountEntity,
@@ -8,7 +8,7 @@ import {
   type CategoryGroupEntity,
   type PayeeEntity,
   type sortByOpType,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 const startDate = monthUtils.subMonths(monthUtils.currentMonth(), 5) + '-01';
 const endDate = monthUtils.currentDay();

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type CategoryEntity } from 'loot-core/types/models/category';
 import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';
 import { type TimeFrame } from 'loot-core/types/models/dashboard';

--- a/packages/desktop-client/src/components/reports/ReportSummary.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSummary.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   amountToCurrency,
   integerToCurrency,
   amountToInteger,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { theme, styles } from '../../style';
 import { Text } from '../common/Text';

--- a/packages/desktop-client/src/components/reports/SaveReport.tsx
+++ b/packages/desktop-client/src/components/reports/SaveReport.tsx
@@ -1,8 +1,8 @@
 import React, { createRef, useRef, useState } from 'react';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
-import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
-import { type CustomReportEntity } from 'loot-core/src/types/models';
+import { send, sendCatch } from 'loot-core/platform/client/fetch';
+import { type CustomReportEntity } from 'loot-core/types/models';
 
 import { SvgExpandArrow } from '../../icons/v0';
 import { Button } from '../common/Button2';

--- a/packages/desktop-client/src/components/reports/getLiveRange.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.ts
@@ -1,4 +1,4 @@
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type TimeFrame } from 'loot-core/types/models';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 

--- a/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/AreaGraph.tsx
@@ -16,11 +16,11 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -19,11 +19,11 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
@@ -19,7 +19,7 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 
 import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -3,11 +3,11 @@ import React, { useState, type CSSProperties } from 'react';
 
 import { PieChart, Pie, Cell, Sector, ResponsiveContainer } from 'recharts';
 
-import { amountToCurrency } from 'loot-core/src/shared/util';
+import { amountToCurrency } from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -16,7 +16,7 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,

--- a/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
@@ -16,8 +16,8 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
-import { type SpendingEntity } from 'loot-core/src/types/models/reports';
+} from 'loot-core/shared/util';
+import { type SpendingEntity } from 'loot-core/types/models/reports';
 
 import { usePrivacyMode } from '../../../hooks/usePrivacyMode';
 import { theme } from '../../../style';

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -17,11 +17,11 @@ import {
 import {
   amountToCurrency,
   amountToCurrencyNoDecimal,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.ts
@@ -1,6 +1,6 @@
 import { type NavigateFunction } from 'react-router-dom';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type AccountEntity } from 'loot-core/types/models/account';
 import { type CategoryEntity } from 'loot-core/types/models/category';
 import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/RenderTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/RenderTableRow.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode, type CSSProperties } from 'react';
 
-import { type GroupedEntity } from 'loot-core/src/types/models/reports';
+import { type GroupedEntity } from 'loot-core/types/models/reports';
 
 import { View } from '../../../common/View';
 

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTable.tsx
@@ -10,7 +10,7 @@ import {
   type GroupedEntity,
   type DataEntity,
   type balanceTypeOpType,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 
 import { type CSSProperties } from '../../../../style';

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableHeader.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableHeader.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import {
   type balanceTypeOpType,
   type IntervalEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { theme } from '../../../../style';
 import { View } from '../../../common/View';

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableList.tsx
@@ -3,7 +3,7 @@ import React, { type ReactNode, type CSSProperties } from 'react';
 import {
   type GroupedEntity,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { theme } from '../../../../style';
 import { View } from '../../../common/View';

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -9,7 +9,7 @@ import {
   amountToCurrency,
   amountToInteger,
   integerToCurrency,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type balanceTypeOpType,
   type GroupedEntity,

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableTotals.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next';
 import {
   type GroupedEntity,
   type DataEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { theme } from '../../../../style';
 import { styles } from '../../../../style/styles';

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -1,4 +1,4 @@
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type TimeFrame } from 'loot-core/types/models';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -14,15 +14,15 @@ import { css } from '@emotion/css';
 import { useDrag } from '@use-gesture/react';
 import { format, parseISO } from 'date-fns';
 
+import { addNotification } from 'loot-core/client/actions';
 import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
 import { useTransactions } from 'loot-core/client/data-hooks/transactions';
 import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 import { q, type Query } from 'loot-core/shared/query';
 import { ungroupTransactions } from 'loot-core/shared/transactions';
 import { amountToCurrency } from 'loot-core/shared/util';
-import { addNotification } from 'loot-core/src/client/actions';
-import * as monthUtils from 'loot-core/src/shared/months';
 import {
   type RuleConditionEntity,
   type CalendarWidget,

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -13,8 +13,8 @@ import { Trans, useTranslation } from 'react-i18next';
 import { format } from 'date-fns';
 import { debounce } from 'debounce';
 
+import * as monthUtils from 'loot-core/shared/months';
 import { amountToCurrency } from 'loot-core/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
 import { type CalendarWidget } from 'loot-core/types/models';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -6,9 +6,9 @@ import * as d from 'date-fns';
 
 import { addNotification } from 'loot-core/client/actions';
 import { useWidget } from 'loot-core/client/data-hooks/widget';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency } from 'loot-core/shared/util';
 import {
   type CashFlowWidget,
   type RuleConditionEntity,

--- a/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 
 import { Bar, BarChart, LabelList, ResponsiveContainer } from 'recharts';
 
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { type CashFlowWidget } from 'loot-core/src/types/models';
+import { integerToCurrency } from 'loot-core/shared/util';
+import { type CashFlowWidget } from 'loot-core/types/models';
 
 import { theme } from '../../../style';
 import { View } from '../../common/View';

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -4,11 +4,11 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import * as d from 'date-fns';
 
-import { useReport as useCustomReport } from 'loot-core/src/client/data-hooks/reports';
-import { calculateHasWarning } from 'loot-core/src/client/reports';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { amountToCurrency } from 'loot-core/src/shared/util';
+import { useReport as useCustomReport } from 'loot-core/client/data-hooks/reports';
+import { calculateHasWarning } from 'loot-core/client/reports';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { amountToCurrency } from 'loot-core/shared/util';
 import { type CategoryEntity } from 'loot-core/types/models/category';
 import {
   type balanceTypeOpType,

--- a/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { addNotification } from 'loot-core/client/actions';
+import { calculateHasWarning } from 'loot-core/client/reports';
 import { send, sendCatch } from 'loot-core/platform/client/fetch/index';
-import { addNotification } from 'loot-core/src/client/actions';
-import { calculateHasWarning } from 'loot-core/src/client/reports';
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type CustomReportEntity } from 'loot-core/types/models/reports';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
+++ b/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import { type AccountEntity } from 'loot-core/types/models/account';
 import { type CategoryEntity } from 'loot-core/types/models/category';
 import { type CategoryGroupEntity } from 'loot-core/types/models/category-group';

--- a/packages/desktop-client/src/components/reports/reports/MarkdownCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/MarkdownCard.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { css } from '@emotion/css';
 
-import { type MarkdownWidget } from 'loot-core/src/types/models';
+import { type MarkdownWidget } from 'loot-core/types/models';
 
 import { styles, theme } from '../../../style';
 import { Menu } from '../../common/Menu';

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -4,11 +4,11 @@ import { useParams } from 'react-router-dom';
 
 import * as d from 'date-fns';
 
-import { addNotification } from 'loot-core/src/client/actions';
-import { useWidget } from 'loot-core/src/client/data-hooks/widget';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { addNotification } from 'loot-core/client/actions';
+import { useWidget } from 'loot-core/client/data-hooks/widget';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency } from 'loot-core/shared/util';
 import { type TimeFrame, type NetWorthWidget } from 'loot-core/types/models';
 
 import { useAccounts } from '../../../hooks/useAccounts';

--- a/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { integerToCurrency } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type NetWorthWidget,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { styles } from '../../../style';
 import { Block } from '../../common/Block';

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -6,9 +6,9 @@ import * as d from 'date-fns';
 
 import { addNotification } from 'loot-core/client/actions';
 import { useWidget } from 'loot-core/client/data-hooks/widget';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { amountToCurrency } from 'loot-core/src/shared/util';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { amountToCurrency } from 'loot-core/shared/util';
 import { type SpendingWidget } from 'loot-core/types/models';
 import { type RuleConditionEntity } from 'loot-core/types/models/rule';
 

--- a/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
-import { amountToCurrency } from 'loot-core/src/shared/util';
-import { type SpendingWidget } from 'loot-core/src/types/models';
+import * as monthUtils from 'loot-core/shared/months';
+import { amountToCurrency } from 'loot-core/shared/util';
+import { type SpendingWidget } from 'loot-core/types/models';
 
 import { styles } from '../../../style/styles';
 import { theme } from '../../../style/theme';

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -4,11 +4,11 @@ import { useParams } from 'react-router-dom';
 
 import { parseISO } from 'date-fns';
 
+import { addNotification } from 'loot-core/client/actions';
 import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 import { amountToCurrency } from 'loot-core/shared/util';
-import { addNotification } from 'loot-core/src/client/actions';
-import * as monthUtils from 'loot-core/src/shared/months';
 import {
   type SummaryContent,
   type SummaryWidget,

--- a/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as monthUtils from 'loot-core/src/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   type SummaryContent,
   type SummaryWidget,

--- a/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
@@ -3,7 +3,7 @@ import {
   type IntervalEntity,
   type GroupedEntity,
   type balanceTypeOpType,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { theme } from '../../../style';
 import { getColorScale } from '../chart-theme';

--- a/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calendar-spreadsheet.ts
@@ -1,10 +1,10 @@
 import * as d from 'date-fns';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
 import { type RuleConditionEntity } from 'loot-core/types/models';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import * as d from 'date-fns';
 import { t } from 'i18next';
 
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
-import { integerToCurrency, integerToAmount } from 'loot-core/src/shared/util';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
+import { integerToCurrency, integerToAmount } from 'loot-core/shared/util';
 import { type RuleConditionEntity } from 'loot-core/types/models';
 
 import { AlignedText } from '../../common/AlignedText';

--- a/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
@@ -1,24 +1,24 @@
 import * as d from 'date-fns';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToAmount } from 'loot-core/src/shared/util';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToAmount } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type PayeeEntity,
   type CategoryEntity,
   type RuleConditionEntity,
   type CategoryGroupEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 import {
   type balanceTypeOpType,
   type sortByOpType,
   type DataEntity,
   type GroupedEntity,
   type IntervalEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 
 import {

--- a/packages/desktop-client/src/components/reports/spreadsheets/filterEmptyRows.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/filterEmptyRows.ts
@@ -1,7 +1,7 @@
 import {
   type balanceTypeOpType,
   type GroupedEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 export function filterEmptyRows({
   showEmpty,

--- a/packages/desktop-client/src/components/reports/spreadsheets/grouped-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/grouped-spreadsheet.ts
@@ -1,8 +1,8 @@
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { type GroupedEntity } from 'loot-core/src/types/models/reports';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { type GroupedEntity } from 'loot-core/types/models/reports';
 
 import {
   categoryLists,

--- a/packages/desktop-client/src/components/reports/spreadsheets/makeQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/makeQuery.ts
@@ -1,4 +1,4 @@
-import { q } from 'loot-core/src/shared/query';
+import { q } from 'loot-core/shared/query';
 
 import { ReportOptions } from '../ReportOptions';
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/net-worth-spreadsheet.ts
@@ -1,16 +1,16 @@
 import * as d from 'date-fns';
 import keyBy from 'lodash/keyBy';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
 import {
   integerToCurrency,
   integerToAmount,
   amountToInteger,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type RuleConditionEntity,

--- a/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
@@ -1,5 +1,5 @@
-import * as monthUtils from 'loot-core/src/shared/months';
-import { amountToInteger, integerToAmount } from 'loot-core/src/shared/util';
+import * as monthUtils from 'loot-core/shared/months';
+import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
 import {
   type GroupedEntity,
   type IntervalEntity,

--- a/packages/desktop-client/src/components/reports/spreadsheets/sortData.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sortData.ts
@@ -2,7 +2,7 @@ import {
   type balanceTypeOpType,
   type sortByOpType,
   type GroupedEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 const reverseSort: Partial<Record<sortByOpType, sortByOpType>> = {
   asc: 'desc',

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -1,17 +1,17 @@
 // @ts-strict-ignore
 import keyBy from 'lodash/keyBy';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
-import { integerToAmount } from 'loot-core/src/shared/util';
-import { type RuleConditionEntity } from 'loot-core/src/types/models';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
+import { integerToAmount } from 'loot-core/shared/util';
+import { type RuleConditionEntity } from 'loot-core/types/models';
 import {
   type SpendingMonthEntity,
   type SpendingEntity,
-} from 'loot-core/src/types/models/reports';
+} from 'loot-core/types/models/reports';
 
 import { makeQuery } from './makeQuery';
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -1,10 +1,10 @@
 import * as d from 'date-fns';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { type useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
-import { send } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { type useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
 import {
   type SummaryContent,
   type RuleConditionEntity,

--- a/packages/desktop-client/src/components/reports/useReport.ts
+++ b/packages/desktop-client/src/components/reports/useReport.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
 
 export function useReport<T>(
   sheetName: string,

--- a/packages/desktop-client/src/components/reports/util.ts
+++ b/packages/desktop-client/src/components/reports/util.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import type { Query } from 'loot-core/src/shared/query';
+import { runQuery } from 'loot-core/client/query-helpers';
+import type { Query } from 'loot-core/shared/query';
 
 export function fromDateRepr(date: string): string {
   return date.slice(0, 7);

--- a/packages/desktop-client/src/components/rules/ActionExpression.tsx
+++ b/packages/desktop-client/src/components/rules/ActionExpression.tsx
@@ -5,7 +5,7 @@ import {
   mapField,
   friendlyOp,
   ALLOCATION_METHODS,
-} from 'loot-core/src/shared/rules';
+} from 'loot-core/shared/rules';
 import {
   type SetSplitAmountRuleActionEntity,
   type LinkScheduleRuleActionEntity,
@@ -13,7 +13,7 @@ import {
   type SetRuleActionEntity,
   type AppendNoteRuleActionEntity,
   type PrependNoteRuleActionEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { theme } from '../../style';
 import { Text } from '../common/Text';

--- a/packages/desktop-client/src/components/rules/ConditionExpression.tsx
+++ b/packages/desktop-client/src/components/rules/ConditionExpression.tsx
@@ -1,6 +1,6 @@
 import React, { type CSSProperties } from 'react';
 
-import { mapField, friendlyOp } from 'loot-core/src/shared/rules';
+import { mapField, friendlyOp } from 'loot-core/shared/rules';
 
 import { theme } from '../../style';
 import { Text } from '../common/Text';

--- a/packages/desktop-client/src/components/rules/RuleRow.tsx
+++ b/packages/desktop-client/src/components/rules/RuleRow.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 
 import { v4 as uuid } from 'uuid';
 
-import { friendlyOp } from 'loot-core/src/shared/rules';
-import { type RuleEntity } from 'loot-core/src/types/models';
+import { friendlyOp } from 'loot-core/shared/rules';
+import { type RuleEntity } from 'loot-core/types/models';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useSelectedDispatch } from '../../hooks/useSelected';

--- a/packages/desktop-client/src/components/rules/RulesList.tsx
+++ b/packages/desktop-client/src/components/rules/RulesList.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import React from 'react';
 
-import { type RuleEntity } from 'loot-core/src/types/models';
+import { type RuleEntity } from 'loot-core/types/models';
 
 import { View } from '../common/View';
 

--- a/packages/desktop-client/src/components/rules/ScheduleValue.tsx
+++ b/packages/desktop-client/src/components/rules/ScheduleValue.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo } from 'react';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
+import { getPayeesById } from 'loot-core/client/queries/queriesSlice';
 import { q } from 'loot-core/shared/query';
-import { getPayeesById } from 'loot-core/src/client/queries/queriesSlice';
-import { describeSchedule } from 'loot-core/src/shared/schedules';
-import { type ScheduleEntity } from 'loot-core/src/types/models';
+import { describeSchedule } from 'loot-core/shared/schedules';
+import { type ScheduleEntity } from 'loot-core/types/models';
 
 import { usePayees } from '../../hooks/usePayees';
 import { AnimatedLoading } from '../../icons/AnimatedLoading';

--- a/packages/desktop-client/src/components/rules/Value.tsx
+++ b/packages/desktop-client/src/components/rules/Value.tsx
@@ -4,9 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import { format as formatDate, parseISO } from 'date-fns';
 
-import { getMonthYearFormat } from 'loot-core/src/shared/months';
-import { getRecurringDescription } from 'loot-core/src/shared/schedules';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import { getMonthYearFormat } from 'loot-core/shared/months';
+import { getRecurringDescription } from 'loot-core/shared/schedules';
+import { integerToCurrency } from 'loot-core/shared/util';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { useCategories } from '../../hooks/useCategories';

--- a/packages/desktop-client/src/components/schedules/DiscoverSchedules.tsx
+++ b/packages/desktop-client/src/components/schedules/DiscoverSchedules.tsx
@@ -2,11 +2,11 @@
 import React, { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { q } from 'loot-core/src/shared/query';
-import { getRecurringDescription } from 'loot-core/src/shared/schedules';
-import type { DiscoverScheduleEntity } from 'loot-core/src/types/models';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { send } from 'loot-core/platform/client/fetch';
+import { q } from 'loot-core/shared/query';
+import { getRecurringDescription } from 'loot-core/shared/schedules';
+import type { DiscoverScheduleEntity } from 'loot-core/types/models';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
 import {

--- a/packages/desktop-client/src/components/schedules/PostsOfflineNotification.tsx
+++ b/packages/desktop-client/src/components/schedules/PostsOfflineNotification.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
 import { popModal } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 import { type PayeeEntity } from 'loot-core/types/models';
 
 import { useFormatList } from '../../hooks/useFormatList';

--- a/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
@@ -4,13 +4,13 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { t } from 'i18next';
 
+import { pushModal } from 'loot-core/client/actions/modals';
 import { getPayeesById } from 'loot-core/client/queries/queriesSlice';
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { runQuery, liveQuery } from 'loot-core/src/client/query-helpers';
-import { send, sendCatch } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { q } from 'loot-core/src/shared/query';
-import { extractScheduleConds } from 'loot-core/src/shared/schedules';
+import { runQuery, liveQuery } from 'loot-core/client/query-helpers';
+import { send, sendCatch } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { q } from 'loot-core/shared/query';
+import { extractScheduleConds } from 'loot-core/shared/schedules';
 import {
   type TransactionEntity,
   type ScheduleEntity,

--- a/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
@@ -3,13 +3,13 @@ import React, { useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { q } from 'loot-core/src/shared/query';
+import { useSchedules } from 'loot-core/client/data-hooks/schedules';
+import { send } from 'loot-core/platform/client/fetch';
+import { q } from 'loot-core/shared/query';
 import {
   type ScheduleEntity,
   type TransactionEntity,
-} from 'loot-core/src/types/models';
+} from 'loot-core/types/models';
 
 import { SvgAdd } from '../../icons/v0';
 import { useDispatch } from '../../redux';

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -5,12 +5,12 @@ import { Trans, useTranslation } from 'react-i18next';
 import {
   type ScheduleStatusType,
   type ScheduleStatuses,
-} from 'loot-core/src/client/data-hooks/schedules';
-import { format as monthUtilFormat } from 'loot-core/src/shared/months';
-import { getNormalisedString } from 'loot-core/src/shared/normalisation';
-import { getScheduledAmount } from 'loot-core/src/shared/schedules';
-import { integerToCurrency } from 'loot-core/src/shared/util';
-import { type ScheduleEntity } from 'loot-core/src/types/models';
+} from 'loot-core/client/data-hooks/schedules';
+import { format as monthUtilFormat } from 'loot-core/shared/months';
+import { getNormalisedString } from 'loot-core/shared/normalisation';
+import { getScheduledAmount } from 'loot-core/shared/schedules';
+import { integerToCurrency } from 'loot-core/shared/util';
+import { type ScheduleEntity } from 'loot-core/types/models';
 
 import { useAccounts } from '../../hooks/useAccounts';
 import { useContextMenu } from '../../hooks/useContextMenu';

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { type ScheduleStatusType } from 'loot-core/src/client/data-hooks/schedules';
-import { titleFirst } from 'loot-core/src/shared/util';
+import { type ScheduleStatusType } from 'loot-core/client/data-hooks/schedules';
+import { titleFirst } from 'loot-core/shared/util';
 
 import {
   SvgAlertTriangle,

--- a/packages/desktop-client/src/components/schedules/index.tsx
+++ b/packages/desktop-client/src/components/schedules/index.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
+import { useSchedules } from 'loot-core/client/data-hooks/schedules';
+import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { type ScheduleEntity } from 'loot-core/src/types/models';
+import { type ScheduleEntity } from 'loot-core/types/models';
 
 import { useDispatch } from '../../redux';
 import { theme } from '../../style';

--- a/packages/desktop-client/src/components/select/DateSelect.tsx
+++ b/packages/desktop-client/src/components/select/DateSelect.tsx
@@ -24,7 +24,7 @@ import {
   getShortYearFormat,
   getShortYearRegex,
   currentDate,
-} from 'loot-core/src/shared/months';
+} from 'loot-core/shared/months';
 
 import { useSyncedPref } from '../../hooks/useSyncedPref';
 import { styles, theme, type CSSProperties } from '../../style';

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
@@ -8,9 +8,9 @@ import {
 } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
-import { sendCatch } from 'loot-core/src/platform/client/fetch';
-import * as monthUtils from 'loot-core/src/shared/months';
-import { getRecurringDescription } from 'loot-core/src/shared/schedules';
+import { sendCatch } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+import { getRecurringDescription } from 'loot-core/shared/schedules';
 import { type RecurConfig, type RecurPattern } from 'loot-core/types/models';
 import {
   type TransObjectLiteral,

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useState } from 'react';
 import { Trans } from 'react-i18next';
 
-import type { FeatureFlag } from 'loot-core/src/types/prefs';
+import type { FeatureFlag } from 'loot-core/types/prefs';
 
 import { useFeatureFlag } from '../../hooks/useFeatureFlag';
 import { useSyncedPref } from '../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/settings/Export.tsx
+++ b/packages/desktop-client/src/components/settings/Export.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import { format } from 'date-fns';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useMetadataPref } from '../../hooks/useMetadataPref';
 import { theme } from '../../style';

--- a/packages/desktop-client/src/components/settings/Format.tsx
+++ b/packages/desktop-client/src/components/settings/Format.tsx
@@ -4,8 +4,8 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { css } from '@emotion/css';
 
-import { numberFormats } from 'loot-core/src/shared/util';
-import { type SyncedPrefs } from 'loot-core/src/types/prefs';
+import { numberFormats } from 'loot-core/shared/util';
+import { type SyncedPrefs } from 'loot-core/types/prefs';
 
 import { useDateFormat } from '../../hooks/useDateFormat';
 import { useSyncedPref } from '../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/settings/RepairTransactions.tsx
+++ b/packages/desktop-client/src/components/settings/RepairTransactions.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
-import { send } from 'loot-core/src/platform/client/fetch';
-import { type Handlers } from 'loot-core/src/types/handlers';
+import { send } from 'loot-core/platform/client/fetch';
+import { type Handlers } from 'loot-core/types/handlers';
 
 import { theme } from '../../style';
 import { ButtonWithLoading } from '../common/Button2';

--- a/packages/desktop-client/src/components/settings/Reset.tsx
+++ b/packages/desktop-client/src/components/settings/Reset.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Trans } from 'react-i18next';
 
 import { resetSync } from 'loot-core/client/app/appSlice';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useMetadataPref } from '../../hooks/useMetadataPref';
 import { useDispatch } from '../../redux';

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -4,8 +4,8 @@ import { useTranslation, Trans } from 'react-i18next';
 import { css } from '@emotion/css';
 
 import { closeBudget, loadPrefs } from 'loot-core/client/actions';
+import { listen } from 'loot-core/platform/client/fetch';
 import { isElectron } from 'loot-core/shared/environment';
-import { listen } from 'loot-core/src/platform/client/fetch';
 
 import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useIsOutdated, useLatestVersion } from '../../hooks/useLatestVersion';

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -9,7 +9,7 @@ import {
   reopenAccount,
   updateAccount,
 } from 'loot-core/client/queries/queriesSlice';
-import { type AccountEntity } from 'loot-core/src/types/models';
+import { type AccountEntity } from 'loot-core/types/models';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useNotes } from '../../hooks/useNotes';

--- a/packages/desktop-client/src/components/sidebar/BudgetName.tsx
+++ b/packages/desktop-client/src/components/sidebar/BudgetName.tsx
@@ -1,8 +1,8 @@
 import React, { type ReactNode, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { closeBudget } from 'loot-core/src/client/actions';
-import * as Platform from 'loot-core/src/client/platform';
+import { closeBudget } from 'loot-core/client/actions';
+import * as Platform from 'loot-core/client/platform';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useMetadataPref } from '../../hooks/useMetadataPref';

--- a/packages/desktop-client/src/components/sidebar/Sidebar.tsx
+++ b/packages/desktop-client/src/components/sidebar/Sidebar.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
 
-import { replaceModal } from 'loot-core/src/client/actions';
-import * as Platform from 'loot-core/src/client/platform';
+import { replaceModal } from 'loot-core/client/actions';
+import * as Platform from 'loot-core/client/platform';
 
 import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useLocalPref } from '../../hooks/useLocalPref';

--- a/packages/desktop-client/src/components/spreadsheet/index.ts
+++ b/packages/desktop-client/src/components/spreadsheet/index.ts
@@ -1,4 +1,4 @@
-import { type Query } from 'loot-core/src/shared/query';
+import { type Query } from 'loot-core/shared/query';
 
 export type Spreadsheets = {
   account: {

--- a/packages/desktop-client/src/components/spreadsheet/useFormat.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useFormat.ts
@@ -5,7 +5,7 @@ import {
   integerToCurrency,
   parseNumberFormat,
   setNumberFormat,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 
 import { useSyncedPref } from '../../hooks/useSyncedPref';
 

--- a/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
+++ b/packages/desktop-client/src/components/spreadsheet/useSheetValue.ts
@@ -1,7 +1,7 @@
 import { useState, useRef, useLayoutEffect, useMemo } from 'react';
 
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
 import { type Query } from 'loot-core/shared/query';
-import { useSpreadsheet } from 'loot-core/src/client/SpreadsheetProvider';
 
 import { useSheetName } from './useSheetName';
 

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -3,14 +3,14 @@ import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
+import { useSchedules } from 'loot-core/client/data-hooks/schedules';
+import { validForTransfer } from 'loot-core/client/transfer';
+import { q } from 'loot-core/shared/query';
 import {
   scheduleIsRecurring,
   extractScheduleConds,
 } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { validForTransfer } from 'loot-core/src/client/transfer';
-import { q } from 'loot-core/src/shared/query';
 import { type TransactionEntity } from 'loot-core/types/models';
 
 import { useSelectedItems } from '../../hooks/useSelected';

--- a/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/SimpleTransactionsTable.tsx
@@ -13,8 +13,8 @@ import {
   parseISO,
 } from 'date-fns';
 
-import * as monthUtils from 'loot-core/src/shared/months';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency } from 'loot-core/shared/util';
 import { type TransactionEntity } from 'loot-core/types/models';
 
 import { useAccount } from '../../hooks/useAccount';

--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -1,15 +1,15 @@
 import React, { useRef, useCallback, useLayoutEffect } from 'react';
 
 import { pushModal } from 'loot-core/client/actions';
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 import {
   splitTransaction,
   updateTransaction,
   addSplitTransaction,
   realizeTempTransactions,
   applyTransactionDiff,
-} from 'loot-core/src/shared/transactions';
-import { getChangedValues, applyChanges } from 'loot-core/src/shared/util';
+} from 'loot-core/shared/transactions';
+import { getChangedValues, applyChanges } from 'loot-core/shared/util';
 
 import { useNavigate } from '../../hooks/useNavigate';
 import { useSyncedPref } from '../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
@@ -2,13 +2,13 @@ import React, { useMemo, type ComponentPropsWithoutRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { pushModal } from 'loot-core/client/actions';
+import { useSchedules } from 'loot-core/client/data-hooks/schedules';
+import { q } from 'loot-core/shared/query';
 import {
   scheduleIsRecurring,
   extractScheduleConds,
 } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
-import { useSchedules } from 'loot-core/src/client/data-hooks/schedules';
-import { q } from 'loot-core/src/shared/query';
 import { type TransactionEntity } from 'loot-core/types/models';
 
 import { useDispatch } from '../../redux';

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -21,15 +21,15 @@ import {
 } from 'date-fns';
 
 import { addNotification, pushModal } from 'loot-core/client/actions';
-import { useCachedSchedules } from 'loot-core/src/client/data-hooks/schedules';
+import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
 import {
   getAccountsById,
   getPayeesById,
   getCategoriesById,
-} from 'loot-core/src/client/queries/queriesSlice';
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import { currentDay } from 'loot-core/src/shared/months';
-import * as monthUtils from 'loot-core/src/shared/months';
+} from 'loot-core/client/queries/queriesSlice';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { currentDay } from 'loot-core/shared/months';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   splitTransaction,
   updateTransaction,
@@ -39,12 +39,12 @@ import {
   ungroupTransactions,
   isTemporaryId,
   isPreviewId,
-} from 'loot-core/src/shared/transactions';
+} from 'loot-core/shared/transactions';
 import {
   integerToCurrency,
   amountToInteger,
   titleFirst,
-} from 'loot-core/src/shared/util';
+} from 'loot-core/shared/util';
 
 import { useContextMenu } from '../../hooks/useContextMenu';
 import { useMergedRefs } from '../../hooks/useMergedRefs';

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -5,21 +5,21 @@ import userEvent from '@testing-library/user-event';
 import { format as formatDate, parse as parseDate } from 'date-fns';
 import { v4 as uuidv4 } from 'uuid';
 
-import { SchedulesProvider } from 'loot-core/src/client/data-hooks/schedules';
-import { SpreadsheetProvider } from 'loot-core/src/client/SpreadsheetProvider';
+import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
+import { SpreadsheetProvider } from 'loot-core/client/SpreadsheetProvider';
 import {
   generateTransaction,
   generateAccount,
   generateCategoryGroups,
-} from 'loot-core/src/mocks';
-import { initServer } from 'loot-core/src/platform/client/fetch';
+} from 'loot-core/mocks';
+import { initServer } from 'loot-core/platform/client/fetch';
 import {
   addSplitTransaction,
   realizeTempTransactions,
   splitTransaction,
   updateTransaction,
-} from 'loot-core/src/shared/transactions';
-import { integerToCurrency } from 'loot-core/src/shared/util';
+} from 'loot-core/shared/transactions';
+import { integerToCurrency } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type CategoryEntity,
@@ -36,7 +36,7 @@ import { ResponsiveProvider } from '../responsive/ResponsiveProvider';
 
 import { TransactionTable } from './TransactionsTable';
 
-vi.mock('loot-core/src/platform/client/fetch');
+vi.mock('loot-core/platform/client/fetch');
 vi.mock('../../hooks/useFeatureFlag', () => ({
   default: vi.fn().mockReturnValue(false),
 }));

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -10,8 +10,8 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
-import { amountToInteger, appendDecimals } from 'loot-core/src/shared/util';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { amountToInteger, appendDecimals } from 'loot-core/shared/util';
 
 import { useMergedRefs } from '../../hooks/useMergedRefs';
 import { useSyncedPref } from '../../hooks/useSyncedPref';

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { useReports } from 'loot-core/client/data-hooks/reports';
-import { getMonthYearFormat } from 'loot-core/src/shared/months';
-import { integerToAmount, amountToInteger } from 'loot-core/src/shared/util';
+import { getMonthYearFormat } from 'loot-core/shared/months';
+import { integerToAmount, amountToInteger } from 'loot-core/shared/util';
 
 import { useCategories } from '../../hooks/useCategories';
 import { useDateFormat } from '../../hooks/useDateFormat';

--- a/packages/desktop-client/src/components/util/LoadComponent.tsx
+++ b/packages/desktop-client/src/components/util/LoadComponent.tsx
@@ -2,7 +2,7 @@ import { type ComponentType, useEffect, useState } from 'react';
 
 import promiseRetry from 'promise-retry';
 
-import { LazyLoadFailedError } from 'loot-core/src/shared/errors';
+import { LazyLoadFailedError } from 'loot-core/shared/errors';
 
 import { AnimatedLoading } from '../../icons/AnimatedLoading';
 import { theme, styles } from '../../style';

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -8,7 +8,7 @@ import React, {
   type CSSProperties,
 } from 'react';
 
-import { evalArithmetic } from 'loot-core/src/shared/arithmetic';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
 
 import { useMergedRefs } from '../../hooks/useMergedRefs';
 import { Input } from '../common/Input';

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -14,10 +14,10 @@ import {
   getCategories,
   getPayees,
 } from 'loot-core/client/queries/queriesSlice';
+import * as sharedListeners from 'loot-core/client/shared-listeners';
 import { type AppStore } from 'loot-core/client/store';
-import * as sharedListeners from 'loot-core/src/client/shared-listeners';
-import { listen } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
+import { listen } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
 
 export function handleGlobalEvents(store: AppStore) {
   const unlistenServerError = listen('server-error', () => {

--- a/packages/desktop-client/src/gocardless.ts
+++ b/packages/desktop-client/src/gocardless.ts
@@ -1,7 +1,7 @@
+import { pushModal } from 'loot-core/client/actions/modals';
 import { type AppDispatch } from 'loot-core/client/store';
-import { pushModal } from 'loot-core/src/client/actions/modals';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { type GoCardlessToken } from 'loot-core/src/types/models';
+import { send } from 'loot-core/platform/client/fetch';
+import { type GoCardlessToken } from 'loot-core/types/models';
 
 function _authorize(
   dispatch: AppDispatch,

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -1,4 +1,4 @@
-import type { FeatureFlag } from 'loot-core/src/types/prefs';
+import type { FeatureFlag } from 'loot-core/types/prefs';
 
 import { useSyncedPref } from './useSyncedPref';
 

--- a/packages/desktop-client/src/hooks/useGlobalPref.ts
+++ b/packages/desktop-client/src/hooks/useGlobalPref.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
-import { saveGlobalPrefs } from 'loot-core/src/client/actions';
-import { type GlobalPrefs } from 'loot-core/src/types/prefs';
+import { saveGlobalPrefs } from 'loot-core/client/actions';
+import { type GlobalPrefs } from 'loot-core/types/prefs';
 
 import { useSelector, useDispatch } from '../redux';
 

--- a/packages/desktop-client/src/hooks/useGoCardlessStatus.ts
+++ b/packages/desktop-client/src/hooks/useGoCardlessStatus.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useSyncServerStatus } from './useSyncServerStatus';
 

--- a/packages/desktop-client/src/hooks/useLocalPref.ts
+++ b/packages/desktop-client/src/hooks/useLocalPref.ts
@@ -1,6 +1,6 @@
 import { useLocalStorage } from 'usehooks-ts';
 
-import { type LocalPrefs } from 'loot-core/src/types/prefs';
+import { type LocalPrefs } from 'loot-core/types/prefs';
 
 import { useMetadataPref } from './useMetadataPref';
 

--- a/packages/desktop-client/src/hooks/useSelected.tsx
+++ b/packages/desktop-client/src/hooks/useSelected.tsx
@@ -11,9 +11,9 @@ import React, {
   type ReactNode,
 } from 'react';
 
-import { listen } from 'loot-core/src/platform/client/fetch';
-import * as undo from 'loot-core/src/platform/client/undo';
-import { type UndoState } from 'loot-core/src/server/undo';
+import { listen } from 'loot-core/platform/client/fetch';
+import * as undo from 'loot-core/platform/client/undo';
+import { type UndoState } from 'loot-core/server/undo';
 
 type Range<T> = { start: T; end: T | null };
 type Item = { id: string };

--- a/packages/desktop-client/src/hooks/useSendPlatformRequest.ts
+++ b/packages/desktop-client/src/hooks/useSendPlatformRequest.ts
@@ -1,8 +1,8 @@
 // @ts-strict-ignore
 import { useEffect, useState } from 'react';
 
-import { send } from 'loot-core/src/platform/client/fetch';
-import type { Handlers } from 'loot-core/src/types/handlers';
+import { send } from 'loot-core/platform/client/fetch';
+import type { Handlers } from 'loot-core/types/handlers';
 
 export function useSendPlatformRequest<K extends keyof Handlers>(
   name: K,

--- a/packages/desktop-client/src/hooks/useSimpleFinStatus.ts
+++ b/packages/desktop-client/src/hooks/useSimpleFinStatus.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { send } from 'loot-core/src/platform/client/fetch';
+import { send } from 'loot-core/platform/client/fetch';
 
 import { useSyncServerStatus } from './useSyncServerStatus';
 

--- a/packages/desktop-client/src/hooks/useSyncedPref.ts
+++ b/packages/desktop-client/src/hooks/useSyncedPref.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { saveSyncedPrefs } from 'loot-core/client/actions';
-import { type SyncedPrefs } from 'loot-core/src/types/prefs';
+import { type SyncedPrefs } from 'loot-core/types/prefs';
 
 import { useSelector, useDispatch } from '../redux';
 

--- a/packages/desktop-client/src/hooks/useSyncedPrefs.ts
+++ b/packages/desktop-client/src/hooks/useSyncedPrefs.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { saveSyncedPrefs } from 'loot-core/client/actions';
-import { type SyncedPrefs } from 'loot-core/src/types/prefs';
+import { type SyncedPrefs } from 'loot-core/types/prefs';
 
 import { useSelector, useDispatch } from '../redux';
 

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -1,6 +1,7 @@
 import { pushModal } from 'loot-core/client/actions';
 import { runQuery } from 'loot-core/client/query-helpers';
 import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
 import {
   deleteTransaction,
@@ -10,7 +11,6 @@ import {
   updateTransaction,
 } from 'loot-core/shared/transactions';
 import { applyChanges, type Diff } from 'loot-core/shared/util';
-import * as monthUtils from 'loot-core/src/shared/months';
 import {
   type AccountEntity,
   type ScheduleEntity,

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,15 +13,15 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as accountsSlice from 'loot-core/src/client/accounts/accountsSlice';
-import * as actions from 'loot-core/src/client/actions';
-import * as appSlice from 'loot-core/src/client/app/appSlice';
-import * as queriesSlice from 'loot-core/src/client/queries/queriesSlice';
-import { runQuery } from 'loot-core/src/client/query-helpers';
-import { store } from 'loot-core/src/client/store';
-import { redo, undo } from 'loot-core/src/client/undo';
-import { send } from 'loot-core/src/platform/client/fetch';
-import { q } from 'loot-core/src/shared/query';
+import * as accountsSlice from 'loot-core/client/accounts/accountsSlice';
+import * as actions from 'loot-core/client/actions';
+import * as appSlice from 'loot-core/client/app/appSlice';
+import * as queriesSlice from 'loot-core/client/queries/queriesSlice';
+import { runQuery } from 'loot-core/client/query-helpers';
+import { store } from 'loot-core/client/store';
+import { redo, undo } from 'loot-core/client/undo';
+import { send } from 'loot-core/platform/client/fetch';
+import { q } from 'loot-core/shared/query';
 
 import { AuthProvider } from './auth/AuthProvider';
 import { App } from './components/App';

--- a/packages/desktop-client/src/setupTests.js
+++ b/packages/desktop-client/src/setupTests.js
@@ -1,4 +1,4 @@
-import { resetMockStore } from 'loot-core/src/client/store/mock';
+import { resetMockStore } from 'loot-core/client/store/mock';
 
 import { installPolyfills } from './polyfills';
 

--- a/packages/desktop-client/src/style/styles.ts
+++ b/packages/desktop-client/src/style/styles.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { styles as baseStyles } from '@actual-app/components/styles';
 
-import * as Platform from 'loot-core/src/client/platform';
+import * as Platform from 'loot-core/client/platform';
 
 export { type CSSProperties } from '@actual-app/components/styles';
 

--- a/packages/desktop-client/src/style/theme.tsx
+++ b/packages/desktop-client/src/style/theme.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import { isNonProductionEnvironment } from 'loot-core/src/shared/environment';
-import type { DarkTheme, Theme } from 'loot-core/src/types/prefs';
+import { isNonProductionEnvironment } from 'loot-core/shared/environment';
+import type { DarkTheme, Theme } from 'loot-core/types/prefs';
 
 import { useGlobalPref } from '../hooks/useGlobalPref';
 

--- a/packages/desktop-client/src/util/versions.ts
+++ b/packages/desktop-client/src/util/versions.ts
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import * as Platform from 'loot-core/src/client/platform';
+import * as Platform from 'loot-core/client/platform';
 
 function parseSemanticVersion(versionString): [number, number, number] {
   return versionString

--- a/upcoming-release-notes/4349.md
+++ b/upcoming-release-notes/4349.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Replace `loot-core/src/*` imports with `loot-core/*`


### PR DESCRIPTION
Cleanup: removing `loot-core/src/*` imports in favour of `loot-core/*`.

This standardisation will also help eventually to move to proper monorepo module resolution via yarn instead of mixing yarn & ts for this.