### PR TITLE
Round template amounts if hide deciamals is set.

### DIFF
--- a/upcoming-release-notes/5288.md
+++ b/upcoming-release-notes/5288.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Round all template amounts when hide decimals is set


### PR DESCRIPTION
In the case of currencies where there are no decimal places templates may still try to budget factional amounts in a category.  This blocks that from happening if the hide decimal setting is enabled.  All templates will round away fractional amounts if the processing returns it.
