### PR TITLE
Fix net worth graph gradient conflict

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -75,6 +75,7 @@ export function NetWorthGraph({
   };
 
   const off = gradientOffset();
+  const gradientId = `splitColor-${id}`;
 
   type PayloadItem = {
     payload: {
@@ -181,13 +182,7 @@ export function NetWorthGraph({
                   />
                 )}
                 <defs>
-                  <linearGradient
-                    id={`splitColor-${id}`}
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
+                  <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                     <stop
                       offset={off}
                       stopColor={theme.reportsBlue}
@@ -208,7 +203,7 @@ export function NetWorthGraph({
                   animationDuration={0}
                   dataKey="y"
                   stroke={theme.reportsBlue}
-                  fill={`url(#splitColor-${id})`}
+                  fill={`url(#${gradientId})`}
                   fillOpacity={1}
                 />
               </AreaChart>

--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React from 'react';
+import React, { useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AlignedText } from '@actual-app/components/aligned-text';
@@ -50,6 +50,7 @@ export function NetWorthGraph({
 }: NetWorthGraphProps) {
   const { t } = useTranslation();
   const privacyMode = usePrivacyMode();
+  const id = useId();
 
   const tickFormatter = tick => {
     const res = privacyMode
@@ -180,7 +181,13 @@ export function NetWorthGraph({
                   />
                 )}
                 <defs>
-                  <linearGradient id="splitColor" x1="0" y1="0" x2="0" y2="1">
+                  <linearGradient
+                    id={`splitColor-${id}`}
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
                     <stop
                       offset={off}
                       stopColor={theme.reportsBlue}
@@ -201,7 +208,7 @@ export function NetWorthGraph({
                   animationDuration={0}
                   dataKey="y"
                   stroke={theme.reportsBlue}
-                  fill="url(#splitColor)"
+                  fill={`url(#splitColor-${id})`}
                   fillOpacity={1}
                 />
               </AreaChart>

--- a/upcoming-release-notes/5129.md
+++ b/upcoming-release-notes/5129.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [OlivierKamers]
+---
+
+Fix net worth graph colors when using multiple graphs that are positive/negative


### PR DESCRIPTION
Fixes #3965

Ensures that the net worth graph's gradient ID is unique to prevent conflicts when multiple graphs are rendered on the same page.

To verify, I added a Net Worth Chart to the reports page of the test budget, where I simply added a filter `amount < 1000` to make the net worth negative.

**Before**

<img width="1170" alt="Screenshot 2025-06-08 at 15 53 53" src="https://github.com/user-attachments/assets/46a9f3d6-3f77-48c0-a768-4e6667e32d8f" />

**After**

<img width="1126" alt="Screenshot 2025-06-08 at 15 54 00" src="https://github.com/user-attachments/assets/c79fbeea-d35d-4da5-9142-6c89f5da198b" />
