### PR TITLE
Show the last bank sync in plain language instead of timestamp

### DIFF
--- a/packages/desktop-client/src/components/banksync/AccountRow.tsx
+++ b/packages/desktop-client/src/components/banksync/AccountRow.tsx
@@ -3,19 +3,12 @@ import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 
-import { format } from 'loot-core/src/shared/months';
+import { tsToRelativeTime } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/src/types/models';
 
-import { useDateFormat } from '../../hooks/useDateFormat';
+import { useGlobalPref } from '../../hooks/useGlobalPref';
 import { theme } from '../../style';
 import { Row, Cell } from '../table';
-
-const tsToString = (ts: string | null, dateFormat: string) => {
-  if (!ts) return 'Unknown';
-
-  const parsed = new Date(parseInt(ts, 10));
-  return `${format(parsed, dateFormat)} ${format(parsed, 'HH:mm:ss')}`;
-};
 
 type AccountRowProps = {
   account: AccountEntity;
@@ -28,9 +21,11 @@ export const AccountRow = memo(
   ({ account, hovered, onHover, onAction }: AccountRowProps) => {
     const backgroundFocus = hovered;
 
-    const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+    const [language = 'en-US'] = useGlobalPref('language');
 
-    const lastSync = tsToString(account.last_sync, dateFormat);
+    const lastSync = tsToRelativeTime(account.last_sync, language, {
+      capitalize: true,
+    });
 
     return (
       <Row

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -487,7 +487,13 @@ export function sortByKey<T>(arr: T[], key: keyof T): T[] {
 
 // Date utilities
 
-export function tsToRelativeTime(ts: string | null, language: string): string {
+export function tsToRelativeTime(
+  ts: string | null,
+  language: string,
+  options: {
+    capitalize: boolean;
+  } = { capitalize: false },
+): string {
   if (!ts) return 'Unknown';
 
   const parsed = new Date(parseInt(ts, 10));
@@ -495,5 +501,11 @@ export function tsToRelativeTime(ts: string | null, language: string): string {
     locales[language.replace('-', '') as keyof typeof locales] ??
     locales['enUS'];
 
-  return formatDistanceToNow(parsed, { addSuffix: true, locale });
+  let distance = formatDistanceToNow(parsed, { addSuffix: true, locale });
+
+  if (options.capitalize) {
+    distance = distance.charAt(0).toUpperCase() + distance.slice(1);
+  }
+
+  return distance;
 }

--- a/upcoming-release-notes/4523.md
+++ b/upcoming-release-notes/4523.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Show the last bank sync in plain language instead of timestamp


### PR DESCRIPTION
Thanks to the helper @tostasmistas introduced in https://github.com/actualbudget/actual/pull/4459, this looks much better!

Before:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/43d9dbb0-d8ac-4255-926e-99ed0a20a8e8" />

After:
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/5dec2be7-b7fa-4de4-85a1-5286a26c377f" />

Those screenshots are taken on different instances so the dates don't match.