### PR TITLE
Fix UI glitches when splitting existing transactions

### DIFF
--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -898,6 +898,7 @@ export type TableHandleRef<T extends TableItem = TableItem> = {
   anchor(): void;
   unanchor(): void;
   isAnchored(): boolean;
+  getEditingState(): { editingId: T['id'] | null; focusedField: string | null };
 };
 
 type TableWithNavigatorProps = TableProps & {
@@ -1033,6 +1034,13 @@ export const Table = forwardRef(
 
       isAnchored() {
         return list.current && list.current.isAnchored();
+      },
+
+      getEditingState() {
+        return {
+          editingId: navigator.editingId,
+          focusedField: navigator.focusedField,
+        };
       },
     }));
 

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -66,15 +66,31 @@ async function saveDiff(diff, learnCategories) {
   return {};
 }
 
-async function saveDiffAndApply(diff, changes, onChange, learnCategories) {
+function getIsUserEditing(tableRef) {
+  const editingState = tableRef.current?.getEditingState?.();
+  return editingState?.editingId !== null;
+}
+
+async function saveDiffAndApply(
+  diff,
+  changes,
+  onChange,
+  learnCategories,
+  tableRef,
+) {
   const remoteDiff = await saveDiff(diff, learnCategories);
-  onChange(
-    // TODO:
-    // @ts-ignore testing
-    applyTransactionDiff(changes.newTransaction, remoteDiff),
-    // @ts-ignore testing
-    applyChanges(remoteDiff, changes.data),
-  );
+
+  const isUserEditing = getIsUserEditing(tableRef);
+
+  if (!isUserEditing) {
+    onChange(
+      // TODO:
+      // @ts-ignore testing
+      applyTransactionDiff(changes.newTransaction, remoteDiff),
+      // @ts-ignore testing
+      applyChanges(remoteDiff, changes.data),
+    );
+  }
 }
 
 type TransactionListProps = Pick<
@@ -206,11 +222,12 @@ export function TransactionList({
             changes,
             onChange,
             isLearnCategoriesEnabled,
+            tableRef,
           );
         }
       }
     },
-    [isLearnCategoriesEnabled, onChange, onRefetch],
+    [isLearnCategoriesEnabled, onChange, onRefetch, tableRef],
   );
 
   const onAddSplit = useCallback(
@@ -222,10 +239,11 @@ export function TransactionList({
         changes,
         onChange,
         isLearnCategoriesEnabled,
+        tableRef,
       );
       return changes.diff.added[0].id;
     },
-    [isLearnCategoriesEnabled, onChange],
+    [isLearnCategoriesEnabled, onChange, tableRef],
   );
 
   const onSplit = useCallback(
@@ -237,10 +255,11 @@ export function TransactionList({
         changes,
         onChange,
         isLearnCategoriesEnabled,
+        tableRef,
       );
       return changes.diff.added[0].id;
     },
-    [isLearnCategoriesEnabled, onChange],
+    [isLearnCategoriesEnabled, onChange, tableRef],
   );
 
   const onApplyRules = useCallback(

--- a/upcoming-release-notes/5227.md
+++ b/upcoming-release-notes/5227.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Ditti4]
+---
+
+Fix UI glitches when splitting existing transactions


### PR DESCRIPTION
When splitting an existing transaction, we apply the changes to the UI
immediately, then synchronize with the server and apply the
server-approved changes again. This causes split transactions to
disappear and reappear while trying to split an existing transaction.

To fix this, we can simply avoid applying the server-provided changes
while we're actively editing a transaction.

Fixes #5217.
