### PR TITLE
Fix rule templating on date causing crash

### DIFF
--- a/packages/loot-core/src/server/rules/index.ts
+++ b/packages/loot-core/src/server/rules/index.ts
@@ -707,7 +707,10 @@ export class Action {
               object[this.field] = parseFloat(object[this.field]);
               break;
             case 'date':
-              object[this.field] = parseDate(object[this.field]);
+              object[this.field] = format(
+                parseDate(object[this.field]),
+                'yyyy-MM-dd',
+              );
               break;
             case 'boolean':
               object[this.field] = object[this.field] === 'true';

--- a/packages/loot-core/src/server/rules/index.ts
+++ b/packages/loot-core/src/server/rules/index.ts
@@ -707,10 +707,18 @@ export class Action {
               object[this.field] = parseFloat(object[this.field]);
               break;
             case 'date':
-              object[this.field] = format(
-                parseDate(object[this.field]),
-                'yyyy-MM-dd',
-              );
+              const parsed = parseDate(object[this.field]);
+              if (parsed && dateFns.isValid(parsed)) {
+                object[this.field] = format(parsed, 'yyyy-MM-dd');
+              } else {
+                // Keep original string; log for diagnostics but avoid hard crash
+                console.error(
+                  `rules: invalid date produced by template for field “${this.field}”:`,
+                  object[this.field],
+                );
+                // Make it stick like a sore thumb
+                object[this.field] = '9999-12-31';
+              }
               break;
             case 'boolean':
               object[this.field] = object[this.field] === 'true';

--- a/upcoming-release-notes/5259.md
+++ b/upcoming-release-notes/5259.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [pogman-code]
+---
+
+Fix rule templating on date causing crash


### PR DESCRIPTION
Fixes #5258 

Long story short, the "set" rule set a Date object to the transaction instead of a "yyyy-MM-dd" string.  
Causing a crash when calling `parseISO(date)` in the `serializeTransaction` function.