### PR TITLE
fix: add missing 'enabled' in sentence.

### DIFF
--- a/packages/desktop-client/src/components/settings/Reset.tsx
+++ b/packages/desktop-client/src/components/settings/Reset.tsx
@@ -81,6 +81,7 @@ export function ResetSync() {
         <Text>
           <Trans>
             <strong>Reset sync</strong> is only available when syncing is
+            enabled.
           </Trans>
         </Text>
       )}

--- a/upcoming-release-notes/5133.md
+++ b/upcoming-release-notes/5133.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [OlivierKamers]
+---
+
+Add missing 'enabled' in translated text


### PR DESCRIPTION
I was looking at contributing to some Dutch translations in Weblate and I noticed a strange key ([link](https://hosted.weblate.org/translate/actualbudget/actual/nl/?checksum=a96993dec4a7e11a)) that didn't make sense to me. Looking in the source code it appears this sentence dropped the `enabled.` in [this commit](https://github.com/actualbudget/actual/commit/0c94214a8ff5bdb802004cdeb323adcdffaa24f4#diff-506178988b30d52a1676964800c6206d8f4c2dbfc46c99fb77a755b9bfa690f6L75) by accident.

Are there certain steps I should follow due to updating a translation key or will it just be picked up as a new key to be translated in Weblate?