### PR TITLE
Fix new transactions account notes not clearing

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -483,7 +483,8 @@ const TransactionEditInner = memo(function TransactionEditInner({
 
   useEffect(() => {
     if (history.state === null) {
-      history.pushState(null, '', '/accounts');
+      history.replaceState(null, 'Actual Budget', '/');
+      history.pushState(null, 'Add Transaction', '/transactions/new');
     }
   }, []);
 

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -481,6 +481,12 @@ const TransactionEditInner = memo(function TransactionEditInner({
   );
   const { grouped: categoryGroups } = useCategories();
 
+  useEffect(() => {
+    if (history.state === null) {
+      history.pushState(null, '', '/accounts');
+    }
+  }, []);
+
   const [transaction, ...childTransactions] = transactions;
 
   const { editingField, onRequestActiveEdit, onClearActiveEdit } =

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -483,8 +483,8 @@ const TransactionEditInner = memo(function TransactionEditInner({
 
   useEffect(() => {
     if (history.state === null) {
-      history.replaceState(null, 'Actual Budget', '/');
-      history.pushState(null, 'Add Transaction', '/transactions/new');
+      window.history.replaceState(null, 'Actual Budget', '/');
+      window.history.pushState(null, 'Add Transaction', '/transactions/new');
     }
   }, []);
 

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -482,7 +482,7 @@ const TransactionEditInner = memo(function TransactionEditInner({
   const { grouped: categoryGroups } = useCategories();
 
   useEffect(() => {
-    if (history.state === null) {
+    if (window.history.length === 1) {
       window.history.replaceState(null, 'Actual Budget', '/');
       window.history.pushState(null, 'Add Transaction', '/transactions/new');
     }

--- a/upcoming-release-notes/4914.md
+++ b/upcoming-release-notes/4914.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [alecbakholdin]
+---
+
+Fixed issue with account and notes not clearing when launching action from PWA


### PR DESCRIPTION
When launching quick action for PWA, there is no history entry for the New Transaction page to go back to. The UX of that is 
1. the back button at the top left doesn't work
2. the accounts and notes fields get stuck

Adding a history entry for this page solves that.

Closes #4794