### PR TITLE
prevent subsequent builds from failing when fetching translations

### DIFF
--- a/bin/package-browser
+++ b/bin/package-browser
@@ -9,6 +9,7 @@ if ! [ -d packages/desktop-client/locale ]; then
     git clone https://github.com/actualbudget/translations packages/desktop-client/locale
 fi
 pushd packages/desktop-client/locale > /dev/null
+git checkout .
 git pull
 popd > /dev/null
 packages/desktop-client/bin/remove-untranslated-languages

--- a/bin/package-electron
+++ b/bin/package-electron
@@ -42,6 +42,7 @@ if ! [ -d packages/desktop-client/locale ]; then
     git clone https://github.com/actualbudget/translations packages/desktop-client/locale
 fi
 pushd packages/desktop-client/locale > /dev/null
+git checkout .
 git pull
 popd > /dev/null
 packages/desktop-client/bin/remove-untranslated-languages

--- a/upcoming-release-notes/4485.md
+++ b/upcoming-release-notes/4485.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Prevent subsequent builds from failing when fetching translations


### PR DESCRIPTION
This stops subsequent builds failing when pulling the transactions repo in.

```
$ yarn build:browser
Updating translations...
error: cannot pull with rebase: You have unstaged changes.
error: please commit or stash them.
```

```
$ pwd
/Users/matt/actual/packages/desktop-client/locale

$ git status --short --branch .
## main...origin/main
 D ar.json
 D ca.json
 D cs.json
 D da.json
 D el.json
 D fi.json
 D hu.json
 D id.json
 D it.json
 D lt.json
 D nb-NO.json
 D pl.json
 D pt.json
 D ru.json
 D sv.json
 D ta.json
 D tr.json
 D zh-Hans.json
 D zh-Hant.json
```