### PR TITLE
Fix crash on transactions table with new transaction popup open

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -2017,7 +2017,7 @@ function TransactionTableInner({
               onDistributeRemainder={props.onDistributeRemainder}
               balance={
                 props.transactions?.length > 0
-                  ? props.balances?.[props.transactions[0]?.id]?.balance
+                  ? (props.balances?.[props.transactions[0]?.id]?.balance ?? 0)
                   : 0
               }
             />

--- a/upcoming-release-notes/4812.md
+++ b/upcoming-release-notes/4812.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Fix crash on transactions table with new transaction popup open


### PR DESCRIPTION
Closes #4811

Steps to repro on edge (web, not mobile):
1. Navigate to an account.
1. Turn on running balance.
1. Click "Add New" but don't edit the transaction.
1. Click "Reconcile" and change the value to anything else.
1. Click "Create reconciliation transaction".
1. Observe the crash.

Performing the same steps on this PR's preview will not crash.