### PR TITLE
Trim EndToEndID from the Danish Danske Bank branch

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/danskebank_privat.js
+++ b/packages/sync-server/src/app-gocardless/banks/danskebank_privat.js
@@ -6,7 +6,9 @@ import Fallback from './integration-bank.js';
 export default {
   ...Fallback,
 
-  institutionIds: ['DANSKEBANK_DABANO22'],
+  // TODO: Add other Danske Bank BICs?
+  // https://danskeci.com/ci/transaction-banking/bank-identifier-code
+  institutionIds: ['DANSKEBANK_DABADKKK', 'DANSKEBANK_DABANO22'],
 
   normalizeTransaction(transaction, booked) {
     const editedTrans = { ...transaction };

--- a/upcoming-release-notes/5101.md
+++ b/upcoming-release-notes/5101.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [AlbertSPedersen]
+---
+
+Trim EndToEndID from transactions for the Danish Danske Bank branch in addition to the Norwegian branch


### PR DESCRIPTION
For the Norwegian Branch of Danske Bank, a `EndToEndID: NOTPROVIDED` suffix is appended to all SEPA transactions. The Danish branch of Danske Bank seems to use the same system as the Norwegian branch, and so `EndToEndID: NOTPROVIDED` is also appended to notes from this bank. This PR adds the Danish branch to `institutionIds`.

I've looked at the code responsible for loading bank overrides, and it seems like this fix should work, but I am not familiar with the code-base of Actual Budget, so please keep that in mind when reviewing.