### PR TITLE
Resolves #4429 crash where clicking "manage payees" with an empty payee then clicking dropdown

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -220,7 +220,7 @@ export function TransactionList({
 
   const onManagePayees = useCallback(
     id => {
-      navigate('/payees', { state: { selectedPayee: id } });
+      navigate('/payees', id && { state: { selectedPayee: id } });
     },
     [navigate],
   );

--- a/upcoming-release-notes/4462.md
+++ b/upcoming-release-notes/4462.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed bug where navigating to payees page by clicking "manage payees" with an empty payee from a transaction would result in a crash.


### PR DESCRIPTION
When clicking "manage payees" from an empty payee:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/5b1dc246-3b8f-4289-b56d-cfef21bda4c6" />

Notice below that the checkbox in the top left of the table is selected even though there are no checked payees. This is because an undefined payee has been set during the navigate() call.
<img width="780" alt="image" src="https://github.com/user-attachments/assets/9e5d5fbd-a289-471c-9fa7-2b4931ffcf50" />

clicking the dropdown above the table would result in an unrecoverable crash:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/52db2668-c4ea-4abb-a84b-4cf451199ab7" />

After fix:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/fda2896e-30e8-4c30-a1da-8ba1bc2104ba" />
 
