### PR TITLE
Fix missing space in bank sync strings

### DIFF
--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -291,11 +291,9 @@ export function CreateAccountModal({ upgradingAccountId }: CreateAccountProps) {
                           <strong>
                             Link a <em>European</em> bank account
                           </strong>{' '}
-                          to automatically download transactions.
-                        </Trans>
-                        <Trans>
-                          GoCardless provides reliable, up-to-date information
-                          from hundreds of banks.
+                          to automatically download transactions. GoCardless
+                          provides reliable, up-to-date information from
+                          hundreds of banks.
                         </Trans>
                       </Text>
                       <View
@@ -356,11 +354,9 @@ export function CreateAccountModal({ upgradingAccountId }: CreateAccountProps) {
                           <strong>
                             Link a <em>North American</em> bank account
                           </strong>{' '}
-                          to automatically download transactions.
-                        </Trans>
-                        <Trans>
-                          SimpleFIN provides reliable, up-to-date information
-                          from hundreds of banks.
+                          to automatically download transactions. SimpleFIN
+                          provides reliable, up-to-date information from
+                          hundreds of banks.
                         </Trans>
                       </Text>
                     </>

--- a/upcoming-release-notes/4463.md
+++ b/upcoming-release-notes/4463.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Add missing space in translation for bank sync


### PR DESCRIPTION
On edge, there is a missing space in the bank sync translations:
<img width="509" alt="image" src="https://github.com/user-attachments/assets/3c9fc35f-cabf-4662-9266-6d9110e0a6b6" />

It's fixed in this PR:
<img width="508" alt="image" src="https://github.com/user-attachments/assets/d67d0adf-8dac-4192-9919-b7336ccb32f4" />

Unfortunately this change will require re-translation. We'll probably want to disable string pruning at some point (or at least move it later in the build process). Will take a look at some point.