### PR TITLE
Update parsing of schedule names (issue #4607)

### DIFF
--- a/packages/loot-core/src/server/budget/goal-template.pegjs
+++ b/packages/loot-core/src/server/budget/goal-template.pegjs
@@ -87,16 +87,16 @@ day 'day' = $(d d)
 date = $(month '-' day)
 currencySymbol 'currency symbol' = symbol: . & { return /\p{Sc}/u.test(symbol) }
 
-// Match schedule name including spaces up until we see a [, looking ahead to make sure it's followed by increase/decrease
+// Match schedule name including spaces and brackets, but stop before percentage modifiers
 rawScheduleName = $(
   (
-    [^ \t\r\n\[]        // First character can't be space or [
+    !('['('increase'i/'decrease'i)) // Don't start with [increase/decrease
+    [^ \t\r\n]                     // First character can't be whitespace
     (
-      [^\r\n\[]         // Subsequent characters can include spaces but not [
-      / 
-      (![^\r\n\[]* '['('increase'i/'decrease'i)) [ ] // Or spaces if not followed by [increase/decrease
+      !(_ '['('increase'i/'decrease'i)) // Don't match if followed by [increase/decrease modifier
+      [^\r\n]                       // Any character except newlines
     )*
   )
-) { return text() }
+) { return text().trim() }
 
 name 'Name' = $([^\r\n\t]+) { return text() }

--- a/upcoming-release-notes/5189.md
+++ b/upcoming-release-notes/5189.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MattFaz]
+---
+
+Fix parsing of schedule names containing square brackets conflicting with increase/decrease modifiers


### PR DESCRIPTION
Fixes issue #4607 which was introduced by feature #4257 

The changes fix parsing of schedule names containing square brackets by modifying the grammar rules:

 - **Before:** Schedule names couldn't contain `[` characters at all, causing failures when brackets appeared
  in schedule names
 - **After:** Schedule names can now contain brackets, but the parser stops parsing the name when it
  encounters `[increase` or `[decrease` modifiers (using negative lookahead)
 - Also trims whitespace from the parsed schedule name

 This allows schedule names like "My Schedule [2024]" to work properly while still recognizing increase/decrease modifiers.

https://github.com/user-attachments/assets/6221058c-954e-4b3a-9b6a-b5a1c18ffa93