### PR TITLE
Move `loot-core/client` code over to `desktop-client` package

### DIFF
--- a/packages/desktop-client/src/accounts/accountsSlice.ts
+++ b/packages/desktop-client/src/accounts/accountsSlice.ts
@@ -1,23 +1,23 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { send } from '../../platform/client/fetch';
-import { type SyncResponseWithErrors } from '../../server/accounts/app';
+import { resetApp } from 'loot-core/client/app/appSlice';
+import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
+import {
+  getAccounts,
+  getPayees,
+  setNewTransactions,
+} from 'loot-core/client/queries/queriesSlice';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { type AppDispatch } from 'loot-core/client/store';
+import { send } from 'loot-core/platform/client/fetch';
+import { type SyncResponseWithErrors } from 'loot-core/server/accounts/app';
 import {
   type SyncServerGoCardlessAccount,
   type AccountEntity,
   type TransactionEntity,
   type SyncServerSimpleFinAccount,
   type SyncServerPluggyAiAccount,
-} from '../../types/models';
-import { resetApp } from '../app/appSlice';
-import { addNotification } from '../notifications/notificationsSlice';
-import {
-  getAccounts,
-  getPayees,
-  setNewTransactions,
-} from '../queries/queriesSlice';
-import { createAppAsyncThunk } from '../redux';
-import { type AppDispatch } from '../store';
+} from 'loot-core/types/models';
 
 const sliceName = 'account';
 

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -18,7 +18,6 @@ import { debounce } from 'debounce';
 import { t } from 'i18next';
 import { v4 as uuidv4 } from 'uuid';
 
-import { unlinkAccount } from 'loot-core/client/accounts/accountsSlice';
 import { syncAndDownload } from 'loot-core/client/app/appSlice';
 import { useFilters } from 'loot-core/client/data-hooks/filters';
 import {
@@ -69,6 +68,7 @@ import {
   type TransactionFilterEntity,
 } from 'loot-core/types/models';
 
+import { unlinkAccount } from '../../accounts/accountsSlice';
 import { useAccountPreviewTransactions } from '../../hooks/useAccountPreviewTransactions';
 import { useAccounts } from '../../hooks/useAccounts';
 import { useCategories } from '../../hooks/useCategories';

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
@@ -8,9 +8,9 @@ import { Popover } from '@actual-app/components/popover';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { unlinkAccount } from 'loot-core/client/accounts/accountsSlice';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { unlinkAccount } from '../../accounts/accountsSlice';
 import { authorizeBank } from '../../gocardless';
 import { useAccounts } from '../../hooks/useAccounts';
 import { useFailedAccounts } from '../../hooks/useFailedAccounts';

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -9,7 +9,6 @@ import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
-import { unlinkAccount } from 'loot-core/client/accounts/accountsSlice';
 import { useTransactions } from 'loot-core/client/data-hooks/transactions';
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
@@ -24,6 +23,7 @@ import {
   type AccountEntity,
 } from 'loot-core/types/models';
 
+import { unlinkAccount } from '../../accounts/accountsSlice';
 import { useSyncedPref } from '../../hooks/useSyncedPref';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
@@ -27,12 +27,12 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { moveAccount } from 'loot-core/client/accounts/accountsSlice';
 import { syncAndDownload } from 'loot-core/client/app/appSlice';
 import { replaceModal } from 'loot-core/client/modals/modalsSlice';
 import * as queries from 'loot-core/client/queries';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { moveAccount } from '../../../accounts/accountsSlice';
 import { useAccounts } from '../../../hooks/useAccounts';
 import { useFailedAccounts } from '../../../hooks/useFailedAccounts';
 import { useLocalPref } from '../../../hooks/useLocalPref';

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
@@ -7,14 +7,14 @@ import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
+import { closeModal } from 'loot-core/client/modals/modalsSlice';
+
 import {
   linkAccount,
   linkAccountPluggyAi,
   linkAccountSimpleFin,
   unlinkAccount,
-} from 'loot-core/client/accounts/accountsSlice';
-import { closeModal } from 'loot-core/client/modals/modalsSlice';
-
+} from '../../accounts/accountsSlice';
 import { useAccounts } from '../../hooks/useAccounts';
 import { useDispatch } from '../../redux';
 import { Autocomplete } from '../autocomplete/Autocomplete';

--- a/packages/desktop-client/src/components/sidebar/Accounts.tsx
+++ b/packages/desktop-client/src/components/sidebar/Accounts.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { moveAccount } from 'loot-core/client/accounts/accountsSlice';
 import * as queries from 'loot-core/client/queries';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { moveAccount } from '../../accounts/accountsSlice';
 import { useAccounts } from '../../hooks/useAccounts';
 import { useClosedAccounts } from '../../hooks/useClosedAccounts';
 import { useFailedAccounts } from '../../hooks/useFailedAccounts';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as accountsSlice from 'loot-core/client/accounts/accountsSlice';
 import * as appSlice from 'loot-core/client/app/appSlice';
 import * as budgetsSlice from 'loot-core/client/budgets/budgetsSlice';
 import * as modalsSlice from 'loot-core/client/modals/modalsSlice';
@@ -27,6 +26,7 @@ import * as usersSlice from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 
+import * as accountsSlice from './accounts/accountsSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import { App } from './components/App';
 import { ServerProvider } from './components/ServerContext';

--- a/packages/loot-core/src/client/app/appSlice.ts
+++ b/packages/loot-core/src/client/app/appSlice.ts
@@ -1,3 +1,6 @@
+// This is temporary until we move all loot-core/client over to desktop-client.
+// eslint-disable-next-line no-restricted-imports
+import { syncAccounts } from '@actual-app/web/src/accounts/accountsSlice';
 import {
   createAction,
   createSlice,
@@ -8,7 +11,6 @@ import { send } from '../../platform/client/fetch';
 import { getUploadError } from '../../shared/errors';
 import { type AccountEntity } from '../../types/models';
 import { type AtLeastOne } from '../../types/util';
-import { syncAccounts } from '../accounts/accountsSlice';
 import { pushModal } from '../modals/modalsSlice';
 import { loadPrefs } from '../prefs/prefsSlice';
 import { createAppAsyncThunk } from '../redux';

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -1,3 +1,9 @@
+// This is temporary until we move all loot-core/client over to desktop-client.
+// eslint-disable-next-line no-restricted-imports
+import {
+  name as accountsSliceName,
+  reducer as accountsSliceReducer,
+} from '@actual-app/web/src/accounts/accountsSlice';
 import {
   combineReducers,
   configureStore,
@@ -5,10 +11,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as accountsSliceName,
-  reducer as accountsSliceReducer,
-} from '../accounts/accountsSlice';
 import {
   name as appSliceName,
   reducer as appSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -1,9 +1,11 @@
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-
+// This is temporary until we move all loot-core/client over to desktop-client.
+// eslint-disable-next-line no-restricted-imports
 import {
   name as accountsSliceName,
   reducer as accountsSliceReducer,
-} from '../accounts/accountsSlice';
+} from '@actual-app/web/src/accounts/accountsSlice';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
 import {
   name as appSliceName,
   reducer as appSliceReducer,

--- a/upcoming-release-notes/4816.md
+++ b/upcoming-release-notes/4816.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client codes over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [ ] accounts folder
- [ ] app folder
- [ ] budgets folder
- [ ] modals folder
- [ ] notifications folder
- [ ] prefs folder
- [ ] queries folder
- [ ] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder