### PR TITLE
🐛 Fix `On budget` / `Off budget` underline with translated languages

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -62,6 +62,7 @@ type AccountProps<FieldName extends SheetFields<'account'>> = {
   outerStyle?: CSSProperties;
   onDragChange?: OnDragChangeCallback<{ id: string }>;
   onDrop?: OnDropCallback;
+  titleAccount?: boolean;
 };
 
 export function Account<FieldName extends SheetFields<'account'>>({
@@ -77,6 +78,7 @@ export function Account<FieldName extends SheetFields<'account'>>({
   outerStyle,
   onDragChange,
   onDrop,
+  titleAccount,
 }: AccountProps<FieldName>) {
   const type = account
     ? account.closed
@@ -178,7 +180,7 @@ export function Account<FieldName extends SheetFields<'account'>>({
 
             <AlignedText
               style={
-                (name === 'Off budget' || name === 'On budget') && {
+                titleAccount && {
                   borderBottom: `1.5px solid rgba(255,255,255,0.4)`,
                   paddingBottom: '3px',
                 }

--- a/packages/desktop-client/src/components/sidebar/Accounts.tsx
+++ b/packages/desktop-client/src/components/sidebar/Accounts.tsx
@@ -108,6 +108,7 @@ export function Accounts() {
               marginTop: 13,
               marginBottom: 5,
             }}
+            titleAccount={true}
           />
         )}
 
@@ -138,6 +139,7 @@ export function Accounts() {
               marginTop: 13,
               marginBottom: 5,
             }}
+            titleAccount={true}
           />
         )}
 

--- a/upcoming-release-notes/4417.md
+++ b/upcoming-release-notes/4417.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix `On budget` / `Off budget` underline with translated languages


### PR DESCRIPTION
The current implementation checks for the account text to show or not the underline. For translated account names, it does not work.
Added new variable to control when show or not the underline