### PR TITLE
fix(template): update `up to` logic to handle future months

### DIFF
--- a/packages/loot-core/src/server/budget/categoryTemplate.ts
+++ b/packages/loot-core/src/server/budget/categoryTemplate.ts
@@ -49,10 +49,17 @@ export class CategoryTemplate {
       `carryover-${category.id}`,
     );
     let fromLastMonth;
+    const isFutureMonth =
+      monthUtils.differenceInCalendarMonths(month, monthUtils.currentMonth()) >
+      0;
+    const isSingleSimpleTemplate =
+      templates.length === 1 && templates[0].type === 'simple';
     if (lastMonthBalance < 0 && !carryover) {
       fromLastMonth = 0;
     } else if (category.is_income) {
       //for tracking budget
+      fromLastMonth = 0;
+    } else if (isFutureMonth && isSingleSimpleTemplate) {
       fromLastMonth = 0;
     } else {
       fromLastMonth = lastMonthBalance;

--- a/upcoming-release-notes/4877.md
+++ b/upcoming-release-notes/4877.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kopach]
+---
+
+fix(template): update `up to` logic to handle future months


### PR DESCRIPTION
Fixes `#template up to <amount>` logic to ignore future month balances when applying templates, enabling accurate forward budgeting as discussed in: https://discord.com/channels/937901803608096828/1364159049553281109

**Context**

Previously, `#template up to` would incorrectly consider the category balance when budgeting future months — causing potential underfunding when previous months would be used up fully.


**Fix**

This PR adjusts the behavior of `#template up to`:

- **Current month budgeting**: no changes, still respects the actual balance (for refill behavior).
- **Future months budgeting**: ignores balance entirely, assuming it to be 0, enabling consistent monthly assignments regardless of rollovers.
  
This behavior now matches YNAB’s **“Refill up to”** approach and allows users to simulate a worst-case scenario of no carry over — essential forward budgeting, aka **financial cushion**