### PR TITLE
Enhance PullToRefresh component to ensure full height usage on mobile devices

### DIFF
--- a/packages/desktop-client/src/components/mobile/PullToRefresh.tsx
+++ b/packages/desktop-client/src/components/mobile/PullToRefresh.tsx
@@ -7,7 +7,7 @@ type PullToRefreshProps = ComponentProps<typeof BasePullToRefresh>;
 
 export function PullToRefresh(props: PullToRefreshProps) {
   return (
-    <div style={{ overflow: 'auto' }}>
+    <div style={{ overflow: 'auto', flex: 1 }}>
       <BasePullToRefresh
         pullDownThreshold={80}
         resistance={2}

--- a/upcoming-release-notes/5179.md
+++ b/upcoming-release-notes/5179.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix transaction list on mobile to occupy full height even if there are not many transactions.


### PR DESCRIPTION
Reproduction (on mobile):

1. create a new account
2. add a single transaction
3. pull down to refresh
    1. before: only a small section of the page is "pullable" down (hard to describe what I mean, but you'll get it when you see the issue..)
    2. after: transaction list expands to 100% height of the page