### PR TITLE
✨ [Feature] Manually merge transactions

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1248,6 +1248,18 @@ class AccountInternal extends PureComponent<
     });
   };
 
+  onMergeTransactions = async (ids: string[]) => {
+    const keptId = await send(
+      'transactions-merge',
+      ids.map(id => ({ id })),
+    );
+    await this.refetchTransactions();
+    this.dispatchSelected?.({
+      type: 'select-all',
+      ids: [keptId],
+    });
+  };
+
   checkForReconciledTransactions = async (
     ids: string[],
     confirmReason: string,
@@ -1833,6 +1845,7 @@ class AccountInternal extends PureComponent<
                 onSetTransfer={this.onSetTransfer}
                 onMakeAsSplitTransaction={this.onMakeAsSplitTransaction}
                 onMakeAsNonSplitTransactions={this.onMakeAsNonSplitTransactions}
+                onMergeTransactions={this.onMergeTransactions}
               />
 
               <View style={{ flex: 1 }}>

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -122,6 +122,7 @@ type AccountHeaderProps = {
   | 'onSetTransfer'
   | 'onMakeAsSplitTransaction'
   | 'onMakeAsNonSplitTransactions'
+  | 'onMergeTransactions'
 > &
   Pick<
     ComponentProps<typeof FiltersStack>,
@@ -189,6 +190,7 @@ export function AccountHeader({
   onRunRules,
   onMakeAsSplitTransaction,
   onMakeAsNonSplitTransactions,
+  onMergeTransactions,
 }: AccountHeaderProps) {
   const { t } = useTranslation();
 
@@ -379,6 +381,7 @@ export function AccountHeader({
               showMakeTransfer={showMakeTransfer}
               onMakeAsSplitTransaction={onMakeAsSplitTransaction}
               onMakeAsNonSplitTransactions={onMakeAsNonSplitTransactions}
+              onMergeTransactions={onMergeTransactions}
             />
           )}
           <View style={{ flex: '0 0 auto', marginLeft: 10 }}>

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -293,6 +293,7 @@ function SelectedTransactionsFloatingActionBar({
     onBatchLinkSchedule,
     onBatchUnlinkSchedule,
     onSetTransfer,
+    onMerge,
   } = useTransactionBatchActions();
 
   const navigate = useNavigate();
@@ -315,25 +316,37 @@ function SelectedTransactionsFloatingActionBar({
     };
   }, [dispatch]);
 
+  const twoTransactions: [TransactionEntity, TransactionEntity] | undefined =
+    useMemo(() => {
+      // only two selected
+      if (selectedTransactionsArray.length !== 2) {
+        return undefined;
+      }
+
+      const [a, b] = selectedTransactionsArray.map(id =>
+        transactions.find(t => t.id === id),
+      );
+      if (!a || !b) {
+        return undefined;
+      }
+
+      return [a, b];
+    }, [selectedTransactionsArray, transactions]);
+
   const canBeTransfer = useMemo(() => {
-    // only two selected
-    if (selectedTransactionsArray.length !== 2) {
+    if (!twoTransactions) {
       return false;
     }
-    const fromTrans = transactions.find(
-      t => t.id === selectedTransactionsArray[0],
-    );
-    const toTrans = transactions.find(
-      t => t.id === selectedTransactionsArray[1],
-    );
-
-    // previously selected transactions aren't always present in current transaction list
-    if (!fromTrans || !toTrans) {
-      return false;
-    }
-
+    const [fromTrans, toTrans] = twoTransactions;
     return validForTransfer(fromTrans, toTrans);
-  }, [selectedTransactionsArray, transactions]);
+  }, [twoTransactions]);
+
+  const canMerge = useMemo(() => {
+    return Boolean(
+      twoTransactions &&
+        twoTransactions[0].amount === twoTransactions[1].amount,
+    );
+  }, [twoTransactions]);
 
   const moreOptionsMenuItems: MenuItem<string>[] = [
     {
@@ -349,6 +362,11 @@ function SelectedTransactionsFloatingActionBar({
     {
       name: 'delete',
       text: t('Delete'),
+    },
+    {
+      name: 'merge',
+      text: t('Merge'),
+      disabled: !canMerge,
     },
   ];
 
@@ -602,6 +620,12 @@ function SelectedTransactionsFloatingActionBar({
                           count: ids.length,
                         },
                       ),
+                    }),
+                  );
+                } else if (type === 'merge') {
+                  onMerge?.(selectedTransactionsArray, () =>
+                    showUndoNotification({
+                      message: t('Successfully merged transactions'),
                     }),
                   );
                 }

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -18,6 +18,7 @@ import { type TransactionEntity } from 'loot-core/types/models';
 import { useSelectedItems } from '../../hooks/useSelected';
 import { useDispatch } from '../../redux';
 import { SelectedItemsButton } from '../table';
+import { selected } from '../../style/colors';
 
 type SelectedTransactionsButtonProps = {
   getTransaction: (id: string) => TransactionEntity | undefined;
@@ -136,8 +137,9 @@ export function SelectedTransactionsButton({
   }, [twoTransactions]);
 
   const canMerge = useMemo(() => {
-    return (
-      twoTransactions && twoTransactions[0].amount === twoTransactions[1].amount
+    return Boolean(
+      twoTransactions &&
+        twoTransactions[0].amount === twoTransactions[1].amount,
     );
   }, [twoTransactions]);
 

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -47,6 +47,7 @@ type SelectedTransactionsButtonProps = {
   showMakeTransfer: boolean;
   onMakeAsSplitTransaction: (selectedIds: string[]) => void;
   onMakeAsNonSplitTransactions: (selectedIds: string[]) => void;
+  onMergeTransactions: (selectedIds: string[]) => void;
 };
 
 export function SelectedTransactionsButton({
@@ -64,6 +65,7 @@ export function SelectedTransactionsButton({
   showMakeTransfer,
   onMakeAsSplitTransaction,
   onMakeAsNonSplitTransactions,
+  onMergeTransactions,
 }: SelectedTransactionsButtonProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -110,21 +112,34 @@ export function SelectedTransactionsButton({
     );
   }, [types.preview, selectedIds, getTransaction]);
 
+  const twoTransactions: [TransactionEntity, TransactionEntity] | undefined =
+    useMemo(() => {
+      if (selectedIds?.length !== 2) {
+        return undefined;
+      }
+      const [t0, t1] = selectedIds.map(getTransaction);
+      // previously selected transactions aren't always present in current transaction list
+      if (!t0 || !t1) {
+        return undefined;
+      }
+
+      return [t0, t1];
+    }, [selectedIds, getTransaction]);
+
   const canBeTransfer = useMemo(() => {
     // only two selected
-    if (selectedIds.length !== 2) {
+    if (!twoTransactions) {
       return false;
     }
-    const fromTrans = getTransaction(selectedIds[0]);
-    const toTrans = getTransaction(selectedIds[1]);
-
-    // previously selected transactions aren't always present in current transaction list
-    if (!fromTrans || !toTrans) {
-      return false;
-    }
-
+    const [fromTrans, toTrans] = twoTransactions;
     return validForTransfer(fromTrans, toTrans);
-  }, [selectedIds, getTransaction]);
+  }, [twoTransactions]);
+
+  const canMerge = useMemo(() => {
+    return (
+      twoTransactions && twoTransactions[0].amount === twoTransactions[1].amount
+    );
+  }, [twoTransactions]);
 
   const canBeSkipped = useMemo(() => {
     const recurringSchedules = selectedSchedules.filter(s => {
@@ -249,6 +264,12 @@ export function SelectedTransactionsButton({
     },
     [onLinkSchedule, onViewSchedule, linked, selectedIds],
   );
+  useHotkeys(
+    'm',
+    () => canMerge && onMergeTransactions(selectedIds),
+    hotKeyOptions,
+    [onMergeTransactions, selectedIds],
+  );
 
   return (
     <SelectedItemsButton
@@ -339,6 +360,15 @@ export function SelectedTransactionsButton({
                     } as const,
                   ]
                 : []),
+              ...(canMerge
+                ? [
+                    {
+                      name: 'merge-transactions',
+                      text: t('Merge'),
+                      key: 'M',
+                    } as const,
+                  ]
+                : []),
               Menu.line,
               { type: Menu.label, name: t('Edit field'), text: '' } as const,
               { name: 'date', text: t('Date') } as const,
@@ -366,6 +396,9 @@ export function SelectedTransactionsButton({
             break;
           case 'unsplit-transactions':
             onMakeAsNonSplitTransactions(selectedIds);
+            break;
+          case 'merge-transactions':
+            onMergeTransactions(selectedIds);
             break;
           case 'post-transaction':
           case 'skip':

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -18,7 +18,6 @@ import { type TransactionEntity } from 'loot-core/types/models';
 import { useSelectedItems } from '../../hooks/useSelected';
 import { useDispatch } from '../../redux';
 import { SelectedItemsButton } from '../table';
-import { selected } from '../../style/colors';
 
 type SelectedTransactionsButtonProps = {
   getTransaction: (id: string) => TransactionEntity | undefined;

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -502,6 +502,14 @@ export function useTransactionBatchActions() {
     );
   };
 
+  const onMerge = async (ids: string[], onSuccess: () => void) => {
+    const keptId = await send(
+      'transactions-merge',
+      ids.map(id => ({ id })),
+    );
+    onSuccess([keptId]);
+  };
+
   return {
     onBatchEdit,
     onBatchDuplicate,
@@ -509,5 +517,6 @@ export function useTransactionBatchActions() {
     onBatchLinkSchedule,
     onBatchUnlinkSchedule,
     onSetTransfer,
+    onMerge,
   };
 }

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -503,11 +503,11 @@ export function useTransactionBatchActions() {
   };
 
   const onMerge = async (ids: string[], onSuccess: () => void) => {
-    const keptId = await send(
+    await send(
       'transactions-merge',
       ids.map(id => ({ id })),
     );
-    onSuccess([keptId]);
+    onSuccess();
   };
 
   return {

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -15,6 +15,7 @@ import * as fs from '../../platform/server/fs';
 import * as sqlite from '../../platform/server/sqlite';
 import * as monthUtils from '../../shared/months';
 import { groupById } from '../../shared/util';
+import { TransactionEntity } from '../../types/models';
 import { WithRequired } from '../../types/util';
 import {
   schema,
@@ -774,7 +775,9 @@ export async function getTransactions(accountId: DbTransaction['acct']) {
   );
 }
 
-export function insertTransaction(transaction) {
+export function insertTransaction(
+  transaction,
+): Promise<TransactionEntity['id']> {
   return insertWithSchema('transactions', transaction);
 }
 

--- a/packages/loot-core/src/server/transactions/app.ts
+++ b/packages/loot-core/src/server/transactions/app.ts
@@ -12,6 +12,7 @@ import { undoable } from '../undo';
 
 import { exportQueryToCSV, exportToCSV } from './export/export-to-csv';
 import { parseFile, ParseFileOptions } from './import/parse-file';
+import { mergeTransactions } from './merge';
 
 import { batchUpdateTransactions } from '.';
 
@@ -23,6 +24,7 @@ export type TransactionHandlers = {
   'transactions-parse-file': typeof parseTransactionsFile;
   'transactions-export': typeof exportTransactions;
   'transactions-export-query': typeof exportTransactionsQuery;
+  'transactions-merge': typeof mergeTransactions;
   'get-earliest-transaction': typeof getEarliestTransaction;
 };
 
@@ -113,4 +115,5 @@ app.method('transaction-delete', mutator(deleteTransaction));
 app.method('transactions-parse-file', mutator(parseTransactionsFile));
 app.method('transactions-export', mutator(exportTransactions));
 app.method('transactions-export-query', mutator(exportTransactionsQuery));
+app.method('transactions-merge', mutator(mergeTransactions));
 app.method('get-earliest-transaction', getEarliestTransaction);

--- a/packages/loot-core/src/server/transactions/app.ts
+++ b/packages/loot-core/src/server/transactions/app.ts
@@ -108,6 +108,7 @@ app.method(
   'transactions-batch-update',
   mutator(undoable(handleBatchUpdateTransactions)),
 );
+app.method('transactions-merge', mutator(undoable(mergeTransactions)));
 
 app.method('transaction-add', mutator(addTransaction));
 app.method('transaction-update', mutator(updateTransaction));
@@ -115,5 +116,4 @@ app.method('transaction-delete', mutator(deleteTransaction));
 app.method('transactions-parse-file', mutator(parseTransactionsFile));
 app.method('transactions-export', mutator(exportTransactions));
 app.method('transactions-export-query', mutator(exportTransactionsQuery));
-app.method('transactions-merge', mutator(mergeTransactions));
 app.method('get-earliest-transaction', getEarliestTransaction);

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -93,6 +93,8 @@ describe('Merging success', () => {
     notes: 'notes1',
     category: '1',
     amount: 5,
+    cleared: false,
+    reconciled: false,
   } as TransactionEntity;
 
   const transaction2 = {
@@ -102,6 +104,8 @@ describe('Merging success', () => {
     notes: 'notes2',
     category: '2',
     amount: 5,
+    cleared: true,
+    reconciled: true,
   } as TransactionEntity;
 
   it('two imported transactions keeps older transaction', async () => {

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -1,0 +1,133 @@
+// @ts-strict-ignore
+import { TransactionEntity } from '@actual-app/api/@types/loot-core/types/models';
+import * as db from '../db';
+
+import { mergeTransactions } from './merge';
+import { Transaction } from '../../../../sync-server/src/app-gocardless/gocardless-node.types';
+
+describe('Merging fails for invalid quantity', () => {
+  const tests: [TransactionEntity[], string][] = [
+    [[{} as TransactionEntity], 'one transaction'],
+    [[], 'no transactions'],
+    [undefined as unknown as TransactionEntity[], 'undefined'],
+    [[{}, {}, {}] as TransactionEntity[], 'three transactions'],
+    [
+      [{}, undefined] as TransactionEntity[],
+      'two transactions but one is undefined',
+    ],
+  ];
+  tests.forEach(([arr, message]) =>
+    it(message, () => expect(() => mergeTransactions(arr)).rejects.toThrow()),
+  );
+});
+
+async function prepareDatabase() {
+  await db.insertCategoryGroup({ id: 'group1', name: 'group1', is_income: 0 });
+  await db.insertCategory({
+    id: '1',
+    name: 'cat1',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+  await db.insertCategory({
+    id: '2',
+    name: 'cat2',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+  await db.insertAccount({ id: 'one', name: 'one' });
+  await db.insertAccount({ id: 'two', name: 'two' });
+  await db.insertAccount({ id: 'three', name: 'three', offbudget: 1 });
+  await db.insertPayee({ id: 'payee1', name: 'one' });
+  await db.insertPayee({ id: 'payee2', name: 'two' });
+  await db.insertPayee({ id: 'payee3', name: 'three' });
+}
+
+function getAllTransactions() {
+  return db.all<db.DbViewTransaction & { payee_name: db.DbPayee['name'] }>(
+    `SELECT t.*, p.name as payee_name
+       FROM v_transactions t
+       LEFT JOIN payees p ON p.id = t.payee
+       ORDER BY date DESC, amount DESC, id
+     `,
+  );
+}
+
+describe('Merging success', () => {
+  beforeEach(global.emptyDatabase());
+  beforeEach(prepareDatabase);
+  const transaction1 = {
+    account: 'one',
+    date: '2025-01-01',
+    payee: 'payee1',
+    notes: 'notes1',
+    category: '1',
+    amount: 1,
+  } as TransactionEntity;
+
+  const transaction2 = {
+    account: 'two',
+    date: '2025-02-02',
+    payee: 'payee2',
+    notes: 'notes2',
+    category: '2',
+    amount: 2,
+  } as TransactionEntity;
+
+  it('two imported transactions keeps older transaction', async () => {
+    const t1 = await db.insertTransaction({
+      ...transaction1,
+      imported_id: 'imported_1',
+    });
+    const t2 = await db.insertTransaction({
+      ...transaction2,
+      imported_id: 'imported_2',
+    });
+
+    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...transaction1,
+      date: 20250101,
+      imported_id: 'imported_1',
+    });
+  });
+
+  it('first imported, second manual keeps manual values', async () => {
+    const t1 = await db.insertTransaction({
+      ...transaction1,
+      imported_id: 'imported_1',
+    });
+    const t2 = await db.insertTransaction(transaction2);
+
+    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...transaction2,
+      date: 20250202,
+      imported_id: 'imported_1',
+    });
+  });
+
+  it('second imported, first manual keeps manual values', async () => {
+    const t1 = await db.insertTransaction(transaction1);
+    const t2 = await db.insertTransaction({
+      ...transaction2,
+      imported_id: 'imported_2',
+    });
+
+    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...transaction1,
+      date: 20250101,
+      imported_id: 'imported_2',
+    });
+  });
+});

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -1,9 +1,8 @@
 // @ts-strict-ignore
-import { TransactionEntity } from '@actual-app/api/@types/loot-core/types/models';
+import { TransactionEntity } from '../../types/models';
 import * as db from '../db';
 
 import { mergeTransactions } from './merge';
-import { Transaction } from '../../../../sync-server/src/app-gocardless/gocardless-node.types';
 
 describe('Merging fails for invalid quantity', () => {
   const tests: [TransactionEntity[], string][] = [
@@ -84,7 +83,7 @@ describe('Merging success', () => {
       imported_id: 'imported_2',
     });
 
-    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t1);
 
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
@@ -102,7 +101,7 @@ describe('Merging success', () => {
     });
     const t2 = await db.insertTransaction(transaction2);
 
-    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t2);
 
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
@@ -120,7 +119,7 @@ describe('Merging success', () => {
       imported_id: 'imported_2',
     });
 
-    await mergeTransactions([{ id: t1 }, { id: t2 }]);
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t1);
 
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -167,6 +167,80 @@ describe('Merging success', () => {
     });
   });
 
+  it('first file imported, second banksycned keeps banksynced values', async () => {
+    const t1 = await db.insertTransaction({
+      ...transaction1,
+      imported_payee: 'payee',
+    });
+    const t2 = await db.insertTransaction({
+      ...transaction2,
+      imported_id: 'imported_2',
+    });
+
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t2);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...dbTransaction2,
+      imported_id: 'imported_2',
+    });
+  });
+
+  it('second file imported, first banksycned keeps banksynced values', async () => {
+    const t1 = await db.insertTransaction({
+      ...transaction1,
+      imported_id: 'imported_1',
+    });
+    const t2 = await db.insertTransaction({
+      ...transaction2,
+      imported_payee: 'payee',
+    });
+
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t1);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...dbTransaction1,
+      imported_id: 'imported_1',
+    });
+  });
+
+  it('second file imported, first manual keeps file imported values', async () => {
+    const t1 = await db.insertTransaction(transaction1);
+    const t2 = await db.insertTransaction({
+      ...transaction2,
+      imported_payee: 'payee',
+    });
+
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t2);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...dbTransaction2,
+      imported_payee: 'payee',
+    });
+  });
+
+  it('first file imported, second manual keeps file imported values', async () => {
+    const t1 = await db.insertTransaction({
+      ...transaction1,
+      imported_payee: 'payee',
+    });
+    const t2 = await db.insertTransaction(transaction2);
+
+    expect(await mergeTransactions([{ id: t1 }, { id: t2 }])).toBe(t1);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.length).toBe(1);
+    expect(transactions[0]).toMatchObject({
+      ...dbTransaction1,
+      imported_payee: 'payee',
+    });
+  });
+
   it('second banksynced, first manual keeps banksynced values', async () => {
     const t1 = await db.insertTransaction(transaction1);
     const t2 = await db.insertTransaction({

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -6,6 +6,7 @@ import { mergeTransactions } from './merge';
 
 describe('Merging fails for invalid quantity', () => {
   beforeEach(global.emptyDatabase());
+  afterEach(global.emptyDatabase());
 
   const tests: [TransactionEntity[], string][] = [
     [[{} as TransactionEntity], 'one transaction'],
@@ -86,6 +87,7 @@ function getAllTransactions() {
 describe('Merging success', () => {
   beforeEach(global.emptyDatabase());
   beforeEach(prepareDatabase);
+  afterEach(global.emptyDatabase());
   const transaction1 = {
     account: 'one',
     date: '2025-01-01',

--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -97,6 +97,17 @@ describe('Merging success', () => {
     reconciled: false,
   } as TransactionEntity;
 
+  const dbTransaction1 = {
+    account: 'one',
+    date: 20250101,
+    payee: 'payee1',
+    notes: 'notes1',
+    category: '1',
+    amount: 5,
+    cleared: 1,
+    reconciled: 1,
+  } as db.DbViewTransaction;
+
   const transaction2 = {
     account: 'two',
     date: '2025-02-02',
@@ -108,7 +119,18 @@ describe('Merging success', () => {
     reconciled: true,
   } as TransactionEntity;
 
-  it('two imported transactions keeps older transaction', async () => {
+  const dbTransaction2 = {
+    account: 'two',
+    date: 20250202,
+    payee: 'payee2',
+    notes: 'notes2',
+    category: '2',
+    amount: 5,
+    cleared: 1,
+    reconciled: 1,
+  } as db.DbViewTransaction;
+
+  it('two banksynced transactions keeps older transaction', async () => {
     const t1 = await db.insertTransaction({
       ...transaction1,
       imported_id: 'imported_1',
@@ -123,13 +145,12 @@ describe('Merging success', () => {
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
     expect(transactions[0]).toMatchObject({
-      ...transaction1,
-      date: 20250101,
+      ...dbTransaction1,
       imported_id: 'imported_1',
     });
   });
 
-  it('first imported, second manual keeps imported values', async () => {
+  it('first banksynced, second manual keeps banksynced values', async () => {
     const t1 = await db.insertTransaction({
       ...transaction1,
       imported_id: 'imported_1',
@@ -141,13 +162,12 @@ describe('Merging success', () => {
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
     expect(transactions[0]).toMatchObject({
-      ...transaction1,
-      date: 20250101,
+      ...dbTransaction1,
       imported_id: 'imported_1',
     });
   });
 
-  it('second imported, first manual keeps imported values', async () => {
+  it('second banksynced, first manual keeps banksynced values', async () => {
     const t1 = await db.insertTransaction(transaction1);
     const t2 = await db.insertTransaction({
       ...transaction2,
@@ -159,8 +179,7 @@ describe('Merging success', () => {
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
     expect(transactions[0]).toMatchObject({
-      ...transaction2,
-      date: 20250202,
+      ...dbTransaction2,
       imported_id: 'imported_2',
     });
   });
@@ -179,7 +198,7 @@ describe('Merging success', () => {
     const transactions = await getAllTransactions();
     expect(transactions.length).toBe(1);
     expect(transactions[0]).toMatchObject({
-      ...transaction2,
+      ...dbTransaction2,
       // values that should be kept from t1
       id: t1,
       account: 'one',

--- a/packages/loot-core/src/server/transactions/merge.ts
+++ b/packages/loot-core/src/server/transactions/merge.ts
@@ -17,11 +17,20 @@ export async function mergeTransactions(
   const [a, b]: TransactionEntity[] = await Promise.all(
     txIds.map(db.getTransaction),
   );
+  if (!a || !b) {
+    throw new Error('One of the provided transactions does not exist');
+  } else if (a.amount !== b.amount) {
+    throw new Error('Transaction amounts must match for merge');
+  }
   const { keep, drop } = determineKeepDrop(a, b);
 
   await Promise.all([
     db.updateTransaction({
       id: keep.id,
+      date: keep.date || drop.date,
+      payee: keep.payee || drop.payee,
+      category: keep.category || drop.category,
+      notes: keep.notes || drop.notes,
       imported_id: keep.imported_id || drop.imported_id,
     } as TransactionEntity),
     db.deleteTransaction(drop),

--- a/packages/loot-core/src/server/transactions/merge.ts
+++ b/packages/loot-core/src/server/transactions/merge.ts
@@ -42,10 +42,18 @@ function determineKeepDrop(
   a: TransactionEntity,
   b: TransactionEntity,
 ): { keep: TransactionEntity; drop: TransactionEntity } {
-  // if one is imported and the other is manual, keep the manual transaction
+  // if one is imported through bank sync and the other is manual,
+  // keep the imported transaction
   if (b.imported_id && !a.imported_id) {
     return { keep: b, drop: a };
   } else if (a.imported_id && !b.imported_id) {
+    return { keep: a, drop: b };
+  }
+
+  // same logic but for imported transactions
+  if (b.imported_payee && !a.imported_payee) {
+    return { keep: b, drop: a };
+  } else if (a.imported_payee && !b.imported_payee) {
     return { keep: a, drop: b };
   }
 

--- a/packages/loot-core/src/server/transactions/merge.ts
+++ b/packages/loot-core/src/server/transactions/merge.ts
@@ -30,6 +30,8 @@ export async function mergeTransactions(
       payee: keep.payee || drop.payee,
       category: keep.category || drop.category,
       notes: keep.notes || drop.notes,
+      cleared: keep.cleared || drop.cleared,
+      reconciled: keep.reconciled || drop.reconciled,
     } as TransactionEntity),
     db.deleteTransaction(drop),
   ]);

--- a/packages/loot-core/src/server/transactions/merge.ts
+++ b/packages/loot-core/src/server/transactions/merge.ts
@@ -27,11 +27,9 @@ export async function mergeTransactions(
   await Promise.all([
     db.updateTransaction({
       id: keep.id,
-      date: keep.date || drop.date,
       payee: keep.payee || drop.payee,
       category: keep.category || drop.category,
       notes: keep.notes || drop.notes,
-      imported_id: keep.imported_id || drop.imported_id,
     } as TransactionEntity),
     db.deleteTransaction(drop),
   ]);
@@ -44,9 +42,9 @@ function determineKeepDrop(
 ): { keep: TransactionEntity; drop: TransactionEntity } {
   // if one is imported and the other is manual, keep the manual transaction
   if (b.imported_id && !a.imported_id) {
-    return { keep: a, drop: b };
-  } else if (a.imported_id && !b.imported_id) {
     return { keep: b, drop: a };
+  } else if (a.imported_id && !b.imported_id) {
+    return { keep: a, drop: b };
   }
 
   // keep the earlier transaction

--- a/upcoming-release-notes/4739.md
+++ b/upcoming-release-notes/4739.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [alecbakholdin]
+---
+
+added ability to merge transactions


### PR DESCRIPTION
Attempts to implement the manual transaction merge option described first in #669 and seen again in #4676

Merge is only selectable only when two transactions with matching amounts are selected:
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/2919d016-b827-4cd5-9fb2-27c9869e4c00" />
<img width="443" alt="image" src="https://github.com/user-attachments/assets/9ca6600a-8d90-4d1e-a090-1a4c18b14168" />


Does not show up with one selected on desktop
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/73a8b359-5c94-4404-9b0e-69ac3c6579d0" />

Greyed out on mobile when conditions are not met
<img width="427" alt="image" src="https://github.com/user-attachments/assets/26d01b04-3438-45a0-8c67-51c201fd23e0" />

For the two transactions, one is kept and one is dropped using the following logic:
1. If only one of the two is bank synced (only one of them has imported_id set), that one is kept
2. If only one of the transactions is imported by file (only one of them has imported_payee set), that one is kept
3. The earlier transaction is kept

The following fields can be affected by merge:
1. payee
2. notes
3. category
4. cleared
5. reconciled

If any of these fields is empty in the kept transaction (for cleared and reconciled, empty = false), they are copied from the dropped transaction.

resolves #669
