### PR TITLE
Automatically generate GitHub release text

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -19,64 +19,10 @@ concurrency:
 jobs:
   build:
     # this is so the assets can be added to the release
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - if: ${{ startsWith(matrix.os, 'windows') }}
-        run: pip.exe install setuptools
-      - if: ${{ ! startsWith(matrix.os, 'windows') }}
-        run: |
-          mkdir .venv
-          python3 -m venv .venv
-          source .venv/bin/activate
-          python3 -m pip install setuptools
-      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install flatpak -y
-          sudo apt-get install flatpak-builder -y
-          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
-          sudo flatpak install org.freedesktop.Platform/x86_64/23.08 -y
-          sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y
-      - name: Set up environment
-        uses: ./.github/actions/setup
-      - name: Build Electron for Mac
-        if: ${{ startsWith(matrix.os, 'macos') }}
-        run: ./bin/package-electron
-        env:
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-      - name: Build Electron
-        if: ${{ ! startsWith(matrix.os, 'macos') }}
-        run: ./bin/package-electron
-      - name: Upload Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: actual-electron-${{ matrix.os }}
-          path: |
-            packages/desktop-electron/dist/*.dmg
-            packages/desktop-electron/dist/*.exe
-            !packages/desktop-electron/dist/Actual-windows.exe
-            packages/desktop-electron/dist/*.AppImage
-            packages/desktop-electron/dist/*.flatpak
-      - name: Upload Windows Store Build
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: actual-electron-${{ matrix.os }}-appx
-          path: |
-            packages/desktop-electron/dist/*.appx
       - name: Process release version
         id: process_version
         run: |

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -19,10 +19,64 @@ concurrency:
 jobs:
   build:
     # this is so the assets can be added to the release
-    runs-on: ubuntu-latest
     permissions:
       contents: write
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        run: pip.exe install setuptools
+      - if: ${{ ! startsWith(matrix.os, 'windows') }}
+        run: |
+          mkdir .venv
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install setuptools
+      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install flatpak -y
+          sudo apt-get install flatpak-builder -y
+          sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install org.freedesktop.Sdk/x86_64/23.08 -y
+          sudo flatpak install org.freedesktop.Platform/x86_64/23.08 -y
+          sudo flatpak install org.electronjs.Electron2.BaseApp/x86_64/23.08 -y
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Build Electron for Mac
+        if: ${{ startsWith(matrix.os, 'macos') }}
+        run: ./bin/package-electron
+        env:
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+      - name: Build Electron
+        if: ${{ ! startsWith(matrix.os, 'macos') }}
+        run: ./bin/package-electron
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: actual-electron-${{ matrix.os }}
+          path: |
+            packages/desktop-electron/dist/*.dmg
+            packages/desktop-electron/dist/*.exe
+            !packages/desktop-electron/dist/Actual-windows.exe
+            packages/desktop-electron/dist/*.AppImage
+            packages/desktop-electron/dist/*.flatpak
+      - name: Upload Windows Store Build
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: actual-electron-${{ matrix.os }}-appx
+          path: |
+            packages/desktop-electron/dist/*.appx
       - name: Process release version
         id: process_version
         run: |

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -77,10 +77,23 @@ jobs:
           name: actual-electron-${{ matrix.os }}-appx
           path: |
             packages/desktop-electron/dist/*.appx
-      - name: Add to Release
+      - name: Process release version
+        id: process_version
+        run: |
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Add to new release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          body: |
+            :link: [View release notes](https://actualbudget.org/blog/release-${{ steps.process_version.outputs.version }})
+
+            ## Desktop releases
+            Please note: Microsoft store updates can sometimes lag behind the main release by a couple of days while they verify the new version.
+
+            <a href="https://apps.microsoft.com/detail/9p2hmlhsdbrm?cid=Github+Releases&mode=direct">
+              <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200"/>
+            </a>
           files: |
             packages/desktop-electron/dist/*.dmg
             packages/desktop-electron/dist/*.exe

--- a/upcoming-release-notes/4932.md
+++ b/upcoming-release-notes/4932.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Automatically generate GitHub release text


### PR DESCRIPTION
Removes a manual step from releasing. See https://github.com/jfdoming/actual/releases/tag/v25.5.1 for an example of release notes generated by this action.