### PR TITLE
Move loot-core/client/queries code over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/accounts/accountsSlice.ts
+++ b/packages/desktop-client/src/accounts/accountsSlice.ts
@@ -1,10 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import {
-  getAccounts,
-  getPayees,
-  setNewTransactions,
-} from 'loot-core/client/queries/queriesSlice';
 import { createAppAsyncThunk } from 'loot-core/client/redux';
 import { type AppDispatch } from 'loot-core/client/store';
 import { send } from 'loot-core/platform/client/fetch';
@@ -19,6 +14,11 @@ import {
 
 import { resetApp } from '../app/appSlice';
 import { addNotification } from '../notifications/notificationsSlice';
+import {
+  getAccounts,
+  getPayees,
+  setNewTransactions,
+} from '../queries/queriesSlice';
 
 const sliceName = 'account';
 

--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -16,7 +16,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { initiallyLoadPayees } from 'loot-core/client/queries/queriesSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
@@ -26,6 +25,7 @@ import { describeSchedule } from 'loot-core/shared/schedules';
 import { type RuleEntity, type NewRuleEntity } from 'loot-core/types/models';
 
 import { pushModal } from '../modals/modalsSlice';
+import { initiallyLoadPayees } from '../queries/queriesSlice';
 import { useDispatch } from '../redux';
 
 import { InfiniteScrollWrapper } from './common/InfiniteScrollWrapper';

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -23,14 +23,6 @@ import {
 } from 'loot-core/client/data-hooks/schedules';
 import * as queries from 'loot-core/client/queries';
 import {
-  createPayee,
-  initiallyLoadPayees,
-  markAccountRead,
-  reopenAccount,
-  updateAccount,
-  updateNewTransactions,
-} from 'loot-core/client/queries/queriesSlice';
-import {
   aqlQuery,
   pagedQuery,
   type PagedQuery,
@@ -67,6 +59,14 @@ import {
   replaceModal,
 } from '../../modals/modalsSlice';
 import { addNotification } from '../../notifications/notificationsSlice';
+import {
+  createPayee,
+  initiallyLoadPayees,
+  markAccountRead,
+  reopenAccount,
+  updateAccount,
+  updateNewTransactions,
+} from '../../queries/queriesSlice';
 import { useSelector, useDispatch } from '../../redux';
 import { type SavedFilter } from '../filters/SavedFilterMenuButton';
 import { TransactionList } from '../transactions/TransactionList';

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -22,13 +22,10 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
 
-import {
-  createPayee,
-  getActivePayees,
-} from 'loot-core/client/queries/queriesSlice';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { type AccountEntity, type PayeeEntity } from 'loot-core/types/models';
 
+import { createPayee, getActivePayees } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 
 import {

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -5,6 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+
+import { pushModal } from '../../modals/modalsSlice';
+import { addNotification } from '../../notifications/notificationsSlice';
 import {
   applyBudgetAction,
   createCategory,
@@ -16,13 +22,7 @@ import {
   moveCategoryGroup,
   updateCategory,
   updateGroup,
-} from 'loot-core/client/queries/queriesSlice';
-import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
-import { send } from 'loot-core/platform/client/fetch';
-import * as monthUtils from 'loot-core/shared/months';
-
-import { pushModal } from '../../modals/modalsSlice';
-import { addNotification } from '../../notifications/notificationsSlice';
+} from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { NamespaceContext } from '../spreadsheet/NamespaceContext';
 

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -22,11 +22,6 @@ import {
   useTransactionsSearch,
 } from 'loot-core/client/data-hooks/transactions';
 import * as queries from 'loot-core/client/queries';
-import {
-  markAccountRead,
-  reopenAccount,
-  updateAccount,
-} from 'loot-core/client/queries/queriesSlice';
 import { listen, send } from 'loot-core/platform/client/fetch';
 import { type Query } from 'loot-core/shared/query';
 import { isPreviewId } from 'loot-core/shared/transactions';
@@ -41,6 +36,11 @@ import {
   openAccountCloseModal,
   pushModal,
 } from '../../../modals/modalsSlice';
+import {
+  markAccountRead,
+  reopenAccount,
+  updateAccount,
+} from '../../../queries/queriesSlice';
 import { useSelector, useDispatch } from '../../../redux';
 import { MobilePageHeader, Page } from '../../Page';
 import { MobileBackButton } from '../MobileBackButton';

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryList.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryList.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@actual-app/components/theme';
 import { css } from '@emotion/css';
 
-import { moveCategory } from 'loot-core/client/queries/queriesSlice';
 import {
   type CategoryGroupEntity,
   type CategoryEntity,
 } from 'loot-core/types/models';
 
+import { moveCategory } from '../../../queries/queriesSlice';
 import { useDispatch } from '../../../redux';
 
 import { ExpenseCategoryListItem } from './ExpenseCategoryListItem';

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseGroupList.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseGroupList.tsx
@@ -5,12 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@actual-app/components/theme';
 import { css } from '@emotion/css';
 
-import { moveCategoryGroup } from 'loot-core/client/queries/queriesSlice';
 import {
   type CategoryEntity,
   type CategoryGroupEntity,
 } from 'loot-core/types/models';
 
+import { moveCategoryGroup } from '../../../queries/queriesSlice';
 import { useDispatch } from '../../../redux';
 
 import {

--- a/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/IncomeCategoryList.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@actual-app/components/theme';
 import { css } from '@emotion/css';
 
-import { moveCategory } from 'loot-core/client/queries/queriesSlice';
 import { type CategoryEntity } from 'loot-core/types/models';
 
+import { moveCategory } from '../../../queries/queriesSlice';
 import { useDispatch } from '../../../redux';
 
 import { IncomeCategoryListItem } from './IncomeCategoryListItem';

--- a/packages/desktop-client/src/components/mobile/budget/index.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/index.tsx
@@ -5,6 +5,12 @@ import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
+import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
+
+import { sync } from '../../../app/appSlice';
+import { collapseModals, pushModal } from '../../../modals/modalsSlice';
 import {
   applyBudgetAction,
   createCategory,
@@ -13,13 +19,7 @@ import {
   deleteGroup,
   updateCategory,
   updateGroup,
-} from 'loot-core/client/queries/queriesSlice';
-import { useSpreadsheet } from 'loot-core/client/SpreadsheetProvider';
-import { send } from 'loot-core/platform/client/fetch';
-import * as monthUtils from 'loot-core/shared/months';
-
-import { sync } from '../../../app/appSlice';
-import { collapseModals, pushModal } from '../../../modals/modalsSlice';
+} from '../../../queries/queriesSlice';
 import { useDispatch } from '../../../redux';
 import { prewarmMonth } from '../../budget/util';
 import { NamespaceContext } from '../../spreadsheet/NamespaceContext';

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -31,7 +31,6 @@ import {
 } from 'date-fns';
 
 import * as Platform from 'loot-core/client/platform';
-import { setLastTransaction } from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
@@ -56,6 +55,7 @@ import {
 } from 'loot-core/shared/util';
 
 import { pushModal } from '../../../modals/modalsSlice';
+import { setLastTransaction } from '../../../queries/queriesSlice';
 import { useSelector, useDispatch } from '../../../redux';
 import { MobilePageHeader, Page } from '../../Page';
 import { AmountInput } from '../../util/AmountInput';

--- a/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CloseAccountModal.tsx
@@ -12,12 +12,12 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { closeAccount } from 'loot-core/client/queries/queriesSlice';
 import { integerToCurrency } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 
 import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
+import { closeAccount } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
@@ -12,10 +12,10 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { createAccount } from 'loot-core/client/queries/queriesSlice';
 import { toRelaxedNumber } from 'loot-core/shared/util';
 
 import { closeModal } from '../../modals/modalsSlice';
+import { createAccount } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import {

--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -24,7 +24,6 @@ import { css } from '@emotion/css';
 import { v4 as uuid } from 'uuid';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { initiallyLoadPayees } from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { enableUndo, disableUndo } from 'loot-core/client/undo';
 import { send } from 'loot-core/platform/client/fetch';
@@ -48,6 +47,7 @@ import {
   amountToInteger,
 } from 'loot-core/shared/util';
 
+import { initiallyLoadPayees } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { StatusBadge } from '../schedules/StatusBadge';

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -10,14 +10,14 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import deepEqual from 'deep-equal';
 
+import { send } from 'loot-core/platform/client/fetch';
+import { amountToInteger } from 'loot-core/shared/util';
+
 import {
   getPayees,
   importPreviewTransactions,
   importTransactions,
-} from 'loot-core/client/queries/queriesSlice';
-import { send } from 'loot-core/platform/client/fetch';
-import { amountToInteger } from 'loot-core/shared/util';
-
+} from '../../../queries/queriesSlice';
 import { useDispatch } from '../../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../../common/Modal';
 import { SectionLabel } from '../../forms';

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -1,9 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
-import {
-  getPayees,
-  initiallyLoadPayees,
-} from 'loot-core/client/queries/queriesSlice';
 import { send, listen } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { type UndoState } from 'loot-core/server/undo';
@@ -11,6 +7,7 @@ import { applyChanges, type Diff } from 'loot-core/shared/util';
 import { type NewRuleEntity, type PayeeEntity } from 'loot-core/types/models';
 
 import { pushModal } from '../../modals/modalsSlice';
+import { getPayees, initiallyLoadPayees } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 
 import { ManagePayees } from './ManagePayees';

--- a/packages/desktop-client/src/components/rules/ScheduleValue.tsx
+++ b/packages/desktop-client/src/components/rules/ScheduleValue.tsx
@@ -4,10 +4,11 @@ import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { View } from '@actual-app/components/view';
 
 import { useSchedules } from 'loot-core/client/data-hooks/schedules';
-import { getPayeesById } from 'loot-core/client/queries/queriesSlice';
 import { q } from 'loot-core/shared/query';
 import { describeSchedule } from 'loot-core/shared/schedules';
 import { type ScheduleEntity } from 'loot-core/types/models';
+
+import { getPayeesById } from '../../queries/queriesSlice';
 
 import { Value } from './Value';
 

--- a/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleDetails.tsx
@@ -10,7 +10,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { t } from 'i18next';
 
-import { getPayeesById } from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery, liveQuery } from 'loot-core/client/query-helpers';
 import { send, sendCatch } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
@@ -24,6 +23,7 @@ import {
 } from 'loot-core/types/models';
 
 import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
+import { getPayeesById } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { PayeeAutocomplete } from '../autocomplete/PayeeAutocomplete';

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -14,13 +14,10 @@ import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
 
 import * as Platform from 'loot-core/client/platform';
-import {
-  reopenAccount,
-  updateAccount,
-} from 'loot-core/client/queries/queriesSlice';
 import { type AccountEntity } from 'loot-core/types/models';
 
 import { openAccountCloseModal } from '../../modals/modalsSlice';
+import { reopenAccount, updateAccount } from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { Link } from '../common/Link';
 import { Notes } from '../Notes';

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.jsx
@@ -42,11 +42,6 @@ import {
 } from 'date-fns';
 
 import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
-import {
-  getAccountsById,
-  getPayeesById,
-  getCategoriesById,
-} from 'loot-core/client/queries/queriesSlice';
 import { evalArithmetic } from 'loot-core/shared/arithmetic';
 import { currentDay } from 'loot-core/shared/months';
 import * as monthUtils from 'loot-core/shared/months';
@@ -69,6 +64,11 @@ import {
 
 import { pushModal } from '../../modals/modalsSlice';
 import { addNotification } from '../../notifications/notificationsSlice';
+import {
+  getAccountsById,
+  getPayeesById,
+  getCategoriesById,
+} from '../../queries/queriesSlice';
 import { useDispatch } from '../../redux';
 import { AccountAutocomplete } from '../autocomplete/AccountAutocomplete';
 import { CategoryAutocomplete } from '../autocomplete/CategoryAutocomplete';

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,9 +1,4 @@
 // @ts-strict-ignore
-import {
-  getAccounts,
-  getCategories,
-  getPayees,
-} from 'loot-core/client/queries/queriesSlice';
 import * as sharedListeners from 'loot-core/client/shared-listeners';
 import { type AppStore } from 'loot-core/client/store';
 import { listen } from 'loot-core/platform/client/fetch';
@@ -17,6 +12,7 @@ import {
   addNotification,
 } from './notifications/notificationsSlice';
 import { loadPrefs } from './prefs/prefsSlice';
+import { getAccounts, getCategories, getPayees } from './queries/queriesSlice';
 
 export function handleGlobalEvents(store: AppStore) {
   const unlistenServerError = listen('server-error', () => {

--- a/packages/desktop-client/src/hooks/useAccounts.ts
+++ b/packages/desktop-client/src/hooks/useAccounts.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
-import { getAccounts } from 'loot-core/client/queries/queriesSlice';
-
+import { getAccounts } from '../queries/queriesSlice';
 import { useSelector, useDispatch } from '../redux';
 
 import { useInitialMount } from './useInitialMount';

--- a/packages/desktop-client/src/hooks/useCategories.ts
+++ b/packages/desktop-client/src/hooks/useCategories.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
-import { getCategories } from 'loot-core/client/queries/queriesSlice';
-
+import { getCategories } from '../queries/queriesSlice';
 import { useSelector, useDispatch } from '../redux';
 
 import { useInitialMount } from './useInitialMount';

--- a/packages/desktop-client/src/hooks/usePayees.ts
+++ b/packages/desktop-client/src/hooks/usePayees.ts
@@ -1,10 +1,6 @@
 import { useEffect } from 'react';
 
-import {
-  getCommonPayees,
-  getPayees,
-} from 'loot-core/client/queries/queriesSlice';
-
+import { getCommonPayees, getPayees } from '../queries/queriesSlice';
 import { useSelector, useDispatch } from '../redux';
 
 import { useInitialMount } from './useInitialMount';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -25,7 +25,6 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -13,7 +13,6 @@ import { Provider } from 'react-redux';
 import { bindActionCreators } from '@reduxjs/toolkit';
 import { createRoot } from 'react-dom/client';
 
-import * as queriesSlice from 'loot-core/client/queries/queriesSlice';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { store } from 'loot-core/client/store';
 import { redo, undo } from 'loot-core/client/undo';
@@ -33,6 +32,7 @@ import { ServerProvider } from './components/ServerContext';
 import * as modalsSlice from './modals/modalsSlice';
 import * as notificationsSlice from './notifications/notificationsSlice';
 import * as prefsSlice from './prefs/prefsSlice';
+import * as queriesSlice from './queries/queriesSlice';
 
 const boundActions = bindActionCreators(
   {

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -25,6 +25,7 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
+import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/queries/queriesSlice.ts
+++ b/packages/desktop-client/src/queries/queriesSlice.ts
@@ -1,26 +1,24 @@
 // @ts-strict-ignore
-// This is temporary until we move all loot-core/client over to desktop-client.
-/* eslint-disable no-restricted-imports */
-import { resetApp } from '@actual-app/web/src/app/appSlice';
-import {
-  addGenericErrorNotification,
-  addNotification,
-} from '@actual-app/web/src/notifications/notificationsSlice';
-/* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 import memoizeOne from 'memoize-one';
 
-import { send } from '../../platform/client/fetch';
-import { groupById } from '../../shared/util';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { send } from 'loot-core/platform/client/fetch';
+import { groupById } from 'loot-core/shared/util';
 import {
   type CategoryEntity,
   type CategoryGroupEntity,
   type TransactionEntity,
   type AccountEntity,
   type PayeeEntity,
-} from '../../types/models';
-import { createAppAsyncThunk } from '../redux';
+} from 'loot-core/types/models';
+
+import { resetApp } from '../app/appSlice';
+import {
+  addGenericErrorNotification,
+  addNotification,
+} from '../notifications/notificationsSlice';
 
 const sliceName = 'queries';
 

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -12,12 +12,16 @@ import {
   type Notification,
 } from '@actual-app/web/src/notifications/notificationsSlice';
 import { loadPrefs } from '@actual-app/web/src/prefs/prefsSlice';
+import {
+  getAccounts,
+  getCategories,
+  getPayees,
+} from '@actual-app/web/src/queries/queriesSlice';
 /* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 
 import { listen, send } from '../platform/client/fetch';
 
-import { getAccounts, getCategories, getPayees } from './queries/queriesSlice';
 import { type AppStore } from './store';
 import { signOut } from './users/usersSlice';
 

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -25,6 +25,10 @@ import {
   name as prefsSliceName,
   reducer as prefsSliceReducer,
 } from '@actual-app/web/src/prefs/prefsSlice';
+import {
+  name as queriesSliceName,
+  reducer as queriesSliceReducer,
+} from '@actual-app/web/src/queries/queriesSlice';
 /* eslint-enable no-restricted-imports */
 import {
   combineReducers,
@@ -33,10 +37,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as queriesSliceName,
-  reducer as queriesSliceReducer,
-} from '../queries/queriesSlice';
 import {
   name as usersSliceName,
   reducer as usersSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -25,13 +25,13 @@ import {
   name as prefsSliceName,
   reducer as prefsSliceReducer,
 } from '@actual-app/web/src/prefs/prefsSlice';
-/* eslint-enable */
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-
 import {
   name as queriesSliceName,
   reducer as queriesSliceReducer,
-} from '../queries/queriesSlice';
+} from '@actual-app/web/src/queries/queriesSlice';
+/* eslint-enable */
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+
 import {
   name as usersSliceName,
   reducer as usersSliceReducer,

--- a/upcoming-release-notes/4822.md
+++ b/upcoming-release-notes/4822.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/queries code over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [x] modals folder
- [x] notifications folder
- [x] prefs folder
- [x] queries folder
- [ ] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Move folder from loot-core to desktop-client (vscode does the import updates)
2. Run yarn lint:fix
3. Suppress some @actual-app/web imports in loot-core (temporary until all loot-core/client is moved over to desktop-client)