### PR TITLE
Add Abanca to the list of banks with limited history

### DIFF
--- a/packages/sync-server/src/app-gocardless/bank-factory.js
+++ b/packages/sync-server/src/app-gocardless/bank-factory.js
@@ -31,6 +31,7 @@ export function BankFactory(institutionId) {
 }
 
 export const BANKS_WITH_LIMITED_HISTORY = [
+  'ABANCA_CAGLESMM',
   'AIRBANK_AIRACZPP',
   'BANCA_AIDEXA_AIDXITMM',
   'BANCA_PATRIMONI_SENVITT1',

--- a/upcoming-release-notes/4970.md
+++ b/upcoming-release-notes/4970.md
@@ -1,5 +1,5 @@
 ---
-category: Maintenance
+category: Enhancements
 authors: [sergiomola]
 ---
 

--- a/upcoming-release-notes/4970.md
+++ b/upcoming-release-notes/4970.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [sergiomola]
+---
+
+Add Abanca to banks with limited history


### PR DESCRIPTION
ABANCA recently has implemented a new feature that ask for an sms code if the user requests more than 90 days of history, breaking the synchronization throgh gocardless. Adding it to the list of banks with limited history solves the issue.