### PR TITLE
[WIP] Add fallback value for payeename: 'undefined'

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/cbc_cregbebb.js
+++ b/packages/sync-server/src/app-gocardless/banks/cbc_cregbebb.js
@@ -16,7 +16,9 @@ export default {
 
     if (Number(transaction.transactionAmount.amount) > 0) {
       editedTrans.payeeName =
-        transaction.debtorName || transaction.remittanceInformationUnstructured;
+        transaction.debtorName ||
+        transaction.remittanceInformationUnstructured ||
+        'undefined';
     } else {
       editedTrans.payeeName =
         transaction.creditorName ||


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Similarly to [PR#533](https://github.com/actualbudget/actual-server/pull/533), this fix provides a default fallback payeename value ('undefined') for the CBC bank in case the payeename is missing. 