### PR TITLE
🐛 Fix goals tooltip obstructing cover spending context menu

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -98,6 +98,7 @@ type BalanceWithCarryoverProps = Omit<
   isDisabled?: boolean;
   shouldInlineGoalStatus?: boolean;
   CarryoverIndicator?: ComponentType<CarryoverIndicatorProps>;
+  tooltipDisabled?: boolean;
 };
 
 export function BalanceWithCarryover({
@@ -109,6 +110,7 @@ export function BalanceWithCarryover({
   isDisabled,
   shouldInlineGoalStatus,
   CarryoverIndicator: CarryoverIndicatorComponent = CarryoverIndicator,
+  tooltipDisabled,
   children,
   ...props
 }: BalanceWithCarryoverProps) {
@@ -259,7 +261,7 @@ export function BalanceWithCarryover({
             triggerProps={{
               delay: 750,
               isDisabled:
-                !isGoalTemplatesEnabled || goalValue == null || isNarrowWidth,
+                !isGoalTemplatesEnabled || goalValue == null || isNarrowWidth || tooltipDisabled ,
             }}
           >
             {children ? (

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -496,6 +496,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
             goal={envelopeBudget.catGoal(category.id)}
             budgeted={envelopeBudget.catBudgeted(category.id)}
             longGoal={envelopeBudget.catLongGoal(category.id)}
+            tooltipDisabled={balanceMenuOpen}
           />
         </span>
 

--- a/upcoming-release-notes/5051.md
+++ b/upcoming-release-notes/5051.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [johnn27]
+---
+
+🐛 Fix goals tooltip obstructing cover spending context menu


### PR DESCRIPTION
**Fixes: #4939 - Tooltip appears over popover in budget category balance**

**Problem:**
When right-clicking (or clicking the chevron) on a category's balance in the budget table to open the context menu (Popover), the hover-triggered tooltip for the balance can still appear, creating a "double popup" that is visually confusing.

**Solution:**
This PR prevents the tooltip from appearing when its associated Popover (context menu) is already open.

**Technical Changes:**

1.  **`BalanceWithCarryover.tsx`:**
    *   Added a new optional prop `tooltipDisabled?: boolean` to `BalanceWithCarryoverProps`.
    *   The `Tooltip` component's `triggerProps.isDisabled` condition has been updated to:
        `isDisabled: tooltipDisabled || !isGoalTemplatesEnabled || goalValue == null || isNarrowWidth`.
        This ensures the tooltip is disabled if `tooltipDisabled` is true, in addition to the existing conditions.

2.  **`EnvelopeBudgetComponents.tsx` (within `ExpenseCategoryMonth`):**
    *   The `balanceMenuOpen` state (which tracks if the balance context menu Popover is open) is now passed to the `<BalanceWithCarryover />` component's new `tooltipDisabled` prop:
        `<BalanceWithCarryover ... tooltipDisabled={balanceMenuOpen} />`

**Impact:**
This change provides a cleaner user experience on the desktop budget screen by ensuring only one popup (either the tooltip or the context menu) is active at a time for the category balance. This fix is targeted at the desktop UI where this specific interaction occurs.