### PR TITLE
:electron:  Fix loot-core resolution

### DIFF
--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -127,6 +127,7 @@
     "./server/*": "./src/server/*.ts",
     "./shared/*": "./src/shared/*.ts",
     "./types/models": "./src/types/models/index.d.ts",
-    "./types/*": "./src/types/*.d.ts"
+    "./types/*": "./src/types/*.d.ts",
+    "./lib-dist/electron/bundle.desktop.js": "./lib-dist/electron/bundle.desktop.js"
   }
 }

--- a/upcoming-release-notes/4767.md
+++ b/upcoming-release-notes/4767.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Fix loot core resolution for electron in dev mode


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->


Looks like I missed this in this fix: https://github.com/actualbudget/actual/pull/4668

It allows us to reference the loot-core desktop bundle in dev mode. We need it so that we can run the backend in a worker process.