### PR TITLE
Fix goals tooltip translation

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -187,10 +187,7 @@ export function BalanceWithCarryover({
                     <div>
                       {
                         {
-                          type:
-                            longGoalValue === 1
-                              ? t('Long', { context: 'noun' })
-                              : t('Template'),
+                          type: longGoalValue === 1 ? t('Long') : t('Template'),
                         } as TransObjectLiteral
                       }
                     </div>


### PR DESCRIPTION
Looks like adding in a context flag modifies the base key, which we cant do since the key is what gets used for English text.

To test, add a `#goal` to a category and look at the tooltip after running templates.  On edge it will say "Long_noun" on the PR it will just say "Long".  You will need to be on English and not "British English" language.
