### PR TITLE
🐛 Fix sync server build not copying sql files over

### DIFF
--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "yarn build && node build/app",
     "start-monitor": "nodemon --exec 'tsc && node build/app' --ignore './build/**/*' --ext 'ts,js' build/app",
-    "build": "tsc",
+    "build": "tsc && cp -r src/sql build/src/sql",
     "test": "NODE_ENV=test NODE_OPTIONS='--experimental-vm-modules --trace-warnings' vitest",
     "db:migrate": "yarn build && cross-env NODE_ENV=development node build/src/scripts/run-migrations.js up",
     "db:downgrade": "yarn build && cross-env NODE_ENV=development node build/src/scripts/run-migrations.js down",

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "start": "yarn build && node build/app",
     "start-monitor": "nodemon --exec 'tsc && node build/app' --ignore './build/**/*' --ext 'ts,js' build/app",
-    "build": "tsc && cp -r src/sql build/src/sql",
+    "build": "tsc && yarn copy-static-assets",
+    "copy-static-assets": "rm -rf build/src/sql && cp -r src/sql build/src/sql",
     "test": "NODE_ENV=test NODE_OPTIONS='--experimental-vm-modules --trace-warnings' vitest",
     "db:migrate": "yarn build && cross-env NODE_ENV=development node build/src/scripts/run-migrations.js up",
     "db:downgrade": "yarn build && cross-env NODE_ENV=development node build/src/scripts/run-migrations.js down",

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -10,9 +10,9 @@ const require = createRequire(import.meta.url);
 const debug = createDebug('actual:config');
 const debugSensitive = createDebug('actual-sensitive:config');
 
-const projectRoot = path
-  .dirname(path.dirname(fileURLToPath(import.meta.url)))
-  .replace(/[\\/]build$/, '');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const projectRoot = path.dirname(__dirname).replace(/[\\/]build$/, '');
 const defaultDataDir = process.env.ACTUAL_DATA_DIR
   ? process.env.ACTUAL_DATA_DIR
   : fs.existsSync('/data')
@@ -21,7 +21,7 @@ const defaultDataDir = process.env.ACTUAL_DATA_DIR
 
 debug(`Project root: '${projectRoot}'`);
 
-export const sqlDir = path.join(projectRoot, 'src', 'sql');
+export const sqlDir = path.join(__dirname, 'sql');
 
 const actualAppWebBuildPath = path.join(
   path.dirname(require.resolve('@actual-app/web/package.json')),

--- a/upcoming-release-notes/4968.md
+++ b/upcoming-release-notes/4968.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Ensuring new sync-server build process copies over sql files


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

The new sync-server build process wasn't copying over non js/ts files. This casues new budgets to be created without the `messages_merkles` and `messages_binary` table. The budget will still load on the client, but the server will give errors.

From my digging I believe this is the only directory that is missed during the build process.

- Tested locally
