### PR TITLE
resets transaction search even if search text is not empty

### DIFF
--- a/packages/loot-core/src/client/data-hooks/transactions.ts
+++ b/packages/loot-core/src/client/data-hooks/transactions.ts
@@ -317,6 +317,7 @@ export function useTransactionsSearch({
           resetQuery();
           setIsSearching(false);
         } else if (searchText) {
+          resetQuery();
           updateQuery(previousQuery =>
             queries.transactionsSearch(previousQuery, searchText, dateFormat),
           );

--- a/upcoming-release-notes/4461.md
+++ b/upcoming-release-notes/4461.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed bug where partially erasing search string would not reset search and result in incorrect search results.


### PR DESCRIPTION
Resolves #4436 

---
category: Bugfix
authors: [alecbakholdin]
---

Fixed bug where partially erasing search string would not reset search and result in incorrect search results.