### PR TITLE
[Mobile] Show hidden overspent categories on Cover overspending modal

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -1573,6 +1573,7 @@ function OverspendingBanner({ month, onBudgetAction, ...props }) {
             title: t('Cover overspending'),
             month,
             categoryGroups: categoryGroupsToShow,
+            showHiddenCategories: true,
             onSelect: onOpenCoverCategoryModal,
             clearOnSelect: true,
             closeOnSelect: false,

--- a/upcoming-release-notes/4680.md
+++ b/upcoming-release-notes/4680.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Show hidden overspent categories


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fix issue where Cover overspending modal shows no categories when the overspent categories are hidden.