### PR TITLE
🐛 Sync server - resolving the user-files and server-files to an absolute dir

### DIFF
--- a/packages/sync-server/bin/actual-server.js
+++ b/packages/sync-server/bin/actual-server.js
@@ -71,12 +71,12 @@ const setupDataDir = (dataDir = undefined) => {
     if (existsSync('./data')) {
       // The default data directory exists - use it
       console.info('Found existing data directory');
-      process.env.ACTUAL_DATA_DIR = './data';
+      process.env.ACTUAL_DATA_DIR = resolve('./data');
     } else {
       console.info(
         'Using default data directory. You can specify a custom config with --config',
       );
-      process.env.ACTUAL_DATA_DIR = './';
+      process.env.ACTUAL_DATA_DIR = resolve('./');
     }
 
     console.info(`Data directory: ${process.env.ACTUAL_DATA_DIR}`);

--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import * as bcrypt from 'bcrypt';
 
@@ -11,7 +11,7 @@ let _accountDb;
 
 export function getAccountDb() {
   if (_accountDb === undefined) {
-    const dbPath = join(config.get('serverFiles'), 'account.sqlite');
+    const dbPath = join(resolve(config.get('serverFiles')), 'account.sqlite');
     _accountDb = openDatabase(dbPath);
   }
 

--- a/packages/sync-server/src/util/paths.js
+++ b/packages/sync-server/src/util/paths.js
@@ -1,13 +1,13 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import { config } from '../load-config.js';
 
 /** @param {string} fileId */
 export function getPathForUserFile(fileId) {
-  return join(config.get('userFiles'), `file-${fileId}.blob`);
+  return join(resolve(config.get('userFiles')), `file-${fileId}.blob`);
 }
 
 /** @param {string} groupId */
 export function getPathForGroupFile(groupId) {
-  return join(config.get('userFiles'), `group-${groupId}.sqlite`);
+  return join(resolve(config.get('userFiles')), `group-${groupId}.sqlite`);
 }

--- a/upcoming-release-notes/4954.md
+++ b/upcoming-release-notes/4954.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Ensure sync server uses absolute directories so users can configure relative paths for user-files


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Reported on Discord: https://discord.com/channels/937901803608096828/1369372745036595260

The issue here is that the user files and server files aren't always being resolved to an **absolute directory**. 

This is not just happening on the sync server CLI, but it's also happening when specifying the values for userFiles and serverFiles via config.json. 

Example of failing config: 
```
{
  "serverFiles": "./serverFiles",
  "userFiles": "./userFiles",
  "port": 5007
}
```

To make it fail:
- setup a server with the config above
- open the server url & upload a budget 
- expose it with a reverse proxy
- logon to the proxy & download the budget

`Rejection: TypeError: path must be absolute or specify root to res.sendFile`

If the user doesn't try to override it it doesn't normally fail because it picks the default project root - that'll be why nobody's caught it.