### PR TITLE
[WIP] Added Schedule functionality to the API + a few more funtions

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -814,9 +814,18 @@ test('Schedules: successfully complete schedules operations', async () => {
     expect.arrayContaining([
       expect.objectContaining({
         id: ScheduleId1,
-        name: 'test-account1',
-        closed: true,
-        offbudget: false,
+        posts_transaction: true,
+        amount: -5000,
+        amountOp: 'is',
+        date: {
+          frequency: 'monthly',
+          interval: 1,
+          start: '2025-06-13',
+          patterns: [],
+          skipWeekend: false,
+          weekendSolveMode: 'after',
+          endMode: 'never',
+        },
       }),
       expect.not.objectContaining({ id: ScheduleId2 }),
     ]),

--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -740,3 +740,84 @@ describe('API CRUD operations', () => {
     expect(transactions[0].notes).toBeNull();
   });
 });
+
+//apis: createSchedule, getSchedules, updateSchedule, deleteSchedule
+test('Schedules: successfully complete account operators', async () => {
+  //test a schedule with a recuring configuration
+  const ScheduleId1 = await api.createSchedule({
+    name: 'test-schedule 1',
+    posts_transaction: true,
+    amount: -5000,
+    amountOp: 'is',
+    date: {
+      frequency: 'monthly',
+      interval: 1,
+      start: '2025-06-13',
+      patterns: [],
+      skipWeekend: false,
+      weekendSolveMode: 'after',
+      endMode: 'never',
+    },
+  });
+  //test the creation of non recurring schedule
+  const ScheduleId2 = await api.createSchedule({
+    name: 'test-schedule 2',
+    posts_transaction: false,
+    amount: 4000,
+    amountOp: 'is',
+    date: '2025-06-13',
+  });
+  let schedules = await api.getSchedules();
+
+  // Schedules successfully created
+  expect(schedules).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'test-schedule 1',
+        posts_transaction: true,
+        amount: -5000,
+        amountOp: 'is',
+        date: {
+          frequency: 'monthly',
+          interval: 1,
+          start: '2025-06-13',
+          patterns: [],
+          skipWeekend: false,
+          weekendSolveMode: 'after',
+          endMode: 'never',
+        },
+      }),
+      expect.objectContaining({
+        name: 'test-schedule 2',
+        posts_transaction: false,
+        amount: 4000,
+        amountOp: 'is',
+        date: '2025-06-13',
+      }),
+    ]),
+  );
+
+  expect(await api.getIDByName('schedules', 'test-schedule 1')).toEqual(
+    ScheduleId1,
+  );
+  expect(await api.getIDByName('schedules', 'test-schedule 2')).toEqual(
+    ScheduleId2,
+  );
+
+  await api.updateSchedule(ScheduleId1, { amount: -10000 });
+  await api.deleteSchedule(ScheduleId2);
+
+  // schedules successfully updated, and one of them deleted
+  schedules = await api.getSchedules();
+  expect(schedules).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: ScheduleId1,
+        name: 'test-account1',
+        closed: true,
+        offbudget: false,
+      }),
+      expect.not.objectContaining({ id: ScheduleId2 }),
+    ]),
+  );
+});

--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -742,7 +742,8 @@ describe('API CRUD operations', () => {
 });
 
 //apis: createSchedule, getSchedules, updateSchedule, deleteSchedule
