### PR TITLE
Move loot-core/client/prefs code over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/app/appSlice.ts
+++ b/packages/desktop-client/src/app/appSlice.ts
@@ -4,7 +4,6 @@ import {
   type PayloadAction,
 } from '@reduxjs/toolkit';
 
-import { loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { createAppAsyncThunk } from 'loot-core/client/redux';
 import { send } from 'loot-core/platform/client/fetch';
 import { getUploadError } from 'loot-core/shared/errors';
@@ -13,6 +12,7 @@ import { type AtLeastOne } from 'loot-core/types/util';
 
 import { syncAccounts } from '../accounts/accountsSlice';
 import { pushModal } from '../modals/modalsSlice';
+import { loadPrefs } from '../prefs/prefsSlice';
 
 const sliceName = 'app';
 

--- a/packages/desktop-client/src/budgets/budgetsSlice.ts
+++ b/packages/desktop-client/src/budgets/budgetsSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 
-import { loadGlobalPrefs, loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { createAppAsyncThunk } from 'loot-core/client/redux';
 import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
@@ -13,6 +12,7 @@ import { type Handlers } from 'loot-core/types/handlers';
 
 import { resetApp, setAppState } from '../app/appSlice';
 import { closeModal, pushModal } from '../modals/modalsSlice';
+import { loadGlobalPrefs, loadPrefs } from '../prefs/prefsSlice';
 
 const sliceName = 'budgets';
 

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -15,7 +15,6 @@ import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
 import * as Platform from 'loot-core/client/platform';
-import { loadGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { SpreadsheetProvider } from 'loot-core/client/SpreadsheetProvider';
 import { signOut } from 'loot-core/client/users/usersSlice';
 import { init as initConnection, send } from 'loot-core/platform/client/fetch';
@@ -26,6 +25,7 @@ import { handleGlobalEvents } from '../global-events';
 import { setI18NextLanguage } from '../i18n';
 import { addNotification } from '../notifications/notificationsSlice';
 import { installPolyfills } from '../polyfills';
+import { loadGlobalPrefs } from '../prefs/prefsSlice';
 import { useDispatch, useSelector, useStore } from '../redux';
 import { hasHiddenScrollbars, ThemeStyle, useTheme } from '../style';
 import { ExposeNavigate } from '../util/router-tools';

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -14,13 +14,13 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { loadGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getCreateKeyError } from 'loot-core/shared/errors';
 
 import { sync } from '../../app/appSlice';
 import { loadAllFiles } from '../../budgets/budgetsSlice';
 import { type Modal as ModalType } from '../../modals/modalsSlice';
+import { loadGlobalPrefs } from '../../prefs/prefsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -10,11 +10,11 @@ import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { listen } from 'loot-core/platform/client/fetch';
 import { isElectron } from 'loot-core/shared/environment';
 
 import { closeBudget } from '../../budgets/budgetsSlice';
+import { loadPrefs } from '../../prefs/prefsSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { FormField, FormLabel } from '../forms';

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { loadPrefs } from 'loot-core/client/prefs/prefsSlice';
 import {
   getAccounts,
   getCategories,
@@ -17,6 +16,7 @@ import {
   addGenericErrorNotification,
   addNotification,
 } from './notifications/notificationsSlice';
+import { loadPrefs } from './prefs/prefsSlice';
 
 export function handleGlobalEvents(store: AppStore) {
   const unlistenServerError = listen('server-error', () => {

--- a/packages/desktop-client/src/hooks/useGlobalPref.ts
+++ b/packages/desktop-client/src/hooks/useGlobalPref.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 
-import { saveGlobalPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { type GlobalPrefs } from 'loot-core/types/prefs';
 
+import { saveGlobalPrefs } from '../prefs/prefsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 type SetGlobalPrefAction<K extends keyof GlobalPrefs> = (

--- a/packages/desktop-client/src/hooks/useMetadataPref.ts
+++ b/packages/desktop-client/src/hooks/useMetadataPref.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 
-import { savePrefs } from 'loot-core/client/prefs/prefsSlice';
 import { type MetadataPrefs } from 'loot-core/types/prefs';
 
+import { savePrefs } from '../prefs/prefsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 type SetMetadataPrefAction<K extends keyof MetadataPrefs> = (

--- a/packages/desktop-client/src/hooks/useSyncedPref.ts
+++ b/packages/desktop-client/src/hooks/useSyncedPref.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 
-import { saveSyncedPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 
+import { saveSyncedPrefs } from '../prefs/prefsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 type SetSyncedPrefAction<K extends keyof SyncedPrefs> = (

--- a/packages/desktop-client/src/hooks/useSyncedPrefs.ts
+++ b/packages/desktop-client/src/hooks/useSyncedPrefs.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 
-import { saveSyncedPrefs } from 'loot-core/client/prefs/prefsSlice';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 
+import { saveSyncedPrefs } from '../prefs/prefsSlice';
 import { useSelector, useDispatch } from '../redux';
 
 type SetSyncedPrefsAction = (value: Partial<SyncedPrefs>) => void;

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as prefsSlice from 'loot-core/client/prefs/prefsSlice';
 import * as queriesSlice from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { store } from 'loot-core/client/store';
@@ -33,6 +32,7 @@ import { App } from './components/App';
 import { ServerProvider } from './components/ServerContext';
 import * as modalsSlice from './modals/modalsSlice';
 import * as notificationsSlice from './notifications/notificationsSlice';
+import * as prefsSlice from './prefs/prefsSlice';
 
 const boundActions = bindActionCreators(
   {

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -26,7 +26,6 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -26,6 +26,7 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
+import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/prefs/prefsSlice.ts
+++ b/packages/desktop-client/src/prefs/prefsSlice.ts
@@ -1,19 +1,17 @@
-// This is temporary until we move all loot-core/client over to desktop-client.
-/* eslint-disable no-restricted-imports */
-import { resetApp } from '@actual-app/web/src/app/appSlice';
-import { setI18NextLanguage } from '@actual-app/web/src/i18n';
-import { closeModal } from '@actual-app/web/src/modals/modalsSlice';
-/* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { send } from '../../platform/client/fetch';
-import { parseNumberFormat, setNumberFormat } from '../../shared/util';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { send } from 'loot-core/platform/client/fetch';
+import { parseNumberFormat, setNumberFormat } from 'loot-core/shared/util';
 import {
   type GlobalPrefs,
   type MetadataPrefs,
   type SyncedPrefs,
-} from '../../types/prefs';
-import { createAppAsyncThunk } from '../redux';
+} from 'loot-core/types/prefs';
+
+import { resetApp } from '../app/appSlice';
+import { setI18NextLanguage } from '../i18n';
+import { closeModal } from '../modals/modalsSlice';
 
 const sliceName = 'prefs';
 

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -11,12 +11,12 @@ import {
   addNotification,
   type Notification,
 } from '@actual-app/web/src/notifications/notificationsSlice';
+import { loadPrefs } from '@actual-app/web/src/prefs/prefsSlice';
 /* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 
 import { listen, send } from '../platform/client/fetch';
 
-import { loadPrefs } from './prefs/prefsSlice';
 import { getAccounts, getCategories, getPayees } from './queries/queriesSlice';
 import { type AppStore } from './store';
 import { signOut } from './users/usersSlice';

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -21,6 +21,10 @@ import {
   reducer as notificationsSliceReducer,
   addNotification,
 } from '@actual-app/web/src/notifications/notificationsSlice';
+import {
+  name as prefsSliceName,
+  reducer as prefsSliceReducer,
+} from '@actual-app/web/src/prefs/prefsSlice';
 /* eslint-enable no-restricted-imports */
 import {
   combineReducers,
@@ -29,10 +33,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as prefsSliceName,
-  reducer as prefsSliceReducer,
-} from '../prefs/prefsSlice';
 import {
   name as queriesSliceName,
   reducer as queriesSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -21,13 +21,13 @@ import {
   name as notificationsSliceName,
   reducer as notificationsSliceReducer,
 } from '@actual-app/web/src/notifications/notificationsSlice';
-/* eslint-enable */
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-
 import {
   name as prefsSliceName,
   reducer as prefsSliceReducer,
-} from '../prefs/prefsSlice';
+} from '@actual-app/web/src/prefs/prefsSlice';
+/* eslint-enable */
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
 import {
   name as queriesSliceName,
   reducer as queriesSliceReducer,

--- a/packages/loot-core/src/client/users/usersSlice.ts
+++ b/packages/loot-core/src/client/users/usersSlice.ts
@@ -5,12 +5,12 @@ import {
   closeBudget,
   loadAllFiles,
 } from '@actual-app/web/src/budgets/budgetsSlice';
+import { loadGlobalPrefs } from '@actual-app/web/src/prefs/prefsSlice';
 /* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { send } from '../../platform/client/fetch';
 import { type Handlers } from '../../types/handlers';
-import { loadGlobalPrefs } from '../prefs/prefsSlice';
 import { createAppAsyncThunk } from '../redux';
 
 const sliceName = 'user';

--- a/upcoming-release-notes/4821.md
+++ b/upcoming-release-notes/4821.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/prefs code over to desktop-client package

--- a/upcoming-release-notes/4821.md
+++ b/upcoming-release-notes/4821.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [joel-jeremy]
 ---
 
-Move loot-core/client/prefs code over to desktop-client package
+Move loot-core/client/prefs code over to desktop-client package.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [x] modals folder
- [x] notifications folder
- [x] prefs folder
- [ ] queries folder
- [ ] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Move folder from loot-core to desktop-client (vscode does the import updates)
2. Run yarn lint:fix
3. Suppress some @actual-app/web imports in loot-core (temporary until all loot-core/client is moved over to desktop-client)