### PR TITLE
Use the latest release tag instead of the latest tag for version checks

### DIFF
--- a/packages/desktop-client/src/util/versions.ts
+++ b/packages/desktop-client/src/util/versions.ts
@@ -25,15 +25,10 @@ export async function getLatestVersion(): Promise<string | 'unknown'> {
 
   try {
     const response = await fetch(
-      'https://api.github.com/repos/actualbudget/actual/tags',
+      'https://api.github.com/repos/actualbudget/actual/releases/latest',
     );
     const json = await response.json();
-    const tags = json
-      .map(t => t.name)
-      .concat([`v${window.Actual.ACTUAL_VERSION}`]);
-    tags.sort(cmpSemanticVersion);
-
-    return tags[tags.length - 1];
+    return json?.tag_name ?? 'unknown';
   } catch {
     // Rate limit exceeded? Or perhaps GitHub is down?
     return 'unknown';

--- a/upcoming-release-notes/4933.md
+++ b/upcoming-release-notes/4933.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Use the latest release tag instead of the latest tag for version checks


### PR DESCRIPTION
Motivation: Currently, releasing is a multi-step process. First, a PR is merged and tagged on master, which triggers release builds to _start_. Second, completed _desktop app_ release builds create a draft GitHub release. Finally, a maintainer manually marks the release as non-draft. This results in a poor user experience with updates, because the first step (tagging) would trigger a notification in all apps before the builds are even completed.

This PR updates the notification checking logic to use the latest (non-draft) release, rather than the latest tag. This means that update notifications will not be sent out until a maintainer manually un-drafts a GitHub release as the final step of the process (we do this anyway as noted above).

There's still a bit of a confusing situation for folks on Pikapods and in the Windows Store, where updates are not available as soon as we push them. But this should result in a better experience for those who do manage their own updates.