### PR TITLE
add some basic linting rules for translation consistency

### DIFF
--- a/bin/release-note-generator.ts
+++ b/bin/release-note-generator.ts
@@ -6,7 +6,7 @@ import prompts from 'prompts';
 
 async function run() {
   const username = await execAsync(
-    // eslint-disable-next-line rulesdir/typography
+    // eslint-disable-next-line actual/typography
     "gh api user --jq '.login'",
     'To avoid having to enter your username, consider installing the official GitHub CLI (https://github.com/cli/cli) and logging in with `gh auth login`.',
   );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,3 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
 import globals from 'globals';
 
 import pluginImport from 'eslint-plugin-import';
@@ -12,9 +9,6 @@ import pluginTypescriptPaths from 'eslint-plugin-typescript-paths';
 import pluginActual from './packages/eslint-plugin-actual/lib/index.js';
 
 import tsParser from '@typescript-eslint/parser';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 const confusingBrowserGlobals = [
   // https://github.com/facebook/create-react-app/tree/main/packages/confusing-browser-globals

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -796,8 +796,6 @@ export default pluginTypescript.config(
     rules: {
       'import/no-anonymous-default-export': 'off',
       'import/no-default-export': 'off',
-      // can be re-enabled after https://github.com/actualbudget/actual/pull/4253
-      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ import pluginReactHooks from 'eslint-plugin-react-hooks';
 import pluginRulesDir from 'eslint-plugin-rulesdir';
 import pluginTypescript from 'typescript-eslint';
 import pluginTypescriptPaths from 'eslint-plugin-typescript-paths';
+import pluginActual from './packages/eslint-plugin-actual/lib/index.js';
 
 import tsParser from '@typescript-eslint/parser';
 
@@ -167,10 +168,15 @@ export default pluginTypescript.config(
   pluginImport.flatConfigs.recommended,
   {
     plugins: {
+      actual: pluginActual,
       'react-hooks': pluginReactHooks,
       'jsx-a11y': pluginJSXA11y,
       rulesdir: pluginRulesDir,
       'typescript-paths': pluginTypescriptPaths,
+    },
+    rules: {
+      'actual/no-untranslated-strings': 'error',
+      'actual/prefer-trans-over-t': 'error',
     },
   },
   {
@@ -779,6 +785,7 @@ export default pluginTypescript.config(
 
     rules: {
       'rulesdir/typography': 'off',
+      'actual/no-untranslated-strings': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,6 @@ import pluginImport from 'eslint-plugin-import';
 import pluginJSXA11y from 'eslint-plugin-jsx-a11y';
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
-import pluginRulesDir from 'eslint-plugin-rulesdir';
 import pluginTypescript from 'typescript-eslint';
 import pluginTypescriptPaths from 'eslint-plugin-typescript-paths';
 import pluginActual from './packages/eslint-plugin-actual/lib/index.js';
@@ -16,14 +15,6 @@ import tsParser from '@typescript-eslint/parser';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-pluginRulesDir.RULES_DIR = path.join(
-  __dirname,
-  'packages',
-  'eslint-plugin-actual',
-  'lib',
-  'rules',
-);
 
 const confusingBrowserGlobals = [
   // https://github.com/facebook/create-react-app/tree/main/packages/confusing-browser-globals
@@ -171,7 +162,6 @@ export default pluginTypescript.config(
       actual: pluginActual,
       'react-hooks': pluginReactHooks,
       'jsx-a11y': pluginJSXA11y,
-      rulesdir: pluginRulesDir,
       'typescript-paths': pluginTypescriptPaths,
     },
     rules: {
@@ -464,8 +454,8 @@ export default pluginTypescript.config(
         },
       ],
 
-      'rulesdir/typography': 'warn',
-      'rulesdir/prefer-if-statement': 'warn',
+      'actual/typography': 'warn',
+      'actual/prefer-if-statement': 'warn',
 
       // Note: base rule explicitly disabled in favor of the TS one
       'no-unused-vars': 'off',
@@ -784,7 +774,7 @@ export default pluginTypescript.config(
     ],
 
     rules: {
-      'rulesdir/typography': 'off',
+      'actual/typography': 'off',
       'actual/no-untranslated-strings': 'off',
     },
   },
@@ -804,7 +794,7 @@ export default pluginTypescript.config(
     // TODO: fix the issues in these files
     rules: {
       'import/extensions': 'off',
-      'rulesdir/typography': 'off',
+      'actual/typography': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-rulesdir": "^0.2.2",
     "eslint-plugin-typescript-paths": "^0.0.33",
     "globals": "^15.15.0",
     "html-to-image": "^1.11.13",

--- a/packages/component-library/src/Toggle.tsx
+++ b/packages/component-library/src/Toggle.tsx
@@ -62,7 +62,7 @@ export const Toggle = ({
           data-on={isOn}
           className={css(
             {
-              // eslint-disable-next-line rulesdir/typography
+              // eslint-disable-next-line actual/typography
               content: '" "',
               position: 'absolute',
               top: '2px',

--- a/packages/component-library/src/styles.ts
+++ b/packages/component-library/src/styles.ts
@@ -91,7 +91,7 @@ export const styles: Record<string, any> = {
   },
   shadowLarge,
   tnum: {
-    // eslint-disable-next-line rulesdir/typography
+    // eslint-disable-next-line actual/typography
     fontFeatureSettings: '"tnum"',
   },
   notFixed: { fontFeatureSettings: '' },

--- a/packages/desktop-client/e2e/fixtures.ts
+++ b/packages/desktop-client/e2e/fixtures.ts
@@ -14,7 +14,7 @@ export const expect = baseExpect.extend({
     }
 
     const config = {
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       mask: [locator.locator('[data-vrt-mask="true"]')],
       maxDiffPixels: 5,
     };

--- a/packages/desktop-client/src/auth/ProtectedRoute.tsx
+++ b/packages/desktop-client/src/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactElement } from 'react';
+import { Trans } from 'react-i18next';
 
 import { View } from '@actual-app/components/view';
 
@@ -60,7 +61,9 @@ export const ProtectedRoute = ({
         margin: '50px',
       }}
     >
-      <h3>You don&apos;t have permission to view this page</h3>
+      <h3>
+        <Trans>You don’t have permission to view this page</Trans>
+      </h3>
     </View>
   );
 };

--- a/packages/desktop-client/src/components/CommandBar.tsx
+++ b/packages/desktop-client/src/components/CommandBar.tsx
@@ -245,7 +245,7 @@ export function CommandBar() {
                             'var(--color-menuItemBackgroundHover)',
                           color: 'var(--color-menuItemTextHover)',
                         },
-                      // eslint-disable-next-line rulesdir/typography
+                      // eslint-disable-next-line actual/typography
                       "&[data-selected='true']": {
                         backgroundColor: 'var(--color-menuItemBackgroundHover)',
                         color: 'var(--color-menuItemTextHover)',

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -114,13 +114,17 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
         </EnvelopeCellValue>
       </View>
       <View style={headerLabelStyle}>
-        <Text style={{ color: theme.tableHeaderText }}>Spent</Text>
+        <Text style={{ color: theme.tableHeaderText }}>
+          <Trans>Spent</Trans>
+        </Text>
         <EnvelopeCellValue binding={envelopeBudget.totalSpent} type="financial">
           {props => <CellValueText {...props} style={cellStyle} />}
         </EnvelopeCellValue>
       </View>
       <View style={headerLabelStyle}>
-        <Text style={{ color: theme.tableHeaderText }}>Balance</Text>
+        <Text style={{ color: theme.tableHeaderText }}>
+          <Trans>Balance</Trans>
+        </Text>
         <EnvelopeCellValue
           binding={envelopeBudget.totalBalance}
           type="financial"

--- a/packages/desktop-client/src/components/forms.tsx
+++ b/packages/desktop-client/src/components/forms.tsx
@@ -96,11 +96,11 @@ export const Checkbox = (props: CheckboxProps) => {
               display: 'block',
               background:
                 theme.checkboxBackgroundSelected +
-                // eslint-disable-next-line rulesdir/typography
+                // eslint-disable-next-line actual/typography
                 ' url(\'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="white" d="M0 11l2-2 5 5L18 3l2 2L7 18z"/></svg>\') 9px 9px',
               width: 9,
               height: 9,
-              // eslint-disable-next-line rulesdir/typography
+              // eslint-disable-next-line actual/typography
               content: '" "',
             },
           },
@@ -124,7 +124,7 @@ export const Checkbox = (props: CheckboxProps) => {
               right: -5,
               border: '2px solid ' + theme.checkboxBorderSelected,
               borderRadius: 6,
-              // eslint-disable-next-line rulesdir/typography
+              // eslint-disable-next-line actual/typography
               content: '" "',
             },
           },

--- a/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileBackButton.tsx
@@ -1,5 +1,5 @@
 import React, { type ComponentPropsWithoutRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgCheveronLeft } from '@actual-app/components/icons/v1';
@@ -15,7 +15,6 @@ export function MobileBackButton({
   style,
   ...props
 }: MobileBackButtonProps) {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   return (
     <Button
@@ -38,7 +37,7 @@ export function MobileBackButton({
           marginRight: 5,
         }}
       >
-        {t('Back')}
+        <Trans>Back</Trans>
       </Text>
     </Button>
   );

--- a/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/AccountMenuModal.tsx
@@ -5,7 +5,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
@@ -187,7 +187,7 @@ export function AccountMenuModal({
                   height={20}
                   style={{ paddingRight: 5 }}
                 />
-                {t('Edit notes')}
+                <Trans>Edit notes</Trans>
               </Button>
             </View>
           </View>

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   type CSSProperties,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
@@ -49,7 +49,6 @@ export function CategoryGroupMenuModal({
   onToggleVisibility,
   onClose,
 }: CategoryGroupMenuModalProps) {
-  const { t } = useTranslation();
   const { grouped: categoryGroups } = useCategories();
   const group = categoryGroups.find(g => g.id === groupId);
   const notes = useNotes(group.id);
@@ -156,7 +155,7 @@ export function CategoryGroupMenuModal({
             >
               <Button style={buttonStyle} onPress={_onAddCategory}>
                 <SvgAdd width={17} height={17} style={{ paddingRight: 5 }} />
-                {t('Add category')}
+                <Trans>Add category</Trans>
               </Button>
               <Button style={buttonStyle} onPress={_onEditNotes}>
                 <SvgNotesPaper
@@ -164,7 +163,7 @@ export function CategoryGroupMenuModal({
                   height={20}
                   style={{ paddingRight: 5 }}
                 />
-                {t('Edit notes')}
+                <Trans>Edit notes</Trans>
               </Button>
             </View>
           </View>

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { useRef, useState, type CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
@@ -148,7 +148,7 @@ export function CategoryMenuModal({
                   height={20}
                   style={{ paddingRight: 5 }}
                 />
-                {t('Edit notes')}
+                <Trans>Edit notes</Trans>
               </Button>
             </View>
           </View>

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -164,7 +164,7 @@ export function ConfirmCategoryDeleteModal({
                   }
                 }}
               >
-                {t('Delete')}
+                <Trans>Delete</Trans>
               </Button>
             </View>
           </View>

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next'; // Import useTranslation
+import { Trans, useTranslation } from 'react-i18next'; // Import useTranslation
 
 import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
@@ -73,23 +73,45 @@ export function ConfirmCategoryDeleteModal({
           <View style={{ lineHeight: 1.5 }}>
             {group ? (
               <Block>
-                Categories in the group <strong>{group.name}</strong> are used
-                by existing transactions
-                {!isIncome &&
-                  ' or it has a positive leftover balance currently'}
-                . <strong>Are you sure you want to delete it?</strong> If so,
-                you must select another category to transfer existing
-                transactions and balance to.
+                {!isIncome ? (
+                  <Trans>
+                    Categories in the group{' '}
+                    <strong>{{ group: group.name }}</strong> are used by
+                    existing transactions.
+                  </Trans>
+                ) : (
+                  <Trans>
+                    Categories in the group{' '}
+                    <strong>{{ group: group.name }}</strong> are used by
+                    existing transactions or it has a positive leftover balance
+                    currently.
+                  </Trans>
+                )}
+                <Trans>
+                  <strong>Are you sure you want to delete it?</strong> If so,
+                  you must select another category to transfer existing
+                  transactions and balance to.
+                </Trans>
               </Block>
             ) : (
               <Block>
-                <strong>{category.name}</strong> is used by existing
-                transactions
-                {!isIncome &&
-                  ' or it has a positive leftover balance currently'}
-                . <strong>Are you sure you want to delete it?</strong> If so,
-                you must select another category to transfer existing
-                transactions and balance to.
+                {!isIncome ? (
+                  <Trans>
+                    <strong>{{ category: category.name }}</strong> is used by
+                    existing transactions.
+                  </Trans>
+                ) : (
+                  <Trans>
+                    <strong>{{ category: category.name }}</strong> is used by
+                    existing transactions or it has a positive leftover balance
+                    currently.
+                  </Trans>
+                )}
+                <Trans>
+                  <strong>Are you sure you want to delete it?</strong> If so,
+                  you must select another category to transfer existing
+                  transactions and balance to.
+                </Trans>
               </Block>
             )}
 

--- a/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmCategoryDeleteModal.tsx
@@ -8,6 +8,8 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
+import { type TransObjectLiteral } from 'loot-core/types/util';
+
 import { CategoryAutocomplete } from '@desktop-client/components/autocomplete/CategoryAutocomplete';
 import {
   Modal,
@@ -76,15 +78,19 @@ export function ConfirmCategoryDeleteModal({
                 {!isIncome ? (
                   <Trans>
                     Categories in the group{' '}
-                    <strong>{{ group: group.name }}</strong> are used by
-                    existing transactions.
+                    <strong>
+                      {{ group: group.name } as TransObjectLiteral}
+                    </strong>{' '}
+                    are used by existing transactions.
                   </Trans>
                 ) : (
                   <Trans>
                     Categories in the group{' '}
-                    <strong>{{ group: group.name }}</strong> are used by
-                    existing transactions or it has a positive leftover balance
-                    currently.
+                    <strong>
+                      {{ group: group.name } as TransObjectLiteral}
+                    </strong>{' '}
+                    are used by existing transactions or it has a positive
+                    leftover balance currently.
                   </Trans>
                 )}
                 <Trans>
@@ -97,14 +103,18 @@ export function ConfirmCategoryDeleteModal({
               <Block>
                 {!isIncome ? (
                   <Trans>
-                    <strong>{{ category: category.name }}</strong> is used by
-                    existing transactions.
+                    <strong>
+                      {{ category: category.name } as TransObjectLiteral}
+                    </strong>{' '}
+                    is used by existing transactions.
                   </Trans>
                 ) : (
                   <Trans>
-                    <strong>{{ category: category.name }}</strong> is used by
-                    existing transactions or it has a positive leftover balance
-                    currently.
+                    <strong>
+                      {{ category: category.name } as TransObjectLiteral}
+                    </strong>{' '}
+                    is used by existing transactions or it has a positive
+                    leftover balance currently.
                   </Trans>
                 )}
                 <Trans>

--- a/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionDeleteModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
@@ -55,7 +55,7 @@ export function ConfirmTransactionDeleteModal({
                 }}
                 onPress={close}
               >
-                {t('Cancel')}
+                <Trans>Cancel</Trans>
               </Button>
               <InitialFocus>
                 <Button
@@ -66,7 +66,7 @@ export function ConfirmTransactionDeleteModal({
                     close();
                   }}
                 >
-                  {t('Delete')}
+                  <Trans>Delete</Trans>
                 </Button>
               </InitialFocus>
             </View>

--- a/packages/desktop-client/src/components/modals/ConfirmUnlinkAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmUnlinkAccountModal.tsx
@@ -60,7 +60,7 @@ export function ConfirmUnlinkAccountModal({
               }}
             >
               <Button style={{ marginRight: 10 }} onPress={close}>
-                {t('Cancel')}
+                <Trans>Cancel</Trans>
               </Button>
               <InitialFocus>
                 <Button
@@ -70,7 +70,7 @@ export function ConfirmUnlinkAccountModal({
                     close();
                   }}
                 >
-                  {t('Unlink')}
+                  <Trans>Unlink</Trans>
                 </Button>
               </InitialFocus>
             </View>

--- a/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateAccountModal.tsx
@@ -359,7 +359,7 @@ export function CreateAccountModal({
                     }}
                     onPress={onCreateLocalAccount}
                   >
-                    {t('Create a local account')}
+                    <Trans>Create a local account</Trans>
                   </Button>
                 </InitialFocus>
                 <View style={{ lineHeight: '1.4em', fontSize: 15 }}>

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -103,7 +103,7 @@ export function CreateEncryptionKeyModal({
                     to="https://actualbudget.org/docs/getting-started/sync/#end-to-end-encryption"
                     linkColor="purple"
                   >
-                    {t('Learn more')}
+                    <Trans>Learn more</Trans>
                   </Link>
                 </Paragraph>
                 <Paragraph>

--- a/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateLocalAccountModal.tsx
@@ -179,18 +179,20 @@ export function CreateLocalAccountModal() {
               </InlineField>
               {balanceError && (
                 <FormError style={{ marginLeft: 75 }}>
-                  {t('Balance must be a number')}
+                  <Trans>Balance must be a number</Trans>
                 </FormError>
               )}
 
               <ModalButtons>
-                <Button onPress={close}>{t('Back')}</Button>
+                <Button onPress={close}>
+                  <Trans>Back</Trans>
+                </Button>
                 <Button
                   type="submit"
                   variant="primary"
                   style={{ marginLeft: 10 }}
                 >
-                  {t('Create')}
+                  <Trans>Create</Trans>
                 </Button>
               </ModalButtons>
             </Form>

--- a/packages/desktop-client/src/components/modals/EditAccess.tsx
+++ b/packages/desktop-client/src/components/modals/EditAccess.tsx
@@ -149,7 +149,7 @@ export function EditUserAccess({
               style={{ marginRight: 10 }}
               onPress={() => dispatch(popModal())}
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </Button>
             <Button
               variant="primary"

--- a/packages/desktop-client/src/components/modals/EditFieldModal.tsx
+++ b/packages/desktop-client/src/components/modals/EditFieldModal.tsx
@@ -4,7 +4,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
@@ -140,7 +140,7 @@ export function EditFieldModal({
                 noteInputRef.current?.focus();
               }}
             >
-              {t('Prepend')}
+              <Trans>Prepend</Trans>
             </Button>
             <Button
               style={{
@@ -171,7 +171,7 @@ export function EditFieldModal({
                 noteInputRef.current?.focus();
               }}
             >
-              {t('Replace')}
+              <Trans>Replace</Trans>
             </Button>
             <Button
               style={{
@@ -202,7 +202,7 @@ export function EditFieldModal({
                 noteInputRef.current?.focus();
               }}
             >
-              {t('Append')}
+              <Trans>Append</Trans>
             </Button>
           </View>
           <Input

--- a/packages/desktop-client/src/components/modals/EditRuleModal.jsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.jsx
@@ -1298,7 +1298,9 @@ export function EditRuleModal({
                   justify="flex-end"
                   style={{ marginTop: 20 }}
                 >
-                  <Button onClick={close}>{t('Cancel')}</Button>
+                  <Button onClick={close}>
+                    <Trans>Cancel</Trans>
+                  </Button>
                   <Button variant="primary" onPress={() => onSave(close)}>
                     <Trans>Save</Trans>
                   </Button>

--- a/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBalanceMenuModal.tsx
@@ -1,5 +1,5 @@
 import React, { type CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
@@ -40,7 +40,6 @@ export function EnvelopeBalanceMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
-  const { t } = useTranslation();
   const category = useCategory(categoryId);
 
   if (!category) {
@@ -68,7 +67,7 @@ export function EnvelopeBalanceMenuModal({
                 fontWeight: 400,
               }}
             >
-              {t('Balance')}
+              <Trans>Balance</Trans>
             </Text>
             <BalanceWithCarryover
               isDisabled

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMenuModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, type CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
@@ -41,7 +41,6 @@ export function EnvelopeBudgetMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
-  const { t } = useTranslation();
   const budgeted = useEnvelopeSheetValue(
     envelopeBudget.catBudgeted(categoryId),
   );
@@ -85,7 +84,7 @@ export function EnvelopeBudgetMenuModal({
                 fontWeight: 400,
               }}
             >
-              {t('Budgeted')}
+              <Trans>Budgeted</Trans>
             </Text>
             <FocusableAmountInput
               value={integerToAmount(budgeted || 0)}

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetMonthMenuModal.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
@@ -125,7 +125,7 @@ export function EnvelopeBudgetMonthMenuModal({
                     height={20}
                     style={{ paddingRight: 5 }}
                   />
-                  {t('Edit notes')}
+                  <Trans>Edit notes</Trans>
                 </Button>
               </View>
               <View>
@@ -155,7 +155,7 @@ export function EnvelopeBudgetMonthMenuModal({
                       style={{ paddingRight: 5 }}
                     />
                   )}
-                  {t('Actions')}
+                  <Trans>Actions</Trans>
                 </Button>
               </View>
             </View>

--- a/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
 import { Form } from 'react-aria-components';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button, ButtonWithLoading } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
@@ -91,7 +91,7 @@ export function FixEncryptionKeyModal({
                   variant="external"
                   to="https://actualbudget.org/docs/getting-started/sync/#end-to-end-encryption"
                 >
-                  {t('Learn more')}
+                  <Trans>Learn more</Trans>
                 </Link>
               </Paragraph>
             ) : (
@@ -103,7 +103,7 @@ export function FixEncryptionKeyModal({
                   variant="external"
                   to="https://actualbudget.org/docs/getting-started/sync/#end-to-end-encryption"
                 >
-                  {t('Learn more')}
+                  <Trans>Learn more</Trans>
                 </Link>
               </Paragraph>
             )}
@@ -122,7 +122,7 @@ export function FixEncryptionKeyModal({
               }}
             >
               <Text style={{ fontWeight: 600, marginBottom: 5 }}>
-                {t('Password')}
+                <Trans>Password</Trans>
               </Text>{' '}
               {error && (
                 <View
@@ -152,7 +152,7 @@ export function FixEncryptionKeyModal({
                     type="checkbox"
                     onClick={() => setShowPassword(!showPassword)}
                   />{' '}
-                  {t('Show password')}
+                  <Trans>Show password</Trans>
                 </label>
               </Text>
             </View>
@@ -166,7 +166,7 @@ export function FixEncryptionKeyModal({
                 }}
                 onPress={close}
               >
-                {t('Back')}
+                <Trans>Back</Trans>
               </Button>
               <ButtonWithLoading
                 type="submit"

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { InitialFocus } from '@actual-app/components/initial-focus';
@@ -79,7 +79,7 @@ export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
               }}
               onPress={() => _onSubmit(amount)}
             >
-              {t('Hold')}
+              <Trans>Hold</Trans>
             </Button>
           </View>
         </>

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -807,7 +807,7 @@ export function ImportTransactionsModal({
                         fontStyle: 'italic',
                       }}
                     >
-                      {t('No transactions found')}
+                      <Trans>No transactions found</Trans>
                     </View>
                   );
                 }}
@@ -914,7 +914,7 @@ export function ImportTransactionsModal({
                 setReconcile(!reconcile);
               }}
             >
-              {t('Merge with existing transactions')}
+              <Trans>Merge with existing transactions</Trans>
             </CheckboxOption>
           )}
 

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/Transaction.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/Transaction.tsx
@@ -128,7 +128,7 @@ export function Transaction({
                             background:
                               theme.checkboxBackgroundSelected +
                               // update sign from packages/desktop-client/src/icons/v1/layer.svg
-                              // eslint-disable-next-line rulesdir/typography
+                              // eslint-disable-next-line actual/typography
                               ' url(\'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="white" d="M10 1l10 6-10 6L0 7l10-6zm6.67 10L20 13l-10 6-10-6 3.33-2L10 15l6.67-4z" /></svg>\') 9px 9px',
                           },
                         },
@@ -143,11 +143,11 @@ export function Transaction({
                             background:
                               theme.buttonNormalDisabledBorder +
                               // minus sign adapted from packages/desktop-client/src/icons/v1/add.svg
-                              // eslint-disable-next-line rulesdir/typography
+                              // eslint-disable-next-line actual/typography
                               ' url(\'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="white" className="path" d="M23,11.5 L23,11.5 L23,11.5 C23,12.3284271 22.3284271,13 21.5,13 L1.5,13 L1.5,13 C0.671572875,13 1.01453063e-16,12.3284271 0,11.5 L0,11.5 L0,11.5 C-1.01453063e-16,10.6715729 0.671572875,10 1.5,10 L21.5,10 L21.5,10 C22.3284271,10 23,10.6715729 23,11.5 Z" /></svg>\') 9px 9px',
                             width: 9,
                             height: 9,
-                            // eslint-disable-next-line rulesdir/typography
+                            // eslint-disable-next-line actual/typography
                             content: '" "',
                           },
                         },
@@ -158,7 +158,7 @@ export function Transaction({
                             background:
                               theme.checkboxBackgroundSelected +
                               // plus sign from packages/desktop-client/src/icons/v1/add.svg
-                              // eslint-disable-next-line rulesdir/typography
+                              // eslint-disable-next-line actual/typography
                               ' url(\'data:image/svg+xml; utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="white" className="path" d="M23,11.5 L23,11.5 L23,11.5 C23,12.3284271 22.3284271,13 21.5,13 L1.5,13 L1.5,13 C0.671572875,13 1.01453063e-16,12.3284271 0,11.5 L0,11.5 L0,11.5 C-1.01453063e-16,10.6715729 0.671572875,10 1.5,10 L21.5,10 L21.5,10 C22.3284271,10 23,10.6715729 23,11.5 Z" /><path fill="white" className="path" d="M11.5,23 C10.6715729,23 10,22.3284271 10,21.5 L10,1.5 C10,0.671572875 10.6715729,1.52179594e-16 11.5,0 C12.3284271,-1.52179594e-16 13,0.671572875 13,1.5 L13,21.5 C13,22.3284271 12.3284271,23 11.5,23 Z" /></svg>\') 9px 9px',
                           },
                         },

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { Paragraph } from '@actual-app/components/paragraph';
@@ -31,7 +31,6 @@ export function MergeUnusedPayeesModal({
   payeeIds,
   targetPayeeId,
 }: MergeUnusedPayeesModalProps) {
-  const { t } = useTranslation();
   const allPayees = usePayees();
   const modalStack = useSelector(state => state.modals.modalStack);
   const isEditingRule = !!modalStack.find(m => m.name === 'edit-rule');
@@ -199,7 +198,7 @@ export function MergeUnusedPayeesModal({
                   close();
                 }}
               >
-                {t('Merge')}
+                <Trans>Merge</Trans>
               </Button>
               {!isEditingRule && (
                 <Button
@@ -209,11 +208,11 @@ export function MergeUnusedPayeesModal({
                     close();
                   }}
                 >
-                  {t('Merge and edit rule')}
+                  <Trans>Merge and edit rule</Trans>
                 </Button>
               )}
               <Button style={{ marginRight: 10 }} onPress={close}>
-                {t('Do nothing')}
+                <Trans>Do nothing</Trans>
               </Button>
             </ModalButtons>
           </View>

--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { Paragraph } from '@actual-app/components/paragraph';
@@ -9,6 +9,7 @@ import { View } from '@actual-app/components/view';
 
 import { send } from 'loot-core/platform/client/fetch';
 import { type PayeeEntity } from 'loot-core/types/models';
+import { type TransObjectLiteral } from 'loot-core/types/util';
 
 import { Information } from '@desktop-client/components/alerts';
 import { Modal, ModalButtons } from '@desktop-client/components/common/Modal';
@@ -109,16 +110,28 @@ export function MergeUnusedPayeesModal({
           <View>
             <Paragraph style={{ marginBottom: 10, fontWeight: 500 }}>
               {payees.length === 1 ? (
-                <>
-                  The payee <Text style={highlightStyle}>{payees[0].name}</Text>{' '}
+                <Trans>
+                  The payee{' '}
+                  <Text style={highlightStyle}>
+                    {{ payee: payees[0].name } as TransObjectLiteral}
+                  </Text>{' '}
                   is not used by transactions any more. Would like to merge it
-                  with <Text style={highlightStyle}>{targetPayee.name}</Text>?
-                </>
+                  with{' '}
+                  <Text style={highlightStyle}>
+                    {{ payee: targetPayee.name } as TransObjectLiteral}
+                  </Text>
+                  ?
+                </Trans>
               ) : (
                 <>
-                  The following payees are not used by transactions any more.
-                  Would like to merge them with{' '}
-                  <Text style={highlightStyle}>{targetPayee.name}</Text>?
+                  <Trans>
+                    The following payees are not used by transactions any more.
+                    Would like to merge them with{' '}
+                    <Text style={highlightStyle}>
+                      {{ payee: targetPayee.name } as TransObjectLiteral}
+                    </Text>
+                    ?
+                  </Trans>
                   <ul
                     ref={flashRef}
                     style={{
@@ -139,15 +152,15 @@ export function MergeUnusedPayeesModal({
             </Paragraph>
 
             <Information>
-              {t(
-                'Merging will remove the payee and transfer any existing rules to the new payee.',
-              )}
+              <Trans>
+                Merging will remove the payee and transfer any existing rules to
+                the new payee.
+              </Trans>
               {!isEditingRule && (
-                <>
-                  {' '}
+                <Trans>
                   If checked below, a rule will be created to do this rename
                   while importing transactions.
-                </>
+                </Trans>
               )}
             </Information>
 
@@ -169,9 +182,9 @@ export function MergeUnusedPayeesModal({
                   onChange={e => setShouldCreateRule(e.target.checked)}
                 />
                 <Text style={{ marginLeft: 3 }}>
-                  Automatically rename{' '}
-                  {payees.length === 1 ? 'this payee' : 'these payees'} in the
-                  future
+                  <Trans count={payees.length}>
+                    Automatically rename these payees in the future
+                  </Trans>
                 </Text>
               </label>
             )}

--- a/packages/desktop-client/src/components/modals/NotesModal.tsx
+++ b/packages/desktop-client/src/components/modals/NotesModal.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgCheck } from '@actual-app/components/icons/v2';
@@ -82,7 +82,7 @@ export function NotesModal({ id, name, onSave }: NotesModalProps) {
                 }}
               >
                 <SvgCheck width={17} height={17} style={{ paddingRight: 5 }} />
-                {t('Save notes')}
+                <Trans>Save notes</Trans>
               </Button>
             </View>
           </View>

--- a/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/ScheduledTransactionMenuModal.tsx
@@ -3,7 +3,7 @@ import React, {
   type ComponentPropsWithoutRef,
   type CSSProperties,
 } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
 import { styles } from '@actual-app/components/styles';
@@ -40,7 +40,6 @@ export function ScheduledTransactionMenuModal({
   onComplete,
 }: ScheduledTransactionMenuModalProps) {
   const locale = useLocale();
-  const { t } = useTranslation();
   const defaultMenuItemStyle: CSSProperties = {
     ...styles.mobileMenuItem,
     color: theme.menuItemText,
@@ -82,7 +81,7 @@ export function ScheduledTransactionMenuModal({
             }}
           >
             <Text style={{ fontSize: 17, fontWeight: 400 }}>
-              {t('Scheduled date')}
+              <Trans>Scheduled date</Trans>
             </Text>
             <Text style={{ fontSize: 17, fontWeight: 700 }}>
               {format(schedule?.next_date || '', 'MMMM dd, yyyy', locale)}

--- a/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBalanceMenuModal.tsx
@@ -1,5 +1,5 @@
 import React, { type CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
@@ -38,7 +38,6 @@ export function TrackingBalanceMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
-  const { t } = useTranslation();
   const category = useCategory(categoryId);
 
   if (!category) {
@@ -66,7 +65,7 @@ export function TrackingBalanceMenuModal({
                 fontWeight: 400,
               }}
             >
-              {t('Balance')}
+              <Trans>Balance</Trans>
             </Text>
             <BalanceWithCarryover
               isDisabled

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMenuModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, type CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
@@ -41,7 +41,6 @@ export function TrackingBudgetMenuModal({
     borderTop: `1px solid ${theme.pillBorder}`,
   };
 
-  const { t } = useTranslation();
   const budgeted = useTrackingSheetValue(
     trackingBudget.catBudgeted(categoryId),
   );
@@ -85,7 +84,7 @@ export function TrackingBudgetMenuModal({
                 fontWeight: 400,
               }}
             >
-              {t('Budgeted')}
+              <Trans>Budgeted</Trans>
             </Text>
             <FocusableAmountInput
               value={integerToAmount(budgeted || 0)}

--- a/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/TrackingBudgetMonthMenuModal.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
@@ -127,7 +127,7 @@ export function TrackingBudgetMonthMenuModal({
                     height={20}
                     style={{ paddingRight: 5 }}
                   />
-                  {t('Edit notes')}
+                  <Trans>Edit notes</Trans>
                 </Button>
               </View>
               <View>
@@ -157,7 +157,7 @@ export function TrackingBudgetMonthMenuModal({
                       style={{ paddingRight: 5 }}
                     />
                   )}
-                  {t('Actions')}
+                  <Trans>Actions</Trans>
                 </Button>
               </View>
             </View>

--- a/packages/desktop-client/src/components/modals/TransferOwnership.tsx
+++ b/packages/desktop-client/src/components/modals/TransferOwnership.tsx
@@ -166,7 +166,7 @@ export function TransferOwnership({
                     marginTop: 5,
                   }}
                 >
-                  {t('No users available')}
+                  <Trans>No users available</Trans>
                 </Text>
               )}
             </FormField>

--- a/packages/desktop-client/src/components/payees/ManagePayees.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayees.tsx
@@ -313,7 +313,7 @@ export const ManagePayees = ({
                 marginTop: 5,
               }}
             >
-              {t('No payees')}
+              <Trans>No payees</Trans>
             </View>
           ) : (
             <PayeeTable

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -214,7 +214,7 @@ const intervalOptions: intervalOptionsProps[] = [
     description: t('Monthly'),
     key: 'Monthly',
     name: 'Month',
-    // eslint-disable-next-line rulesdir/typography
+    // eslint-disable-next-line actual/typography
     format: "MMM ''yy",
     range: 'rangeInclusive',
   },

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -472,7 +472,7 @@ export function ReportSidebar({
               onSelectRange(customReportItems.dateRange);
             }}
           >
-            Live
+            <Trans>Live</Trans>
           </ModeButton>
           <ModeButton
             selected={customReportItems.isDateStatic}

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -509,7 +509,11 @@ export function ReportSidebar({
               customReportItems.includeCurrentInterval && (
                 <Tooltip
                   placement="bottom start"
-                  content={<Text>{t('Current month')}</Text>}
+                  content={
+                    <Text>
+                      <Trans>Current month</Trans>
+                    </Text>
+                  }
                   style={{
                     ...styles.tooltip,
                     lineHeight: 1.5,

--- a/packages/desktop-client/src/components/reports/ReportSummary.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSummary.tsx
@@ -169,7 +169,14 @@ export function ReportSummary({
           </PrivacyFilter>
         </Text>
         <Text style={{ fontWeight: 600 }}>
-          Per {(ReportOptions.intervalMap.get(interval) || '').toLowerCase()}
+          <Trans>
+            Per{' '}
+            {{
+              interval: (
+                ReportOptions.intervalMap.get(interval) || ''
+              ).toLowerCase(),
+            }}
+          </Trans>
         </Text>
       </View>
     </View>

--- a/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CashFlowGraph.tsx
@@ -139,7 +139,7 @@ export function CashFlowGraph({
               dataKey="date"
               tick={{ fill: theme.reportsLabel }}
               tickFormatter={x => {
-                // eslint-disable-next-line rulesdir/typography
+                // eslint-disable-next-line actual/typography
                 return d.format(x, isConcise ? "MMM ''yy" : 'MMM d', {
                   locale,
                 });
@@ -159,7 +159,7 @@ export function CashFlowGraph({
             />
             <Tooltip
               labelFormatter={x => {
-                // eslint-disable-next-line rulesdir/typography
+                // eslint-disable-next-line actual/typography
                 return d.format(x, isConcise ? "MMM ''yy" : 'MMM d', {
                   locale,
                 });

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -326,7 +326,9 @@ function SummaryInner({ widget }: SummaryInnerProps) {
             padding: 16,
           }}
         >
-          <span style={{ marginRight: 4 }}>{t('Show as')}</span>
+          <span style={{ marginRight: 4 }}>
+            <Trans>Show as</Trans>
+          </span>
           <FieldSelect
             style={{ marginRight: 16 }}
             fields={[

--- a/packages/desktop-client/src/components/rules/RuleRow.tsx
+++ b/packages/desktop-client/src/components/rules/RuleRow.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import React, { memo, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgRightArrow2 } from '@actual-app/components/icons/v0';
@@ -219,7 +219,9 @@ export const RuleRow = memo(
         </Field>
 
         <Cell name="edit" plain style={{ padding: '0 15px', paddingLeft: 5 }}>
-          <Button onPress={() => onEditRule(rule)}>{t('Edit')}</Button>
+          <Button onPress={() => onEditRule(rule)}>
+            <Trans>Edit</Trans>
+          </Button>
         </Cell>
       </Row>
     );

--- a/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
+++ b/packages/desktop-client/src/components/select/RecurringSchedulePicker.tsx
@@ -484,7 +484,9 @@ function RecurringScheduleTooltip({
         style={{ marginTop: 10 }}
         spacing={1}
       >
-        <Text style={{ whiteSpace: 'nowrap' }}>{t('Repeat every')}</Text>
+        <Text style={{ whiteSpace: 'nowrap' }}>
+          <Trans>Repeat every</Trans>
+        </Text>
         <Input
           id="interval"
           style={{ width: 40 }}
@@ -507,7 +509,7 @@ function RecurringScheduleTooltip({
             }}
             onPress={() => dispatch({ type: 'add-recurrence' })}
           >
-            {t('Add specific days')}
+            <Trans>Add specific days</Trans>
           </Button>
         ) : null}
       </Stack>

--- a/packages/desktop-client/src/components/settings/Export.tsx
+++ b/packages/desktop-client/src/components/settings/Export.tsx
@@ -48,7 +48,7 @@ export function ExportBudget() {
       primaryAction={
         <>
           <ButtonWithLoading onPress={onExport} isLoading={isLoading}>
-            {t('Export data')}
+            <Trans>Export data</Trans>
           </ButtonWithLoading>
           {error && (
             <Block style={{ color: theme.errorText, marginTop: 15 }}>

--- a/packages/desktop-client/src/hooks/useFormat.ts
+++ b/packages/desktop-client/src/hooks/useFormat.ts
@@ -24,7 +24,7 @@ function format(
   switch (type) {
     case 'string':
       const val = JSON.stringify(value);
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       if (val.charAt(0) === '"' && val.charAt(val.length - 1) === '"') {
         return val.slice(1, -1);
       }

--- a/packages/eslint-plugin-actual/lib/index.js
+++ b/packages/eslint-plugin-actual/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     'no-untranslated-strings': require('./rules/no-untranslated-strings'),
+    'prefer-trans-over-t': require('./rules/prefer-trans-over-t'),
   },
 };

--- a/packages/eslint-plugin-actual/lib/index.js
+++ b/packages/eslint-plugin-actual/lib/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-untranslated-strings': require('./rules/no-untranslated-strings'),
+  },
+};

--- a/packages/eslint-plugin-actual/lib/index.js
+++ b/packages/eslint-plugin-actual/lib/index.js
@@ -2,7 +2,7 @@ module.exports = {
   rules: {
     'no-untranslated-strings': require('./rules/no-untranslated-strings'),
     'prefer-trans-over-t': require('./rules/prefer-trans-over-t'),
-    'typography': require('./rules/typography'),
+    typography: require('./rules/typography'),
     'prefer-if-statement': require('./rules/prefer-if-statement'),
   },
 };

--- a/packages/eslint-plugin-actual/lib/index.js
+++ b/packages/eslint-plugin-actual/lib/index.js
@@ -2,5 +2,7 @@ module.exports = {
   rules: {
     'no-untranslated-strings': require('./rules/no-untranslated-strings'),
     'prefer-trans-over-t': require('./rules/prefer-trans-over-t'),
+    'typography': require('./rules/typography'),
+    'prefer-if-statement': require('./rules/prefer-if-statement'),
   },
 };

--- a/packages/eslint-plugin-actual/lib/rules/no-untranslated-strings.js
+++ b/packages/eslint-plugin-actual/lib/rules/no-untranslated-strings.js
@@ -1,0 +1,89 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow non-translated English strings',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noHardcoded: 'Non-translated English string. Wrap in <Trans>.',
+    },
+  },
+  create(context) {
+    const whitelist = [
+      'Actual',
+      'GoCardless',
+      'SimpleFIN',
+      'Pluggy.ai',
+      'YNAB',
+      'nYNAB',
+      'YNAB4',
+
+      '0',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+      '8',
+      '9',
+    ];
+
+    function isProbablyEnglish(text) {
+      const trimmed = text.trim();
+      if (whitelist.includes(trimmed)) {
+        return false;
+      }
+
+      // very basic - but it'll catch most cases
+      return /^[A-Z][a-z].*[a-z]$/.test(trimmed);
+    }
+
+    function isInsideTrans(node) {
+      let parent = node.parent;
+      while (parent) {
+        if (parent.type === 'JSXElement') {
+          const elementName = parent.openingElement.name;
+          // Check for both JSXIdentifier and JSXMemberExpression (e.g., Trans.Provider)
+          if (
+            elementName.type === 'JSXIdentifier' &&
+            elementName.name === 'Trans'
+          ) {
+            return true;
+          }
+          if (
+            elementName.type === 'JSXMemberExpression' &&
+            elementName.object.name === 'Trans'
+          ) {
+            return true;
+          }
+        }
+        parent = parent.parent;
+      }
+      return false;
+    }
+
+    return {
+      JSXText(node) {
+        if (isProbablyEnglish(node.value) && !isInsideTrans(node)) {
+          context.report({ node, messageId: 'noHardcoded' });
+        }
+      },
+      Literal(node) {
+        if (
+          node.parent &&
+          node.parent.type === 'JSXExpressionContainer' &&
+          typeof node.value === 'string' &&
+          isProbablyEnglish(node.value) &&
+          !isInsideTrans(node)
+        ) {
+          context.report({ node, messageId: 'noHardcoded' });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-actual/lib/rules/prefer-trans-over-t.js
+++ b/packages/eslint-plugin-actual/lib/rules/prefer-trans-over-t.js
@@ -1,0 +1,138 @@
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Prefer <Trans> over t() for simple text content in JSX',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      preferTrans: 'Prefer <Trans>{{ text }}</Trans> over t(\'{{ text }}\') for simple text content in JSX.',
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const simpleTextPattern = /^[A-Z][a-z\s]*[a-z]$/;
+
+    function isSimpleText(text) {
+      const trimmed = text.trim();
+      if (trimmed === '') return false;
+
+      // Skip if it contains interpolation or complex patterns
+      if (trimmed.includes('{{') || trimmed.includes('}}')) return false;
+      if (trimmed.includes('\\') || trimmed.includes('`')) return false;
+
+      return simpleTextPattern.test(trimmed);
+    }
+
+    function isJSXContent(node) {
+      let parent = node.parent;
+
+      // We don't want to outlaw t() calls in these contexts
+      const disallowedTypes = [
+        'AssignmentExpression', // title = t('Text')
+        'VariableDeclarator', // const title = t('Text')
+        'JSXAttribute', // title={t('Text')}
+        'JSXOpeningElement', // <div title={t('Text')}>
+        'ConditionalExpression', // condition ? t('Yes') : t('No')
+        'LogicalExpression', // condition && t('Text')
+        'CallExpression', // someFunction(t('Text'))
+        'Property', // { title: t('Text') }
+      ];
+
+      while (parent) {
+        if (disallowedTypes.includes(parent.type)) {
+          return false;
+        }
+
+        if (parent.type === 'ReturnStatement') {
+          // Checks if return statement is inside JSX context
+          // return <div>{t('Text')}</div> - WILL flag
+          // return t('Text') - will NOT flag
+          let returnParent = parent.parent;
+          while (returnParent) {
+            if (returnParent.type === 'JSXElement') {
+              break;
+            }
+            if (
+              returnParent.type === 'FunctionDeclaration' ||
+              returnParent.type === 'FunctionExpression' ||
+              returnParent.type === 'ArrowFunctionExpression'
+            ) {
+              return false;
+            }
+            returnParent = returnParent.parent;
+          }
+        }
+
+        if (parent.type === 'JSXExpressionContainer') {
+          // Checks if expression container is inside JSX children (not attributes)
+          // <div>{t('Text')}</div> - WILL flag
+          // <div title={t('Text')}></div> - will NOT flag
+          let containerParent = parent.parent;
+          while (containerParent) {
+            if (containerParent.type === 'JSXAttribute') {
+              return false;
+            }
+            if (containerParent.type === 'JSXOpeningElement') {
+              return false;
+            }
+            if (containerParent.type === 'JSXElement') {
+              const children = containerParent.children || [];
+              return children.some(child => 
+                child === parent || 
+                child === node
+              );
+            }
+            containerParent = containerParent.parent;
+          }
+          return true;
+        }
+
+        if (parent.type === 'JSXElement') {
+          // <div>{t('Text')}</div> - WILL flag
+          // <div title={t('Text')}></div> - will NOT flag
+          const children = parent.children || [];
+          return children.some(child => 
+            child === node || 
+            (child.type === 'JSXExpressionContainer' && child.expression === node)
+          );
+        }
+        
+        parent = parent.parent;
+      }
+      
+      return false;
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 't' &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === 'Literal' &&
+          typeof node.arguments[0].value === 'string' &&
+          isSimpleText(node.arguments[0].value) &&
+          isJSXContent(node)
+        ) {
+          context.report({
+            node,
+            messageId: 'preferTrans',
+            data: {
+              text: node.arguments[0].value,
+            },
+            fix(fixer) {
+              const text = node.arguments[0].value;
+              return fixer.replaceText(
+                node,
+                `<Trans>${text}</Trans>`
+              );
+            },
+          });
+        }
+      },
+    };
+  },
+}; 

--- a/packages/eslint-plugin-actual/lib/rules/prefer-trans-over-t.js
+++ b/packages/eslint-plugin-actual/lib/rules/prefer-trans-over-t.js
@@ -8,7 +8,8 @@ module.exports = {
     },
     schema: [],
     messages: {
-      preferTrans: 'Prefer <Trans>{{ text }}</Trans> over t(\'{{ text }}\') for simple text content in JSX.',
+      // eslint-disable-next-line actual/typography
+      preferTrans: "Prefer <Trans>{{ text }}</Trans> over t('{{ text }}')",
     },
     fixable: 'code',
   },
@@ -80,10 +81,7 @@ module.exports = {
             }
             if (containerParent.type === 'JSXElement') {
               const children = containerParent.children || [];
-              return children.some(child => 
-                child === parent || 
-                child === node
-              );
+              return children.some(child => child === parent || child === node);
             }
             containerParent = containerParent.parent;
           }
@@ -94,15 +92,17 @@ module.exports = {
           // <div>{t('Text')}</div> - WILL flag
           // <div title={t('Text')}></div> - will NOT flag
           const children = parent.children || [];
-          return children.some(child => 
-            child === node || 
-            (child.type === 'JSXExpressionContainer' && child.expression === node)
+          return children.some(
+            child =>
+              child === node ||
+              (child.type === 'JSXExpressionContainer' &&
+                child.expression === node),
           );
         }
-        
+
         parent = parent.parent;
       }
-      
+
       return false;
     }
 
@@ -125,14 +125,11 @@ module.exports = {
             },
             fix(fixer) {
               const text = node.arguments[0].value;
-              return fixer.replaceText(
-                node,
-                `<Trans>${text}</Trans>`
-              );
+              return fixer.replaceText(node, `<Trans>${text}</Trans>`);
             },
           });
         }
       },
     };
   },
-}; 
+};

--- a/packages/eslint-plugin-actual/lib/rules/typography.js
+++ b/packages/eslint-plugin-actual/lib/rules/typography.js
@@ -13,7 +13,7 @@ module.exports = {
     fixable: null,
     schema: [],
     messages: {
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       quote: `Avoid using straight quotes (' or ") in user-visible text. Use curly quotes (‘ ’ or “ ”) instead.`,
     },
   },
@@ -26,7 +26,7 @@ module.exports = {
     //----------------------------------------------------------------------
 
     function check(node, { value = node.value, strip = false } = {}) {
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       if (!value.includes("'") && !value.includes('"')) return;
 
       let rawText = context.getSourceCode().getText(node);

--- a/packages/loot-core/migrations/1722804019000_create_dashboard_table.js
+++ b/packages/loot-core/migrations/1722804019000_create_dashboard_table.js
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-/* eslint-disable rulesdir/typography */
+/* eslint-disable actual/typography */
 export default async function runMigration(db) {
   db.transaction(() => {
     db.execQuery(`

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -38,7 +38,7 @@ function isKeyword(str) {
 }
 
 export function quoteAlias(alias) {
-  // eslint-disable-next-line rulesdir/typography
+  // eslint-disable-next-line actual/typography
   return alias.indexOf('.') === -1 && !isKeyword(alias) ? alias : `"${alias}"`;
 }
 
@@ -342,7 +342,7 @@ function val(state, expr, type?: string) {
   }
 
   if (castedExpr.literal) {
-    /* eslint-disable rulesdir/typography */
+    /* eslint-disable actual/typography */
     if (castedExpr.type === 'id') {
       return `'${castedExpr.value}'`;
     } else if (castedExpr.type === 'string') {
@@ -350,7 +350,7 @@ function val(state, expr, type?: string) {
       const value = castedExpr.value.replace(/'/g, "''");
       return `'${value}'`;
     }
-    /* eslint-enable rulesdir/typography */
+    /* eslint-enable actual/typography */
   }
 
   return castedExpr.value;
@@ -718,7 +718,7 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
       const [left, right] = valArray(state, [lhs, rhs], [null, 'array']);
       // Dedupe the ids
       const ids = [...new Set(right)];
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       return `${left} IN (` + ids.map(id => `'${id}'`).join(',') + ')';
     }
     case '$like': {

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -304,7 +304,7 @@ export const schemaConfig: SchemaConfig = {
 
     schedules: {
       v_schedules: internalFields => {
-        /* eslint-disable rulesdir/typography */
+        /* eslint-disable actual/typography */
         const fields = internalFields({
           next_date: `
             CASE
@@ -328,7 +328,7 @@ export const schemaConfig: SchemaConfig = {
         LEFT JOIN rules _rules ON _rules.id = _.rule
         LEFT JOIN payee_mapping pm ON pm.id = json_extract(_rules.conditions, _paths.payee || '.value')
         `;
-        /* eslint-enable rulesdir/typography */
+        /* eslint-enable actual/typography */
       },
     },
 

--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -3,7 +3,7 @@ import { DbSchedule } from '../db';
 
 import { GOAL_PREFIX, TEMPLATE_PREFIX } from './template-notes';
 
-/* eslint-disable rulesdir/typography */
+/* eslint-disable actual/typography */
 export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
   await db.run(
     `
@@ -17,7 +17,7 @@ export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
   );
 }
 
-/* eslint-enable rulesdir/typography */
+/* eslint-enable actual/typography */
 
 export type CategoryWithTemplateNote = {
   id: string;

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -662,7 +662,7 @@ export function getCommonPayees() {
   `);
 }
 
-/* eslint-disable rulesdir/typography */
+/* eslint-disable actual/typography */
 const orphanedPayeesQuery = `
   SELECT p.id
   FROM payees p
@@ -680,7 +680,7 @@ const orphanedPayeesQuery = `
         AND json_extract(cond.value, '$.value') = pm.targetId
     );
 `;
-/* eslint-enable rulesdir/typography */
+/* eslint-enable actual/typography */
 
 export function syncGetOrphanedPayees() {
   return all<Pick<DbPayee, 'id'>>(orphanedPayeesQuery);

--- a/packages/loot-core/src/server/db/util.ts
+++ b/packages/loot-core/src/server/db/util.ts
@@ -30,7 +30,7 @@ export async function incrFetch(
 
 export function whereIn(ids: string[], field: string) {
   const ids2 = [...new Set(ids)];
-  // eslint-disable-next-line rulesdir/typography
+  // eslint-disable-next-line actual/typography
   const filter = `${field} IN (` + ids2.map(id => `'${id}'`).join(',') + ')';
   return filter;
 }

--- a/packages/loot-core/src/server/transactions/import/ofx2json.ts
+++ b/packages/loot-core/src/server/transactions/import/ofx2json.ts
@@ -33,8 +33,8 @@ export function html2Plain(value) {
   return value
     ?.replace(/&lt;/g, '<') // lessthan
     .replace(/&gt;/g, '>') // greaterthan
-    .replace(/&#39;/g, "'") // eslint-disable-line rulesdir/typography
-    .replace(/&quot;/g, '"') // eslint-disable-line rulesdir/typography
+    .replace(/&#39;/g, "'") // eslint-disable-line actual/typography
+    .replace(/&quot;/g, '"') // eslint-disable-line actual/typography
     .replace(/(&amp;|&#038;)/g, '&'); // ampersands
 }
 

--- a/packages/loot-core/src/server/transactions/import/parse-file.ts
+++ b/packages/loot-core/src/server/transactions/import/parse-file.ts
@@ -72,7 +72,7 @@ async function parseCSV(
       columns: options?.hasHeaderRow,
       bom: true,
       delimiter: options?.delimiter || ',',
-      // eslint-disable-next-line rulesdir/typography
+      // eslint-disable-next-line actual/typography
       quote: '"',
       trim: true,
       relax_column_count: true,

--- a/packages/loot-core/src/server/transactions/index.ts
+++ b/packages/loot-core/src/server/transactions/index.ts
@@ -31,7 +31,7 @@ async function getTransactionsByIds(
   return incrFetch(
     (query, params) => db.selectWithSchema('transactions', query, params),
     ids,
-    // eslint-disable-next-line rulesdir/typography
+    // eslint-disable-next-line actual/typography
     id => `id = '${id}'`,
     where => `SELECT * FROM v_transactions_internal WHERE ${where}`,
   );

--- a/packages/sync-server/src/app-gocardless/banks/easybank_bawaatww.js
+++ b/packages/sync-server/src/app-gocardless/banks/easybank_bawaatww.js
@@ -1,5 +1,3 @@
-import * as d from 'date-fns';
-
 import { formatPayeeName } from '../../util/payee-name.js';
 import { title } from '../../util/title/index.js';
 

--- a/packages/sync-server/src/app-gocardless/banks/fortuneo_ftnofrp1xxx.js
+++ b/packages/sync-server/src/app-gocardless/banks/fortuneo_ftnofrp1xxx.js
@@ -1,5 +1,3 @@
-import { formatPayeeName } from '../../util/payee-name.js';
-
 import Fallback from './integration-bank.js';
 
 /** @type {import('./bank.interface.js').IBank} */

--- a/yarn.lock
+++ b/yarn.lock
@@ -7614,7 +7614,6 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
-    eslint-plugin-rulesdir: "npm:^0.2.2"
     eslint-plugin-typescript-paths: "npm:^0.0.33"
     globals: "npm:^15.15.0"
     html-to-image: "npm:^1.11.13"
@@ -10940,13 +10939,6 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
   checksum: 10/ee1bd4e0ec64f29109d5a625bb703d179c82e0159c86c3f1b52fc1209d2994625a137dae303c333fb308a2e38315e44066d5204998177e31974382f9fda25d5c
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-rulesdir@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "eslint-plugin-rulesdir@npm:0.2.2"
-  checksum: 10/aac282554e5eb5b1fb3944dd43a08be5fd3e0bc33a00738f525df08344bc1d54f4abe3303118582d86776b3146ddb9e09d3fd1af502d484b3354da2bfee2ce24
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Here's my stab at getting some linting rules in for translation. These aren't perfect but should lighten the load on reviews.

There are two rules here:
- One to prevent completely untranslated strings
- One to prevent patterns like the below:
```diff
-        {t('Back')}
+        <Trans>Back</Trans>
```

The latter will even autofix, though that can sometimes lead to some `Trans is not defined` errors which would require manual intervention.

The rest of this change is cleanup of the custom lint rules while I was there, fixing the remaining translation issues these rules found, and tidying up a TODO in the lint config.