### PR TITLE
[WIP] Fix/gocardless rate limit select accounts

### DIFF
--- a/packages/sync-server/src/app-gocardless/services/gocardless-service.js
+++ b/packages/sync-server/src/app-gocardless/services/gocardless-service.js
@@ -329,7 +329,7 @@ export const goCardlessService = {
         userLanguage: 'en',
         ssn: null,
         redirectImmediate: false,
-        accountSelection: false,
+        accountSelection: true,
       });
     } catch (error) {
       handleGoCardlessError(error);

--- a/upcoming-release-notes/4993.md
+++ b/upcoming-release-notes/4993.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lorenzenv]
+---
+
+Fix GoCardless institutional rate limit errors during account linking


### PR DESCRIPTION
**Problem:**

Users attempting to link bank accounts via GoCardless frequently encounter "Daily request limit set by the Institution has been exceeded" errors (as reported in issue #4039). This error prevents successful account linking and occurs because the previous integration attempted to fetch details for all of an institution's accounts upfront.

**Solution:**

This PR fixes the issue by modifying the GoCardless integration (`packages/sync-server/src/app-gocardless/services/gocardless-service.js`) to enable server-side account selection provided by GoCardless.

The `accountSelection` parameter in the `client.initSession` call (within the `createRequisition` function) has been changed from `false` to `true`.

**Impact:**

- When a user initiates a new bank link with GoCardless, they will now be redirected to the GoCardless platform, which should prompt them to select the specific account(s) they wish to grant Actual access to.
- Actual's backend will then only receive the IDs for these pre-selected accounts in the requisition.
- This drastically reduces the number of subsequent API calls Actual needs to make, effectively resolving the institutional rate limit errors during the account discovery phase.
- This leads to a more reliable bank linking experience for GoCardless users affected by these limits.

**Testing:**

1. Set up GoCardless credentials in Actual.
2. Attempt to add a new linked account using GoCardless with an institution previously causing rate limit errors.
3. Observe that during the redirection to GoCardless, an account selection step is presented.
4. Select one or more accounts.
5. Upon redirection back to Actual, verify that only the selected accounts are listed and can be linked successfully without rate limit errors.

Closes #4039