### PR TITLE
🐛 [Bug] Cant edit template rules

### DIFF
--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -894,7 +894,10 @@ export function EditRuleModal({
           } else {
             a[field] = value;
             if (a.options?.template !== undefined) {
-              a.options.template = value;
+              a.options = {
+                ...a.options,
+                template: value,
+              };
             }
 
             if (field === 'field') {

--- a/upcoming-release-notes/4686.md
+++ b/upcoming-release-notes/4686.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed bug where saving rules with templates would fail


### PR DESCRIPTION
Resolves #4685

options.template is read-only. this reassigns the entire options object instead of setting template, which avoids the error in the attached issue