### PR TITLE
[Mobile] 🐛 Fix viewing pie/donut charts on mobile

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -24,7 +24,7 @@ import { useNavigate } from '@desktop-client/hooks/useNavigate';
 
 const RADIAN = Math.PI / 180;
 
-const isTouchDevice = () => window.matchMedia('(pointer: coarse)').matches;
+const isTouchDevice = () => window.navigator.maxTouchPoints > 0;
 
 const ActiveShapeMobile = props => {
   const {
@@ -282,9 +282,11 @@ export function DonutGraph({
                     endAngle={-270}
                     onMouseLeave={() => setPointer('')}
                     onMouseEnter={(_, index) => {
-                      setActiveIndex(index);
-                      if (!['Group', 'Interval'].includes(groupBy)) {
-                        setPointer('pointer');
+                      if (!isTouchDevice()) {
+                        setActiveIndex(index);
+                        if (!['Group', 'Interval'].includes(groupBy)) {
+                          setPointer('pointer');
+                        }
                       }
                     }}
                     onClick={(item, index) => {

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -24,6 +24,8 @@ import { useNavigate } from '@desktop-client/hooks/useNavigate';
 
 const RADIAN = Math.PI / 180;
 
+const isTouchDevice = () => window.matchMedia('(pointer: coarse)').matches;
+
 const ActiveShapeMobile = props => {
   const {
     cx,
@@ -285,24 +287,32 @@ export function DonutGraph({
                         setPointer('pointer');
                       }
                     }}
-                    onClick={item =>
-                      ((compact && showTooltip) || !compact) &&
-                      !['Group', 'Interval'].includes(groupBy) &&
-                      showActivity({
-                        navigate,
-                        categories,
-                        accounts,
-                        balanceTypeOp,
-                        filters,
-                        showHiddenCategories,
-                        showOffBudget,
-                        type: 'totals',
-                        startDate: data.startDate,
-                        endDate: data.endDate,
-                        field: groupBy.toLowerCase(),
-                        id: item.id,
-                      })
-                    }
+                    onClick={(item, index) => {
+                      if (isTouchDevice()) {
+                        setActiveIndex(index);
+                      }
+
+                      if (
+                        !['Group', 'Interval'].includes(groupBy) &&
+                        (!isTouchDevice() || activeIndex === index) &&
+                        ((compact && showTooltip) || !compact)
+                      ) {
+                        showActivity({
+                          navigate,
+                          categories,
+                          accounts,
+                          balanceTypeOp,
+                          filters,
+                          showHiddenCategories,
+                          showOffBudget,
+                          type: 'totals',
+                          startDate: data.startDate,
+                          endDate: data.endDate,
+                          field: groupBy.toLowerCase(),
+                          id: item.id,
+                        });
+                      }
+                    }}
                   >
                     {data.legend.map((entry, index) => (
                       <Cell key={`cell-${index}`} fill={entry.color} />

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -24,7 +24,7 @@ import { useNavigate } from '@desktop-client/hooks/useNavigate';
 
 const RADIAN = Math.PI / 180;
 
-const isTouchDevice = () => window.navigator.maxTouchPoints > 0;
+const canDeviceHover = () => window.matchMedia('(hover: hover)').matches;
 
 const ActiveShapeMobile = props => {
   const {
@@ -282,7 +282,7 @@ export function DonutGraph({
                     endAngle={-270}
                     onMouseLeave={() => setPointer('')}
                     onMouseEnter={(_, index) => {
-                      if (!isTouchDevice()) {
+                      if (canDeviceHover()) {
                         setActiveIndex(index);
                         if (!['Group', 'Interval'].includes(groupBy)) {
                           setPointer('pointer');
@@ -290,13 +290,13 @@ export function DonutGraph({
                       }
                     }}
                     onClick={(item, index) => {
-                      if (isTouchDevice()) {
+                      if (!canDeviceHover()) {
                         setActiveIndex(index);
                       }
 
                       if (
                         !['Group', 'Interval'].includes(groupBy) &&
-                        (!isTouchDevice() || activeIndex === index) &&
+                        (canDeviceHover() || activeIndex === index) &&
                         ((compact && showTooltip) || !compact)
                       ) {
                         showActivity({

--- a/upcoming-release-notes/4935.md
+++ b/upcoming-release-notes/4935.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ohNoBigO]
+---
+
+Fix viewing pie/donut charts on mobile


### PR DESCRIPTION
Fixes pie/donut charts viewing on mobile. This change allows users to click on the individual slice of the pie chart on mobile for it to "focus" on that slice. The change only affects touch screen devices, functionality remains in the same for desktop.

Prior to this fix focusing on a slice of the pie chart did not work properly on IOS devices. I am unsure if this was also the case on other mobile devices as I did have some success focusing on a slice by clicking and holding when testing via chrome dev tools but still did not work on my IOS device. 

Unlike in desktop view hovering over the slice doesn't work, clicking a slice of the pie chart results in user being navigated to the "accounts" section instead of focusing on the slice, and click and holding also does not work on my IOS device, therefore there was no way to properly use this type of custom report on these devices.

![image](https://s1.ezgif.com/tmp/ezgif-13873e7a62fec4.gif)
