### PR TITLE
💬 Added Discord link to the help menu for discoverability

### DIFF
--- a/packages/desktop-client/src/components/HelpMenu.tsx
+++ b/packages/desktop-client/src/components/HelpMenu.tsx
@@ -38,7 +38,11 @@ function openDocsForCurrentPage() {
   window.Actual.openURLInBrowser(getPageDocs(window.location.pathname));
 }
 
-type HelpMenuItem = 'docs' | 'keyboard-shortcuts' | 'goal-templates';
+type HelpMenuItem =
+  | 'docs'
+  | 'discord'
+  | 'keyboard-shortcuts'
+  | 'goal-templates';
 
 type HelpButtonProps = {
   onPress?: () => void;
@@ -81,6 +85,10 @@ export const HelpMenu = () => {
       case 'docs':
         openDocsForCurrentPage();
         break;
+      case 'discord':
+        window.Actual.openURLInBrowser('https://discord.gg/pRYNYr4W5A');
+        // dispatch(pushModal({ modal: { name: '' } }));
+        break;
       case 'keyboard-shortcuts':
         dispatch(pushModal({ modal: { name: 'keyboard-shortcuts' } }));
         break;
@@ -112,6 +120,10 @@ export const HelpMenu = () => {
             {
               name: 'docs',
               text: t('Documentation'),
+            },
+            {
+              name: 'discord',
+              text: t('Discord community support'),
             },
             { name: 'keyboard-shortcuts', text: t('Keyboard shortcuts') },
             ...(showGoalTemplates && page === '/budget'

--- a/packages/desktop-client/src/components/HelpMenu.tsx
+++ b/packages/desktop-client/src/components/HelpMenu.tsx
@@ -123,7 +123,7 @@ export const HelpMenu = () => {
             },
             {
               name: 'discord',
-              text: t('Discord community support'),
+              text: t('Community support (Discord)'),
             },
             { name: 'keyboard-shortcuts', text: t('Keyboard shortcuts') },
             ...(showGoalTemplates && page === '/budget'

--- a/packages/desktop-client/src/components/HelpMenu.tsx
+++ b/packages/desktop-client/src/components/HelpMenu.tsx
@@ -87,7 +87,6 @@ export const HelpMenu = () => {
         break;
       case 'discord':
         window.Actual.openURLInBrowser('https://discord.gg/pRYNYr4W5A');
-        // dispatch(pushModal({ modal: { name: '' } }));
         break;
       case 'keyboard-shortcuts':
         dispatch(pushModal({ modal: { name: 'keyboard-shortcuts' } }));

--- a/packages/desktop-electron/menu.ts
+++ b/packages/desktop-electron/menu.ts
@@ -175,7 +175,7 @@ export function getMenu(
           },
         },
         {
-          label: 'Discord community support',
+          label: 'Community Support (Discord)',
           click(_menuItem, focusedWin) {
             focusedWin?.webContents.executeJavaScript(
               'window.open("https://discord.gg/pRYNYr4W5A", "_blank")',

--- a/packages/desktop-electron/menu.ts
+++ b/packages/desktop-electron/menu.ts
@@ -175,6 +175,14 @@ export function getMenu(
           },
         },
         {
+          label: 'Discord community support',
+          click(_menuItem, focusedWin) {
+            focusedWin?.webContents.executeJavaScript(
+              'window.open("https://discord.gg/pRYNYr4W5A", "_blank")',
+            );
+          },
+        },
+        {
           label: 'Keyboard Shortcuts',
           accelerator: '?',
           enabled: !!budgetId,

--- a/upcoming-release-notes/5286.md
+++ b/upcoming-release-notes/5286.md
@@ -1,5 +1,5 @@
 ---
-category: Enhancement
+category: Enhancements
 authors: [MikesGlitch]
 ---
 

--- a/upcoming-release-notes/5286.md
+++ b/upcoming-release-notes/5286.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [MikesGlitch]
+---
+
+Add Discord link to the help menu for improved user discoverability and support.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Adding discord link into help menu so users can more easily find it. 

![image](https://github.com/user-attachments/assets/22f99dab-a8cd-486a-8103-37e3beb3d2e2)


Some users will be coming from the app store/main website and wont realise we have community support via discord. This should make them more aware of it.