### PR TITLE
fix #4445

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -284,7 +284,7 @@ async function processCleanup(month: string): Promise<Notification> {
   }
 
   const budgetAvailable = await getSheetValue(sheetName, `to-budget`);
-  if (budgetAvailable <= 0) {
+  if (budgetAvailable < 0) {
     warnings.push('Global: No funds are available to reallocate.');
   }
 

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -284,7 +284,7 @@ async function processCleanup(month: string): Promise<Notification> {
   }
 
   const budgetAvailable = await getSheetValue(sheetName, `to-budget`);
-  if (budgetAvailable < 0) {
+  if (budgetAvailable <= 0) {
     warnings.push('Global: No funds are available to reallocate.');
   }
 
@@ -350,6 +350,11 @@ async function processCleanup(month: string): Promise<Notification> {
         type: 'warning',
         message: 'Global: Funds not available:',
         pre: warnings.join('\n\n'),
+      };
+    } else if (budgetAvailable == 0) {
+      return {
+        type: 'message',
+        message: 'All categories were up to date.',
       };
     } else {
       return {

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -351,7 +351,7 @@ async function processCleanup(month: string): Promise<Notification> {
         message: 'Global: Funds not available:',
         pre: warnings.join('\n\n'),
       };
-    } else if (budgetAvailable == 0) {
+    } else if (budgetAvailable === 0) {
       return {
         type: 'message',
         message: 'All categories were up to date.',

--- a/upcoming-release-notes/4468.md
+++ b/upcoming-release-notes/4468.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Remove warning on cleanup templates if budget is already "clean"


### PR DESCRIPTION
There would be a warning on a already "clean" budget.  This should skip the warning if "clean" and have a green message instead.

fixes #4445
