### PR TITLE
if BankSyncError is caused by rate limit. display that in toast

### DIFF
--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -848,13 +848,22 @@ function handleSyncError(
   if (err instanceof BankSyncError || (err as any)?.type === 'BankSyncError') {
     const error = err as BankSyncError;
 
-    return {
+    var syncError = {
       type: 'SyncError',
       accountId: acct.id,
       message: 'Failed syncing account “' + acct.name + '.”',
       category: error.category,
       code: error.code,
     };
+
+    if(error.category === 'RATE_LIMIT_EXCEEDED') {
+      return {
+        ...syncError,
+        message: `Failed syncing account ${acct.name}. Rate limit exceeded. Please try again later.`, 
+      }  
+    }
+
+    return syncError
   }
 
   if (err instanceof PostError && err.reason !== 'internal') {

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -848,7 +848,7 @@ function handleSyncError(
   if (err instanceof BankSyncError || (err as any)?.type === 'BankSyncError') {
     const error = err as BankSyncError;
 
-    var syncError = {
+    const syncError = {
       type: 'SyncError',
       accountId: acct.id,
       message: 'Failed syncing account “' + acct.name + '.”',
@@ -856,14 +856,14 @@ function handleSyncError(
       code: error.code,
     };
 
-    if(error.category === 'RATE_LIMIT_EXCEEDED') {
+    if (error.category === 'RATE_LIMIT_EXCEEDED') {
       return {
         ...syncError,
-        message: `Failed syncing account ${acct.name}. Rate limit exceeded. Please try again later.`, 
-      }  
+        message: `Failed syncing account ${acct.name}. Rate limit exceeded. Please try again later.`,
+      };
     }
 
-    return syncError
+    return syncError;
   }
 
   if (err instanceof PostError && err.reason !== 'internal') {

--- a/upcoming-release-notes/5038.md
+++ b/upcoming-release-notes/5038.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [SteinTokvam]
+---
+
+Added information that sync error are caued by a rate limit if that's the case.


### PR DESCRIPTION
---
category: Enhancements
authors: [SteinTokvam]
---

Added information that sync error are caued by a rate limit if that's the case.
