### PR TITLE
Add progress bars for categories and goals

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -89,6 +89,9 @@ export function BudgetTable(props: BudgetTableProps) {
   );
   const [categoryExpandedStatePref] = useGlobalPref('categoryExpandedState');
   const categoryExpandedState = categoryExpandedStatePref ?? 0;
+  const [showProgressBars, setShowProgressBars] = useLocalPref(
+    'budget.showProgressBars',
+  );
   const [editing, setEditing] = useState<{ id: string; cell: string } | null>(
     null,
   );
@@ -227,6 +230,10 @@ export function BudgetTable(props: BudgetTableProps) {
     onCollapse(categoryGroups.map(g => g.id));
   };
 
+  const toggleProgressBars = () => {
+    setShowProgressBars(!showProgressBars);
+  };
+
   return (
     <View
       data-testid="budget-table"
@@ -275,6 +282,7 @@ export function BudgetTable(props: BudgetTableProps) {
           toggleHiddenCategories={toggleHiddenCategories}
           expandAllCategories={expandAllCategories}
           collapseAllCategories={collapseAllCategories}
+          toggleProgressBars={toggleProgressBars}
         />
         <View
           style={{

--- a/packages/desktop-client/src/components/budget/BudgetTotals.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.tsx
@@ -24,6 +24,7 @@ type BudgetTotalsProps = {
   toggleHiddenCategories: () => void;
   expandAllCategories: () => void;
   collapseAllCategories: () => void;
+  toggleProgressBars: () => void;
 };
 
 export const BudgetTotals = memo(function BudgetTotals({
@@ -31,6 +32,7 @@ export const BudgetTotals = memo(function BudgetTotals({
   toggleHiddenCategories,
   expandAllCategories,
   collapseAllCategories,
+  toggleProgressBars,
 }: BudgetTotalsProps) {
   const { t } = useTranslation();
   const [categoryExpandedStatePref, setCategoryExpandedStatePref] =
@@ -153,6 +155,8 @@ export const BudgetTotals = memo(function BudgetTotals({
             onMenuSelect={type => {
               if (type === 'toggle-visibility') {
                 toggleHiddenCategories();
+              } else if (type === 'toggle-progress-bars') {
+                toggleProgressBars();
               } else if (type === 'expandAllCategories') {
                 expandAllCategories();
               } else if (type === 'collapseAllCategories') {
@@ -164,6 +168,10 @@ export const BudgetTotals = memo(function BudgetTotals({
               {
                 name: 'toggle-visibility',
                 text: t('Toggle hidden categories'),
+              },
+              {
+                name: 'toggle-progress-bars',
+                text: t('Toggle progress bars'),
               },
               {
                 name: 'expandAllCategories',

--- a/packages/desktop-client/src/components/budget/ProgressBar.tsx
+++ b/packages/desktop-client/src/components/budget/ProgressBar.tsx
@@ -7,7 +7,7 @@ import { View } from '@actual-app/components/view';
 import { envelopeBudget } from 'loot-core/client/queries';
 import * as monthUtils from 'loot-core/shared/months';
 import { integerToCurrency } from 'loot-core/shared/util';
-import { type CategoryEntity } from 'loot-core/src/types/models';
+import { type CategoryEntity } from 'loot-core/types/models';
 
 import { useSheetValue } from '../spreadsheet/useSheetValue';
 
@@ -78,10 +78,10 @@ function getColorBars(
     leftBar.category = 'Saved';
     rightBar.category = 'Remaining';
   } else if (balance < 0) {
-    // We spent more than or equal to the pre-spending category balance. 
+    // We spent more than or equal to the pre-spending category balance.
     // Overspending will be relative to the prior balance plus budgeted amount
     const available = balance - spent;
-    const total = -spent; // Spending becomes the divisor instead of pre-spending balance 
+    const total = -spent; // Spending becomes the divisor instead of pre-spending balance
     leftBar.width = bound(Math.round((available / total) * 100), 0, 100);
     rightBar.width = 100 - leftBar.width;
 
@@ -119,9 +119,14 @@ function bound(val: number, min: number, max: number): number {
 type ProgressBarProps = {
   month: string;
   category: CategoryEntity;
+  isMobile?: boolean;
 };
 
-export function ProgressBar({ month, category }: ProgressBarProps) {
+export function ProgressBar({
+  month,
+  category,
+  isMobile = false,
+}: ProgressBarProps) {
   const { t } = useTranslation();
   const [leftBar, setLeftBar] = useState<ColorBar>(new ColorBar());
   const [rightBar, setRightBar] = useState<ColorBar>(new ColorBar());
@@ -181,14 +186,22 @@ export function ProgressBar({ month, category }: ProgressBarProps) {
   const PARTIAL_OPACITY = '0.4';
   const FULL_OPACITY = '1';
 
+  // Default styling
   let barOpacity = PARTIAL_OPACITY; // By default, all categories in all months with some activity are partly visible
   if (isCurrentMonth) {
     barOpacity = FULL_OPACITY; // By default, categories in the current month are fully visible
   }
+
+  // Styling during a hover event
   if (isCurrentMonth && hoveredMonth && hoveredMonth !== month) {
     barOpacity = PARTIAL_OPACITY; // If a non-current month is hovered over, lower visibility for the current month
   } else if (hoveredMonth === month) {
     barOpacity = FULL_OPACITY; // If a non-current month is hovered over, raise that month to fully visible
+  }
+
+  // Always fully visible on mobile
+  if (isMobile) {
+    barOpacity = FULL_OPACITY;
   }
 
   return (
@@ -198,7 +211,7 @@ export function ProgressBar({ month, category }: ProgressBarProps) {
         position: 'absolute',
         right: 0,
         bottom: 0,
-        marginBottom: 1,
+        marginBottom: isMobile ? -12 : 0,
         width: '100%',
         opacity: barOpacity,
         transition: 'opacity 0.25s',

--- a/packages/desktop-client/src/components/budget/ProgressBar.tsx
+++ b/packages/desktop-client/src/components/budget/ProgressBar.tsx
@@ -77,35 +77,36 @@ function getColorBars(
 
     leftBar.category = 'Saved';
     rightBar.category = 'Remaining';
-  } else if (spent * -1 >= budgeted) {
-    // We overspent (or are exactly at budget)
-    const overage = budgeted + spent;
-    const total = budgeted + Math.abs(overage);
-    leftBar.width = bound(Math.round((budgeted / total) * 100), 0, 100);
+  } else if (balance < 0) {
+    // We spent more than or equal to the pre-spending category balance. 
+    // Overspending will be relative to the prior balance plus budgeted amount
+    const available = balance - spent;
+    const total = -spent; // Spending becomes the divisor instead of pre-spending balance 
+    leftBar.width = bound(Math.round((available / total) * 100), 0, 100);
     rightBar.width = 100 - leftBar.width;
 
     leftBar.color = ColorDefOverBudgetSpent;
     rightBar.color = ColorDefOverBudgetOverSpent;
 
-    leftBar.rawValue = integerToCurrency(budgeted);
-    rightBar.rawValue = integerToCurrency(overage);
+    leftBar.rawValue = integerToCurrency(available);
+    rightBar.rawValue = integerToCurrency(balance);
 
-    leftBar.category = 'Budgeted';
+    leftBar.category = 'Available';
     rightBar.category = 'Overspent';
   } else {
-    // We are under budget
-    const remaining = budgeted + spent;
-    leftBar.width = bound(Math.round((remaining / budgeted) * 100), 0, 100);
-    rightBar.width = 100 - leftBar.width;
+    // We are under budget.
+    const total = balance - spent;
+    rightBar.width = bound(Math.round((balance / total) * 100), 0, 100);
+    leftBar.width = 100 - rightBar.width;
 
-    leftBar.color = ColorDefUnderBudgetRemaining;
-    rightBar.color = ColorDefUnderBudgetSpent;
+    rightBar.color = ColorDefUnderBudgetRemaining;
+    leftBar.color = ColorDefUnderBudgetSpent;
 
-    leftBar.rawValue = integerToCurrency(remaining);
-    rightBar.rawValue = integerToCurrency(spent);
+    rightBar.rawValue = integerToCurrency(balance);
+    leftBar.rawValue = integerToCurrency(spent);
 
-    leftBar.category = 'Remaining';
-    rightBar.category = 'Spent';
+    rightBar.category = 'Remaining';
+    leftBar.category = 'Spent';
   }
 
   return [leftBar, rightBar];

--- a/packages/desktop-client/src/components/budget/ProgressBar.tsx
+++ b/packages/desktop-client/src/components/budget/ProgressBar.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+import { envelopeBudget } from 'loot-core/client/queries';
+import * as monthUtils from 'loot-core/shared/months';
+import { integerToCurrency } from 'loot-core/shared/util';
+import { type CategoryEntity } from 'loot-core/src/types/models';
+
+import { useSheetValue } from '../spreadsheet/useSheetValue';
+
+import { useEnvelopeBudget } from './envelope/EnvelopeBudgetContext';
+
+const ColorDefUnderBudgetRemaining = theme.reportsGreen;
+const ColorDefUnderBudgetSpent = theme.reportsGray;
+const ColorDefOverBudgetSpent = theme.reportsGray;
+const ColorDefOverBudgetOverSpent = theme.reportsRed;
+const ColorDefGoalRemaining = theme.reportsLabel;
+const ColorDefGoalSaved = theme.reportsBlue;
+const ColorDefEmpty = ''; // No color for default
+
+class ColorBar {
+  color: string;
+  width: number;
+  category: string;
+  rawValue: string;
+
+  constructor(
+    color: string = ColorDefEmpty,
+    width: number = 50,
+    category: string = '',
+    rawValue: string = '',
+  ) {
+    this.color = color;
+    this.width = width;
+    this.category = category;
+    this.rawValue = rawValue;
+  }
+}
+
+/** Generate what the color status bar should look like based on our numbers and the category type */
+function getColorBars(
+  budgeted: number,
+  spent: number,
+  balance: number,
+  goal: number,
+  isLongGoal: boolean,
+) {
+  const leftBar = new ColorBar();
+  const rightBar = new ColorBar();
+
+  if (budgeted === 0) {
+    // If we have nothing budgeted, don't show a bar for this
+  } else if (isLongGoal) {
+    // We have a long-term #goal set. These take visual precedence over a monthly template goal, even if both exist
+    const toGoal = goal - balance;
+
+    if (toGoal <= 0) {
+      // If over the goal, consider it complete
+      leftBar.width = 100;
+    } else if (balance < 0) {
+      // If balance is < 0, show no progress
+      leftBar.width = 0;
+    } else {
+      // Otherwise, standard ratio with a positive balance and a positive amount to reach the goal
+      leftBar.width = bound(Math.round((balance / goal) * 100), 0, 100);
+    }
+    rightBar.width = 100 - leftBar.width;
+
+    leftBar.color = ColorDefGoalSaved;
+    rightBar.color = ColorDefGoalRemaining;
+
+    leftBar.rawValue = integerToCurrency(balance);
+    rightBar.rawValue = integerToCurrency(toGoal);
+
+    leftBar.category = 'Saved';
+    rightBar.category = 'Remaining';
+  } else if (spent * -1 >= budgeted) {
+    // We overspent (or are exactly at budget)
+    const overage = budgeted + spent;
+    const total = budgeted + Math.abs(overage);
+    leftBar.width = bound(Math.round((budgeted / total) * 100), 0, 100);
+    rightBar.width = 100 - leftBar.width;
+
+    leftBar.color = ColorDefOverBudgetSpent;
+    rightBar.color = ColorDefOverBudgetOverSpent;
+
+    leftBar.rawValue = integerToCurrency(budgeted);
+    rightBar.rawValue = integerToCurrency(overage);
+
+    leftBar.category = 'Budgeted';
+    rightBar.category = 'Overspent';
+  } else {
+    // We are under budget
+    const remaining = budgeted + spent;
+    leftBar.width = bound(Math.round((remaining / budgeted) * 100), 0, 100);
+    rightBar.width = 100 - leftBar.width;
+
+    leftBar.color = ColorDefUnderBudgetRemaining;
+    rightBar.color = ColorDefUnderBudgetSpent;
+
+    leftBar.rawValue = integerToCurrency(remaining);
+    rightBar.rawValue = integerToCurrency(spent);
+
+    leftBar.category = 'Remaining';
+    rightBar.category = 'Spent';
+  }
+
+  return [leftBar, rightBar];
+}
+
+function bound(val: number, min: number, max: number): number {
+  return Math.max(min, Math.min(val, max));
+}
+
+type ProgressBarProps = {
+  month: string;
+  category: CategoryEntity;
+};
+
+export function ProgressBar({ month, category }: ProgressBarProps) {
+  const { t } = useTranslation();
+  const [leftBar, setLeftBar] = useState<ColorBar>(new ColorBar());
+  const [rightBar, setRightBar] = useState<ColorBar>(new ColorBar());
+  const { hoveredMonth } = useEnvelopeBudget();
+  const isCurrentMonth = monthUtils.isCurrentMonth(month);
+
+  // The budgeted amount for this month
+  const budgeted = Number(
+    useSheetValue<'envelope-budget', 'budget'>(
+      envelopeBudget.catBudgeted(category.id),
+    ),
+  );
+  // The amount spent this month
+  const spent = Number(
+    useSheetValue<'envelope-budget', 'sum-amount'>(
+      envelopeBudget.catSumAmount(category.id),
+    ),
+  );
+  /* Goal is either the template value or the goal value, so use it in conjunction with long-goal. */
+  const goal = Number(
+    useSheetValue<'envelope-budget', 'goal'>(
+      envelopeBudget.catGoal(category.id),
+    ),
+  );
+  // If a #goal for the category exists.
+  const longGoal = Number(
+    useSheetValue<'envelope-budget', 'long-goal'>(
+      envelopeBudget.catLongGoal(category.id),
+    ),
+  );
+  const isLongGoal = Boolean(longGoal && longGoal > 0);
+  // The current category balance based on the budgeted, spent, and previous balance amounts
+  const balance = Number(
+    useSheetValue<'envelope-budget', 'leftover'>(
+      envelopeBudget.catBalance(category.id),
+    ),
+  );
+
+  useEffect(() => {
+    // Don't show visuals for income categories
+    if (category.is_income) {
+      return;
+    }
+    const [freshLeftBar, freshRightBar] = getColorBars(
+      budgeted,
+      spent,
+      balance,
+      goal,
+      isLongGoal,
+    );
+    setLeftBar(freshLeftBar);
+    setRightBar(freshRightBar);
+  }, [category, budgeted, spent, balance, goal, isLongGoal]);
+
+  const BAR_HEIGHT = 3;
+  const BORDER_RADIUS = 30;
+  const PARTIAL_OPACITY = '0.4';
+  const FULL_OPACITY = '1';
+
+  let barOpacity = PARTIAL_OPACITY; // By default, all categories in all months with some activity are partly visible
+  if (isCurrentMonth) {
+    barOpacity = FULL_OPACITY; // By default, categories in the current month are fully visible
+  }
+  if (isCurrentMonth && hoveredMonth && hoveredMonth !== month) {
+    barOpacity = PARTIAL_OPACITY; // If a non-current month is hovered over, lower visibility for the current month
+  } else if (hoveredMonth === month) {
+    barOpacity = FULL_OPACITY; // If a non-current month is hovered over, raise that month to fully visible
+  }
+
+  return (
+    <View
+      style={{
+        display: 'flex',
+        position: 'absolute',
+        right: 0,
+        bottom: 0,
+        marginBottom: 1,
+        width: '100%',
+        opacity: barOpacity,
+        transition: 'opacity 0.25s',
+      }}
+    >
+      {/* Left side of the bar */}
+      <View
+        style={{
+          height: BAR_HEIGHT,
+          backgroundColor: leftBar.color,
+          width: `${leftBar.width}%`,
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          borderTopLeftRadius: BORDER_RADIUS,
+          borderBottomLeftRadius: BORDER_RADIUS,
+          transition: 'width 0.5s ease-in-out',
+        }}
+        title={`${t(leftBar.category)}: ${leftBar.rawValue}`}
+      />
+      {/* Right side of the bar */}
+      <View
+        style={{
+          height: BAR_HEIGHT,
+          backgroundColor: rightBar.color,
+          width: `${rightBar.width}%`,
+          position: 'absolute',
+          bottom: 0,
+          right: 0,
+          borderTopRightRadius: BORDER_RADIUS,
+          borderBottomRightRadius: BORDER_RADIUS,
+          transition: 'width 0.5s ease-in-out',
+        }}
+        title={`${t(rightBar.category)}: ${rightBar.rawValue}`}
+      />
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -396,7 +396,6 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
             });
           }}
         />
-        {useProgressBars && <ProgressBar month={month} category={category} />}
       </View>
       <Field name="spent" width="flex" style={{ textAlign: 'right' }}>
         <span
@@ -466,6 +465,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
             onClose={() => setBalanceMenuOpen(false)}
           />
         </Popover>
+        {useProgressBars && <ProgressBar month={month} category={category} />}
       </Field>
     </View>
   );

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -24,16 +24,19 @@ import {
   type CategoryEntity,
 } from 'loot-core/types/models';
 
+import { useLocalPref } from '../../../hooks/useLocalPref';
 import { type Binding, type SheetFields } from '../../spreadsheet';
 import { CellValue, CellValueText } from '../../spreadsheet/CellValue';
 import { useSheetName } from '../../spreadsheet/useSheetName';
 import { useSheetValue } from '../../spreadsheet/useSheetValue';
 import { Row, Field, SheetCell, type SheetCellProps } from '../../table';
 import { BalanceWithCarryover } from '../BalanceWithCarryover';
+import { ProgressBar } from '../ProgressBar';
 import { makeAmountGrey } from '../util';
 
 import { BalanceMovementMenu } from './BalanceMovementMenu';
 import { BudgetMenu } from './BudgetMenu';
+import { useEnvelopeBudget } from './EnvelopeBudgetContext';
 
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
 import { useUndo } from '@desktop-client/hooks/useUndo';
@@ -143,6 +146,7 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
   group,
 }: ExpenseGroupMonthProps) {
   const { id } = group;
+  const { setHoveredMonth } = useEnvelopeBudget();
 
   return (
     <View
@@ -153,6 +157,8 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
           ? theme.budgetHeaderCurrentMonth
           : theme.budgetHeaderOtherMonth,
       }}
+      onMouseOver={() => setHoveredMonth(month)}
+      onMouseOut={() => setHoveredMonth('')}
     >
       <EnvelopeSheetCell
         name="budgeted"
@@ -233,6 +239,8 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
   };
 
   const { showUndoNotification } = useUndo();
+  const [useProgressBars] = useLocalPref('budget.showProgressBars');
+  const { setHoveredMonth } = useEnvelopeBudget();
 
   return (
     <View
@@ -250,6 +258,8 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
           opacity: 1,
         },
       }}
+      onMouseOver={() => setHoveredMonth(month)}
+      onMouseOut={() => setHoveredMonth('')}
     >
       <View
         ref={budgetMenuTriggerRef}
@@ -386,6 +396,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
             });
           }}
         />
+        {useProgressBars && <ProgressBar month={month} category={category} />}
       </View>
       <Field name="spent" width="flex" style={{ textAlign: 'right' }}>
         <span

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetContext.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetContext.tsx
@@ -7,6 +7,8 @@ type EnvelopeBudgetContextDefinition = {
   onBudgetAction: (month: string, action: string, arg?: unknown) => void;
   onToggleSummaryCollapse: () => void;
   currentMonth: string;
+  setHoveredMonth: (month: string) => void;
+  hoveredMonth: string;
 };
 
 const EnvelopeBudgetContext = createContext<EnvelopeBudgetContextDefinition>({
@@ -20,6 +22,10 @@ const EnvelopeBudgetContext = createContext<EnvelopeBudgetContextDefinition>({
     );
   },
   currentMonth: 'unknown',
+  hoveredMonth: 'unknown',
+  setHoveredMonth: () => {
+    throw new Error('Unitialised context method called: setHoveredMonth');
+  },
 });
 
 type EnvelopeBudgetProviderProps = Omit<
@@ -33,6 +39,8 @@ export function EnvelopeBudgetProvider({
   onBudgetAction,
   onToggleSummaryCollapse,
   children,
+  hoveredMonth,
+  setHoveredMonth,
 }: EnvelopeBudgetProviderProps) {
   const currentMonth = monthUtils.currentMonth();
 
@@ -43,6 +51,8 @@ export function EnvelopeBudgetProvider({
         summaryCollapsed,
         onBudgetAction,
         onToggleSummaryCollapse,
+        hoveredMonth,
+        setHoveredMonth,
       }}
     >
       {children}

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -85,6 +85,7 @@ function BudgetInner(props: BudgetInnerProps) {
   const maxMonths = maxMonthsPref || 1;
   const [initialized, setInitialized] = useState(false);
   const { grouped: categoryGroups } = useCategories();
+  const [hoveredMonth, setHoveredMonth] = useState<string>();
 
   useEffect(() => {
     async function run() {
@@ -365,6 +366,8 @@ function BudgetInner(props: BudgetInnerProps) {
         summaryCollapsed={summaryCollapsed}
         onBudgetAction={onBudgetAction}
         onToggleSummaryCollapse={onToggleCollapse}
+        setHoveredMonth={setHoveredMonth}
+        hoveredMonth={hoveredMonth}
       >
         <DynamicBudgetTable
           type={budgetType}

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
@@ -35,6 +35,9 @@ import { useSheetValue } from '../../spreadsheet/useSheetValue';
 import { BudgetCell } from './BudgetCell';
 import { getColumnWidth, PILL_STYLE, ROW_HEIGHT } from './BudgetTable';
 
+import { ProgressBar } from '@desktop-client/components/budget/ProgressBar';
+import { useLocalPref } from '@desktop-client/hooks/useLocalPref';
+
 type ExpenseCategoryNameProps = {
   category: CategoryEntity;
   onEditCategory: (id: CategoryEntity['id']) => void;
@@ -132,6 +135,7 @@ function ExpenseCategoryCells({
   });
   const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const [budgetType = 'rollover'] = useSyncedPref('budgetType');
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
 
   const goal =
     budgetType === 'report'
@@ -324,6 +328,9 @@ function ExpenseCategoryCells({
             </Button>
           )}
         </BalanceWithCarryover>
+        {showProgressBars && (
+          <ProgressBar category={category} month={month} isMobile={true} />
+        )}
       </View>
     </View>
   );

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -427,10 +427,19 @@ export function Budget() {
     'budget.showHiddenCategories',
   );
 
+  const [showProgressBars, setShowProgressBarsPref] = useLocalPref(
+    'budget.showProgressBars',
+  );
+
   const onToggleHiddenCategories = useCallback(() => {
     setShowHiddenCategoriesPref(!showHiddenCategories);
     dispatch(collapseModals({ rootModalName: 'budget-page-menu' }));
   }, [dispatch, setShowHiddenCategoriesPref, showHiddenCategories]);
+
+  const onToggleProgressBars = useCallback(() => {
+    setShowProgressBarsPref(!showProgressBars);
+    dispatch(collapseModals({ rootModalName: 'budget-page-menu' }));
+  }, [dispatch, setShowProgressBarsPref, showProgressBars]);
 
   const onOpenBudgetMonthNotesModal = useCallback(
     month => {
@@ -481,6 +490,7 @@ export function Budget() {
             onAddCategoryGroup: onOpenNewCategoryGroupModal,
             onToggleHiddenCategories,
             onSwitchBudgetFile,
+            onToggleProgressBars,
           },
         },
       }),
@@ -490,6 +500,7 @@ export function Budget() {
     onOpenNewCategoryGroupModal,
     onSwitchBudgetFile,
     onToggleHiddenCategories,
+    onToggleProgressBars,
   ]);
 
   if (!categoryGroups || !initialized) {

--- a/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
@@ -23,6 +23,7 @@ export function BudgetPageMenuModal({
   onAddCategoryGroup,
   onToggleHiddenCategories,
   onSwitchBudgetFile,
+  onToggleProgressBars,
 }: BudgetPageMenuModalProps) {
   const defaultMenuItemStyle: CSSProperties = {
     ...styles.mobileMenuItem,
@@ -44,6 +45,7 @@ export function BudgetPageMenuModal({
             onAddCategoryGroup={onAddCategoryGroup}
             onToggleHiddenCategories={onToggleHiddenCategories}
             onSwitchBudgetFile={onSwitchBudgetFile}
+            onToggleProgressBars={onToggleProgressBars}
           />
         </>
       )}
@@ -58,15 +60,18 @@ type BudgetPageMenuProps = Omit<
   onAddCategoryGroup: () => void;
   onToggleHiddenCategories: () => void;
   onSwitchBudgetFile: () => void;
+  onToggleProgressBars: () => void;
 };
 
 function BudgetPageMenu({
   onAddCategoryGroup,
   onToggleHiddenCategories,
   onSwitchBudgetFile,
+  onToggleProgressBars,
   ...props
 }: BudgetPageMenuProps) {
   const [showHiddenCategories] = useLocalPref('budget.showHiddenCategories');
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
 
   const onMenuSelect = (name: string) => {
     switch (name) {
@@ -81,6 +86,9 @@ function BudgetPageMenu({
         break;
       case 'switch-budget-file':
         onSwitchBudgetFile?.();
+        break;
+      case 'toggle-progress-bars':
+        onToggleProgressBars?.();
         break;
       default:
         throw new Error(`Unrecognized menu item: ${name}`);
@@ -104,6 +112,10 @@ function BudgetPageMenu({
         {
           name: 'switch-budget-file',
           text: t('Switch budget file'),
+        },
+        {
+          name: 'toggle-progress-bars',
+          text: `${showProgressBars ? t('Hide progress bars') : t('Show progress bars')}`,
         },
       ]}
     />

--- a/packages/loot-core/src/client/modals/modalsSlice.ts
+++ b/packages/loot-core/src/client/modals/modalsSlice.ts
@@ -439,6 +439,7 @@ export type Modal =
         onAddCategoryGroup: () => void;
         onToggleHiddenCategories: () => void;
         onSwitchBudgetFile: () => void;
+        onToggleProgressBars: () => void;
       };
     }
   | {

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -74,6 +74,7 @@ export type LocalPrefs = Partial<{
   reportsViewLabel: boolean;
   sidebarWidth: number;
   'mobile.showSpentColumn': boolean;
+  'budget.showProgressBars': boolean;
 }>;
 
 export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | 'development';

--- a/upcoming-release-notes/4371.md
+++ b/upcoming-release-notes/4371.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [tbuist]
+---
+
+Add progress bars for categories and goals


### PR DESCRIPTION
Fixes #2965 

This change introduces visual bars to indicate the status of a particular category for that month. 

For standard expense categories, green, red, and gray indicate the value you have remaining/overspent in that category.

For categories with a #goal template, the bar uses blue to indicate the progress.

![image](https://github.com/user-attachments/assets/ffdd0e0c-cf65-4d26-bdd2-edeea2041b27)


<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
