### PR TITLE
fix: align action buttons in modal for confirming transaction edit

### DIFF
--- a/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
@@ -4,7 +4,9 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
+import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { InitialFocus } from '@actual-app/components/initial-focus';
+import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
 import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
@@ -22,6 +24,13 @@ export function ConfirmTransactionEditModal({
   confirmReason,
 }: ConfirmTransactionEditModalProps) {
   const { t } = useTranslation();
+
+  const { isNarrowWidth } = useResponsive();
+  const narrowButtonStyle = isNarrowWidth
+    ? {
+        height: styles.mobileMinHeight,
+      }
+    : {};
 
   return (
     <Modal
@@ -83,44 +92,42 @@ export function ConfirmTransactionEditModal({
                 <Trans>Are you sure you want to edit this transaction?</Trans>
               </Block>
             )}
-
             <View
               style={{
                 marginTop: 20,
                 flexDirection: 'row',
-                justifyContent: 'flex-start',
-                alignItems: 'center',
+                justifyContent: 'flex-end',
               }}
             >
-              <View
+              <Button
+                aria-label={t('Cancel')}
                 style={{
-                  flexDirection: 'row',
-                  justifyContent: 'flex-end',
+                  marginRight: 10,
+                  ...narrowButtonStyle,
+                }}
+                onPress={() => {
+                  close();
+                  onCancel();
                 }}
               >
+                <Trans>Cancel</Trans>
+              </Button>
+              <InitialFocus>
                 <Button
-                  aria-label={t('Cancel')}
-                  style={{ marginRight: 10 }}
+                  aria-label={t('Confirm')}
+                  variant="primary"
+                  style={{
+                    marginRight: 10,
+                    ...narrowButtonStyle,
+                  }}
                   onPress={() => {
                     close();
-                    onCancel();
+                    onConfirm();
                   }}
                 >
-                  <Trans>Cancel</Trans>
+                  <Trans>Confirm</Trans>
                 </Button>
-                <InitialFocus>
-                  <Button
-                    aria-label={t('Confirm')}
-                    variant="primary"
-                    onPress={() => {
-                      close();
-                      onConfirm();
-                    }}
-                  >
-                    <Trans>Confirm</Trans>
-                  </Button>
-                </InitialFocus>
-              </View>
+              </InitialFocus>
             </View>
           </View>
         </>

--- a/upcoming-release-notes/4604.md
+++ b/upcoming-release-notes/4604.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tostasmistas]
+---
+
+Align action buttons in modal for confirming transaction edit


### PR DESCRIPTION
This PR fixes https://github.com/actualbudget/actual/issues/4597.

It aligns the "Cancel" and "Confirm" buttons in the modal for confirming a transaction edit to the right-hand side for consistency.

---

- Before

Desktop     |  Mobile
:----------:|:----------:
<kbd><img width="904" alt="image" src="https://github.com/user-attachments/assets/80bd30d3-a2ed-4133-b4ba-391241b6d627" /></kbd> |<kbd><img width="458" alt="image" src="https://github.com/user-attachments/assets/a1b09e3f-5fb6-4e13-8257-5da4e3e33003" /></kbd>

- After

Desktop     |  Mobile
:----------:|:----------:
<kbd><img width="904" alt="image" src="https://github.com/user-attachments/assets/dcf3ddf2-e788-44d0-b9c7-3b19797214f7" /></kbd> |<kbd><img width="458" alt="image" src="https://github.com/user-attachments/assets/379532cf-421a-4939-9d96-a5568d37b13c" /></kbd>

---