### PR TITLE
:bug: allow templates for daily schedules longer than 1 month to budget in intermediary months

### DIFF
--- a/upcoming-release-notes/5319.md
+++ b/upcoming-release-notes/5319.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Allow templates for daily interval schedules that are longer than 1 month to budget in intermediary months


### PR DESCRIPTION
fixes #4736

Templates for daily interval schedules were treated the same as schedules with a full flag.  So they would only budget in the month of the schedule date.