### PR TITLE
Fix crash when deleting child transactions from an errored split

### DIFF
--- a/packages/loot-core/src/shared/transactions.test.ts
+++ b/packages/loot-core/src/shared/transactions.test.ts
@@ -206,4 +206,23 @@ describe('Transactions', () => {
       expect.objectContaining({ amount: 3002 }),
     ]);
   });
+
+  test('deleting all child split transactions works', () => {
+    const transactions = [
+      makeTransaction({ amount: 2001 }),
+      ...makeSplitTransaction(
+        { id: 't1', amount: 2500, error: splitError(500) },
+        [{ id: 't2', amount: 2000 }],
+      ),
+      makeTransaction({ amount: 3002 }),
+    ];
+    const { data } = deleteTransaction(transactions, 't2');
+
+    expect(data).toEqual([
+      expect.objectContaining({ amount: 2001 }),
+      // Must delete error if no children
+      expect.objectContaining({ amount: 2500, error: null }),
+      expect.objectContaining({ amount: 3002 }),
+    ]);
+  });
 });

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -282,10 +282,11 @@ export function deleteTransaction(
       if (trans.id === id) {
         return null;
       } else if (trans.subtransactions?.length === 1) {
-        const { error, subtransactions, ...rest } = trans;
+        const { subtransactions, ...rest } = trans;
         return {
           ...rest,
           is_parent: false,
+          error: null,
         } satisfies TransactionEntity;
       } else {
         const sub = trans.subtransactions?.filter(t => t.id !== id);

--- a/upcoming-release-notes/4465.md
+++ b/upcoming-release-notes/4465.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix crash when deleting child transactions from an errored split


### PR DESCRIPTION
As it says on the tin. We need to pass `null` as the `error` or else it won't get deleted from the db.