### PR TITLE
✨ [Feature]: Added autocomplete for tags

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -85,6 +85,7 @@ import {
   useSplitsExpanded,
 } from '../../hooks/useSplitsExpanded';
 import { useSyncedPref } from '../../hooks/useSyncedPref';
+import { useTagOptions } from '../../hooks/useTags';
 import { useTransactionBatchActions } from '../../hooks/useTransactionBatchActions';
 import { useSelector, useDispatch } from '../../redux';
 import { type SavedFilter } from '../filters/SavedFilterMenuButton';
@@ -266,11 +267,11 @@ function getField(field?: string) {
 
 type AccountInternalProps = {
   accountId?:
-    | AccountEntity['id']
-    | 'onbudget'
-    | 'offbudget'
-    | 'uncategorized'
-    | undefined;
+  | AccountEntity['id']
+  | 'onbudget'
+  | 'offbudget'
+  | 'uncategorized'
+  | undefined;
   filterConditions: RuleConditionEntity[];
   showBalances?: boolean;
   setShowBalances: (newValue: boolean) => void;
@@ -303,6 +304,7 @@ type AccountInternalProps = {
   failedAccounts: ReturnType<typeof useFailedAccounts>;
   dateFormat: ReturnType<typeof useDateFormat>;
   payees: ReturnType<typeof usePayees>;
+  tagOptions: ReturnType<typeof useTagOptions>;
   categoryGroups: ReturnType<typeof useCategories>['grouped'];
   hideFraction: boolean;
   accountsSyncing: string[];
@@ -1310,17 +1312,17 @@ class AccountInternal extends PureComponent<
 
     const payeeCondition = ruleTransaction.imported_payee
       ? ({
-          field: 'imported_payee',
-          op: 'is',
-          value: ruleTransaction.imported_payee,
-          type: 'string',
-        } satisfies RuleConditionEntity)
+        field: 'imported_payee',
+        op: 'is',
+        value: ruleTransaction.imported_payee,
+        type: 'string',
+      } satisfies RuleConditionEntity)
       : ({
-          field: 'payee',
-          op: 'is',
-          value: ruleTransaction.payee!,
-          type: 'id',
-        } satisfies RuleConditionEntity);
+        field: 'payee',
+        op: 'is',
+        value: ruleTransaction.payee!,
+        type: 'id',
+      } satisfies RuleConditionEntity);
     const amountCondition = {
       field: 'amount',
       op: 'isapprox',
@@ -1335,16 +1337,16 @@ class AccountInternal extends PureComponent<
       actions: [
         ...(childTransactions.length === 0
           ? [
-              {
-                op: 'set',
-                field: 'category',
-                value: ruleTransaction.category,
-                type: 'id',
-                options: {
-                  splitIndex: 0,
-                },
-              } satisfies RuleActionEntity,
-            ]
+            {
+              op: 'set',
+              field: 'category',
+              value: ruleTransaction.category,
+              type: 'id',
+              options: {
+                splitIndex: 0,
+              },
+            } satisfies RuleActionEntity,
+          ]
           : []),
         ...childTransactions.flatMap((sub, index) => [
           {
@@ -1588,7 +1590,7 @@ class AccountInternal extends PureComponent<
       ? this.state.sort?.prevAscDesc
       : prevAscDesc;
 
-    const sortCurrentQuery = function (
+    const sortCurrentQuery = function(
       that: AccountInternal,
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
@@ -1604,7 +1606,7 @@ class AccountInternal extends PureComponent<
       });
     };
 
-    const sortRootQuery = function (
+    const sortRootQuery = function(
       that: AccountInternal,
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
@@ -1624,7 +1626,7 @@ class AccountInternal extends PureComponent<
     };
 
     // sort by previously used sort field, if any
-    const maybeSortByPreviousField = function (
+    const maybeSortByPreviousField = function(
       that: AccountInternal,
       sortPrevField: string,
       sortPrevAscDesc?: 'asc' | 'desc',
@@ -1710,6 +1712,7 @@ class AccountInternal extends PureComponent<
       accounts,
       categoryGroups,
       payees,
+      tagOptions,
       dateFormat,
       hideFraction,
       accountsSyncing,
@@ -1750,8 +1753,8 @@ class AccountInternal extends PureComponent<
 
     const isNameEditable = accountId
       ? accountId !== 'onbudget' &&
-        accountId !== 'offbudget' &&
-        accountId !== 'uncategorized'
+      accountId !== 'offbudget' &&
+      accountId !== 'uncategorized'
       : false;
 
     const balanceQuery = this.getBalanceQuery(accountId);
@@ -1849,6 +1852,7 @@ class AccountInternal extends PureComponent<
                   category={category}
                   categoryGroups={categoryGroups}
                   payees={payees}
+                  tagOptions={tagOptions}
                   balances={allBalances}
                   showBalances={!!allBalances}
                   showReconciled={showReconciled}
@@ -1968,6 +1972,7 @@ export function Account() {
   );
   const accounts = useAccounts();
   const payees = usePayees();
+  const tagOptions = useTagOptions();
   const failedAccounts = useFailedAccounts();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [hideFraction] = useSyncedPref('hideFraction');
@@ -2021,6 +2026,7 @@ export function Account() {
             setShowExtraBalances(String(extraBalances))
           }
           payees={payees}
+          tagOptions={tagOptions}
           modalShowing={modalShowing}
           accountsSyncing={accountsSyncing}
           filterConditions={filterConditions}

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -267,11 +267,11 @@ function getField(field?: string) {
 
 type AccountInternalProps = {
   accountId?:
-  | AccountEntity['id']
-  | 'onbudget'
-  | 'offbudget'
-  | 'uncategorized'
-  | undefined;
+    | AccountEntity['id']
+    | 'onbudget'
+    | 'offbudget'
+    | 'uncategorized'
+    | undefined;
   filterConditions: RuleConditionEntity[];
   showBalances?: boolean;
   setShowBalances: (newValue: boolean) => void;
@@ -1312,17 +1312,17 @@ class AccountInternal extends PureComponent<
 
     const payeeCondition = ruleTransaction.imported_payee
       ? ({
-        field: 'imported_payee',
-        op: 'is',
-        value: ruleTransaction.imported_payee,
-        type: 'string',
-      } satisfies RuleConditionEntity)
+          field: 'imported_payee',
+          op: 'is',
+          value: ruleTransaction.imported_payee,
+          type: 'string',
+        } satisfies RuleConditionEntity)
       : ({
-        field: 'payee',
-        op: 'is',
-        value: ruleTransaction.payee!,
-        type: 'id',
-      } satisfies RuleConditionEntity);
+          field: 'payee',
+          op: 'is',
+          value: ruleTransaction.payee!,
+          type: 'id',
+        } satisfies RuleConditionEntity);
     const amountCondition = {
       field: 'amount',
       op: 'isapprox',
@@ -1337,16 +1337,16 @@ class AccountInternal extends PureComponent<
       actions: [
         ...(childTransactions.length === 0
           ? [
-            {
-              op: 'set',
-              field: 'category',
-              value: ruleTransaction.category,
-              type: 'id',
-              options: {
-                splitIndex: 0,
-              },
-            } satisfies RuleActionEntity,
-          ]
+              {
+                op: 'set',
+                field: 'category',
+                value: ruleTransaction.category,
+                type: 'id',
+                options: {
+                  splitIndex: 0,
+                },
+              } satisfies RuleActionEntity,
+            ]
           : []),
         ...childTransactions.flatMap((sub, index) => [
           {
@@ -1590,7 +1590,7 @@ class AccountInternal extends PureComponent<
       ? this.state.sort?.prevAscDesc
       : prevAscDesc;
 
-    const sortCurrentQuery = function(
+    const sortCurrentQuery = function (
       that: AccountInternal,
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
@@ -1606,7 +1606,7 @@ class AccountInternal extends PureComponent<
       });
     };
 
-    const sortRootQuery = function(
+    const sortRootQuery = function (
       that: AccountInternal,
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
@@ -1626,7 +1626,7 @@ class AccountInternal extends PureComponent<
     };
 
     // sort by previously used sort field, if any
-    const maybeSortByPreviousField = function(
+    const maybeSortByPreviousField = function (
       that: AccountInternal,
       sortPrevField: string,
       sortPrevAscDesc?: 'asc' | 'desc',
@@ -1753,8 +1753,8 @@ class AccountInternal extends PureComponent<
 
     const isNameEditable = accountId
       ? accountId !== 'onbudget' &&
-      accountId !== 'offbudget' &&
-      accountId !== 'uncategorized'
+        accountId !== 'offbudget' &&
+        accountId !== 'uncategorized'
       : false;
 
     const balanceQuery = this.getBalanceQuery(accountId);

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -292,7 +292,6 @@ function SingleAutocomplete<T extends Item>({
   }
 
   function onSelectAfter() {
-    setValue('');
     setSelectedItem(null);
     setHighlightedIndex(null);
     setIsChanged(false);
@@ -514,16 +513,26 @@ function SingleAutocomplete<T extends Item>({
                           // ignore the default behavior of selecting the item. It's too
                           // common to accidentally hover an item and then save it
                           e.preventDefault();
-                        } else {
+                        } else if (strict) {
                           // Otherwise, stop propagation so that the table navigator
                           // doesn't handle it
                           e.stopPropagation();
+                        } else if (!strict) {
+                          const option = filteredSuggestions[highlightedIndex];
+                          if (option) {
+                            // if an option matches, then we use autocomplete handling
+                            // In non strict mode, no match means we treat this
+                            // as just another input
+                            // e.stopPropagation();
+                          }
+                          onSelect(
+                            option?.id,
+                            (e.target as HTMLInputElement).value,
+                          );
                         }
                       } else if (!strict) {
-                        // Handle it ourselves
-                        e.stopPropagation();
                         onSelect(value, (e.target as HTMLInputElement).value);
-                        return onSelectAfter();
+                        onSelectAfter();
                       } else {
                         // No highlighted item, still allow the table to save the item
                         // as `null`, even though we're allowing the table to move

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -317,7 +317,7 @@ function SingleAutocomplete<T extends Item>({
           close();
         }
 
-        if (onSelect) {
+        if (onSelect && strict) {
           // I AM NOT PROUD OF THIS OK??
           // This WHOLE FILE is a mess anyway
           // OK SIT DOWN AND I WILL EXPLAIN

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, {
+import {
   type ChangeEvent,
   type ComponentProps,
   type HTMLProps,
@@ -206,7 +206,11 @@ function defaultItemToString<T extends Item>(item?: T) {
 
 type SingleAutocompleteProps<T extends Item> = CommonAutocompleteProps<T> & {
   type?: 'single' | never;
-  onSelect: (id: T['id'], value: string) => void;
+  onSelect: (
+    id: T['id'],
+    value: string,
+    e?: KeyboardEvent<HTMLInputElement>,
+  ) => void;
   value: null | T | T['id'];
 };
 
@@ -519,15 +523,10 @@ function SingleAutocomplete<T extends Item>({
                           e.stopPropagation();
                         } else if (!strict) {
                           const option = filteredSuggestions[highlightedIndex];
-                          if (option) {
-                            // if an option matches, then we use autocomplete handling
-                            // In non strict mode, no match means we treat this
-                            // as just another input
-                            // e.stopPropagation();
-                          }
                           onSelect(
                             option?.id,
                             (e.target as HTMLInputElement).value,
+                            e,
                           );
                         }
                       } else if (!strict) {

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -53,6 +53,7 @@ import { useResizeObserver } from '../../../hooks/useResizeObserver';
 import { SelectedProviderWithItems } from '../../../hooks/useSelected';
 import { SplitsExpandedProvider } from '../../../hooks/useSplitsExpanded';
 import { useSyncedPref } from '../../../hooks/useSyncedPref';
+import { useTagOptions } from '../../../hooks/useTags';
 import { useDispatch } from '../../../redux';
 import { EditablePageHeaderTitle } from '../../EditablePageHeaderTitle';
 import { MobileBackButton } from '../../mobile/MobileBackButton';
@@ -123,6 +124,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
 
   const accounts = useAccounts();
   const payees = usePayees();
+  const tagOptions = useTagOptions();
   const { grouped: categoryGroups } = useCategories();
 
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
@@ -605,6 +607,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
                     category={undefined}
                     categoryGroups={categoryGroups}
                     payees={payees}
+                    tagOptions={tagOptions}
                     balances={null}
                     showBalances={false}
                     showReconciled={true}

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -349,6 +349,8 @@ function InputValue({
     } else if (shouldSaveFromKey(e)) {
       onUpdate?.(value);
     }
+
+    props?.onKeyDown?.(e);
   }
 
   const ops = ['+', '-', '*', '/', '^'];
@@ -392,6 +394,8 @@ export function InputCell({
   inputProps,
   onUpdate,
   onBlur,
+  onKeyDown,
+  onKeyUp,
   textAlign,
   ...props
 }: InputCellProps) {
@@ -402,6 +406,8 @@ export function InputCell({
           value={props.value}
           onUpdate={onUpdate}
           onBlur={onBlur}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
           style={{ textAlign, ...(inputProps && inputProps.style) }}
           {...inputProps}
         />

--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -69,6 +69,7 @@ export function TransactionList({
   category,
   categoryGroups,
   payees,
+  tagOptions,
   balances,
   showBalances,
   showReconciled,
@@ -264,6 +265,7 @@ export function TransactionList({
       accounts={accounts}
       categoryGroups={categoryGroups}
       payees={payees}
+      tagOptions={tagOptions}
       balances={balances}
       showBalances={showBalances}
       showReconciled={showReconciled}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -809,10 +809,10 @@ function NotesCell({
       // this as a regular input field and do table navigation.
       e?.stopPropagation();
 
-      // setTimeout makes the input value update happen independent of the
+      // requestAnimationFrame makes the input value update happen independent of the
       // onUpdate call, which would otherwise have stripped the trailing
       // whitespace character.
-      setTimeout(() => setInputValue(newValue + ' '), 0);
+      requestAnimationFrame(() => setInputValue(newValue + ' '), 0);
     } else {
       onUpdate(value);
     }
@@ -828,7 +828,7 @@ function NotesCell({
 
   function onKeyDown(e) {
     if (e.key === 'Escape') {
-      // reset to initial vlaue
+      // reset to initial value
       setInputValue(value);
     }
     if (e.key === 'Tab') {

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -877,12 +877,15 @@ function NotesCell({
             if (inputValue.trim() === '' || !cursorPosition) {
               return [];
             }
-            const currentWord = getCurrentWord(inputValue, cursorPosition);
+            const currentWord = getCurrentWord(
+              inputValue,
+              cursorPosition,
+            )?.toLowerCase();
             if (!currentWord || !options) {
               return [];
             }
             return options
-              .filter(o => o.id.startsWith(currentWord))
+              .filter(o => o.id.toLowerCase().startsWith(currentWord))
               .slice(0, 10);
           }}
         />

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -44,13 +44,11 @@ import {
 import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
-import { transactions } from 'loot-core/client/queries';
 import {
   getAccountsById,
   getPayeesById,
   getCategoriesById,
 } from 'loot-core/client/queries/queriesSlice';
-import { useQuery } from 'loot-core/client/query-hooks';
 import { evalArithmetic } from 'loot-core/shared/arithmetic';
 import { currentDay } from 'loot-core/shared/months';
 import * as monthUtils from 'loot-core/shared/months';
@@ -937,7 +935,7 @@ const Transaction = memo(function Transaction({
   onNavigateToSchedule,
   onNotesTagClick,
   splitError,
-  litContainerRef,
+  listContainerRef,
   showSelection,
   allowSplitTransaction,
 }) {

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -406,12 +406,12 @@ function StatusCell({
           ':focus': {
             ...(isPreview
               ? {
-                  boxShadow: 'none',
-                }
+                boxShadow: 'none',
+              }
               : {
-                  border: '1px solid ' + theme.formInputBorderSelected,
-                  boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
-                }),
+                border: '1px solid ' + theme.formInputBorderSelected,
+                boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
+              }),
           },
           cursor: isClearedField ? 'pointer' : 'default',
           ...(isChild && { visibility: 'hidden' }),
@@ -525,8 +525,8 @@ function PayeeCell({
           ':hover': isPreview
             ? {}
             : {
-                border: '1px solid ' + theme.buttonNormalBorder,
-              },
+              border: '1px solid ' + theme.buttonNormalBorder,
+            },
         }}
         disabled={isPreview}
         onSelect={() =>
@@ -1557,9 +1557,9 @@ const Transaction = memo(function Transaction({
           formatter={value =>
             value
               ? getDisplayValue(
-                  getCategoriesById(categoryGroups)[value],
-                  'name',
-                )
+                getCategoriesById(categoryGroups)[value],
+                'name',
+              )
               : transaction.id
                 ? 'Categorize'
                 : ''
@@ -1569,11 +1569,11 @@ const Transaction = memo(function Transaction({
           valueStyle={
             !categoryId
               ? {
-                  // uncategorized transaction
-                  fontStyle: 'italic',
-                  fontWeight: 300,
-                  color: theme.formInputTextHighlight,
-                }
+                // uncategorized transaction
+                fontStyle: 'italic',
+                fontWeight: 300,
+                color: theme.formInputTextHighlight,
+              }
               : valueStyle
           }
           onUpdate={async value => {
@@ -2412,10 +2412,10 @@ export const TransactionTable = forwardRef((props, ref) => {
     fields = item.is_child
       ? ['select', 'payee', 'notes', 'category', 'debit', 'credit']
       : fields.filter(
-          f =>
-            (props.showAccount || f !== 'account') &&
-            (props.showCategory || f !== 'category'),
-        );
+        f =>
+          (props.showAccount || f !== 'account') &&
+          (props.showCategory || f !== 'category'),
+      );
 
     if (isPreviewId(item.id)) {
       fields = ['select'];

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -802,17 +802,12 @@ function NotesCell({
     if (option && e) {
       const newValue =
         value.slice(0, start) + option.name + value.slice(end + 1);
-      onUpdate(newValue);
+      setInputValue(newValue + ' ');
 
       // only stop event propagation (i.e. table navigation) when we want to do
       // autocomplete things. If we don't choose an option, then we want to treat
       // this as a regular input field and do table navigation.
       e?.stopPropagation();
-
-      // requestAnimationFrame makes the input value update happen independent of the
-      // onUpdate call, which would otherwise have stripped the trailing
-      // whitespace character.
-      requestAnimationFrame(() => setInputValue(newValue + ' '), 0);
     } else {
       onUpdate(value);
     }

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -878,7 +878,7 @@ function NotesCell({
               return [];
             }
             const currentWord = getCurrentWord(inputValue, cursorPosition);
-            if (!currentWord) {
+            if (!currentWord || !options) {
               return [];
             }
             return options

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -75,7 +75,6 @@ import { usePrevious } from '../../hooks/usePrevious';
 import { useProperFocus } from '../../hooks/useProperFocus';
 import { useSelectedDispatch, useSelectedItems } from '../../hooks/useSelected';
 import { useSplitsExpanded } from '../../hooks/useSplitsExpanded';
-import { useTags } from '../../hooks/useTags';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { Autocomplete } from '../autocomplete/Autocomplete';
@@ -407,12 +406,12 @@ function StatusCell({
           ':focus': {
             ...(isPreview
               ? {
-                  boxShadow: 'none',
-                }
+                boxShadow: 'none',
+              }
               : {
-                  border: '1px solid ' + theme.formInputBorderSelected,
-                  boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
-                }),
+                border: '1px solid ' + theme.formInputBorderSelected,
+                boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
+              }),
           },
           cursor: isClearedField ? 'pointer' : 'default',
           ...(isChild && { visibility: 'hidden' }),
@@ -526,8 +525,8 @@ function PayeeCell({
           ':hover': isPreview
             ? {}
             : {
-                border: '1px solid ' + theme.buttonNormalBorder,
-              },
+              border: '1px solid ' + theme.buttonNormalBorder,
+            },
         }}
         disabled={isPreview}
         onSelect={() =>
@@ -1558,9 +1557,9 @@ const Transaction = memo(function Transaction({
           formatter={value =>
             value
               ? getDisplayValue(
-                  getCategoriesById(categoryGroups)[value],
-                  'name',
-                )
+                getCategoriesById(categoryGroups)[value],
+                'name',
+              )
               : transaction.id
                 ? 'Categorize'
                 : ''
@@ -1570,11 +1569,11 @@ const Transaction = memo(function Transaction({
           valueStyle={
             !categoryId
               ? {
-                  // uncategorized transaction
-                  fontStyle: 'italic',
-                  fontWeight: 300,
-                  color: theme.formInputTextHighlight,
-                }
+                // uncategorized transaction
+                fontStyle: 'italic',
+                fontWeight: 300,
+                color: theme.formInputTextHighlight,
+              }
               : valueStyle
           }
           onUpdate={async value => {
@@ -2413,10 +2412,10 @@ export const TransactionTable = forwardRef((props, ref) => {
     fields = item.is_child
       ? ['select', 'payee', 'notes', 'category', 'debit', 'credit']
       : fields.filter(
-          f =>
-            (props.showAccount || f !== 'account') &&
-            (props.showCategory || f !== 'category'),
-        );
+        f =>
+          (props.showAccount || f !== 'account') &&
+          (props.showCategory || f !== 'category'),
+      );
 
     if (isPreviewId(item.id)) {
       fields = ['select'];

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -854,7 +854,9 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
             if (!currentWord) {
               return [];
             }
-            return options.filter(o => o.id.startsWith(currentWord));
+            return options
+              .filter(o => o.id.startsWith(currentWord))
+              .slice(0, 10);
           }}
         />
       )}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -77,6 +77,7 @@ import { usePrevious } from '../../hooks/usePrevious';
 import { useProperFocus } from '../../hooks/useProperFocus';
 import { useSelectedDispatch, useSelectedItems } from '../../hooks/useSelected';
 import { useSplitsExpanded } from '../../hooks/useSplitsExpanded';
+import { useTags } from '../../hooks/useTags';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { Autocomplete } from '../autocomplete/Autocomplete';
@@ -787,7 +788,8 @@ function PayeeIcons({
 }
 
 function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
-  const options = ['#tag', '#newtag'].map(o => ({ id: o, name: o }));
+  const tags = useTags();
+  const options = useMemo(() => tags.map(t => ({ id: t, name: t })), [tags]);
   const [cursorPosition, setCursorPosition] = useState(undefined);
 
   function onSelect(optionId, value) {
@@ -839,7 +841,7 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
             if (!currentWord) {
               return [];
             }
-            return options.filter(o => o.name.startsWith(currentWord));
+            return options.filter(o => o.id.startsWith(currentWord));
           }}
         />
       )}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -795,13 +795,20 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
   function onSelect(optionId, value, e) {
     const [start, end] = getCurrentWordRange(value, cursorPosition);
     const option = options.find(o => o.id === optionId);
-    if (option) {
-      // we only stop propagation if we actually have an option to update
-      e?.stopPropagation();
+    if (option && e) {
       const newValue =
         value.slice(0, start) + option.name + value.slice(end + 1);
       onUpdate(newValue);
-      setInputValue(newValue + ' ');
+
+      // only stop event propagation (i.e. table navigation) when we want to do
+      // autocomplete things. If we don't choose an option, then we want to treat
+      // this as a regular input field and do table navigation.
+      e?.stopPropagation();
+
+      // setTimeout makes the input value update happen independent of the
+      // onUpdate call, which would otherwise have stripped the trailing
+      // whitespace character.
+      setTimeout(() => setInputValue(newValue + ' '), 0);
     } else {
       onUpdate(value);
     }

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -822,6 +822,12 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
     }
   }
 
+  function onKeyDown(e) {
+    if (e.key === 'Escape') {
+      setInputValue(value);
+    }
+  }
+
   return (
     <CustomCell
       width="flex"
@@ -832,6 +838,7 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
       exposed={focused}
       onExpose={onExpose}
       onUpdate={onUpdate}
+      onKeyDownCapture={onKeyDown}
     >
       {({ inputStyle, onKeyDown, onBlur, shouldSaveFromKey }) => (
         <Autocomplete

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -881,11 +881,23 @@ function NotesCell({
               inputValue,
               cursorPosition,
             )?.toLowerCase();
-            if (!currentWord || !options) {
+            if (!currentWord || !options || currentWord.charAt(0) !== '#') {
               return [];
             }
+            const currentWordNoHash = currentWord.slice(1);
             return options
-              .filter(o => o.id.toLowerCase().startsWith(currentWord))
+              .filter(o => o.id.toLowerCase().includes(currentWordNoHash))
+              .sort(({ id: a }, { id: b }) => {
+                const aStarts = a.toLowerCase().startsWith(currentWord);
+                const bStarts = b.toLowerCase().startsWith(currentWord);
+                if (aStarts && !bStarts) {
+                  return 1;
+                } else if (!aStarts && bStarts) {
+                  return -1;
+                }
+                const compare = a.toLowerCase().localeCompare(b.toLowerCase());
+                return compare > 0 ? 1 : compare < 0 ? -1 : 0;
+              })
               .slice(0, 10);
           }}
         />

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -407,12 +407,12 @@ function StatusCell({
           ':focus': {
             ...(isPreview
               ? {
-                  boxShadow: 'none',
-                }
+                boxShadow: 'none',
+              }
               : {
-                  border: '1px solid ' + theme.formInputBorderSelected,
-                  boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
-                }),
+                border: '1px solid ' + theme.formInputBorderSelected,
+                boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
+              }),
           },
           cursor: isClearedField ? 'pointer' : 'default',
           ...(isChild && { visibility: 'hidden' }),
@@ -526,8 +526,8 @@ function PayeeCell({
           ':hover': isPreview
             ? {}
             : {
-                border: '1px solid ' + theme.buttonNormalBorder,
-              },
+              border: '1px solid ' + theme.buttonNormalBorder,
+            },
         }}
         disabled={isPreview}
         onSelect={() =>
@@ -824,7 +824,14 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
 
   function onKeyDown(e) {
     if (e.key === 'Escape') {
+      // reset to initial vlaue
       setInputValue(value);
+    }
+    if (e.key === 'Tab') {
+      // set to current value. For some reason this is
+      // is not getting caught by the onBlur handler
+      // likely because of Autocomplete complexity
+      onUpdate(inputValue);
     }
   }
 
@@ -838,6 +845,8 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
       exposed={focused}
       onExpose={onExpose}
       onUpdate={onUpdate}
+      onFocus={() => setInputValue(value)}
+      onBlur={() => onUpdate(inputValue)}
       onKeyDownCapture={onKeyDown}
     >
       {({ inputStyle, onKeyDown, onBlur, shouldSaveFromKey }) => (
@@ -1542,9 +1551,9 @@ const Transaction = memo(function Transaction({
           formatter={value =>
             value
               ? getDisplayValue(
-                  getCategoriesById(categoryGroups)[value],
-                  'name',
-                )
+                getCategoriesById(categoryGroups)[value],
+                'name',
+              )
               : transaction.id
                 ? 'Categorize'
                 : ''
@@ -1554,11 +1563,11 @@ const Transaction = memo(function Transaction({
           valueStyle={
             !categoryId
               ? {
-                  // uncategorized transaction
-                  fontStyle: 'italic',
-                  fontWeight: 300,
-                  color: theme.formInputTextHighlight,
-                }
+                // uncategorized transaction
+                fontStyle: 'italic',
+                fontWeight: 300,
+                color: theme.formInputTextHighlight,
+              }
               : valueStyle
           }
           onUpdate={async value => {
@@ -2392,10 +2401,10 @@ export const TransactionTable = forwardRef((props, ref) => {
     fields = item.is_child
       ? ['select', 'payee', 'notes', 'category', 'debit', 'credit']
       : fields.filter(
-          f =>
-            (props.showAccount || f !== 'account') &&
-            (props.showCategory || f !== 'category'),
-        );
+        f =>
+          (props.showAccount || f !== 'account') &&
+          (props.showCategory || f !== 'category'),
+      );
 
     if (isPreviewId(item.id)) {
       fields = ['select'];

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -406,12 +406,12 @@ function StatusCell({
           ':focus': {
             ...(isPreview
               ? {
-                boxShadow: 'none',
-              }
+                  boxShadow: 'none',
+                }
               : {
-                border: '1px solid ' + theme.formInputBorderSelected,
-                boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
-              }),
+                  border: '1px solid ' + theme.formInputBorderSelected,
+                  boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
+                }),
           },
           cursor: isClearedField ? 'pointer' : 'default',
           ...(isChild && { visibility: 'hidden' }),
@@ -525,8 +525,8 @@ function PayeeCell({
           ':hover': isPreview
             ? {}
             : {
-              border: '1px solid ' + theme.buttonNormalBorder,
-            },
+                border: '1px solid ' + theme.buttonNormalBorder,
+              },
         }}
         disabled={isPreview}
         onSelect={() =>
@@ -1557,9 +1557,9 @@ const Transaction = memo(function Transaction({
           formatter={value =>
             value
               ? getDisplayValue(
-                getCategoriesById(categoryGroups)[value],
-                'name',
-              )
+                  getCategoriesById(categoryGroups)[value],
+                  'name',
+                )
               : transaction.id
                 ? 'Categorize'
                 : ''
@@ -1569,11 +1569,11 @@ const Transaction = memo(function Transaction({
           valueStyle={
             !categoryId
               ? {
-                // uncategorized transaction
-                fontStyle: 'italic',
-                fontWeight: 300,
-                color: theme.formInputTextHighlight,
-              }
+                  // uncategorized transaction
+                  fontStyle: 'italic',
+                  fontWeight: 300,
+                  color: theme.formInputTextHighlight,
+                }
               : valueStyle
           }
           onUpdate={async value => {
@@ -2412,10 +2412,10 @@ export const TransactionTable = forwardRef((props, ref) => {
     fields = item.is_child
       ? ['select', 'payee', 'notes', 'category', 'debit', 'credit']
       : fields.filter(
-        f =>
-          (props.showAccount || f !== 'account') &&
-          (props.showCategory || f !== 'category'),
-      );
+          f =>
+            (props.showAccount || f !== 'account') &&
+            (props.showCategory || f !== 'category'),
+        );
 
     if (isPreviewId(item.id)) {
       fields = ['select'];

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -1413,7 +1413,7 @@ const Transaction = memo(function Transaction({
         onUpdate={value => {
           onUpdate('notes', value?.trim());
         }}
-        onExpose={name => onEdit(id, name)}
+        onExpose={name => !isPreview && onEdit(id, name)}
       />
 
       {(isPreview && !isChild) || isParent ? (

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -407,12 +407,12 @@ function StatusCell({
           ':focus': {
             ...(isPreview
               ? {
-                boxShadow: 'none',
-              }
+                  boxShadow: 'none',
+                }
               : {
-                border: '1px solid ' + theme.formInputBorderSelected,
-                boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
-              }),
+                  border: '1px solid ' + theme.formInputBorderSelected,
+                  boxShadow: '0 1px 2px ' + theme.formInputBorderSelected,
+                }),
           },
           cursor: isClearedField ? 'pointer' : 'default',
           ...(isChild && { visibility: 'hidden' }),
@@ -526,8 +526,8 @@ function PayeeCell({
           ':hover': isPreview
             ? {}
             : {
-              border: '1px solid ' + theme.buttonNormalBorder,
-            },
+                border: '1px solid ' + theme.buttonNormalBorder,
+              },
         }}
         disabled={isPreview}
         onSelect={() =>
@@ -785,16 +785,21 @@ function PayeeIcons({
   );
 }
 
-function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
-  const tags = useTags();
-  const options = useMemo(() => tags.map(t => ({ id: t, name: t })), [tags]);
+function NotesCell({
+  value,
+  focused,
+  onUpdate,
+  onClickTag,
+  onExpose,
+  tagOptions,
+}) {
   const [cursorPosition, setCursorPosition] = useState(undefined);
   const [inputValue, setInputValue] = useState(value);
   useEffect(() => setInputValue(value), [value, setInputValue]);
 
   function onSelect(optionId, value, e) {
     const [start, end] = getCurrentWordRange(value, cursorPosition);
-    const option = options.find(o => o.id === optionId);
+    const option = tagOptions.find(o => o.id === optionId);
     if (option && e) {
       const newValue =
         value.slice(0, start) + option.name + value.slice(end + 1);
@@ -868,7 +873,7 @@ function NotesCell({ value, focused, onUpdate, onClickTag, onExpose }) {
             onChange: v => setInputValue(v),
           }}
           getHighlightedIndex={() => 0}
-          suggestions={options}
+          suggestions={tagOptions}
           filterSuggestions={(options, inputValue) => {
             if (inputValue.trim() === '' || !cursorPosition) {
               return [];
@@ -939,6 +944,7 @@ const Transaction = memo(function Transaction({
   focusedField,
   categoryGroups,
   payees,
+  tagOptions,
   accounts,
   balance,
   dateFormat = 'MM/dd/yyyy',
@@ -1409,6 +1415,7 @@ const Transaction = memo(function Transaction({
       <NotesCell
         value={notes || ''}
         focused={focusedField === 'notes'}
+        tagOptions={tagOptions}
         onClickTag={onNotesTagClick}
         onUpdate={value => {
           onUpdate('notes', value?.trim());
@@ -1551,9 +1558,9 @@ const Transaction = memo(function Transaction({
           formatter={value =>
             value
               ? getDisplayValue(
-                getCategoriesById(categoryGroups)[value],
-                'name',
-              )
+                  getCategoriesById(categoryGroups)[value],
+                  'name',
+                )
               : transaction.id
                 ? 'Categorize'
                 : ''
@@ -1563,11 +1570,11 @@ const Transaction = memo(function Transaction({
           valueStyle={
             !categoryId
               ? {
-                // uncategorized transaction
-                fontStyle: 'italic',
-                fontWeight: 300,
-                color: theme.formInputTextHighlight,
-              }
+                  // uncategorized transaction
+                  fontStyle: 'italic',
+                  fontWeight: 300,
+                  color: theme.formInputTextHighlight,
+                }
               : valueStyle
           }
           onUpdate={async value => {
@@ -1785,6 +1792,7 @@ function NewTransaction({
   accounts,
   categoryGroups,
   payees,
+  tagOptions,
   transferAccountsByTransaction,
   editingTransaction,
   focusedField,
@@ -1853,6 +1861,7 @@ function NewTransaction({
           accounts={accounts}
           categoryGroups={categoryGroups}
           payees={payees}
+          tagOptions={tagOptions}
           dateFormat={dateFormat}
           hideFraction={hideFraction}
           expanded={true}
@@ -1988,6 +1997,7 @@ function TransactionTableInner({
       accounts,
       categoryGroups,
       payees,
+      tagOptions,
       showCleared,
       showAccount,
       showCategory,
@@ -2050,6 +2060,7 @@ function TransactionTableInner({
         accounts={accounts}
         categoryGroups={categoryGroups}
         payees={payees}
+        tagOptions={tagOptions}
         dateFormat={dateFormat}
         hideFraction={hideFraction}
         onEdit={tableNavigator.onEdit}
@@ -2127,6 +2138,7 @@ function TransactionTableInner({
               accounts={props.accounts}
               categoryGroups={props.categoryGroups}
               payees={props.payees || []}
+              tagOptions={props.tagOptions || []}
               showAccount={props.showAccount}
               showCategory={props.showCategory}
               showBalance={props.showBalances}
@@ -2401,10 +2413,10 @@ export const TransactionTable = forwardRef((props, ref) => {
     fields = item.is_child
       ? ['select', 'payee', 'notes', 'category', 'debit', 'credit']
       : fields.filter(
-        f =>
-          (props.showAccount || f !== 'account') &&
-          (props.showCategory || f !== 'category'),
-      );
+          f =>
+            (props.showAccount || f !== 'account') &&
+            (props.showCategory || f !== 'category'),
+        );
 
     if (isPreviewId(item.id)) {
       fields = ['select'];

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -841,10 +841,6 @@ describe('Transactions', () => {
     expect(container.ownerDocument.activeElement).toBe(input);
     expect(input.value).not.toBe('');
 
-    input = await editNewField(container, 'notes');
-    await userEvent.clear(input);
-    await userEvent.type(input, 'a transaction');
-
     input = await editNewField(container, 'debit');
     expect(input.value).toBe('0.00');
     await userEvent.clear(input);

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -848,7 +848,6 @@ describe('Transactions', () => {
 
     expect(getTransactions().length).toBe(6);
     expect(getTransactions()[0].amount).toBe(-10000);
-    expect(getTransactions()[0].notes).toBe('a transaction');
 
     // The date field should be re-focused to enter a new transaction
     expect(container.ownerDocument.activeElement).toBe(

--- a/packages/desktop-client/src/hooks/useTags.ts
+++ b/packages/desktop-client/src/hooks/useTags.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { getTags } from 'loot-core/client/queries/queriesSlice';
 
@@ -19,4 +19,13 @@ export function useTags() {
   }, [dispatch, isInitialMount, tagsLoaded]);
 
   return useSelector(state => state.queries.tags);
+}
+
+// for use with Autocomplete, needs id and name in return type
+export function useTagOptions(): { id: string; name: string }[] {
+  const tags = useTags();
+  return useMemo(
+    () => tags?.map(t => ({ id: t ?? '', name: t ?? '' })) || [],
+    [tags],
+  );
 }

--- a/packages/desktop-client/src/hooks/useTags.ts
+++ b/packages/desktop-client/src/hooks/useTags.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+import { getTags } from 'loot-core/client/queries/queriesSlice';
+
+import { useDispatch, useSelector } from '../redux';
+
+import { useInitialMount } from './useInitialMount';
+
+export function useTags() {
+  const dispatch = useDispatch();
+  const tagsLoaded = useSelector(state => state.queries.tagsLoaded);
+
+  const isInitialMount = useInitialMount();
+
+  useEffect(() => {
+    if (isInitialMount && !tagsLoaded) {
+      dispatch(getTags());
+    }
+  }, [dispatch, isInitialMount, tagsLoaded]);
+
+  return useSelector(state => state.queries.tags);
+}

--- a/packages/loot-core/src/client/queries/queriesSlice.ts
+++ b/packages/loot-core/src/client/queries/queriesSlice.ts
@@ -39,6 +39,8 @@ type QueriesState = {
   commonPayees: PayeeEntity[];
   payees: PayeeEntity[];
   payeesLoaded: boolean;
+  tags: string[];
+  tagsLoaded: boolean;
 };
 
 const initialState: QueriesState = {
@@ -57,6 +59,8 @@ const initialState: QueriesState = {
   commonPayeesLoaded: false,
   payees: [],
   payeesLoaded: false,
+  tags: [],
+  tagsLoaded: false,
 };
 
 type SetNewTransactionsPayload = {
@@ -154,6 +158,12 @@ const queriesSlice = createSlice({
     builder.addCase(getPayees.fulfilled, (state, action) => {
       state.payees = action.payload;
       state.payeesLoaded = true;
+    });
+
+    // Tags
+    builder.addCase(getTags.fulfilled, (state, action) => {
+      state.tags = action.payload;
+      state.tagsLoaded = true;
     });
 
     // App
@@ -417,6 +427,10 @@ export const getPayees = createAppAsyncThunk(
     return payees;
   },
 );
+
+export const getTags = createAppAsyncThunk(`${sliceName}/getTags`, async () => {
+  return send('tags-get');
+});
 
 // Budget actions
 

--- a/packages/loot-core/src/client/query-hooks.ts
+++ b/packages/loot-core/src/client/query-hooks.ts
@@ -29,6 +29,7 @@ export function useQuery<Response = unknown>(
     setIsLoading(!!query);
 
     if (!query) {
+      setData(null);
       return;
     }
 

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -11,7 +11,12 @@ import {
   type Notification,
 } from './notifications/notificationsSlice';
 import { loadPrefs } from './prefs/prefsSlice';
-import { getAccounts, getCategories, getPayees } from './queries/queriesSlice';
+import {
+  getAccounts,
+  getCategories,
+  getPayees,
+  getTags,
+} from './queries/queriesSlice';
 import { type AppStore } from './store';
 import { signOut } from './users/usersSlice';
 
@@ -68,6 +73,10 @@ export function listenForSyncEvent(store: AppStore) {
         tables.includes('category_mapping')
       ) {
         store.dispatch(getCategories());
+      }
+
+      if (tables.includes('transactions')) {
+        store.dispatch(getTags());
       }
 
       if (
@@ -141,11 +150,11 @@ export function listenForSyncEvent(store: AppStore) {
             title: t('Actual has updated the syncing format'),
             message: t(
               'This happens rarely (if ever again). The internal syncing format ' +
-                'has changed and you need to reset sync. This will upload data from ' +
-                'this device and revert all other devices. ' +
-                '[Learn more about what this means](https://actualbudget.org/docs/getting-started/sync/#what-does-resetting-sync-mean).' +
-                '\n\n' +
-                'Old encryption keys are not migrated. If using encryption, [reset encryption here](#makeKey).',
+              'has changed and you need to reset sync. This will upload data from ' +
+              'this device and revert all other devices. ' +
+              '[Learn more about what this means](https://actualbudget.org/docs/getting-started/sync/#what-does-resetting-sync-mean).' +
+              '\n\n' +
+              'Old encryption keys are not migrated. If using encryption, [reset encryption here](#makeKey).',
             ),
             messageActions: {
               makeKey: () =>
@@ -174,7 +183,7 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'Something went wrong when registering your encryption key id. ' +
-                  'You need to recreate your key. ',
+                'You need to recreate your key. ',
               ) + learnMore,
             sticky: true,
             id: 'invalid-key-state',
@@ -198,8 +207,8 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'You need to register it to take advantage ' +
-                  'of syncing which allows you to use it across devices and never worry ' +
-                  'about losing your data.',
+                'of syncing which allows you to use it across devices and never worry ' +
+                'about losing your data.',
               ) +
               ' ' +
               learnMore,
@@ -223,7 +232,7 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'Something went wrong when creating this cloud file. You need ' +
-                  'to upload this file to fix it.',
+                'to upload this file to fix it.',
               ) +
               ' ' +
               learnMore,
@@ -251,8 +260,8 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'You need to revert it to continue syncing. Any unsynced ' +
-                  'data will be lost. If you like, you can instead ' +
-                  '[upload this file](#upload) to be the latest version.',
+                'data will be lost. If you like, you can instead ' +
+                '[upload this file](#upload) to be the latest version.',
               ) +
               ' ' +
               learnMore,
@@ -274,7 +283,7 @@ export function listenForSyncEvent(store: AppStore) {
               title: t('Missing encryption key'),
               message: t(
                 'Unable to encrypt your data because you are missing the key. ' +
-                  'Create your key to sync your data.',
+                'Create your key to sync your data.',
               ),
               sticky: true,
               id: 'encrypt-failure-missing',
@@ -298,8 +307,8 @@ export function listenForSyncEvent(store: AppStore) {
             notif = {
               message: t(
                 'Unable to encrypt your data. You have the correct ' +
-                  'key so this is likely an internal failure. To fix this, ' +
-                  'reset your sync data with a new key.',
+                'key so this is likely an internal failure. To fix this, ' +
+                'reset your sync data with a new key.',
               ),
               sticky: true,
               id: 'encrypt-failure',
@@ -322,7 +331,7 @@ export function listenForSyncEvent(store: AppStore) {
             title: t('Update required'),
             message: t(
               'We couldn’t apply changes from the server. This probably means you ' +
-                'need to update the app to support the latest database.',
+              'need to update the app to support the latest database.',
             ),
             type: 'warning',
           };

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -150,11 +150,11 @@ export function listenForSyncEvent(store: AppStore) {
             title: t('Actual has updated the syncing format'),
             message: t(
               'This happens rarely (if ever again). The internal syncing format ' +
-              'has changed and you need to reset sync. This will upload data from ' +
-              'this device and revert all other devices. ' +
-              '[Learn more about what this means](https://actualbudget.org/docs/getting-started/sync/#what-does-resetting-sync-mean).' +
-              '\n\n' +
-              'Old encryption keys are not migrated. If using encryption, [reset encryption here](#makeKey).',
+                'has changed and you need to reset sync. This will upload data from ' +
+                'this device and revert all other devices. ' +
+                '[Learn more about what this means](https://actualbudget.org/docs/getting-started/sync/#what-does-resetting-sync-mean).' +
+                '\n\n' +
+                'Old encryption keys are not migrated. If using encryption, [reset encryption here](#makeKey).',
             ),
             messageActions: {
               makeKey: () =>
@@ -183,7 +183,7 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'Something went wrong when registering your encryption key id. ' +
-                'You need to recreate your key. ',
+                  'You need to recreate your key. ',
               ) + learnMore,
             sticky: true,
             id: 'invalid-key-state',
@@ -207,8 +207,8 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'You need to register it to take advantage ' +
-                'of syncing which allows you to use it across devices and never worry ' +
-                'about losing your data.',
+                  'of syncing which allows you to use it across devices and never worry ' +
+                  'about losing your data.',
               ) +
               ' ' +
               learnMore,
@@ -232,7 +232,7 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'Something went wrong when creating this cloud file. You need ' +
-                'to upload this file to fix it.',
+                  'to upload this file to fix it.',
               ) +
               ' ' +
               learnMore,
@@ -260,8 +260,8 @@ export function listenForSyncEvent(store: AppStore) {
             message:
               t(
                 'You need to revert it to continue syncing. Any unsynced ' +
-                'data will be lost. If you like, you can instead ' +
-                '[upload this file](#upload) to be the latest version.',
+                  'data will be lost. If you like, you can instead ' +
+                  '[upload this file](#upload) to be the latest version.',
               ) +
               ' ' +
               learnMore,
@@ -283,7 +283,7 @@ export function listenForSyncEvent(store: AppStore) {
               title: t('Missing encryption key'),
               message: t(
                 'Unable to encrypt your data because you are missing the key. ' +
-                'Create your key to sync your data.',
+                  'Create your key to sync your data.',
               ),
               sticky: true,
               id: 'encrypt-failure-missing',
@@ -307,8 +307,8 @@ export function listenForSyncEvent(store: AppStore) {
             notif = {
               message: t(
                 'Unable to encrypt your data. You have the correct ' +
-                'key so this is likely an internal failure. To fix this, ' +
-                'reset your sync data with a new key.',
+                  'key so this is likely an internal failure. To fix this, ' +
+                  'reset your sync data with a new key.',
               ),
               sticky: true,
               id: 'encrypt-failure',
@@ -331,7 +331,7 @@ export function listenForSyncEvent(store: AppStore) {
             title: t('Update required'),
             message: t(
               'We couldn’t apply changes from the server. This probably means you ' +
-              'need to update the app to support the latest database.',
+                'need to update the app to support the latest database.',
             ),
             type: 'warning',
           };

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -650,6 +650,13 @@ export function getCommonPayees() {
   `);
 }
 
+export function getTaggedTransactionNotes() {
+  return all<Pick<DbTransaction, 'notes'>>(
+    // eslint-disable-next-line rulesdir/typography
+    `SELECT notes FROM v_transactions WHERE notes LIKE '%#%' ORDER BY date DESC`,
+  );
+}
+
 /* eslint-disable rulesdir/typography */
 const orphanedPayeesQuery = `
   SELECT p.id

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -61,6 +61,7 @@ import {
 } from './sync';
 import { app as syncApp } from './sync/app';
 import * as syncMigrations from './sync/migrate';
+import { app as tagsApp } from './tags/app';
 import { app as toolsApp } from './tools/app';
 import { app as transactionsApp } from './transactions/app';
 import * as rules from './transactions/transaction-rules';
@@ -1093,6 +1094,7 @@ app.combine(
   transactionsApp,
   accountsApp,
   payeesApp,
+  tagsApp,
   spreadsheetApp,
   syncApp,
 );

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -1,5 +1,5 @@
 import { createApp } from '../app';
-import { getTaggedTransactionNotes } from '../db';
+import { getTransactionTags } from '../db';
 
 export type TagsHandlers = {
   'tags-get': typeof getTags;
@@ -9,19 +9,6 @@ export const app = createApp<TagsHandlers>();
 app.method('tags-get', getTags);
 
 async function getTags(): Promise<Array<string>> {
-  const taggedNotes = await getTaggedTransactionNotes();
-  const tagSet = new Set<string>();
-  const tagArr: string[] = [];
-  for (const taggedNote of taggedNotes) {
-    const note = taggedNote?.notes;
-    if (!note) continue;
-    Array.from(note.matchAll(/(#[^\s]+)\s/g)).forEach(matchArr => {
-      const [_, tag] = matchArr;
-      if (!tagSet.has(tag)) {
-        tagSet.add(tag);
-        tagArr.push(tag);
-      }
-    });
-  }
-  return tagArr;
+  const taggedNotes = await getTransactionTags();
+  return taggedNotes.map(({ tag }) => tag);
 }

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -1,0 +1,29 @@
+import { createApp } from '../app';
+import { getTaggedTransactionNotes } from '../db';
+
+export type TagsHandlers = {
+  'tags-get': typeof getTags;
+};
+
+export const app = createApp<TagsHandlers>();
+app.method('tags-get', getTags);
+
+async function getTags(): Promise<Array<string>> {
+  const taggedNotes = await getTaggedTransactionNotes();
+  const tagSet = new Set<string>();
+  const tagArr: string[] = [];
+  for (const taggedNote of taggedNotes) {
+    const note = taggedNote?.notes;
+    if (!note) continue;
+    for (let i = note.indexOf('#'); i !== -1; i = note.indexOf('#', i + 1)) {
+      // TODO: make this handle other whitespace chars
+      const tagEnd = note.indexOf(' ', i);
+      const tag = note.slice(i, tagEnd === -1 ? note.length : tagEnd);
+      if (!tagSet.has(tag)) {
+        tagArr.push(tag);
+        tagSet.add(tag);
+      }
+    }
+  }
+  return tagArr;
+}

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -15,15 +15,13 @@ async function getTags(): Promise<Array<string>> {
   for (const taggedNote of taggedNotes) {
     const note = taggedNote?.notes;
     if (!note) continue;
-    for (let i = note.indexOf('#'); i !== -1; i = note.indexOf('#', i + 1)) {
-      // TODO: make this handle other whitespace chars
-      const tagEnd = note.indexOf(' ', i);
-      const tag = note.slice(i, tagEnd === -1 ? note.length : tagEnd);
+    Array.from(note.matchAll(/(#[^\s]+)\s/g)).forEach(matchArr => {
+      const [_, tag] = matchArr;
       if (!tagSet.has(tag)) {
-        tagArr.push(tag);
         tagSet.add(tag);
+        tagArr.push(tag);
       }
-    }
+    });
   }
   return tagArr;
 }

--- a/packages/loot-core/src/types/handlers.d.ts
+++ b/packages/loot-core/src/types/handlers.d.ts
@@ -11,6 +11,7 @@ import type { RulesHandlers } from '../server/rules/app';
 import type { SchedulesHandlers } from '../server/schedules/app';
 import type { SpreadsheetHandlers } from '../server/spreadsheet/app';
 import type { SyncHandlers } from '../server/sync/app';
+import type { TagsHandlers } from '../server/tags/app';
 import type { ToolsHandlers } from '../server/tools/app';
 import type { TransactionHandlers } from '../server/transactions/app';
 
@@ -34,6 +35,7 @@ export interface Handlers
     AccountHandlers,
     PayeesHandlers,
     SpreadsheetHandlers,
-    SyncHandlers {}
+    SyncHandlers,
+    TagsHandlers {}
 
 export type HandlerFunctions = Handlers[keyof Handlers];

--- a/upcoming-release-notes/4682.md
+++ b/upcoming-release-notes/4682.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [alecbakholdin]
+---
+
+Added autocomplete for tags in the notes column


### PR DESCRIPTION
I have a lot of tags, and sometimes I forget exactly how they're spelled. In this PR, I've created an autocomplete field in the notes column of the TransactionsTable that makes adding tags easier. I've made it as unobtrusive as possible, and it still supports adding multiple tags per note. To accomplish this, I had to modify the Autocomplete.tsx file. It turns out, this is the only SingleAutocomplete that I could find that is using strict={false}, which made modifying things fairly safe. Let me know what you think.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/243e78a6-e115-402d-8bbb-d7625520dd30" />
