### PR TITLE
Update bump-package-versions script to handle no input version

### DIFF
--- a/.github/actions/bump-package-versions
+++ b/.github/actions/bump-package-versions
@@ -1,7 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-version="${1#v}"
+if [ "$#" -gt 0 ]; then
+    version="${1#v}"
+else
+    version=""
+fi
 
 files_to_bump=(
     packages/api/package.json


### PR DESCRIPTION
Skipping release notes as this is a CI script and only added this month.

Tested by running locally on Linux via Docker—note that there is no error on MacOS which is why this wasn't previously caught :/