### PR TITLE
 :bug: fix category is nothing rule crashing spending report widget

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -44,6 +44,7 @@ export function createSpendingSpreadsheet({
   ) => {
     const { filters } = await send('make-filters-from-conditions', {
       conditions: conditions.filter(cond => !cond.customName),
+      applySpecialCases: false,
     });
 
     const { filters: budgetFilters } = await send(

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -44,7 +44,6 @@ export function createSpendingSpreadsheet({
   ) => {
     const { filters } = await send('make-filters-from-conditions', {
       conditions: conditions.filter(cond => !cond.customName),
-      applySpecialCases: false,
     });
 
     const { filters: budgetFilters } = await send(
@@ -53,6 +52,7 @@ export function createSpendingSpreadsheet({
         conditions: conditions.filter(
           cond => !cond.customName && cond.field === 'category',
         ),
+        applySpecialCases: false,
       },
     );
 

--- a/packages/loot-core/src/server/accounts/transaction-rules.ts
+++ b/packages/loot-core/src/server/accounts/transaction-rules.ts
@@ -337,7 +337,10 @@ function conditionSpecialCases(cond: Condition | null): Condition | null {
 }
 
 // This does the inverse: finds all the transactions matching a rule
-export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
+export function conditionsToAQL(
+  conditions,
+  { recurDateBounds = 100, applySpecialCases = true } = {},
+) {
   const errors = [];
 
   conditions = conditions
@@ -354,7 +357,7 @@ export function conditionsToAQL(conditions, { recurDateBounds = 100 } = {}) {
         return null;
       }
     })
-    .map(conditionSpecialCases)
+    .map(cond => (applySpecialCases ? conditionSpecialCases(cond) : cond))
     .filter(Boolean);
 
   // rule -> actualql

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -515,8 +515,11 @@ handlers['payees-get-rules'] = async function ({ id }) {
   return rules.getRulesForPayee(id).map(rule => rule.serialize());
 };
 
-handlers['make-filters-from-conditions'] = async function ({ conditions }) {
-  return rules.conditionsToAQL(conditions);
+handlers['make-filters-from-conditions'] = async function ({
+  conditions,
+  applySpecialCases,
+}) {
+  return rules.conditionsToAQL(conditions, { applySpecialCases });
 };
 
 handlers['getCell'] = async function ({ sheetName, name }) {

--- a/packages/loot-core/src/types/server-handlers.d.ts
+++ b/packages/loot-core/src/types/server-handlers.d.ts
@@ -127,6 +127,7 @@ export interface ServerHandlers {
 
   'make-filters-from-conditions': (arg: {
     conditions: unknown;
+    applySpecialCases?: boolean;
   }) => Promise<{ filters: unknown[] }>;
 
   getCell: (arg: {

--- a/upcoming-release-notes/4360.md
+++ b/upcoming-release-notes/4360.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix "category is (nothing)" filter crashing the spending analysis report widget.


### PR DESCRIPTION
Closes #4351

Repro:
1. open spending analysis report
2. apply "category is (nothing)" filter
3. the page should NOT show any errors
