### PR TITLE
[Mobile] Fix uncategorized transactions banner on tracking budgets

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -525,7 +525,9 @@ function OverbudgetedBanner({ month, onBudgetAction, ...props }) {
     t,
   ]);
 
-  if (!toBudgetAmount || toBudgetAmount >= 0) {
+  const [budgetType = 'rollover'] = useSyncedPref('budgetType');
+
+  if (budgetType !== 'rollover' || !toBudgetAmount || toBudgetAmount >= 0) {
     return null;
   }
 
@@ -751,7 +753,9 @@ function OverspendingBanner({ month, onBudgetAction, ...props }) {
     previousNumberOfOverspentCategories,
   ]);
 
-  if (numberOfOverspentCategories === 0) {
+  const [budgetType = 'rollover'] = useSyncedPref('budgetType');
+
+  if (budgetType !== 'rollover' || numberOfOverspentCategories === 0) {
     return null;
   }
 
@@ -790,12 +794,6 @@ function OverspendingBanner({ month, onBudgetAction, ...props }) {
 
 function Banners({ month, onBudgetAction }) {
   const { t } = useTranslation();
-  const [budgetType = 'rollover'] = useSyncedPref('budgetType');
-
-  // Limit to rollover for now.
-  if (budgetType !== 'rollover') {
-    return null;
-  }
 
   return (
     <GridList

--- a/upcoming-release-notes/4874.md
+++ b/upcoming-release-notes/4874.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+[Mobile] Fix uncategorized transactions banner on tracking budgets


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Resolves #4849