### PR TITLE
Revert "Mobile running balance"

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -154,7 +154,6 @@ function TransactionListWithPreviews({
       balance={balance}
       balanceCleared={balanceCleared}
       balanceUncleared={balanceUncleared}
-      runningBalances={undefined}
       searchPlaceholder={`Search ${category.name}`}
       onSearch={onSearch}
       isLoadingMore={isLoadingMore}

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -32,11 +32,7 @@ import { View } from '@actual-app/components/view';
 import * as monthUtils from 'loot-core/shared/months';
 import { isPreviewId } from 'loot-core/shared/transactions';
 import { validForTransfer } from 'loot-core/shared/transfer';
-import {
-  groupById,
-  type IntegerAmount,
-  integerToCurrency,
-} from 'loot-core/shared/util';
+import { groupById, integerToCurrency } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type TransactionEntity,
@@ -87,7 +83,6 @@ function Loading({ style, 'aria-label': ariaLabel }: LoadingProps) {
 type TransactionListProps = {
   isLoading: boolean;
   transactions: readonly TransactionEntity[];
-  runningBalances: Map<TransactionEntity['id'], IntegerAmount> | undefined;
   onOpenTransaction?: (transaction: TransactionEntity) => void;
   isLoadingMore: boolean;
   onLoadMore: () => void;
@@ -97,7 +92,6 @@ type TransactionListProps = {
 export function TransactionList({
   isLoading,
   transactions,
-  runningBalances,
   onOpenTransaction,
   isLoadingMore,
   onLoadMore,
@@ -207,7 +201,6 @@ export function TransactionList({
               {transaction => (
                 <TransactionListItem
                   key={transaction.id}
-                  balance={runningBalances?.get(transaction.id) || null}
                   value={transaction}
                   onPress={trans => onTransactionPress(trans)}
                   onLongPress={trans => onTransactionPress(trans, true)}

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
@@ -30,7 +30,7 @@ import {
 } from '@react-aria/interactions';
 
 import { isPreviewId } from 'loot-core/shared/transactions';
-import { type IntegerAmount, integerToCurrency } from 'loot-core/shared/util';
+import { integerToCurrency } from 'loot-core/shared/util';
 import {
   type AccountEntity,
   type TransactionEntity,
@@ -38,10 +38,7 @@ import {
 
 import { lookupName, Status } from './TransactionEdit';
 
-import {
-  makeAmountFullStyle,
-  makeBalanceAmountStyle,
-} from '@desktop-client/components/budget/util';
+import { makeAmountFullStyle } from '@desktop-client/components/budget/util';
 import { useAccount } from '@desktop-client/hooks/useAccount';
 import { useCachedSchedules } from '@desktop-client/hooks/useCachedSchedules';
 import { useCategories } from '@desktop-client/hooks/useCategories';
@@ -76,13 +73,11 @@ const getScheduleIconStyle = ({ isPreview }: { isPreview: boolean }) => ({
 type TransactionListItemProps = ComponentPropsWithoutRef<
   typeof ListBoxItem<TransactionEntity>
 > & {
-  balance: IntegerAmount | null;
   onPress: (transaction: TransactionEntity) => void;
   onLongPress: (transaction: TransactionEntity) => void;
 };
 
 export function TransactionListItem({
-  balance,
   onPress,
   onLongPress,
   ...props
@@ -287,7 +282,7 @@ export function TransactionListItem({
                   </TextOneLine>
                 )}
               </View>
-              <View style={{ textAlign: 'right' }}>
+              <View style={{ justifyContent: 'center' }}>
                 <Text
                   style={{
                     ...textStyle,
@@ -296,17 +291,6 @@ export function TransactionListItem({
                 >
                   {integerToCurrency(amount)}
                 </Text>
-                {balance != null && (
-                  <Text
-                    style={{
-                      fontSize: 11,
-                      fontWeight: '400',
-                      ...makeBalanceAmountStyle(balance || 0),
-                    }}
-                  >
-                    {integerToCurrency(balance)}
-                  </Text>
-                )}
               </View>
             </View>
           </Button>

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -86,7 +86,6 @@ type TransactionListWithBalancesProps = {
   balanceUncleared?:
     | Binding<'category', 'balanceUncleared'>
     | Binding<'account', 'balanceUncleared'>;
-  runningBalances: Map<TransactionEntity['id'], number> | undefined;
   searchPlaceholder: string;
   onSearch: (searchText: string) => void;
   isLoadingMore: boolean;
@@ -102,7 +101,6 @@ export function TransactionListWithBalances({
   balance,
   balanceCleared,
   balanceUncleared,
-  runningBalances,
   searchPlaceholder = 'Search...',
   onSearch,
   isLoadingMore,
@@ -150,7 +148,6 @@ export function TransactionListWithBalances({
           <TransactionList
             isLoading={isLoading}
             transactions={transactions}
-            runningBalances={runningBalances}
             isLoadingMore={isLoadingMore}
             onLoadMore={onLoadMore}
             onOpenTransaction={onOpenTransaction}

--- a/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
@@ -33,7 +33,6 @@ import { validateAccountName } from '@desktop-client/components/util/accountVali
 import { useAccount } from '@desktop-client/hooks/useAccount';
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useNotes } from '@desktop-client/hooks/useNotes';
-import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { type Modal as ModalType } from '@desktop-client/modals/modalsSlice';
 
 type AccountMenuModalProps = Extract<
@@ -48,7 +47,6 @@ export function AccountMenuModal({
   onReopenAccount,
   onEditNotes,
   onClose,
-  onToggleRunningBalance,
 }: AccountMenuModalProps) {
   const { t } = useTranslation();
   const account = useAccount(accountId);
@@ -126,7 +124,6 @@ export function AccountMenuModal({
                 account={account}
                 onClose={onCloseAccount}
                 onReopen={onReopenAccount}
-                onToggleRunningBalance={onToggleRunningBalance}
               />
             }
             title={
@@ -161,7 +158,7 @@ export function AccountMenuModal({
                 notes={
                   originalNotes && originalNotes.length > 0
                     ? originalNotes
-                    : t('No notes')
+                    : 'No notes'
                 }
                 editable={false}
                 focused={false}
@@ -204,16 +201,13 @@ type AdditionalAccountMenuProps = {
   account: AccountEntity;
   onClose?: (accountId: string) => void;
   onReopen?: (accountId: string) => void;
-  onToggleRunningBalance?: () => void;
 };
 
 function AdditionalAccountMenu({
   account,
   onClose,
   onReopen,
-  onToggleRunningBalance,
 }: AdditionalAccountMenuProps) {
-  const { t } = useTranslation();
   const triggerRef = useRef(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const itemStyle: CSSProperties = {
@@ -225,7 +219,6 @@ function AdditionalAccountMenu({
     ...itemStyle,
     ...(item.name === 'close' && { color: theme.errorTextMenu }),
   });
-  const [showBalances] = useSyncedPref(`show-balances-${account.id}`);
 
   return (
     <View>
@@ -251,23 +244,16 @@ function AdditionalAccountMenu({
           <Menu
             getItemStyle={getItemStyle}
             items={[
-              {
-                name: 'balance',
-                text:
-                  showBalances === 'true'
-                    ? t('Hide running balance')
-                    : t('Show running balance'),
-              },
               account.closed
                 ? {
                     name: 'reopen',
-                    text: t('Reopen account'),
+                    text: 'Reopen account',
                     icon: SvgLockOpen,
                     iconSize: 15,
                   }
                 : {
                     name: 'close',
-                    text: t('Close account'),
+                    text: 'Close account',
                     icon: SvgClose,
                     iconSize: 15,
                   },
@@ -280,9 +266,6 @@ function AdditionalAccountMenu({
                   break;
                 case 'reopen':
                   onReopen?.(account.id);
-                  break;
-                case 'balance':
-                  onToggleRunningBalance?.();
                   break;
                 default:
                   throw new Error(`Unrecognized menu option: ${name}`);

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -709,7 +709,6 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
                       onOpenTransaction={onOpenTransaction}
                       isLoadingMore={false}
                       account={undefined}
-                      runningBalances={undefined}
                     />
                   </View>
                 </animated.div>

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { groupById, type IntegerAmount } from 'loot-core/shared/util';
+import { groupById } from 'loot-core/shared/util';
 import {
   type ScheduleEntity,
   type AccountEntity,
@@ -17,7 +17,6 @@ import { accountBalance } from '@desktop-client/spreadsheet/bindings';
 
 type UseAccountPreviewTransactionsProps = {
   accountId?: AccountEntity['id'] | undefined;
-  getRunningBalances?: boolean;
 };
 
 type UseAccountPreviewTransactionsResult = ReturnType<
@@ -30,7 +29,6 @@ type UseAccountPreviewTransactionsResult = ReturnType<
  */
 export function useAccountPreviewTransactions({
   accountId,
-  getRunningBalances,
 }: UseAccountPreviewTransactionsProps): UseAccountPreviewTransactionsResult {
   const accounts = useAccounts();
   const accountsById = useMemo(() => groupById(accounts), [accounts]);
@@ -110,14 +108,11 @@ export function useAccountPreviewTransactions({
     return {
       isLoading,
       previewTransactions,
-      runningBalances: getRunningBalances
-        ? runningBalances
-        : new Map<AccountEntity['id'], IntegerAmount>(),
+      runningBalances,
       error,
     };
   }, [
     accountId,
-    getRunningBalances,
     allPreviewTransactions,
     allRunningBalances,
     error,

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -282,7 +282,6 @@ export type Modal =
         onReopenAccount: (accountId: AccountEntity['id']) => void;
         onEditNotes: (id: NoteEntity['id']) => void;
         onClose?: () => void;
-        onToggleRunningBalance?: () => void;
       };
     }
   | {

--- a/upcoming-release-notes/4809.md
+++ b/upcoming-release-notes/4809.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [youngcw]
----
-
-Add running balance to mobile


### PR DESCRIPTION
Reverts actualbudget/actual#4809

The mobile running balance change has some issues that weren't caught originally:
1. accounts with many transactions load really slow now.  Maybe moving the calculation out of TS and into sql would speed this up.
2. Accounts with many transactions don't get summed up correctly.  This is because the transactions are loaded in pages, so each set of pages is summed within each batch, not all account transactions.
3. Some transactions don't get a balance and I don't know why.  Something to do with transfers it seems