### PR TITLE
sort schedule previews by date, then amount

### DIFF
--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -228,7 +228,9 @@ export function usePreviewTransactions(): UsePreviewTransactionsResult {
       })
       .flat()
       .sort(
-        (a, b) => parseDate(b.date).getTime() - parseDate(a.date).getTime(),
+        (a, b) =>
+          parseDate(b.date).getTime() - parseDate(a.date).getTime() ||
+          a.amount - b.amount,
       );
   }, [isSchedulesLoading, schedules, statuses, upcomingLength]);
 

--- a/upcoming-release-notes/4452.md
+++ b/upcoming-release-notes/4452.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Sort upcoming schedules by date then amount so deposits come before payments


### PR DESCRIPTION
This makes the running balance a little bit more sensible. Neither approach is actually "correct" here, as the order of the preview transactions in Actual is completely unrelated to the order the transactions might actually happen, but this is the more logical order for the transactions to happen in.