### PR TITLE
add weblate widget to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ To add new feature requests, open a new Issue of the "Feature Request" type.
 
 Make Actual Budget accessible to more people by helping with the [Internationalization](https://actualbudget.org/docs/contributing/i18n/) of Actual. We are using a crowd sourcing tool to manage the translations, see our [Weblate Project](https://hosted.weblate.org/projects/actualbudget/). Weblate proudly supports open-source software projects through their [Libre plan](https://weblate.org/en/hosting/#libre). 
 
+<a href="https://hosted.weblate.org/engage/actualbudget/">
+<img src="https://hosted.weblate.org/widget/actualbudget/actual/287x66-grey.png" alt="Translation status" />
+</a>
+
 ## Repo Activity
 
 ![Alt](https://repobeats.axiom.co/api/embed/e20537dd8b74956f86736726ccfbc6f0565bec22.svg 'Repobeats analytics image')


### PR DESCRIPTION
This is provided by Weblate, there are a few different options if this one's not popular, but it felt the least intrusive whilst also being informative.

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/3fbe89c3-8044-4d18-a1d8-67eaedf32667" />
