### PR TITLE
Fixes #5228 - has tag(s) filter now takes values when pressing Enter

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -209,10 +209,14 @@ function ConfigureField({
       <Form
         onSubmit={e => {
           e.preventDefault();
+
+          // Use the live input value to avoid race conditions with fast typing (when pressing Enter)
+          const liveValue = inputRef.current?.value?.trim();
+
           onApply({
             field,
             op,
-            value,
+            value: liveValue,
             options: subfieldToOptions(field, subfield),
           });
         }}

--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -209,14 +209,10 @@ function ConfigureField({
       <Form
         onSubmit={e => {
           e.preventDefault();
-
-          // Use the live input value to avoid race conditions with fast typing (when pressing Enter)
-          const liveValue = inputRef.current?.value?.trim();
-
           onApply({
             field,
             op,
-            value: liveValue,
+            value,
             options: subfieldToOptions(field, subfield),
           });
         }}

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -64,10 +64,9 @@ export function GenericInput({
         return (
           <Input
             ref={ref}
-            defaultValue={value || ''}
+            value={value || ''}
             placeholder={t('nothing')}
-            onEnter={onChange}
-            onUpdate={onChange}
+            onChangeValue={onChange}
           />
         );
     }
@@ -190,10 +189,9 @@ export function GenericInput({
           content = (
             <Input
               ref={ref}
-              defaultValue={value || ''}
+              value={value || ''}
               placeholder={getMonthYearFormat(dateFormat).toLowerCase()}
-              onEnter={onChange}
-              onUpdate={onChange}
+              onChangeValue={onChange}
             />
           );
           break;
@@ -202,10 +200,9 @@ export function GenericInput({
           content = (
             <Input
               ref={ref}
-              defaultValue={value || ''}
+              value={value || ''}
               placeholder="yyyy"
-              onEnter={onChange}
-              onUpdate={onChange}
+              onChangeValue={onChange}
             />
           );
           break;
@@ -262,10 +259,9 @@ export function GenericInput({
         content = (
           <Input
             ref={ref}
-            defaultValue={value || ''}
+            value={value || ''}
             placeholder={t('nothing')}
-            onEnter={onChange}
-            onUpdate={onChange}
+            onChangeValue={onChange}
           />
         );
       }

--- a/upcoming-release-notes/5263.md
+++ b/upcoming-release-notes/5263.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [seabeeberry]
+---
+
+Fix bug where "has tag(s)" filter created empty tag when using Enter key


### PR DESCRIPTION
When quickly typing into the filter input and pressing Enter, the entered value was not always correctly applied. Sometimes it resulted in an empty filter being created. In my test it ocurred for other types of filters as well, not only for "has tag(s)".

Updated the GenericInput component to add onChangeValue={onChange}, as suggested by @mauschil. Changed the defaultValue to value.

Now, however quickly you type a filter name and press Enter, your inputted value is correctly applied.
