### PR TITLE
Update transaction repair tool to remove erroneous transaction errors

### DIFF
--- a/packages/desktop-client/src/components/settings/RepairTransactions.tsx
+++ b/packages/desktop-client/src/components/settings/RepairTransactions.tsx
@@ -25,6 +25,7 @@ function useRenderResults() {
       numDeleted,
       numTransfersFixed,
       mismatchedSplits,
+      numNonParentErrorsFixed,
     } = results;
     const result: string[] = [];
 
@@ -33,6 +34,7 @@ function useRenderResults() {
       numCleared === 0 &&
       numDeleted === 0 &&
       numTransfersFixed === 0 &&
+      numNonParentErrorsFixed === 0 &&
       mismatchedSplits.length === 0
     ) {
       result.push(t('No split transactions found needing repair.'));
@@ -55,6 +57,13 @@ function useRenderResults() {
         result.push(
           t('Fixed {{count}} splits that weren’t properly deleted.', {
             count: numDeleted,
+          }),
+        );
+      }
+      if (numNonParentErrorsFixed > 0) {
+        result.push(
+          t('Fixed {{count}} non-split transactions with split errors.', {
+            count: numNonParentErrorsFixed,
           }),
         );
       }
@@ -153,6 +162,10 @@ export function RepairTransactions() {
             Checks that the sum of all child transactions adds up to the total
             amount. If not, these will be flagged below to allow you to easily
             locate and fix the amounts.
+          </li>
+          <li>
+            Checks for any non-split transactions with erroneous split errors
+            and removes the errors if found.
           </li>
           <li>
             Check if you have any budget transfers that erroneous contain a

--- a/packages/loot-core/src/server/tools/types/handlers.d.ts
+++ b/packages/loot-core/src/server/tools/types/handlers.d.ts
@@ -6,6 +6,7 @@ export interface ToolsHandlers {
     numCleared: number;
     numDeleted: number;
     numTransfersFixed: number;
+    numNonParentErrorsFixed: number;
     mismatchedSplits: TransactionEntity[];
   }>;
 }

--- a/upcoming-release-notes/4464.md
+++ b/upcoming-release-notes/4464.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfix
-authors: [MatissJanis]
+authors: [jfdoming]
 ---
 
 Update transaction repair tool to remove erroneous transaction errors

--- a/upcoming-release-notes/4464.md
+++ b/upcoming-release-notes/4464.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Update transaction repair tool to remove erroneous transaction errors


### PR DESCRIPTION
Opening this now so I don't forget to merge it, but let's not merge before the release just in case. Will open a separate PR to fix the related bug.

To test:
1. Add a split transaction with two children.
2. Delete both children but not the parent.
3. Hit "expand splits" and observe the crash (occurs as of 26/02).
4. Manually navigate to `/settings`, hit "Repair transactions", and observe the message.
5. Navigate back to the account you were previously in and observe the lack of crashes.