### PR TITLE
Create 5235.md

### DIFF
--- a/upcoming-release-notes/5235.md
+++ b/upcoming-release-notes/5235.md
@@ -1,0 +1,7 @@
+---
+category: Enhancements
+authors: [tim_connect]
+---
+This PR adds support for reading the OpenID client secret from a file using the ACTUAL_OPENID_CLIENT_SECRET_FILE environment variable. This enables better handling of secrets in Docker and Kubernetes environments.
+
+If both ACTUAL_OPENID_CLIENT_SECRET and ACTUAL_OPENID_CLIENT_SECRET_FILE are set, the _FILE variant takes precedence.


### PR DESCRIPTION
This PR adds support for reading the OpenID client secret from a file using the ACTUAL_OPENID_CLIENT_SECRET_FILE environment variable. This enables better handling of secrets in Docker and Kubernetes environments.

If both ACTUAL_OPENID_CLIENT_SECRET and ACTUAL_OPENID_CLIENT_SECRET_FILE are set, the _FILE variant takes precedence.