### PR TITLE
Move loot-core/client/data-hooks over to desktop-client package

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -15,7 +15,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { send } from 'loot-core/platform/client/fetch';
 import * as undo from 'loot-core/platform/client/undo';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
@@ -37,6 +36,7 @@ import { RulesList } from './rules/RulesList';
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { usePayees } from '@desktop-client/hooks/usePayees';
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 import {
   useSelected,
   SelectedProvider,

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -16,11 +16,6 @@ import { debounce } from 'debounce';
 import { t } from 'i18next';
 import { v4 as uuidv4 } from 'uuid';
 
-import { useFilters } from 'loot-core/client/data-hooks/filters';
-import {
-  SchedulesProvider,
-  accountSchedulesQuery,
-} from 'loot-core/client/data-hooks/schedules';
 import * as queries from 'loot-core/client/queries';
 import {
   aqlQuery,
@@ -82,6 +77,7 @@ import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFailedAccounts } from '@desktop-client/hooks/useFailedAccounts';
 import { useLocalPref } from '@desktop-client/hooks/useLocalPref';
 import { usePayees } from '@desktop-client/hooks/usePayees';
+import { accountSchedulesQuery } from '@desktop-client/hooks/useSchedules';
 import {
   SelectedProviderWithItems,
   type Actions,
@@ -92,6 +88,7 @@ import {
 } from '@desktop-client/hooks/useSplitsExpanded';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { useTransactionBatchActions } from '@desktop-client/hooks/useTransactionBatchActions';
+import { useTransactionFilters } from '@desktop-client/hooks/useTransactionFilters';
 
 type ConditionEntity = Partial<RuleConditionEntity> | TransactionFilterEntity;
 
@@ -1948,7 +1945,7 @@ export function Account() {
   const accountsSyncing = useSelector(state => state.account.accountsSyncing);
   const filterConditions = location?.state?.filterConditions || [];
 
-  const savedFiters = useFilters();
+  const savedFiters = useTransactionFilters();
 
   const schedulesQuery = useMemo(
     () => accountSchedulesQuery(params.id),

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -72,6 +72,7 @@ import { AccountHeader } from './Header';
 
 import { useAccountPreviewTransactions } from '@desktop-client/hooks/useAccountPreviewTransactions';
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFailedAccounts } from '@desktop-client/hooks/useFailedAccounts';

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -8,7 +8,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { useHover } from 'usehooks-ts';
 
-import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
 import { q, type Query } from 'loot-core/shared/query';
 import { getScheduledAmount } from 'loot-core/shared/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
@@ -20,6 +19,7 @@ import { CellValue, CellValueText } from '../spreadsheet/CellValue';
 import { useFormat } from '../spreadsheet/useFormat';
 import { useSheetValue } from '../spreadsheet/useSheetValue';
 
+import { useCachedSchedules } from '@desktop-client/hooks/useCachedSchedules';
 import { useSelectedItems } from '@desktop-client/hooks/useSelected';
 
 type DetailedBalanceProps = {

--- a/packages/desktop-client/src/components/autocomplete/FilterAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/FilterAutocomplete.tsx
@@ -1,7 +1,8 @@
 import React, { type ComponentProps } from 'react';
 
-import { useFilters } from 'loot-core/client/data-hooks/filters';
 import { type TransactionFilterEntity } from 'loot-core/types/models';
+
+import { useTransactionFilters } from '../../hooks/useTransactionFilters';
 
 import { Autocomplete } from './Autocomplete';
 import { FilterList } from './FilterList';
@@ -12,7 +13,7 @@ export function FilterAutocomplete({
 }: {
   embedded?: boolean;
 } & ComponentProps<typeof Autocomplete<TransactionFilterEntity>>) {
-  const filters = useFilters() || [];
+  const filters = useTransactionFilters() || [];
 
   return (
     <Autocomplete

--- a/packages/desktop-client/src/components/autocomplete/ReportAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/ReportAutocomplete.tsx
@@ -1,7 +1,8 @@
 import React, { type ComponentProps } from 'react';
 
-import { useReports } from 'loot-core/client/data-hooks/reports';
 import { type CustomReportEntity } from 'loot-core/types/models';
+
+import { useReports } from '../../hooks/useReports';
 
 import { Autocomplete } from './Autocomplete';
 import { ReportList } from './ReportList';

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -9,7 +9,6 @@ import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
-import { useTransactions } from 'loot-core/client/data-hooks/transactions';
 import {
   defaultMappings,
   type Mappings,
@@ -31,6 +30,7 @@ import { CheckboxOption } from '../modals/ImportTransactionsModal/CheckboxOption
 import { FieldMapping } from './FieldMapping';
 
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+import { useTransactions } from '@desktop-client/hooks/useTransactions';
 
 export type TransactionDirection = 'payment' | 'deposit';
 

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -9,7 +9,6 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
 import { q } from 'loot-core/shared/query';
 import {
   type CategoryEntity,
@@ -29,6 +28,7 @@ import {
   separateGroups,
 } from './util';
 
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useGlobalPref } from '@desktop-client/hooks/useGlobalPref';
 import { useLocalPref } from '@desktop-client/hooks/useLocalPref';

--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -20,7 +20,6 @@ import {
   isValid as isDateValid,
 } from 'date-fns';
 
-import { useFilters } from 'loot-core/client/data-hooks/filters';
 import { send } from 'loot-core/platform/client/fetch';
 import { getMonthYearFormat } from 'loot-core/shared/months';
 import {
@@ -43,6 +42,7 @@ import { subfieldToOptions } from './subfieldToOptions';
 import { updateFilterReducer } from './updateFilterReducer';
 
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
+import { useTransactionFilters } from '@desktop-client/hooks/useTransactionFilters';
 
 let isDatepickerClick = false;
 
@@ -260,7 +260,7 @@ function ConfigureField({
 
 export function FilterButton({ onApply, compact, hover, exclude }) {
   const { t } = useTranslation();
-  const filters = useFilters();
+  const filters = useTransactionFilters();
   const triggerRef = useRef(null);
 
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -13,14 +13,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  accountSchedulesQuery,
-  SchedulesProvider,
-} from 'loot-core/client/data-hooks/schedules';
-import {
-  useTransactions,
-  useTransactionsSearch,
-} from 'loot-core/client/data-hooks/transactions';
 import * as queries from 'loot-core/client/queries';
 import { listen, send } from 'loot-core/platform/client/fetch';
 import { type Query } from 'loot-core/shared/query';
@@ -51,6 +43,9 @@ import { useAccountPreviewTransactions } from '@desktop-client/hooks/useAccountP
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFailedAccounts } from '@desktop-client/hooks/useFailedAccounts';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { accountSchedulesQuery } from '@desktop-client/hooks/useSchedules';
+import { useTransactions } from '@desktop-client/hooks/useTransactions';
+import { useTransactionsSearch } from '@desktop-client/hooks/useTransactionsSearch';
 
 export function AccountTransactions({
   account,

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -40,6 +40,7 @@ import { AddTransactionButton } from '../transactions/AddTransactionButton';
 import { TransactionListWithBalances } from '../transactions/TransactionListWithBalances';
 
 import { useAccountPreviewTransactions } from '@desktop-client/hooks/useAccountPreviewTransactions';
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFailedAccounts } from '@desktop-client/hooks/useFailedAccounts';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';

--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -23,7 +23,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { AutoTextSize } from 'auto-text-size';
 
-import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
 import {
   envelopeBudget,
   trackingBudget,
@@ -46,6 +45,7 @@ import { PullToRefresh } from '../PullToRefresh';
 import { ExpenseGroupList } from './ExpenseGroupList';
 import { IncomeGroup } from './IncomeGroup';
 
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useLocalPref } from '@desktop-client/hooks/useLocalPref';

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -19,8 +19,8 @@ import { MobileBackButton } from '../MobileBackButton';
 import { AddTransactionButton } from '../transactions/AddTransactionButton';
 import { TransactionListWithBalances } from '../transactions/TransactionListWithBalances';
 
-import { useCategoryPreviewTransactions } from '@desktop-client/hooks/useCategoryPreviewTransactions';
 import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
+import { useCategoryPreviewTransactions } from '@desktop-client/hooks/useCategoryPreviewTransactions';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -3,11 +3,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { TextOneLine } from '@actual-app/components/text-one-line';
 import { View } from '@actual-app/components/view';
 
-import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
-import {
-  useTransactions,
-  useTransactionsSearch,
-} from 'loot-core/client/data-hooks/transactions';
 import * as queries from 'loot-core/client/queries';
 import { listen } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
@@ -25,9 +20,12 @@ import { AddTransactionButton } from '../transactions/AddTransactionButton';
 import { TransactionListWithBalances } from '../transactions/TransactionListWithBalances';
 
 import { useCategoryPreviewTransactions } from '@desktop-client/hooks/useCategoryPreviewTransactions';
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useTransactions } from '@desktop-client/hooks/useTransactions';
+import { useTransactionsSearch } from '@desktop-client/hooks/useTransactionsSearch';
 
 type CategoryTransactionsProps = {
   category: CategoryEntity;

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
@@ -29,7 +29,6 @@ import {
   useLongPress,
 } from '@react-aria/interactions';
 
-import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { integerToCurrency } from 'loot-core/shared/util';
 import {
@@ -43,6 +42,7 @@ import { makeAmountFullStyle } from '../../budget/util';
 import { lookupName, Status } from './TransactionEdit';
 
 import { useAccount } from '@desktop-client/hooks/useAccount';
+import { useCachedSchedules } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useDisplayPayee } from '@desktop-client/hooks/useDisplayPayee';
 import { usePayee } from '@desktop-client/hooks/usePayee';

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
@@ -6,13 +6,14 @@ import { Stack } from '@actual-app/components/stack';
 import { theme } from '@actual-app/components/theme';
 import { uniqueId } from 'lodash';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { type Template } from 'loot-core/server/budget/types/templates';
 import { q } from 'loot-core/shared/query';
 
 import { BudgetAutomation } from '../budget/goals/BudgetAutomation';
 import { useBudgetAutomationCategories } from '../budget/goals/useBudgetAutomationCategories';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';
+
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 
 type TemplateWithId = Template & { id: string };
 

--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -23,7 +23,6 @@ import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 import { v4 as uuid } from 'uuid';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { aqlQuery } from 'loot-core/client/query-helpers';
 import { enableUndo, disableUndo } from 'loot-core/client/undo';
 import { send } from 'loot-core/platform/client/fetch';
@@ -58,6 +57,7 @@ import { GenericInput } from '../util/GenericInput';
 
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 import {
   useSelected,
   SelectedProvider,

--- a/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
@@ -11,7 +11,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { format } from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
 import {
@@ -28,6 +27,7 @@ import {
 } from '../common/Modal';
 
 import { useLocale } from '@desktop-client/hooks/useLocale';
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 
 type ScheduledTransactionMenuModalProps = Extract<
   ModalType,

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -13,8 +13,6 @@ import { Popover } from '@actual-app/components/popover';
 import { breakpoints } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
 
-import { useDashboard } from 'loot-core/client/data-hooks/dashboard';
-import { useReports } from 'loot-core/client/data-hooks/reports';
 import { send } from 'loot-core/platform/client/fetch';
 import {
   type CustomReportWidget,
@@ -43,7 +41,9 @@ import './overview.scss';
 import { SummaryCard } from './reports/SummaryCard';
 
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
+import { useDashboard } from '@desktop-client/hooks/useDashboard';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useReports } from '@desktop-client/hooks/useReports';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { useUndo } from '@desktop-client/hooks/useUndo';
 

--- a/packages/desktop-client/src/components/reports/SaveReport.tsx
+++ b/packages/desktop-client/src/components/reports/SaveReport.tsx
@@ -6,9 +6,10 @@ import { Popover } from '@actual-app/components/popover';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { useReports } from 'loot-core/client/data-hooks/reports';
 import { send, sendCatch } from 'loot-core/platform/client/fetch';
 import { type CustomReportEntity } from 'loot-core/types/models';
+
+import { useReports } from '../../hooks/useReports';
 
 import { SaveReportChoose } from './SaveReportChoose';
 import { SaveReportDelete } from './SaveReportDelete';

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -25,9 +25,6 @@ import { css } from '@emotion/css';
 import { useDrag } from '@use-gesture/react';
 import { format, parseISO } from 'date-fns';
 
-import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
-import { useTransactions } from 'loot-core/client/data-hooks/transactions';
-import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { q, type Query } from 'loot-core/shared/query';
@@ -63,17 +60,20 @@ import { useReport } from '../useReport';
 import { fromDateRepr } from '../util';
 
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useResizeObserver } from '@desktop-client/hooks/useResizeObserver';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
 import { SelectedProviderWithItems } from '@desktop-client/hooks/useSelected';
 import { SplitsExpandedProvider } from '@desktop-client/hooks/useSplitsExpanded';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+import { useTransactions } from '@desktop-client/hooks/useTransactions';
+import { useWidget } from '@desktop-client/hooks/useWidget';
 
 const CHEVRON_HEIGHT = 42;
 const SUMMARY_HEIGHT = 140;
@@ -136,7 +136,10 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
     onDelete: onDeleteFilter,
     onUpdate: onUpdateFilter,
     onConditionsOpChange,
-  } = useFilters(widget?.meta?.conditions, widget?.meta?.conditionsOp);
+  } = useRuleConditionFilters(
+    widget?.meta?.conditions,
+    widget?.meta?.conditionsOp,
+  );
 
   useEffect(() => {
     const day = parameters.get('day');

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -12,7 +12,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
 
-import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { integerToCurrency } from 'loot-core/shared/util';
@@ -36,10 +35,11 @@ import { calculateTimeRange } from '../reportRanges';
 import { cashFlowByDate } from '../spreadsheets/cash-flow-spreadsheet';
 import { useReport } from '../useReport';
 
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+import { useWidget } from '@desktop-client/hooks/useWidget';
 
 export const defaultTimeFrame = {
   start: monthUtils.dayFromDate(monthUtils.currentMonth()),
@@ -77,7 +77,7 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
     onDelete: onDeleteFilter,
     onUpdate: onUpdateFilter,
     onConditionsOpChange,
-  } = useFilters<RuleConditionEntity>(
+  } = useRuleConditionFilters<RuleConditionEntity>(
     widget?.meta?.conditions,
     widget?.meta?.conditionsOp,
   );

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -11,7 +11,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
 
-import { useReport as useCustomReport } from 'loot-core/client/data-hooks/reports';
 import { calculateHasWarning } from 'loot-core/client/reports';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
@@ -58,11 +57,12 @@ import { fromDateRepr } from '../util';
 
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useCategories } from '@desktop-client/hooks/useCategories';
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useLocalPref } from '@desktop-client/hooks/useLocalPref';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { usePayees } from '@desktop-client/hooks/usePayees';
+import { useReport as useCustomReport } from '@desktop-client/hooks/useReport';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 
 /**
@@ -145,7 +145,7 @@ function CustomReportInner({ report: initialReport }: CustomReportInnerProps) {
     onDelete: onDeleteFilter,
     onUpdate: onUpdateFilter,
     onConditionsOpChange,
-  } = useFilters();
+  } = useRuleConditionFilters();
 
   const location = useLocation();
 

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -10,7 +10,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
 
-import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { integerToCurrency } from 'loot-core/shared/util';
@@ -32,10 +31,11 @@ import { useReport } from '../useReport';
 import { fromDateRepr } from '../util';
 
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+import { useWidget } from '@desktop-client/hooks/useWidget';
 
 export function NetWorth() {
   const params = useParams();
@@ -68,7 +68,10 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
     onDelete: onDeleteFilter,
     onUpdate: onUpdateFilter,
     onConditionsOpChange,
-  } = useFilters(widget?.meta?.conditions, widget?.meta?.conditionsOp);
+  } = useRuleConditionFilters(
+    widget?.meta?.conditions,
+    widget?.meta?.conditionsOp,
+  );
 
   const [allMonths, setAllMonths] = useState<Array<{
     name: string;

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -16,7 +16,6 @@ import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
 
-import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { amountToCurrency } from 'loot-core/shared/util';
@@ -42,9 +41,10 @@ import { createSpendingSpreadsheet } from '../spreadsheets/spending-spreadsheet'
 import { useReport } from '../useReport';
 import { fromDateRepr } from '../util';
 
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
+import { useWidget } from '@desktop-client/hooks/useWidget';
 
 export function Spending() {
   const params = useParams();
@@ -76,7 +76,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
     onDelete: onDeleteFilter,
     onUpdate: onUpdateFilter,
     onConditionsOpChange,
-  } = useFilters<RuleConditionEntity>(
+  } = useRuleConditionFilters<RuleConditionEntity>(
     widget?.meta?.conditions,
     widget?.meta?.conditionsOp,
   );

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -15,7 +15,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { parseISO } from 'date-fns';
 
-import { useWidget } from 'loot-core/client/data-hooks/widget';
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { amountToCurrency } from 'loot-core/shared/util';
@@ -43,10 +42,11 @@ import { summarySpreadsheet } from '../spreadsheets/summary-spreadsheet';
 import { useReport } from '../useReport';
 import { fromDateRepr } from '../util';
 
-import { useFilters } from '@desktop-client/hooks/useFilters';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { useRuleConditionFilters } from '@desktop-client/hooks/useRuleConditionFilters';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+import { useWidget } from '@desktop-client/hooks/useWidget';
 
 export function Summary() {
   const params = useParams();
@@ -66,7 +66,7 @@ type SummaryInnerProps = {
   widget?: SummaryWidget;
 };
 
-type FilterObject = ReturnType<typeof useFilters>;
+type FilterObject = ReturnType<typeof useRuleConditionFilters>;
 
 function SummaryInner({ widget }: SummaryInnerProps) {
   const locale = useLocale();
@@ -83,7 +83,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
   const [end, setEnd] = useState(initialEnd);
   const [mode, setMode] = useState(initialMode);
 
-  const dividendFilters: FilterObject = useFilters(
+  const dividendFilters: FilterObject = useRuleConditionFilters(
     widget?.meta?.conditions ?? [],
     widget?.meta?.conditionsOp ?? 'and',
   );
@@ -111,7 +111,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
         },
   );
 
-  const divisorFilters = useFilters(
+  const divisorFilters = useRuleConditionFilters(
     content.type === 'percentage' ? (content?.divisorConditions ?? []) : [],
     content.type === 'percentage'
       ? (content?.divisorConditionsOp ?? 'and')

--- a/packages/desktop-client/src/components/rules/ScheduleValue.tsx
+++ b/packages/desktop-client/src/components/rules/ScheduleValue.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from 'react';
 import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { View } from '@actual-app/components/view';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { q } from 'loot-core/shared/query';
 import { describeSchedule } from 'loot-core/shared/schedules';
 import { type ScheduleEntity } from 'loot-core/types/models';
@@ -13,6 +12,7 @@ import { getPayeesById } from '../../queries/queriesSlice';
 import { Value } from './Value';
 
 import { usePayees } from '@desktop-client/hooks/usePayees';
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 
 type ScheduleValueProps = {
   value: ScheduleEntity;

--- a/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleLink.tsx
@@ -8,10 +8,10 @@ import { InitialFocus } from '@actual-app/components/initial-focus';
 import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 
+import { useSchedules } from '../../hooks/useSchedules';
 import { type Modal as ModalType, pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Modal, ModalCloseButton, ModalHeader } from '../common/Modal';

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -11,10 +11,6 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import {
-  type ScheduleStatusType,
-  type ScheduleStatuses,
-} from 'loot-core/client/data-hooks/schedules';
 import { format as monthUtilFormat } from 'loot-core/shared/months';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { getScheduledAmount } from 'loot-core/shared/schedules';
@@ -31,6 +27,10 @@ import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { usePayees } from '@desktop-client/hooks/usePayees';
+import {
+  type ScheduleStatusType,
+  type ScheduleStatuses,
+} from '@desktop-client/hooks/useSchedules';
 
 type SchedulesTableProps = {
   isLoading?: boolean;

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -14,8 +14,9 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { type ScheduleStatusType } from 'loot-core/client/data-hooks/schedules';
 import { titleFirst } from 'loot-core/shared/util';
+
+import { type ScheduleStatusType } from '../../hooks/useSchedules';
 
 // Consists of Schedule Statuses + Transaction statuses
 export type StatusTypes =

--- a/packages/desktop-client/src/components/schedules/index.tsx
+++ b/packages/desktop-client/src/components/schedules/index.tsx
@@ -5,11 +5,11 @@ import { Button } from '@actual-app/components/button';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { send } from 'loot-core/platform/client/fetch';
 import { q } from 'loot-core/shared/query';
 import { type ScheduleEntity } from 'loot-core/types/models';
 
+import { useSchedules } from '../../hooks/useSchedules';
 import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { Search } from '../common/Search';

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { validForTransfer } from 'loot-core/client/transfer';
 import { q } from 'loot-core/shared/query';
 import {
@@ -18,6 +17,7 @@ import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 import { SelectedItemsButton } from '../table';
 
+import { useSchedules } from '@desktop-client/hooks/useSchedules';
 import { useSelectedItems } from '@desktop-client/hooks/useSelected';
 
 type SelectedTransactionsButtonProps = {

--- a/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionMenu.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
 
-import { useSchedules } from 'loot-core/client/data-hooks/schedules';
 import { q } from 'loot-core/shared/query';
 import {
   scheduleIsRecurring,
@@ -12,6 +11,7 @@ import {
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { type TransactionEntity } from 'loot-core/types/models';
 
+import { useSchedules } from '../../hooks/useSchedules';
 import { pushModal } from '../../modals/modalsSlice';
 import { useDispatch } from '../../redux';
 

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { format as formatDate, parse as parseDate } from 'date-fns';
 import { v4 as uuidv4 } from 'uuid';
 
-import { SchedulesProvider } from 'loot-core/client/data-hooks/schedules';
 import { SpreadsheetProvider } from 'loot-core/client/SpreadsheetProvider';
 import {
   generateTransaction,
@@ -33,6 +32,7 @@ import { TestProvider } from '../../redux/mock';
 
 import { TransactionTable } from './TransactionsTable';
 
+import { SchedulesProvider } from '@desktop-client/hooks/useCachedSchedules';
 import { SelectedProviderWithItems } from '@desktop-client/hooks/useSelected';
 import { SplitsExpandedProvider } from '@desktop-client/hooks/useSplitsExpanded';
 

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -43,7 +43,6 @@ import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 import { format as formatDate, parseISO } from 'date-fns';
 
-import { useCachedSchedules } from 'loot-core/client/data-hooks/schedules';
 import * as monthUtils from 'loot-core/shared/months';
 import {
   addSplitTransaction,
@@ -70,11 +69,6 @@ import {
   type TransactionEntity,
 } from 'loot-core/types/models';
 
-import { useContextMenu } from '../../hooks/useContextMenu';
-import { useDisplayPayee } from '../../hooks/useDisplayPayee';
-import { useMergedRefs } from '../../hooks/useMergedRefs';
-import { usePrevious } from '../../hooks/usePrevious';
-import { useProperFocus } from '../../hooks/useProperFocus';
 import { useSelectedDispatch, useSelectedItems } from '../../hooks/useSelected';
 import {
   type SplitsExpandedContextValue,
@@ -118,6 +112,12 @@ import { TransactionMenu } from './TransactionMenu';
 
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import { addNotification } from '@desktop-client/notifications/notificationsSlice';
+import { useCachedSchedules } from '@desktop-client/hooks/useCachedSchedules';
+import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
+import { useDisplayPayee } from '@desktop-client/hooks/useDisplayPayee';
+import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
+import { usePrevious } from '@desktop-client/hooks/usePrevious';
+import { useProperFocus } from '@desktop-client/hooks/useProperFocus';
 import {
   getAccountsById,
   getPayeesById,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -110,14 +110,14 @@ import {
 } from './table/utils';
 import { TransactionMenu } from './TransactionMenu';
 
-import { pushModal } from '@desktop-client/modals/modalsSlice';
-import { addNotification } from '@desktop-client/notifications/notificationsSlice';
 import { useCachedSchedules } from '@desktop-client/hooks/useCachedSchedules';
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
 import { useDisplayPayee } from '@desktop-client/hooks/useDisplayPayee';
 import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
 import { usePrevious } from '@desktop-client/hooks/usePrevious';
 import { useProperFocus } from '@desktop-client/hooks/useProperFocus';
+import { pushModal } from '@desktop-client/modals/modalsSlice';
+import { addNotification } from '@desktop-client/notifications/notificationsSlice';
 import {
   getAccountsById,
   getPayeesById,

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { Input } from '@actual-app/components/input';
 import { View } from '@actual-app/components/view';
 
-import { useReports } from 'loot-core/client/data-hooks/reports';
 import { getMonthYearFormat } from 'loot-core/shared/months';
 import { integerToAmount, amountToInteger } from 'loot-core/shared/util';
 
@@ -24,6 +23,7 @@ import { PercentInput } from './PercentInput';
 
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
+import { useReports } from '@desktop-client/hooks/useReports';
 
 export function GenericInput({
   field,

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react';
 
+import { accountBalance } from 'loot-core/client/queries';
+import { groupById } from 'loot-core/shared/util';
 import {
   type ScheduleEntity,
   type AccountEntity,
@@ -12,8 +14,6 @@ import { usePayees } from './usePayees';
 import { usePreviewTransactions } from './usePreviewTransactions';
 
 import { useSheetValue } from '@desktop-client/components/spreadsheet/useSheetValue';
-import { groupById } from 'loot-core/shared/util';
-import { accountBalance } from 'loot-core/client/queries';
 
 type UseAccountPreviewTransactionsProps = {
   accountId?: AccountEntity['id'] | undefined;

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -1,8 +1,5 @@
 import { useCallback, useMemo } from 'react';
 
-import { usePreviewTransactions } from 'loot-core/client/data-hooks/transactions';
-import { accountBalance } from 'loot-core/client/queries';
-import { groupById } from 'loot-core/shared/util';
 import {
   type ScheduleEntity,
   type AccountEntity,
@@ -12,8 +9,11 @@ import {
 
 import { useAccounts } from './useAccounts';
 import { usePayees } from './usePayees';
+import { usePreviewTransactions } from './usePreviewTransactions';
 
 import { useSheetValue } from '@desktop-client/components/spreadsheet/useSheetValue';
+import { groupById } from 'loot-core/shared/util';
+import { accountBalance } from 'loot-core/client/queries';
 
 type UseAccountPreviewTransactionsProps = {
   accountId?: AccountEntity['id'] | undefined;

--- a/packages/desktop-client/src/hooks/useCachedSchedules.tsx
+++ b/packages/desktop-client/src/hooks/useCachedSchedules.tsx
@@ -1,0 +1,40 @@
+import React, {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+} from 'react';
+
+import {
+  type UseSchedulesResult,
+  type UseSchedulesProps,
+  useSchedules,
+} from './useSchedules';
+
+type SchedulesContextValue = UseSchedulesResult;
+
+const SchedulesContext = createContext<SchedulesContextValue | undefined>(
+  undefined,
+);
+
+type SchedulesProviderProps = PropsWithChildren<{
+  query?: UseSchedulesProps['query'];
+}>;
+
+export function SchedulesProvider({ query, children }: SchedulesProviderProps) {
+  const data = useSchedules({ query });
+  return (
+    <SchedulesContext.Provider value={data}>
+      {children}
+    </SchedulesContext.Provider>
+  );
+}
+
+export function useCachedSchedules() {
+  const context = useContext(SchedulesContext);
+  if (!context) {
+    throw new Error(
+      'useCachedSchedules must be used within a SchedulesProvider',
+    );
+  }
+  return context;
+}

--- a/packages/desktop-client/src/hooks/useCategoryPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useCategoryPreviewTransactions.ts
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react';
 
-import { usePreviewTransactions } from 'loot-core/client/data-hooks/transactions';
 import { categoryBalance } from 'loot-core/client/queries';
 import * as monthUtils from 'loot-core/shared/months';
 import {
@@ -10,6 +9,7 @@ import {
 
 import { useCategory } from './useCategory';
 import { useCategoryScheduleGoalTemplates } from './useCategoryScheduleGoalTemplates';
+import { usePreviewTransactions } from './usePreviewTransactions';
 
 import { useSheetValue } from '@desktop-client/components/spreadsheet/useSheetValue';
 

--- a/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
+++ b/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 import { type TFunction } from 'i18next';
 
-import { type ScheduleStatusType } from 'loot-core/client/data-hooks/schedules';
 import * as monthUtils from 'loot-core/shared/months';
 import {
   type CategoryEntity,
@@ -12,6 +11,7 @@ import {
 
 import { useCategoryScheduleGoalTemplates } from './useCategoryScheduleGoalTemplates';
 import { useLocale } from './useLocale';
+import { type ScheduleStatusType } from './useSchedules';
 
 type UseCategoryScheduleGoalTemplateProps = {
   category: CategoryEntity;

--- a/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplates.ts
+++ b/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplates.ts
@@ -1,16 +1,16 @@
 import { useMemo } from 'react';
 
 import {
-  type ScheduleStatuses,
-  type ScheduleStatusLabels,
-  useCachedSchedules,
-} from 'loot-core/client/data-hooks/schedules';
-import {
   type ScheduleEntity,
   type CategoryEntity,
 } from 'loot-core/types/models';
 
+import { useCachedSchedules } from './useCachedSchedules';
 import { useFeatureFlag } from './useFeatureFlag';
+import {
+  type ScheduleStatuses,
+  type ScheduleStatusLabels,
+} from './useSchedules';
 
 type ScheduleGoalDefinition = {
   type: 'schedule';

--- a/packages/desktop-client/src/hooks/useDashboard.ts
+++ b/packages/desktop-client/src/hooks/useDashboard.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
-import { q } from '../../shared/query';
-import { type Widget } from '../../types/models';
-import { useQuery } from '../query-hooks';
+import { useQuery } from 'loot-core/client/query-hooks';
+import { q } from 'loot-core/shared/query';
+import { type Widget } from 'loot-core/types/models';
 
 export function useDashboard() {
   const { data: queryData, isLoading } = useQuery<Widget>(

--- a/packages/desktop-client/src/hooks/useDisplayPayee.ts
+++ b/packages/desktop-client/src/hooks/useDisplayPayee.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useTransactions } from 'loot-core/client/data-hooks/transactions';
 import { q } from 'loot-core/shared/query';
 import {
   type AccountEntity,
@@ -12,6 +11,7 @@ import {
 import { useAccounts } from './useAccounts';
 import { usePayee } from './usePayee';
 import { usePayees } from './usePayees';
+import { useTransactions } from './useTransactions';
 
 type Counts = {
   counts: Record<PayeeEntity['id'], number>;

--- a/packages/desktop-client/src/hooks/useReport.ts
+++ b/packages/desktop-client/src/hooks/useReport.ts
@@ -1,0 +1,15 @@
+import { useMemo } from 'react';
+
+import { useReports } from './useReports';
+
+export function useReport(id: string) {
+  const { data, isLoading } = useReports();
+
+  return useMemo(
+    () => ({
+      data: data.find(report => report.id === id),
+      isLoading,
+    }),
+    [data, id, isLoading],
+  );
+}

--- a/packages/desktop-client/src/hooks/useReports.ts
+++ b/packages/desktop-client/src/hooks/useReports.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 
-import { q } from '../../shared/query';
+import { useQuery } from 'loot-core/client/query-hooks';
+import { q } from 'loot-core/shared/query';
 import {
   type CustomReportData,
   type CustomReportEntity,
-} from '../../types/models';
-import { useQuery } from '../query-hooks';
+} from 'loot-core/types/models';
 
 function toJS(rows: CustomReportData[]) {
   const reports: CustomReportEntity[] = rows.map(row => {
@@ -60,13 +60,4 @@ export function useReports() {
     }),
     [isLoading, queryData],
   );
-}
-
-export function useReport(id: string) {
-  const { data, isLoading } = useReports();
-
-  return {
-    data: data.find(report => report.id === id),
-    isLoading,
-  };
 }

--- a/packages/desktop-client/src/hooks/useRuleConditionFilters.ts
+++ b/packages/desktop-client/src/hooks/useRuleConditionFilters.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { type RuleConditionEntity } from 'loot-core/types/models';
 
-export function useFilters<T extends RuleConditionEntity>(
+export function useRuleConditionFilters<T extends RuleConditionEntity>(
   initialConditions: T[] = [],
   initialConditionsOp: 'and' | 'or' = 'and',
 ) {

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -1,29 +1,20 @@
-// @ts-strict-ignore
-import React, {
-  createContext,
-  type PropsWithChildren,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useState, useRef, useEffect } from 'react';
 
-// eslint-disable-next-line no-restricted-imports -- fix me -- do not import @actual-app/web in loot-core
-import { useSyncedPref } from '@actual-app/web/src/hooks/useSyncedPref';
-
-import { q, type Query } from '../../shared/query';
+import { accountFilter } from 'loot-core/client/queries';
+import { liveQuery, type LiveQuery } from 'loot-core/client/query-helpers';
+import { q, type Query } from 'loot-core/shared/query';
 import {
-  getHasTransactionsQuery,
   getStatus,
   getStatusLabel,
-} from '../../shared/schedules';
-import {
-  type AccountEntity,
-  type ScheduleEntity,
-  type TransactionEntity,
-} from '../../types/models';
-import { accountFilter } from '../queries';
-import { type LiveQuery, liveQuery } from '../query-helpers';
+  getHasTransactionsQuery,
+} from 'loot-core/shared/schedules';
+import type {
+  AccountEntity,
+  ScheduleEntity,
+  TransactionEntity,
+} from 'loot-core/types/models';
+
+import { useSyncedPref } from './useSyncedPref';
 
 export type ScheduleStatusType = ReturnType<typeof getStatus>;
 export type ScheduleStatuses = Map<ScheduleEntity['id'], ScheduleStatusType>;
@@ -33,12 +24,11 @@ export type ScheduleStatusLabels = Map<
   ScheduleEntity['id'],
   ScheduleStatusLabelType
 >;
-
 function loadStatuses(
   schedules: readonly ScheduleEntity[],
   onData: (data: ScheduleStatuses) => void,
   onError: (error: Error) => void,
-  upcomingLength: string,
+  upcomingLength: string = '7',
 ) {
   return liveQuery<TransactionEntity>(getHasTransactionsQuery(schedules), {
     onData: data => {
@@ -61,8 +51,7 @@ function loadStatuses(
     onError,
   });
 }
-
-type UseSchedulesProps = {
+export type UseSchedulesProps = {
   query?: Query;
 };
 type ScheduleData = {
@@ -70,7 +59,7 @@ type ScheduleData = {
   statuses: ScheduleStatuses;
   statusLabels: ScheduleStatusLabels;
 };
-type UseSchedulesResult = ScheduleData & {
+export type UseSchedulesResult = ScheduleData & {
   readonly isLoading: boolean;
   readonly error?: Error;
 };
@@ -126,7 +115,7 @@ export function useSchedules({
                 statusLabels: new Map(
                   [...statuses.keys()].map(key => [
                     key,
-                    getStatusLabel(statuses.get(key)),
+                    getStatusLabel(statuses.get(key) || ''),
                   ]),
                 ),
               });
@@ -153,36 +142,6 @@ export function useSchedules({
     ...data,
   };
 }
-
-type SchedulesContextValue = UseSchedulesResult;
-
-const SchedulesContext = createContext<SchedulesContextValue | undefined>(
-  undefined,
-);
-
-type SchedulesProviderProps = PropsWithChildren<{
-  query?: UseSchedulesProps['query'];
-}>;
-
-export function SchedulesProvider({ query, children }: SchedulesProviderProps) {
-  const data = useSchedules({ query });
-  return (
-    <SchedulesContext.Provider value={data}>
-      {children}
-    </SchedulesContext.Provider>
-  );
-}
-
-export function useCachedSchedules() {
-  const context = useContext(SchedulesContext);
-  if (!context) {
-    throw new Error(
-      'useCachedSchedules must be used within a SchedulesProvider',
-    );
-  }
-  return context;
-}
-
 export function accountSchedulesQuery(
   accountId?: AccountEntity['id'] | 'onbudget' | 'offbudget' | 'uncategorized',
 ) {

--- a/packages/desktop-client/src/hooks/useTransactionFilters.ts
+++ b/packages/desktop-client/src/hooks/useTransactionFilters.ts
@@ -1,9 +1,9 @@
 // @ts-strict-ignore
 import { useMemo } from 'react';
 
-import { q } from '../../shared/query';
-import { type TransactionFilterEntity } from '../../types/models';
-import { useQuery } from '../query-hooks';
+import { useQuery } from 'loot-core/client/query-hooks';
+import { q } from 'loot-core/shared/query';
+import { type TransactionFilterEntity } from 'loot-core/types/models';
 
 function toJS(rows): TransactionFilterEntity[] {
   const filters = rows.map(row => {
@@ -19,7 +19,7 @@ function toJS(rows): TransactionFilterEntity[] {
   return filters;
 }
 
-export function useFilters(): TransactionFilterEntity[] {
+export function useTransactionFilters(): TransactionFilterEntity[] {
   const { data } = useQuery<TransactionFilterEntity>(
     () => q('transaction_filters').select('*'),
     [],

--- a/packages/desktop-client/src/hooks/useTransactions.ts
+++ b/packages/desktop-client/src/hooks/useTransactions.ts
@@ -1,0 +1,114 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+import { type PagedQuery, pagedQuery } from 'loot-core/client/query-helpers';
+import type { Query } from 'loot-core/shared/query';
+import type { TransactionEntity } from 'loot-core/types/models';
+
+type UseTransactionsProps = {
+  /**
+   * The Query class is immutable so it is important to memoize the query object
+   * to prevent unnecessary re-renders i.e. `useMemo`, `useState`, etc.
+   */
+  query?: Query;
+  options?: {
+    pageCount?: number;
+  };
+};
+type UseTransactionsResult = {
+  transactions: ReadonlyArray<TransactionEntity>;
+  isLoading: boolean;
+  error?: Error;
+  reload: () => void;
+  loadMore: () => void;
+  isLoadingMore: boolean;
+};
+
+export function useTransactions({
+  query,
+  options = { pageCount: 50 },
+}: UseTransactionsProps): UseTransactionsResult {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [transactions, setTransactions] = useState<
+    ReadonlyArray<TransactionEntity>
+  >([]);
+
+  const pagedQueryRef = useRef<PagedQuery<TransactionEntity> | null>(null);
+
+  // We don't want to re-render if options changes.
+  // Putting options in a ref will prevent that and
+  // allow us to use the latest options on next render.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    let isUnmounted = false;
+
+    setError(undefined);
+
+    if (!query) {
+      return;
+    }
+
+    function onError(error: Error) {
+      if (!isUnmounted) {
+        setError(error);
+        setIsLoading(false);
+      }
+    }
+
+    if (query.state.table !== 'transactions') {
+      onError(new Error('Query must be a transactions query.'));
+      return;
+    }
+
+    setIsLoading(true);
+
+    pagedQueryRef.current = pagedQuery<TransactionEntity>(query, {
+      onData: data => {
+        if (!isUnmounted) {
+          setTransactions(data);
+          setIsLoading(false);
+        }
+      },
+      onError,
+      options: optionsRef.current.pageCount
+        ? { pageCount: optionsRef.current.pageCount }
+        : {},
+    });
+
+    return () => {
+      isUnmounted = true;
+      pagedQueryRef.current?.unsubscribe();
+    };
+  }, [query]);
+
+  const loadMore = useCallback(async () => {
+    if (!pagedQueryRef.current) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+
+    await pagedQueryRef.current
+      .fetchNext()
+      .catch(setError)
+      .finally(() => {
+        setIsLoadingMore(false);
+      });
+  }, []);
+
+  const reload = useCallback(() => {
+    pagedQueryRef.current?.run();
+  }, []);
+
+  return {
+    transactions,
+    isLoading,
+    ...(error && { error }),
+    reload,
+    loadMore,
+    isLoadingMore,
+  };
+}

--- a/packages/desktop-client/src/hooks/useTransactionsSearch.ts
+++ b/packages/desktop-client/src/hooks/useTransactionsSearch.ts
@@ -1,0 +1,52 @@
+import { useState, useMemo, useEffect } from 'react';
+
+import { debounce } from 'lodash';
+
+import * as queries from 'loot-core/client/queries';
+import type { Query } from 'loot-core/shared/query';
+
+type UseTransactionsSearchProps = {
+  updateQuery: (updateFn: (searchQuery: Query) => Query) => void;
+  resetQuery: () => void;
+  dateFormat: string;
+  delayMs?: number;
+};
+type UseTransactionsSearchResult = {
+  isSearching: boolean;
+  search: (searchText: string) => void;
+};
+
+export function useTransactionsSearch({
+  updateQuery,
+  resetQuery,
+  dateFormat,
+  delayMs = 150,
+}: UseTransactionsSearchProps): UseTransactionsSearchResult {
+  const [isSearching, setIsSearching] = useState(false);
+
+  const updateSearchQuery = useMemo(
+    () =>
+      debounce((searchText: string) => {
+        if (searchText === '') {
+          resetQuery();
+          setIsSearching(false);
+        } else if (searchText) {
+          resetQuery();
+          updateQuery(previousQuery =>
+            queries.transactionsSearch(previousQuery, searchText, dateFormat),
+          );
+          setIsSearching(true);
+        }
+      }, delayMs),
+    [dateFormat, delayMs, resetQuery, updateQuery],
+  );
+
+  useEffect(() => {
+    return () => updateSearchQuery.cancel();
+  }, [updateSearchQuery]);
+
+  return {
+    isSearching,
+    search: updateSearchQuery,
+  };
+}

--- a/packages/desktop-client/src/hooks/useWidget.ts
+++ b/packages/desktop-client/src/hooks/useWidget.ts
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 
-import { q } from '../../shared/query';
-import { type Widget } from '../../types/models';
-import { useQuery } from '../query-hooks';
+import { useQuery } from 'loot-core/client/query-hooks';
+import { q } from 'loot-core/shared/query';
+import { type Widget } from 'loot-core/types/models';
 
 export function useWidget<W extends Widget>(id: W['id'], type: W['type']) {
   const { data = [], isLoading } = useQuery<W>(

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -22,6 +22,7 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
+import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/desktop-client/src/index.tsx
+++ b/packages/desktop-client/src/index.tsx
@@ -22,7 +22,6 @@ import * as accountsSlice from './accounts/accountsSlice';
 import * as appSlice from './app/appSlice';
 import { AuthProvider } from './auth/AuthProvider';
 import * as budgetsSlice from './budgets/budgetsSlice';
-import * as modalsSlice from './modals/modalsSlice';
 // See https://github.com/WICG/focus-visible. Only makes the blue
 // focus outline appear from keyboard events.
 import 'focus-visible';

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -12,7 +12,7 @@ export function getStatus(
   nextDate: string,
   completed: boolean,
   hasTrans: boolean,
-  upcomingLength: string,
+  upcomingLength: string = '7',
 ) {
   const upcomingDays = getUpcomingDays(upcomingLength);
   const today = monthUtils.currentDay();

--- a/upcoming-release-notes/4828.md
+++ b/upcoming-release-notes/4828.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [joel-jeremy]
+---
+
+Move loot-core/client/data-hooks over to desktop-client package


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
The original reason this was designed this way it to share the code with a mobile app. But since we no longer have a mobile app, these codes can now be merged to `desktop-client` package.

- [x] accounts folder
- [x] app folder
- [x] budgets folder
- [x] modals folder
- [x] notifications folder
- [x] prefs folder
- [x] queries folder
- [x] users folder
- [x] data-hooks folder
- [x] store folder
- [ ] files under root `loot-core/client` folder

There will be some suppressed import warning due to loot-core importing some desktop-client files but this is only temporary until we migrate all the files 

# Changes done:
1. Break-up files under `data-hooks` folder into one file per hook i.e.
  - `useSchedules`
  - `useCachedSchedules`
  - `useTransactions`
  - `usePreviewTransactions`
  - `useTransactionsSearch`
  - `useTransactionFilters` <-- **Renamed from useFilters**
  - `useDashboard`
  - `useWidget`
  - `useReports`
  - `useReport`
2. Move the new files to `desktop-client/src/hooks` (vscode handles updating of imports)
3. Renamed `desktop-client/src/hooks/useFilters` to `useRuleConditionFilters` to disambiguate from the `useFilters` from `loot-core/client/data-hooks`
4. Run `yarn lint:fix`