### PR TITLE
feat: add "last reconciled" timestamp to accounts

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1010,6 +1010,13 @@ class AccountInternal extends PureComponent<
 
   onDoneReconciling = async () => {
     const { accountId } = this.props;
+    const account = this.props.accounts.find(
+      account => account.id === accountId,
+    );
+    if (!account) {
+      throw new Error(`Account with ID ${accountId} not found.`);
+    }
+
     const { reconcileAmount } = this.state;
 
     const { data } = await runQuery(
@@ -1033,6 +1040,13 @@ class AccountInternal extends PureComponent<
     if (targetDiff === 0) {
       await this.lockTransactions();
     }
+
+    const lastReconciled = new Date().getTime().toString();
+    this.props.dispatch(
+      updateAccount({
+        account: { ...account, last_reconciled: lastReconciled },
+      }),
+    );
 
     this.setState({
       reconcileAmount: null,

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -4,8 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
-import { formatDistanceToNow } from 'date-fns';
-import * as locales from 'date-fns/locale';
 import { useHover } from 'usehooks-ts';
 
 import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
@@ -14,9 +12,7 @@ import { getScheduledAmount } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { type AccountEntity } from 'loot-core/types/models';
 
-import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useSelectedItems } from '../../hooks/useSelected';
-import { SvgLockClosed } from '../../icons/v1';
 import { SvgArrowButtonRight1 } from '../../icons/v2';
 import { theme } from '../../style';
 import { PrivacyFilter } from '../PrivacyFilter';
@@ -147,23 +143,11 @@ function FilteredBalance({ filteredAmount }: FilteredBalanceProps) {
   );
 }
 
-const tsToRelativeTime = (ts: string | null, language: string): string => {
-  if (!ts) return 'Unknown';
-
-  const parsed = new Date(parseInt(ts, 10));
-  const locale =
-    locales[language.replace('-', '') as keyof typeof locales] ??
-    locales['enUS'];
-
-  return formatDistanceToNow(parsed, { addSuffix: true, locale });
-};
-
 type MoreBalancesProps = {
   balanceQuery: { name: `balance-query-${string}`; query: Query };
-  lastReconciled?: string | null;
 };
 
-function MoreBalances({ balanceQuery, lastReconciled }: MoreBalancesProps) {
+function MoreBalances({ balanceQuery }: MoreBalancesProps) {
   const { t } = useTranslation();
 
   const cleared = useSheetValue<'balance', `balance-query-${string}-cleared`>({
@@ -179,33 +163,10 @@ function MoreBalances({ balanceQuery, lastReconciled }: MoreBalancesProps) {
     query: balanceQuery.query.filter({ cleared: false }),
   });
 
-  const [language] = useGlobalPref('language');
-
   return (
     <View style={{ flexDirection: 'row' }}>
       <DetailedBalance name={t('Cleared total:')} balance={cleared ?? 0} />
       <DetailedBalance name={t('Uncleared total:')} balance={uncleared ?? 0} />
-      <Text
-        style={{
-          marginLeft: 15,
-          borderRadius: 4,
-          padding: '4px 6px',
-          color: theme.pillText,
-          backgroundColor: theme.pillBackground,
-        }}
-      >
-        <SvgLockClosed
-          style={{
-            width: 11,
-            height: 11,
-            color: theme.pillText,
-            marginRight: 5,
-          }}
-        />
-        {lastReconciled
-          ? `${t('Reconciled')} ${tsToRelativeTime(lastReconciled, language || 'en-US')}`
-          : t('Not yet reconciled')}
-      </Text>
     </View>
   );
 }
@@ -291,12 +252,7 @@ export function Balances({
         />
       </Button>
 
-      {showExtraBalances && (
-        <MoreBalances
-          balanceQuery={balanceQuery}
-          lastReconciled={account?.last_reconciled}
-        />
-      )}
+      {showExtraBalances && <MoreBalances balanceQuery={balanceQuery} />}
 
       {selectedItems.size > 0 && (
         <SelectedBalance selectedItems={selectedItems} account={account} />

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
+import { formatDistanceToNow } from 'date-fns';
+import * as locales from 'date-fns/locale';
 import { useHover } from 'usehooks-ts';
 
 import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
@@ -12,7 +14,9 @@ import { getScheduledAmount } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useSelectedItems } from '../../hooks/useSelected';
+import { SvgLockClosed } from '../../icons/v1';
 import { SvgArrowButtonRight1 } from '../../icons/v2';
 import { theme } from '../../style';
 import { PrivacyFilter } from '../PrivacyFilter';
@@ -143,11 +147,23 @@ function FilteredBalance({ filteredAmount }: FilteredBalanceProps) {
   );
 }
 
-type MoreBalancesProps = {
-  balanceQuery: { name: `balance-query-${string}`; query: Query };
+const tsToRelativeTime = (ts: string | null, language: string): string => {
+  if (!ts) return 'Unknown';
+
+  const parsed = new Date(parseInt(ts, 10));
+  const locale =
+    locales[language.replace('-', '') as keyof typeof locales] ??
+    locales['enUS'];
+
+  return formatDistanceToNow(parsed, { addSuffix: true, locale });
 };
 
-function MoreBalances({ balanceQuery }: MoreBalancesProps) {
+type MoreBalancesProps = {
+  balanceQuery: { name: `balance-query-${string}`; query: Query };
+  lastReconciled?: string | null;
+};
+
+function MoreBalances({ balanceQuery, lastReconciled }: MoreBalancesProps) {
   const { t } = useTranslation();
 
   const cleared = useSheetValue<'balance', `balance-query-${string}-cleared`>({
@@ -163,10 +179,33 @@ function MoreBalances({ balanceQuery }: MoreBalancesProps) {
     query: balanceQuery.query.filter({ cleared: false }),
   });
 
+  const [language] = useGlobalPref('language');
+
   return (
     <View style={{ flexDirection: 'row' }}>
       <DetailedBalance name={t('Cleared total:')} balance={cleared ?? 0} />
       <DetailedBalance name={t('Uncleared total:')} balance={uncleared ?? 0} />
+      <Text
+        style={{
+          marginLeft: 15,
+          borderRadius: 4,
+          padding: '4px 6px',
+          color: theme.pillText,
+          backgroundColor: theme.pillBackground,
+        }}
+      >
+        <SvgLockClosed
+          style={{
+            width: 11,
+            height: 11,
+            color: theme.pillText,
+            marginRight: 5,
+          }}
+        />
+        {lastReconciled
+          ? `${t('Reconciled')} ${tsToRelativeTime(lastReconciled, language || 'en-US')}`
+          : t('Not yet reconciled')}
+      </Text>
     </View>
   );
 }
@@ -251,7 +290,13 @@ export function Balances({
           }}
         />
       </Button>
-      {showExtraBalances && <MoreBalances balanceQuery={balanceQuery} />}
+
+      {showExtraBalances && (
+        <MoreBalances
+          balanceQuery={balanceQuery}
+          lastReconciled={account?.last_reconciled}
+        />
+      )}
 
       {selectedItems.size > 0 && (
         <SelectedBalance selectedItems={selectedItems} account={account} />

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -14,8 +14,10 @@ import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
 import { Stack } from '@actual-app/components/stack';
 import { styles } from '@actual-app/components/styles';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
+import { tsToRelativeTime } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type RuleConditionEntity,
@@ -23,6 +25,7 @@ import {
   type TransactionFilterEntity,
 } from 'loot-core/types/models';
 
+import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { useLocalPref } from '../../hooks/useLocalPref';
 import { useSplitsExpanded } from '../../hooks/useSplitsExpanded';
 import { useSyncServerStatus } from '../../hooks/useSyncServerStatus';
@@ -185,6 +188,8 @@ export function AccountHeader({
   onMakeAsNonSplitTransactions,
 }: AccountHeaderProps) {
   const { t } = useTranslation();
+  const [language] = useGlobalPref('language');
+
   const [menuOpen, setMenuOpen] = useState(false);
   const [reconcileOpen, setReconcileOpen] = useState(false);
   const searchInput = useRef<HTMLInputElement>(null);
@@ -374,19 +379,33 @@ export function AccountHeader({
               onMakeAsNonSplitTransactions={onMakeAsNonSplitTransactions}
             />
           )}
-          <View style={{ flex: '0 0 auto' }}>
+          <View style={{ flex: '0 0 auto', marginLeft: 10 }}>
             {account && (
-              <>
+              <Tooltip
+                style={{
+                  ...styles.tooltip,
+                  marginBottom: 10,
+                }}
+                content={
+                  account?.last_reconciled
+                    ? `${t('Reconciled')} ${tsToRelativeTime(account.last_reconciled, language || 'en-US')}`
+                    : t('Not yet reconciled')
+                }
+                placement="top"
+                triggerProps={{
+                  isDisabled: reconcileOpen,
+                }}
+              >
                 <Button
                   ref={reconcileRef}
                   variant="bare"
                   aria-label={t('Reconcile')}
-                  style={{ padding: 6, marginLeft: 10 }}
+                  style={{ padding: 6 }}
                   onPress={() => {
                     setReconcileOpen(true);
                   }}
                 >
-                  <View title={t('Reconcile')}>
+                  <View>
                     <SvgLockClosed width={14} height={14} />
                   </View>
                 </Button>
@@ -403,7 +422,7 @@ export function AccountHeader({
                     onReconcile={onReconcile}
                   />
                 </Popover>
-              </>
+              </Tooltip>
             )}
           </View>
           <Button

--- a/packages/desktop-client/src/components/spreadsheet/index.ts
+++ b/packages/desktop-client/src/components/spreadsheet/index.ts
@@ -14,6 +14,7 @@ export type Spreadsheets = {
     'offbudget-accounts-balance': number;
     balanceCleared: number;
     balanceUncleared: number;
+    lastReconciled: string | null;
   };
   category: {
     // Common fields

--- a/packages/loot-core/migrations/1740506588539_add_last_reconciled_at.sql
+++ b/packages/loot-core/migrations/1740506588539_add_last_reconciled_at.sql
@@ -1,0 +1,5 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE accounts ADD COLUMN last_reconciled text;
+
+COMMIT;

--- a/packages/loot-core/src/mocks/index.ts
+++ b/packages/loot-core/src/mocks/index.ts
@@ -22,6 +22,7 @@ export function generateAccount(
     name,
     offbudget: offbudget ? 1 : 0,
     sort_order: 0,
+    last_reconciled: new Date().getTime().toString(),
     tombstone: 0,
     closed: 0,
     ...emptySyncFields(),

--- a/packages/loot-core/src/mocks/index.ts
+++ b/packages/loot-core/src/mocks/index.ts
@@ -22,7 +22,7 @@ export function generateAccount(
     name,
     offbudget: offbudget ? 1 : 0,
     sort_order: 0,
-    last_reconciled: new Date().getTime().toString(),
+    last_reconciled: null,
     tombstone: 0,
     closed: 0,
     ...emptySyncFields(),

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -59,8 +59,17 @@ export type AccountHandlers = {
   'account-unlink': typeof unlinkAccount;
 };
 
-async function updateAccount({ id, name }: Pick<AccountEntity, 'id' | 'name'>) {
-  await db.update('accounts', { id, name });
+async function updateAccount({
+  id,
+  name,
+  last_reconciled,
+}: Pick<AccountEntity, 'id' | 'name'> &
+  Partial<Pick<AccountEntity, 'last_reconciled'>>) {
+  await db.update('accounts', {
+    id,
+    name,
+    ...(last_reconciled && { last_reconciled }),
+  });
   return {};
 }
 

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -74,6 +74,7 @@ export const schema = {
     account_id: f('string'),
     official_name: f('string'),
     account_sync_source: f('string'),
+    last_reconciled: f('string'),
     last_sync: f('string'),
   },
   categories: {

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -1,4 +1,7 @@
 // @ts-strict-ignore
+import { formatDistanceToNow } from 'date-fns';
+import * as locales from 'date-fns/locale';
+
 export function last<T>(arr: Array<T>) {
   return arr[arr.length - 1];
 }
@@ -480,4 +483,17 @@ export function sortByKey<T>(arr: T[], key: keyof T): T[] {
     }
     return 0;
   });
+}
+
+// Date utilities
+
+export function tsToRelativeTime(ts: string | null, language: string): string {
+  if (!ts) return 'Unknown';
+
+  const parsed = new Date(parseInt(ts, 10));
+  const locale =
+    locales[language.replace('-', '') as keyof typeof locales] ??
+    locales['enUS'];
+
+  return formatDistanceToNow(parsed, { addSuffix: true, locale });
 }

--- a/packages/loot-core/src/types/models/account.d.ts
+++ b/packages/loot-core/src/types/models/account.d.ts
@@ -4,6 +4,7 @@ export type AccountEntity = {
   offbudget: 0 | 1;
   closed: 0 | 1;
   sort_order: number;
+  last_reconciled: string | null;
   tombstone: 0 | 1;
 } & (_SyncFields<true> | _SyncFields<false>);
 

--- a/upcoming-release-notes/4459.md
+++ b/upcoming-release-notes/4459.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [tostasmistas]
+---
+
+Add "last reconciled" timestamp to accounts


### PR DESCRIPTION
**⚠️ This PR contains a migration ⚠️**

---

This PR resolves #2967. 

It adds a `last_reconciled` column to the `accounts` table, which stores a UNIX timestamp indicating when each account was last reconciled. Upon initial release, all accounts will display "Not yet reconciled"; however, after completing reconciliation and pressing the "Done reconciling" button, the timestamp will be updated accordingly.

---

<kbd><img width="793" alt="imagem" src="https://github.com/user-attachments/assets/0ac295fd-8c23-41d0-8d41-6363191475b1" /></kbd>

<kbd><img width="855" alt="imagem" src="https://github.com/user-attachments/assets/a0159795-f924-4c1a-a11a-60c67a933cb5" /></kbd>

<kbd><img width="852" alt="imagem" src="https://github.com/user-attachments/assets/9b511a17-a2bd-4952-b41c-abb7babb24b5" /></kbd>

<kbd><img width="927" alt="imagem" src="https://github.com/user-attachments/assets/6e57265e-49a2-475b-8861-879755c8d508" /></kbd>


---