### PR TITLE
disable mangling when building

### DIFF
--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -109,6 +109,10 @@ export default defineConfig(async ({ mode }) => {
     base: '/',
     envPrefix: 'REACT_APP_',
     build: {
+      terserOptions: {
+        compress: false,
+        mangle: false,
+      },
       target: 'es2022',
       sourcemap: true,
       outDir: mode === 'desktop' ? 'build-electron' : 'build',

--- a/packages/loot-core/webpack/webpack.browser.config.js
+++ b/packages/loot-core/webpack/webpack.browser.config.js
@@ -83,7 +83,7 @@ module.exports = {
           compress: {
             drop_debugger: false,
           },
-          mangle: true,
+          mangle: false,
         },
       }),
     ],

--- a/upcoming-release-notes/4532.md
+++ b/upcoming-release-notes/4532.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Disable mangling on build


### PR DESCRIPTION
We expect a bump in bundle size here, but the benefits to debugging outweigh the expected impact.