### PR TITLE
:electron: Prep for configure server page

### DIFF
--- a/packages/desktop-client/src/browser-preload.browser.js
+++ b/packages/desktop-client/src/browser-preload.browser.js
@@ -86,6 +86,12 @@ global.Actual = {
       });
   },
 
+  startSyncServer: () => {},
+
+  stopSyncServer: () => {},
+
+  isSyncServerRunning: () => false,
+
   startOAuthServer: () => {
     return '';
   },

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -311,9 +311,9 @@ async function startSyncServer() {
 }
 
 async function stopSyncServer() {
-  logMessage('info', 'Stopping sync server...');
   syncServerProcess?.kill();
   syncServerProcess = null;
+  logMessage('info', 'Sync-Server: Stopped');
 }
 
 async function createWindow() {

--- a/packages/desktop-electron/preload.ts
+++ b/packages/desktop-electron/preload.ts
@@ -29,6 +29,12 @@ contextBridge.exposeInMainWorld('Actual', {
     });
   },
 
+  startSyncServer: () => ipcRenderer.invoke('start-sync-server'),
+
+  stopSyncServer: () => ipcRenderer.invoke('stop-sync-server'),
+
+  isSyncServerRunning: () => ipcRenderer.invoke('is-sync-server-running'),
+
   startOAuthServer: () => ipcRenderer.invoke('start-oauth-server'),
 
   relaunch: () => {

--- a/packages/loot-core/src/platform/server/asyncStorage/__mocks__/index.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/__mocks__/index.ts
@@ -20,14 +20,19 @@ export const removeItem: T.RemoveItem = async function (key) {
 
 export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
   keys: K,
-) {
-  return new Promise(function (resolve) {
-    return resolve(
-      keys.map(function (key) {
-        return [key, store[key]];
-      }) as { [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]] },
-    );
-  });
+): Promise<{ [P in K[number]]: GlobalPrefsJson[P] }> {
+  const results = keys.map(key => [key, store[key]]) as {
+    [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]];
+  };
+
+  // Convert the array of tuples to an object with properly typed properties
+  return results.reduce(
+    (acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    },
+    {} as { [P in K[number]]: GlobalPrefsJson[P] },
+  );
 }
 
 export const multiSet: T.MultiSet = async function (keyValues) {

--- a/packages/loot-core/src/platform/server/asyncStorage/index.d.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.d.ts
@@ -21,7 +21,8 @@ export type RemoveItem = typeof removeItem;
 
 export function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
   keys: K,
-): Promise<{ [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]] }>;
+): Promise<{ [P in K[number]]: GlobalPrefsJson[P] }>;
+
 export type MultiGet = typeof multiGet;
 
 export function multiSet<K extends keyof GlobalPrefsJson>(

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -58,10 +58,19 @@ export const removeItem: T.RemoveItem = function (key) {
 
 export async function multiGet<K extends readonly (keyof GlobalPrefsJson)[]>(
   keys: K,
-) {
-  return keys.map(key => [key, store[key]]) as {
+): Promise<{ [P in K[number]]: GlobalPrefsJson[P] }> {
+  const results = keys.map(key => [key, store[key]]) as {
     [P in keyof K]: [K[P], GlobalPrefsJson[K[P]]];
   };
+
+  // Convert the array of tuples to an object with properly typed properties
+  return results.reduce(
+    (acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    },
+    {} as { [P in K[number]]: GlobalPrefsJson[P] },
+  );
 }
 
 export const multiSet: T.MultiSet = function (keyValues) {

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -883,10 +883,8 @@ async function accountsBankSync({
 }: {
   ids: Array<AccountEntity['id']>;
 }): Promise<SyncResponseWithErrors> {
-  const [[, userId], [, userKey]] = await asyncStorage.multiGet([
-    'user-id',
-    'user-key',
-  ]);
+  const { 'user-id': userId, 'user-key': userKey } =
+    await asyncStorage.multiGet(['user-id', 'user-key']);
 
   const accounts = await db.runQuery<
     db.DbAccount & { bankId: db.DbBank['bank_id'] }

--- a/packages/loot-core/src/server/preferences/app.ts
+++ b/packages/loot-core/src/server/preferences/app.ts
@@ -99,21 +99,25 @@ async function saveGlobalPrefs(prefs: GlobalPrefs) {
       prefs.serverSelfSignedCert,
     );
   }
+  if (prefs.syncServerConfig !== undefined) {
+    await asyncStorage.setItem('syncServerConfig', prefs.syncServerConfig);
+  }
   return 'ok';
 }
 
 async function loadGlobalPrefs(): Promise<GlobalPrefs> {
-  const [
-    [, floatingSidebar],
-    [, categoryExpandedState],
-    [, maxMonths],
-    [, documentDir],
-    [, encryptKey],
-    [, language],
-    [, theme],
-    [, preferredDarkTheme],
-    [, serverSelfSignedCert],
-  ] = await asyncStorage.multiGet([
+  const {
+    'floating-sidebar': floatingSidebar,
+    'category-expanded-state': categoryExpandedState,
+    'max-months': maxMonths,
+    'document-dir': documentDir,
+    'encrypt-key': encryptKey,
+    language,
+    theme,
+    'preferred-dark-theme': preferredDarkTheme,
+    'server-self-signed-cert': serverSelfSignedCert,
+    syncServerConfig,
+  } = await asyncStorage.multiGet([
     'floating-sidebar',
     'category-expanded-state',
     'max-months',
@@ -123,6 +127,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
     'theme',
     'preferred-dark-theme',
     'server-self-signed-cert',
+    'syncServerConfig',
   ] as const);
   return {
     floatingSidebar: floatingSidebar === 'true',
@@ -144,6 +149,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
         ? preferredDarkTheme
         : 'dark',
     serverSelfSignedCert: serverSelfSignedCert || undefined,
+    syncServerConfig: syncServerConfig || undefined,
   };
 }
 

--- a/packages/loot-core/typings/window.d.ts
+++ b/packages/loot-core/typings/window.d.ts
@@ -29,6 +29,9 @@ type Actual = {
   ) => void;
   isUpdateReadyForDownload: () => boolean;
   waitForUpdateReadyForDownload: () => Promise<void>;
+  startSyncServer: () => Promise<void>;
+  stopSyncServer: () => Promise<void>;
+  isSyncServerRunning: () => Promise<boolean>;
   startOAuthServer: () => Promise<string>;
 };
 

--- a/upcoming-release-notes/4847.md
+++ b/upcoming-release-notes/4847.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Allowing the UI to call internal sync server commands when running in the Desktop app


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Exposing some functions to allow the Electron UI to perform the following actions: 
- Start sync server
- Stop sync server
- Get sync server running status

I've also updated the multiGet to be type safe - it was typing everything as string values.

![woot](https://github.com/user-attachments/assets/c6b95509-5252-40de-87b2-894d41fa515b)