-test('Schedules: successfully complete account operators', async () => {
+test('Schedules: successfully complete schedules operations', async () => {
+  await api.loadBudget(budgetName);
   //test a schedule with a recuring configuration
   const ScheduleId1 = await api.createSchedule({
     name: 'test-schedule 1',

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -239,3 +239,31 @@ export function holdBudgetForNextMonth(month, amount) {
 export function resetBudgetHold(month) {
   return send('api/budget-reset-hold', { month });
 }
+
+export function createSchedule(schedule) {
+  return send('api/schedule-create', schedule);
+}
+
+export function updateSchedule(id, fields, resetNextDate?: boolean) {
+  return send('api/schedule-update', {
+    id,
+    fields,
+    resetNextDate,
+  });
+}
+
+export function deleteSchedule(scheduleId) {
+  return send('api/schedule-delete', scheduleId);
+}
+
+export function getSchedules() {
+  return send('api/schedules-get');
+}
+
+export function getIDByName(type, name) {
+  return send('api/get-id-by-name', { type, name });
+}
+
+export function getServerVersion() {
+  return send('api/get-server-version');
+}

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -817,13 +817,13 @@ handlers['api/schedule-update'] = withMutation(async function ({
     switch (typedKey) {
       case 'name':
         const newName = value as string;
-        const { data } = await aqlQuery(q('schedules').filter({ newName }).select('*'));
+        const { data } = await aqlQuery(
+          q('schedules').filter({ newName }).select('*'),
+        );
         if (!data || data.length === 0 || data[0].id === sched.id) {
-        sched.name = newName;
-        conditionsUpdated = true;
-        }
-        else
-        {
+          sched.name = newName;
+          conditionsUpdated = true;
+        } else {
           console.warn('There is already a schedule with this name');
           return;
         }
@@ -894,11 +894,10 @@ handlers['api/schedule-delete'] = withMutation(async function (id: string) {
   return handlers['schedule/delete']({ id });
 });
 
-
 handlers['api/get-id-by-name'] = withMutation(async function ({ type, name }) {
   const allowedTypes = ['payees', 'categories', 'schedules', 'accounts'];
   if (!allowedTypes.includes(type)) {
-    return 'Error: Provide a valid type'
+    return 'Error: Provide a valid type';
   }
   const { data } = await aqlQuery(q(type).filter({ name }).select('*'));
   if (!data || data.length === 0) {
@@ -906,8 +905,6 @@ handlers['api/get-id-by-name'] = withMutation(async function ({ type, name }) {
   }
   return data[0].id;
 });
-
-
 
 handlers['api/get-server-version'] = withMutation(async function () {
   checkFileOpen();

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -17,7 +17,11 @@ import {
 } from '../shared/transactions';
 import { integerToAmount } from '../shared/util';
 import { Handlers } from '../types/handlers';
-import { AccountEntity, CategoryGroupEntity } from '../types/models';
+import {
+  AccountEntity,
+  CategoryGroupEntity,
+  ScheduleEntity,
+} from '../types/models';
 import { ServerHandlers } from '../types/server-handlers';
 
 import { addTransactions } from './accounts/sync';
@@ -28,6 +32,9 @@ import {
   categoryGroupModel,
   payeeModel,
   remoteFileModel,
+  scheduleModel,
+  APIScheduleEntity,
+  AmountOPType,
 } from './api-models';
 import { aqlQuery } from './aql';
 import * as cloudStorage from './cloud-storage';
@@ -764,6 +771,147 @@ handlers['api/rule-update'] = withMutation(async function ({ rule }) {
 handlers['api/rule-delete'] = withMutation(async function (id) {
   checkFileOpen();
   return handlers['rule-delete'](id);
+});
+
+handlers['api/schedules-get'] = withMutation(async function () {
+  checkFileOpen();
+  const { data } = await aqlQuery(
+    q('schedules')
+      .select('*')
+      .filter({
+        $and: [{ '_account.closed': false }],
+      }),
+  );
+  const schedules = data as ScheduleEntity[];
+
+  return schedules.map(schedule => scheduleModel.toExternal(schedule));
+});
+
+handlers['api/schedule-create'] = withMutation(async function (schedule) {
+  checkFileOpen();
+  const internalSchedule = scheduleModel.fromExternal(schedule);
+  const partialSchedule = {
+    name: internalSchedule.name,
+    posts_transaction: internalSchedule.posts_transaction,
+  };
+  return handlers['schedule/create']({
+    schedule: partialSchedule,
+    conditions: internalSchedule._conditions,
+  });
+});
+
+handlers['api/schedule-update'] = withMutation(async function ({
+  id,
+  fields,
+  resetNextDate,
+}) {
+  checkFileOpen();
+  const { data } = await aqlQuery(q('schedules').filter({ id }).select('*'));
+  const sched = data[0] as ScheduleEntity;
+  let conditionsUpdated = false as boolean;
+
+  for (const key in fields) {
+    const typedKey = key as keyof APIScheduleEntity;
+    const value = fields[typedKey];
+
+    switch (typedKey) {
+      case 'name':
+        const newName = value as string;
+        const { data } = await aqlQuery(q('schedules').filter({ newName }).select('*'));
+        if (!data || data.length === 0 || data[0].id === sched.id) {
+        sched.name = newName;
+        conditionsUpdated = true;
+        }
+        else
+        {
+          console.warn('There is already a schedule with this name');
+          return;
+        }
+        break;
+      case 'rule':
+        console.warn('Editing `rule` is not allowed via schedule-update.');
+        break;
+
+      case 'next_date':
+      case 'completed':
+        console.warn(
+          `Field ‘${typedKey}’ is system-managed and not user-editable.`,
+        );
+        break;
+
+      case 'posts_transaction':
+        sched.posts_transaction = value as boolean;
+        conditionsUpdated = true;
+        break;
+
+      case 'payee':
+        sched._conditions[0].value = value;
+        conditionsUpdated = true;
+        break;
+
+      case 'account':
+        sched._conditions[1].value = value;
+        conditionsUpdated = true;
+        break;
+
+      case 'amountOp':
+        sched._conditions[3].op = value as AmountOPType;
+        conditionsUpdated = true;
+        break;
+
+      case 'amount':
+        sched._conditions[3].value = value;
+        conditionsUpdated = true;
+        break;
+
+      case 'date':
+        sched._conditions[2].value = value;
+        conditionsUpdated = true;
+        break;
+
+      default:
+        console.warn(`Unhandled field: ${typedKey}`);
+        break;
+    }
+  }
+  if (conditionsUpdated) {
+    return handlers['schedule/update']({
+      schedule: {
+        id: sched.id,
+        posts_transaction: sched.posts_transaction,
+        name: sched.name,
+      },
+      conditions: sched._conditions,
+      resetNextDate,
+    });
+  } else {
+    return null;
+  }
+});
+
+handlers['api/schedule-delete'] = withMutation(async function (id: string) {
+  checkFileOpen();
+  return handlers['schedule/delete']({ id });
+});
+
+
+handlers['api/get-id-by-name'] = withMutation(async function ({ type, name }) {
+  const allowedTypes = ['payees', 'categories', 'schedules', 'accounts'];
+  if (!allowedTypes.includes(type)) {
+    return 'Error: Provide a valid type'
+  }
+  const { data } = await aqlQuery(q(type).filter({ name }).select('*'));
+  if (!data || data.length === 0) {
+    return 'Error: Not found';
+  }
+  return data[0].id;
+});
+
+
+
+handlers['api/get-server-version'] = withMutation(async function () {
+  checkFileOpen();
+  return handlers['get-server-version']();
 });
 
 export function installAPI(serverHandlers: ServerHandlers) {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -8,6 +8,7 @@ import type {
   APICategoryGroupEntity,
   APIFileEntity,
   APIPayeeEntity,
+  APIScheduleEntity,
 } from '../server/api-models';
 import { BudgetFileHandlers } from '../server/budgetfiles/app';
 import { type batchUpdateTransactions } from '../server/transactions';
@@ -17,6 +18,9 @@ import type {
   NewRuleEntity,
   RuleEntity,
   TransactionEntity,
+  DiscoverScheduleEntity,
+  ScheduleEntity,
+  RecurConfig,
 } from './models';
 
 export interface ApiHandlers {
@@ -88,7 +92,7 @@ export interface ApiHandlers {
 
   'api/transactions-import': (arg: {
     accountId;
-    transactions: ImportTransactionEntity[];
+    transactions;
     isPreview?;
     opts?: ImportTransactionsOpts;
   }) => Promise<ImportTransactionsResult>;
@@ -188,4 +192,25 @@ export interface ApiHandlers {
   'api/rule-update': (arg: { rule: RuleEntity }) => Promise<RuleEntity>;
 
   'api/rule-delete': (id: string) => Promise<boolean>;
+
+  'api/schedule-create': (
+    schedule: APIScheduleEntity,
+  ) => Promise<ScheduleEntity['id']>;
+
+  'api/schedule-update': (arg: {
+    id: ScheduleEntity['id'];
+    fields: Partial<APIScheduleEntity>;
+    resetNextDate?: boolean;
+  }) => Promise<ScheduleEntity['id']>;
+
+  'api/schedule-delete': (id: string) => Promise<void>;
+
+  'api/schedules-get': () => Promise<APIScheduleEntity[]>;
+  'api/get-id-by-name': (arg: {
+    type: string;
+    name: string;
+  }) => Promise<string>;
+  'api/get-server-version': () => Promise<
+    { error?: string } | { version: string }
+  >;
 }

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -14,13 +14,10 @@ import { BudgetFileHandlers } from '../server/budgetfiles/app';
 import { type batchUpdateTransactions } from '../server/transactions';
 
 import type {
-  ImportTransactionEntity,
   NewRuleEntity,
   RuleEntity,
   TransactionEntity,
-  DiscoverScheduleEntity,
-  ScheduleEntity,
-  RecurConfig,
+  ScheduleEntity
 } from './models';
 
 export interface ApiHandlers {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -14,10 +14,13 @@ import { BudgetFileHandlers } from '../server/budgetfiles/app';
 import { type batchUpdateTransactions } from '../server/transactions';
 
 import type {
+  ImportTransactionEntity,
   NewRuleEntity,
   RuleEntity,
   TransactionEntity,
+  DiscoverScheduleEntity,
   ScheduleEntity,
+  RecurConfig,
 } from './models';
 
 export interface ApiHandlers {
@@ -89,7 +92,7 @@ export interface ApiHandlers {
 
   'api/transactions-import': (arg: {
     accountId;
-    transactions;
+    transactions: ImportTransactionEntity[];
     isPreview?;
     opts?: ImportTransactionsOpts;
   }) => Promise<ImportTransactionsResult>;

--- a/upcoming-release-notes/5291.md
+++ b/upcoming-release-notes/5291.md
@@ -3,7 +3,4 @@ category: Enhancements
 authors: [Karim Kodera, alecbakholdin]
 ---
 
-Introduction of APIs to handle Schedule + a bit more
-- Create necessary CRUD functions for schedule.
-- Get server version API.
-- getIDByName Function to simply creating of schedules and other API as well. 
+Introduction of APIs to handle Schedule + a bit more. Refer to updated API documentation PR2811 on documentation.

--- a/upcoming-release-notes/5291.md
+++ b/upcoming-release-notes/5291.md
@@ -1,10 +1,6 @@
 ---
 category: Enhancements
-authors: [Karim Kodera , alecbakholdin]
+authors: [Karim Kodera, alecbakholdin]
 ---
 
-Introduction of APIs to handle Schedule + a bit more
-- Create necessary CRUD functions for schedule.
-- Get server version API.
-- getIDByName Function to simply creating of schedules and other API as well. 
-
+Introduction of APIs to handle Schedule + a bit more- Create necessary CRUD functions for schedule.- Get server version API.- getIDByName Function to simply creating of schedules and other API as well. 

--- a/upcoming-release-notes/5291.md
+++ b/upcoming-release-notes/5291.md
@@ -1,0 +1,10 @@
+---
+category: Enhancements
+authors: [Karim Kodera , alecbakholdin]
+---
+
+Introduction of APIs to handle Schedule + a bit more
+- Create necessary CRUD functions for schedule.
+- Get server version API.
+- getIDByName Function to simply creating of schedules and other API as well. 
+

--- a/upcoming-release-notes/5291.md
+++ b/upcoming-release-notes/5291.md
@@ -6,4 +6,4 @@ authors: [Karim Kodera, alecbakholdin]
 Introduction of APIs to handle Schedule + a bit more
 - Create necessary CRUD functions for schedule.
 - Get server version API.
-- - getIDByName Function to simply creating of schedules and other API as well. 
+- getIDByName Function to simply creating of schedules and other API as well. 

--- a/upcoming-release-notes/5291.md
+++ b/upcoming-release-notes/5291.md
@@ -3,4 +3,7 @@ category: Enhancements
 authors: [Karim Kodera, alecbakholdin]
 ---
 
-Introduction of APIs to handle Schedule + a bit more- Create necessary CRUD functions for schedule.- Get server version API.- getIDByName Function to simply creating of schedules and other API as well. 
+Introduction of APIs to handle Schedule + a bit more
+- Create necessary CRUD functions for schedule.
+- Get server version API.
+- - getIDByName Function to simply creating of schedules and other API as well. 


### PR DESCRIPTION
Introduction of APIs to handle Schedule + a bit more
- Create necessary CRUD functions for schedule.
- Get server version API.
- getIDByName Function to simply creating of schedules and other API as well. 

Alec have started the initial implementation based on my original request. The PR never made it because it needed documentation. As I worked to write docs and tests, I found the APIs are exposing internal APIs to the user which was not easy to document. I have opted to follow the way the API code was structured by creating a model to translate the internal structure and build the API based on the CRUD model described on the web. Full documentation of the API on PR # 729 https://github.com/actualbudget/docs/pull/729 on the documentation. 
