### PR TITLE
🐛 Fix new proxy middleware dependency missing on prod build

### DIFF
--- a/packages/sync-server/src/app.js
+++ b/packages/sync-server/src/app.js
@@ -5,7 +5,6 @@ import cors from 'cors';
 import express from 'express';
 import actuator from 'express-actuator';
 import rateLimit from 'express-rate-limit';
-import { createProxyMiddleware } from 'http-proxy-middleware';
 
 import * as accountApp from './app-account.js';
 import * as adminApp from './app-admin.js';
@@ -76,8 +75,12 @@ if (process.env.NODE_ENV === 'development') {
     'Running in development mode - Proxying frontend routes to React Dev Server',
   );
 
+  // Imported within Dev block to allow dev dependency in package.json (reduces package size in production)
+  // const { createProxyMiddleware } = import('http-proxy-middleware');
+  const httpProxyMiddleware = await import('http-proxy-middleware');
+
   app.use(
-    createProxyMiddleware({
+    httpProxyMiddleware.createProxyMiddleware({
       target: 'http://localhost:3001',
       changeOrigin: true,
       ws: true,

--- a/packages/sync-server/src/app.js
+++ b/packages/sync-server/src/app.js
@@ -76,7 +76,6 @@ if (process.env.NODE_ENV === 'development') {
   );
 
   // Imported within Dev block to allow dev dependency in package.json (reduces package size in production)
-  // const { createProxyMiddleware } = import('http-proxy-middleware');
   const httpProxyMiddleware = await import('http-proxy-middleware');
 
   app.use(

--- a/upcoming-release-notes/4400.md
+++ b/upcoming-release-notes/4400.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Fix new proxy middleware importing in production when only required in developement


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The new proxy middleware was added as a dev dependency but imported in production as well. 

The fix is to only import the dev dependency when in dev mode.