### PR TITLE
Run rules on transactions created by a transfer.

### DIFF
--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import * as db from '../db';
 
-import { runRules } from "./transaction-rules";
+import { runRules } from './transaction-rules';
 
 async function getPayee(acct) {
   return db.first<db.DbPayee>('SELECT * FROM payees WHERE transfer_acct = ?', [

--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 import * as db from '../db';
-import { runRules } from '../transactions/transaction-rules'
+
+import { runRules } from "./transaction-rules";
 
 async function getPayee(acct) {
   return db.first<db.DbPayee>('SELECT * FROM payees WHERE transfer_acct = ?', [
@@ -71,7 +72,7 @@ export async function addTransfer(transaction, transferredAccount) {
   const id = await db.insertTransaction({
     ...transferTransaction,
     notes,
-    cleared
+    cleared,
   });
 
   await db.updateTransaction({ id: transaction.id, transfer_id: id });

--- a/upcoming-release-notes/5279.md
+++ b/upcoming-release-notes/5279.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Rapha149]
+---
+
+Run rules on transactions created by a transfer (only applying to the fields notes and cleared).


### PR DESCRIPTION
Implements #5154: running rules on transactions created by a transfer, until now when you manually or automatically create a transfer transaction the rules are only applied to the original transaction, not the transaction created by the transfer on the other account.
I implemented this, but only for the fields `notes` and `cleared` because if other fields were changed then the transactions from the transfer would not have the same/complementary information anymore (e.g. changing the payee/amount/...). 
What I didn't add is tests in the `transfer.test.ts` file because the rules are already tested in `transaction-rules.test.ts` but if that's needed there as well, I can add it.
I hope I did everything right in the code / in the pr because this is my first time with Typescript and with contributing to this project.