### PR TITLE
fix pseudo-element quotes in ColorPicker

### DIFF
--- a/packages/component-library/src/ColorPicker.tsx
+++ b/packages/component-library/src/ColorPicker.tsx
@@ -65,7 +65,8 @@ function ColorSwatchPicker() {
                 cursor: 'pointer',
 
                 '&[data-selected]::after': {
-                  content: '‘’',
+                  // eslint-disable-next-line actual/typography
+                  content: '""',
                   position: 'absolute',
                   inset: 0,
                   border: '2px solid black',

--- a/upcoming-release-notes/5335.md
+++ b/upcoming-release-notes/5335.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [pogman-code]
+---
+
+fix pseudo-element quotes in ColorPicker

--- a/upcoming-release-notes/5335.md
+++ b/upcoming-release-notes/5335.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [pogman-code]
 ---
 
-fix pseudo-element quotes in ColorPicker
+Fix pseudo-element quotes in ColorPicker


### PR DESCRIPTION
I the original PR I replace `'""'` by `'‘’'` to fis eslint issue but it broke emotion/css, my bad

See: https://discord.com/channels/937901803608096828/1027831756545609789/1393967029689778336
And https://github.com/emotion-js/emotion/issues/1435#issue-469332317
