### PR TITLE
:keyboard: Enhanced keyboard shortcuts modal

### DIFF
--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -501,7 +501,7 @@ export function KeyboardShortcutModal() {
                 </View>
               ) : isSearching || isInSection ? (
                 // Show individual shortcuts (either search results or section details)
-                itemsToShow.map(shortcut => (
+                (itemsToShow as Shortcut[]).map(shortcut => (
                   <ShortcutListItem
                     key={shortcut.id}
                     shortcut={shortcut.shortcut}
@@ -513,7 +513,7 @@ export function KeyboardShortcutModal() {
                 ))
               ) : (
                 // Show section list
-                itemsToShow.map(section => (
+                (itemsToShow as ShortcutCategories[]).map(section => (
                   <ListItem
                     key={section.id}
                     onClick={() => {

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  type CSSProperties,
-  useMemo,
-  type ReactNode,
-  createRef,
-} from 'react';
+import { useState, type CSSProperties, useMemo, type ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -215,7 +215,7 @@ export function KeyboardShortcutModal() {
             description: t('View current month'),
           },
           {
-            id: 'View previous month',
+            id: 'view-previous-month',
             shortcut: '←',
             description: t('View previous month'),
           },
@@ -331,14 +331,14 @@ export function KeyboardShortcutModal() {
             description: t('Move to the next transaction up'),
           },
           {
-            id: 'move-next-transaction-scroll',
+            id: 'move-previous-transaction-scroll',
             shortcut: '↑',
-            description: t('Move to the next transaction down and scroll'),
+            description: t('Move to the previous transaction and scroll'),
           },
           {
-            id: 'move-previous-transaction-scroll',
+            id: 'move-next-transaction-scroll',
             shortcut: '↓',
-            description: t('Move to the next transaction up and scroll'),
+            description: t('Move to the next transaction and scroll'),
           },
           {
             id: 'toggle-selection-current-transaction',

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -1,8 +1,15 @@
-import { useState, type CSSProperties, useMemo, type ReactNode } from 'react';
+import {
+  useState,
+  type CSSProperties,
+  useMemo,
+  type ReactNode,
+  createRef,
+} from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgArrowLeft } from '@actual-app/components/icons/v1';
+import { InitialFocus } from '@actual-app/components/initial-focus';
 import { styles as baseStyles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
@@ -445,24 +452,29 @@ export function KeyboardShortcutModal() {
               padding: '0 16px 16px 16px',
             }}
           >
-            <Search
-              value={searchText}
-              onChange={text => {
-                setSearchText(text);
-                // Clear category selection when searching to search all shortcuts
-                if (text && selectedCategoryId) {
-                  setSelectedCategoryId(null);
-                }
-              }}
-              placeholder={t('Search shortcuts')}
-              width="100%"
-              style={{
-                backgroundColor: theme.tableBackground,
-                borderColor: theme.formInputBorder,
-                marginBottom: 10,
-              }}
-            />
-
+            <InitialFocus<HTMLInputElement>>
+              {ref => (
+                <Search
+                  inputRef={ref}
+                  value={searchText}
+                  isInModal
+                  onChange={text => {
+                    setSearchText(text);
+                    // Clear category selection when searching to search all shortcuts
+                    if (text && selectedCategoryId) {
+                      setSelectedCategoryId(null);
+                    }
+                  }}
+                  placeholder={t('Search shortcuts')}
+                  width="100%"
+                  style={{
+                    backgroundColor: theme.tableBackground,
+                    borderColor: theme.formInputBorder,
+                    marginBottom: 10,
+                  }}
+                />
+              )}
+            </InitialFocus>
             <View
               style={{
                 flexDirection: 'column',

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -155,7 +155,9 @@ export function KeyboardShortcutModal() {
     null,
   );
 
-  const shortcuts: ShortcutCategories[] = useMemo(
+  // In future, we may move this to state and pull overrides from config/db
+  // This would allow us to drive our shortcuts from state instead of hardcoding them
+  const defaultShortcuts: ShortcutCategories[] = useMemo(
     () => [
       {
         name: t('General'),
@@ -364,7 +366,7 @@ export function KeyboardShortcutModal() {
 
       if (isSearching) {
         // Show all matching shortcuts across all categories
-        const allMatches = shortcuts.flatMap(category =>
+        const allMatches = defaultShortcuts.flatMap(category =>
           category.items.filter(item =>
             item.description.toLowerCase().includes(searchText.toLowerCase()),
           ),
@@ -379,7 +381,9 @@ export function KeyboardShortcutModal() {
 
       if (isInCategory) {
         // Show shortcuts for selected category
-        const category = shortcuts.find(s => s.id === selectedCategoryId);
+        const category = defaultShortcuts.find(
+          s => s.id === selectedCategoryId,
+        );
         return {
           isSearching: false,
           isInCategory: true,
@@ -393,9 +397,9 @@ export function KeyboardShortcutModal() {
         isSearching: false,
         isInCategory: false,
         currentCategory: null,
-        itemsToShow: shortcuts,
+        itemsToShow: defaultShortcuts,
       };
-    }, [searchText, selectedCategoryId, shortcuts]);
+    }, [searchText, selectedCategoryId, defaultShortcuts]);
 
   const showingShortcuts = isSearching || isInCategory;
 

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -65,10 +65,6 @@ function ListItem({
 }) {
   const clickStyles = onClick && {
     cursor: 'pointer',
-    ':hover': {
-      backgroundColor: theme.tableRowBackgroundHover,
-      color: theme.tableText,
-    },
   };
 
   return (
@@ -79,27 +75,15 @@ function ListItem({
         justifyContent: 'space-between',
         width: '100%',
         gap: 5,
-
-        // Working on the below
         padding: 12,
         backgroundColor: theme.tableBackground,
-        borderLeftWidth: 1,
-        borderRightWidth: 1,
         borderBottomWidth: 1,
-        borderTopWidth: 1,
         borderColor: theme.tableBorder,
         height: 45,
         flexShrink: 0,
-        '&:not(:first-child)': {
-          borderTopWidth: 0,
-        },
-        '&:first-child': {
-          borderTopLeftRadius: baseStyles.menuBorderRadius,
-          borderTopRightRadius: baseStyles.menuBorderRadius,
-        },
-        '&:last-child': {
-          borderBottomLeftRadius: baseStyles.menuBorderRadius,
-          borderBottomRightRadius: baseStyles.menuBorderRadius,
+        ':hover': {
+          backgroundColor: theme.tableRowBackgroundHover,
+          color: theme.tableText,
         },
         ...clickStyles,
         ...style,
@@ -478,7 +462,11 @@ export function KeyboardShortcutModal() {
               style={{
                 flexDirection: 'column',
                 overflowY: 'auto',
-                maxHeight: '50vh',
+                maxHeight: '40vh',
+                height: 400,
+                backgroundColor: theme.tableBackground,
+                border: `1px solid ${theme.tableBorder}`,
+                borderRadius: baseStyles.menuBorderRadius,
               }}
             >
               {itemsToShow.length === 0 ? (

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -1,7 +1,15 @@
-import { useState, type CSSProperties, useMemo } from 'react';
+import {
+  useState,
+  type CSSProperties,
+  useMemo,
+  useCallback,
+  type ReactNode,
+} from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
+import { SvgArrowLeft } from '@actual-app/components/icons/v1';
+import { styles as baseStyles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
@@ -52,6 +60,63 @@ function KeyIcon({ shortcut, style }: KeyIconProps) {
   );
 }
 
+function ListItem({
+  children,
+  style,
+  onClick,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+  onClick?: () => void;
+}) {
+  const clickStyles = onClick && {
+    cursor: 'pointer',
+    ':hover': {
+      backgroundColor: theme.tableRowBackgroundHover,
+      color: theme.tableText,
+    },
+  };
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        width: '100%',
+        gap: 5,
+
+        // Working on the below
+        padding: 12,
+        backgroundColor: theme.tableBackground,
+        borderLeftWidth: 1,
+        borderRightWidth: 1,
+        borderBottomWidth: 1,
+        borderTopWidth: 1,
+        borderColor: theme.tableBorder,
+        height: 45,
+        flexShrink: 0,
+        '&:not(:first-child)': {
+          borderTopWidth: 0,
+        },
+        '&:first-child': {
+          borderTopLeftRadius: baseStyles.menuBorderRadius,
+          borderTopRightRadius: baseStyles.menuBorderRadius,
+        },
+        '&:last-child': {
+          borderBottomLeftRadius: baseStyles.menuBorderRadius,
+          borderBottomRightRadius: baseStyles.menuBorderRadius,
+        },
+        ...clickStyles,
+        ...style,
+      }}
+      onClick={onClick}
+    >
+      {children}
+    </View>
+  );
+}
+
 function ShortcutListItem({
   shortcut,
   description,
@@ -60,14 +125,7 @@ function ShortcutListItem({
   style,
 }: ShortcutListItemProps) {
   return (
-    <View
-      style={{
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        width: '100%',
-      }}
-    >
+    <ListItem>
       <Text>{description}</Text>
 
       <View
@@ -75,6 +133,7 @@ function ShortcutListItem({
           flexDirection: 'row',
           gap: 4,
           alignItems: 'center',
+          flexShrink: 0,
         }}
       >
         {shift && (
@@ -91,7 +150,7 @@ function ShortcutListItem({
         )}
         <KeyIcon shortcut={shortcut} style={style} />
       </View>
-    </View>
+    </ListItem>
   );
 }
 
@@ -116,53 +175,208 @@ export function KeyboardShortcutModal() {
   const [searchText, setSearchText] = useState('');
 
   // Track the current view - either "sections", a specific section ID, or "search-results"
-  const [currentView, setCurrentView] = useState<string>('sections');
+  const [currentView, setCurrentView] = useState<
+    'sections' | 'search-results' | string
+  >('sections');
 
-  const shortcuts: ShortcutCategories[] = [
-    {
-      name: t('General'),
-      id: 'general',
-      items: [
-        {
-          id: 'help',
-          shortcut: '?',
-          description: t('Open the help menu'),
-        },
-        {
-          id: 'command-palette',
-          shortcut: 'K',
-          description: t('Open the Command Palette'),
-          meta: ctrl,
-        },
-        {
-          id: 'close-budget',
-          shortcut: 'O',
-          description: t('Close the current budget and open another'),
-          meta: ctrl,
-        },
-        {
-          id: 'toggle-privacy-filter',
-          shortcut: 'P',
-          description: t('Toggle the privacy filter'),
-          meta: ctrl,
-          shift: true,
-        },
-      ],
-    },
-    {
-      id: 'account-page',
-      name: t('Account page'),
-      items: [
-        // Add your account page shortcuts here
-        {
-          id: 'move-down',
-          shortcut: 'Enter',
-          description: t('Move down when editing'),
-        },
-      ],
-    },
-    // Add other sections as needed
-  ];
+  const shortcuts: ShortcutCategories[] = useMemo(
+    () => [
+      {
+        name: t('General'),
+        id: 'general',
+        items: [
+          {
+            id: 'help',
+            shortcut: '?',
+            description: t('Open the help menu'),
+          },
+          {
+            id: 'command-palette',
+            shortcut: 'K',
+            description: t('Open the Command Palette'),
+            meta: ctrl,
+          },
+          {
+            id: 'close-budget',
+            shortcut: 'O',
+            description: t('Close the current budget and open another'),
+            meta: ctrl,
+          },
+          {
+            id: 'toggle-privacy-filter',
+            shortcut: 'P',
+            description: t('Toggle the privacy filter'),
+            meta: ctrl,
+            shift: true,
+          },
+          {
+            id: 'undo-last-change',
+            shortcut: 'Z',
+            description: t('Undo the last change'),
+            meta: ctrl,
+          },
+          {
+            id: 'redo-last-change',
+            shortcut: 'Z',
+            description: t('Redo the last undone change'),
+            shift: true,
+            meta: ctrl,
+          },
+        ],
+      },
+      {
+        id: 'budget-page',
+        name: t('Budget page'),
+        items: [
+          {
+            id: 'current-month',
+            shortcut: '0',
+            description: t('View current month'),
+          },
+          {
+            id: 'View previous month',
+            shortcut: '←',
+            description: t('View previous month'),
+          },
+          {
+            id: 'view-next-month',
+            shortcut: '→',
+            description: t('View next month'),
+          },
+        ],
+      },
+      {
+        id: 'account-page',
+        name: t('Account page'),
+        items: [
+          {
+            id: 'move-down',
+            shortcut: 'Enter',
+            description: t('Move down when editing'),
+          },
+          {
+            id: 'move-up',
+            shortcut: 'Enter',
+            shift: true,
+            description: t('Move up when editing'),
+          },
+          {
+            id: 'import-transactions',
+            shortcut: 'I',
+            meta: ctrl,
+            description: t('Import transactions'),
+          },
+          {
+            id: 'bank-sync',
+            shortcut: 'B',
+            meta: ctrl,
+            description: t('Bank sync'),
+          },
+          {
+            id: 'filter-to-selected-transactions',
+            shortcut: 'F',
+            description: t('Filter to the selected transactions'),
+          },
+          {
+            id: 'delete-selected-transactions',
+            shortcut: 'D',
+            description: t('Delete the selected transactions'),
+          },
+          {
+            id: 'set-account-for-selected-transactions',
+            shortcut: 'A',
+            description: t('Set account for selected transactions'),
+          },
+          {
+            id: 'set-payee-for-selected-transactions',
+            shortcut: 'P',
+            description: t('Set payee for selected transactions'),
+          },
+          {
+            id: 'set-notes-for-selected-transactions',
+            shortcut: 'N',
+            description: t('Set notes for selected transactions'),
+          },
+          {
+            id: 'set-category-for-selected-transactions',
+            shortcut: 'C',
+            description: t('Set category for selected transactions'),
+          },
+          {
+            id: 'toggle-cleared-for-selected-transactions',
+            shortcut: 'L',
+            description: t('Toggle cleared for selected transactions'),
+          },
+          {
+            id: 'link-or-view-schedule-for-selected-transactions',
+            shortcut: 'S',
+            description: t('Link or view schedule for selected transactions'),
+          },
+          {
+            id: 'select-all-transactions',
+            shortcut: 'A',
+            description: t('Select all transactions'),
+            meta: ctrl,
+          },
+          {
+            id: 'move-left-when-editing',
+            shortcut: 'Tab',
+            description: t('Move left when editing'),
+            shift: true,
+          },
+          {
+            id: 'move-right-when-editing',
+            shortcut: 'Tab',
+            description: t('Move right when editing'),
+          },
+          {
+            id: 'add-new-transaction',
+            shortcut: 'T',
+            description: t('Add a new transaction'),
+          },
+          {
+            id: 'filter-transactions',
+            shortcut: 'F',
+            description: t('Filter transactions'),
+          },
+          {
+            id: 'move-next-transaction',
+            shortcut: 'J',
+            description: t('Move to the next transaction down'),
+          },
+          {
+            id: 'move-previous-transaction',
+            shortcut: 'K',
+            description: t('Move to the next transaction up'),
+          },
+          {
+            id: 'move-next-transaction-scroll',
+            shortcut: '↑',
+            description: t('Move to the next transaction down and scroll'),
+          },
+          {
+            id: 'move-previous-transaction-scroll',
+            shortcut: '↓',
+            description: t('Move to the next transaction up and scroll'),
+          },
+          {
+            id: 'toggle-selection-current-transaction',
+            shortcut: 'Space',
+            description: t('Toggle selection of current transaction'),
+          },
+          {
+            id: 'toggle-selection-all-transactions',
+            shortcut: 'Space',
+            description: t(
+              'Toggle transactions between current and most recently selected transaction',
+            ),
+            shift: true,
+          },
+        ],
+      },
+    ],
+    [t, ctrl],
+  );
 
   // Filter sections and their items based on search text
   const getFilteredShortcuts = (searchText: string) => {
@@ -178,21 +392,24 @@ export function KeyboardShortcutModal() {
   };
 
   // Get all matching shortcuts across all sections as a flat list
-  const getAllMatchingShortcuts = (searchText: string) => {
-    if (!searchText) return [];
+  const getAllMatchingShortcuts = useCallback(
+    (searchText: string) => {
+      if (!searchText) return [];
 
-    const searchTextLower = searchText.toLowerCase();
-    return shortcuts.flatMap(section =>
-      section.items.filter(item =>
-        item.description.toLowerCase().includes(searchTextLower),
-      ),
-    );
-  };
+      const searchTextLower = searchText.toLowerCase();
+      return shortcuts.flatMap(section =>
+        section.items.filter(item =>
+          item.description.toLowerCase().includes(searchTextLower),
+        ),
+      );
+    },
+    [shortcuts],
+  );
 
   const [filteredShortcuts, setFilteredShortcuts] = useState(shortcuts);
   const allMatchingShortcuts = useMemo(
     () => getAllMatchingShortcuts(searchText),
-    [searchText],
+    [getAllMatchingShortcuts, searchText],
   );
 
   // Get the current section being viewed (if any)
@@ -202,7 +419,7 @@ export function KeyboardShortcutModal() {
       : null;
 
   return (
-    <Modal name="keyboard-shortcuts">
+    <Modal name="keyboard-shortcuts" containerProps={{ style: { width: 700 } }}>
       {({ state: { close } }) => (
         <>
           <ModalHeader
@@ -220,14 +437,18 @@ export function KeyboardShortcutModal() {
                 <Button
                   variant="bare"
                   onClick={() => {
+                    setSearchText('');
+                    setFilteredShortcuts(getFilteredShortcuts(''));
                     setCurrentView('sections');
-                    if (currentView === 'search-results') {
-                      setSearchText('');
-                    }
                   }}
-                  style={{ marginRight: 10, zIndex: 3000 }}
+                  style={{ marginRight: 10, marginLeft: 15, zIndex: 3000 }}
                 >
-                  ← <Trans>Back</Trans>
+                  <SvgArrowLeft
+                    width={10}
+                    height={10}
+                    style={{ marginRight: 5, color: 'currentColor' }}
+                  />
+                  <Trans>Back</Trans>
                 </Button>
               ) : null
             }
@@ -259,14 +480,20 @@ export function KeyboardShortcutModal() {
               style={{
                 backgroundColor: theme.tableBackground,
                 borderColor: theme.formInputBorder,
-                marginBottom: 16,
+                marginBottom: 10,
               }}
             />
 
-            {/* Main view - List of sections */}
-            {currentView === 'sections' && (
-              <View>
-                {filteredShortcuts.length === 0 ? (
+            <View
+              style={{
+                flexDirection: 'column',
+                overflowY: 'auto',
+                maxHeight: '50vh',
+              }}
+            >
+              {/* Main view - List of sections */}
+              {currentView === 'sections' &&
+                (filteredShortcuts.length === 0 ? (
                   <View
                     style={{
                       alignItems: 'center',
@@ -280,24 +507,8 @@ export function KeyboardShortcutModal() {
                   </View>
                 ) : (
                   filteredShortcuts.map(section => (
-                    <View
+                    <ListItem
                       key={section.id}
-                      style={{
-                        padding: 12,
-                        backgroundColor: theme.tableBackground,
-                        borderRadius: 6,
-                        marginBottom: 8,
-                        cursor: 'pointer',
-                        borderWidth: 1,
-                        borderColor: theme.tableBorder,
-                        height: 40,
-                        display: 'flex',
-                        justifyContent: 'center',
-                        ':hover': {
-                          backgroundColor: theme.tableRowBackgroundHover,
-                          color: theme.tableText,
-                        },
-                      }}
                       onClick={() => {
                         if (section.items.length > 0) {
                           setCurrentView(section.id);
@@ -308,7 +519,7 @@ export function KeyboardShortcutModal() {
                         style={{
                           flexDirection: 'row',
                           justifyContent: 'space-between',
-                          alignItems: 'center',
+                          width: '100%',
                         }}
                       >
                         <Text style={{ fontWeight: 'bold' }}>
@@ -322,16 +533,13 @@ export function KeyboardShortcutModal() {
                           ›
                         </Text>
                       </View>
-                    </View>
+                    </ListItem>
                   ))
-                )}
-              </View>
-            )}
+                ))}
 
-            {/* Search results view - Shows all matching shortcuts */}
-            {currentView === 'search-results' && (
-              <View style={{ flexDirection: 'column' }}>
-                {allMatchingShortcuts.length === 0 ? (
+              {/* Search results view - Shows all matching shortcuts */}
+              {currentView === 'search-results' &&
+                (allMatchingShortcuts.length === 0 ? (
                   <View
                     style={{
                       alignItems: 'center',
@@ -345,74 +553,46 @@ export function KeyboardShortcutModal() {
                   </View>
                 ) : (
                   allMatchingShortcuts.map(shortcut => (
-                    <View
+                    <ShortcutListItem
                       key={shortcut.id}
-                      style={{
-                        padding: 12,
-                        backgroundColor: theme.tableBackground,
-                        borderRadius: 6,
-                        marginBottom: 8,
-                        borderWidth: 1,
-                        borderColor: theme.tableBorder,
-                        height: 40,
-                      }}
-                    >
-                      <ShortcutListItem
-                        shortcut={shortcut.shortcut}
-                        description={shortcut.description}
-                        meta={shortcut.meta}
-                        shift={shortcut.shift}
-                        style={shortcut.style}
-                      />
-                    </View>
+                      shortcut={shortcut.shortcut}
+                      description={shortcut.description}
+                      meta={shortcut.meta}
+                      shift={shortcut.shift}
+                      style={shortcut.style}
+                    />
                   ))
-                )}
-              </View>
-            )}
+                ))}
 
-            {/* Section detail view */}
-            {currentView !== 'sections' &&
-              currentView !== 'search-results' &&
-              currentSection && (
-                <View style={{ flexDirection: 'column' }}>
-                  {currentSection.items.length === 0 ? (
-                    <View
-                      style={{
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        padding: 20,
-                      }}
-                    >
-                      <Text style={{ fontSize: 15 }}>
-                        <Trans>No shortcuts in this section</Trans>
-                      </Text>
-                    </View>
-                  ) : (
-                    currentSection.items.map(shortcut => (
-                      <View
-                        key={shortcut.id}
-                        style={{
-                          padding: 12,
-                          backgroundColor: theme.tableBackground,
-                          borderRadius: 6,
-                          marginBottom: 8,
-                          borderWidth: 1,
-                          borderColor: theme.tableBorder,
-                          height: 40,
-                        }}
-                      >
-                        <ShortcutListItem
-                          shortcut={shortcut.shortcut}
-                          description={shortcut.description}
-                          meta={shortcut.meta}
-                          shift={shortcut.shift}
-                          style={shortcut.style}
-                        />
-                      </View>
-                    ))
-                  )}
-                </View>
-              )}
+              {/* Section detail view */}
+              {currentView !== 'sections' &&
+                currentView !== 'search-results' &&
+                currentSection &&
+                (currentSection.items.length === 0 ? (
+                  <View
+                    style={{
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      padding: 20,
+                    }}
+                  >
+                    <Text style={{ fontSize: 15 }}>
+                      <Trans>No shortcuts in this section</Trans>
+                    </Text>
+                  </View>
+                ) : (
+                  currentSection.items.map(shortcut => (
+                    <ShortcutListItem
+                      key={shortcut.id}
+                      shortcut={shortcut.shortcut}
+                      description={shortcut.description}
+                      meta={shortcut.meta}
+                      shift={shortcut.shift}
+                      style={shortcut.style}
+                    />
+                  ))
+                ))}
+            </View>
           </View>
         </>
       )}

--- a/upcoming-release-notes/5340.md
+++ b/upcoming-release-notes/5340.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MikesGlitch]
+---
+
+Enhanced Keyboard Shortcuts modal to be searchable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Improve the keyboard shortcuts modal by making it searchable and more extendable. This should make it easier in future to allow the user to rebind their shortcuts.

Have gotten some community feedback here: https://discord.com/channels/937901803608096828/1389677350215618623/1396402979350908958

**Demo:** 

![shortcuts](https://github.com/user-attachments/assets/6e9291fb-1116-4300-9074-5d7b4600b648)

**The new modal would replace this:** 
<img width="1168" height="817" alt="image" src="https://github.com/user-attachments/assets/eaf3c37c-0d9e-449c-aa10-a6fd4addc91c" />

- It's unsearchable
- It's large and will only going to get larger as new shortcuts are added
- It would be difficult to extend it to allow users to rebind their shortcuts


