### PR TITLE
[WIP] fix: save category expansion state when value is 0

### DIFF
--- a/packages/loot-core/src/server/preferences/app.ts
+++ b/packages/loot-core/src/server/preferences/app.ts
@@ -69,7 +69,7 @@ async function saveGlobalPrefs(prefs: GlobalPrefs) {
   if (prefs.maxMonths !== undefined) {
     await asyncStorage.setItem('max-months', '' + prefs.maxMonths);
   }
-  if (prefs.categoryExpandedState) {
+  if (prefs.categoryExpandedState !== undefined) {
     await asyncStorage.setItem(
       'category-expanded-state',
       '' + prefs.categoryExpandedState,

--- a/upcoming-release-notes/5069.md
+++ b/upcoming-release-notes/5069.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [misu-dev]
+---
+
+Fixes a bug where the category expansion state was not saved when its value was 0


### PR DESCRIPTION
This fixes a bug where the category expansion state is not saved correcly when the value is 0 (see comments in https://github.com/actualbudget/actual/pull/4807).
