### PR TITLE
[sync-server] @types/node version bump to  18.x 

### DIFF
--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -50,7 +50,7 @@
     "@types/express": "^5.0.0",
     "@types/express-actuator": "^1.8.3",
     "@types/jest": "^29.5.14",
-    "@types/node": "^17.0.45",
+    "@types/node": "18.19.80",
     "@types/supertest": "^2.0.12",
     "@types/uuid": "^9.0.8",
     "http-proxy-middleware": "^3.0.3",

--- a/packages/sync-server/tsconfig.json
+++ b/packages/sync-server/tsconfig.json
@@ -12,8 +12,8 @@
     "jsx": "preserve",
     // Check JS files too
     "allowJs": true,
-    "moduleResolution": "node16",
-    "module": "node16",
+    "moduleResolution": "bundler",
+    "module": "es2022",
     "outDir": "build"
   },
   "include": ["src/**/*.js", "types/global.d.ts"],

--- a/upcoming-release-notes/4611.md
+++ b/upcoming-release-notes/4611.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [alec-bakholdin]
+---
+
+Upgraded sync-server @types/node to 18 and aligined module and moduleResolution with base tsconfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,7 @@ __metadata:
     "@types/express": "npm:^5.0.0"
     "@types/express-actuator": "npm:^1.8.3"
     "@types/jest": "npm:^29.5.14"
-    "@types/node": "npm:^17.0.45"
+    "@types/node": "npm:18.19.80"
     "@types/supertest": "npm:^2.0.12"
     "@types/uuid": "npm:^9.0.8"
     bcrypt: "npm:^5.1.1"
@@ -5996,10 +5996,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^17.0.45":
-  version: 17.0.45
-  resolution: "@types/node@npm:17.0.45"
-  checksum: 10/b45fff7270b5e81be19ef91a66b764a8b21473a97a8d211218a52e3426b79ad48f371819ab9153370756b33ba284e5c875463de4d2cf48a472e9098d7f09e8a2
+"@types/node@npm:18.19.80":
+  version: 18.19.80
+  resolution: "@types/node@npm:18.19.80"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10/05a54af019aae1fa7d7f8e6475071a7486cb8554f638894b5697ef1cad3b5ac6cbdd5fdfe3d8d70b3af7e56e0245b0033a986c00e1c09e80cb584db06e40c0ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fetch api wasn't working in sync-server because @types/node was outdated.