### PR TITLE
fix defaultCleared options not used when importTransactions

### DIFF
--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1091,7 +1091,7 @@ async function importTransactions({
   transactions: ImportTransactionEntity[];
   isPreview: boolean;
   opts?: {
-    defaultCleared: boolean;
+    defaultCleared?: boolean;
   };
 }): Promise<ImportTransactionsResult> {
   if (typeof accountId !== 'string') {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -480,12 +480,14 @@ handlers['api/transactions-import'] = withMutation(async function ({
   accountId,
   transactions,
   isPreview = false,
+  opts,
 }) {
   checkFileOpen();
   return handlers['transactions-import']({
     accountId,
     transactions,
     isPreview,
+    opts,
   });
 });
 

--- a/upcoming-release-notes/5247.md
+++ b/upcoming-release-notes/5247.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ngoc-minh-do]
+---
+
+Fix issue that importTransactions() options (defaultCleared) was not used


### PR DESCRIPTION
Fix issue that importTransactions() options was not used