### PR TITLE
Fix hidden categories

### DIFF
--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -243,7 +243,7 @@ export async function copySinglePreviousMonth({
 
 export async function setZero({ month }: { month: string }): Promise<void> {
   const categories = await db.all<db.DbViewCategory>(
-    'SELECT * FROM v_categories WHERE tombstone = 0',
+    'SELECT * FROM v_categories WHERE tombstone = 0 AND hidden = 0',
   );
 
   await batchMessages(async () => {
@@ -262,7 +262,7 @@ export async function set3MonthAvg({
   month: string;
 }): Promise<void> {
   const categories = await db.all<db.DbViewCategory>(
-    'SELECT * FROM v_categories WHERE tombstone = 0',
+    'SELECT * FROM v_categories WHERE tombstone = 0 AND hidden = 0',
   );
 
   const prevMonth1 = monthUtils.prevMonth(month);
@@ -305,7 +305,7 @@ export async function set12MonthAvg({
   month: string;
 }): Promise<void> {
   const categories = await db.all<db.DbViewCategory>(
-    'SELECT * FROM v_categories WHERE tombstone = 0',
+    'SELECT * FROM v_categories WHERE tombstone = 0 AND hidden = 0',
   );
 
   await batchMessages(async () => {
@@ -324,7 +324,7 @@ export async function set6MonthAvg({
   month: string;
 }): Promise<void> {
   const categories = await db.all<db.DbViewCategory>(
-    'SELECT * FROM v_categories WHERE tombstone = 0',
+    'SELECT * FROM v_categories WHERE tombstone = 0 AND hidden = 0',
   );
 
   await batchMessages(async () => {

--- a/upcoming-release-notes/5239.md
+++ b/upcoming-release-notes/5239.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lougeorge]
+---
+
+Fixed the functions to set budget targets based on past averages to correctly ignore hidden categories. Further work is required to handle hidden category groups, including potentially creating new views or migrations to expose relevant information to the target setting functions.


### PR DESCRIPTION
Fixes #5128

Fix the functions to set budget targets based on past averages to correctly ignore hidden categories. Further work is required to handle hidden category groups, including potentially creating new views or migrations to expose relevant information to the target setting functions as the view these functions are pulling from has no knowledge of whether a category is in a hidden category group or not, and currently hiding a category group does not set the hidden flag of each category contained within.


### Release Notes ### 
category: Bugfix
authors: lougeorge
PR number: 5239
Summary: This PR adds logic to exclude hidden categories from functions to set budget targets based on past data
