### PR TITLE
fix: ensure correct PR number is used for release notes file

### DIFF
--- a/bin/release-note-generator.ts
+++ b/bin/release-note-generator.ts
@@ -16,7 +16,7 @@ async function run() {
       `Found potentially matching PR ${activePr.number}: ${activePr.title}`,
     );
   }
-  const prNumber = activePr?.number ?? (await getNextPrNumber());
+  const initialPrNumber = activePr?.number ?? (await getNextPrNumber());
 
   const result = await prompts([
     {
@@ -29,7 +29,7 @@ async function run() {
       name: 'pullRequestNumber',
       message: 'PR Number',
       type: 'number',
-      initial: prNumber,
+      initial: initialPrNumber,
     },
     {
       name: 'releaseNoteType',
@@ -53,7 +53,8 @@ async function run() {
   if (
     !result.githubUsername ||
     !result.oneLineSummary ||
-    !result.releaseNoteType
+    !result.releaseNoteType ||
+    !result.pullRequestNumber
   ) {
     console.log('All questions must be answered. Exiting');
     exit(1);
@@ -64,6 +65,7 @@ async function run() {
     result.githubUsername,
     result.oneLineSummary,
   );
+  const prNumber = result.pullRequestNumber;
 
   const filepath = `./upcoming-release-notes/${prNumber}.md`;
   if (existsSync(filepath)) {
@@ -83,9 +85,7 @@ async function run() {
       console.error('Failed to write release note file:', err);
       exit(1);
     } else {
-      console.log(
-        `Release note generated successfully: ./upcoming-release-notes/${prNumber}.md`,
-      );
+      console.log(`Release note generated successfully: ${filepath}`);
     }
   });
 }

--- a/upcoming-release-notes/5134.md
+++ b/upcoming-release-notes/5134.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [OlivierKamers]
+---
+
+Fix PR number in release-note-generator


### PR DESCRIPTION
I usually create a draft PR before I generate the release notes and I found that the prompt value for PR number is not used for determining the file path, as it only uses the initial value. For me this didn't work because I'm not authenticated through the Github CLI so it will always use the value from `getNextPrNumber`, which is my draft PR number + 1. This change fixes it by using the inferred number as initial value for the command line prompt, and reading the actual value to be used for the file path.
