### PR TITLE
fix: apply filters in Reports dashboard for cash flow widget

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
+++ b/packages/desktop-client/src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx
@@ -35,6 +35,8 @@ export function simpleCashFlow(
       return q('transactions')
         .filter({
           [conditionsOpKey]: filters,
+        })
+        .filter({
           $and: [
             { date: { $gte: start } },
             {

--- a/upcoming-release-notes/4683.md
+++ b/upcoming-release-notes/4683.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tostasmistas]
+---
+
+Fix filtering in Reports dashboard for cash flow widget


### PR DESCRIPTION
This PR fixes https://github.com/actualbudget/actual/issues/4663 and fixes https://github.com/actualbudget/actual/issues/3915.

It fixes an issue where filters set in the widget editor for the cash flow widget were not applied in the Reports dashboard.

---

<kbd><img width="1351" alt="image" src="https://github.com/user-attachments/assets/8aa30027-600f-4cfd-a720-48ee01734fbb" /></kbd>

---

- Before

<kbd><img width="446" alt="image" src="https://github.com/user-attachments/assets/5f5cfed5-33fe-4e8b-b9e0-c2d6b0b2c9c6" /></kbd>

- After

<kbd><img width="446" alt="image" src="https://github.com/user-attachments/assets/85f31bce-2f21-464e-a243-c8adde0960ae" /></kbd>

---