### PR TITLE
Improve Boursobank Gocardless transaction parsing

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
+++ b/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
@@ -3,7 +3,7 @@ import { title } from '../../util/title/index.js';
 import Fallback from './integration-bank.js';
 
 const regexCard =
-  /^CARTE \d{2}\/\d{2}\/\d{2} (?<payeeName>.+?)( CB\*)?( ?\d{4,})?$/;
+  /^CARTE \d{2}\/\d{2}\/\d{2} (?<payeeName>.+?)( \d+)?( CB\*\d{4})?$/;
 const regexAtmWithdrawal =
   /^RETRAIT DAB \d{2}\/\d{2}\/\d{2} (?<locationName>.+?) CB\*\d{4,}/;
 const regexTransfer = /^VIR /;
@@ -101,7 +101,7 @@ export default {
 
       if (!identified) {
         // Unknown transaction type
-        editedTrans.payeeName = title(firstLine);
+        editedTrans.payeeName = title(firstLine.replace(/ \d+$/, ''));
       }
     }
 

--- a/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
+++ b/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
@@ -69,7 +69,7 @@ export default {
       let identified = false;
 
       // Instant transfer
-      for (let line of infoArray) {
+      for (const line of infoArray) {
         if (line.match(regexInstantTransfer)) {
           editedTrans.payeeName = title(line.replace(regexInstantTransfer, ''));
           editedTrans.notes = infoArray.filter(l => l !== line).join(' ');
@@ -80,7 +80,7 @@ export default {
 
       // SEPA transfer
       if (!identified) {
-        for (let line of infoArray) {
+        for (const line of infoArray) {
           if (line.match(regexSepa)) {
             editedTrans.payeeName = title(line.replace(regexSepa, ''));
             editedTrans.notes = infoArray.filter(l => l !== line).join(' ');
@@ -93,7 +93,7 @@ export default {
       // Other transfer
       // Must be evaluated after the other transfers as they're more specific (here VIR only)
       if (!identified) {
-        for (let line of infoArray) {
+        for (const line of infoArray) {
           if (line.match(regexTransfer)) {
             const infoArrayWithoutLine = infoArray.filter(l => l !== line);
             editedTrans.payeeName = title(infoArrayWithoutLine.join(' '));

--- a/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
+++ b/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
@@ -10,6 +10,8 @@ const regexTransfer = /^VIR /;
 const regexInstantTransfer = /^VIR INST /;
 const regexSepa = /^(PRLV|VIR) SEPA /;
 const regexLoan = /^ECH PRET:/;
+const regexCreditNote =
+  /^AVOIR (?<date>\d{2}\/\d{2}\/\d{2}) (?<payeeName>.+?) CB\*\d{4,}/;
 
 /** @type {import('./bank.interface.js').IBank} */
 export default {
@@ -52,6 +54,11 @@ export default {
       if (infoArray.length > 1) {
         editedTrans.notes += ' ' + infoArray[1];
       }
+    } else if (firstLine.match(regexCreditNote)) {
+      // Credit note (refund)
+      const match = firstLine.match(regexCreditNote);
+      editedTrans.payeeName = title(match.groups.payeeName);
+      editedTrans.notes = `Avoir ${match.groups.date}`;
     } else {
       // For the next patterns, we need to check all lines as the identifier can be anywhere
       let identified = false;

--- a/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
+++ b/packages/sync-server/src/app-gocardless/banks/boursobank_bousfrppxxx.js
@@ -23,9 +23,9 @@ export default {
     const editedTrans = { ...transaction };
 
     editedTrans.remittanceInformationUnstructuredArray =
-      // Remove the backslashes that are sometimes present
+      // Remove the localisation with backslashes that are sometimes present
       transaction.remittanceInformationUnstructuredArray
-        .map(line => line.replace(/\\ ?/g, ' '))
+        .map(line => line.replace(/\\.+/g, ''))
         // Remove an unwanted line that pollutes the remittance information
         .filter(line => line.startsWith('Réf : ') === false);
 

--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -33,6 +33,11 @@ describe('BoursoBank', () => {
         'Text put by the sender',
       ],
       [
+        ['PAYEE NAME', 'VIR Text put by the sender'],
+        'Payee Name',
+        'Text put by the sender',
+      ],
+      [
         [
           'VIR Text put by the sender',
           'PAYEE NAME',
@@ -45,6 +50,15 @@ describe('BoursoBank', () => {
         [
           'VIR Text put by the sender',
           'Réf : SOME TEXT PUT BY THE BANK',
+          'PAYEE NAME',
+        ],
+        'Payee Name',
+        'Text put by the sender',
+      ],
+      [
+        [
+          'Réf : SOME TEXT PUT BY THE BANK',
+          'VIR Text put by the sender',
           'PAYEE NAME',
         ],
         'Payee Name',
@@ -56,6 +70,17 @@ describe('BoursoBank', () => {
         'Text put by the sender',
       ],
       [
+        ['Text put by the sender', 'VIR INST PAYEE NAME'],
+        'Payee Name',
+        'Text put by the sender',
+      ],
+      [['VIR INST PAYEE NAME'], 'Payee Name', ''],
+      [
+        ['PAYEE NAME', 'VIR Text put by the sender'],
+        'Payee Name',
+        'Text put by the sender',
+      ],
+      [
         [
           'VIR SEPA PAYEE NAME',
           'SOME TEXT',
@@ -63,7 +88,17 @@ describe('BoursoBank', () => {
           'YET ANOTHER TEXT',
         ],
         'Payee Name',
-        '',
+        'SOME TEXT ANOTHER TEXT YET ANOTHER TEXT',
+      ],
+      [
+        [
+          'SOME TEXT',
+          'ANOTHER TEXT',
+          'VIR SEPA PAYEE NAME',
+          'YET ANOTHER TEXT',
+        ],
+        'Payee Name',
+        'SOME TEXT ANOTHER TEXT YET ANOTHER TEXT',
       ],
       [
         [
@@ -74,7 +109,18 @@ describe('BoursoBank', () => {
           'PRELEVEMENT FOO BAR BAZ du',
         ],
         'Payee Name',
-        '',
+        'HERE IS SOMETHING SOME OTHER TEXT 30/04/2025 PRELEVEMENT FOO BAR BAZ du',
+      ],
+      [
+        [
+          '30/05/2025',
+          'SOME.TEXT.123.456',
+          'PRELEVEMENT FOO BAR BAZ du',
+          'PRLV SEPA Payee Name',
+          'ABC 1934821371',
+        ],
+        'Payee Name',
+        '30/05/2025 SOME.TEXT.123.456 PRELEVEMENT FOO BAR BAZ du ABC 1934821371',
       ],
       [
         ['ECH PRET:1823918329832913'],

--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -129,7 +129,8 @@ describe('BoursoBank', () => {
         'ECH PRET:1823918329832913',
       ],
       [['PAYEE NAME 411'], 'Payee Name', ''],
-      [['PAYEE\\NAME\\ BIS'], 'Payee Name Bis', ''],
+      [['PAYEE NAME\\PARIS\\ FR'], 'Payee Name', ''],
+      [['PAYEE NAME 1\\PARIS\\ FR'], 'Payee Name', ''],
       [['AVOIR 17/06/25 PAYEE NAME CB*1234'], 'Payee Name', 'Avoir 17/06/25'],
     ])(
       'normalizes transaction with %s',

--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -3,22 +3,26 @@ import BoursoBank from '../boursobank_bousfrppxxx.js';
 describe('BoursoBank', () => {
   describe('#normalizeTransaction', () => {
     it.each([
-      [['CARTE 01/03/25 PAYEE NAME CB*4567'], 'Payee Name', ''],
-      [['CARTE 01/03/25 PAYEE NAME 713621 CB*4567'], 'Payee Name', ''],
-      [['CARTE 01/03/25 PAYEE NAME'], 'Payee Name', ''],
-      [['CARTE 01/03/25 PAYEE NAME 7428347'], 'Payee Name', ''],
+      [['CARTE 01/03/25 PAYEE NAME CB*4567'], 'Payee Name', 'Carte 01/03/25'],
+      [
+        ['CARTE 01/03/25 PAYEE NAME 713621 CB*4567'],
+        'Payee Name',
+        'Carte 01/03/25',
+      ],
+      [['CARTE 01/03/25 PAYEE NAME'], 'Payee Name', 'Carte 01/03/25'],
+      [['CARTE 01/03/25 PAYEE NAME 7428347'], 'Payee Name', 'Carte 01/03/25'],
       [
         [
           'CARTE 03/02/25 PAYEE NAME CB*1234',
           '2,80 NZD / 1 euro = 1,818181818',
         ],
         'Payee Name',
-        '2,80 NZD / 1 euro = 1,818181818',
+        'Carte 03/02/25 2,80 NZD / 1 euro = 1,818181818',
       ],
       [
         ['RETRAIT DAB 01/03/25 My location CB*9876'],
         'Retrait DAB',
-        'My location',
+        'Retrait 01/03/25 My location',
       ],
       [
         [
@@ -26,7 +30,7 @@ describe('BoursoBank', () => {
           '2,80 NZD / 1 euro = 1,818181818',
         ],
         'Retrait DAB',
-        'My location 2,80 NZD / 1 euro = 1,818181818',
+        'Retrait 01/03/25 My location 2,80 NZD / 1 euro = 1,818181818',
       ],
       [
         ['VIR Text put by the sender', 'PAYEE NAME'],

--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -4,6 +4,7 @@ describe('BoursoBank', () => {
   describe('#normalizeTransaction', () => {
     it.each([
       [['CARTE 01/03/25 PAYEE NAME CB*4567'], 'Payee Name', ''],
+      [['CARTE 01/03/25 PAYEE NAME 713621 CB*4567'], 'Payee Name', ''],
       [['CARTE 01/03/25 PAYEE NAME'], 'Payee Name', ''],
       [['CARTE 01/03/25 PAYEE NAME 7428347'], 'Payee Name', ''],
       [
@@ -127,7 +128,7 @@ describe('BoursoBank', () => {
         'Prêt bancaire',
         'ECH PRET:1823918329832913',
       ],
-      [['PAYEE NAME'], 'Payee Name', ''],
+      [['PAYEE NAME 411'], 'Payee Name', ''],
       [['PAYEE\\NAME\\ BIS'], 'Payee Name Bis', ''],
       [['AVOIR 17/06/25 PAYEE NAME CB*1234'], 'Payee Name', 'Avoir 17/06/25'],
     ])(

--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -129,6 +129,7 @@ describe('BoursoBank', () => {
       ],
       [['PAYEE NAME'], 'Payee Name', ''],
       [['PAYEE\\NAME\\ BIS'], 'Payee Name Bis', ''],
+      [['AVOIR 17/06/25 PAYEE NAME CB*1234'], 'Payee Name', 'Avoir 17/06/25'],
     ])(
       'normalizes transaction with %s',
       (

--- a/upcoming-release-notes/5202.md
+++ b/upcoming-release-notes/5202.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Aerion]
+---
+
+Improve Boursobank GoCardless transaction parsing


### PR DESCRIPTION
This is a followup of https://github.com/actualbudget/actual/pull/4958, where the Boursobank Gocardless was introduced.

This PR addresses two comments made on the original PR:
- The payee name for transfers wasn't read properly (caused by a non-deterministic order of the transaction details array)
- Adding the date for card transactions in the notes

This PR also introduces enhanced transaction parsing:
- Removing unwanted parts of the transaction name
- Identifying a credit note / refund on the account