### PR TITLE
👷 Typescript: Improving typing of asyncStorage (global-store.json)

### DIFF
--- a/packages/loot-core/src/platform/server/asyncStorage/index.d.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.d.ts
@@ -1,20 +1,34 @@
+import { GlobalPrefs, GlobalPrefsJson } from '../../../types/prefs';
+
 export function init(opts?: { persist?: boolean }): void;
 export type Init = typeof init;
 
-export function getItem(key: string): Promise<string>;
+type InferType<K extends keyof GlobalPrefsJson> = GlobalPrefs[K];
+
+export function getItem<K extends keyof GlobalPrefsJson>(
+  key: K,
+): Promise<GlobalPrefsJson[K]>;
 export type GetItem = typeof getItem;
 
-export function setItem(key: string, value: unknown): void;
+export function setItem<K extends keyof GlobalPrefsJson>(
+  key: K,
+  value: GlobalPrefsJson[K],
+): void;
 export type SetItem = typeof setItem;
 
-export function removeItem(key: string): void;
+export function removeItem(key: keyof GlobalPrefsJson): void;
 export type RemoveItem = typeof removeItem;
 
-export function multiGet(keys: string[]): Promise<[string, string][]>;
+export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
+  keys: K,
+): Promise<{ [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]] }>;
 export type MultiGet = typeof multiGet;
 
-export function multiSet(keyValues: [string, unknown][]): void;
+export function multiSet<K extends keyof GlobalPrefsJson>(
+  keyValues: Array<[K, GlobalPrefsJson[K]]>,
+): void;
+
 export type MultiSet = typeof multiSet;
 
-export function multiRemove(keys: string[]): void;
+export function multiRemove(keys: (keyof GlobalPrefsJson)[]): void;
 export type MultiRemove = typeof multiRemove;

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import * as fs from 'fs';
 import { join } from 'path';
 

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -1,13 +1,13 @@
-// @ts-strict-ignore
 import * as fs from 'fs';
 import { join } from 'path';
 
+import { GlobalPrefsJson } from '../../../types/prefs';
 import * as lootFs from '../fs';
 
 import * as T from '.';
 
 const getStorePath = () => join(lootFs.getDataDir(), 'global-store.json');
-let store;
+let store: GlobalPrefsJson;
 let persisted = true;
 
 export const init: T.Init = function ({ persist = true } = {}) {
@@ -55,15 +55,17 @@ export const removeItem: T.RemoveItem = function (key) {
   return _saveStore();
 };
 
-export const multiGet: T.MultiGet = function (keys) {
+export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
+  keys: K,
+) {
   return new Promise(function (resolve) {
     return resolve(
       keys.map(function (key) {
         return [key, store[key]];
-      }),
+      }) as { [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]] },
     );
   });
