### PR TITLE
improve compatibility with OFX/QFX files

### DIFF
--- a/packages/loot-core/src/server/transactions/import/ofx2json.ts
+++ b/packages/loot-core/src/server/transactions/import/ofx2json.ts
@@ -125,7 +125,7 @@ function mapOfxTransaction(stmtTrn): OFXTransaction {
 
 export async function ofx2json(ofx: string): Promise<OFXParseResult> {
   // firstly, split into the header attributes and the footer sgml
-  const contents = ofx.split('<OFX>', 2);
+  const contents = ofx.split(/<OFX\s?>/, 2);
 
   // firstly, parse the headers
   const headerString = contents[0].split(/\r?\n/);

--- a/upcoming-release-notes/5203.md
+++ b/upcoming-release-notes/5203.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Improve compatibility with OFX/QFX files


### PR DESCRIPTION
Reported on Discord, the bank provides a QFX with `<OFX >` instead of `<OFX>` as the opening tag, breaking our parsing.

It's not technically compliant with the standard, but it doesn't hurt to support it