### PR TITLE
Split transactions repair tool to remove categories from parent transactions + prevent adding/updating parent transactions with categories

### DIFF
--- a/packages/desktop-client/src/components/settings/RepairTransactions.tsx
+++ b/packages/desktop-client/src/components/settings/RepairTransactions.tsx
@@ -25,6 +25,7 @@ function useRenderResults() {
       numTransfersFixed,
       mismatchedSplits,
       numNonParentErrorsFixed,
+      numParentTransactionsWithCategoryFixed,
     } = results;
     const result: string[] = [];
 
@@ -34,7 +35,8 @@ function useRenderResults() {
       numDeleted === 0 &&
       numTransfersFixed === 0 &&
       numNonParentErrorsFixed === 0 &&
-      mismatchedSplits.length === 0
+      mismatchedSplits.length === 0 &&
+      numParentTransactionsWithCategoryFixed === 0
     ) {
       result.push(t('No split transactions found needing repair.'));
     } else {
@@ -83,6 +85,13 @@ function useRenderResults() {
             'Found {{count}} split transactions with mismatched amounts on the below dates. Please review them manually:',
             { count: mismatchedSplits.length },
           ) + `\n${mismatchedSplitInfo}`,
+        );
+      }
+      if (numParentTransactionsWithCategoryFixed > 0) {
+        result.push(
+          t('Fixed {{count}} split transactions with non-null category.', {
+            count: numParentTransactionsWithCategoryFixed,
+          }),
         );
       }
     }
@@ -169,6 +178,10 @@ export function RepairTransactions() {
           <li>
             Check if you have any budget transfers that erroneous contain a
             category, and remove the category.
+          </li>
+          <li>
+            Checks for any parent transactions with a category and removes the
+            category if found.
           </li>
         </ul>
       </Trans>

--- a/packages/loot-core/src/server/tools/app.ts
+++ b/packages/loot-core/src/server/tools/app.ts
@@ -125,14 +125,19 @@ async function fixSplitTransactions(): Promise<{
   });
 
   // 7. Clear categories of parent transactions
-  const parentTransactionsWithCategory = await db.all<Pick<db.DbViewTransactionInternal, 'id'>>(`
+  const parentTransactionsWithCategory = await db.all<
+    Pick<db.DbViewTransactionInternal, 'id'>
+  >(`
     SELECT id FROM transactions WHERE isParent = 1 AND category IS NOT NULL
   `);
 
   console.log('parentTransactionsWithCategory', parentTransactionsWithCategory);
 
   await runMutator(async () => {
-    const updated = parentTransactionsWithCategory.map(({ id }) => ({ id, category: null }));
+    const updated = parentTransactionsWithCategory.map(({ id }) => ({
+      id,
+      category: null,
+    }));
     await batchUpdateTransactions({ updated });
   });
 
@@ -142,7 +147,8 @@ async function fixSplitTransactions(): Promise<{
     numDeleted: deletedRows.length,
     numTransfersFixed: brokenTransfers.length,
     numNonParentErrorsFixed: errorRows.length,
-    numParentTransactionsWithCategoryFixed: parentTransactionsWithCategory.length,
+    numParentTransactionsWithCategoryFixed:
+      parentTransactionsWithCategory.length,
     mismatchedSplits,
   };
 }

--- a/packages/loot-core/src/server/tools/app.ts
+++ b/packages/loot-core/src/server/tools/app.ts
@@ -131,8 +131,6 @@ async function fixSplitTransactions(): Promise<{
     SELECT id FROM transactions WHERE isParent = 1 AND category IS NOT NULL
   `);
 
-  console.log('parentTransactionsWithCategory', parentTransactionsWithCategory);
-
   await runMutator(async () => {
     const updated = parentTransactionsWithCategory.map(({ id }) => ({
       id,

--- a/packages/loot-core/src/server/transactions/index.ts
+++ b/packages/loot-core/src/server/transactions/index.ts
@@ -81,8 +81,9 @@ export async function batchUpdateTransactions({
     if (added) {
       addedIds = await Promise.all(
         added.map(async t => {
+          // Offbudget account transactions and parent transactions should not have categories.
           const account = accounts.find(acct => acct.id === t.account);
-          if (account.offbudget === 1) {
+          if (t.is_parent || account.offbudget === 1) {
             t.category = null;
           }
           return db.insertTransaction(t);
@@ -107,9 +108,9 @@ export async function batchUpdateTransactions({
         updated.map(async t => {
           if (t.account) {
             // Moving transactions off budget should always clear the
-            // category
+            // category. Parent transactions should not have categories.
             const account = accounts.find(acct => acct.id === t.account);
-            if (account.offbudget === 1) {
+            if (t.is_parent || account.offbudget === 1) {
               t.category = null;
             }
           }

--- a/upcoming-release-notes/4889.md
+++ b/upcoming-release-notes/4889.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Add a functionality to split transactions repair tool to remove categories from parent transactions and prevent adding/update parent transactions with categories


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
This fixes an issue where an existing parent transaction is still set to a category and you cannot delete the category due to it being used by a parent transaction - **this is not obvious and you cannot see this in UI because we don't show category for parent transactions**. This tool removes those categories from parent transactions so users can delete.

Without this tool, the way to fix the issue it to:
1. Find which parent transaction is using the category you want to delete (by exporting the DB and querying)
2. Recreate the split transaction and make sure parent transaction is not set to any category (best to not set category before splitting)
3. Delete the original split transaction
4. Delete the category

This PR will also prevent future split transactions from setting the category on any parent transactions.