### PR TITLE
fix: commerzbank escape payee

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/commerzbank_cobadeff.js
+++ b/packages/sync-server/src/app-gocardless/banks/commerzbank_cobadeff.js
@@ -1,4 +1,5 @@
 import Fallback from './integration-bank.js';
+import { escapeRegExp } from './util/escape-regexp.js';
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -38,7 +39,9 @@ export default {
     // Clean up remittanceInformation, deduplicate payee (removing slashes ...
     // ... that are added to the remittanceInformation field), and ...
     // ... remove clutter like "End-to-End-Ref.: NOTPROVIDED"
-    const payee = transaction.creditorName || transaction.debtorName || '';
+    const payee = escapeRegExp(
+      transaction.creditorName || transaction.debtorName || '',
+    );
     editedTrans.remittanceInformationUnstructured =
       editedTrans.remittanceInformationUnstructured
         .replace(/\s*(,)?\s+/g, '$1 ')

--- a/packages/sync-server/src/app-gocardless/banks/tests/commerzbank_cobadeff.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/commerzbank_cobadeff.spec.js
@@ -106,5 +106,28 @@ describe('CommerzbankCobadeff', () => {
         'CREDITOR00BIC CREDITOR000IBAN DESCRIPTION, Dauerauftrag',
       );
     });
+
+    it('correctly uses regex on payee with special characters', () => {
+      const transaction = {
+        endToEndId: '1234567890',
+        mandateId: '1234567890',
+        bookingDate: '2025-04-18',
+        valueDate: '2025-04-18',
+        transactionAmount: {
+          amount: '-1',
+          currency: 'EUR',
+        },
+        creditorName: 'Netto Marken-Discount Halle (Saale',
+        remittanceInformationUnstructured: 'Example',
+        remittanceInformationUnstructuredArray: ['Example'],
+        remittanceInformationStructured: 'Example',
+        // internalTransactionId: '3815213adb654baeadfb231c853',
+      };
+      const normalizedTransaction = CommerzbankCobadeff.normalizeTransaction(
+        transaction,
+        false,
+      );
+      expect(normalizedTransaction.notes).toEqual('Example');
+    });
   });
 });

--- a/packages/sync-server/src/app-gocardless/banks/util/escape-regexp.js
+++ b/packages/sync-server/src/app-gocardless/banks/util/escape-regexp.js
@@ -1,0 +1,4 @@
+// Escape special characters in the string to create a valid regular expression
+export function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/upcoming-release-notes/4845.md
+++ b/upcoming-release-notes/4845.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [misu-dev]
+---
+
+Escape Payee for Commerzbank RegExp


### PR DESCRIPTION
This should fix the Issue #4788. Now the Payee is escaped, so that the regular expression can work