### PR TITLE
Exclude hidden categories from the overspent categories banner on tracking budgets

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetTable.jsx
@@ -567,15 +567,21 @@ function OverbudgetedBanner({ month, onBudgetAction, ...props }) {
   );
 }
 
-function OverspendingBanner({ month, onBudgetAction, ...props }) {
+function OverspendingBanner({ month, onBudgetAction, budgetType, ...props }) {
   const { t } = useTranslation();
 
   const { list: categories, grouped: categoryGroups } = useCategories();
   const categoriesById = groupById(categories);
+  const groupsById = groupById(categoryGroups);
 
   const dispatch = useDispatch();
 
-  const overspentCategories = useOverspentCategories({ month });
+  const overspentCategories = useOverspentCategories({ month }).filter(c => {
+    if (budgetType === 'tracking') {
+      return !c.hidden && !groupsById[c.group].hidden;
+    }
+    return true;
+  });
 
   const categoryGroupsToShow = useMemo(
     () =>
@@ -694,7 +700,11 @@ function Banners({ month, onBudgetAction }) {
       style={{ backgroundColor: theme.mobilePageBackground }}
     >
       <UncategorizedTransactionsBanner />
-      <OverspendingBanner month={month} onBudgetAction={onBudgetAction} />
+      <OverspendingBanner
+        month={month}
+        onBudgetAction={onBudgetAction}
+        budgetType={budgetType}
+      />
       {budgetType === 'envelope' && (
         <OverbudgetedBanner month={month} onBudgetAction={onBudgetAction} />
       )}

--- a/upcoming-release-notes/5305.md
+++ b/upcoming-release-notes/5305.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix overspent categories banner including hidden categories in the tracking budget


### PR DESCRIPTION
Fixes #5022 The overspent categories banner on mobile was including all categories that were overspent.  IN the tracking budget hidden categories are not included in the budget totals so it didn't make sense that hidden categories should be considered as overspent.

Example with no banner showing in a tracking budget because the category is hidden
![image](https://github.com/user-attachments/assets/d654b331-fb10-4cc9-b5e4-67f3a97bd20c)


Test budget:
[banner_test.zip](https://github.com/user-attachments/files/21125822/banner_test.zip)

