### PR TITLE
fix goal type templates

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -26,7 +26,7 @@ expr
     { return { type: 'average', numMonths: +amount, priority: template.priority, directive: template.directive }}
   / template: template _ 'copy from'i _ lookBack: positive _ 'months ago'i limit:limit?
     { return { type: 'copy', priority: template.priority, directive: template.directive, lookBack: +lookBack, limit }}
-  / goal: goal amount: amount { return {type: 'simple', amount: amount, priority: null, directive: goal }}
+  / goal: goal amount: amount { return {type: 'goal', amount: amount, priority: null, directive: goal }}
 
 modifiers = _ '[' modifier:modifier ']' { return modifier }
 

--- a/upcoming-release-notes/5120.md
+++ b/upcoming-release-notes/5120.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix applying goal templates


### PR DESCRIPTION
The processing code was looking for the wrong type when filtering out goal type templates.  I fixed the type being added by the parser to match.  This makes it so we can probably remove the directive field in the future as well.
