### PR TITLE
Fix bump versions script

### DIFF
--- a/.github/actions/bump-package-versions
+++ b/.github/actions/bump-package-versions
@@ -11,6 +11,7 @@ files_to_bump=(
     packages/api/package.json
     packages/desktop-client/package.json
     packages/desktop-electron/package.json
+    packages/sync-server/package.json
 )
 
 for file in "${files_to_bump[@]}"; do

--- a/.github/actions/bump-package-versions
+++ b/.github/actions/bump-package-versions
@@ -17,8 +17,30 @@ files_to_bump=(
 for file in "${files_to_bump[@]}"; do
     if [ -z "$version" ]; then
         # version format: YY.MM.patch
-        # logic: if before the 25th, bump patch, else set minor/major to next month
-        version="$(jq -r .version "$file" | perl -e '($y,$m,$p)=split/\./,<>;$d=(localtime)[3];$d>25?($p=0,++$m,$m>12&&($m=1,++$y)):$p++;print"$y.$m.$p\n"')"
+        version="$(jq -r .version "$file" | perl -e '
+            ($y,$m,$p)=split(/\./,<>);
+            ($sec,$min,$hour,$day,$mon,$year)=localtime();
+            $year -= 100;  # Perl year starts at 1900
+            $mon++;  # Adjust 0-indexed month to 1-indexed
+            if ($y == $year && $m == $mon) {
+                if ($day <= 25) {
+                    # Patch release for the current month
+                    $p++;
+                } else {
+                    # Use next month for a new release period
+                    $p = 0;
+                    $m++;
+                    $m > 12 && ($m=1, $y++);
+                }
+            } else {
+                # Use the current date for a new release period
+                $y = $year;
+                $m = $mon;
+                $p = 0;
+            }
+            print "$y.$m.$p\n";
+        ')"
+
         if [ -z "$version" ]; then
             echo "Error: Failed to calculate new version" >&2
             exit 1

--- a/upcoming-release-notes/4740.md
+++ b/upcoming-release-notes/4740.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Fix bump versions script behaviour


### PR DESCRIPTION
Two issues that came up this release:
- `packages/sync-server/package.json` was not added as part of the server migration; this has been fixed.
- Versions were not being correctly generated if the month had rolled over. This PR fixes the logic such that a minor version increment will still occur past the 1st of the month.