### PR TITLE
:recycle: (api) removing deprecated 'methods' export

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1,8 +1,7 @@
 import type {
   RequestInfo as FetchInfo,
   RequestInit as FetchInit,
-  // @ts-ignore: false-positive commonjs module error on build until typescript 5.3
-} from 'node-fetch'; // with { 'resolution-mode': 'import' };
+} from 'node-fetch';
 
 // loot-core types
 import type { InitConfig } from 'loot-core/server/main';
@@ -15,9 +14,6 @@ import { validateNodeVersion } from './validateNodeVersion';
 
 let actualApp: null | typeof bundle.lib;
 export const internal = bundle.lib;
-
-// DEPRECATED: remove the next line in @actual-app/api v7
-export * as methods from './methods';
 
 export * from './methods';
 export * as utils from './utils';

--- a/upcoming-release-notes/4350.md
+++ b/upcoming-release-notes/4350.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+API: remove deprecated exports of methods.


### PR DESCRIPTION
The export should have been removed a long time ago.. 😅 