### PR TITLE
Move loot-core/client/users code over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/budgets/budgetsSlice.ts
+++ b/packages/desktop-client/src/budgets/budgetsSlice.ts
@@ -2,7 +2,6 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
 
 import { createAppAsyncThunk } from 'loot-core/client/redux';
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { type RemoteFile } from 'loot-core/server/cloud-storage';
 import { getDownloadError, getSyncError } from 'loot-core/shared/errors';
@@ -13,6 +12,7 @@ import { type Handlers } from 'loot-core/types/handlers';
 import { resetApp, setAppState } from '../app/appSlice';
 import { closeModal, pushModal } from '../modals/modalsSlice';
 import { loadGlobalPrefs, loadPrefs } from '../prefs/prefsSlice';
+import { signOut } from '../users/usersSlice';
 
 const sliceName = 'budgets';
 

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -16,7 +16,6 @@ import { View } from '@actual-app/components/view';
 
 import * as Platform from 'loot-core/client/platform';
 import { SpreadsheetProvider } from 'loot-core/client/SpreadsheetProvider';
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { init as initConnection, send } from 'loot-core/platform/client/fetch';
 
 import { setAppState, sync } from '../app/appSlice';
@@ -28,6 +27,7 @@ import { installPolyfills } from '../polyfills';
 import { loadGlobalPrefs } from '../prefs/prefsSlice';
 import { useDispatch, useSelector, useStore } from '../redux';
 import { hasHiddenScrollbars, ThemeStyle, useTheme } from '../style';
+import { signOut } from '../users/usersSlice';
 import { ExposeNavigate } from '../util/router-tools';
 
 import { AppBackground } from './AppBackground';

--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -10,7 +10,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { getUserData, signOut } from 'loot-core/client/users/usersSlice';
 import { listen } from 'loot-core/platform/client/fetch';
 import { type RemoteFile, type SyncedLocalFile } from 'loot-core/types/file';
 import { type TransObjectLiteral } from 'loot-core/types/util';
@@ -19,6 +18,7 @@ import { useAuth } from '../auth/AuthProvider';
 import { Permissions } from '../auth/types';
 import { closeBudget } from '../budgets/budgetsSlice';
 import { useSelector, useDispatch } from '../redux';
+import { getUserData, signOut } from '../users/usersSlice';
 
 import { PrivacyFilter } from './PrivacyFilter';
 import { useMultiuserEnabled, useServerURL } from './ServerContext';

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccessRow.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccessRow.tsx
@@ -5,13 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getUserAccessErrors } from 'loot-core/shared/errors';
 import { type UserAvailable } from 'loot-core/types/models';
 
 import { addNotification } from '../../../notifications/notificationsSlice';
 import { useDispatch } from '../../../redux';
+import { signOut } from '../../../users/usersSlice';
 import { Checkbox } from '../../forms';
 import { Row, Cell } from '../../table';
 

--- a/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
+++ b/packages/desktop-client/src/components/admin/UserDirectory/UserDirectory.tsx
@@ -16,7 +16,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
@@ -24,6 +23,7 @@ import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
 import { pushModal } from '../../../modals/modalsSlice';
 import { addNotification } from '../../../notifications/notificationsSlice';
 import { useDispatch } from '../../../redux';
+import { signOut } from '../../../users/usersSlice';
 import { InfiniteScrollWrapper } from '../../common/InfiniteScrollWrapper';
 import { Link } from '../../common/Link';
 import { Search } from '../../common/Search';

