### PR TITLE
:bug: (mobile) fix - show loading indicator if schedules not yet loaded

### DIFF
--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -251,7 +251,7 @@ function TransactionListWithPreviews({
   );
   const {
     transactions,
-    isLoading,
+    isLoading: isTransactionsLoading,
     reload: reloadTransactions,
     isLoadingMore,
     loadMore: loadMoreTransactions,
@@ -259,9 +259,10 @@ function TransactionListWithPreviews({
     query: transactionsQuery,
   });
 
-  const { previewTransactions } = useAccountPreviewTransactions({
-    accountId: account?.id,
-  });
+  const { previewTransactions, isLoading: isPreviewTransactionsLoading } =
+    useAccountPreviewTransactions({
+      accountId: account?.id,
+    });
 
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const dispatch = useDispatch();
@@ -361,7 +362,9 @@ function TransactionListWithPreviews({
 
   return (
     <TransactionListWithBalances
-      isLoading={isLoading}
+      isLoading={
+        isSearching ? isTransactionsLoading : isPreviewTransactionsLoading
+      }
       transactions={transactionsToDisplay}
       balance={balanceQueries.balance}
       balanceCleared={balanceQueries.cleared}

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -341,6 +341,7 @@ export function usePreviewTransactions({
     setError(undefined);
 
     if (scheduleTransactions.length === 0) {
+      setIsLoading(false);
       setPreviewTransactions([]);
       return;
     }

--- a/upcoming-release-notes/5080.md
+++ b/upcoming-release-notes/5080.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Show loading indicator in mobile transaction list if schedules are not yet loaded


### PR DESCRIPTION
Sometimes loading schedules takes a bit of time. Having schedules fully loaded is a pre-requisite for bank-sync to work. So if a user is quick to perform the pull-to-refresh operation - it is just ignored.

Updated the logic to show a loading indicator if schedules are not yet fully loaded.

Should fix #5005