### PR TITLE
Set yarn engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "engines": {
     "node": ">=20",
-    "yarn": ">=4.7.0"
+    "yarn": "^4.7.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,json,yml}": [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "rollup": "4.40.1"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20",
+    "yarn": ">=4.7.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,md,json,yml}": [

--- a/upcoming-release-notes/5011.md
+++ b/upcoming-release-notes/5011.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [rgoldfinger]
+---
+
+Add a package.json engine version for Yarn


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Sets an engine version for yarn so that users with the wrong yarn version get early feedback and a clear error message. 
