### PR TITLE
:electron:  Fix electron loot core resolutions

### DIFF
--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -70,7 +70,6 @@
         {
           "target": "nsis",
           "arch": [
-            "x64",
             "ia32",
             "x64",
             "arm64"

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -17,6 +17,7 @@
     "appId": "com.actualbudget.actual",
     "files": [
       "build",
+      "!node_modules/@actual-app/web",
       "node_modules/@actual-app/web/build",
       "node_modules/@actual-app/web/package.json",
       "!node_modules/better-sqlite3/{benchmark,src,bin,docs,deps,build/Release/obj,build/Release/sqlite3.a,build/Release/test_extension.node}",
@@ -59,19 +60,9 @@
     "win": {
       "target": [
         {
-          "target": "appx",
-          "arch": [
-            "ia32",
-            "x64",
-            "arm64"
-          ]
-        },
-        {
           "target": "nsis",
           "arch": [
-            "ia32",
-            "x64",
-            "arm64"
+            "x64"
           ]
         }
       ],

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -18,7 +18,7 @@
     "files": [
       "build",
       "!node_modules/better-sqlite3/{benchmark,src,bin,docs,deps,build/Release/obj,build/Release/sqlite3.a,build/Release/test_extension.node}",
-      "!node_modules/@actual-app/web/build-electron",
+      "node_modules/@actual-app/web/{build,package.json}",
       "!**/*.js.map",
       "!**/stats.json",
       "!build/client-build/sql-wasm.wasm",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -17,8 +17,9 @@
     "appId": "com.actualbudget.actual",
     "files": [
       "build",
+      "node_modules/@actual-app/web/build",
+      "node_modules/@actual-app/web/package.json",
       "!node_modules/better-sqlite3/{benchmark,src,bin,docs,deps,build/Release/obj,build/Release/sqlite3.a,build/Release/test_extension.node}",
-      "node_modules/@actual-app/web/{build,package.json}",
       "!**/*.js.map",
       "!**/stats.json",
       "!build/client-build/sql-wasm.wasm",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -18,6 +18,7 @@
     "files": [
       "build",
       "!node_modules/better-sqlite3/{benchmark,src,bin,docs,deps,build/Release/obj,build/Release/sqlite3.a,build/Release/test_extension.node}",
+      "!node_modules/@actual-app/web/build-electron",
       "!**/*.js.map",
       "!**/stats.json",
       "!build/client-build/sql-wasm.wasm",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -60,9 +60,20 @@
     "win": {
       "target": [
         {
+          "target": "appx",
+          "arch": [
+            "ia32",
+            "x64",
+            "arm64"
+          ]
+        },
+        {
           "target": "nsis",
           "arch": [
-            "x64"
+            "x64",
+            "ia32",
+            "x64",
+            "arm64"
           ]
         }
       ],

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -97,10 +97,6 @@
     "./client/store": "./src/client/store/index.ts",
     "./client/store/mock": "./src/client/store/mock.ts",
     "./client/users/*": "./src/client/users/*.ts",
-    "./client/platform": {
-      "node": "./src/client/platform.electron.ts",
-      "default": "./src/client/platform.web.ts"
-    },
     "./client/queries": "./src/client/queries.ts",
     "./client/query-helpers": "./src/client/query-helpers.ts",
     "./client/query-hooks": "./src/client/query-hooks.ts",
@@ -110,10 +106,6 @@
     "./client/transfer": "./src/client/transfer.ts",
     "./client/undo": "./src/client/undo.ts",
     "./mocks": "./src/mocks/index.ts",
-    "./platform/client/fetch": {
-      "node": "./src/platform/client/fetch/index.ts",
-      "default": "./src/platform/client/fetch/index.browser.ts"
-    },
     "./platform/client/undo": "./src/platform/client/undo/index.ts",
     "./platform/exceptions": "./src/platform/exceptions/index.ts",
     "./platform/server/asyncStorage": "./src/platform/server/asyncStorage/index.ts",
@@ -127,6 +119,7 @@
     "./server/*": "./src/server/*.ts",
     "./shared/*": "./src/shared/*.ts",
     "./types/models": "./src/types/models/index.d.ts",
-    "./types/*": "./src/types/*.d.ts"
+    "./types/*": "./src/types/*.d.ts",
+    "./lib-dist/electron/*": "./lib-dist/electron/*"
   }
 }

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -82,5 +82,51 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
     "yargs": "^17.7.2"
+  },
+  "exports": {
+    "./client/accounts/*": "./src/client/accounts/*.ts",
+    "./client/app/*": "./src/client/app/*.ts",
+    "./client/budgets/*": "./src/client/budgets/*.ts",
+    "./client/data-hooks/schedules": "./src/client/data-hooks/schedules.tsx",
+    "./client/data-hooks/*": "./src/client/data-hooks/*.ts",
+    "./client/modals/*": "./src/client/modals/*.ts",
+    "./client/notifications/*": "./src/client/notifications/*.ts",
+    "./client/prefs/*": "./src/client/prefs/*.ts",
+    "./client/queries/*": "./src/client/queries/*.ts",
+    "./client/redux": "./src/client/redux/index.ts",
+    "./client/store": "./src/client/store/index.ts",
+    "./client/store/mock": "./src/client/store/mock.ts",
+    "./client/users/*": "./src/client/users/*.ts",
+    "./client/platform": {
+      "node": "./src/client/platform.electron.ts",
+      "default": "./src/client/platform.web.ts"
+    },
+    "./client/queries": "./src/client/queries.ts",
+    "./client/query-helpers": "./src/client/query-helpers.ts",
+    "./client/query-hooks": "./src/client/query-hooks.ts",
+    "./client/reports": "./src/client/reports.ts",
+    "./client/shared-listeners": "./src/client/shared-listeners.ts",
+    "./client/SpreadsheetProvider": "./src/client/SpreadsheetProvider.tsx",
+    "./client/transfer": "./src/client/transfer.ts",
+    "./client/undo": "./src/client/undo.ts",
+    "./mocks": "./src/mocks/index.ts",
+    "./platform/client/fetch": {
+      "node": "./src/platform/client/fetch/index.ts",
+      "default": "./src/platform/client/fetch/index.browser.ts"
+    },
+    "./platform/client/undo": "./src/platform/client/undo/index.ts",
+    "./platform/exceptions": "./src/platform/exceptions/index.ts",
+    "./platform/server/asyncStorage": "./src/platform/server/asyncStorage/index.ts",
+    "./platform/server/connection": "./src/platform/server/connection/index.ts",
+    "./platform/server/fetch": "./src/platform/server/fetch/index.web.ts",
+    "./platform/server/fs": "./src/platform/server/fs/index.web.ts",
+    "./platform/server/indexeddb": "./src/platform/server/indexeddb/index.web.ts",
+    "./platform/server/log": "./src/platform/server/log/index.web.ts",
+    "./platform/server/sqlite": "./src/platform/server/sqlite/index.web.ts",
+    "./server/budget/types/*": "./src/server/budget/types/*.d.ts",
+    "./server/*": "./src/server/*.ts",
+    "./shared/*": "./src/shared/*.ts",
+    "./types/models": "./src/types/models/index.d.ts",
+    "./types/*": "./src/types/*.d.ts"
   }
 }

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -97,6 +97,10 @@
     "./client/store": "./src/client/store/index.ts",
     "./client/store/mock": "./src/client/store/mock.ts",
     "./client/users/*": "./src/client/users/*.ts",
+    "./client/platform": {
+      "node": "./src/client/platform.electron.ts",
+      "default": "./src/client/platform.web.ts"
+    },
     "./client/queries": "./src/client/queries.ts",
     "./client/query-helpers": "./src/client/query-helpers.ts",
     "./client/query-hooks": "./src/client/query-hooks.ts",
@@ -106,6 +110,10 @@
     "./client/transfer": "./src/client/transfer.ts",
     "./client/undo": "./src/client/undo.ts",
     "./mocks": "./src/mocks/index.ts",
+    "./platform/client/fetch": {
+      "node": "./src/platform/client/fetch/index.ts",
+      "default": "./src/platform/client/fetch/index.browser.ts"
+    },
     "./platform/client/undo": "./src/platform/client/undo/index.ts",
     "./platform/exceptions": "./src/platform/exceptions/index.ts",
     "./platform/server/asyncStorage": "./src/platform/server/asyncStorage/index.ts",

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -82,52 +82,5 @@
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^5.1.4",
     "yargs": "^17.7.2"
-  },
-  "exports": {
-    "./client/accounts/*": "./src/client/accounts/*.ts",
-    "./client/app/*": "./src/client/app/*.ts",
-    "./client/budgets/*": "./src/client/budgets/*.ts",
-    "./client/data-hooks/schedules": "./src/client/data-hooks/schedules.tsx",
-    "./client/data-hooks/*": "./src/client/data-hooks/*.ts",
-    "./client/modals/*": "./src/client/modals/*.ts",
-    "./client/notifications/*": "./src/client/notifications/*.ts",
-    "./client/prefs/*": "./src/client/prefs/*.ts",
-    "./client/queries/*": "./src/client/queries/*.ts",
-    "./client/redux": "./src/client/redux/index.ts",
-    "./client/store": "./src/client/store/index.ts",
-    "./client/store/mock": "./src/client/store/mock.ts",
-    "./client/users/*": "./src/client/users/*.ts",
-    "./client/platform": {
-      "node": "./src/client/platform.electron.ts",
-      "default": "./src/client/platform.web.ts"
-    },
-    "./client/queries": "./src/client/queries.ts",
-    "./client/query-helpers": "./src/client/query-helpers.ts",
-    "./client/query-hooks": "./src/client/query-hooks.ts",
-    "./client/reports": "./src/client/reports.ts",
-    "./client/shared-listeners": "./src/client/shared-listeners.ts",
-    "./client/SpreadsheetProvider": "./src/client/SpreadsheetProvider.tsx",
-    "./client/transfer": "./src/client/transfer.ts",
-    "./client/undo": "./src/client/undo.ts",
-    "./mocks": "./src/mocks/index.ts",
-    "./platform/client/fetch": {
-      "node": "./src/platform/client/fetch/index.ts",
-      "default": "./src/platform/client/fetch/index.browser.ts"
-    },
-    "./platform/client/undo": "./src/platform/client/undo/index.ts",
-    "./platform/exceptions": "./src/platform/exceptions/index.ts",
-    "./platform/server/asyncStorage": "./src/platform/server/asyncStorage/index.ts",
-    "./platform/server/connection": "./src/platform/server/connection/index.ts",
-    "./platform/server/fetch": "./src/platform/server/fetch/index.web.ts",
-    "./platform/server/fs": "./src/platform/server/fs/index.web.ts",
-    "./platform/server/indexeddb": "./src/platform/server/indexeddb/index.web.ts",
-    "./platform/server/log": "./src/platform/server/log/index.web.ts",
-    "./platform/server/sqlite": "./src/platform/server/sqlite/index.web.ts",
-    "./server/budget/types/*": "./src/server/budget/types/*.d.ts",
-    "./server/*": "./src/server/*.ts",
-    "./shared/*": "./src/shared/*.ts",
-    "./types/models": "./src/types/models/index.d.ts",
-    "./types/*": "./src/types/*.d.ts",
-    "./lib-dist/electron/*": "./lib-dist/electron/*"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,11 +30,8 @@
     // Until/if we build using tsc
     "noEmit": true,
     "paths": {
-      // Electron needs this because it's unable to resolve using "node" in the exports
-      "loot-core/platform/client/fetch": [
-        "./packages/loot-core/src/platform/client/fetch"
-      ],
-      "loot-core/client/platform": ["./packages/loot-core/src/client/platform"]
+      // TEMPORARY: Until we can fix the "exports" in the loot-core package.json
+      "loot-core/*": ["./packages/loot-core/src/*"]
     },
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,13 @@
     "module": "es2022",
     // Until/if we build using tsc
     "noEmit": true,
+    "paths": {
+      // Electron needs this because it's unable to resolve using "node" in the exports
+      "loot-core/platform/client/fetch": [
+        "./packages/loot-core/src/platform/client/fetch"
+      ],
+      "loot-core/client/platform": ["./packages/loot-core/src/client/platform"]
+    },
     "plugins": [
       {
         "name": "typescript-strict-plugin",

--- a/upcoming-release-notes/4668.md
+++ b/upcoming-release-notes/4668.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Remove loot-core exports to fix Electron


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

This is a temporary fix for an Electron issue that was brought in by: https://github.com/actualbudget/actual/pull/4592/files

Basically the app wont start because it's resolving the wrong files in loot-core. I think the API will be broken too, I haven't tested it though.

I think there's more than one issue with that exports list so I couldn't fix it without spending a lot of time. This will make edge builds work again until we sort it out.

Example of the issue: 
```
    "./client/platform": {
      "node": "./src/client/platform.electron.ts",
      "default": "./src/client/platform.web.ts"
    },
```
Node doesn't get resolved by electron.

Another issue: 
```
    "./platform/server/fetch": "./src/platform/server/fetch/index.web.ts",
```
Server fetch is always resolving the web. If we're in Electron it should resolve the electron extension.