--- a/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
@@ -36,7 +36,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
-import { getUserData } from 'loot-core/client/users/usersSlice';
 import {
   isElectron,
   isNonProductionEnvironment,
@@ -59,6 +58,7 @@ import {
 } from '../../budgets/budgetsSlice';
 import { pushModal } from '../../modals/modalsSlice';
 import { useSelector, useDispatch } from '../../redux';
+import { getUserData } from '../../users/usersSlice';
 import { useMultiuserEnabled } from '../ServerContext';
 
 import { useInitialMount } from '@desktop-client/hooks/useInitialMount';

--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -9,7 +9,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { loggedIn, signOut } from 'loot-core/client/users/usersSlice';
 import {
   isNonProductionEnvironment,
   isElectron,
@@ -17,6 +16,7 @@ import {
 
 import { createBudget } from '../../budgets/budgetsSlice';
 import { useDispatch } from '../../redux';
+import { loggedIn, signOut } from '../../users/usersSlice';
 import { Link } from '../common/Link';
 import { useServerURL, useSetServerURL } from '../ServerContext';
 

--- a/packages/desktop-client/src/components/manager/ManagementApp.tsx
+++ b/packages/desktop-client/src/components/manager/ManagementApp.tsx
@@ -7,7 +7,6 @@ import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 
-
 import { setAppState } from '../../app/appSlice';
 import { ProtectedRoute } from '../../auth/ProtectedRoute';
 import { Permissions } from '../../auth/types';

--- a/packages/desktop-client/src/components/manager/ManagementApp.tsx
+++ b/packages/desktop-client/src/components/manager/ManagementApp.tsx
@@ -7,12 +7,12 @@ import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 
-import { loggedIn } from 'loot-core/client/users/usersSlice';
 
 import { setAppState } from '../../app/appSlice';
 import { ProtectedRoute } from '../../auth/ProtectedRoute';
 import { Permissions } from '../../auth/types';
 import { useSelector, useDispatch } from '../../redux';
+import { loggedIn } from '../../users/usersSlice';
 import {
   BackToFileListButton,
   UserDirectoryPage,

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -15,13 +15,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { loggedIn } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { isElectron } from 'loot-core/shared/environment';
 import { type OpenIdConfig } from 'loot-core/types/models';
 
 import { useDispatch } from '../../../redux';
 import { warningBackground } from '../../../style/themes/dark';
+import { loggedIn } from '../../../users/usersSlice';
 import { Link } from '../../common/Link';
 import { useAvailableLoginMethods, useLoginMethod } from '../../ServerContext';
 

--- a/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
+++ b/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 
-import { loggedIn } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 
 import { useDispatch } from '../../../redux';
+import { loggedIn } from '../../../users/usersSlice';
 
 export function OpenIdCallback() {
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/modals/EditAccess.tsx
+++ b/packages/desktop-client/src/components/modals/EditAccess.tsx
@@ -9,13 +9,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { getUserAccessErrors } from 'loot-core/shared/errors';
 
 import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { addNotification } from '../../notifications/notificationsSlice';
 import { useDispatch } from '../../redux';
+import { signOut } from '../../users/usersSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { FormField, FormLabel } from '../forms';
 

--- a/packages/desktop-client/src/components/modals/EditUser.tsx
+++ b/packages/desktop-client/src/components/modals/EditUser.tsx
@@ -10,7 +10,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { PossibleRoles } from 'loot-core/shared/user';
 import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
@@ -18,6 +17,7 @@ import { type NewUserEntity, type UserEntity } from 'loot-core/types/models';
 import { type Modal as ModalType, popModal } from '../../modals/modalsSlice';
 import { addNotification } from '../../notifications/notificationsSlice';
 import { useDispatch } from '../../redux';
+import { signOut } from '../../users/usersSlice';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
 import { Checkbox, FormField, FormLabel } from '../forms';
 

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -24,6 +24,7 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
+import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -16,7 +16,6 @@ import { createRoot } from 'react-dom/client';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { store } from 'loot-core/client/store';
 import { redo, undo } from 'loot-core/client/undo';
-import * as usersSlice from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 
@@ -33,6 +32,7 @@ import * as modalsSlice from './modals/modalsSlice';
 import * as notificationsSlice from './notifications/notificationsSlice';
 import * as prefsSlice from './prefs/prefsSlice';
 import * as queriesSlice from './queries/queriesSlice';
+import * as usersSlice from './users/usersSlice';
 
 const boundActions = bindActionCreators(
   {

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -24,7 +24,6 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { createAppAsyncThunk } from 'loot-core/client/redux';
-import { signOut } from 'loot-core/client/users/usersSlice';
 import { send } from 'loot-core/platform/client/fetch';
 import { type File } from 'loot-core/types/file';
 import {
@@ -21,6 +20,7 @@ import {
 } from 'loot-core/types/models';
 
 import { resetApp, setAppState } from '../app/appSlice';
+import { signOut } from '../users/usersSlice';
 
 const sliceName = 'modals';
 

--- a/packages/desktop-client/src/users/usersSlice.ts
+++ b/packages/desktop-client/src/users/usersSlice.ts
@@ -1,17 +1,13 @@
-// This is temporary until we move all loot-core/client over to desktop-client.
-/* eslint-disable no-restricted-imports */
-import { resetApp } from '@actual-app/web/src/app/appSlice';
-import {
-  closeBudget,
-  loadAllFiles,
-} from '@actual-app/web/src/budgets/budgetsSlice';
-import { loadGlobalPrefs } from '@actual-app/web/src/prefs/prefsSlice';
-/* eslint-enable no-restricted-imports */
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { send } from '../../platform/client/fetch';
-import { type Handlers } from '../../types/handlers';
-import { createAppAsyncThunk } from '../redux';
+import { createAppAsyncThunk } from 'loot-core/client/redux';
+import { send } from 'loot-core/platform/client/fetch';
+import { type Handlers } from 'loot-core/types/handlers';
+
+import { resetApp } from '../app/appSlice';
+import { closeBudget, loadAllFiles } from '../budgets/budgetsSlice';
+import { loadGlobalPrefs } from '../prefs/prefsSlice';
+
 
 const sliceName = 'user';
 

--- a/packages/desktop-client/src/users/usersSlice.ts
+++ b/packages/desktop-client/src/users/usersSlice.ts
@@ -8,7 +8,6 @@ import { resetApp } from '../app/appSlice';
 import { closeBudget, loadAllFiles } from '../budgets/budgetsSlice';
 import { loadGlobalPrefs } from '../prefs/prefsSlice';
 
-
 const sliceName = 'user';
 
 export const getUserData = createAppAsyncThunk(

--- a/packages/loot-core/src/client/shared-listeners.ts
+++ b/packages/loot-core/src/client/shared-listeners.ts
@@ -17,13 +17,13 @@ import {
   getCategories,
   getPayees,
 } from '@actual-app/web/src/queries/queriesSlice';
+import { signOut } from '@actual-app/web/src/users/usersSlice';
 /* eslint-enable no-restricted-imports */
 import { t } from 'i18next';
 
 import { listen, send } from '../platform/client/fetch';
 
 import { type AppStore } from './store';
-import { signOut } from './users/usersSlice';
 
 export function listenForSyncEvent(store: AppStore) {
   // TODO: Should this run on mobile too?

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -29,6 +29,10 @@ import {
   name as queriesSliceName,
   reducer as queriesSliceReducer,
 } from '@actual-app/web/src/queries/queriesSlice';
+import {
+  name as usersSliceName,
+  reducer as usersSliceReducer,
+} from '@actual-app/web/src/users/usersSlice';
 /* eslint-enable no-restricted-imports */
 import {
   combineReducers,
@@ -37,10 +41,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-import {
-  name as usersSliceName,
-  reducer as usersSliceReducer,
-} from '../users/usersSlice';
 
 const rootReducer = combineReducers({
   [accountsSliceName]: accountsSliceReducer,

--- a/packages/loot-core/src/client/store/index.ts
+++ b/packages/loot-core/src/client/store/index.ts
@@ -41,7 +41,6 @@ import {
   isRejected,
 } from '@reduxjs/toolkit';
 
-
 const rootReducer = combineReducers({
   [accountsSliceName]: accountsSliceReducer,
   [appSliceName]: appSliceReducer,

--- a/packages/loot-core/src/client/store/mock.ts
+++ b/packages/loot-core/src/client/store/mock.ts
@@ -29,13 +29,12 @@ import {
   name as queriesSliceName,
   reducer as queriesSliceReducer,
 } from '@actual-app/web/src/queries/queriesSlice';
-/* eslint-enable */
-import { configureStore, combineReducers } from '@reduxjs/toolkit';
-
 import {
   name as usersSliceName,
   reducer as usersSliceReducer,
-} from '../users/usersSlice';
+} from '@actual-app/web/src/users/usersSlice';
+/* eslint-enable */
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 
 import { type store as realStore } from './index';
 

--- a/upcoming-release-notes/4823.md
+++ b/upcoming-release-notes/4823.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/users code over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [x] modals folder
- [x] notifications folder
- [x] prefs folder
- [x] queries folder
- [x] users folder
- [ ] data-hooks folder
- [ ] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Move folder from loot-core to desktop-client (vscode does the import updates)
2. Run yarn lint:fix
3. Suppress some @actual-app/web imports in loot-core (temporary until all loot-core/client is moved over to desktop-client)