### PR TITLE
fix: bottom UI overlap with iOS Home Indicator

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -202,6 +202,7 @@ function Footer({
         backgroundColor: theme.tableHeaderBackground,
         borderTopWidth: 1,
         borderColor: theme.tableBorder,
+        marginBottom: 10,
       }}
     >
       {transaction.error?.type === 'SplitTransactionError' ? (

--- a/upcoming-release-notes/5121.md
+++ b/upcoming-release-notes/5121.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [danishjoseph]
+---
+
+Fixed UI issue where bottom buttons were hidden by the iOS Home Indicator.


### PR DESCRIPTION
Fixes #4967 

## Screenshots

### Old:

![image](https://github.com/user-attachments/assets/e493d8c7-d805-4fdc-9cd6-664438d899a1)
![image](https://github.com/user-attachments/assets/2e02fda6-f06b-427c-8e77-a55880f3a15b)
![image](https://github.com/user-attachments/assets/ab8551fa-92af-43e0-b647-78b8a5bed4b5)


### Updated: 

![image](https://github.com/user-attachments/assets/1cd51f63-7303-42a8-9a1e-dce29a2af48b)
![image](https://github.com/user-attachments/assets/b81f2fe6-0aa3-41f1-935f-70baac1cf180)
![image](https://github.com/user-attachments/assets/c81b0a69-cc89-4b7b-9d8d-7817c54ad4ab)
