### PR TITLE
Replacing Actuator with our own implementation

### DIFF
--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -37,7 +37,6 @@
     "date-fns": "^2.30.0",
     "debug": "^4.4.0",
     "express": "4.21.2",
-    "express-actuator": "1.8.4",
     "express-rate-limit": "^7.5.0",
     "express-response-size": "^0.0.3",
     "express-winston": "^4.2.0",

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -1,4 +1,6 @@
-import fs from 'node:fs';
+import fs, { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -65,6 +67,20 @@ app.use('/openid', openidApp.handlers);
 
 app.get('/mode', (req, res) => {
   res.send(config.get('mode'));
+});
+
+app.get('/info', (req, res) => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = resolve(__dirname, '../package.json');
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  res.status(200).json({
+    build: {
+      name: packageJson.name,
+      description: packageJson.description,
+      version: packageJson.version,
+    },
+    git: {},
+  });
 });
 
 app.use(actuator()); // Provides /health, /metrics, /info

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -1,7 +1,5 @@
 import { createRequire } from 'module';
 import fs, { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import bodyParser from 'body-parser';
 import cors from 'cors';

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -78,7 +78,7 @@ app.get('/info', (_req, res) => {
     build: {
       name: packageJson.name,
       description: packageJson.description,
-      version: process.env.npm_package_version,
+      version: packageJson.version,
     },
   });
 });

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -77,6 +77,7 @@ app.get('/info', (_req, res) => {
   res.status(200).json({
     build: {
       name: packageJson.name,
+      description: packageJson.description,
       version: process.env.npm_package_version,
     },
   });

--- a/upcoming-release-notes/4897.md
+++ b/upcoming-release-notes/4897.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Replace Actutor dependency with our own implementation to ensure the Server version displays properly in all scenarios

--- a/upcoming-release-notes/4897.md
+++ b/upcoming-release-notes/4897.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MikesGlitch]
 ---
 
-Replace Actutor dependency with our own implementation to ensure the Server version displays properly in all scenarios
+Replace Actuator dependency with our own implementation to ensure the Server version displays properly in all scenarios

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,7 +104,6 @@ __metadata:
     date-fns: "npm:^2.30.0"
     debug: "npm:^4.4.0"
     express: "npm:4.21.2"
-    express-actuator: "npm:1.8.4"
     express-rate-limit: "npm:^7.5.0"
     express-response-size: "npm:^0.0.3"
     express-winston: "npm:^4.2.0"
@@ -8827,13 +8826,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.3":
-  version: 1.11.13
-  resolution: "dayjs@npm:1.11.13"
-  checksum: 10/7374d63ab179b8d909a95e74790def25c8986e329ae989840bacb8b1888be116d20e1c4eee75a69ea0dfbae13172efc50ef85619d304ee7ca3c01d5878b704f5
-  languageName: node
-  linkType: hard
-
 "debounce@npm:^1.2.1":
   version: 1.2.1
   resolution: "debounce@npm:1.2.1"
@@ -10478,16 +10470,6 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 10/2d9bbb6473de7051f96790d5f9a678f32e60ed0aa70741dc7fdc96fec8d631124ec3374ac144387604f05afff9500f31a1d45bd9eee4cdc2e4f9ad2d9b9d5dbd
-  languageName: node
-  linkType: hard
-
-"express-actuator@npm:1.8.4":
-  version: 1.8.4
-  resolution: "express-actuator@npm:1.8.4"
-  dependencies:
-    dayjs: "npm:^1.11.3"
-    properties-reader: "npm:^2.2.0"
-  checksum: 10/5f55418bfd660e8781a777bf48c7eeda2d0a38fa11b2f4670555123380f522eed5bb884df297fb420904663bd2057834227c0eea68d6f852432ac3bc77842c09
   languageName: node
   linkType: hard
 
@@ -16177,15 +16159,6 @@ __metadata:
     object-assign: "npm:^4.1.1"
     react-is: "npm:^16.13.1"
   checksum: 10/7d959caec002bc964c86cdc461ec93108b27337dabe6192fb97d69e16a0c799a03462713868b40749bfc1caf5f57ef80ac3e4ffad3effa636ee667582a75e2c0
-  languageName: node
-  linkType: hard
-
-"properties-reader@npm:^2.2.0":
-  version: 2.3.0
-  resolution: "properties-reader@npm:2.3.0"
-  dependencies:
-    mkdirp: "npm:^1.0.4"
-  checksum: 10/0b41eb4136dc278ae0d97968ccce8de2d48d321655b319192e31f2424f1c6e052182204671e65aa8967216360cb3e7cbd9129830062e058fe9d6a1d74964c29a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

There are issues with the way Actuator reads the package.json. It works for most Node applications, but when embedded in a CLI tool or Electron, the package.json cannot be resolved, resulting in no version being displayed in the UI. 

This implementation should work both for CLI and when embedded in Electron.

**Actuator package:** https://github.com/rcruzper/express-actuator/tree/master

**Before:** 

![image](https://github.com/user-attachments/assets/0d638dcd-5107-4450-9f3e-282b17d26ef5)

**After:** 

![image](https://github.com/user-attachments/assets/be64c47e-63e1-4d96-95d1-55e64edfc9b1)

_NOTE: I incremented the version of the cli tool locally_


