### PR TITLE
🐛 [Bug]: Focused console warning

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -461,7 +461,6 @@ function SingleAutocomplete<T extends Item>({
           <View ref={triggerRef} style={{ flexShrink: 0 }}>
             {renderInput(
               getInputProps({
-                focused,
                 inputRef,
                 ...inputProps,
                 onFocus: e => {

--- a/upcoming-release-notes/4735.md
+++ b/upcoming-release-notes/4735.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Got rid of unnecessary warning when developing Actual


### PR DESCRIPTION
Resolves #4734

See here: https://www.w3schools.com/tags/tag_input.asp 
There is no `focused` HTML input attribute.