### PR TITLE
use fallback linking parameters if initial GoCardless linking process fails

### DIFF
--- a/packages/sync-server/src/app-gocardless/services/gocardless-service.js
+++ b/packages/sync-server/src/app-gocardless/services/gocardless-service.js
@@ -317,24 +317,36 @@ export const goCardlessService = {
       institution.supported_features?.includes('account_selection') ?? false;
 
     let response;
+    const body = {
+      redirectUrl: host + '/gocardless/link',
+      institutionId,
+      referenceId: uuidv4(),
+      accessValidForDays: institution.max_access_valid_for_days,
+      maxHistoricalDays: BANKS_WITH_LIMITED_HISTORY.includes(institutionId)
+        ? Number(institution.transaction_total_days) >= 90
+          ? '89'
+          : institution.transaction_total_days
+        : institution.transaction_total_days,
+      userLanguage: 'en',
+      ssn: null,
+      redirectImmediate: false,
+      accountSelection,
+    };
     try {
-      response = await client.initSession({
-        redirectUrl: host + '/gocardless/link',
-        institutionId,
-        referenceId: uuidv4(),
-        accessValidForDays: institution.max_access_valid_for_days,
-        maxHistoricalDays: BANKS_WITH_LIMITED_HISTORY.includes(institutionId)
-          ? Number(institution.transaction_total_days) >= 90
-            ? '89'
-            : institution.transaction_total_days
-          : institution.transaction_total_days,
-        userLanguage: 'en',
-        ssn: null,
-        redirectImmediate: false,
-        accountSelection,
-      });
+      response = await client.initSession(body);
     } catch (error) {
-      handleGoCardlessError(error);
+      try {
+        console.log('Failed to link using:');
+        console.log(body);
+        console.log('Falling back to accessValidForDays = 90');
+
+        response = await client.initSession({
+          ...body,
+          accessValidForDays: 90,
+        });
+      } catch (error) {
+        handleGoCardlessError(error);
+      }
     }
 
     const { link, id: requisitionId } = response;

--- a/upcoming-release-notes/5150.md
+++ b/upcoming-release-notes/5150.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Use fallback linking parameters if initial GoCardless linking process fails


### PR DESCRIPTION
Sometimes, it appears, GoCardless provide an `institution.max_access_valid_for_days` value that actually causes the requesition request to fail. This is just a simple change to give it another go with the default 90 days before we pass the error along to the front end.

Annoyingly, when it fails for this reason, the server returns a 404, with extra hidden information saying "ERR BAD REQUEST" instead of a 400/500 etc...