### PR TITLE
Replace category DB queries in server handlers with AQL queries + implement category_groups AQL executor

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -38,7 +38,7 @@ import { useSheetValue } from '../spreadsheet/useSheetValue';
 import { Autocomplete, defaultFilterSuggestion } from './Autocomplete';
 import { ItemHeader } from './ItemHeader';
 
-type CategoryAutocompleteItem = CategoryEntity & {
+type CategoryAutocompleteItem = Omit<CategoryEntity, 'group'> & {
   group?: CategoryGroupEntity;
 };
 
@@ -105,9 +105,10 @@ function CategoryList({
             });
           }
 
-          const showGroup = item.cat_group !== lastGroup;
+          const groupId = item.group?.id;
+          const showGroup = groupId !== lastGroup;
           const groupName = `${item.group?.name}${item.group?.hidden ? ' ' + t('(hidden)') : ''}`;
-          lastGroup = item.cat_group;
+          lastGroup = groupId;
           return (
             <Fragment key={item.id}>
               {showGroup && item.group?.name && (
@@ -195,13 +196,15 @@ export function CategoryAutocomplete({
         (list, group) =>
           list.concat(
             (group.categories || [])
-              .filter(category => category.cat_group === group.id)
+              .filter(category => category.group === group.id)
               .map(category => ({
                 ...category,
                 group,
               })),
           ),
-        showSplitOption ? [{ id: 'split', name: '' } as CategoryEntity] : [],
+        showSplitOption
+          ? [{ id: 'split', name: '' } as CategoryAutocompleteItem]
+          : [],
       ),
     [defaultCategoryGroups, categoryGroups, showSplitOption],
   );

--- a/packages/desktop-client/src/components/budget/BudgetCategories.jsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.jsx
@@ -217,7 +217,7 @@ export const BudgetCategories = memo(
                   <SidebarCategory
                     category={{
                       name: '',
-                      cat_group: newCategoryForGroup,
+                      group: newCategoryForGroup,
                       is_income:
                         newCategoryForGroup ===
                         categoryGroups.find(g => g.is_income).id,

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
@@ -55,7 +55,7 @@ export function ExpenseCategory({
 }: ExpenseCategoryProps) {
   let dragging = dragState && dragState.item === cat;
 
-  if (dragState && dragState.item.id === cat.cat_group) {
+  if (dragState && dragState.item.id === cat.group) {
     dragging = true;
   }
 

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -163,7 +163,7 @@ function BudgetInner(props: BudgetInnerProps) {
     const cats = await send('get-categories');
     const exists =
       cats.grouped
-        .filter(g => g.id === category.cat_group)[0]
+        .filter(g => g.id === category.group)[0]
         .categories.filter(
           c => c.name.toUpperCase() === category.name.toUpperCase(),
         )
@@ -179,7 +179,7 @@ function BudgetInner(props: BudgetInnerProps) {
       dispatch(
         createCategory({
           name: category.name,
-          groupId: category.cat_group,
+          groupId: category.group,
           isIncome: category.is_income,
           isHidden: category.hidden,
         }),

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -27,15 +27,11 @@ export function addToBeBudgetedGroup(groups: CategoryGroupEntity[]) {
       categories: [
         {
           id: 'to-budget',
-          name: t('To Budget'),
-          cat_group: 'to-budget',
-          group: {
-            id: 'to-budget',
-            name: t('To Budget'),
-          },
+          name: t('To  Budget'),
+          group: 'to-budget',
         },
       ],
-    },
+    } as CategoryGroupEntity,
     ...groups,
   ];
 }

--- a/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
@@ -83,7 +83,7 @@ export function IncomeCategoryList({
         );
       }
 
-      if (!categoryToMove.cat_group) {
+      if (!categoryToMove.group) {
         throw new Error(
           `Internal error: category ${categoryIdToMove} is not in a group and cannot be moved.`,
         );
@@ -95,7 +95,7 @@ export function IncomeCategoryList({
         dispatch(
           moveCategory({
             id: categoryToMove.id,
-            groupId: categoryToMove.cat_group,
+            groupId: categoryToMove.group,
             targetId: targetCategoryId,
           }),
         );
@@ -115,7 +115,7 @@ export function IncomeCategoryList({
         dispatch(
           moveCategory({
             id: categoryToMove.id,
-            groupId: categoryToMove.cat_group,
+            groupId: categoryToMove.group,
             // Due to the way `moveCategory` works, we use the category next to the
             // actual target category here because `moveCategory` always shoves the
             // category *before* the target category.

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -46,7 +46,7 @@ export function CategoryMenuModal({
 }: CategoryMenuModalProps) {
   const { t } = useTranslation();
   const category = useCategory(categoryId);
-  const categoryGroup = useCategoryGroup(category?.cat_group);
+  const categoryGroup = useCategoryGroup(category?.group);
   const originalNotes = useNotes(category.id);
 
   const onRename = newName => {

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -3,10 +3,8 @@ import { t } from 'i18next';
 import * as monthUtils from 'loot-core/shared/months';
 import {
   type CustomReportEntity,
-  type AccountEntity,
   type CategoryEntity,
   type CategoryGroupEntity,
-  type PayeeEntity,
   type sortByOpType,
 } from 'loot-core/types/models';
 
@@ -272,7 +270,7 @@ type UncategorizedId = 'off_budget' | 'transfer' | 'other' | 'all';
 
 export type UncategorizedEntity = Pick<
   CategoryEntity,
-  'id' | 'name' | 'hidden' | 'cat_group'
+  'id' | 'name' | 'hidden'
 > & {
   uncategorized_id?: UncategorizedId;
 };
@@ -320,8 +318,8 @@ export const categoryLists = (categories: {
   const categoryList: UncategorizedEntity[] = [
     ...categoriesToSort.sort((a, b) => {
       //The point of this sorting is to make the graphs match the "budget" page
-      const catGroupA = categories.grouped.find(f => f.id === a.cat_group);
-      const catGroupB = categories.grouped.find(f => f.id === b.cat_group);
+      const catGroupA = categories.grouped.find(f => f.id === a.group);
+      const catGroupB = categories.grouped.find(f => f.id === b.group);
       //initial check that both a and b have a sort_order and category group
       return a.sort_order && b.sort_order && catGroupA && catGroupB
         ? /*sorting by "is_income" because sort_order for this group is
@@ -348,9 +346,9 @@ export const categoryLists = (categories: {
 export const groupBySelections = (
   groupBy: string,
   categoryList: UncategorizedEntity[],
-  categoryGroup: CategoryGroupEntity[],
-  payees: PayeeEntity[],
-  accounts: AccountEntity[],
+  categoryGroup: UncategorizedEntity[],
+  payees: UncategorizedEntity[],
+  accounts: UncategorizedEntity[],
 ): [
   UncategorizedEntity[],
   'category' | 'categoryGroup' | 'payee' | 'account',

--- a/packages/loot-core/src/mocks/budget.ts
+++ b/packages/loot-core/src/mocks/budget.ts
@@ -14,12 +14,13 @@ import { q } from '../shared/query';
 import type { Handlers } from '../types/handlers';
 import type {
   CategoryGroupEntity,
-  NewCategoryGroupEntity,
   PayeeEntity,
   TransactionEntity,
 } from '../types/models';
 
 import { random } from './random';
+
+import { CategoryGroupDefinition } from '.';
 
 type MockPayeeEntity = Partial<PayeeEntity> & { bill?: boolean };
 
@@ -651,7 +652,7 @@ export async function createTestBudget(handlers: Handlers) {
     }),
   );
 
-  const newCategoryGroups: Array<NewCategoryGroupEntity> = [
+  const newCategoryGroups: Array<CategoryGroupDefinition> = [
     {
       name: 'Usual Expenses',
       categories: [
@@ -710,6 +711,7 @@ export async function createTestBudget(handlers: Handlers) {
         categoryGroups[categoryGroups.length - 1].categories.push({
           ...category,
           id: categoryId,
+          group: groupId,
         });
       }
     }

--- a/packages/loot-core/src/mocks/index.ts
+++ b/packages/loot-core/src/mocks/index.ts
@@ -6,7 +6,6 @@ import type {
   AccountEntity,
   CategoryEntity,
   CategoryGroupEntity,
-  NewCategoryGroupEntity,
   TransactionEntity,
 } from '../types/models';
 
@@ -73,7 +72,7 @@ export function generateCategory(
   return {
     id: uuidv4(),
     name,
-    cat_group: group,
+    group,
     is_income: isIncome,
     sort_order: sortOrder++,
   };
@@ -92,8 +91,15 @@ export function generateCategoryGroup(
   };
 }
 
+export type CategoryGroupDefinition = Omit<
+  CategoryGroupEntity,
+  'id' | 'categories'
+> & {
+  categories: Omit<CategoryEntity, 'id' | 'group'>[];
+};
+
 export function generateCategoryGroups(
-  definition: Partial<NewCategoryGroupEntity>[],
+  definition: Partial<CategoryGroupDefinition>[],
 ): CategoryGroupEntity[] {
   return definition.map(group => {
     const g = generateCategoryGroup(group.name ?? '', group.is_income);

--- a/packages/loot-core/src/server/api-models.ts
+++ b/packages/loot-core/src/server/api-models.ts
@@ -42,7 +42,7 @@ export type APICategoryEntity = Pick<
   CategoryEntity,
   'id' | 'name' | 'is_income' | 'hidden'
 > & {
-  group_id?: string;
+  group_id: string;
 };
 
 export const categoryModel = {
@@ -54,17 +54,16 @@ export const categoryModel = {
       name: category.name,
       is_income: category.is_income ? true : false,
       hidden: category.hidden ? true : false,
-      ...(category.cat_group && { group_id: category.cat_group }),
+      group_id: category.group,
     };
   },
 
   fromExternal(category: APICategoryEntity) {
-    const { group_id: _, ...result }: { group_id?: string } & CategoryEntity =
-      category;
-
-    if ('group_id' in category) {
-      result.cat_group = category.group_id;
-    }
+    const { group_id, ...apiCategory } = category;
+    const result: CategoryEntity = {
+      ...apiCategory,
+      group: group_id,
+    };
     return result;
   },
 };

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -357,7 +357,7 @@ handlers['api/budget-month'] = async function ({ month }) {
   await validateMonth(month);
 
   const { data: groups }: { data: CategoryGroupEntity[] } = await aqlQuery(
-    q('category_group').select('*'),
+    q('category_groups').select('*'),
   );
   const sheetName = monthUtils.sheetForMonth(month);
 

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -356,9 +356,9 @@ handlers['api/budget-month'] = async function ({ month }) {
   checkFileOpen();
   await validateMonth(month);
 
-  // TODO: Force cast to CategoryGroupEntity. This should be updated to an AQL query.
-  const groups =
-    (await db.getCategoriesGrouped()) as unknown as CategoryGroupEntity[];
+  const { data: groups }: { data: CategoryGroupEntity[] } = await aqlQuery(
+    q('category_group').select('*'),
+  );
   const sheetName = monthUtils.sheetForMonth(month);
 
   function value(name) {

--- a/packages/loot-core/src/server/aql/schema/executors.ts
+++ b/packages/loot-core/src/server/aql/schema/executors.ts
@@ -1,9 +1,14 @@
 // @ts-strict-ignore
+
+import { q } from '../../../shared/query';
+import { CategoryEntity, CategoryGroupEntity } from '../../../types/models';
 import * as db from '../../db';
 import { whereIn } from '../../db/util';
 import { isAggregateQuery } from '../compiler';
 import { execQuery } from '../exec';
 import { convertOutputType } from '../schema-helpers';
+
+import { runQuery as aqlQuery } from './run-query';
 
 // Transactions executor
 
@@ -230,6 +235,71 @@ async function execTransactionsBasic(
   return execQuery(queryState, state, s, params, outputTypes);
 }
 
+async function execCategoryGroups(state, query, sql, params, outputTypes) {
+  const tableOptions = query.tableOptions || {};
+  const categoriesOption = tableOptions.categories || 'all';
+
+  if (categoriesOption !== 'none') {
+    return execCategoryGroupsWithCategories(
+      state,
+      query,
+      sql,
+      params,
+      categoriesOption,
+      outputTypes,
+    );
+  }
+  return execCategoryGroupsBasic(state, query, sql, params, outputTypes);
+}
+
+async function execCategoryGroupsWithCategories(
+  state,
+  queryState,
+  sql,
+  params,
+  categoriesOption,
+  outputTypes,
+) {
+  const categoryGroups = (await execCategoryGroupsBasic(
+    state,
+    queryState,
+    sql,
+    params,
+    outputTypes,
+  )) as CategoryGroupEntity[];
+
+  if (categoriesOption === 'none') {
+    return categoryGroups;
+  }
+
+  const { data: categories }: { data: CategoryEntity[] } = await aqlQuery(
+    q('categories')
+      .filter({
+        group: { $oneof: categoryGroups.map(cg => cg.id) },
+      })
+      .select('*'),
+  );
+
+  return categoryGroups.map(group => {
+    const cats = categories.filter(cat => cat.group === group.id);
+    return {
+      ...group,
+      categories: cats,
+    };
+  });
+}
+
+async function execCategoryGroupsBasic(
+  state,
+  queryState,
+  sql,
+  params,
+  outputTypes,
+) {
+  return execQuery(queryState, state, sql, params, outputTypes);
+}
+
 export const schemaExecutors = {
   transactions: execTransactions,
+  category_groups: execCategoryGroups,
 };

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -249,6 +249,10 @@ export const schemaConfig: SchemaConfig = {
             { sort_order: 'desc' },
             'id',
           ];
+        case 'category_groups':
+          return ['is_income', 'sort_order', 'id'];
+        case 'categories':
+          return ['sort_order', 'id'];
         case 'payees':
           return [
             { $condition: { transfer_acct: null }, $dir: 'desc' },

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -1,6 +1,8 @@
 import * as monthUtils from '../../shared/months';
+import { q } from '../../shared/query';
 import { CategoryEntity, CategoryGroupEntity } from '../../types/models';
 import { createApp } from '../app';
+import { runQuery as aqlQuery } from '../aql';
 import * as db from '../db';
 import { APIError } from '../errors';
 import { categoryGroupModel, categoryModel } from '../models';
@@ -359,7 +361,9 @@ async function deleteCategory({
 
 // Server must return AQL entities not the raw DB data
 async function getCategoryGroups() {
-  return (await db.getCategoriesGrouped()) as unknown as CategoryGroupEntity[];
+  const { data: categoryGroups }: { data: CategoryGroupEntity[] } =
+    await aqlQuery(q('category_groups').select('*'));
+  return categoryGroups;
 }
 
 async function createCategoryGroup({

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -1,6 +1,9 @@
 // @ts-strict-ignore
 import * as monthUtils from '../../shared/months';
+import { q } from '../../shared/query';
 import { getChangedValues } from '../../shared/util';
+import { CategoryGroupEntity } from '../../types/models';
+import { runQuery as aqlQuery } from '../aql';
 import * as db from '../db';
 import * as sheet from '../sheet';
 import { resolveName } from '../spreadsheet/util';
@@ -390,8 +393,10 @@ export async function doTransfer(categoryIds, transferId) {
 }
 
 export async function createBudget(months) {
-  const categories = await db.getCategories();
-  const groups = await db.getCategoriesGrouped();
+  const { data: groups }: { data: CategoryGroupEntity[] } = await aqlQuery(
+    q('category_groups').select('*'),
+  );
+  const categories = groups.flatMap(group => group.categories);
 
   sheet.startTransaction();
   const meta = sheet.get().meta();

--- a/packages/loot-core/src/server/budget/goalsSchedule.test.ts
+++ b/packages/loot-core/src/server/budget/goalsSchedule.test.ts
@@ -1,3 +1,4 @@
+import { CategoryEntity } from '../../types/models';
 import * as db from '../db';
 import { getRuleForSchedule } from '../schedules/app';
 
@@ -35,7 +36,7 @@ describe('goalsSchedule', () => {
     const last_month_balance = 0;
     const to_budget = 0;
     const errors: string[] = [];
-    const category = { id: '1', name: 'Test Category' };
+    const category = { id: '1', name: 'Test Category' } as CategoryEntity;
 
     (db.first as jest.Mock).mockResolvedValue({ id: 1, completed: 0 });
     (getRuleForSchedule as jest.Mock).mockResolvedValue({
@@ -105,7 +106,7 @@ describe('goalsSchedule', () => {
     const last_month_balance = 12000;
     const to_budget = 0;
     const errors: string[] = [];
-    const category = { id: '1', name: 'Test Category' };
+    const category = { id: '1', name: 'Test Category' } as CategoryEntity;
 
     (db.first as jest.Mock).mockResolvedValue({ id: 1, completed: 0 });
     (getRuleForSchedule as jest.Mock).mockResolvedValue({

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -318,7 +318,13 @@ export async function getCategories(
 
 export async function getCategoriesGrouped(
   ids?: Array<DbCategoryGroup['id']>,
-): Promise<Array<DbCategoryGroup & { categories: DbCategory[] }>> {
+): Promise<
+  Array<
+    DbCategoryGroup & {
+      categories: DbCategory[];
+    }
+  >
+> {
   const categoryGroupWhereIn = ids
     ? `cg.id IN (${toSqlQueryParameters(ids)}) AND`
     : '';
@@ -401,7 +407,7 @@ export async function moveCategoryGroup(
 
 export async function deleteCategoryGroup(
   group: Pick<DbCategoryGroup, 'id'>,
-  transferId?: string,
+  transferId?: DbCategory['id'],
 ) {
   const categories = await all<DbCategory>(
     'SELECT * FROM categories WHERE cat_group = ?',
@@ -460,6 +466,9 @@ export async function insertCategory(
       sort_order,
     };
 
+    // Change from cat_group to group because category AQL schema named it group.
+    // const { cat_group: group, ...rest } = category;
+
     const id = await insertWithUUID('categories', category);
     // Create an entry in the mapping table that points it to itself
     await insert('category_mapping', { id, transferId: id });
@@ -475,6 +484,8 @@ export function updateCategory(
   >,
 ) {
   category = categoryModel.validate(category, { update: true });
+  // Change from cat_group to group because category AQL schema named it group.
+  // const { cat_group: group, ...rest } = category;
   return update('categories', category);
 }
 
@@ -512,7 +523,10 @@ export async function deleteCategory(
       [category.id],
     );
     for (const mapping of existingTransfers) {
-      await update('category_mapping', { id: mapping.id, transferId });
+      await update('category_mapping', {
+        id: mapping.id,
+        transferId,
+      });
     }
 
     // Finally, map the category we're about to delete to the new one

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -466,9 +466,6 @@ export async function insertCategory(
       sort_order,
     };
 
-    // Change from cat_group to group because category AQL schema named it group.
-    // const { cat_group: group, ...rest } = category;
-
     const id = await insertWithUUID('categories', category);
     // Create an entry in the mapping table that points it to itself
     await insert('category_mapping', { id, transferId: id });

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -8,7 +8,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import * as monthUtils from '../../shared/months';
 import { sortByKey, groupBy } from '../../shared/util';
-import { CategoryGroupEntity } from '../../types/models';
 
 import { YNAB5 } from './ynab5-types';
 
@@ -535,16 +534,16 @@ function equalsIgnoreCase(stringa: string, stringb: string): boolean {
   );
 }
 
-function findByNameIgnoreCase(
-  categories: (YNAB5.CategoryGroup | CategoryGroupEntity)[],
+function findByNameIgnoreCase<T extends { name: string }>(
+  categories: T[],
   name: string,
 ) {
   return categories.find(cat => equalsIgnoreCase(cat.name, name));
 }
 
-function findIdByName(
-  categories: (YNAB5.CategoryGroup | CategoryGroupEntity)[],
+function findIdByName<T extends { id: string; name: string }>(
+  categories: Array<T>,
   name: string,
 ) {
-  return findByNameIgnoreCase(categories, name)?.id;
+  return findByNameIgnoreCase<T>(categories, name)?.id;
 }

--- a/packages/loot-core/src/server/models.ts
+++ b/packages/loot-core/src/server/models.ts
@@ -88,28 +88,10 @@ export const categoryModel = {
     category: CategoryEntity,
     { update }: { update?: boolean } = {},
   ): DbCategory {
-    const { cat_group: group, ...rest } = category;
-    // TODO: This is a workaround.
-    // Entity model does not match AQL so we rename it here.
-    // It should be updated later to match AQL.
-    const catWithGroupRenamed = {
-      ...rest,
-      group,
-    };
     return (
       update
-        ? convertForUpdate(
-            schema,
-            schemaConfig,
-            'categories',
-            catWithGroupRenamed,
-          )
-        : convertForInsert(
-            schema,
-            schemaConfig,
-            'categories',
-            catWithGroupRenamed,
-          )
+        ? convertForUpdate(schema, schemaConfig, 'categories', category)
+        : convertForInsert(schema, schemaConfig, 'categories', category)
     ) as DbCategory;
   },
   fromDb(category: DbCategory): CategoryEntity {

--- a/packages/loot-core/src/types/models/category-group.d.ts
+++ b/packages/loot-core/src/types/models/category-group.d.ts
@@ -1,15 +1,11 @@
 import { CategoryEntity } from './category';
 
-export interface NewCategoryGroupEntity {
+export interface CategoryGroupEntity {
+  id: string;
   name: string;
   is_income?: boolean;
   sort_order?: number;
   tombstone?: boolean;
   hidden?: boolean;
-  categories?: Omit<CategoryEntity, 'id'>[];
-}
-
-export interface CategoryGroupEntity extends NewCategoryGroupEntity {
-  id: string;
   categories?: CategoryEntity[];
 }

--- a/packages/loot-core/src/types/models/category.d.ts
+++ b/packages/loot-core/src/types/models/category.d.ts
@@ -4,7 +4,7 @@ export interface CategoryEntity {
   id: string;
   name: string;
   is_income?: boolean;
-  cat_group?: CategoryGroupEntity['id'];
+  group: CategoryGroupEntity['id'];
   sort_order?: number;
   tombstone?: boolean;
   hidden?: boolean;

--- a/upcoming-release-notes/4544.md
+++ b/upcoming-release-notes/4544.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Use AQL query to query category groups in loot-core server handlers and add a new `categories` query option for `category_groups` table to include/exclude querying of associated categories i.e. `q('category_groups').options({ categories: 'all' }).select('*')`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Right now there is a mismatch between the AQL schema and the `CategoryEntity` model. The schema defines a `group` property but the `CategoryEntity` defined a `cat_group` property. This PR is to align the two and modify the entity model to match the schema.

I have also updated the server handlers to use AQL to query categories so that we avoid directly returning the DB models to the client side.

A new AQL executor is also added for category_groups to quickly filter out categories if needed via the `categories` query option (similar to how transactions query have the `splits` option).
Example:
```typescript
// Returns groups with categories included. This is default behavior.
aqlQuery(q('category_groups').options({ categories: 'all' }).select('*'))

// Returns groups without categories.
aqlQuery(q('category_groups').options({ categories: 'none' }).select('*'))
```