### PR TITLE
Revert "Reload on all redirects to handle Cloudflare Access auth expiration"

### DIFF
--- a/packages/loot-core/src/platform/server/fetch/index.ts
+++ b/packages/loot-core/src/platform/server/fetch/index.ts
@@ -2,18 +2,17 @@ import * as connection from '../connection';
 
 export const fetch = async (
   input: RequestInfo | URL,
-  options: RequestInit = {},
+  options?: RequestInit,
 ): Promise<Response> => {
-  // Set redirect to manual so that we can detect and respond to redirects.
-  if (!options.redirect) options.redirect = 'manual';
-
   const response = await globalThis.fetch(input, options);
 
-  // Authentication proxies redirect when authentication has expired. In this case,
-  // we want to fully reload and yeild control from the service worker back to the server.
-  if (response.type === 'opaqueredirect') {
+  // Detect if the API query has been redirected to a different origin. This may indicate that the
+  // request has been intercepted by an authentication proxy
+  const originalUrl = new URL(input instanceof Request ? input.url : input);
+  const responseUrl = new URL(response.url);
+  if (response.redirected && responseUrl.host !== originalUrl.host) {
     connection.send('api-fetch-redirected');
-    throw new Error(`API request redirected`);
+    throw new Error(`API request redirected to ${responseUrl.host}`);
   }
 
   return response;

--- a/upcoming-release-notes/4706.md
+++ b/upcoming-release-notes/4706.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [rgoldfinger]
----
-
-Reload on all redirects to handle Cloudflare Access expiration. This fixes issue #4422


### PR DESCRIPTION
Reverts actualbudget/actual#4706

#4706 may be incompatible with [this line](https://github.com/actualbudget/actual/blob/master/packages/sync-server/src/app-openid.js#L105). Reverting to investigate.