### PR TITLE
:electron: Fix Load Backup backup modal

### DIFF
--- a/packages/desktop-electron/menu.ts
+++ b/packages/desktop-electron/menu.ts
@@ -16,7 +16,7 @@ export function getMenu(
             if (focusedWindow && budgetId) {
               if (focusedWindow.webContents.getTitle() === 'Actual') {
                 focusedWindow.webContents.executeJavaScript(
-                  `__actionsForMenu.replaceModal('load-backup', { budgetId: '${budgetId}' })`,
+                  `__actionsForMenu.replaceModal({ modal: { name: 'load-backup', options: { budgetId: '${budgetId}' } } })`,
                 );
               }
             }

--- a/upcoming-release-notes/4853.md
+++ b/upcoming-release-notes/4853.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix load backup modal giving a blank screen when opened in the desktop app


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes load backup modal not triggered correctly, resulting in a blank screen.

Reported on Discord: https://discord.com/channels/937901803608096828/1361876081405071421/1361876081405071421

Related to: https://github.com/actualbudget/actual/issues/4703