### PR TITLE
Fix: display notifications below modal windows

### DIFF
--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -22,6 +22,7 @@ import { View } from '@actual-app/components/view';
 import { css } from '@emotion/css';
 
 import { Link } from './common/Link';
+import { MODAL_Z_INDEX } from './common/Modal';
 
 import {
   removeNotification,
@@ -313,7 +314,7 @@ export function Notifications({ style }: { style?: CSSProperties }) {
         top: notificationInset?.top,
         right: notificationInset?.right || 13,
         left: notificationInset?.left || (isNarrowWidth ? 13 : undefined),
-        zIndex: 10000,
+        zIndex: MODAL_Z_INDEX - 1,
         ...style,
       }}
     >

--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -33,6 +33,8 @@ import { AutoTextSize } from 'auto-text-size';
 
 import { useModalState } from '@desktop-client/hooks/useModalState';
 
+export const MODAL_Z_INDEX = 3000;
+
 type ModalProps = ComponentPropsWithRef<typeof ReactAriaModal> & {
   name: string;
   isLoading?: boolean;
@@ -80,7 +82,7 @@ export const Modal = ({
       style={{
         position: 'fixed',
         inset: 0,
-        zIndex: 3000,
+        zIndex: MODAL_Z_INDEX,
         fontSize: 14,
         willChange: 'transform',
         // on mobile, we disable the blurred background for performance reasons

--- a/upcoming-release-notes/5165.md
+++ b/upcoming-release-notes/5165.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Display notifications below the modals.


### PR DESCRIPTION
This gets really annoying if you are doing multiple quick operations and the screen has 3+ notifications. Suddenly they start overlaying also the modal content window - which obviously isn't great UX.

Before:
<img width="483" alt="Screenshot 2025-06-14 at 13 28 41" src="https://github.com/user-attachments/assets/7a97dbf8-f798-44c9-b05d-8b004a6a5164" />


After:
<img width="484" alt="Screenshot 2025-06-14 at 13 23 53" src="https://github.com/user-attachments/assets/5c24c41f-b67c-4508-8cf0-cbc1308ae13e" />
