### PR TITLE
🐛 fixed can't rename notes

### DIFF
--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -84,6 +84,7 @@ export const schema = {
     is_income: f('boolean'),
     hidden: f('boolean'),
     group: f('id', { ref: 'category_groups' }),
+    goal_def: f('string'),
     sort_order: f('float'),
     tombstone: f('boolean'),
   },

--- a/upcoming-release-notes/4675.md
+++ b/upcoming-release-notes/4675.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed category renaming


### PR DESCRIPTION
After some recent change can no longer rename categories. Identified that it was because the database schema was missing goal_def for categories.

Resolves #4679