### PR TITLE
✨ Bank sync avoid reimporting deleted transactions

### DIFF
--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -2,8 +2,11 @@ import React, { useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
+import { SvgQuestion } from '@actual-app/components/icons/v1';
 import { Stack } from '@actual-app/components/stack';
 import { Text } from '@actual-app/components/text';
+import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
 
 import { useTransactions } from 'loot-core/client/data-hooks/transactions';
 import {
@@ -238,7 +241,24 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
             checked={reimportDeleted}
             onChange={() => setReimportDeleted(!reimportDeleted)}
           >
-            <Trans>Reimport deleted transactions</Trans>
+            <Tooltip
+              content={t(
+                'By default imported transactions that you delete will be re-imported with the next bank sync operation. To disable this behaviour - untick this box.',
+              )}
+            >
+              <View
+                style={{
+                  display: 'flex',
+                  flexWrap: 'nowrap',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 4,
+                }}
+              >
+                <Trans>Reimport deleted transactions</Trans>
+                <SvgQuestion height={12} width={12} cursor="pointer" />
+              </View>
+            </Tooltip>
           </CheckboxOption>
 
           <Stack

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -234,7 +234,7 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
           </CheckboxOption>
 
           <CheckboxOption
-            id="form_deleted_notes"
+            id="form_reimport_deleted"
             checked={reimportDeleted}
             onChange={() => setReimportDeleted(!reimportDeleted)}
           >

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -122,6 +122,9 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
   const [savedImportPending = true, setSavedImportPending] = useSyncedPref(
     `sync-import-pending-${account.id}`,
   );
+  const [savedReimportDeleted = true, setSavedReimportDeleted] = useSyncedPref(
+    `sync-reimport-deleted-${account.id}`,
+  );
 
   const [transactionDirection, setTransactionDirection] =
     useState<TransactionDirection>('payment');
@@ -130,6 +133,9 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
   );
   const [importNotes, setImportNotes] = useState(
     String(savedImportNotes) === 'true',
+  );
+  const [reimportDeleted, setReimportDeleted] = useState(
+    String(savedReimportDeleted) === 'true',
   );
   const [mappings, setMappings] = useState<Mappings>(
     mappingsFromString(savedMappings),
@@ -168,6 +174,7 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
     setSavedMappings(mappingsStr);
     setSavedImportPending(String(importPending));
     setSavedImportNotes(String(importNotes));
+    setSavedReimportDeleted(String(reimportDeleted));
     close();
   };
 
@@ -224,6 +231,14 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
             onChange={() => setImportNotes(!importNotes)}
           >
             <Trans>Import transaction notes</Trans>
+          </CheckboxOption>
+
+          <CheckboxOption
+            id="form_deleted_notes"
+            checked={reimportDeleted}
+            onChange={() => setReimportDeleted(!reimportDeleted)}
+          >
+            <Trans>Reimport deleted notes</Trans>
           </CheckboxOption>
 
           <Stack

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -238,7 +238,7 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
             checked={reimportDeleted}
             onChange={() => setReimportDeleted(!reimportDeleted)}
           >
-            <Trans>Reimport deleted notes</Trans>
+            <Trans>Reimport deleted transactions</Trans>
           </CheckboxOption>
 
           <Stack

--- a/packages/loot-core/src/server/accounts/__snapshots__/sync.test.ts.snap
+++ b/packages/loot-core/src/server/accounts/__snapshots__/sync.test.ts.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Account sync reconcile does rematch deleted transactions by default 1`] = `
+[
+  {
+    "account": "one",
+    "amount": 0,
+    "category": null,
+    "cleared": 1,
+    "date": 20200101,
+    "error": null,
+    "id": "id3",
+    "imported_id": "finid",
+    "imported_payee": null,
+    "is_child": 0,
+    "is_parent": 0,
+    "notes": null,
+    "parent_id": null,
+    "payee": null,
+    "payee_name": null,
+    "raw_synced_data": null,
+    "reconciled": 0,
+    "schedule": null,
+    "sort_order": 123456789,
+    "starting_balance_flag": 0,
+    "tombstone": 1,
+    "transfer_id": null,
+  },
+  {
+    "account": "one",
+    "amount": 0,
+    "category": null,
+    "cleared": 1,
+    "date": 20200101,
+    "error": null,
+    "id": "id4",
+    "imported_id": "finid",
+    "imported_payee": null,
+    "is_child": 0,
+    "is_parent": 0,
+    "notes": null,
+    "parent_id": null,
+    "payee": null,
+    "payee_name": null,
+    "raw_synced_data": null,
+    "reconciled": 0,
+    "schedule": null,
+    "sort_order": 123456789,
+    "starting_balance_flag": 0,
+    "tombstone": 0,
+    "transfer_id": null,
+  },
+]
+`;
+
+exports[`Account sync reconcile doesnt rematch deleted transactions if reimport disabled 1`] = `
+[
+  {
+    "account": "one",
+    "amount": 0,
+    "category": null,
+    "cleared": 1,
+    "date": 20200101,
+    "error": null,
+    "id": "id3",
+    "imported_id": "finid",
+    "imported_payee": null,
+    "is_child": 0,
+    "is_parent": 0,
+    "notes": null,
+    "parent_id": null,
+    "payee": null,
+    "payee_name": null,
+    "raw_synced_data": null,
+    "reconciled": 0,
+    "schedule": null,
+    "sort_order": 123456789,
+    "starting_balance_flag": 0,
+    "tombstone": 1,
+    "transfer_id": null,
+  },
+]
+`;
+
 exports[`Account sync reconcile handles transactions with undefined fields 1`] = `
 [
   {

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import * as monthUtils from '../../shared/months';
+import { SyncedPrefs } from '../../types/prefs';
 import * as db from '../db';
 import { loadMappings } from '../db/mappings';
 import { post } from '../post';
@@ -7,7 +8,6 @@ import { getServer } from '../server-config';
 import { loadRules, insertRule } from '../transactions/transaction-rules';
 
 import { reconcileTransactions, addTransactions } from './sync';
-import { SyncedPrefs } from 'loot-core/types/prefs';
 
 jest.mock('../../shared/months', () => ({
   ...jest.requireActual('../../shared/months'),

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { account } from 'loot-core/mocks/arbitrary-schema';
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 import { loadMappings } from '../db/mappings';

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { saveSyncedPrefs } from 'loot-core/client/prefs/prefsSlice';
 import * as monthUtils from '../../shared/months';
 import * as db from '../db';
 import { loadMappings } from '../db/mappings';

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -649,8 +649,8 @@ export async function matchTransactions(
     // is the highest fidelity match and should always be attempted
     // first.
     if (trans.imported_id) {
-      match = await db.first<db.DbViewTransaction>(
-        'SELECT * FROM v_transactions WHERE imported_id = ? AND account = ?',
+      match = await db.first<db.DbTransaction>(
+        'SELECT * FROM v_transactions_internal WHERE imported_id = ? AND account = ?',
         [trans.imported_id, acctId],
       );
 

--- a/packages/loot-core/src/types/prefs.d.ts
+++ b/packages/loot-core/src/types/prefs.d.ts
@@ -32,6 +32,7 @@ export type SyncedPrefs = Partial<
     | `csv-has-header-${string}`
     | `custom-sync-mappings-${string}`
     | `sync-import-pending-${string}`
+    | `sync-reimport-deleted-${string}`
     | `sync-import-notes-${string}`
     | `ofx-fallback-missing-payee-${string}`
     | `flip-amount-${string}-${'csv' | 'qif'}`

--- a/upcoming-release-notes/4644.md
+++ b/upcoming-release-notes/4644.md
@@ -1,6 +1,6 @@
 ---
-category: Bugfix
+category: Enhancements
 authors: [alecbakholdin]
 ---
 
-Fixed bug where deleted transactions kept getting reimported
+Added ability to configure whether deleted transactions are reimported on bank sync

--- a/upcoming-release-notes/4644.md
+++ b/upcoming-release-notes/4644.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed bug where deleted transactions kept getting reimported


### PR DESCRIPTION
When you import a transaction using bank-sync, delete it, then re-import it, the transaction gets reimported instead of getting ignored. The reason for this is the v_transactions view filters out deleted transactions. I've updated the matchTransactions method to use the v_transactions_internal "view" (js-defined, looks like?), which includes deleted transactions.