### PR TITLE
🐳 Docker images to be published under the actual repo

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -24,6 +24,7 @@ env:
   IMAGES: |
     actualbudget/actual-server
     ghcr.io/actualbudget/actual-server
+    ghcr.io/actualbudget/actual
 
   # Creates the following tags:
   # - actual-server:edge

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,6 +13,7 @@ env:
   IMAGES: |
     actualbudget/actual-server
     ghcr.io/actualbudget/actual-server
+    ghcr.io/actualbudget/actual
 
   # Creates the following tags:
   # - actual-server:latest (see docker/metadata-action flavor inputs, below)

--- a/upcoming-release-notes/4483.md
+++ b/upcoming-release-notes/4483.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Publishing the docker images to the actual repo packages area in github


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

The docker images are currently published to the actual-server repo: https://github.com/actualbudget/actual-server/pkgs/container/actual-server

It has a message saying the repo is readonly so it's not ideal. This PR should publish to this repo as well. We can phase out the old actual-server images in future.