### PR TITLE
fix: persist filters in Custom Report on interval or date range change

### DIFF
--- a/upcoming-release-notes/4724.md
+++ b/upcoming-release-notes/4724.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tostasmistas]
+---
+
+Persist filters in Custom Report on interval or date range change


### PR DESCRIPTION
This PR fixes https://github.com/actualbudget/actual/issues/4444.

It ensures that modified filters are reapplied to the Custom Report when changing its interval or date range, rather than reverting to the last saved state, which could overwrite unsaved changes to the filters or their conditional operand.

---

- Before

![Untitled](https://github.com/user-attachments/assets/d96c2e44-d69a-40a9-bbe6-47a22741430c)

- After

![Untitled1](https://github.com/user-attachments/assets/cdb62d5f-21fd-48d9-bf9b-fc8e508fa4da)

---