### PR TITLE
fix: missing table column on mobile devices

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -91,7 +91,11 @@ function ToBudget({ toBudget, onPress, show3Columns }) {
     >
       <Button variant="bare" onPress={onPress}>
         <View>
-          <Label
+          <AutoTextSize
+            as={Label}
+            minFontSizePx={6}
+            maxFontSizePx={12}
+            mode="oneline"
             title={amount < 0 ? t('Overbudgeted') : t('To Budget')}
             style={{
               ...(amount < 0 ? styles.smallText : {}),
@@ -323,7 +327,7 @@ export function BudgetTable({
 }) {
   const { t } = useTranslation();
   const { width } = useResponsive();
-  const show3Columns = width >= 360;
+  const show3Columns = width >= 300;
 
   // let editMode = false; // neuter editMode -- sorry, not rewriting drag-n-drop right now
 
@@ -805,7 +809,11 @@ function BudgetTableHeader({
                         }}
                       />
                     )}
-                    <Label
+                    <AutoTextSize
+                      as={Label}
+                      minFontSizePx={6}
+                      maxFontSizePx={12}
+                      mode="oneline"
                       title={t('Budgeted')}
                       style={{ color: theme.formInputText, paddingRight: 4 }}
                     />
@@ -867,7 +875,11 @@ function BudgetTableHeader({
                         }}
                       />
                     )}
-                    <Label
+                    <AutoTextSize
+                      as={Label}
+                      minFontSizePx={6}
+                      maxFontSizePx={12}
+                      mode="oneline"
                       title={t('Spent')}
                       style={{ color: theme.formInputText, paddingRight: 4 }}
                     />
@@ -904,8 +916,12 @@ function BudgetTableHeader({
         >
           {({ type, value }) => (
             <View style={{ width: columnWidth }}>
-              <View style={{ flex: 1, alignItems: 'flex-end' }}>
-                <Label
+              <View style={{ flex: 1, alignItems: 'flex-end !important' }}>
+                <AutoTextSize
+                  as={Label}
+                  minFontSizePx={6}
+                  maxFontSizePx={12}
+                  mode="oneline"
                   title={t('Balance')}
                   style={{ color: theme.formInputText }}
                 />


### PR DESCRIPTION
Enhances the mobile budget table's responsiveness by implementing `AutoTextSize` for better text scaling and adjusting the responsive breakpoint to provide a better user experience on smaller screens.

### Changes Made

1. **Responsive Text Sizing**: Replaced static `Label` components with `AutoTextSize` to automatically adjust font sizes based on available space
2. **Responsive Breakpoint**: Reduced the 3-column layout threshold from 370px to 300px for better mobile experience

### Visual Impact

*[Screenshots will be added to show the before/after visual differences]*

| Before | After |
|--------|-------|
| <img width="313" alt="Screenshot 2025-06-07 at 8 07 01 PM" src="https://github.com/user-attachments/assets/f32c3501-7a44-4d61-ba19-cfff19c72ba7" /> | <img width="312" alt="Screenshot 2025-06-07 at 8 06 32 PM" src="https://github.com/user-attachments/assets/ba46bdfd-41d5-4717-8b4f-9e69ee7047f6" /> |