### PR TITLE
Fix bank sync reimporting transactions that were moved to another account

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -660,7 +660,7 @@ export async function matchTransactions(
         : 'v_transactions_internal';
       match = await db.first<db.DbTransaction>(
         `SELECT * FROM ${table} WHERE imported_id = ? AND account = ?`,
-        [trans.imported_id, acctId],
+        [trans.imported_id, trans.account],
       );
 
       if (match) {
@@ -707,7 +707,7 @@ export async function matchTransactions(
             sevenDaysBefore,
             sevenDaysAfter,
             trans.amount || 0,
-            acctId,
+            trans.account,
           ],
         );
       } else {
@@ -730,7 +730,7 @@ export async function matchTransactions(
           `SELECT id, is_parent, date, imported_id, payee, imported_payee, category, notes, reconciled, cleared, amount
           FROM v_transactions
           WHERE date >= ? AND date <= ? AND amount = ? AND account = ?`,
-          [sevenDaysBefore, sevenDaysAfter, trans.amount || 0, acctId],
+          [sevenDaysBefore, sevenDaysAfter, trans.amount || 0, trans.account],
         );
       }
 

--- a/upcoming-release-notes/5302.md
+++ b/upcoming-release-notes/5302.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [rjackson]
+---
+
+Fix bank sync reimporting transactions that were moved to another account


### PR DESCRIPTION
When using the Monzo bank with pots, Monzo reports transactions from pots under the main current account with the payee suffixed "from [pot name]" rather than under the pot's own account. To fix this in my budget instance, I have created a rule which moves any transactions with suffixes matching my pots to their relevant pot accounts in Actual Budget.

When re-syncing however, the transactions are imported again, and again, and again – because the reconciliation logic here isn't accounting for the fact accounts could change after rules have been processed. We can fix this by making sure we try to match using `trans.account` instead of `acctId`.