### PR TITLE
:electron:  Copy budget files to succeed even if cleanup fails & adding retries

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -554,14 +554,25 @@ ipcMain.handle(
 
       await copy(currentBudgetDirectory, newDirectory, {
         overwrite: true,
+        preserveTimestamps: true,
       });
-      await remove(currentBudgetDirectory);
     } catch (error) {
       logMessage(
         'error',
         `There was an error moving your directory:  ${error}`,
       );
       throw error;
+    }
+
+    try {
+      await remove(currentBudgetDirectory);
+    } catch (error) {
+      // Fail silently. The move worked, but the old directory wasn't cleaned up - most likely a permission issue.
+      // This call needs to succeed to allow the user to continue using the app with the files in the new location.
+      logMessage(
+        'error',
+        `There was an error removing the old directory: ${error}`,
+      );
     }
   },
 );

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -565,7 +565,13 @@ ipcMain.handle(
     }
 
     try {
-      await remove(currentBudgetDirectory);
+      await promiseRetry(retry => {
+        logMessage(
+          'info',
+          `Cleaning up old directory: ${currentBudgetDirectory}`,
+        );
+        return remove(currentBudgetDirectory).catch(retry);
+      });
     } catch (error) {
       // Fail silently. The move worked, but the old directory wasn't cleaned up - most likely a permission issue.
       // This call needs to succeed to allow the user to continue using the app with the files in the new location.

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -578,7 +578,7 @@ ipcMain.handle(
             retry(error);
           }
         },
-        { maxTimeout: 200 },
+        { minTimeout: 200, maxTimeout: 500, factor: 1.25 },
       );
     } catch (error) {
       // Fail silently. The move worked, but the old directory wasn't cleaned up - most likely a permission issue.

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^11.7.0",
-    "fs-extra": "^11.2.0",
+    "fs-extra": "^11.3.0",
     "promise-retry": "^2.0.1"
   },
   "devDependencies": {

--- a/upcoming-release-notes/4507.md
+++ b/upcoming-release-notes/4507.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Allow desktop app to move budget files even when cleanup tasks fail

--- a/yarn.lock
+++ b/yarn.lock
@@ -10172,7 +10172,7 @@ __metadata:
     cross-env: "npm:^7.0.3"
     electron: "npm:30.0.6"
     electron-builder: "npm:24.13.3"
-    fs-extra: "npm:^11.2.0"
+    fs-extra: "npm:^11.3.0"
     promise-retry: "npm:^2.0.1"
     typescript: "npm:^5.5.4"
   languageName: unknown
@@ -12425,7 +12425,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.1.0, fs-extra@npm:^11.2.0":
+"fs-extra@npm:^11.1.0":
   version: 11.2.0
   resolution: "fs-extra@npm:11.2.0"
   dependencies:
@@ -12433,6 +12433,17 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10/0579bf6726a4cd054d4aa308f10b483f52478bb16284f32cf60b4ce0542063d551fca1a08a2af365e35db21a3fa5a06cf2a6ed614004b4368982bc754cb816b3
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:^11.3.0":
+  version: 11.3.0
+  resolution: "fs-extra@npm:11.3.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10/c9fe7b23dded1efe7bbae528d685c3206477e20cc60e9aaceb3f024f9b9ff2ee1f62413c161cb88546cc564009ab516dec99e9781ba782d869bb37e4fe04a97f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

When the user tries to move their budget directory there's a chance the directory will fail if the permissions aren't right or the files are locked. 

The current issue is that if it fails it leaves the users budget files in one place, but the app still references the old file location. So their budget files appear to be gone. 

The fix is to allow the budget directory to succeed if the budget files moved, which allows the app to set the new budget directory. To mitigate file locking I've added retries.
