### PR TITLE
Fixes #5238 last synced button text not visible on light theme.

### DIFF
--- a/packages/desktop-client/src/style/themes/light.ts
+++ b/packages/desktop-client/src/style/themes/light.ts
@@ -89,8 +89,8 @@ export const markdownDark = colorPalette.purple400;
 export const markdownLight = colorPalette.purple100;
 
 // Button
-export const buttonMenuText = colorPalette.navy100;
-export const buttonMenuTextHover = colorPalette.navy50;
+export const buttonMenuText = colorPalette.navy500;
+export const buttonMenuTextHover = colorPalette.navy900;
 export const buttonMenuBackground = 'transparent';
 export const buttonMenuBackgroundHover = 'rgba(200, 200, 200, .25)';
 export const buttonMenuBorder = colorPalette.navy500;

--- a/upcoming-release-notes/5240.md
+++ b/upcoming-release-notes/5240.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [mauschil]
 ---
 
-Changed the buttonMenuText color for the light theme so that text is visible on light background as well.
+Change the buttonMenuText color for the light theme so that text is visible on light backgrounds as well.

--- a/upcoming-release-notes/5240.md
+++ b/upcoming-release-notes/5240.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mauschil]
+---
+
+Changed the buttonMenuText color for the light theme so that text is visible on light background as well.


### PR DESCRIPTION
### Related Issue
#5238 

### Release Notes
category: Bugfix
authors: [mauschil]

Change the buttonMenuText color for the light theme so that text is visible on light backgrounds as well.

### Screenshots
Before
<img width="283" alt="image" src="https://github.com/user-attachments/assets/1fb97963-b2fb-4aea-a2ef-88b40d7c823e" />
<img width="364" alt="image" src="https://github.com/user-attachments/assets/72059d1b-3f31-41dd-b6e3-98964464cbd9" />



After
<img width="284" alt="image" src="https://github.com/user-attachments/assets/c2bce846-cbd5-4f5e-bb3e-d8fc946c3eb0" />
<img width="365" alt="image" src="https://github.com/user-attachments/assets/0ff8c867-71e0-4b5e-8212-cd18f84b77cd" />

### Additional Notes
In the light theme, the menus for any transaction menu (payee, category, date, etc) are still using a dark background. That means that buttonMenuText to has to be readable on both a dark and light background.

An alternative solution to this fix is to change the background color of the light transaction menus as well. Happy to do that, but since its my first PR, I'd leave the choice of whether to do it up to the maintainers.
