### PR TITLE
🐛 CLI: Fix ACTUAL_DATA_DIR env variable not respected in some cases

### DIFF
--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -81,7 +81,7 @@ const setupDataDir = (dataDir = undefined) => {
 
     console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);
   }
-}
+};
 
 if (values.config) {
   const configExists = existsSync(values.config);

--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -76,9 +76,7 @@ const setupDataDir = (dataDir = undefined) => {
       console.info(
         'Using default data directory. You can specify a custom config with --config',
       );
-
-      mkdirSync('./data');
-      process.env.ACTUAL_DATA_DIR = './data';
+      process.env.ACTUAL_DATA_DIR = './';
     }
 
     console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);

--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -76,7 +76,9 @@ const setupDataDir = (dataDir = undefined) => {
       console.info(
         'Using default data directory. You can specify a custom config with --config',
       );
-      process.env.ACTUAL_DATA_DIR = './';
+
+      mkdirSync('./data');
+      process.env.ACTUAL_DATA_DIR = './data';
     }
 
     console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);

--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -75,13 +75,19 @@ if (values.config) {
   }
 } else {
   // No config specified, use reasonable defaults
-  console.info(
-    'Using default config. You can specify a custom config with --config',
-  );
-  process.env.ACTUAL_DATA_DIR = './';
-  console.info(
-    'user-files and server-files will be created in the current directory',
-  );
+  if (!process.env.ACTUAL_DATA_DIR) {
+    if (existsSync('./data')) {
+      console.info('Found existing data directory');
+      process.env.ACTUAL_DATA_DIR = './data';
+    } else {
+      console.info(
+        'Using default data directory. You can specify a custom config with --config',
+      );
+      process.env.ACTUAL_DATA_DIR = './';
+    }
+
+    console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);
+  }
 }
 
 // start the sync server

--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -59,8 +59,15 @@ if (values.version) {
   process.exit();
 }
 
-const setupDataDir = () => {
-  if (!process.env.ACTUAL_DATA_DIR) {
+const setupDataDir = (dataDir = undefined) => {
+  if (process.env.ACTUAL_DATA_DIR) {
+    return; // Env variables must not be overwritten
+  }
+
+  if (dataDir) {
+    process.env.ACTUAL_DATA_DIR = dataDir; // Use the dir specified
+  } else {
+    // Setup defaults
     if (existsSync('./data')) {
       // The default data directory exists - use it
       console.info('Found existing data directory');
@@ -74,7 +81,7 @@ const setupDataDir = () => {
 
     console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);
   }
-};
+}
 
 if (values.config) {
   const configExists = existsSync(values.config);
@@ -87,12 +94,9 @@ if (values.config) {
     process.exit();
   } else {
     console.log(`Loading config from ${values.config}`);
-    process.env.ACTUAL_CONFIG_PATH = values.config;
-
     const configJson = JSON.parse(readFileSync(values.config, 'utf-8'));
-    if (!configJson.dataDir) {
-      setupDataDir();
-    }
+    process.env.ACTUAL_CONFIG_PATH = values.config;
+    setupDataDir(configJson.dataDir);
   }
 } else {
   // If no config is specified, check for a default config in the current directory
@@ -103,12 +107,9 @@ if (values.config) {
     console.info('Found config.json in the current directory');
     const configJson = JSON.parse(readFileSync(defaultConfigJsonFile, 'utf-8'));
     process.env.ACTUAL_CONFIG_PATH = defaultConfigJsonFile;
-
-    if (!configJson.dataDir) {
-      setupDataDir(); // No dataDir specified in config.json. Set it up
-    }
+    setupDataDir(configJson.dataDir);
   } else {
-    setupDataDir(); // No default config exists - setup data dir
+    setupDataDir(); // No default config exists - setup data dir with defaults
   }
 }
 

--- a/upcoming-release-notes/4825.md
+++ b/upcoming-release-notes/4825.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix CLI issue where ACTAUL_DATA_DIR env variable was not being respected when no config is present


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

**Two issues fixed - both to do with the data directory:**
1. When ACTAUL_DATA_DIR is set and --config isn't set, the environment variable specified was not being respected.
2. When  no --config is set, look for a default config.json (this is the current server behavior). 
    - If it exists and has a dataDir value, use it. Otherwise default it to the directory where the command was run 
    - If it doesn't exist, also default the data dir to where the command was run

Defaulting the `data` directory and `config.json` in this script ensures that it works the same way as is described here: https://actualbudget.org/docs/config/. 

If we don't set them here manually, the server will search for the files in the project root, which is the node_modules folder because this is installed as node module.


