### PR TITLE
Add error boundary to modal content

### DIFF
--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -32,6 +32,7 @@ import { css } from '@emotion/css';
 import { AutoTextSize } from 'auto-text-size';
 
 import { useModalState } from '../../hooks/useModalState';
+import { ErrorBoundary } from 'react-error-boundary';
 
 type ModalProps = ComponentPropsWithRef<typeof ReactAriaModal> & {
   name: string;
@@ -139,11 +140,13 @@ export const Modal = ({
                   ...containerProps?.style,
                 }}
               >
-                <View style={{ paddingTop: 0, flex: 1, flexShrink: 0 }}>
-                  {typeof children === 'function'
-                    ? children(modalProps)
-                    : children}
-                </View>
+                <ErrorBoundary FallbackComponent={ErrorFallback}>
+                  <View style={{ paddingTop: 0, flex: 1, flexShrink: 0 }}>
+                    {typeof children === 'function'
+                      ? children(modalProps)
+                      : children}
+                  </View>
+                </ErrorBoundary>
                 {isLoading && (
                   <View
                     style={{
@@ -487,5 +490,14 @@ export function ModalCloseButton({ onPress, style }: ModalCloseButtonProps) {
     >
       <SvgDelete width={10} style={style} />
     </Button>
+  );
+}
+
+function ErrorFallback() {
+  const { t } = useTranslation();
+  return (
+      <Text style={{ ...styles.mediumText, color: theme.errorText }}>
+        {t('There was a problem loading the modal')}
+      </Text>
   );
 }

--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -13,6 +13,7 @@ import {
   Modal as ReactAriaModal,
   Dialog,
 } from 'react-aria-components';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useHotkeysContext } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
@@ -32,7 +33,6 @@ import { css } from '@emotion/css';
 import { AutoTextSize } from 'auto-text-size';
 
 import { useModalState } from '../../hooks/useModalState';
-import { ErrorBoundary } from 'react-error-boundary';
 
 type ModalProps = ComponentPropsWithRef<typeof ReactAriaModal> & {
   name: string;
@@ -496,8 +496,8 @@ export function ModalCloseButton({ onPress, style }: ModalCloseButtonProps) {
 function ErrorFallback() {
   const { t } = useTranslation();
   return (
-      <Text style={{ ...styles.mediumText, color: theme.errorText }}>
-        {t('There was a problem loading the modal')}
-      </Text>
+    <Text style={{ ...styles.mediumText, color: theme.errorText }}>
+      {t('There was a problem loading the modal')}
+    </Text>
   );
 }

--- a/upcoming-release-notes/4708.md
+++ b/upcoming-release-notes/4708.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [koonweee]
+---
+
+Added error boundary to Modal


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes #4703 

## Demo
![CleanShot 2025-03-29 at 17 34 19](https://github.com/user-attachments/assets/3afd22e7-1665-40fb-be9a-930a0359484a)

