### PR TITLE
:recycle: (components) rename SimpleTable to InfiniteScrollWrapper and cleanup

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { Stack } from '@actual-app/components/stack';
 import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
@@ -30,11 +31,10 @@ import { useCategories } from '../hooks/useCategories';
 import { usePayees } from '../hooks/usePayees';
 import { useSelected, SelectedProvider } from '../hooks/useSelected';
 import { useDispatch } from '../redux';
-import { theme } from '../style';
 
+import { InfiniteScrollWrapper } from './common/InfiniteScrollWrapper';
 import { Link } from './common/Link';
 import { Search } from './common/Search';
-import { SimpleTable } from './common/SimpleTable';
 import { RulesHeader } from './rules/RulesHeader';
 import { RulesList } from './rules/RulesList';
 
@@ -322,11 +322,7 @@ export function ManageRules({
         </View>
         <View style={{ flex: 1 }}>
           <RulesHeader />
-          <SimpleTable
-            loadMore={loadMore}
-            // Hide the last border of the item in the table
-            style={{ marginBottom: -1 }}
-          >
+          <InfiniteScrollWrapper loadMore={loadMore}>
             {filteredRules.length === 0 ? (
               <EmptyMessage text={t('No rules')} style={{ marginTop: 15 }} />
             ) : (
@@ -339,7 +335,7 @@ export function ManageRules({
                 onDeleteRule={rule => onDeleteRule(rule.id)}
               />
             )}
-          </SimpleTable>
+          </InfiniteScrollWrapper>
         </View>
         <View
           style={{

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
@@ -11,7 +11,10 @@ import React, {
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
+import { SvgLockOpen } from '@actual-app/components/icons/v1';
+import { SvgLockClosed } from '@actual-app/components/icons/v2';
 import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
@@ -23,13 +26,10 @@ import { type UserAvailable } from 'loot-core/types/models';
 import { type UserAccessEntity } from 'loot-core/types/models/userAccess';
 
 import { useMetadataPref } from '../../../hooks/useMetadataPref';
-import { SvgLockOpen } from '../../../icons/v1';
-import { SvgLockClosed } from '../../../icons/v2';
 import { useDispatch } from '../../../redux';
-import { theme } from '../../../style';
+import { InfiniteScrollWrapper } from '../../common/InfiniteScrollWrapper';
 import { Link } from '../../common/Link';
 import { Search } from '../../common/Search';
-import { SimpleTable } from '../../common/SimpleTable';
 
 import { UserAccessHeader } from './UserAccessHeader';
 import { UserAccessRow } from './UserAccessRow';
@@ -190,17 +190,13 @@ function UserAccessContent({
       </View>
       <View style={{ flex: 1 }}>
         <UserAccessHeader />
-        <SimpleTable
-          loadMore={loadMore}
-          // Hide the last border of the item in the table
-          style={{ marginBottom: -1 }}
-        >
+        <InfiniteScrollWrapper loadMore={loadMore}>
           <UserAccessList
             accesses={filteredAccesses}
             hoveredAccess={hoveredUserAccess}
             onHover={onHover}
           />
-        </SimpleTable>
+        </InfiniteScrollWrapper>
       </View>
       <View
         style={{

--- a/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
+++ b/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
@@ -13,6 +13,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Button } from '@actual-app/components/button';
 import { Stack } from '@actual-app/components/stack';
 import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { signOut } from 'loot-core/client/actions';
@@ -27,10 +28,9 @@ import {
 
 import { SelectedProvider, useSelected } from '../../../hooks/useSelected';
 import { useDispatch } from '../../../redux';
-import { theme } from '../../../style';
+import { InfiniteScrollWrapper } from '../../common/InfiniteScrollWrapper';
 import { Link } from '../../common/Link';
 import { Search } from '../../common/Search';
-import { SimpleTable } from '../../common/SimpleTable';
 
 import { UserDirectoryHeader } from './UserDirectoryHeader';
 import { UserDirectoryRow } from './UserDirectoryRow';
@@ -299,11 +299,7 @@ function UserDirectoryContent({
 
         <View style={{ flex: 1 }}>
           <UserDirectoryHeader />
-          <SimpleTable
-            loadMore={loadMore}
-            // Hide the last border of the item in the table
-            style={{ marginBottom: -1 }}
-          >
+          <InfiniteScrollWrapper loadMore={loadMore}>
             {filteredUsers.length === 0 ? (
               <EmptyMessage text={t('No users')} style={{ marginTop: 15 }} />
             ) : (
@@ -315,7 +311,7 @@ function UserDirectoryContent({
                 onEditUser={onEditUser}
               />
             )}
-          </SimpleTable>
+          </InfiniteScrollWrapper>
         </View>
         <View
           style={{

--- a/packages/desktop-client/src/components/common/InfiniteScrollWrapper.tsx
+++ b/packages/desktop-client/src/components/common/InfiniteScrollWrapper.tsx
@@ -1,28 +1,22 @@
-// @ts-strict-ignore
-import React, {
-  type ReactNode,
-  type UIEvent,
-  useRef,
-  type CSSProperties,
-} from 'react';
+import React, { useRef, type ReactNode, type UIEvent } from 'react';
 
 import { View } from '@actual-app/components/view';
 
-type SimpleTableProps = {
+type InfiniteScrollWrapperProps = {
   loadMore?: () => void;
-  style?: CSSProperties;
-  onHoverLeave?: () => void;
   children: ReactNode;
 };
 
-export function SimpleTable({
+/**
+ * Wrapper around an infinitely loading list.
+ * Calls the `loadMore` callback when the bottom of the list is reached
+ * by scrolling to the bottom of the list.
+ */
+export function InfiniteScrollWrapper({
   loadMore,
-  style,
-  onHoverLeave,
   children,
-}: SimpleTableProps) {
-  const contentRef = useRef<HTMLDivElement>();
-  const scrollRef = useRef<HTMLDivElement>();
+}: InfiniteScrollWrapperProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   function onScroll(e: UIEvent<HTMLElement>) {
     if (
@@ -43,7 +37,9 @@ export function SimpleTable({
         flex: 1,
         outline: 'none',
         '& .animated .animated-row': { transition: '.25s transform' },
-        ...style,
+
+        // Hide the last border of the item in the table
+        marginBottom: -1,
       }}
       tabIndex={1}
       data-testid="table"
@@ -53,9 +49,7 @@ export function SimpleTable({
         style={{ maxWidth: '100%', overflow: 'auto' }}
         onScroll={onScroll}
       >
-        <div ref={contentRef} onMouseLeave={onHoverLeave}>
-          {children}
-        </div>
+        {children}
       </View>
     </View>
   );

--- a/upcoming-release-notes/4578.md
+++ b/upcoming-release-notes/4578.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Renamed `SimpleTable` component to `InfiniteScrollWrapper` and cleaned up the logic (removed unused code, etc.).


### PR DESCRIPTION
1. renamed `SimpleTable` to `InfiniteScrollWrapper` to better reflect what it actually does
2. removed some unused functionality from the component