### PR TITLE
[WIP] Switch source string language from EN to 'untranslated'

### DIFF
--- a/packages/desktop-client/bin/remove-untranslated-languages
+++ b/packages/desktop-client/bin/remove-untranslated-languages
@@ -9,19 +9,19 @@ const localRepoPath = './packages/desktop-client/locale';
 const processTranslations = () => {
   try {
     const files = fs.readdirSync(localRepoPath);
-    const enJsonPath = path.join(localRepoPath, 'en.json');
+    const untranslatedJsonPath = path.join(localRepoPath, 'untranslated.json');
 
-    if (!fs.existsSync(enJsonPath)) {
-      throw new Error('en.json not found in the repository.');
+    if (!fs.existsSync(untranslatedJsonPath)) {
+      throw new Error('untranslated.json not found in the repository.');
     }
 
-    const enJson = JSON.parse(fs.readFileSync(enJsonPath, 'utf8'));
-    const enKeysCount = Object.keys(enJson).length;
+    const untranslatedJson = JSON.parse(fs.readFileSync(untranslatedJsonPath, 'utf8'));
+    const untranslatedKeysCount = Object.keys(untranslatedJson).length;
 
-    console.log(`en.json has ${enKeysCount} keys.`);
+    console.log(`untranslated.json has ${untranslatedKeysCount} keys.`);
 
     files.forEach(file => {
-      if (file === 'en.json' || path.extname(file) !== '.json') return;
+      if (file === 'untranslated.json' || path.extname(file) !== '.json') return;
 
       if (file.startsWith('en-')) {
         console.log(`Keeping ${file} as it's an English language.`);
@@ -32,8 +32,8 @@ const processTranslations = () => {
       const jsonData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       const fileKeysCount = Object.keys(jsonData).length;
 
-      // Calculate the percentage of keys present compared to en.json
-      const percentage = (fileKeysCount / enKeysCount) * 100;
+      // Calculate the percentage of keys present compared to untranslated.json
+      const percentage = (fileKeysCount / untranslatedKeysCount) * 100;
       console.log(
         `${file} has ${fileKeysCount} keys (${percentage.toFixed(2)}%).`,
       );

--- a/packages/desktop-client/bin/remove-untranslated-languages
+++ b/packages/desktop-client/bin/remove-untranslated-languages
@@ -15,13 +15,16 @@ const processTranslations = () => {
       throw new Error('untranslated.json not found in the repository.');
     }
 
-    const untranslatedJson = JSON.parse(fs.readFileSync(untranslatedJsonPath, 'utf8'));
+    const untranslatedJson = JSON.parse(
+      fs.readFileSync(untranslatedJsonPath, 'utf8'),
+    );
     const untranslatedKeysCount = Object.keys(untranslatedJson).length;
 
     console.log(`untranslated.json has ${untranslatedKeysCount} keys.`);
 
     files.forEach(file => {
-      if (file === 'untranslated.json' || path.extname(file) !== '.json') return;
+      if (file === 'untranslated.json' || path.extname(file) !== '.json')
+        return;
 
       if (file.startsWith('en-')) {
         console.log(`Keeping ${file} as it's an English language.`);

--- a/packages/desktop-client/i18next-parser.config.js
+++ b/packages/desktop-client/i18next-parser.config.js
@@ -1,12 +1,12 @@
 module.exports = {
   input: ['src/**/*.{js,jsx,ts,tsx}', '../loot-core/src/**/*.{js,jsx,ts,tsx}'],
   output: 'locale/$LOCALE.json',
-  locales: ['en'],
+  locales: ['untranslated'],
   sort: true,
   keySeparator: false,
   namespaceSeparator: false,
   defaultValue: (locale, ns, key, value) => {
-    if (locale === 'en') {
+    if (locale === 'untranslated') {
       return value || key;
     }
     return '';

--- a/upcoming-release-notes/5210.md
+++ b/upcoming-release-notes/5210.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Switch source string language from EN to 'untranslated'


### PR DESCRIPTION
I noticed that we're currently not correctly pluralizing many strings in English throughout the app, which is ultimately due to not having translations for them. Weblate appears to prevent modifications to source string translations, so instead I'm hoping to switch the source string language to one called "untranslated"—this should allow us to check in pluralized strings for regular English (not just dialects).