### PR TITLE
fix: reapply thousand separators before passing input to appendDecimals

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -19,6 +19,7 @@ import {
   amountToCurrency,
   appendDecimals,
   currencyToAmount,
+  reapplyThousandSeparators,
 } from 'loot-core/shared/util';
 
 import { makeAmountFullStyle } from '@desktop-client/components/budget/util';
@@ -113,6 +114,7 @@ const AmountInput = memo(function AmountInput({
   };
 
   const onChangeText = (text: string) => {
+    text = reapplyThousandSeparators(text);
     text = appendDecimals(text, String(hideFraction) === 'true');
     setEditing(true);
     setText(text);

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -18,7 +18,11 @@ import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
 
 import { evalArithmetic } from 'loot-core/shared/arithmetic';
-import { amountToInteger, appendDecimals } from 'loot-core/shared/util';
+import {
+  amountToInteger,
+  appendDecimals,
+  reapplyThousandSeparators,
+} from 'loot-core/shared/util';
 
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
@@ -96,6 +100,7 @@ export function AmountInput({
   }
 
   function onInputTextChange(val) {
+    val = reapplyThousandSeparators(val);
     val = autoDecimals
       ? appendDecimals(val, String(hideFraction) === 'true')
       : val;

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -214,6 +214,17 @@ export function titleFirst(str: string | null | undefined) {
   return str[0].toUpperCase() + str.slice(1);
 }
 
+export function reapplyThousandSeparators(amountText: string) {
+  const { decimalSeparator, thousandsSeparator } = getNumberFormat();
+  const [integerPartRaw, decimalPart = ''] = amountText.split(decimalSeparator);
+  const integerPart = Number(integerPartRaw.replaceAll(thousandsSeparator, ''))
+    .toLocaleString('en-US')
+    .replaceAll(',', thousandsSeparator);
+  return decimalPart
+    ? integerPart + decimalSeparator + decimalPart
+    : integerPart;
+}
+
 export function appendDecimals(
   amountText: string,
   hideDecimals = false,

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -215,9 +215,19 @@ export function titleFirst(str: string | null | undefined) {
 }
 
 export function reapplyThousandSeparators(amountText: string) {
+  if (!amountText || typeof amountText !== 'string') {
+    return amountText;
+  }
+
   const { decimalSeparator, thousandsSeparator } = getNumberFormat();
   const [integerPartRaw, decimalPart = ''] = amountText.split(decimalSeparator);
-  const integerPart = Number(integerPartRaw.replaceAll(thousandsSeparator, ''))
+
+  const numericValue = Number(integerPartRaw.replaceAll(thousandsSeparator, ''));
+  if (isNaN(numericValue)) {
+    return amountText; // Return original if parsing fails
+  }
+
+  const integerPart = numericValue
     .toLocaleString('en-US')
     .replaceAll(',', thousandsSeparator);
   return decimalPart

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -222,7 +222,9 @@ export function reapplyThousandSeparators(amountText: string) {
   const { decimalSeparator, thousandsSeparator } = getNumberFormat();
   const [integerPartRaw, decimalPart = ''] = amountText.split(decimalSeparator);
 
-  const numericValue = Number(integerPartRaw.replaceAll(thousandsSeparator, ''));
+  const numericValue = Number(
+    integerPartRaw.replaceAll(thousandsSeparator, ''),
+  );
   if (isNaN(numericValue)) {
     return amountText; // Return original if parsing fails
   }

--- a/upcoming-release-notes/5220.md
+++ b/upcoming-release-notes/5220.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [intagaming]
+---
+
+Reapply thousand separators before passing input to appendDecimals


### PR DESCRIPTION
Fixes #5218

This ensures that the input going into `appendDecimals` is not malformed when the  `hideFraction` option is On, otherwise when hitting delete on the text `"1,234,567"`, it will result in the text `"1,234,56"` which the formatter will parse as `1234.56`. This doesn't happen when `hideFraction` is off since hitting delete on the text `"12,345.67"` results in `"12,345.6"`, which `appendDecimals` will happily handle in a separate case to provide `"12345.6"` as the input into `currencyToAmount`.
