### PR TITLE
[Mobile] Fix income categories not changing colors based on active month

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
@@ -133,6 +133,7 @@ export function IncomeCategoryList({
       aria-label={t('Income categories')}
       items={categories}
       dragAndDropHooks={dragAndDropHooks}
+      dependencies={[month, onEditCategory, onBudgetAction]}
     >
       {category => (
         <IncomeCategoryListItem

--- a/upcoming-release-notes/4774.md
+++ b/upcoming-release-notes/4774.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+[Mobile] Fix income categories not changing colors based on active month


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fixes #4723 and applying to #4484 as well