### PR TITLE
 :wrench: added needs-triage label to all new bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report also known as an issue or problem.
 title: '[Bug]: '
-labels: ['needs-grooming', 'bug']
+labels: ['needs triaging', 'bug']
 body:
   - type: markdown
     id: intro-md

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report also known as an issue or problem.
 title: '[Bug]: '
-labels: ['bug']
+labels: ['needs-grooming', 'bug']
 body:
   - type: markdown
     id: intro-md

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: File a bug report also known as an issue or problem.
 title: '[Bug]: '
-labels: ['needs triaging', 'bug']
+labels: ['needs triage', 'bug']
 body:
   - type: markdown
     id: intro-md

--- a/upcoming-release-notes/5070.md
+++ b/upcoming-release-notes/5070.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Added 'needs-grooming' label to all new bug issues

--- a/upcoming-release-notes/5070.md
+++ b/upcoming-release-notes/5070.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MatissJanis]
 ---
 
-Added 'needs-grooming' label to all new bug issues
+Added 'needs triage' label to all new bug issues


### PR DESCRIPTION
I plan on retroactively adding this label to all the existing issues that have only the "bug" label too. Via some sort of one-off usage script I'll cook up later.