### PR TITLE
fix: filtering of transfer transactions

### DIFF
--- a/packages/loot-core/src/client/queries.ts
+++ b/packages/loot-core/src/client/queries.ts
@@ -101,6 +101,7 @@ export function transactionsSearch(
   return currentQuery.filter({
     $or: {
       'payee.name': { $like: `%${search}%` },
+      'payee.transfer_acct.name': { $like: `%${search}%` },
       notes: { $like: `%${search}%` },
       'category.name': { $like: `%${search}%` },
       'account.name': { $like: `%${search}%` },

--- a/upcoming-release-notes/4519.md
+++ b/upcoming-release-notes/4519.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tostasmistas]
+---
+
+Fix filtering of transfer transactions


### PR DESCRIPTION
This PR fixes https://github.com/actualbudget/actual/issues/3042.

It fixes an issue where transactions for transfers between accounts (i.e., transactions where the payee is another account) were not properly filtered during searches.

---

- Before

<kbd><img width="1565" alt="image" src="https://github.com/user-attachments/assets/7d14a2b9-be27-46df-8bc0-6e5833a5a904" /></kbd>

- After

<kbd><img width="1567" alt="image" src="https://github.com/user-attachments/assets/6d333eab-10b7-4838-b420-4f6a77f2f9db" /></kbd>

---