### PR TITLE
Load backup not working electron

### DIFF
--- a/packages/desktop-electron/menu.ts
+++ b/packages/desktop-electron/menu.ts
@@ -16,7 +16,7 @@ export function getMenu(
             if (focusedWindow && budgetId) {
               if (focusedWindow.webContents.getTitle() === 'Actual') {
                 focusedWindow.webContents.executeJavaScript(
-                  `__actionsForMenu.replaceModal('load-backup', { budgetId: '${budgetId}' })`,
+                  `__actionsForMenu.replaceModal({modal:{name:'load-backup'},options:{budgetId:'${budgetId}'}})`,
                 );
               }
             }

--- a/upcoming-release-notes/4865.md
+++ b/upcoming-release-notes/4865.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed issue where File > Load Budget didn't work on Electron app


### PR DESCRIPTION
Resolves #4858

Picture of functioning load backup screen:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/9d027928-277a-4e53-b6df-fcbb394ccd71" />

Tried to improve typing but that involves adding imports which breaks the build
