### PR TITLE
increase OpenID timeout

### DIFF
--- a/packages/sync-server/src/accounts/openid.js
+++ b/packages/sync-server/src/accounts/openid.js
@@ -1,4 +1,4 @@
-import { generators, Issuer } from 'openid-client';
+import { custom, generators, Issuer } from 'openid-client';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -28,6 +28,10 @@ export async function bootstrapOpenId(configParameter) {
   if (!('server_hostname' in configParameter)) {
     return { error: 'missing-server-hostname' };
   }
+
+  custom.setHttpOptionsDefaults({
+    timeout: 20 * 1000, // 20 seconds
+  });
 
   try {
     //FOR BACKWARD COMPATIBLITY:

--- a/upcoming-release-notes/4980.md
+++ b/upcoming-release-notes/4980.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Increase OpenID request timeout


### PR DESCRIPTION
Found in the docs here: https://github.com/panva/openid-client/tree/v5.7.0/docs#customizing-http-requests

Fixes an issue reported on Discord where self hosted Authentik can reply quite slowly. https://discord.com/channels/937901803608096828/1371254299392479292