### PR TITLE
add last bank sync tracking back in

### DIFF
--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -634,7 +634,7 @@ async function handleSyncResponse(
     updated: Array<TransactionEntity['id']>;
   },
   acct: db.DbAccount,
-): SyncResponse {
+): Promise<SyncResponse> {
   const { added, updated } = res;
   const newTransactions: Array<TransactionEntity['id']> = [];
   const matchedTransactions: Array<TransactionEntity['id']> = [];

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -648,8 +648,7 @@ async function handleSyncResponse(
   }
 
   const ts = new Date().getTime().toString();
-  const id = acct.id;
-  await db.runQuery(`UPDATE accounts SET last_sync = ? WHERE id = ?`, [ts, id]);
+  await db.update('accounts', { id: acct.id, last_sync: ts });
 
   return {
     newTransactions,

--- a/upcoming-release-notes/4472.md
+++ b/upcoming-release-notes/4472.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Add last bank sync tracking back in


### PR DESCRIPTION
Looks like this was accidentally removed in https://github.com/actualbudget/actual/pull/4227