### PR TITLE
[Mobile] Fix category transactions screen not showing child transactions

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -144,8 +144,7 @@ function TransactionListWithPreviews({
   });
 
   const transactionsToDisplay = !isSearching
-    ? // Do not render child transactions in the list, unless searching
-      previewTransactions.concat(transactions.filter(t => !t.is_child))
+    ? previewTransactions.concat(transactions)
     : transactions;
 
   return (

--- a/upcoming-release-notes/4998.md
+++ b/upcoming-release-notes/4998.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+[Mobile] Fix category transactions screen not showing child transactions


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fixes https://github.com/actualbudget/actual/issues/4989