### PR TITLE
:bug: (bank-sync) improved error handling for initial gocardless account linking

### DIFF
--- a/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
@@ -66,12 +66,18 @@ function useAvailableBanks(country: string) {
   };
 }
 
-function renderError(error: 'unknown' | 'timeout', t: (key: string) => string) {
+function renderError(
+  error: { code: 'unknown' | 'timeout'; message?: string },
+  t: ReturnType<typeof useTranslation>['t'],
+) {
   return (
-    <Error style={{ alignSelf: 'center' }}>
-      {error === 'timeout'
+    <Error style={{ alignSelf: 'center', marginBottom: 10 }}>
+      {error.code === 'timeout'
         ? t('Timed out. Please try again.')
-        : t('An error occurred while linking your account, sorry!')}
+        : t(
+            'An error occurred while linking your account, sorry! The potential issue could be: {{ message }}',
+            { message: error.message },
+          )}
     </Error>
   );
 }
@@ -94,7 +100,10 @@ export function GoCardlessExternalMsgModal({
   const [success, setSuccess] = useState<boolean>(false);
   const [institutionId, setInstitutionId] = useState<string>();
   const [country, setCountry] = useState<string>();
-  const [error, setError] = useState<'unknown' | 'timeout' | null>(null);
+  const [error, setError] = useState<{
+    code: 'unknown' | 'timeout';
+    message?: string;
+  } | null>(null);
   const [isGoCardlessSetupComplete, setIsGoCardlessSetupComplete] = useState<
     boolean | null
   >(null);
@@ -116,7 +125,10 @@ export function GoCardlessExternalMsgModal({
 
     const res = await onMoveExternal({ institutionId });
     if ('error' in res) {
-      setError(res.error);
+      setError({
+        code: res.error,
+        message: 'message' in res ? res.message : undefined,
+      });
       setWaiting(null);
       return;
     }

--- a/packages/loot-core/src/client/modals/modalsSlice.ts
+++ b/packages/loot-core/src/client/modals/modalsSlice.ts
@@ -117,7 +117,9 @@ export type Modal =
         onMoveExternal: (arg: {
           institutionId: string;
         }) => Promise<
-          { error: 'unknown' | 'timeout' } | { data: GoCardlessToken }
+          | { error: 'timeout' }
+          | { error: 'unknown'; message?: string }
+          | { data: GoCardlessToken }
         >;
         onClose?: (() => void) | undefined;
         onSuccess: (data: GoCardlessToken) => Promise<void>;

--- a/upcoming-release-notes/4756.md
+++ b/upcoming-release-notes/4756.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Gocardless bank sync: improved error handling for initial account linking.


### PR DESCRIPTION
Currently if the initial account linking fails - there is no friendly error message. I am patching this + surfacing the API error in the UI for the user to see.

Also: improving some type definitions.

Related: https://github.com/actualbudget/actual/issues/4695