### PR TITLE
🔧 Added release-notes-generator.ts under generate:release-notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,1 @@
-<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->
+<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
+Before opening a pull request, try running `yarn generate:release-notes`!
+
 Please review the contributing documentation on our website: https://actualbudget.org/docs/contributing/

--- a/bin/release-note-generator.ts
+++ b/bin/release-note-generator.ts
@@ -1,0 +1,67 @@
+import { writeFile } from 'node:fs';
+
+import prompts from 'prompts';
+
+async function run() {
+  const result = await prompts([
+    {
+      name: 'pullRequestNumber',
+      message: 'Existing PR number (if applicable)',
+      type: 'number',
+    },
+    {
+      name: 'releaseNoteType',
+      message: 'Release Note Type',
+      type: 'select',
+      choices: [
+        { title: 'Features' },
+        { title: 'Enhancements' },
+        { title: 'Bugfix' },
+        { title: 'Maintenance' },
+      ],
+    },
+    {
+      name: 'oneLineSummary',
+      message: 'Brief Summary',
+      type: 'text',
+    },
+    {
+      name: 'githubUsername',
+      message: 'Comma-separted GitHub username(s)',
+      type: 'text',
+    },
+  ]);
+
+  const fileContents = getFileContents(
+    result.releaseNoteType,
+    result.githubUsername,
+    result.oneLineSummary,
+  );
+
+  const prNumber = result.pullRequestNumber || (await getNextPrNumber());
+
+  writeFile(`./upcoming-release-notes/${prNumber}.md`, fileContents, err => {
+    if (err) {
+      console.error(err);
+    }
+  });
+}
+
+async function getNextPrNumber(): Promise<string> {
+  const resp = await fetch(
+    'https://internal.floralily.dev/next-pr-number-api/?owner=actualbudget&name=actual',
+  );
+  return await resp.text();
+}
+
+function getFileContents(type: string, username: string, summary: string) {
+  return `---
+category: ${type},
+authors: [${username}],
+---
+
+${summary}
+`;
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:desktop": "./bin/package-electron",
     "build:api": "yarn workspace @actual-app/api build",
     "generate:i18n": "yarn workspace @actual-app/web generate:i18n",
+    "generate:release-notes": "npx tsx ./bin/release-note-generator.ts",
     "test": "yarn workspaces foreach --all --parallel --verbose run test",
     "test:debug": "yarn workspaces foreach --all --verbose run test",
     "e2e": "yarn workspaces foreach --all --parallel --verbose run e2e",
@@ -51,6 +52,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@types/prompts": "^2",
     "@typescript-eslint/parser": "^8.26.1",
     "cross-env": "^7.0.3",
     "eslint": "^9.22.0",
@@ -68,6 +70,7 @@
     "node-jq": "^4.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.5.3",
+    "prompts": "^2.4.2",
     "source-map-support": "^0.5.21",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",

--- a/upcoming-release-notes/4664.md
+++ b/upcoming-release-notes/4664.md
@@ -1,0 +1,6 @@
+---
+category: 1,
+authors: [alecbakholdin],
+---
+
+Added release note generator to make things easier when contributing

--- a/yarn.lock
+++ b/yarn.lock
@@ -6185,6 +6185,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prompts@npm:^2":
+  version: 2.4.9
+  resolution: "@types/prompts@npm:2.4.9"
+  dependencies:
+    "@types/node": "npm:*"
+    kleur: "npm:^3.0.3"
+  checksum: 10/69b8372f4c790b45fea16a46ff8d1bcc71b14579481776b67bd6263637118a7ecb1f12e1311506c29fadc81bf618dc64f1a91f903cfd5be67a0455a227b3e462
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
@@ -6908,6 +6918,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "actual@workspace:."
   dependencies:
+    "@types/prompts": "npm:^2"
     "@typescript-eslint/parser": "npm:^8.26.1"
     cross-env: "npm:^7.0.3"
     eslint: "npm:^9.22.0"
@@ -6925,6 +6936,7 @@ __metadata:
     node-jq: "npm:^4.0.1"
     npm-run-all: "npm:^4.1.5"
     prettier: "npm:^3.5.3"
+    prompts: "npm:^2.4.2"
     source-map-support: "npm:^0.5.21"
     typescript: "npm:^5.8.2"
     typescript-eslint: "npm:^8.26.1"
@@ -16893,7 +16905,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.0.1":
+"prompts@npm:^2.0.1, prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:


### PR DESCRIPTION
Added release-note-generator.ts. You can run it by using `yarn generate:release-notes` anytime prior to creating your pull request. If you have a PR number already, you can input it. Otherwise, it will find the next PR number using `https://internal.floralily.dev/next-pr-number-api/?owner=actualbudget&name=actual` (thanks @matt-fidd !)