### PR TITLE
feat(CommandBar): add aggregated acct views

### DIFF
--- a/packages/desktop-client/src/components/CommandBar.tsx
+++ b/packages/desktop-client/src/components/CommandBar.tsx
@@ -10,6 +10,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import {
   SvgCog,
+  SvgLibrary,
   SvgPiggyBank,
   SvgReports,
   SvgStoreFront,
@@ -70,6 +71,12 @@ export function CommandBar() {
       { id: 'rules', name: t('Rules'), path: '/rules', Icon: SvgTuning },
       { id: 'tags', name: t('Tags'), path: '/tags', Icon: SvgTag },
       { id: 'settings', name: t('Settings'), path: '/settings', Icon: SvgCog },
+      {
+        id: 'accounts',
+        name: t('All Accounts'),
+        path: '/accounts',
+        Icon: SvgLibrary,
+      },
     ],
     [t],
   );
@@ -126,10 +133,22 @@ export function CommandBar() {
     {
       key: 'accounts',
       heading: t('Accounts'),
-      items: accounts.map(account => ({
-        ...account,
-        Icon: SvgPiggyBank,
-      })),
+      items: [
+        {
+          id: 'onbudget',
+          name: t('On Budget'),
+          Icon: SvgLibrary,
+        },
+        {
+          id: 'offbudget',
+          name: t('Off Budget'),
+          Icon: SvgLibrary,
+        },
+        ...accounts.map(account => ({
+          ...account,
+          Icon: SvgPiggyBank,
+        })),
+      ],
       onSelect: ({ id }) => handleNavigate(`/accounts/${id}`),
     },
     {

--- a/upcoming-release-notes/5348.md
+++ b/upcoming-release-notes/5348.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [elijaholmos]
 ---
 
-add aggregated account views (On Budget, Off Budget, All Accounts) to Command Bar
+Add aggregated account views (On Budget, Off Budget, All Accounts) to Command Bar

--- a/upcoming-release-notes/5348.md
+++ b/upcoming-release-notes/5348.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [elijaholmos]
+---
+
+add aggregated account views (On Budget, Off Budget, All Accounts) to Command Bar


### PR DESCRIPTION
## Description
Adds the following items to the Command Bar:
- Navigation
	- All Accounts (redirects to `/accounts`)
- Accounts
	- On Budget (redirects to `/accounts/onbudget`)
	- Off Budget (redirects to `/accounts/offbudget`)

The library icon is used instead of the piggy bank, to indicate a multi/aggregated acct view vs a single acct view.

Resolves #5339 

## Preview
<img width="619" height="352" alt="image" src="https://github.com/user-attachments/assets/8876f3c1-a487-48b8-8d92-f416fb4d0d68" />
