### PR TITLE
use correct running balance when adding a new transaction

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2199,7 +2199,9 @@ function TransactionTableInner({
               onDistributeRemainder={props.onDistributeRemainder}
               balance={
                 props.transactions?.length > 0
-                  ? (props.balances?.[props.transactions[0]?.id]?.balance ?? 0)
+                  ? (props.balances?.[
+                      props.transactions.filter(t => t.schedule === null)[0]?.id
+                    ]?.balance ?? 0)
                   : 0
               }
             />

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1615,7 +1615,7 @@ const Transaction = memo(function Transaction({
           /* Balance field for all transactions */
           name="balance"
           value={
-            runningBalance == null || isChild
+            runningBalance == null || isChild || isTemporaryId(id)
               ? ''
               : integerToCurrency(runningBalance)
           }
@@ -1723,7 +1723,6 @@ function TransactionError({
 
 type NewTransactionProps = {
   accounts: AccountEntity[];
-  balance: number;
   categoryGroups: CategoryGroupEntity[];
   dateFormat: string;
   editingTransaction: TransactionEntity['id'];
@@ -1750,6 +1749,7 @@ type NewTransactionProps = {
   payees: PayeeEntity[];
   showAccount?: boolean;
   showBalance?: boolean;
+  balance?: number | null;
   showCleared?: boolean;
   transactions: TransactionEntity[];
   transferAccountsByTransaction: {
@@ -1843,7 +1843,7 @@ function NewTransaction({
           onNavigateToTransferAccount={onNavigateToTransferAccount}
           onNavigateToSchedule={onNavigateToSchedule}
           onNotesTagClick={onNotesTagClick}
-          balance={balance}
+          balance={balance ?? 0}
           showSelection={true}
           allowSplitTransaction={true}
         />
@@ -2197,18 +2197,6 @@ function TransactionTableInner({
               onNavigateToSchedule={onNavigateToSchedule}
               onNotesTagClick={onNotesTagClick}
               onDistributeRemainder={props.onDistributeRemainder}
-              balance={
-                props.transactions?.length > 0
-                  ? (() => {
-                      const id = props.transactions.find(
-                        t => !isPreviewId(t.id),
-                      )?.id;
-                      return id !== undefined
-                        ? (props.balances?.[id]?.balance ?? 0)
-                        : 0;
-                    })()
-                  : 0
-              }
             />
           </View>
         )}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2199,9 +2199,14 @@ function TransactionTableInner({
               onDistributeRemainder={props.onDistributeRemainder}
               balance={
                 props.transactions?.length > 0
-                  ? (props.balances?.[
-                      props.transactions.find(t => t.schedule === null)?.id
-                    ]?.balance ?? 0)
+                  ? (() => {
+                      const id = props.transactions.find(
+                        t => t.schedule === null,
+                      )?.id;
+                      return id !== undefined
+                        ? (props.balances?.[id]?.balance ?? 0)
+                        : 0;
+                    })()
                   : 0
               }
             />

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2201,7 +2201,7 @@ function TransactionTableInner({
                 props.transactions?.length > 0
                   ? (() => {
                       const id = props.transactions.find(
-                        t => t.schedule === null,
+                        t => !isPreviewId(t.id),
                       )?.id;
                       return id !== undefined
                         ? (props.balances?.[id]?.balance ?? 0)

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2200,7 +2200,7 @@ function TransactionTableInner({
               balance={
                 props.transactions?.length > 0
                   ? (props.balances?.[
-                      props.transactions.filter(t => t.schedule === null)[0]?.id
+                      props.transactions.find(t => t.schedule === null)?.id
                     ]?.balance ?? 0)
                   : 0
               }

--- a/upcoming-release-notes/5207.md
+++ b/upcoming-release-notes/5207.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [matt-fidd]
 ---
 
-Use correct running balance when adding a new transaction
+Hide running balance when adding a new transaction

--- a/upcoming-release-notes/5207.md
+++ b/upcoming-release-notes/5207.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Use correct running balance when adding a new transaction


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5170

It's easier to use the right balance than it is to completely hide it. I can probably work round it if we prefer that, but this is better than the current version.