### PR TITLE
Move loot-core/client/budgets code over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/budgets/budgetsSlice.ts
+++ b/packages/desktop-client/src/budgets/budgetsSlice.ts
@@ -1,5 +1,3 @@
-// This is temporary until we move all loot-core/client over to desktop-client.
- 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 

--- a/packages/desktop-client/src/budgets/budgetsSlice.ts
+++ b/packages/desktop-client/src/budgets/budgetsSlice.ts
@@ -1,19 +1,20 @@
 // This is temporary until we move all loot-core/client over to desktop-client.
-// eslint-disable-next-line no-restricted-imports
-import { resetApp, setAppState } from '@actual-app/web/src/app/appSlice';
+ 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 
-import { send } from '../../platform/client/fetch';
-import { type RemoteFile } from '../../server/cloud-storage';
-import { getDownloadError, getSyncError } from '../../shared/errors';
-import { type Budget } from '../../types/budget';
-import { type File } from '../../types/file';
-import { type Handlers } from '../../types/handlers';
-import { closeModal, pushModal } from '../modals/modalsSlice';
-import { loadGlobalPrefs, loadPrefs } from '../prefs/prefsSlice';
-import { createAppAsyncThunk } from '../redux';
-import { signOut } from '../users/usersSlice';
+import { closeModal, pushModal } from 'loot-core/client/modals/modalsSlice';
+import { loadGlobalPrefs, loadPrefs } from 'loot-core/client/prefs/prefsSlice';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { signOut } from 'loot-core/client/users/usersSlice';
+import { send } from 'loot-core/platform/client/fetch';
+import { type RemoteFile } from 'loot-core/server/cloud-storage';
+import { getDownloadError, getSyncError } from 'loot-core/shared/errors';
+import { type Budget } from 'loot-core/types/budget';
+import { type File } from 'loot-core/types/file';
+import { type Handlers } from 'loot-core/types/handlers';
+
+import { resetApp, setAppState } from '../app/appSlice';
 
 const sliceName = 'budgets';
 

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -14,7 +14,6 @@ import { BrowserRouter } from 'react-router-dom';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget, loadBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import * as Platform from 'loot-core/client/platform';
 import { loadGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
@@ -23,6 +22,7 @@ import { signOut } from 'loot-core/client/users/usersSlice';
 import { init as initConnection, send } from 'loot-core/platform/client/fetch';
 
 import { setAppState, sync } from '../app/appSlice';
+import { closeBudget, loadBudget } from '../budgets/budgetsSlice';
 import { handleGlobalEvents } from '../global-events';
 import { setI18NextLanguage } from '../i18n';
 import { installPolyfills } from '../polyfills';

--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -10,7 +10,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { getUserData, signOut } from 'loot-core/client/users/usersSlice';
 import { listen } from 'loot-core/platform/client/fetch';
 import { type RemoteFile, type SyncedLocalFile } from 'loot-core/types/file';
@@ -18,6 +17,7 @@ import { type TransObjectLiteral } from 'loot-core/types/util';
 
 import { useAuth } from '../auth/AuthProvider';
 import { Permissions } from '../auth/types';
+import { closeBudget } from '../budgets/budgetsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 import { PrivacyFilter } from './PrivacyFilter';

--- a/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
@@ -36,14 +36,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import {
-  closeAndDownloadBudget,
-  closeAndLoadBudget,
-  createBudget,
-  downloadBudget,
-  loadAllFiles,
-  loadBudget,
-} from 'loot-core/client/budgets/budgetsSlice';
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { getUserData } from 'loot-core/client/users/usersSlice';
 import {
@@ -58,6 +50,14 @@ import {
   type SyncedLocalFile,
 } from 'loot-core/types/file';
 
+import {
+  closeAndDownloadBudget,
+  closeAndLoadBudget,
+  createBudget,
+  downloadBudget,
+  loadAllFiles,
+  loadBudget,
+} from '../../budgets/budgetsSlice';
 import { useSelector, useDispatch } from '../../redux';
 import { useMultiuserEnabled } from '../ServerContext';
 

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -8,13 +8,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { createBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { loggedIn, signOut } from 'loot-core/client/users/usersSlice';
 import {
   isNonProductionEnvironment,
   isElectron,
 } from 'loot-core/shared/environment';
 
+import { createBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { useServerURL, useSetServerURL } from '../ServerContext';

--- a/packages/desktop-client/src/components/manager/WelcomeScreen.tsx
+++ b/packages/desktop-client/src/components/manager/WelcomeScreen.tsx
@@ -8,9 +8,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { createBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
 
+import { createBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
@@ -8,9 +8,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { createBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 
+import { createBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Link } from '../../common/Link';
 import { useRefreshLoginMethods } from '../../ServerContext';

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -14,13 +14,13 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { loadAllFiles } from 'loot-core/client/budgets/budgetsSlice';
 import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { loadGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getCreateKeyError } from 'loot-core/shared/errors';
 
 import { sync } from '../../app/appSlice';
+import { loadAllFiles } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
+++ b/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
@@ -7,11 +7,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { loadBackup, makeBackup } from 'loot-core/client/budgets/budgetsSlice';
 import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send, listen } from 'loot-core/platform/client/fetch';
 import { type Backup } from 'loot-core/server/budgetfiles/backups';
 
+import { loadBackup, makeBackup } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Row, Cell } from '../table';

--- a/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
@@ -7,7 +7,6 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
 import {
   type Modal as ModalType,
   popModal,
@@ -17,6 +16,7 @@ import * as asyncStorage from 'loot-core/platform/server/asyncStorage';
 import { getOpenIdErrors } from 'loot-core/shared/errors';
 import { type OpenIdConfig } from 'loot-core/types/models';
 
+import { closeBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Error } from '../alerts';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/OutOfSyncMigrationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/OutOfSyncMigrationsModal.tsx
@@ -6,8 +6,7 @@ import { Paragraph } from '@actual-app/components/paragraph';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
-
+import { closeBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { Modal, ModalHeader, ModalTitle } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
@@ -7,7 +7,6 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
 import {
   type Modal as ModalType,
   popModal,
@@ -15,6 +14,7 @@ import {
 import { send } from 'loot-core/platform/client/fetch';
 import * as asyncStorage from 'loot-core/platform/server/asyncStorage';
 
+import { closeBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Error as ErrorAlert } from '../alerts';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/TransferOwnership.tsx
+++ b/packages/desktop-client/src/components/modals/TransferOwnership.tsx
@@ -9,7 +9,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeAndLoadBudget } from 'loot-core/client/budgets/budgetsSlice';
 import {
   type Modal as ModalType,
   popModal,
@@ -21,6 +20,7 @@ import { type Budget } from 'loot-core/types/budget';
 import { type RemoteFile, type SyncedLocalFile } from 'loot-core/types/file';
 import { type Handlers } from 'loot-core/types/handlers';
 
+import { closeAndLoadBudget } from '../../budgets/budgetsSlice';
 import { useDispatch, useSelector } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
@@ -6,9 +6,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { deleteBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 
+import { deleteBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
@@ -10,11 +10,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { duplicateBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 
+import { duplicateBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import {
   Modal,

--- a/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
@@ -8,9 +8,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { loadAllFiles } from 'loot-core/client/budgets/budgetsSlice';
 import { pushModal } from 'loot-core/client/modals/modalsSlice';
 
+import { loadAllFiles } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/ImportActualModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportActualModal.tsx
@@ -9,8 +9,7 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { importBudget } from 'loot-core/client/budgets/budgetsSlice';
-
+import { importBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/ImportYNAB4Modal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportYNAB4Modal.tsx
@@ -9,8 +9,7 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { importBudget } from 'loot-core/client/budgets/budgetsSlice';
-
+import { importBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/ImportYNAB5Modal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportYNAB5Modal.tsx
@@ -9,8 +9,7 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { importBudget } from 'loot-core/client/budgets/budgetsSlice';
-
+import { importBudget } from '../../../budgets/budgetsSlice';
 import { useDispatch } from '../../../redux';
 import { Link } from '../../common/Link';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -10,11 +10,11 @@ import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
 import { loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { listen } from 'loot-core/platform/client/fetch';
 import { isElectron } from 'loot-core/shared/environment';
 
+import { closeBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/components/sidebar/BudgetName.tsx
+++ b/packages/desktop-client/src/components/sidebar/BudgetName.tsx
@@ -11,9 +11,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeBudget } from 'loot-core/client/budgets/budgetsSlice';
 import * as Platform from 'loot-core/client/platform';
 
+import { closeBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
 
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { closeBudgetUI } from 'loot-core/client/budgets/budgetsSlice';
 import {
   closeModal,
   pushModal,
@@ -21,6 +20,7 @@ import { listen } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 
 import { setAppState } from './app/appSlice';
+import { closeBudgetUI } from './budgets/budgetsSlice';
 
 export function handleGlobalEvents(store: AppStore) {
   const unlistenServerError = listen('server-error', () => {

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as budgetsSlice from 'loot-core/client/budgets/budgetsSlice';
 import * as modalsSlice from 'loot-core/client/modals/modalsSlice';
 import * as notificationsSlice from 'loot-core/client/notifications/notificationsSlice';
 import * as prefsSlice from 'loot-core/client/prefs/prefsSlice';
@@ -28,6 +27,8 @@ import { q } from 'loot-core/shared/query';
 import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
+import * as budgetsSlice from './budgets/budgetsSlice';
+
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -28,7 +28,6 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -2,7 +2,10 @@
 // This is temporary until we move all loot-core/client over to desktop-client.
 /* eslint-disable no-restricted-imports */
 import { resetSync, sync } from '@actual-app/web/src/app/appSlice';
-import { closeAndDownloadBudget, uploadBudget } from '@actual-app/web/src/budgets/budgetsSlice';
+import {
+  closeAndDownloadBudget,
+  uploadBudget,
+} from '@actual-app/web/src/budgets/budgetsSlice';
 /* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -1,12 +1,13 @@
 // @ts-strict-ignore
 // This is temporary until we move all loot-core/client over to desktop-client.
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable no-restricted-imports */
 import { resetSync, sync } from '@actual-app/web/src/app/appSlice';
+import { closeAndDownloadBudget, uploadBudget } from '@actual-app/web/src/budgets/budgetsSlice';
+/* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 
 import { listen, send } from '../platform/client/fetch';
 
-import { closeAndDownloadBudget, uploadBudget } from './budgets/budgetsSlice';
 import { pushModal } from './modals/modalsSlice';
 import {
   addNotification,

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -8,6 +8,10 @@ import {
   name as appSliceName,
   reducer as appSliceReducer,
 } from '@actual-app/web/src/app/appSlice';
+import {
+  name as budgetsSliceName,
+  reducer as budgetsSliceReducer,
+} from '@actual-app/web/src/budgets/budgetsSlice';
 /* eslint-enable no-restricted-imports */
 import {
   combineReducers,
@@ -16,10 +20,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as budgetsSliceName,
-  reducer as budgetsSliceReducer,
-} from '../budgets/budgetsSlice';
 import {
   name as modalsSliceName,
   reducer as modalsSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -8,14 +8,14 @@ import {
   name as appSliceName,
   reducer as appSliceReducer,
 } from '@actual-app/web/src/app/appSlice';
-/* eslint-enable */
-
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
 
 import {
   name as budgetsSliceName,
   reducer as budgetsSliceReducer,
-} from '../budgets/budgetsSlice';
+} from '@actual-app/web/src/budgets/budgetsSlice';
+/* eslint-enable */
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
 import {
   name as modalsSliceName,
   reducer as modalsSliceReducer,

--- a/packages/loot-core/src/client/users/usersSlice.ts
+++ b/packages/loot-core/src/client/users/usersSlice.ts
@@ -1,7 +1,10 @@
 // This is temporary until we move all loot-core/client over to desktop-client.
 /* eslint-disable no-restricted-imports */
 import { resetApp } from '@actual-app/web/src/app/appSlice';
-import { closeBudget, loadAllFiles } from '@actual-app/web/src/budgets/budgetsSlice';
+import {
+  closeBudget,
+  loadAllFiles,
+} from '@actual-app/web/src/budgets/budgetsSlice';
 /* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 

--- a/packages/loot-core/src/client/users/usersSlice.ts
+++ b/packages/loot-core/src/client/users/usersSlice.ts
@@ -1,11 +1,12 @@
 // This is temporary until we move all loot-core/client over to desktop-client.
-// eslint-disable-next-line no-restricted-imports
+/* eslint-disable no-restricted-imports */
 import { resetApp } from '@actual-app/web/src/app/appSlice';
+import { closeBudget, loadAllFiles } from '@actual-app/web/src/budgets/budgetsSlice';
+/* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { send } from '../../platform/client/fetch';
 import { type Handlers } from '../../types/handlers';
-import { closeBudget, loadAllFiles } from '../budgets/budgetsSlice';
 import { loadGlobalPrefs } from '../prefs/prefsSlice';
 import { createAppAsyncThunk } from '../redux';
 

--- a/upcoming-release-notes/4818.md
+++ b/upcoming-release-notes/4818.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/budgets code over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [ ] modals folder
- [ ] notifications folder
- [ ] prefs folder
- [ ] queries folder
- [ ] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Move folder from loot-core to desktop-client (vscode does the import updates)
2. Run yarn lint:fix
3. Suppress some @actual-app/web imports in loot-core (temporary until all loot-core/client is moved over to desktop-client)