### PR TITLE
increase timeout for SimpleFIN batch sync and add debug logging

### DIFF
--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
@@ -46,6 +46,9 @@ function useErrorMessage() {
       case 'RATE_LIMIT_EXCEEDED':
         return t('Rate limit exceeded for this item. Please try again later.');
 
+      case 'TIMED_OUT':
+        return t('The request timed out. Please try again later.');
+
       case 'INVALID_ACCESS_TOKEN':
         return t(
           'Your SimpleFIN Access Token is no longer valid. Please reset and generate a new token.',

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -696,13 +696,17 @@ function handleSyncError(
   err: Error | PostError | BankSyncError,
   acct: db.DbAccount,
 ): SyncError {
-  if (err instanceof BankSyncError) {
+  // TODO: refactor bank sync logic to use BankSyncError properly
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (err instanceof BankSyncError || (err as any)?.type === 'BankSyncError') {
+    const error = err as BankSyncError;
+
     return {
       type: 'SyncError',
       accountId: acct.id,
       message: 'Failed syncing account “' + acct.name + '.”',
-      category: err.category,
-      code: err.code,
+      category: error.category,
+      code: error.code,
     };
   }
 

--- a/upcoming-release-notes/4515.md
+++ b/upcoming-release-notes/4515.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Increase timeout for SimpleFIN batch sync and add debug logging


### PR DESCRIPTION
This is a shot at fixing https://github.com/actualbudget/actual/issues/4480. Regardless of a new solution from SimpleFIN, the 60s timeout is probably not enough for them to respond to batch requests for 40+ accounts in some cases.

This change increases the timeout to 5 minutes for batch sync operations, shows a more elegant error, and adds some debug logging if it was to fail.

Tested this by making the server to hang indefinitely on request to '/transactions'.