### PR TITLE
Move loot-core/client/modals code over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/app/appSlice.ts
+++ b/packages/desktop-client/src/app/appSlice.ts
@@ -4,7 +4,6 @@ import {
   type PayloadAction,
 } from '@reduxjs/toolkit';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { createAppAsyncThunk } from 'loot-core/client/redux';
 import { send } from 'loot-core/platform/client/fetch';
@@ -13,6 +12,7 @@ import { type AccountEntity } from 'loot-core/types/models';
 import { type AtLeastOne } from 'loot-core/types/util';
 
 import { syncAccounts } from '../accounts/accountsSlice';
+import { pushModal } from '../modals/modalsSlice';
 
 const sliceName = 'app';
 

--- a/packages/desktop-client/src/budgets/budgetsSlice.ts
+++ b/packages/desktop-client/src/budgets/budgetsSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 
-import { closeModal, pushModal } from 'loot-core/client/modals/modalsSlice';
 import { loadGlobalPrefs, loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { createAppAsyncThunk } from 'loot-core/client/redux';
 import { signOut } from 'loot-core/client/users/usersSlice';
@@ -13,6 +12,7 @@ import { type File } from 'loot-core/types/file';
 import { type Handlers } from 'loot-core/types/handlers';
 
 import { resetApp, setAppState } from '../app/appSlice';
+import { closeModal, pushModal } from '../modals/modalsSlice';
 
 const sliceName = 'budgets';
 

--- a/packages/desktop-client/src/components/HelpMenu.tsx
+++ b/packages/desktop-client/src/components/HelpMenu.tsx
@@ -10,8 +10,7 @@ import { Popover } from '@actual-app/components/popover';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import { useToggle } from 'usehooks-ts';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
-
+import { pushModal } from '../modals/modalsSlice';
 import { useDispatch } from '../redux';
 
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';

--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -16,7 +16,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { initiallyLoadPayees } from 'loot-core/client/queries/queriesSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
@@ -26,6 +25,7 @@ import { mapField, friendlyOp } from 'loot-core/shared/rules';
 import { describeSchedule } from 'loot-core/shared/schedules';
 import { type RuleEntity, type NewRuleEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../modals/modalsSlice';
 import { useDispatch } from '../redux';
 
 import { InfiniteScrollWrapper } from './common/InfiniteScrollWrapper';

--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -2,10 +2,10 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import { closeModal } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { closeModal } from '../modals/modalsSlice';
 import { useDispatch } from '../redux';
 
 import { EditSyncAccount } from './banksync/EditSyncAccount';

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -21,11 +21,6 @@ import {
   SchedulesProvider,
   accountSchedulesQuery,
 } from 'loot-core/client/data-hooks/schedules';
-import {
-  openAccountCloseModal,
-  pushModal,
-  replaceModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import * as queries from 'loot-core/client/queries';
 import {
@@ -67,6 +62,11 @@ import {
 
 import { unlinkAccount } from '../../accounts/accountsSlice';
 import { syncAndDownload } from '../../app/appSlice';
+import {
+  openAccountCloseModal,
+  pushModal,
+  replaceModal,
+} from '../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../redux';
 import { type SavedFilter } from '../filters/SavedFilterMenuButton';
 import { TransactionList } from '../transactions/TransactionList';

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccess.tsx
@@ -17,7 +17,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
@@ -27,6 +26,7 @@ import {
   type UserAccessEntity,
 } from 'loot-core/types/models';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { InfiniteScrollWrapper } from '../../common/InfiniteScrollWrapper';
 import { Link } from '../../common/Link';

--- a/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
+++ b/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
@@ -16,13 +16,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { InfiniteScrollWrapper } from '../../common/InfiniteScrollWrapper';
 import { Link } from '../../common/Link';

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -10,7 +10,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
 import { useTransactions } from 'loot-core/client/data-hooks/transactions';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
   defaultMappings,
   type Mappings,
@@ -24,6 +23,7 @@ import {
 } from 'loot-core/types/models';
 
 import { unlinkAccount } from '../../accounts/accountsSlice';
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { CheckboxOption } from '../modals/ImportTransactionsModal/CheckboxOption';

--- a/packages/desktop-client/src/components/banksync/index.tsx
+++ b/packages/desktop-client/src/components/banksync/index.tsx
@@ -5,12 +5,12 @@ import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
   type BankSyncProviders,
   type AccountEntity,
 } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { MOBILE_NAV_HEIGHT } from '../mobile/MobileNavTabs';
 import { Page } from '../Page';

--- a/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
+++ b/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
@@ -4,9 +4,9 @@ import { Button } from '@actual-app/components/button';
 import { SvgChartPie } from '@actual-app/components/icons/v1';
 import { theme } from '@actual-app/components/theme';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { type Template } from 'loot-core/server/budget/types/templates';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import {
   applyBudgetAction,
@@ -23,6 +22,7 @@ import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { NamespaceContext } from '../spreadsheet/NamespaceContext';
 

--- a/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
@@ -36,7 +36,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { getUserData } from 'loot-core/client/users/usersSlice';
 import {
   isElectron,
@@ -58,6 +57,7 @@ import {
   loadAllFiles,
   loadBudget,
 } from '../../budgets/budgetsSlice';
+import { pushModal } from '../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../redux';
 import { useMultiuserEnabled } from '../ServerContext';
 

--- a/packages/desktop-client/src/components/manager/WelcomeScreen.tsx
+++ b/packages/desktop-client/src/components/manager/WelcomeScreen.tsx
@@ -8,9 +8,8 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
-
 import { createBudget } from '../../budgets/budgetsSlice';
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -21,11 +21,6 @@ import {
   useTransactions,
   useTransactionsSearch,
 } from 'loot-core/client/data-hooks/transactions';
-import {
-  collapseModals,
-  openAccountCloseModal,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import * as queries from 'loot-core/client/queries';
 import {
   markAccountRead,
@@ -41,6 +36,11 @@ import {
 } from 'loot-core/types/models';
 
 import { syncAndDownload } from '../../../app/appSlice';
+import {
+  collapseModals,
+  openAccountCloseModal,
+  pushModal,
+} from '../../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../../redux';
 import { MobilePageHeader, Page } from '../../Page';
 import { MobileBackButton } from '../MobileBackButton';

--- a/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/Accounts.tsx
@@ -27,12 +27,12 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { replaceModal } from 'loot-core/client/modals/modalsSlice';
 import * as queries from 'loot-core/client/queries';
 import { type AccountEntity } from 'loot-core/types/models';
 
 import { moveAccount } from '../../../accounts/accountsSlice';
 import { syncAndDownload } from '../../../app/appSlice';
+import { replaceModal } from '../../../modals/modalsSlice';
 import { useDispatch, useSelector } from '../../../redux';
 import { makeAmountFullStyle } from '../../budget/util';
 import { MobilePageHeader, Page } from '../../Page';

--- a/packages/desktop-client/src/components/mobile/budget/BudgetCell.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetCell.tsx
@@ -6,10 +6,10 @@ import { type CSSProperties } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { AutoTextSize } from 'auto-text-size';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { integerToCurrency } from 'loot-core/shared/util';
 import { type CategoryEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { makeAmountGrey } from '../../budget/util';
 import { PrivacyFilter } from '../../PrivacyFilter';

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -24,7 +24,6 @@ import { View } from '@actual-app/components/view';
 import { AutoTextSize } from 'auto-text-size';
 
 import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
   envelopeBudget,
   trackingBudget,
@@ -34,6 +33,7 @@ import * as monthUtils from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
 import { groupById } from 'loot-core/shared/util';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { MobilePageHeader, Page } from '../../Page';
 import { PrivacyFilter } from '../../PrivacyFilter';

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
@@ -9,7 +9,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { collapseModals, pushModal } from 'loot-core/client/modals/modalsSlice';
 import { envelopeBudget, trackingBudget } from 'loot-core/client/queries';
 import { type BudgetType } from 'loot-core/server/prefs';
 import * as monthUtils from 'loot-core/shared/months';
@@ -20,6 +19,7 @@ import { useCategories } from '../../../hooks/useCategories';
 import { useNavigate } from '../../../hooks/useNavigate';
 import { useSyncedPref } from '../../../hooks/useSyncedPref';
 import { useUndo } from '../../../hooks/useUndo';
+import { collapseModals, pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { useSheetValue } from '../../spreadsheet/useSheetValue';
 

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -5,7 +5,6 @@ import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { collapseModals, pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
   applyBudgetAction,
   createCategory,
@@ -20,6 +19,7 @@ import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 
 import { sync } from '../../../app/appSlice';
+import { collapseModals, pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { prewarmMonth } from '../../budget/util';
 import { NamespaceContext } from '../../spreadsheet/NamespaceContext';

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -30,7 +30,6 @@ import {
   isValid as isValidDate,
 } from 'date-fns';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import * as Platform from 'loot-core/client/platform';
 import { setLastTransaction } from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
@@ -56,6 +55,7 @@ import {
   groupById,
 } from 'loot-core/shared/util';
 
+import { pushModal } from '../../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../../redux';
 import { MobilePageHeader, Page } from '../../Page';
 import { AmountInput } from '../../util/AmountInput';

--- a/packages/desktop-client/src/components/modals/AccountAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/AccountAutocompleteModal.tsx
@@ -5,8 +5,7 @@ import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import {
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
@@ -20,9 +20,9 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   Modal,
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetPageMenuModal.tsx
@@ -8,8 +8,7 @@ import { Menu } from '@actual-app/components/menu';
 import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 
 import { useLocalPref } from '@desktop-client/hooks/useLocalPref';

--- a/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryAutocompleteModal.tsx
@@ -5,9 +5,9 @@ import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';
 import {
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -24,8 +24,7 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   Modal,
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -18,8 +18,7 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   Modal,
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
@@ -12,15 +12,12 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { closeAccount } from 'loot-core/client/queries/queriesSlice';
 import { integerToCurrency } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -8,8 +8,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
@@ -8,8 +8,7 @@ import { Paragraph } from '@actual-app/components/paragraph';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 
 type ConfirmTransactionDeleteModalProps = Extract<

--- a/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
@@ -9,8 +9,7 @@ import { InitialFocus } from '@actual-app/components/initial-focus';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 
 type ConfirmTransactionEditModalProps = Extract<

--- a/packages/desktop-client/src/components/modals/ConfirmUnlinkAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmUnlinkAccountModal.tsx
@@ -6,8 +6,7 @@ import { InitialFocus } from '@actual-app/components/initial-focus';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 
 type ConfirmUnlinkAccountModalProps = Extract<

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -5,11 +5,7 @@ import { Button } from '@actual-app/components/button';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import {
   addToBeBudgetedGroup,

--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -12,16 +12,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 
 import { useAuth } from '../../auth/AuthProvider';
 import { Permissions } from '../../auth/types';
 import { authorizeBank } from '../../gocardless';
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Warning } from '../alerts';
 import { Link } from '../common/Link';

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -14,13 +14,13 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { loadGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getCreateKeyError } from 'loot-core/shared/errors';
 
 import { sync } from '../../app/appSlice';
 import { loadAllFiles } from '../../budgets/budgetsSlice';
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
@@ -12,10 +12,10 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeModal } from 'loot-core/client/modals/modalsSlice';
 import { createAccount } from 'loot-core/client/queries/queriesSlice';
 import { toRelaxedNumber } from 'loot-core/shared/util';
 
+import { closeModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/EditAccess.tsx
+++ b/packages/desktop-client/src/components/modals/EditAccess.tsx
@@ -9,15 +9,12 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  popModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getUserAccessErrors } from 'loot-core/shared/errors';
 
+import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/components/modals/EditFieldModal.tsx
+++ b/packages/desktop-client/src/components/modals/EditFieldModal.tsx
@@ -13,10 +13,10 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { parseISO, format as formatDate, parse as parseDate } from 'date-fns';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { currentDay, dayFromDate } from 'loot-core/shared/months';
 import { amountToInteger } from 'loot-core/shared/util';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { SectionLabel } from '../forms';
 import { DateSelect } from '../select/DateSelect';

--- a/packages/desktop-client/src/components/modals/EditUser.tsx
+++ b/packages/desktop-client/src/components/modals/EditUser.tsx
@@ -10,16 +10,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  popModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { PossibleRoles } from 'loot-core/shared/user';
 import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
 
+import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Checkbox, FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
@@ -6,9 +6,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { envelopeBudget } from 'loot-core/client/queries';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   BalanceWithCarryover,
   CarryoverIndicator,

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
@@ -6,11 +6,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import * as Platform from 'loot-core/client/platform';
 import { envelopeBudget } from 'loot-core/client/queries';
 import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { BudgetMenu } from '../budget/envelope/BudgetMenu';
 import { useEnvelopeSheetValue } from '../budget/envelope/EnvelopeBudgetComponents';
 import {

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
@@ -13,9 +13,9 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { BudgetMonthMenu } from '../budget/envelope/budgetsummary/BudgetMonthMenu';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Notes } from '../Notes';

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
@@ -3,15 +3,15 @@ import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 
-import {
-  collapseModals,
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { envelopeBudget } from 'loot-core/client/queries';
 import { format, sheetForMonth, prevMonth } from 'loot-core/shared/months';
 import { groupById, integerToCurrency } from 'loot-core/shared/util';
 
+import {
+  collapseModals,
+  type Modal as ModalType,
+  pushModal,
+} from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { ToBudgetAmount } from '../budget/envelope/budgetsummary/ToBudgetAmount';
 import { TotalsList } from '../budget/envelope/budgetsummary/TotalsList';

--- a/packages/desktop-client/src/components/modals/EnvelopeToBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeToBudgetMenuModal.tsx
@@ -3,8 +3,7 @@ import React, { type CSSProperties } from 'react';
 import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { ToBudgetMenu } from '../budget/envelope/budgetsummary/ToBudgetMenu';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
@@ -13,10 +13,10 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getTestKeyError } from 'loot-core/shared/errors';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Link } from '../common/Link';
 import {
   Modal,

--- a/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessExternalMsgModal.tsx
@@ -8,16 +8,13 @@ import { Paragraph } from '@actual-app/components/paragraph';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { sendCatch } from 'loot-core/platform/client/fetch';
 import {
   type GoCardlessInstitution,
   type GoCardlessToken,
 } from 'loot-core/types/models';
 
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Error, Warning } from '../alerts';
 import { Autocomplete } from '../autocomplete/Autocomplete';

--- a/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
@@ -8,10 +8,10 @@ import { Input } from '@actual-app/components/input';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getSecretsError } from 'loot-core/shared/errors';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Error } from '../alerts';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -6,9 +6,9 @@ import { InitialFocus } from '@actual-app/components/initial-focus';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { envelopeBudget } from 'loot-core/client/queries';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { useEnvelopeSheetValue } from '../budget/envelope/EnvelopeBudgetComponents';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { FieldLabel } from '../mobile/MobileForms';

--- a/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
+++ b/packages/desktop-client/src/components/modals/LoadBackupModal.tsx
@@ -7,11 +7,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send, listen } from 'loot-core/platform/client/fetch';
 import { type Backup } from 'loot-core/server/budgetfiles/backups';
 
 import { loadBackup, makeBackup } from '../../budgets/budgetsSlice';
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Row, Cell } from '../table';

--- a/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
+++ b/packages/desktop-client/src/components/modals/ManageRulesModal.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { isNonProductionEnvironment } from 'loot-core/shared/environment';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { ManageRules } from '../ManageRules';
 

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -7,13 +7,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  replaceModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { type PayeeEntity } from 'loot-core/types/models';
 
+import {
+  type Modal as ModalType,
+  replaceModal,
+} from '../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../redux';
 import { Information } from '../alerts';
 import { Modal, ModalButtons } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/NewCategoryGroupModal.tsx
+++ b/packages/desktop-client/src/components/modals/NewCategoryGroupModal.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { type Modal } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal } from '../../modals/modalsSlice';
 import { ModalHeader, ModalTitle } from '../common/Modal';
 
 import { SingleInputModal } from './SingleInputModal';

--- a/packages/desktop-client/src/components/modals/NewCategoryModal.tsx
+++ b/packages/desktop-client/src/components/modals/NewCategoryModal.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
-import { type Modal } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal } from '../../modals/modalsSlice';
 import { ModalHeader, ModalTitle } from '../common/Modal';
 
 import { SingleInputModal } from './SingleInputModal';

--- a/packages/desktop-client/src/components/modals/NotesModal.tsx
+++ b/packages/desktop-client/src/components/modals/NotesModal.tsx
@@ -6,8 +6,7 @@ import { Button } from '@actual-app/components/button';
 import { SvgCheck } from '@actual-app/components/icons/v2';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Notes } from '../Notes';
 

--- a/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
@@ -7,16 +7,13 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  popModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as asyncStorage from 'loot-core/platform/server/asyncStorage';
 import { getOpenIdErrors } from 'loot-core/shared/errors';
 import { type OpenIdConfig } from 'loot-core/types/models';
 
 import { closeBudget } from '../../budgets/budgetsSlice';
+import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Error } from '../alerts';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/PasswordEnableModal.tsx
@@ -7,14 +7,11 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  popModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as asyncStorage from 'loot-core/platform/server/asyncStorage';
 
 import { closeBudget } from '../../budgets/budgetsSlice';
+import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Error as ErrorAlert } from '../alerts';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/PayeeAutocompleteModal.tsx
@@ -4,8 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { theme } from '@actual-app/components/theme';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { PayeeAutocomplete } from '../autocomplete/PayeeAutocomplete';
 import {
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/PluggyAiInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/PluggyAiInitialiseModal.tsx
@@ -8,10 +8,10 @@ import { Input } from '@actual-app/components/input';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getSecretsError } from 'loot-core/shared/errors';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Error } from '../alerts';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
@@ -12,7 +12,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { format } from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
 import {
@@ -20,6 +19,7 @@ import {
   extractScheduleConds,
 } from 'loot-core/shared/schedules';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   Modal,
   ModalCloseButton,

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
@@ -7,7 +7,6 @@ import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
-
 import {
   linkAccount,
   linkAccountPluggyAi,

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.jsx
@@ -7,7 +7,6 @@ import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
-import { closeModal } from 'loot-core/client/modals/modalsSlice';
 
 import {
   linkAccount,
@@ -15,6 +14,7 @@ import {
   linkAccountSimpleFin,
   unlinkAccount,
 } from '../../accounts/accountsSlice';
+import { closeModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Autocomplete } from '../autocomplete/Autocomplete';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
@@ -7,10 +7,10 @@ import { Input } from '@actual-app/components/input';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getSecretsError } from 'loot-core/shared/errors';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { Error } from '../alerts';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
@@ -6,9 +6,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { trackingBudget } from 'loot-core/client/queries';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import {
   BalanceWithCarryover,
   CarryoverIndicator,

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
@@ -6,11 +6,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import * as Platform from 'loot-core/client/platform';
 import { trackingBudget } from 'loot-core/client/queries';
 import { amountToInteger, integerToAmount } from 'loot-core/shared/util';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { BudgetMenu } from '../budget/tracking/BudgetMenu';
 import { useTrackingSheetValue } from '../budget/tracking/TrackingBudgetComponents';
 import {

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
@@ -13,9 +13,9 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { BudgetMonthMenu } from '../budget/tracking/budgetsummary/BudgetMonthMenu';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Notes } from '../Notes';

--- a/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetSummaryModal.tsx
@@ -4,10 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { Stack } from '@actual-app/components/stack';
 import { styles } from '@actual-app/components/styles';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { sheetForMonth } from 'loot-core/shared/months';
 import * as monthUtils from 'loot-core/shared/months';
 
+import { type Modal as ModalType } from '../../modals/modalsSlice';
 import { ExpenseTotal } from '../budget/tracking/budgetsummary/ExpenseTotal';
 import { IncomeTotal } from '../budget/tracking/budgetsummary/IncomeTotal';
 import { Saved } from '../budget/tracking/budgetsummary/Saved';

--- a/packages/desktop-client/src/components/modals/TransferModal.tsx
+++ b/packages/desktop-client/src/components/modals/TransferModal.tsx
@@ -6,11 +6,7 @@ import { InitialFocus } from '@actual-app/components/initial-focus';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import {
   addToBeBudgetedGroup,

--- a/packages/desktop-client/src/components/modals/TransferOwnership.tsx
+++ b/packages/desktop-client/src/components/modals/TransferOwnership.tsx
@@ -9,10 +9,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type Modal as ModalType,
-  popModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getUserAccessErrors } from 'loot-core/shared/errors';
@@ -21,6 +17,7 @@ import { type RemoteFile, type SyncedLocalFile } from 'loot-core/types/file';
 import { type Handlers } from 'loot-core/types/handlers';
 
 import { closeAndLoadBudget } from '../../budgets/budgetsSlice';
+import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { useDispatch, useSelector } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DeleteFileModal.tsx
@@ -6,9 +6,8 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
-
 import { deleteBudget } from '../../../budgets/budgetsSlice';
+import { type Modal as ModalType } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/DuplicateFileModal.tsx
@@ -10,11 +10,11 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type Modal as ModalType } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 
 import { duplicateBudget } from '../../../budgets/budgetsSlice';
+import { type Modal as ModalType } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import {
   Modal,

--- a/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
@@ -8,7 +8,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-
 import { loadAllFiles } from '../../../budgets/budgetsSlice';
 import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';

--- a/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/FilesSettingsModal.tsx
@@ -8,9 +8,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 
 import { loadAllFiles } from '../../../budgets/budgetsSlice';
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/modals/manager/ImportModal.tsx
+++ b/packages/desktop-client/src/components/modals/manager/ImportModal.tsx
@@ -8,8 +8,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
-
+import { pushModal } from '../../../modals/modalsSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 

--- a/packages/desktop-client/src/components/payees/ManagePayees.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayees.tsx
@@ -14,11 +14,11 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import memoizeOne from 'memoize-one';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { type Diff, groupById } from 'loot-core/shared/util';
 import { type PayeeEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Search } from '../common/Search';
 import { TableHeader, Cell, SelectCell } from '../table';

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import {
   getPayees,
   initiallyLoadPayees,
@@ -11,6 +10,7 @@ import { type UndoState } from 'loot-core/server/undo';
 import { applyChanges, type Diff } from 'loot-core/shared/util';
 import { type NewRuleEntity, type PayeeEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 
 import { ManagePayees } from './ManagePayees';

--- a/packages/desktop-client/src/components/schedules/PostsOfflineNotification.tsx
+++ b/packages/desktop-client/src/components/schedules/PostsOfflineNotification.tsx
@@ -8,10 +8,10 @@ import { Stack } from '@actual-app/components/stack';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 
-import { popModal } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { type PayeeEntity } from 'loot-core/types/models';
 
+import { popModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { DisplayId } from '../util/DisplayId';

--- a/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
@@ -10,10 +10,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { t } from 'i18next';
 
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { getPayeesById } from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery, liveQuery } from 'loot-core/client/query-helpers';
 import { send, sendCatch } from 'loot-core/platform/client/fetch';
@@ -27,6 +23,7 @@ import {
   type RecurConfig,
 } from 'loot-core/types/models';
 
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { PayeeAutocomplete } from '../autocomplete/PayeeAutocomplete';

--- a/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
@@ -9,13 +9,10 @@ import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import {
-  type Modal as ModalType,
-  pushModal,
-} from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 
+import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Search } from '../common/Search';

--- a/packages/desktop-client/src/components/schedules/index.tsx
+++ b/packages/desktop-client/src/components/schedules/index.tsx
@@ -6,11 +6,11 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 import { type ScheduleEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Search } from '../common/Search';
 import { Page } from '../Page';

--- a/packages/desktop-client/src/components/settings/AuthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/AuthSettings.tsx
@@ -6,8 +6,7 @@ import { Label } from '@actual-app/components/label';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
-
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { useMultiuserEnabled, useLoginMethod } from '../ServerContext';
 

--- a/packages/desktop-client/src/components/settings/Encryption.tsx
+++ b/packages/desktop-client/src/components/settings/Encryption.tsx
@@ -5,8 +5,7 @@ import { Button } from '@actual-app/components/button';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
-
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { useServerURL } from '../ServerContext';

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -13,7 +13,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
 
-import { openAccountCloseModal } from 'loot-core/client/modals/modalsSlice';
 import * as Platform from 'loot-core/client/platform';
 import {
   reopenAccount,
@@ -21,6 +20,7 @@ import {
 } from 'loot-core/client/queries/queriesSlice';
 import { type AccountEntity } from 'loot-core/types/models';
 
+import { openAccountCloseModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { Notes } from '../Notes';

--- a/packages/desktop-client/src/components/sidebar/Sidebar.tsx
+++ b/packages/desktop-client/src/components/sidebar/Sidebar.tsx
@@ -9,9 +9,9 @@ import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
 
-import { replaceModal } from 'loot-core/client/modals/modalsSlice';
 import * as Platform from 'loot-core/client/platform';
 
+import { replaceModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 
 import { Accounts } from './Accounts';

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next';
 import { Menu } from '@actual-app/components/menu';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { validForTransfer } from 'loot-core/client/transfer';
 import { q } from 'loot-core/shared/query';
 import {
@@ -15,6 +14,7 @@ import {
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { type TransactionEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { SelectedItemsButton } from '../table';
 

--- a/packages/desktop-client/src/components/transactions/TransactionList.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.jsx
@@ -2,7 +2,6 @@ import React, { useRef, useCallback, useLayoutEffect } from 'react';
 
 import { theme } from '@actual-app/components/theme';
 
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import {
   splitTransaction,
@@ -13,6 +12,7 @@ import {
 } from 'loot-core/shared/transactions';
 import { getChangedValues, applyChanges } from 'loot-core/shared/util';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 
 import { TransactionTable } from './TransactionsTable';

--- a/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { Menu } from '@actual-app/components/menu';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { q } from 'loot-core/shared/query';
 import {
   scheduleIsRecurring,
@@ -13,6 +12,7 @@ import {
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { type TransactionEntity } from 'loot-core/types/models';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 
 type BalanceMenuProps = Omit<

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -42,7 +42,6 @@ import {
 } from 'date-fns';
 
 import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { addNotification } from 'loot-core/client/notifications/notificationsSlice';
 import {
   getAccountsById,
@@ -69,6 +68,7 @@ import {
   amountToCurrency,
 } from 'loot-core/shared/util';
 
+import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,10 +1,5 @@
 // @ts-strict-ignore
 import {
-  closeModal,
-  pushModal,
-  replaceModal,
-} from 'loot-core/client/modals/modalsSlice';
-import {
   addGenericErrorNotification,
   addNotification,
 } from 'loot-core/client/notifications/notificationsSlice';
@@ -21,6 +16,7 @@ import * as undo from 'loot-core/platform/client/undo';
 
 import { setAppState } from './app/appSlice';
 import { closeBudgetUI } from './budgets/budgetsSlice';
+import { closeModal, pushModal, replaceModal } from './modals/modalsSlice';
 
 export function handleGlobalEvents(store: AppStore) {
   const unlistenServerError = listen('server-error', () => {

--- a/packages/desktop-client/src/gocardless.ts
+++ b/packages/desktop-client/src/gocardless.ts
@@ -1,7 +1,8 @@
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { type AppDispatch } from 'loot-core/client/store';
 import { send } from 'loot-core/platform/client/fetch';
 import { type GoCardlessToken } from 'loot-core/types/models';
+
+import { pushModal } from './modals/modalsSlice';
 
 function _authorize(
   dispatch: AppDispatch,

--- a/packages/desktop-client/src/hooks/useModalState.ts
+++ b/packages/desktop-client/src/hooks/useModalState.ts
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
-import { type Modal, popModal } from 'loot-core/client/modals/modalsSlice';
-
+import { type Modal, popModal } from '../modals/modalsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 type ModalState = {

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -1,4 +1,3 @@
-import { pushModal } from 'loot-core/client/modals/modalsSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { validForTransfer } from 'loot-core/client/transfer';
 import { send } from 'loot-core/platform/client/fetch';
@@ -19,6 +18,7 @@ import {
   type TransactionEntity,
 } from 'loot-core/types/models';
 
+import { pushModal } from '../modals/modalsSlice';
 import { useDispatch } from '../redux';
 
 type BatchEditProps = {

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as modalsSlice from 'loot-core/client/modals/modalsSlice';
 import * as notificationsSlice from 'loot-core/client/notifications/notificationsSlice';
 import * as prefsSlice from 'loot-core/client/prefs/prefsSlice';
 import * as queriesSlice from 'loot-core/client/queries/queriesSlice';
@@ -28,6 +27,7 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
+import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -27,12 +27,12 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';
 import { App } from './components/App';
 import { ServerProvider } from './components/ServerContext';
+import * as modalsSlice from './modals/modalsSlice';
 
 const boundActions = bindActionCreators(
   {

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -1,9 +1,9 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { createAppAsyncThunk } from '../../../loot-core/src/client/redux';
-import { signOut } from '../../../loot-core/src/client/users/usersSlice';
-import { send } from '../../../loot-core/src/platform/client/fetch';
-import { type File } from '../../../loot-core/src/types/file';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { signOut } from 'loot-core/client/users/usersSlice';
+import { send } from 'loot-core/platform/client/fetch';
+import { type File } from 'loot-core/types/file';
 import {
   type AccountEntity,
   type AccountSyncSource,
@@ -18,7 +18,7 @@ import {
   type UserAccessEntity,
   type NewUserEntity,
   type NoteEntity,
-} from '../../../loot-core/src/types/models';
+} from 'loot-core/types/models';
 import { resetApp, setAppState } from '../app/appSlice';
 
 const sliceName = 'modals';

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -1,5 +1,3 @@
-// This is temporary until we move all loot-core/client over to desktop-client.
- 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { createAppAsyncThunk } from '../../../loot-core/src/client/redux';
@@ -21,8 +19,7 @@ import {
   type NewUserEntity,
   type NoteEntity,
 } from '../../../loot-core/src/types/models';
-
-import { resetApp, setAppState } from '@actual-app/web/src/app/appSlice';
+import { resetApp, setAppState } from '../app/appSlice';
 
 const sliceName = 'modals';
 

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -1,10 +1,11 @@
 // This is temporary until we move all loot-core/client over to desktop-client.
-// eslint-disable-next-line no-restricted-imports
-import { resetApp, setAppState } from '@actual-app/web/src/app/appSlice';
+ 
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { send } from '../../platform/client/fetch';
-import { type File } from '../../types/file';
+import { createAppAsyncThunk } from '../../../loot-core/src/client/redux';
+import { signOut } from '../../../loot-core/src/client/users/usersSlice';
+import { send } from '../../../loot-core/src/platform/client/fetch';
+import { type File } from '../../../loot-core/src/types/file';
 import {
   type AccountEntity,
   type AccountSyncSource,
@@ -19,9 +20,9 @@ import {
   type UserAccessEntity,
   type NewUserEntity,
   type NoteEntity,
-} from '../../types/models';
-import { createAppAsyncThunk } from '../redux';
-import { signOut } from '../users/usersSlice';
+} from '../../../loot-core/src/types/models';
+
+import { resetApp, setAppState } from '@actual-app/web/src/app/appSlice';
 
 const sliceName = 'modals';
 

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -19,6 +19,7 @@ import {
   type NewUserEntity,
   type NoteEntity,
 } from 'loot-core/types/models';
+
 import { resetApp, setAppState } from '../app/appSlice';
 
 const sliceName = 'modals';

--- a/packages/loot-core/src/client/prefs/prefsSlice.ts
+++ b/packages/loot-core/src/client/prefs/prefsSlice.ts
@@ -2,6 +2,7 @@
 /* eslint-disable no-restricted-imports */
 import { resetApp } from '@actual-app/web/src/app/appSlice';
 import { setI18NextLanguage } from '@actual-app/web/src/i18n';
+import { closeModal } from '@actual-app/web/src/modals/modalsSlice';
 /* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
@@ -12,7 +13,6 @@ import {
   type MetadataPrefs,
   type SyncedPrefs,
 } from '../../types/prefs';
-import { closeModal } from '../modals/modalsSlice';
 import { createAppAsyncThunk } from '../redux';
 
 const sliceName = 'prefs';

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -6,12 +6,12 @@ import {
   closeAndDownloadBudget,
   uploadBudget,
 } from '@actual-app/web/src/budgets/budgetsSlice';
+import { pushModal } from '@actual-app/web/src/modals/modalsSlice';
 /* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 
 import { listen, send } from '../platform/client/fetch';
 
-import { pushModal } from './modals/modalsSlice';
 import {
   addNotification,
   type Notification,

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -12,6 +12,10 @@ import {
   name as budgetsSliceName,
   reducer as budgetsSliceReducer,
 } from '@actual-app/web/src/budgets/budgetsSlice';
+import {
+  name as modalsSliceName,
+  reducer as modalsSliceReducer,
+} from '@actual-app/web/src/modals/modalsSlice';
 /* eslint-enable no-restricted-imports */
 import {
   combineReducers,
@@ -20,10 +24,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as modalsSliceName,
-  reducer as modalsSliceReducer,
-} from '../modals/modalsSlice';
 import {
   name as notificationsSliceName,
   reducer as notificationsSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -13,13 +13,13 @@ import {
   name as budgetsSliceName,
   reducer as budgetsSliceReducer,
 } from '@actual-app/web/src/budgets/budgetsSlice';
-/* eslint-enable */
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-
 import {
   name as modalsSliceName,
   reducer as modalsSliceReducer,
-} from '../modals/modalsSlice';
+} from '@actual-app/web/src/modals/modalsSlice';
+/* eslint-enable */
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
 import {
   name as notificationsSliceName,
   reducer as notificationsSliceReducer,

--- a/packages/loot-core/src/platform/client/undo/index.ts
+++ b/packages/loot-core/src/platform/client/undo/index.ts
@@ -1,6 +1,8 @@
+// This is temporary until we move all loot-core/client over to desktop-client.
+// eslint-disable-next-line no-restricted-imports
+import { Modal } from '@actual-app/web/src/modals/modalsSlice';
 import { v4 as uuidv4 } from 'uuid';
 
-import { Modal } from '../../../client/modals/modalsSlice';
 import { UndoState as ServerUndoState } from '../../../server/undo';
 
 type UndoState = {

--- a/upcoming-release-notes/4819.md
+++ b/upcoming-release-notes/4819.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/modals code over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [x] modals folder
- [ ] notifications folder
- [ ] prefs folder
- [ ] queries folder
- [ ] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Move folder from loot-core to desktop-client (vscode does the import updates)
2. Run yarn lint:fix
3. Suppress some @actual-app/web imports in loot-core (temporary until all loot-core/client is moved over to desktop-client)