### PR TITLE
:wrench: (eslint) patch no-restricted-imports rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,11 +108,10 @@ export default pluginTypescript.config(
       'packages/desktop-electron/client-build/',
       'packages/desktop-electron/build/',
       'packages/desktop-electron/dist/',
-      'packages/import-ynab4/**/node_modules/*',
-      'packages/import-ynab5/**/node_modules/*',
       'packages/loot-core/**/node_modules/*',
       'packages/loot-core/**/lib-dist/*',
       'packages/loot-core/**/proto/*',
+      'packages/sync-server/build/',
       '.yarn/*',
       '.github/*',
     ],
@@ -504,6 +503,32 @@ export default pluginTypescript.config(
       'no-restricted-imports': [
         'warn',
         {
+          paths: [
+            {
+              name: 'react-router-dom',
+              importNames: ['useNavigate'],
+              message:
+                "Please import Actual's useNavigate() hook from `src/hooks` instead.",
+            },
+            {
+              name: 'react-redux',
+              importNames: ['useDispatch'],
+              message:
+                "Please import Actual's useDispatch() hook from `src/redux` instead.",
+            },
+            {
+              name: 'react-redux',
+              importNames: ['useSelector'],
+              message:
+                "Please import Actual's useSelector() hook from `src/redux` instead.",
+            },
+            {
+              name: 'react-redux',
+              importNames: ['useStore'],
+              message:
+                "Please import Actual's useStore() hook from `src/redux` instead.",
+            },
+          ],
           patterns: [
             {
               group: ['*.api', '*.web', '*.electron'],
@@ -518,6 +543,10 @@ export default pluginTypescript.config(
               group: ['**/style', '**/colors'],
               importNames: ['colors'],
               message: 'Please use themes instead of colors',
+            },
+            {
+              group: ['@actual-app/web/*'],
+              message: 'Please do not import `@actual-app/web` in `loot-core`',
             },
           ],
         },
@@ -653,88 +682,6 @@ export default pluginTypescript.config(
     },
   },
   {
-    files: ['packages/desktop-client/**/*'],
-    ignores: ['packages/desktop-client/src/hooks/useNavigate.{ts,tsx}'],
-
-    rules: {
-      'no-restricted-imports': [
-        'warn',
-        {
-          paths: [
-            {
-              name: 'react-router-dom',
-              importNames: ['useNavigate'],
-              message:
-                "Please import Actual's useNavigate() hook from `src/hooks` instead.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    files: ['packages/desktop-client/**/*', 'packages/loot-core/**/*'],
-    ignores: ['packages/desktop-client/src/redux/index.{ts,tsx}'],
-
-    rules: {
-      'no-restricted-imports': [
-        'warn',
-        {
-          paths: [
-            {
-              name: 'react-redux',
-              importNames: ['useDispatch'],
-              message:
-                "Please import Actual's useDispatch() hook from `src/redux` instead.",
-            },
-            {
-              name: 'react-redux',
-              importNames: ['useSelector'],
-              message:
-                "Please import Actual's useSelector() hook from `src/redux` instead.",
-            },
-            {
-              name: 'react-redux',
-              importNames: ['useStore'],
-              message:
-                "Please import Actual's useStore() hook from `src/redux` instead.",
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
-    files: ['packages/loot-core/src/**/*'],
-    rules: {
-      'no-restricted-imports': [
-        'warn',
-        {
-          patterns: [
-            {
-              group: ['*.api', '*.web', '*.electron'],
-              message: "Don't directly reference imports from other platforms",
-            },
-            {
-              group: ['uuid'],
-              importNames: ['*'],
-              message: "Use `import { v4 as uuidv4 } from 'uuid'` instead",
-            },
-            {
-              group: ['loot-core/**'],
-              message:
-                'Please use relative imports in loot-core instead of importing from `loot-core/*`',
-            },
-            {
-              group: ['@actual-app/web/*'],
-              message: 'Please do not import `@actual-app/web` in `loot-core`',
-            },
-          ],
-        },
-      ],
-    },
-  },
-  {
     files: [
       'packages/loot-core/src/types/**/*',
       'packages/loot-core/src/client/state-types/**/*',
@@ -746,27 +693,6 @@ export default pluginTypescript.config(
 
     rules: {
       'import/no-unused-modules': 'off',
-    },
-  },
-  {
-    files: [
-      'packages/desktop-client/src/style/index.*',
-      'packages/desktop-client/src/style/palette.*',
-    ],
-
-    rules: {
-      'no-restricted-imports': [
-        'off',
-        {
-          patterns: [
-            {
-              group: ['**/style', '**/colors'],
-              importNames: ['colors'],
-              message: 'Please use themes instead of colors',
-            },
-          ],
-        },
-      ],
     },
   },
   {

--- a/packages/desktop-client/src/hooks/useNavigate.ts
+++ b/packages/desktop-client/src/hooks/useNavigate.ts
@@ -5,6 +5,7 @@ import {
   type NavigateOptions,
   type To,
   useLocation,
+  // eslint-disable-next-line no-restricted-imports
   useNavigate as useNavigateReactRouter,
 } from 'react-router-dom';
 

--- a/packages/desktop-client/src/redux/index.ts
+++ b/packages/desktop-client/src/redux/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {
   useDispatch as useReduxDispatch,
   useSelector as useReduxSelector,

--- a/packages/desktop-client/src/style/index.ts
+++ b/packages/desktop-client/src/style/index.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 export * as colors from './colors';
 export * from './styles';
 export * from './theme';

--- a/packages/desktop-client/src/style/palette.ts
+++ b/packages/desktop-client/src/style/palette.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import * as oldColors from './colors';
 
 // Only for use in contextual color definitions

--- a/packages/desktop-client/src/style/themes/dark.ts
+++ b/packages/desktop-client/src/style/themes/dark.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import * as colorPalette from '@desktop-client/style/palette';
 
 export const pageBackground = colorPalette.gray900;

--- a/packages/desktop-client/src/style/themes/development.ts
+++ b/packages/desktop-client/src/style/themes/development.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import * as colorPalette from '@desktop-client/style/palette';
 
 export const pageBackground = colorPalette.navy100;

--- a/packages/desktop-client/src/style/themes/light.ts
+++ b/packages/desktop-client/src/style/themes/light.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import * as colorPalette from '@desktop-client/style/palette';
 
 export const pageBackground = colorPalette.navy100;

--- a/packages/desktop-client/src/style/themes/midnight.ts
+++ b/packages/desktop-client/src/style/themes/midnight.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports
 import * as colorPalette from '@desktop-client/style/palette';
 
 export const pageBackground = colorPalette.gray600;

--- a/packages/desktop-electron/e2e/onboarding.test.ts
+++ b/packages/desktop-electron/e2e/onboarding.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- fix me
 import { ConfigurationPage } from '@actual-app/web/e2e/page-models/configuration-page';
 import { expect } from '@playwright/test';
 

--- a/upcoming-release-notes/5081.md
+++ b/upcoming-release-notes/5081.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Patch no-restricted-imports eslint rule


### PR DESCRIPTION
This issue has been annoying me for a while now. Let me explain what I'm doing here.

Eslint has a flat configuration object. It does not support partial rule config overrides.

For example: we can globally restrict importing from dependency A. If some file needs to have another different import restriction - there is no way to merge "restrict importing A" + "local restriction". The last applied config always takes priority.

Fortunately we don't have any violations because of the rule conflicts. But better fix this issue now and forget about it..

---

Alternative solution would be to bring back package-specific eslint runners & config files (& maybe also a shared config package so we could inherit the global config). But that would be a significantly heavier lift with more long-term maintenance costs.