### PR TITLE
🐛  Fix Initializing the connection to the local database hang

### DIFF
--- a/packages/loot-core/src/platform/client/fetch/index.browser.ts
+++ b/packages/loot-core/src/platform/client/fetch/index.browser.ts
@@ -96,11 +96,15 @@ function connectWorker(worker, onOpen, onError) {
     // ready to handle messages.
     if (msg.type === 'connect') {
       // Send any messages that were queued while closed
-      if (messageQueue.length > 0) {
+      if (messageQueue?.length > 0) {
         messageQueue.forEach(msg => worker.postMessage(msg));
         messageQueue = null;
       }
 
+      // signal to the backend that we're connected to it
+      globalWorker.postMessage({
+        name: 'client-connected-to-backend',
+      });
       onOpen();
     } else if (msg.type === 'app-init-failure') {
       onError(msg);

--- a/packages/loot-core/src/platform/server/connection/index.web.ts
+++ b/packages/loot-core/src/platform/server/connection/index.web.ts
@@ -44,6 +44,12 @@ export const init: T.Init = function (serverChn, handlers) {
         return;
       }
 
+      if (msg.name === 'client-connected-to-backend') {
+        // the client is indicating that it is connected to this backend. Stop attempting to connect
+        clearInterval(reconnectToClientInterval);
+        return;
+      }
+
       const { id, name, args, undoTag, catchErrors } = msg;
 
       if (handlers[name]) {
@@ -98,7 +104,19 @@ export const init: T.Init = function (serverChn, handlers) {
     false,
   );
 
-  serverChannel.postMessage({ type: 'connect' });
+  const RECONNECT_INTERVAL_MS = 200;
+  const MAX_RECONNECT_ATTEMPTS = 500;
+  let reconnectAttempts = 0;
+
+  const reconnectToClientInterval = setInterval(() => {
+    serverChannel.postMessage({ type: 'connect' });
+    reconnectAttempts++;
+    if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      // Failed to connect to client - signal server error
+      send('server-error');
+      clearInterval(reconnectToClientInterval);
+    }
+  }, RECONNECT_INTERVAL_MS);
 };
 
 export const send: T.Send = function (name, args) {

--- a/upcoming-release-notes/4375.md
+++ b/upcoming-release-notes/4375.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Prevent the app getting stuck on the "Initializing the connection to the local database..." screen


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

It was a race condition. The backend was loading in faster than the frontend. It was sending the **_connect_**  message to the frontend and the frontend wasn't ready to receive it. 

We can't guarantee the order that the frontend or backend will load in, so we have to add retries to deal with it. 

**Fixes this:** 

![test](https://github.com/user-attachments/assets/71c5c50a-b9c4-4e7c-8f46-3da36499f1c1)


Fixes: https://github.com/actualbudget/actual/issues/2893
