### PR TITLE
Add transfers to merge

### DIFF
--- a/upcoming-release-notes/5001.md
+++ b/upcoming-release-notes/5001.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [alecbakholdin]
+---
+
+added transfer support to merge


### PR DESCRIPTION
Closes #5000 

Initially discussed in #4899 

Adds support for merging transferred transaction.  
1) If a kept transaction has no payee (including transfer) and the dropped transaction is a transfer, the dropped transaction's transfer is redirected to point to the kept transaction. **Notably, this also clears out the kept transaction's category**
2) Otherwise, if the dropped transaction is a transfer and is not going to be redirected, the corresponding transfer in the other account is **also dropped**

Please, someone confirm if this sounds okay. This is all reversible with ctrl + z but I worry especially about the second point. To me it sounds reasonable but the alternative is we make the other transaction payee-less instead of deleting it. That seems odd as well but need advice.