### PR TITLE
[WIP] Allow early payment of scheduled transactions

### DIFF
--- a/upcoming-release-notes/4433.md
+++ b/upcoming-release-notes/4433.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [AntoineTA]
+---
+
+Allow early payment of scheduled transactions 


### PR DESCRIPTION
Fixes #1957 

Currently, a scheduled transaction is considered "Paid" iff there is an actual transaction such that

1. it is associated with the relevant schedule AND
2. its date is the same as the date of the scheduled transaction (or at most two days before, if schedule uses approximate date). 

This makes it impossible for a schedule transaction to be paid in advance, causing the behaviour described in the issue.

This PR proposes to solve this by changing the conditions under which a scheduled transaction is considered paid. More precisely, a scheduled transaction will now be paid iff there is an actual transaction such that

1. it is associated with the relevant schedule AND
2. its date is less than or equal to the date of the scheduled transaction
3. its date is greater than the date of the _previous_ scheduled transaction in this schedule (apply only to recurring schedules).