### PR TITLE
fix row spacing on bank sync page

### DIFF
--- a/packages/desktop-client/src/components/banksync/AccountsList.tsx
+++ b/packages/desktop-client/src/components/banksync/AccountsList.tsx
@@ -24,7 +24,11 @@ export function AccountsList({
   }
 
   return (
-    <View>
+    <View
+      style={{
+        minHeight: 'initial',
+      }}
+    >
       {accounts.map(account => {
         const hovered = hoveredAccount === account.id;
 

--- a/packages/desktop-client/src/components/banksync/index.tsx
+++ b/packages/desktop-client/src/components/banksync/index.tsx
@@ -115,7 +115,7 @@ export function BankSync() {
         )}
         {Object.entries(groupedAccounts).map(([syncProvider, accounts]) => {
           return (
-            <View key={syncProvider}>
+            <View key={syncProvider} style={{ minHeight: 'initial' }}>
               {Object.keys(groupedAccounts).length > 1 && (
                 <Text
                   style={{ fontWeight: 500, fontSize: 20, margin: '.5em 0' }}

--- a/upcoming-release-notes/4458.md
+++ b/upcoming-release-notes/4458.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix row spacing on bank sync page


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/4457

To test, open the bank sync page on edge and decrease the window height, the rows will collapse into each other. They won't on this deploy.

Before:
<img width="814" alt="image" src="https://github.com/user-attachments/assets/286b0236-a235-49d5-95cf-a7eaf7ae07bf" />


After:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/f6071557-3162-4071-a5ec-9e227d02969b" />