### PR TITLE
[bugfix] Include split transactions in select-all

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1713,6 +1713,14 @@ class AccountInternal extends PureComponent<
 
     const balanceQuery = this.getBalanceQuery(accountId);
 
+    const selectAllFilter = (item: TransactionEntity) => {
+      if (item.is_parent) {
+        const children = transactions.filter(t => t.parent_id === item.id);
+        return children.every(t => selectAllFilter(t));
+      }
+      return !item._unmatched;
+    };
+
     return (
       <AllTransactions
         account={account}
@@ -1727,7 +1735,7 @@ class AccountInternal extends PureComponent<
             items={allTransactions}
             fetchAllIds={this.fetchAllIds}
             registerDispatch={dispatch => (this.dispatchSelected = dispatch)}
-            selectAllFilter={item => !item._unmatched && !item.is_parent}
+            selectAllFilter={selectAllFilter}
           >
             <View style={styles.page}>
               <AccountHeader


### PR DESCRIPTION
**Fixes issue #5074**: Include split transactions in select-all actions when all of their children should be selected.


Behavior introduced in PR #283, I made sure to maintain filter behavior: parent transactions should only be selected when all children are selected.

**Demo:**

https://github.com/user-attachments/assets/8dbcb4cb-6a1c-48bc-826b-4afc87ad803d