### PR TITLE
prevent nightly npm packages publishing on push

### DIFF
--- a/.github/workflows/publish-nightly-npm-packages.yml
+++ b/.github/workflows/publish-nightly-npm-packages.yml
@@ -2,9 +2,6 @@ name: Publish nightly npm packages
 
 # Nightly npm packages are built daily
 on:
-  push:
-    branches:
-      - master
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
