### PR TITLE
Stabilize electron build directory paths

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -32,12 +32,14 @@ import {
 
 import './security';
 
+const BUILD_ROOT = `${__dirname}/..`;
+
 const isPlaywrightTest = process.env.EXECUTION_CONTEXT === 'playwright';
 const isDev = !isPlaywrightTest && !app.isPackaged; // dev mode if not packaged and not playwright
 
 process.env.lootCoreScript = isDev
   ? 'loot-core/lib-dist/electron/bundle.desktop.js' // serve from local output in development (provides hot-reloading)
-  : path.resolve(__dirname, 'loot-core/lib-dist/electron/bundle.desktop.js'); // serve from build in production
+  : path.resolve(BUILD_ROOT, 'loot-core/lib-dist/electron/bundle.desktop.js'); // serve from build in production
 
 // This allows relative URLs to be resolved to app:// which makes
 // local assets load correctly
@@ -487,13 +489,13 @@ app.on('ready', async () => {
 
     const pathname = parsedUrl.pathname;
 
-    let filePath = path.normalize(`${__dirname}/client-build/index.html`); // default web path
+    let filePath = path.normalize(`${BUILD_ROOT}/client-build/index.html`); // default web path
 
     if (pathname.startsWith('/static')) {
       // static assets
-      filePath = path.normalize(`${__dirname}/client-build${pathname}`);
+      filePath = path.normalize(`${BUILD_ROOT}/client-build${pathname}`);
       const resolvedPath = path.resolve(filePath);
-      const clientBuildPath = path.resolve(__dirname, 'client-build');
+      const clientBuildPath = path.resolve(BUILD_ROOT, 'client-build');
 
       // Ensure filePath is within client-build directory - prevents directory traversal vulnerability
       if (!resolvedPath.startsWith(clientBuildPath)) {

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -9,11 +9,11 @@
     "update-client": "bin/update-client",
     "build": "yarn build:dist && electron-builder",
     "build:dist": "tsc --p tsconfig.dist.json && yarn copy-static-assets",
-    "copy-static-assets": "copyfiles --exclude 'build/**/*' **/*.html icons/**/* build",
+    "copy-static-assets": "copyfiles --exclude 'build/**/*' **/*.html icons/**/* build/desktop-electron",
     "watch": "yarn build:dist && cross-env ACTUAL_DOCUMENT_DIR=\"../../data\" ACTUAL_DATA_DIR=\"../../data\" electron .",
     "e2e": "npx playwright test"
   },
-  "main": "build/index.js",
+  "main": "build/desktop-electron/index.js",
   "build": {
     "appId": "com.actualbudget.actual",
     "files": [
@@ -27,7 +27,7 @@
       "!build/client-build/sql-wasm.wasm",
       "!build/loot-core/lib-dist/electron/{browser,bundle.mobile*}"
     ],
-    "beforePack": "./build/beforePackHook.js",
+    "beforePack": "./build/desktop-electron/beforePackHook.js",
     "mac": {
       "category": "public.app-category.finance",
       "icon": "icons/icon.icns",

--- a/packages/desktop-electron/tsconfig.dist.json
+++ b/packages/desktop-electron/tsconfig.dist.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node10",
     "noEmit": false,
     "declaration": true,
-    "outDir": "build"
+    "outDir": "build",
+    "rootDir": ".."
   },
   "include": ["."],
   "exclude": ["**/node_modules/*", "build/**/*", "e2e/**/*"]

--- a/upcoming-release-notes/4864.md
+++ b/upcoming-release-notes/4864.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Stabilize electron build directory paths


### PR DESCRIPTION
I noticed as part of https://github.com/actualbudget/actual/pull/4862 that pulling in any `.ts` file to `desktop-electron` causes the directory structure in `packages/desktop-electron/build/` to change (to having one subdirectory per package), resulting in broken Electron artifacts. This PR aims to fix that issue.