### PR TITLE
[WIP] Added Make Transfer button to mobile.

### DIFF
--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -347,6 +347,7 @@ function TransactionListWithPreviews({
       onSearch={onSearch}
       onOpenTransaction={onOpenTransaction}
       onRefresh={onRefresh}
+      account={account}
     />
   );
 }

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -17,6 +17,7 @@ import { useSheetValue } from '../../spreadsheet/useSheetValue';
 import { PullToRefresh } from '../PullToRefresh';
 
 import { TransactionList } from './TransactionList';
+import {type AccountEntity} from 'loot-core/types/models';
 
 type TransactionSearchInputProps = {
   placeholder: string;
@@ -91,6 +92,7 @@ type TransactionListWithBalancesProps = {
   onLoadMore: () => void;
   onOpenTransaction: (transaction: TransactionEntity) => void;
   onRefresh?: () => void;
+  account: AccountEntity;
 };
 
 export function TransactionListWithBalances({
@@ -105,6 +107,7 @@ export function TransactionListWithBalances({
   onLoadMore,
   onOpenTransaction,
   onRefresh,
+  account,
 }: TransactionListWithBalancesProps) {
   const selectedInst = useSelected('transactions', [...transactions], []);
 
@@ -148,6 +151,7 @@ export function TransactionListWithBalances({
             isLoadingMore={isLoadingMore}
             onLoadMore={onLoadMore}
             onOpenTransaction={onOpenTransaction}
+            account={account}
           />
         </PullToRefresh>
       </>


### PR DESCRIPTION
- Added the Make Transfer button to the mobile client.

This was the only functionality missing in the mobile client for my day to day budgeting. With this change, many users including myself should no longer need to regularly open the desktop client.

Most of this code is reused from the desktop client.