### PR TITLE
update mapping data for existing synced transactions and always show direction dropdown

### DIFF
--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -179,22 +179,13 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
             <Trans>Field mapping</Trans>
           </Text>
 
-          {fields.length > 0 ? (
-            <FieldMapping
-              transactionDirection={transactionDirection}
-              setTransactionDirection={setTransactionDirection}
-              fields={fields as MappableFieldWithExample[]}
-              mapping={mapping!}
-              setMapping={setMapping}
-            />
-          ) : (
-            <Text style={{ margin: '1em 0 .5em 0' }}>
-              <Trans>
-                No transactions found with mappable fields, accounts must have
-                been synced at least once for this function to be available.
-              </Trans>
-            </Text>
-          )}
+          <FieldMapping
+            transactionDirection={transactionDirection}
+            setTransactionDirection={setTransactionDirection}
+            fields={fields as MappableFieldWithExample[]}
+            mapping={mapping!}
+            setMapping={setMapping}
+          />
 
           <Text style={{ fontSize: 15, margin: '1em 0 .5em 0' }}>
             <Trans>Options</Trans>

--- a/packages/desktop-client/src/components/banksync/FieldMapping.tsx
+++ b/packages/desktop-client/src/components/banksync/FieldMapping.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Text } from '@actual-app/components/text';
 
@@ -65,92 +65,103 @@ export function FieldMapping({
         }}
       />
 
-      <TableHeader>
-        <Cell
-          value={t('Actual field')}
-          width={100}
-          style={{ paddingLeft: '10px' }}
-        />
-        <Cell
-          value={t('Bank field')}
-          width={330}
-          style={{ paddingLeft: '10px' }}
-        />
-        <Cell
-          value={t('Example')}
-          width="flex"
-          style={{ paddingLeft: '10px' }}
-        />
-      </TableHeader>
-
-      {fields.map(field => {
-        return (
-          <Row
-            key={field.actualField}
-            style={{
-              fontSize: 13,
-              backgroundColor: theme.tableRowBackgroundHover,
-              display: 'flex',
-              alignItems: 'center',
-              border: '1px solid var(--color-tableBorder)',
-              minHeight: '40px',
-            }}
-            collapsed={true}
-          >
+      {fields.length === 0 ? (
+        <Text style={{ margin: '1em 0 .5em 0' }}>
+          <Trans>
+            No transactions found with mappable fields, accounts must have been
+            synced at least once for this function to be available.
+          </Trans>
+        </Text>
+      ) : (
+        <>
+          <TableHeader>
             <Cell
-              value={field.actualField}
-              width={75}
-              style={{ paddingLeft: '10px', height: '100%', border: 0 }}
+              value={t('Actual field')}
+              width={100}
+              style={{ paddingLeft: '10px' }}
             />
-
-            <Text>
-              <SvgRightArrow2
-                style={{
-                  width: 15,
-                  height: 15,
-                  color: theme.tableText,
-                  marginRight: '20px',
-                }}
-              />
-            </Text>
-
-            <Select
-              aria-label={t('Synced field to map to {{field}}', {
-                field: field.actualField,
-              })}
-              options={field.syncFields.map(({ field }) => [field, field])}
-              value={mapping.get(field.actualField)}
-              style={{
-                width: 290,
-              }}
-              onChange={newValue => {
-                if (newValue) setMapping(field.actualField, newValue);
-              }}
-            />
-
-            <Text>
-              <SvgEquals
-                style={{
-                  width: 12,
-                  height: 12,
-                  color: theme.tableText,
-                  marginLeft: '20px',
-                }}
-              />
-            </Text>
-
             <Cell
-              value={
-                field.syncFields.find(
-                  f => f.field === mapping.get(field.actualField),
-                )?.example
-              }
+              value={t('Bank field')}
+              width={330}
+              style={{ paddingLeft: '10px' }}
+            />
+            <Cell
+              value={t('Example')}
               width="flex"
-              style={{ paddingLeft: '10px', height: '100%', border: 0 }}
+              style={{ paddingLeft: '10px' }}
             />
-          </Row>
-        );
-      })}
+          </TableHeader>
+
+          {fields.map(field => {
+            return (
+              <Row
+                key={field.actualField}
+                style={{
+                  fontSize: 13,
+                  backgroundColor: theme.tableRowBackgroundHover,
+                  display: 'flex',
+                  alignItems: 'center',
+                  border: '1px solid var(--color-tableBorder)',
+                  minHeight: '40px',
+                }}
+                collapsed={true}
+              >
+                <Cell
+                  value={field.actualField}
+                  width={75}
+                  style={{ paddingLeft: '10px', height: '100%', border: 0 }}
+                />
+
+                <Text>
+                  <SvgRightArrow2
+                    style={{
+                      width: 15,
+                      height: 15,
+                      color: theme.tableText,
+                      marginRight: '20px',
+                    }}
+                  />
+                </Text>
+
+                <Select
+                  aria-label={t('Synced field to map to {{field}}', {
+                    field: field.actualField,
+                  })}
+                  options={field.syncFields.map(({ field }) => [field, field])}
+                  value={mapping.get(field.actualField)}
+                  style={{
+                    width: 290,
+                  }}
+                  onChange={newValue => {
+                    if (newValue) setMapping(field.actualField, newValue);
+                  }}
+                />
+
+                <Text>
+                  <SvgEquals
+                    style={{
+                      width: 12,
+                      height: 12,
+                      color: theme.tableText,
+                      marginLeft: '20px',
+                    }}
+                  />
+                </Text>
+
+                <Cell
+                  value={
+                    field.syncFields.find(
+                      f => f.field === mapping.get(field.actualField),
+                    )?.example
+                  }
+                  width="flex"
+                  style={{ paddingLeft: '10px', height: '100%', border: 0 }}
+                />
+              </Row>
+            );
+          })}
+        </>
+      )}
     </>
   );
 }

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -475,10 +475,19 @@ export async function reconcileTransactions(
         notes: existing.notes || trans.notes || null,
         cleared: trans.cleared ?? existing.cleared,
         raw_synced_data:
-          existing.raw_synced_data || trans.raw_synced_data || null,
+          existing.raw_synced_data ?? trans.raw_synced_data ?? null,
       };
 
