### PR TITLE
🐛 Fix `Make Transfer` closing the Popover when clicked

### DIFF
--- a/packages/component-library/src/Input.tsx
+++ b/packages/component-library/src/Input.tsx
@@ -2,11 +2,8 @@ import React, {
   type InputHTMLAttributes,
   type KeyboardEvent,
   type Ref,
-  useRef,
 } from 'react';
 
-import { useMergedRefs } from '@actual-app/web/src/hooks/useMergedRefs';
-import { useProperFocus } from '@actual-app/web/src/hooks/useProperFocus';
 import { css, cx } from '@emotion/css';
 
 import { styles, type CSSProperties } from './styles';
@@ -41,14 +38,9 @@ export function Input({
   className,
   ...nativeProps
 }: InputProps) {
-  const ref = useRef<HTMLInputElement>(null);
-  useProperFocus(ref, true);
-
-  const mergedRef = useMergedRefs<HTMLInputElement>(ref, inputRef);
-
   return (
     <input
-      ref={mergedRef}
+      ref={inputRef}
       className={cx(
         css(
           defaultInputStyle,

--- a/packages/component-library/src/Input.tsx
+++ b/packages/component-library/src/Input.tsx
@@ -5,12 +5,12 @@ import React, {
   useRef,
 } from 'react';
 
+import { useMergedRefs } from '@actual-app/web/src/hooks/useMergedRefs';
+import { useProperFocus } from '@actual-app/web/src/hooks/useProperFocus';
 import { css, cx } from '@emotion/css';
 
 import { styles, type CSSProperties } from './styles';
 import { theme } from './theme';
-import { useProperFocus } from '@actual-app/web/src/hooks/useProperFocus';
-import { useMergedRefs } from '@actual-app/web/src/hooks/useMergedRefs';
 
 export const defaultInputStyle = {
   outline: 0,

--- a/packages/component-library/src/Input.tsx
+++ b/packages/component-library/src/Input.tsx
@@ -2,12 +2,15 @@ import React, {
   type InputHTMLAttributes,
   type KeyboardEvent,
   type Ref,
+  useRef,
 } from 'react';
 
 import { css, cx } from '@emotion/css';
 
 import { styles, type CSSProperties } from './styles';
 import { theme } from './theme';
+import { useProperFocus } from '@actual-app/web/src/hooks/useProperFocus';
+import { useMergedRefs } from '@actual-app/web/src/hooks/useMergedRefs';
 
 export const defaultInputStyle = {
   outline: 0,
@@ -38,9 +41,14 @@ export function Input({
   className,
   ...nativeProps
 }: InputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+  useProperFocus(ref, true);
+
+  const mergedRef = useMergedRefs<HTMLInputElement>(ref, inputRef);
+
   return (
     <input
-      ref={inputRef}
+      ref={mergedRef}
       className={cx(
         css(
           defaultInputStyle,

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -302,7 +302,7 @@ function SingleAutocomplete<T extends Item>({
 
   const filtered = isChanged ? filteredSuggestions || suggestions : suggestions;
   const inputRef = useRef(null);
-  useProperFocus(inputRef, true);
+  useProperFocus(inputRef, focused);
 
   return (
     <Downshift
@@ -664,11 +664,10 @@ function MultiAutocomplete<T extends Item>({
   clearOnBlur = true,
   ...props
 }: MultiAutocompleteProps<T>) {
-  const inputRef = useRef(null);
-  useProperFocus(inputRef, true);
-
   const [focused, setFocused] = useState(false);
   const selectedItemIds = selectedItems.map(getItemId);
+  const inputRef = useRef(null);
+  useProperFocus(inputRef, focused);
 
   function onRemoveItem(id: T['id']) {
     const items = selectedItemIds.filter(i => i !== id);

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -24,6 +24,8 @@ import Downshift, { type StateChangeTypes } from 'downshift';
 
 import { getNormalisedString } from 'loot-core/shared/normalisation';
 
+import { useProperFocus } from '../../hooks/useProperFocus';
+
 type CommonAutocompleteProps<T extends Item> = {
   focused?: boolean;
   embedded?: boolean;
@@ -299,6 +301,8 @@ function SingleAutocomplete<T extends Item>({
   }
 
   const filtered = isChanged ? filteredSuggestions || suggestions : suggestions;
+  const inputRef = useRef(null);
+  useProperFocus(inputRef, true);
 
   return (
     <Downshift
@@ -458,6 +462,7 @@ function SingleAutocomplete<T extends Item>({
             {renderInput(
               getInputProps({
                 focused,
+                inputRef,
                 ...inputProps,
                 onFocus: e => {
                   inputProps.onFocus?.(e);
@@ -659,6 +664,9 @@ function MultiAutocomplete<T extends Item>({
   clearOnBlur = true,
   ...props
 }: MultiAutocompleteProps<T>) {
+  const inputRef = useRef(null);
+  useProperFocus(inputRef, true);
+
   const [focused, setFocused] = useState(false);
   const selectedItemIds = selectedItems.map(getItemId);
 
@@ -728,6 +736,7 @@ function MultiAutocomplete<T extends Item>({
           })}
           <Input
             {...inputProps}
+            inputRef={inputRef}
             onKeyDown={e => onKeyDown(e, inputProps.onKeyDown)}
             onFocus={e => {
               setFocused(true);

--- a/upcoming-release-notes/4697.md
+++ b/upcoming-release-notes/4697.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+[WIP] 🐛 Fix `Make Transfer` closing the Popover when clicked

--- a/upcoming-release-notes/4697.md
+++ b/upcoming-release-notes/4697.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [lelemm]
 ---
 
-[WIP] 🐛 Fix `Make Transfer` closing the Popover when clicked
+🐛 Fix `Make Transfer` closing the Popover when clicked


### PR DESCRIPTION
Fix `Make Transfer` closing the Popover when clicked