### PR TITLE
fix: wrong payeeName for KBC Brussels

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/kbc_kredbebb.js
+++ b/packages/sync-server/src/app-gocardless/banks/kbc_kredbebb.js
@@ -5,7 +5,7 @@ import { extractPayeeNameFromRemittanceInfo } from './util/extract-payeeName-fro
 export default {
   ...Fallback,
 
-  institutionIds: ['KBC_KREDBEBB'],
+  institutionIds: ['KBC_KREDBEBB', 'KBC_BRUSSELS_KREDBEBB'],
 
   /**
    * For negative amounts, the only payee information we have is returned in

--- a/upcoming-release-notes/5193.md
+++ b/upcoming-release-notes/5193.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [wachkyri]
+---
+
+Fix wrong payeeName used for KBC Brussels


### PR DESCRIPTION
It is the same fix as done for KBC Bank in https://github.com/actualbudget/actual-server/pull/442 
In between there was a refactor done for CBC https://github.com/actualbudget/actual-server/pull/451 
KBC and KBC Brussels are the same banks in Belgium, the latter being the Brussels branch.

To be honest, I don't know the exact differences between the two, I think it is only for administrative reasons. I can log in both KBC and KBC Brussels without differences. The same applies to sync with GoCardLess. 

However, if I select sync with KBC Brussels, the fix for payeeName for KBC is not applied.

Please check if the fix I've done is the correct way to do it. I didn't want to create duplicate code which serves the same purpose. 

I tested the fix successfully on my build with KBC Brussels