### PR TITLE
Add pre-commit hook to prevent commits to master branch

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,13 @@
+#!/usr/bin/env sh
+
+# Prevent committing to master branch
+current_branch=$(git symbolic-ref --short HEAD)
+if [ "$current_branch" = "master" ]; then
+  echo "❌ Error: Committing directly to the master branch is not allowed."
+  echo "Please create a feature branch and submit a pull request instead."
+  echo "Current branch: $current_branch"
+  exit 1
+fi
+
+# Run lint-staged to check staged files
 yarn lint-staged

--- a/upcoming-release-notes/5254.md
+++ b/upcoming-release-notes/5254.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add pre-commit hook to prevent commits to master branch.


### PR DESCRIPTION
I recently accidentally pushed to `master` and thus had to overwrite my changes and do a force push.. this is not great.

Adding a pre-commit hook that prohibits committing directly to the `master` branch.