### PR TITLE
🐛 Fix for var `ACTUAL_OPENID_ENFORCE`

### DIFF
--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -221,6 +221,10 @@ export function Login() {
   const loginMethods = useAvailableLoginMethods();
 
   useEffect(() => {
+    setMethod(defaultLoginMethod);
+  }, [defaultLoginMethod]);
+
+  useEffect(() => {
     if (checked && !searchParams.has('error')) {
       (async () => {
         if (method === 'header') {

--- a/packages/sync-server/src/app-account.js
+++ b/packages/sync-server/src/app-account.js
@@ -30,12 +30,16 @@ export { app as handlers };
 // /login
 
 app.get('/needs-bootstrap', (req, res) => {
+  const availableLoginMethods = listLoginMethods();
   res.send({
     status: 'ok',
     data: {
       bootstrapped: !needsBootstrap(),
-      loginMethod: getLoginMethod(),
-      availableLoginMethods: listLoginMethods(),
+      loginMethod:
+        availableLoginMethods.length === 1
+          ? availableLoginMethods[0].method
+          : getLoginMethod(),
+      availableLoginMethods,
       multiuser: getActiveLoginMethod() === 'openid',
     },
   });

--- a/upcoming-release-notes/4533.md
+++ b/upcoming-release-notes/4533.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix for variable `ACTUAL_OPENID_ENFORCE`. OpenID was not being enforced at some conditions.


### PR DESCRIPTION
Sometimes the variable `ACTUAL_OPENID_ENFORCE` was not being enforced.
Fixes #4509