### PR TITLE
Add keyboard shortcuts to duplicate transaction, edit amount, and edit date

### DIFF
--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -232,8 +232,16 @@ export function SelectedTransactionsButton({
     onShow,
     selectedIds,
   ]);
+  useHotkeys('u', () => onDuplicate(selectedIds), hotKeyOptions, [
+    onDuplicate,
+    selectedIds,
+  ]);
   useHotkeys('d', () => onDelete(selectedIds), hotKeyOptions, [
     onDelete,
+    selectedIds,
+  ]);
+  useHotkeys('t', () => onEdit('date', selectedIds), hotKeyOptions, [
+    onEdit,
     selectedIds,
   ]);
   useHotkeys('a', () => onEdit('account', selectedIds), hotKeyOptions, [
@@ -249,6 +257,10 @@ export function SelectedTransactionsButton({
     selectedIds,
   ]);
   useHotkeys('c', () => onEdit('category', selectedIds), hotKeyOptions, [
+    onEdit,
+    selectedIds,
+  ]);
+  useHotkeys('m', () => onEdit('amount', selectedIds), hotKeyOptions, [
     onEdit,
     selectedIds,
   ]);
@@ -302,6 +314,7 @@ export function SelectedTransactionsButton({
               {
                 name: 'duplicate',
                 text: t('Duplicate'),
+                key: 'U',
                 disabled: ambiguousDuplication,
               } as const,
               { name: 'delete', text: t('Delete'), key: 'D' } as const,
@@ -372,12 +385,12 @@ export function SelectedTransactionsButton({
                 : []),
               Menu.line,
               { type: Menu.label, name: t('Edit field'), text: '' } as const,
-              { name: 'date', text: t('Date') } as const,
+              { name: 'date', text: t('Date'), key: 'T' } as const,
               { name: 'account', text: t('Account'), key: 'A' } as const,
               { name: 'payee', text: t('Payee'), key: 'P' } as const,
               { name: 'notes', text: t('Notes'), key: 'N' } as const,
               { name: 'category', text: t('Category'), key: 'C' } as const,
-              { name: 'amount', text: t('Amount') } as const,
+              { name: 'amount', text: t('Amount'), key: 'M' } as const,
               { name: 'cleared', text: t('Cleared'), key: 'L' } as const,
             ]),
       ]}

--- a/upcoming-release-notes/5330.md
+++ b/upcoming-release-notes/5330.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jat255]
+---
+
+Add keyboard shortcuts for duplicating transaction, editing date, and editing amount


### PR DESCRIPTION
As in the title...

Fixes #4926.

Discovered issue #5329 while implementing this. This PR doesn't address that issue.

Should add these shortcuts to the documentation as well.