-};
+}
 
 export const multiSet: T.MultiSet = function (keyValues) {
   keyValues.forEach(function ([key, value]) {

--- a/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { GlobalPrefsJson } from '../../../types/prefs';
 
 import * as T from '.';

--- a/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
@@ -1,7 +1,8 @@
-// @ts-strict-ignore
+import { GlobalPrefsJson } from '../../../types/prefs';
+
 import * as T from '.';
 
-const store = {};
+const store: Partial<GlobalPrefsJson> = {};
 
 export const init: T.Init = function () {};
 
@@ -19,15 +20,17 @@ export const removeItem: T.RemoveItem = function (key) {
   delete store[key];
 };
 
-export const multiGet: T.MultiGet = function (keys) {
+export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
+  keys: K,
+) {
   return new Promise(function (resolve) {
     return resolve(
       keys.map(function (key) {
         return [key, store[key]];
-      }),
+      }) as { [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]] },
     );
   });
-};
+}
 
 export const multiSet: T.MultiSet = function (keyValues) {
   keyValues.forEach(function ([key, value]) {

--- a/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.testing.ts
@@ -3,7 +3,7 @@ import { GlobalPrefsJson } from '../../../types/prefs';
 
 import * as T from '.';
 
-const store: Partial<GlobalPrefsJson> = {};
+const store: GlobalPrefsJson = {};
 
 export const init: T.Init = function () {};
 

--- a/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
@@ -1,4 +1,4 @@
-// @ts-strict-ignore
+import { GlobalPrefsJson } from '../../../types/prefs';
 import { getDatabase } from '../indexeddb';
 
 import * as T from '.';
@@ -53,7 +53,9 @@ export const removeItem: T.RemoveItem = async function (key) {
   });
 };
 
-export const multiGet: T.MultiGet = async function (keys) {
+export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
+  keys: K,
+) {
   const db = await getDatabase();
 
   const transaction = db.transaction(['asyncStorage'], 'readonly');
@@ -71,7 +73,7 @@ export const multiGet: T.MultiGet = async function (keys) {
 
   commit(transaction);
   return promise;
-};
+}
 
 export const multiSet: T.MultiSet = async function (keyValues) {
   const db = await getDatabase();

--- a/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.web.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import { GlobalPrefsJson } from '../../../types/prefs';
 import { getDatabase } from '../indexeddb';
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -1096,7 +1096,7 @@ handlers['accounts-bank-sync'] = async function ({ ids = [] }) {
   const [[, userId], [, userKey]] = await asyncStorage.multiGet([
     'user-id',
     'user-key',
-  ]);
+  ] as const);
 
   const accounts = await db.runQuery(
     `
@@ -1390,7 +1390,7 @@ handlers['load-global-prefs'] = async function () {
     'theme',
     'preferred-dark-theme',
     'server-self-signed-cert',
-  ]);
+  ] as const);
   return {
     floatingSidebar: floatingSidebar === 'true' ? true : false,
     maxMonths: stringToInteger(maxMonths || ''),

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -104,7 +104,6 @@ export type GlobalPrefsJson = Partial<{
   theme?: GlobalPrefs['theme'];
   'preferred-dark-theme'?: GlobalPrefs['preferredDarkTheme'];
   'server-self-signed-cert'?: GlobalPrefs['serverSelfSignedCert'];
-  ngrokConfig?: GlobalPrefs['ngrokConfig'];
 }>;
 
 export type AuthMethods = 'password' | 'openid';

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -73,6 +73,8 @@ export type LocalPrefs = Partial<{
 
 export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | 'development';
 export type DarkTheme = 'dark' | 'midnight';
+
+// GlobalPrefs are the parsed global-store.json values
 export type GlobalPrefs = Partial<{
   floatingSidebar: boolean;
   maxMonths: number;
@@ -82,6 +84,27 @@ export type GlobalPrefs = Partial<{
   preferredDarkTheme: DarkTheme;
   documentDir: string; // Electron only
   serverSelfSignedCert: string; // Electron only
+}>;
+
+// GlobalPrefsJson represents what's saved in the global-store.json file
+export type GlobalPrefsJson = Partial<{
+  'user-id'?: string;
+  'user-key'?: string;
+  'encrypt-keys'?: string;
+  lastBudget?: string;
+  readOnly?: string;
+  'server-url'?: string;
+  'did-bootstrap'?: boolean;
+  'user-token'?: string;
+  'floating-sidebar'?: string; // "true" or "false"
+  'max-months'?: string; // e.g. "2" or "3"
+  'document-dir'?: GlobalPrefs['documentDir'];
+  'encrypt-key'?: string;
+  language?: GlobalPrefs['language'];
+  theme?: GlobalPrefs['theme'];
+  'preferred-dark-theme'?: GlobalPrefs['preferredDarkTheme'];
+  'server-self-signed-cert'?: GlobalPrefs['serverSelfSignedCert'];
+  ngrokConfig?: GlobalPrefs['ngrokConfig'];
 }>;
 
 export type AuthMethods = 'password' | 'openid';

--- a/upcoming-release-notes/4369.md
+++ b/upcoming-release-notes/4369.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Adding typescript type for the global-store.json setting file


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

### Problem:

Every setting from global-store.json was being treated like a string and then parsed. There are values in the global-store.json that aren't strings. E.g. ```did-bootstrap```

I've added a new type to represent the global-store.json file as it currently stands. The existing GlobalStore represents the values after they have been parsed. 

This makes it a lot easier to add more complex types/types that aren't just strings. It also gives us intellisense/type safety on the prefs functions (e.g. multiGet). 

This should help me out in https://github.com/actualbudget/actual/pull/4357 where I want to add a global-store setting like:
``` 
syncServerSettings: {
   port: 5007,
   autoStart: true,
   ngrok: {
      token: 'thetoken',
      domain: 'thengrokdomain.com'
   }
}
```

![test](https://github.com/user-attachments/assets/e598e60b-94b4-4176-9352-453403b0c770)


#1483
