### PR TITLE
✨Enforce OPENID login

### DIFF
--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -29,7 +29,7 @@ export function listLoginMethods() {
   const rows = accountDb.all('SELECT method, display_name, active FROM auth');
   return rows
     .filter(f =>
-      rows.length > 1 && config.enforceOpenID ? f.method === 'openid' : true,
+      rows.length > 1 && config.enforceOpenId ? f.method === 'openid' : true,
     )
     .map(r => ({
       method: r.method,

--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -27,11 +27,15 @@ export function needsBootstrap() {
 export function listLoginMethods() {
   const accountDb = getAccountDb();
   const rows = accountDb.all('SELECT method, display_name, active FROM auth');
-  return rows.map(r => ({
-    method: r.method,
-    active: r.active,
-    displayName: r.display_name,
-  }));
+  return rows
+    .filter(f =>
+      rows.length > 1 && config.enforceOpenID ? f.method === 'openid' : true,
+    )
+    .map(r => ({
+      method: r.method,
+      active: r.active,
+      displayName: r.display_name,
+    }));
 }
 
 export function getActiveLoginMethod() {

--- a/packages/sync-server/src/config-types.ts
+++ b/packages/sync-server/src/config-types.ts
@@ -37,8 +37,8 @@ export interface Config {
     client_secret: string;
     server_hostname: string;
     authMethod?: 'openid' | 'oauth2';
-    enforceOpenId?: boolean;
   };
   multiuser: boolean;
   token_expiration?: 'never' | 'openid-provider' | number;
+  enforceOpenId: boolean;
 }

--- a/packages/sync-server/src/config-types.ts
+++ b/packages/sync-server/src/config-types.ts
@@ -37,6 +37,7 @@ export interface Config {
     client_secret: string;
     server_hostname: string;
     authMethod?: 'openid' | 'oauth2';
+    enforceOpenId?: boolean;
   };
   multiuser: boolean;
   token_expiration?: 'never' | 'openid-provider' | number;

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -221,6 +221,17 @@ const finalConfig = {
   token_expiration: process.env.ACTUAL_TOKEN_EXPIRATION
     ? process.env.ACTUAL_TOKEN_EXPIRATION
     : config.token_expiration,
+  enforceOpenID: process.env.ACTUAL_OPENID_ENFORCE
+    ? (() => {
+        const value = process.env.ACTUAL_OPENID_ENFORCE.toLowerCase();
+        if (!['true', 'false'].includes(value)) {
+          throw new Error(
+            'ACTUAL_OPENID_ENFORCE must be either "true" or "false"',
+          );
+        }
+        return value === 'true';
+      })()
+    : config.multiuser,
 };
 debug(`using port ${finalConfig.port}`);
 debug(`using hostname ${finalConfig.hostname}`);

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -221,7 +221,7 @@ const finalConfig = {
   token_expiration: process.env.ACTUAL_TOKEN_EXPIRATION
     ? process.env.ACTUAL_TOKEN_EXPIRATION
     : config.token_expiration,
-  enforceOpenID: process.env.ACTUAL_OPENID_ENFORCE
+  enforceOpenId: process.env.ACTUAL_OPENID_ENFORCE
     ? (() => {
         const value = process.env.ACTUAL_OPENID_ENFORCE.toLowerCase();
         if (!['true', 'false'].includes(value)) {
@@ -231,7 +231,7 @@ const finalConfig = {
         }
         return value === 'true';
       })()
-    : config.multiuser,
+    : config.enforceOpenId,
 };
 debug(`using port ${finalConfig.port}`);
 debug(`using hostname ${finalConfig.hostname}`);

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -88,6 +88,7 @@ const defaultConfig = {
   projectRoot,
   multiuser: false,
   token_expiration: 'never',
+  enforceOpenId: false,
 };
 
 /** @type {import('./config-types.js').Config} */

--- a/upcoming-release-notes/4423.md
+++ b/upcoming-release-notes/4423.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [lelemm]
+---
+
+Added `ACTUAL_OPENID_ENFORCE=true` enviroment variable to enforce only OpenID auth.


### PR DESCRIPTION
Added environment variable `ACTUAL_OPENID_ENFORCE=true` to enforce OPENID only.
If the user wants to disable fallback login mechanics, they set this variable.