### PR TITLE
🐛 Fix for ACTUAL_PORT and PORT vars

### DIFF
--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -64,8 +64,8 @@ const configSchema = convict({
   port: {
     doc: 'Port to run the server on.',
     format: 'port',
-    default: 5006,
-    env: ['ACTUAL_PORT', 'PORT'],
+    default: process.env.PORT ? process.env.PORT : 5006,
+    env: 'ACTUAL_PORT',
   },
   hostname: {
     doc: 'Server hostname.',

--- a/upcoming-release-notes/4537.md
+++ b/upcoming-release-notes/4537.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix for ACTUAL_PORT and PORT vars


### PR DESCRIPTION
Port variables are being ignored at the moment with the config refactory