### PR TITLE
🐛 Fixing docker edge

### DIFF
--- a/packages/sync-server/src/migrations.js
+++ b/packages/sync-server/src/migrations.js
@@ -1,4 +1,5 @@
-import path from 'node:path';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import migrate from 'migrate';
 
@@ -9,13 +10,16 @@ export function run(direction = 'up') {
     `Checking if there are any migrations to run for direction "${direction}"...`,
   );
 
+  const __dirname = dirname(fileURLToPath(import.meta.url)); // this directory
+  console.info('directory', __dirname);
+
   return new Promise(resolve =>
     migrate.load(
       {
         stateStore: `${path.join(config.get('dataDir'), '.migrate')}${
           config.get('mode') === 'test' ? '-test' : ''
         }`,
-        migrationsDirectory: `${path.join(config.get('projectRoot'), config.get('mode') === 'test' ? '' : 'build', 'migrations')}`,
+        migrationsDirectory: path.join(__dirname, '../migrations'),
       },
       (err, set) => {
         if (err) {

--- a/packages/sync-server/src/migrations.js
+++ b/packages/sync-server/src/migrations.js
@@ -11,7 +11,6 @@ export function run(direction = 'up') {
   );
 
   const __dirname = dirname(fileURLToPath(import.meta.url)); // this directory
-  console.info('directory', __dirname);
 
   return new Promise(resolve =>
     migrate.load(

--- a/upcoming-release-notes/4953.md
+++ b/upcoming-release-notes/4953.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix server migrations directory reference


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Referencing the migrations relatively so the app doesn't need to know what folder it has been built to. 

This is an alternative approach to: https://github.com/actualbudget/actual/pull/4952 . I think they'll both do the job, but removing references to the build folder is ideal.
