### PR TITLE
Ignore user's fly.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ bundle.mobile.js.map
 
 # build output
 package.tgz
+
+# Fly.io configuration
+fly.toml

--- a/upcoming-release-notes/4508.md
+++ b/upcoming-release-notes/4508.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [mahmoudhossam]
+---
+
+Ignore fly.toml on the actualbudget/actual repo


### PR DESCRIPTION
This file was ignored on the actual-server repo but not here.

Will make it easier for people with fly.io deployments to keep track with changes without having to stash/unstash.
