### PR TITLE
:wrench: added eslint auto-fix to the lint-staged step

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,10 @@
     "node": ">=18.0.0"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,md,json,yml}": "prettier --write"
+    "*.{js,jsx,ts,tsx,md,json,yml}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   },
   "packageManager": "yarn@4.7.0",
   "browserslist": [

--- a/upcoming-release-notes/4757.md
+++ b/upcoming-release-notes/4757.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+add eslint auto-fixer to lint-staged


### PR DESCRIPTION
This might be controversial so I am looking for 2+ maintainer approvals and NO disapprovals.

After the change in https://github.com/actualbudget/actual/pull/4710 - eslint has become much quicker. So quick in fact that I would propose to run it in the `lint-staged` step.

**What does this entail?**

`lint-staged` runs the lint jobs on the staged (read: changed) files. It does **not** run it on ALL the files. Since the amount of files it runs on is small - the operation is super quick (for me the whole lint-staged operation takes ~2s).

Running both eslint & prettier as part of this step allows us to surface issues quicker. Instead of having to wait for CI jobs to finish - we can identify new issues quickly on your local machine prior to pushing.

This might not matter much for active contributors, but for newcomers or less-so-active folks - this change allows them to catch lint issues before they open a PR. Thus makes the development experience for newcomers slightly more convenient.