### PR TITLE
Fix Boursorama GoCardless transaction ordering

### DIFF
--- a/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
+++ b/packages/sync-server/src/app-gocardless/banks/tests/boursobank_bousfrppxxx.spec.js
@@ -20,6 +20,19 @@ describe('BoursoBank', () => {
         'Carte 03/02/25 2,80 NZD / 1 euro = 1,818181818',
       ],
       [
+        [
+          '2,80 NZD / 1 euro = 1,818181818',
+          'CARTE 03/02/25 PAYEE NAME CB*1234',
+        ],
+        'Payee Name',
+        'Carte 03/02/25 2,80 NZD / 1 euro = 1,818181818',
+      ],
+      [
+        ['110,04 GBP / 1 euro = 0,860763454', 'CARTE 13/07/25 PAYEE NAME'],
+        'Payee Name',
+        'Carte 13/07/25 110,04 GBP / 1 euro = 0,860763454',
+      ],
+      [
         ['RETRAIT DAB 01/03/25 My location CB*9876'],
         'Retrait DAB',
         'Retrait 01/03/25 My location',
@@ -28,6 +41,14 @@ describe('BoursoBank', () => {
         [
           'RETRAIT DAB 01/03/25 My location CB*9876',
           '2,80 NZD / 1 euro = 1,818181818',
+        ],
+        'Retrait DAB',
+        'Retrait 01/03/25 My location 2,80 NZD / 1 euro = 1,818181818',
+      ],
+      [
+        [
+          '2,80 NZD / 1 euro = 1,818181818',
+          'RETRAIT DAB 01/03/25 My location CB*9876',
         ],
         'Retrait DAB',
         'Retrait 01/03/25 My location 2,80 NZD / 1 euro = 1,818181818',

--- a/upcoming-release-notes/5344.md
+++ b/upcoming-release-notes/5344.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Aerion]
+---
+
+Fix Boursorama GoCardless wrong payee for multiline transactions


### PR DESCRIPTION
I wrongly thought that all the card transactions will always have their first line with the `CARTE` identifier. But as I have seen recently, it's not the case, and we shouldn't rely on the ordering of the array returned by the Boursorama GoCardless integration.

Thus, check for transaction patterns in all of the lines of the unstructured array.

This addresses a true case (added in test) where the payee name was wrongly extracted as being `110,04 Gbp / 1 Euro = 0,860763454`.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
