### PR TITLE
feat(currency): add currency setting and format

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -392,7 +392,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
               return integerToCurrency(expr);
             },
             unformatExpr: expr => {
-              return amountToInteger(evalArithmetic(expr, 0) || 0);
+              return amountToInteger(evalArithmetic(expr, 0) ?? 0);
             },
           }}
           inputProps={{

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -392,7 +392,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
               return integerToCurrency(expr);
             },
             unformatExpr: expr => {
-              return amountToInteger(evalArithmetic(expr, 0));
+              return amountToInteger(evalArithmetic(expr, 0) || 0);
             },
           }}
           inputProps={{

--- a/packages/desktop-client/src/components/settings/Currency.tsx
+++ b/packages/desktop-client/src/components/settings/Currency.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { useTranslation, Trans } from 'react-i18next';
+
+import { Select } from '@actual-app/components/select';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+import { css } from '@emotion/css';
+
+import {
+  currencies,
+  getLocalizedCurrencyOption,
+} from 'loot-core/shared/currencies';
+
+import { Setting } from './UI';
+
+import { Checkbox } from '@desktop-client/components/forms';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
+
+export function CurrencySettings() {
+  const { t } = useTranslation();
+
+  const [currencyCode, setCurrencyCodePref] = useSyncedPref('currencyCode');
+  const selectedCurrencyCode = currencyCode || '';
+
+  const [symbolPosition, setSymbolPositionPref] = useSyncedPref(
+    'currencySymbolPosition',
+  );
+  const [spaceEnabled, setSpaceEnabledPref] = useSyncedPref(
+    'currencySpaceBetweenAmountAndSymbol',
+  );
+
+  const selectButtonClassName = css({
+    '&[data-hovered]': {
+      backgroundColor: theme.buttonNormalBackgroundHover,
+    },
+  });
+
+  const handleCurrencyChange = (code: string) => {
+    setCurrencyCodePref(code);
+  };
+
+  const symbolPositionOptions = [
+    { value: 'before', label: t('Before amount (e.g. $100)') },
+    { value: 'after', label: t('After amount (e.g. 100€)') },
+  ];
+
+  return (
+    <Setting
+      primaryAction={
+        <View
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1.5em',
+            width: '100%',
+          }}
+        >
+          <View style={{ width: 'fit-content' }}>
+            <Text style={{ fontWeight: 500, marginBottom: '0.5em' }}>
+              {t('Currency')}
+            </Text>
+            <Select
+              value={selectedCurrencyCode}
+              onChange={handleCurrencyChange}
+              options={currencies.map(getLocalizedCurrencyOption)}
+              className={selectButtonClassName}
+              style={{ width: 'fit-content' }}
+            />
+          </View>
+
+          {selectedCurrencyCode !== '' && (
+            <>
+              <View style={{ width: 'fit-content' }}>
+                <Text style={{ fontWeight: 500, marginBottom: '0.5em' }}>
+                  {t('Symbol Position')}
+                </Text>
+                <Select
+                  value={symbolPosition || 'before'}
+                  onChange={value => setSymbolPositionPref(value)}
+                  options={symbolPositionOptions.map(f => [f.value, f.label])}
+                  className={selectButtonClassName}
+                  style={{ width: 'auto' }}
+                />
+              </View>
+
+              <View
+                style={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'flex-start',
+                }}
+              >
+                <Checkbox
+                  id="settings-spaceEnabled"
+                  checked={spaceEnabled === 'true'}
+                  onChange={e =>
+                    setSpaceEnabledPref(e.target.checked ? 'true' : 'false')
+                  }
+                />
+                <label
+                  htmlFor="settings-spaceEnabled"
+                  style={{ marginLeft: '0.5em' }}
+                >
+                  <Trans>Add space between amount and symbol</Trans>
+                </label>
+              </View>
+            </>
+          )}
+        </View>
+      }
+    >
+      <Text>
+        <Trans>
+          <strong>Currency settings</strong> affect how amounts are displayed
+          throughout the application.
+        </Trans>
+      </Text>
+    </Setting>
+  );
+}

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -105,6 +105,9 @@ export function ExperimentalFeatures() {
             >
               <Trans>Pluggy.ai Bank Sync (Brazilian banks only)</Trans>
             </FeatureToggle>
+            <FeatureToggle flag="currency">
+              <Trans>Currency support</Trans>
+            </FeatureToggle>
           </View>
         ) : (
           <Link

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -105,7 +105,10 @@ export function ExperimentalFeatures() {
             >
               <Trans>Pluggy.ai Bank Sync (Brazilian banks only)</Trans>
             </FeatureToggle>
-            <FeatureToggle flag="currency">
+            <FeatureToggle
+              flag="currency"
+              feedbackLink="https://github.com/actualbudget/actual/issues/5191"
+            >
               <Trans>Currency support</Trans>
             </FeatureToggle>
           </View>

--- a/packages/desktop-client/src/components/settings/Format.tsx
+++ b/packages/desktop-client/src/components/settings/Format.tsx
@@ -12,7 +12,7 @@ import { css } from '@emotion/css';
 import { numberFormats } from 'loot-core/shared/util';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
 
-import { Setting } from './UI';
+import { Column, Setting } from './UI';
 
 import { Checkbox } from '@desktop-client/components/forms';
 import { useSidebar } from '@desktop-client/components/sidebar/SidebarProvider';
@@ -46,22 +46,6 @@ const dateFormats: { value: SyncedPrefs['dateFormat']; label: string }[] = [
   { value: 'MM.dd.yyyy', label: 'MM.DD.YYYY' },
   { value: 'dd.MM.yyyy', label: 'DD.MM.YYYY' },
 ];
-
-function Column({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <View
-      style={{
-        alignItems: 'flex-start',
-        flexGrow: 1,
-        gap: '0.5em',
-        width: '100%',
-      }}
-    >
-      <Text style={{ fontWeight: 500 }}>{title}</Text>
-      <View style={{ alignItems: 'flex-start', gap: '1em' }}>{children}</View>
-    </View>
-  );
-}
 
 export function FormatSettings() {
   const { t } = useTranslation();

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -10,7 +10,7 @@ import { css } from '@emotion/css';
 
 import { type DarkTheme, type Theme } from 'loot-core/types/prefs';
 
-import { Setting } from './UI';
+import { Column, Setting } from './UI';
 
 import { useSidebar } from '@desktop-client/components/sidebar/SidebarProvider';
 import {
@@ -19,22 +19,6 @@ import {
   usePreferredDarkTheme,
   darkThemeOptions,
 } from '@desktop-client/style';
-
-function Column({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <View
-      style={{
-        alignItems: 'flex-start',
-        flexGrow: 1,
-        gap: '0.5em',
-        width: '100%',
-      }}
-    >
-      <Text style={{ fontWeight: 500 }}>{title}</Text>
-      <View style={{ alignItems: 'flex-start', gap: '1em' }}>{children}</View>
-    </View>
-  );
-}
 
 export function ThemeSettings() {
   const { t } = useTranslation();

--- a/packages/desktop-client/src/components/settings/UI.tsx
+++ b/packages/desktop-client/src/components/settings/UI.tsx
@@ -3,6 +3,7 @@ import { Trans } from 'react-i18next';
 import { useLocation } from 'react-router';
 
 import { type CSSProperties } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
@@ -95,3 +96,28 @@ export const AdvancedToggle = ({ children }: AdvancedToggleProps) => {
     </Link>
   );
 };
+
+export function Column({
+  title,
+  children,
+  style,
+}: {
+  title: string;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <View
+      style={{
+        alignItems: 'flex-start',
+        flexGrow: 1,
+        gap: '0.5em',
+        width: '100%',
+        ...style,
+      }}
+    >
+      <Text style={{ fontWeight: 500 }}>{title}</Text>
+      <View style={{ alignItems: 'flex-start', gap: '1em' }}>{children}</View>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -16,6 +16,7 @@ import { isElectron } from 'loot-core/shared/environment';
 import { AuthSettings } from './AuthSettings';
 import { Backups } from './Backups';
 import { BudgetTypeSettings } from './BudgetTypeSettings';
+import { CurrencySettings } from './Currency';
 import { EncryptionSettings } from './Encryption';
 import { ExperimentalFeatures } from './Experimental';
 import { ExportBudget } from './Export';
@@ -32,12 +33,14 @@ import { FormField, FormLabel } from '@desktop-client/components/forms';
 import { MOBILE_NAV_HEIGHT } from '@desktop-client/components/mobile/MobileNavTabs';
 import { Page } from '@desktop-client/components/Page';
 import { useServerVersion } from '@desktop-client/components/ServerContext';
+import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';
 import { useGlobalPref } from '@desktop-client/hooks/useGlobalPref';
 import {
   useIsOutdated,
   useLatestVersion,
 } from '@desktop-client/hooks/useLatestVersion';
 import { useMetadataPref } from '@desktop-client/hooks/useMetadataPref';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { loadPrefs } from '@desktop-client/prefs/prefsSlice';
 import { useDispatch } from '@desktop-client/redux';
 
@@ -149,6 +152,8 @@ export function Settings() {
   const [floatingSidebar] = useGlobalPref('floatingSidebar');
   const [budgetName] = useMetadataPref('budgetName');
   const dispatch = useDispatch();
+  const isCurrencyExperimentalEnabled = useFeatureFlag('currency');
+  const [_, setCurrencyCodePref] = useSyncedPref('currencyCode');
 
   const onCloseBudget = () => {
     dispatch(closeBudget());
@@ -162,6 +167,12 @@ export function Settings() {
     dispatch(loadPrefs());
     return () => unlisten();
   }, [dispatch]);
+
+  useEffect(() => {
+    if (!isCurrencyExperimentalEnabled) {
+      setCurrencyCodePref('');
+    }
+  }, [isCurrencyExperimentalEnabled, setCurrencyCodePref]);
 
   const { isNarrowWidth } = useResponsive();
 
@@ -203,6 +214,7 @@ export function Settings() {
         <About />
         <ThemeSettings />
         <FormatSettings />
+        {isCurrencyExperimentalEnabled && <CurrencySettings />}
         <LanguageSettings />
         <AuthSettings />
         <EncryptionSettings />

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -153,7 +153,7 @@ export function Settings() {
   const [budgetName] = useMetadataPref('budgetName');
   const dispatch = useDispatch();
   const isCurrencyExperimentalEnabled = useFeatureFlag('currency');
-  const [_, setCurrencyCodePref] = useSyncedPref('currencyCode');
+  const [_, setDefaultCurrencyCodePref] = useSyncedPref('defaultCurrencyCode');
 
   const onCloseBudget = () => {
     dispatch(closeBudget());
@@ -170,9 +170,9 @@ export function Settings() {
 
   useEffect(() => {
     if (!isCurrencyExperimentalEnabled) {
-      setCurrencyCodePref('');
+      setDefaultCurrencyCodePref('');
     }
-  }, [isCurrencyExperimentalEnabled, setCurrencyCodePref]);
+  }, [isCurrencyExperimentalEnabled, setDefaultCurrencyCodePref]);
 
   const { isNarrowWidth } = useResponsive();
 

--- a/packages/desktop-client/src/components/spreadsheet/CellValue.tsx
+++ b/packages/desktop-client/src/components/spreadsheet/CellValue.tsx
@@ -83,10 +83,15 @@ export function CellValueText<
   ...props
 }: CellValueTextProps<SheetName, FieldName>) {
   const format = useFormat();
+  const isFinancial =
+    type === 'financial' ||
+    type === 'financial-with-sign' ||
+    type === 'financial-no-decimals';
   return (
     <Text
       style={{
-        ...(type === 'financial' && styles.tnum),
+        ...(isFinancial && styles.tnum),
+        ...(isFinancial && { whiteSpace: 'nowrap' }),
         ...style,
       }}
       data-testid={name}

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -90,7 +90,9 @@ export function PercentInput({
   }
 
   function fireUpdate() {
-    const clampedValue = clampToPercent(evalArithmetic(value.replace('%', '')));
+    const clampedValue = clampToPercent(
+      evalArithmetic(value.replace('%', '')) ?? 0,
+    );
     onUpdatePercent?.(clampedValue);
     onInputTextChange(String(clampedValue));
   }

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -91,7 +91,7 @@ export function PercentInput({
 
   function fireUpdate() {
     const clampedValue = clampToPercent(
-      evalArithmetic(value.replace('%', '')) ?? 0,
+      evalArithmetic(value.replace('%', ''), 0) ?? 0,
     );
     onUpdatePercent?.(clampedValue);
     onInputTextChange(String(clampedValue));

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -7,6 +7,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesUIEnabled: false,
   actionTemplating: false,
   pluggyAiBankSync: false,
+  currency: false,
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/desktop-client/src/hooks/useFormat.ts
+++ b/packages/desktop-client/src/hooks/useFormat.ts
@@ -1,7 +1,13 @@
 import { useCallback, useEffect, useMemo } from 'react';
 
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { type Currency, getCurrency } from 'loot-core/shared/currencies';
 import {
+  amountToInteger,
+  currencyToAmount,
   getNumberFormat,
+  type IntegerAmount,
+  integerToAmount,
   integerToCurrency,
   parseNumberFormat,
   setNumberFormat,
@@ -14,58 +20,93 @@ export type FormatType =
   | 'number'
   | 'percentage'
   | 'financial'
-  | 'financial-with-sign';
+  | 'financial-with-sign'
+  | 'financial-no-decimals';
+
+export type UseFormatResult = {
+  (value: unknown, type?: FormatType): string;
+  forEdit: (value: IntegerAmount) => string;
+  fromEdit: (
+    value: string,
+    defaultValue?: number | null,
+  ) => IntegerAmount | null;
+  currency: Currency;
+};
 
 function format(
   value: unknown,
-  type: FormatType = 'string',
-  formatter?: Intl.NumberFormat,
+  type: FormatType,
+  formatter: Intl.NumberFormat,
+  decimalPlaces: number,
 ): string {
   switch (type) {
-    case 'string':
+    case 'string': {
       const val = JSON.stringify(value);
       // eslint-disable-next-line rulesdir/typography
       if (val.charAt(0) === '"' && val.charAt(val.length - 1) === '"') {
         return val.slice(1, -1);
       }
       return val;
+    }
     case 'number':
-      return '' + value;
-    case 'percentage':
-      return value + '%';
-    case 'financial-with-sign':
-      const formatted = format(value, 'financial', formatter);
-      if (typeof value === 'number' && value >= 0) {
-        return '+' + formatted;
-      }
-      return formatted;
-    case 'financial':
-      if (value == null || value === '' || value === 0) {
-        return integerToCurrency(0, formatter);
-      } else if (typeof value === 'string') {
-        const parsed = parseFloat(value);
-        value = isNaN(parsed) ? 0 : parsed;
-      }
-
       if (typeof value !== 'number') {
         throw new Error(
           'Value is not a number (' + typeof value + '): ' + value,
         );
       }
+      return formatter.format(value);
+    case 'percentage':
+      return value + '%';
+    case 'financial-with-sign': {
+      const formatted = format(value, 'financial', formatter, decimalPlaces);
+      if (typeof value === 'number' && value >= 0) {
+        return '+' + formatted;
+      }
+      return formatted;
+    }
+    case 'financial-no-decimals':
+    case 'financial': {
+      let localValue = value;
+      if (localValue == null || localValue === '' || localValue === 0) {
+        return integerToCurrency(0, formatter, decimalPlaces);
+      } else if (typeof localValue === 'string') {
+        const parsed = parseFloat(localValue);
+        localValue = isNaN(parsed) ? 0 : parsed;
+      }
 
-      return integerToCurrency(value, formatter);
+      if (typeof localValue !== 'number') {
+        throw new Error(
+          'Value is not a number (' + typeof localValue + '): ' + localValue,
+        );
+      }
+
+      return integerToCurrency(localValue, formatter, decimalPlaces);
+    }
     default:
       throw new Error('Unknown format type: ' + type);
   }
 }
 
-export function useFormat() {
-  const [numberFormat] = useSyncedPref('numberFormat');
-  const [hideFraction] = useSyncedPref('hideFraction');
+export function useFormat(): UseFormatResult {
+  const [numberFormatPref] = useSyncedPref('numberFormat');
+  const [hideFractionPref] = useSyncedPref('hideFraction');
+  const [currencyCodePref] = useSyncedPref('currencyCode');
+  const [symbolPositionPref] = useSyncedPref('currencySymbolPosition');
+  const [spaceEnabledPref] = useSyncedPref(
+    'currencySpaceBetweenAmountAndSymbol',
+  );
 
-  const config = useMemo(
-    () => parseNumberFormat({ format: numberFormat, hideFraction }),
-    [numberFormat, hideFraction],
+  const activeCurrency = useMemo(() => {
+    return getCurrency(currencyCodePref || '');
+  }, [currencyCodePref]);
+
+  const numberFormatConfig = useMemo(
+    () =>
+      parseNumberFormat({
+        format: numberFormatPref,
+        hideFraction: hideFractionPref === 'true',
+      }),
+    [numberFormatPref, hideFractionPref],
   );
 
   // Hack: keep the global number format in sync - update the settings when
@@ -73,12 +114,129 @@ export function useFormat() {
   // This should be patched by moving all number-formatting utilities away from
   // the global `getNumberFormat()` and to using the reactive `useFormat` hook.
   useEffect(() => {
-    setNumberFormat(config);
-  }, [config]);
+    setNumberFormat(numberFormatConfig);
+  }, [numberFormatConfig]);
 
-  return useCallback(
-    (value: unknown, type: FormatType = 'string') =>
-      format(value, type, getNumberFormat(config).formatter),
-    [config],
+  const applyCurrencyStyling = useCallback(
+    (formattedNumericValue: string, currencySymbol: string): string => {
+      if (!currencySymbol) {
+        return formattedNumericValue;
+      }
+
+      const space = spaceEnabledPref === 'true' ? '\u00A0' : '';
+      const position = symbolPositionPref || 'before';
+
+      return position === 'after'
+        ? `${formattedNumericValue}${space}${currencySymbol}`
+        : `${currencySymbol}${space}${formattedNumericValue}`;
+    },
+    [symbolPositionPref, spaceEnabledPref],
   );
+
+  const formatDisplay = useCallback(
+    (value: unknown, type: FormatType = 'string'): string => {
+      const isFinancialType =
+        type === 'financial' ||
+        type === 'financial-with-sign' ||
+        type === 'financial-no-decimals';
+
+      let displayDecimalPlaces: number | undefined;
+
+      if (isFinancialType) {
+        if (type === 'financial-no-decimals' || hideFractionPref === 'true') {
+          displayDecimalPlaces = 0;
+        } else {
+          displayDecimalPlaces = activeCurrency.decimalPlaces;
+        }
+      }
+
+      const intlFormatter = getNumberFormat({
+        format: numberFormatConfig.format,
+        decimalPlaces: displayDecimalPlaces,
+      }).formatter;
+
+      const baseFormattedValue = format(
+        value,
+        type,
+        intlFormatter,
+        activeCurrency.decimalPlaces,
+      );
+
+      if (isFinancialType && activeCurrency && activeCurrency.code !== '') {
+        return applyCurrencyStyling(baseFormattedValue, activeCurrency.symbol);
+      }
+
+      return baseFormattedValue;
+    },
+    [
+      activeCurrency,
+      numberFormatConfig,
+      applyCurrencyStyling,
+      hideFractionPref,
+    ],
+  );
+
+  const toAmount = useCallback(
+    (value: number) => integerToAmount(value, activeCurrency.decimalPlaces),
+    [activeCurrency.decimalPlaces],
+  );
+
+  const fromAmount = useCallback(
+    (value: number) => amountToInteger(value, activeCurrency.decimalPlaces),
+    [activeCurrency.decimalPlaces],
+  );
+
+  const forEdit = useCallback(
+    (value: IntegerAmount) => {
+      const amount = toAmount(value);
+      const decimalPlaces =
+        hideFractionPref === 'true' ? 0 : activeCurrency.decimalPlaces;
+      const editFormatter = getNumberFormat({
+        format: numberFormatConfig.format,
+        decimalPlaces,
+      }).formatter;
+      return editFormatter.format(amount);
+    },
+    [
+      toAmount,
+      hideFractionPref,
+      activeCurrency.decimalPlaces,
+      numberFormatConfig.format,
+    ],
+  );
+
+  const fromEdit = useCallback(
+    (
+      value: string,
+      defaultValue: number | null = null,
+    ): IntegerAmount | null => {
+      if (value == null) {
+        return defaultValue;
+      }
+
+      const trimmed = value.trim();
+      if (trimmed === '') {
+        return defaultValue;
+      }
+
+      let numericValue: number | null = evalArithmetic(trimmed, null);
+
+      if (numericValue === null || isNaN(numericValue)) {
+        numericValue = currencyToAmount(trimmed);
+      }
+
+      if (numericValue !== null && !isNaN(numericValue)) {
+        return fromAmount(numericValue);
+      }
+
+      return defaultValue;
+    },
+    [fromAmount],
+  );
+
+  return Object.assign(formatDisplay, {
+    forEdit,
+    fromEdit,
+    currency: activeCurrency,
+  });
 }

--- a/packages/desktop-client/src/hooks/useFormat.ts
+++ b/packages/desktop-client/src/hooks/useFormat.ts
@@ -109,15 +109,15 @@ function format(
 export function useFormat(): UseFormatResult {
   const [numberFormatPref] = useSyncedPref('numberFormat');
   const [hideFractionPref] = useSyncedPref('hideFraction');
-  const [currencyCodePref] = useSyncedPref('currencyCode');
+  const [defaultCurrencyCodePref] = useSyncedPref('defaultCurrencyCode');
   const [symbolPositionPref] = useSyncedPref('currencySymbolPosition');
   const [spaceEnabledPref] = useSyncedPref(
     'currencySpaceBetweenAmountAndSymbol',
   );
 
   const activeCurrency = useMemo(() => {
-    return getCurrency(currencyCodePref || '');
-  }, [currencyCodePref]);
+    return getCurrency(defaultCurrencyCodePref || '');
+  }, [defaultCurrencyCodePref]);
 
   const numberFormatConfig = useMemo(
     () =>

--- a/packages/loot-core/src/shared/arithmetic.ts
+++ b/packages/loot-core/src/shared/arithmetic.ts
@@ -112,7 +112,7 @@ function evaluate(ast): number {
 export function evalArithmetic(
   expression: string,
   defaultValue: number | null = null,
-): number {
+): number | null {
   // An empty expression always evals to the default
   if (expression === '') {
     return defaultValue;

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -1,0 +1,40 @@
+import { t } from 'i18next';
+
+export type Currency = {
+  code: string;
+  symbol: string;
+  name: string;
+  decimalPlaces: number;
+};
+
+// When adding a new currency with a higher decimal precision, make sure to update
+// the MAX_SAFE_NUMBER in util.ts.
+export const currencies: Currency[] = [
+  { code: '', name: t('None'), symbol: '', decimalPlaces: 2 },
+  { code: 'AUD', name: t('Australian Dollar'), symbol: 'A$', decimalPlaces: 2 },
+  { code: 'CAD', name: t('Canadian Dollar'), symbol: 'CA$', decimalPlaces: 2 },
+  { code: 'CHF', name: t('Swiss Franc'), symbol: 'Fr.', decimalPlaces: 2 },
+  { code: 'CNY', name: t('Yuan Renminbi'), symbol: '¥', decimalPlaces: 2 },
+  { code: 'EUR', name: t('Euro'), symbol: '€', decimalPlaces: 2 },
+  { code: 'GBP', name: t('Pound Sterling'), symbol: '£', decimalPlaces: 2 },
+  { code: 'HKD', name: t('Hong Kong Dollar'), symbol: 'HK$', decimalPlaces: 2 },
+  // { code: 'JPY', name: t('Yen'), symbol: '¥', decimalPlaces: 0 },
+  { code: 'SGD', name: t('Singapore Dollar'), symbol: 'S$', decimalPlaces: 2 },
+  { code: 'USD', name: t('US Dollar'), symbol: '$', decimalPlaces: 2 },
+];
+
+export function getCurrency(code: string): Currency {
+  return currencies.find(c => c.code === code) || currencies[0];
+}
+
+export function getLocalizedCurrencyOption(
+  currency: Currency,
+): [string, string] {
+  if (currency.code === '') {
+    return [currency.code, t('None')];
+  }
+  return [
+    currency.code,
+    `${currency.code} - ${currency.name} (${currency.symbol})`,
+  ];
+}

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -10,17 +10,17 @@ export type Currency = {
 // When adding a new currency with a higher decimal precision, make sure to update
 // the MAX_SAFE_NUMBER in util.ts.
 export const currencies: Currency[] = [
-  { code: '', name: t('None'), symbol: '', decimalPlaces: 2 },
-  { code: 'AUD', name: t('Australian Dollar'), symbol: 'A$', decimalPlaces: 2 },
-  { code: 'CAD', name: t('Canadian Dollar'), symbol: 'CA$', decimalPlaces: 2 },
-  { code: 'CHF', name: t('Swiss Franc'), symbol: 'Fr.', decimalPlaces: 2 },
-  { code: 'CNY', name: t('Yuan Renminbi'), symbol: '¥', decimalPlaces: 2 },
-  { code: 'EUR', name: t('Euro'), symbol: '€', decimalPlaces: 2 },
-  { code: 'GBP', name: t('Pound Sterling'), symbol: '£', decimalPlaces: 2 },
-  { code: 'HKD', name: t('Hong Kong Dollar'), symbol: 'HK$', decimalPlaces: 2 },
-  // { code: 'JPY', name: t('Yen'), symbol: '¥', decimalPlaces: 0 },
-  { code: 'SGD', name: t('Singapore Dollar'), symbol: 'S$', decimalPlaces: 2 },
-  { code: 'USD', name: t('US Dollar'), symbol: '$', decimalPlaces: 2 },
+  { code: '', name: 'None', symbol: '', decimalPlaces: 2 },
+  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', decimalPlaces: 2 },
+  { code: 'CAD', name: 'Canadian Dollar', symbol: 'CA$', decimalPlaces: 2 },
+  { code: 'CHF', name: 'Swiss Franc', symbol: 'Fr.', decimalPlaces: 2 },
+  { code: 'CNY', name: 'Yuan Renminbi', symbol: '¥', decimalPlaces: 2 },
+  { code: 'EUR', name: 'Euro', symbol: '€', decimalPlaces: 2 },
+  { code: 'GBP', name: 'Pound Sterling', symbol: '£', decimalPlaces: 2 },
+  { code: 'HKD', name: 'Hong Kong Dollar', symbol: 'HK$', decimalPlaces: 2 },
+  // { code: 'JPY', name: 'Yen', symbol: '¥', decimalPlaces: 0 },
+  { code: 'SGD', name: 'Singapore Dollar', symbol: 'S$', decimalPlaces: 2 },
+  { code: 'USD', name: 'US Dollar', symbol: '$', decimalPlaces: 2 },
 ];
 
 export function getCurrency(code: string): Currency {
@@ -33,8 +33,6 @@ export function getLocalizedCurrencyOption(
   if (currency.code === '') {
     return [currency.code, t('None')];
   }
-  return [
-    currency.code,
-    `${currency.code} - ${currency.name} (${currency.symbol})`,
-  ];
+  const name = t(currency.name);
+  return [currency.code, `${currency.code} - ${name} (${currency.symbol})`];
 }

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -1,5 +1,3 @@
-import { t } from 'i18next';
-
 export type Currency = {
   code: string;
   symbol: string;
@@ -9,6 +7,9 @@ export type Currency = {
 
 // When adding a new currency with a higher decimal precision, make sure to update
 // the MAX_SAFE_NUMBER in util.ts.
+// When adding a currency, also update the translation map in
+// at packages/desktop-client/src/components/settings/Currency.tsx
+// for the translation
 export const currencies: Currency[] = [
   { code: '', name: 'None', symbol: '', decimalPlaces: 2 },
   { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', decimalPlaces: 2 },
@@ -25,14 +26,4 @@ export const currencies: Currency[] = [
 
 export function getCurrency(code: string): Currency {
   return currencies.find(c => c.code === code) || currencies[0];
-}
-
-export function getLocalizedCurrencyOption(
-  currency: Currency,
-): [string, string] {
-  if (currency.code === '') {
-    return [currency.code, t('None')];
-  }
-  const name = t(currency.name);
-  return [currency.code, `${currency.code} - ${name} (${currency.symbol})`];
 }

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -2,7 +2,8 @@ export type FeatureFlag =
   | 'goalTemplatesEnabled'
   | 'goalTemplatesUIEnabled'
   | 'actionTemplating'
-  | 'pluggyAiBankSync';
+  | 'pluggyAiBankSync'
+  | 'currency';
 
 /**
  * Cross-device preferences. These sync across devices when they are changed.
@@ -16,6 +17,9 @@ export type SyncedPrefs = Partial<
     | 'numberFormat'
     | 'hideFraction'
     | 'isPrivacyEnabled'
+    | 'currencyCode'
+    | 'currencySymbolPosition'
+    | 'currencySpaceBetweenAmountAndSymbol'
     | `show-balances-${string}`
     | `show-extra-balances-${string}`
     | `hide-cleared-${string}`

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -17,9 +17,9 @@ export type SyncedPrefs = Partial<
     | 'numberFormat'
     | 'hideFraction'
     | 'isPrivacyEnabled'
-    | 'currencyCode'
     | 'currencySymbolPosition'
     | 'currencySpaceBetweenAmountAndSymbol'
+    | 'defaultCurrencyCode'
     | `show-balances-${string}`
     | `show-extra-balances-${string}`
     | `hide-cleared-${string}`

--- a/upcoming-release-notes/5167.md
+++ b/upcoming-release-notes/5167.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [misu-dev]
+---
+
+Introduce an experimental feature to display currencies in the app

--- a/upcoming-release-notes/5167.md
+++ b/upcoming-release-notes/5167.md
@@ -3,4 +3,4 @@ category: Features
 authors: [misu-dev]
 ---
 
-Introduce an experimental feature to display currencies in the app
+Introduce an experimental feature to display currency symbols in the app


### PR DESCRIPTION
This PR introduces the currency setting and the display in the useFormat hook.
I put the currency select into an experimental feature. For now I disabled YEN as currency, as this will not work at the current state (later PRs will fix this).

This is a part of multiple PRs to start intoducing a currency to the budget-file and display it. 
The full implementation can be seen here: https://github.com/actualbudget/actual/pull/4890