### PR TITLE
[Experiment] - Adding workflow to create a server package

### DIFF
--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Web
         run: ./bin/package-browser
       - name: Install Dependencies
-        run: yarn config set supportedArchitectures.cpu x64 && yarn workspaces focus @actual-app/sync-server --production
+        run: npm_config_arch=x64 yarn workspaces focus @actual-app/sync-server --production
       - name: Upload x64 Build
         uses: actions/upload-artifact@v4
         with:
@@ -36,6 +36,6 @@ jobs:
             package.json
             packages/sync-server/package.json
             packages/sync-server/app.js
-            app/packages/sync-server/src
+            packages/sync-server/src
             packages/sync-server/migrations
             node_modules

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Web
         run: ./bin/package-browser
       - name: Install Dependencies
-        run: npm_config_target_arch=x64 true yarn workspaces focus @actual-app/sync-server --production
+        run: npm_config_target_arch=x64 yarn workspaces focus @actual-app/sync-server --production
       - name: Upload x64 Build
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Package Server
 
 defaults:
   run:

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build Web
         run: ./bin/package-browser
       - name: Install Dependencies
-        run: npm_config_arch=x64 yarn workspaces focus @actual-app/sync-server --production
+        run: npm_config_arch=x64 npm_config_build_from_source=true yarn workspaces focus @actual-app/sync-server --production
       - name: Upload x64 Build
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -34,7 +34,8 @@ jobs:
           name: sync-server x64
           path: |
             package.json
-            packages/sync-server/package.json
+            yarn.lock
+            packages/*/package.json
             packages/sync-server/app.js
             packages/sync-server/src
             packages/sync-server/migrations

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -1,0 +1,37 @@
+name: Build
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CI: true
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  package-server:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Build Web
+        run: ./bin/package-browser
+      - name: Install Dependencies
+        run: yarn workspaces focus @actual-app/sync-server --production
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-server
+          path: |
+            packages/sync-server
+            node_modules

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Build Web
         run: ./bin/package-browser
       - name: Install Dependencies
-        run: yarn workspaces focus @actual-app/sync-server --production
-      - name: Upload Build
+        run: npm_config_target_arch=x64 true yarn workspaces focus @actual-app/sync-server --production
+      - name: Upload x64 Build
         uses: actions/upload-artifact@v4
         with:
-          name: sync-server
+          name: sync-server x64
           path: |
             packages/sync-server
             node_modules

--- a/.github/workflows/package-server.yml
+++ b/.github/workflows/package-server.yml
@@ -27,11 +27,15 @@ jobs:
       - name: Build Web
         run: ./bin/package-browser
       - name: Install Dependencies
-        run: npm_config_target_arch=x64 yarn workspaces focus @actual-app/sync-server --production
+        run: yarn config set supportedArchitectures.cpu x64 && yarn workspaces focus @actual-app/sync-server --production
       - name: Upload x64 Build
         uses: actions/upload-artifact@v4
         with:
           name: sync-server x64
           path: |
-            packages/sync-server
+            package.json
+            packages/sync-server/package.json
+            packages/sync-server/app.js
+            app/packages/sync-server/src
+            packages/sync-server/migrations
             node_modules


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Attempting to make local installs as easy as downloading the package.

~Note, we'd need to package for x64, x32, arm64. Will need to rebuild yarn dependencies before packaging.~

I think the user will always need to run yarn install because the binaries for bettersqlite etc need to be build for that version. Yarn does it for us.

This is probably not workable right now. Would need to bundle it properly.