### PR TITLE
[WIP] Docker compose remove empty environment tag

### DIFF
--- a/packages/sync-server/docker-compose.yml
+++ b/packages/sync-server/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       # This line makes Actual available at port 5006 of the device you run the server on,
       # i.e. http://localhost:5006. You can change the first number to change the port, if you want.
       - '5006:5006'
-    environment:
+    # environment:
       # Uncomment any of the lines below to set configuration options.
       # - ACTUAL_HTTPS_KEY=/data/selfhost.key
       # - ACTUAL_HTTPS_CERT=/data/selfhost.crt


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

This is a quick one - while the docker compose file specifies pretty clearly that if no option is specified, the user needs to uncomment the environment tag, it still adds to the user friction when running `docker compose up -d` following the doc doesn't work straight away. This removes this small road block for first time users. 