### PR TITLE
Prevent docker-edge workflow from running on pushes to forks

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -33,6 +33,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event.repository.fork == false }}
     name: Build Docker image
     runs-on: ubuntu-latest
     strategy:

--- a/upcoming-release-notes/4430.md
+++ b/upcoming-release-notes/4430.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Prevent GitHub docker workflow from running on pushes to forks


### PR DESCRIPTION
I'm getting the following email every time I sync my fork to master, this should stop it running on forks (but not PRs from forks).

<img width="471" alt="image" src="https://github.com/user-attachments/assets/29d2c368-2c03-421f-889d-81d9fd019d42" />
