### PR TITLE
🐛 Allowing service worker to cache files up to 5mb - fixes edge & offline mode 

### DIFF
--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -165,6 +165,7 @@ export default defineConfig(async ({ mode }) => {
               ],
               ignoreURLParametersMatching: [/^v$/],
               navigateFallback: '/index.html',
+              maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5MB
               navigateFallbackDenylist: [
                 /^\/account\/.*$/,
                 /^\/admin\/.*$/,

--- a/upcoming-release-notes/4665.md
+++ b/upcoming-release-notes/4665.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Allowing service worker to cache files up to 5mb


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes -->

Fixes offline mode when the server is offline. Also fixes it when the new version of the app is out and the service worker is still hanging onto the old version (the issue on edge).

We should look into reducing the size of the index.x.js file after. It's currently over 2MB.