### PR TITLE
📚 Start the application with the browser default language

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -28,6 +28,7 @@ import { init as initConnection, send } from 'loot-core/platform/client/fetch';
 
 import { handleGlobalEvents } from '../global-events';
 import { useMetadataPref } from '../hooks/useMetadataPref';
+import { setI18NextLanguage } from '../i18n';
 import { installPolyfills } from '../polyfills';
 import { useDispatch, useSelector, useStore } from '../redux';
 import { hasHiddenScrollbars, ThemeStyle, useTheme } from '../style';
@@ -66,6 +67,8 @@ function AppInner() {
     };
 
     async function init() {
+      setI18NextLanguage(null);
+
       const socketName = await maybeUpdate(() =>
         global.Actual.getServerSocket(),
       );

--- a/upcoming-release-notes/4415.md
+++ b/upcoming-release-notes/4415.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [lelemm]
+---
+
+Start the application with the browser's default language


### PR DESCRIPTION
When starting the application (for the first time mainly), the strings are not loaded because the loadPrefs is called way later.
With this change, we force the initial labels to use the default browser language