-      if (hasFieldsChanged(existing, updates, Object.keys(updates))) {
+      const fieldsToMarkUpdated = Object.keys(updates).filter(k => {
+        // do not mark raw_synced_data if it's gone from falsy to falsy
+        if (!existing.raw_synced_data && !trans.raw_synced_data) {
+          return k !== 'raw_synced_data';
+        }
+
+        return true;
+      });
+
+      if (hasFieldsChanged(existing, updates, fieldsToMarkUpdated)) {
         updated.push({ id: existing.id, ...updates });
         if (!existingPayeeMap.has(existing.payee)) {
           const payee = await db.getPayee(existing.payee);

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -474,6 +474,8 @@ export async function reconcileTransactions(
         imported_payee: trans.imported_payee || null,
         notes: existing.notes || trans.notes || null,
         cleared: trans.cleared ?? existing.cleared,
+        raw_synced_data:
+          existing.raw_synced_data || trans.raw_synced_data || null,
       };
 
       if (hasFieldsChanged(existing, updates, Object.keys(updates))) {

--- a/upcoming-release-notes/4403.md
+++ b/upcoming-release-notes/4403.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Update bank sync mapping data for existing transactions on sync


### PR DESCRIPTION
From feedback in #4253 

> @matt-fidd Some edge cases Ive found testing in my instance.
> 
> Old transactions don't pick up the raw data from the sync so only new data is available to use for the mapper. (this is a cause of below)
> If there is only data for Payments and not Deposits, you can open the account mapper settings and change to Deposits, but cant change back to Payments. This is because there are no Deposits that have raw data so you get the message about needing data. (The selection box for switching between Payment and Deposit should either always show, or show if either of them have data)