### PR TITLE
🐛 Fix the default language init for electron

### DIFF
--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -54,6 +54,10 @@ function AppInner() {
   const userData = useSelector(state => state.user.data);
 
   useEffect(() => {
+    setI18NextLanguage(null);
+  }, []);
+
+  useEffect(() => {
     const maybeUpdate = async <T,>(cb?: () => T): Promise<T> => {
       if (global.Actual.isUpdateReadyForDownload()) {
         dispatch(
@@ -67,8 +71,6 @@ function AppInner() {
     };
 
     async function init() {
-      setI18NextLanguage(null);
-
       const socketName = await maybeUpdate(() =>
         global.Actual.getServerSocket(),
       );

--- a/upcoming-release-notes/4439.md
+++ b/upcoming-release-notes/4439.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix the default language init for electron


### PR DESCRIPTION
Electron build keeps changing the language and never stops