### PR TITLE
 :bug: fix rules page table incorrect row heights

### DIFF
--- a/packages/desktop-client/src/components/common/InfiniteScrollWrapper.tsx
+++ b/packages/desktop-client/src/components/common/InfiniteScrollWrapper.tsx
@@ -49,7 +49,7 @@ export function InfiniteScrollWrapper({
         style={{ maxWidth: '100%', overflow: 'auto' }}
         onScroll={onScroll}
       >
-        {children}
+        <div>{children}</div>
       </View>
     </View>
   );

--- a/upcoming-release-notes/4586.md
+++ b/upcoming-release-notes/4586.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix rules page table calculating incorrect row heights.


### PR DESCRIPTION
Turns out the wrapping `div` element was necessary after all.. who knew?

Bug introduced in: https://github.com/actualbudget/actual/pull/4578

Reported in: https://discord.com/channels/937901803608096828/1348454815394431071/1348454815394431071

![image](https://github.com/user-attachments/assets/efd61538-072d-4abc-a9a6-c4be5f8f753b)
