### PR TITLE
🐛 Fix pluggy.ai foreigner currency transaction

### DIFF
--- a/packages/sync-server/src/app-pluggyai/app-pluggyai.js
+++ b/packages/sync-server/src/app-pluggyai/app-pluggyai.js
@@ -129,6 +129,8 @@ app.post(
         newTrans.transactionId = trans.id;
         newTrans.sortOrder = transactionDate.getTime();
 
+        delete trans.amount;
+
         const finalTrans = { ...flattenObject(trans), ...newTrans };
         if (newTrans.booked) {
           booked.push(finalTrans);

--- a/upcoming-release-notes/4712.md
+++ b/upcoming-release-notes/4712.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lelemm]
+---
+
+Fix pluggy.ai foreigner currency transaction


### PR DESCRIPTION
Deleting `Amount` before spreading prevents this error. `Amount` is not needed