### PR TITLE
prevent bank sync from crashing when payee not found

### DIFF
--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -7,11 +7,12 @@ async function getPayee(acct) {
 
 async function getTransferredAccount(transaction) {
   if (transaction.payee) {
-    const { transfer_acct } = await db.first(
+    const result = await db.first(
       'SELECT id, transfer_acct FROM v_payees WHERE id = ?',
       [transaction.payee],
     );
-    return transfer_acct;
+
+    return result?.transfer_acct || null;
   }
   return null;
 }

--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -8,7 +8,7 @@ async function getPayee(acct) {
 async function getTransferredAccount(transaction) {
   if (transaction.payee) {
     const result = await db.first(
-      'SELECT id, transfer_acct FROM v_payees WHERE id = ?',
+      'SELECT transfer_acct FROM v_payees WHERE id = ?',
       [transaction.payee],
     );
 

--- a/upcoming-release-notes/4413.md
+++ b/upcoming-release-notes/4413.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix crash during bank sync when the payee is not found


### PR DESCRIPTION
This issue has been reported a few times on Discord, most recently https://discord.com/channels/937901803608096828/1335338862125256704

There seems to be an edge case where the payee is not found when processing the transfers, this stops it from crashing the sync. The transaction still goes through, but is not considered as a transfer.

```
main.ts:1121 Bank Sync operation for account: xxxx
sync.ts:194 Pulling transactions from SimpleFin
sync.ts:244 Response: {transactions: Array(xx), accountBalance: Array(xx), startingBalance: xxxx}
sync.ts:398 Performing transaction reconciliation
sync.ts:516 Performing transaction reconciliation matching
index.web.ts:4 [Exception] TypeError: Failed syncing account “xxxx”
    at gg (https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:199:137027)
    at async gE (https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:199:138352)
    at async Promise.all (index 0)
    at async https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:199:139547
    at async lU (https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:116:1007)
    at async gO (https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:199:139490)
    at async yr (https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:206:5818)
    at async https://localhost:5006/kcab/kcab.worker.1e21d5133f60a8255cff.js:214:1860
Notifications.tsx:111 Internal error: TypeError: Cannot destructure property 'transfer_acct' of '(intermediate value)' as it is null.
```