### PR TITLE
[Bugfix] SimpleFin Account Current Balance

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -954,7 +954,20 @@ async function processBankSyncDownload(
       useStrictIdChecking,
     );
 
-    if (accountBalance) await updateAccountBalance(id, accountBalance);
+    if (accountBalance) {
+      let balance = accountBalance;
+      if (
+        acctRow.account_sync_source === 'simpleFin' &&
+        Array.isArray(accountBalance)
+      ) {
+        const expectedBalance = accountBalance.find(
+          b => b.balanceType === 'expected',
+        );
+        balance = expectedBalance.balanceAmount.amount;
+      }
+
+      await updateAccountBalance(id, balance);
+    }
 
     return result;
   });

--- a/upcoming-release-notes/4988.md
+++ b/upcoming-release-notes/4988.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [passabilities]
+---
+
+Fix storing SimpleFin account balance


### PR DESCRIPTION
# Feature
Fix storing current account balance (at least for SimpleFin)

## Problem
I live in the US and am currently only using SimpleFin to sync accounts. After checking the DB, it was clear that the `account.balance_current` was not being stored.

## Solution
When accounts are being synced and the `processBankSyncDownload` function runs, it assumes the `accountBalance` value is a number, however, I was able to debug it and it is an array of objects that contain different balance values.

![image](https://github.com/user-attachments/assets/767c8be4-bc9f-4bf8-ab13-6ead3f862dc0)

Shows the account's **synced balance** and amount **out of sync**

![image](https://github.com/user-attachments/assets/6a4771d5-71aa-498d-b085-06fccfdea3a9)

Looks like #4799 is similar