### PR TITLE
[Enhancement] Disable Sidebar Tooltip on Touchscreen Device

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -114,8 +114,10 @@ export function Account<FieldName extends SheetFields<'account'>>({
   const [isEditing, setIsEditing] = useState(false);
 
   const accountNote = useNotes(`account-${account?.id}`);
-  const canDeviceHover = window.matchMedia('(hover: hover)').matches;
-  const needsTooltip = !!account?.id && canDeviceHover;
+  const isTouchDevice =
+    window.matchMedia('(hover: none)').matches ||
+    window.matchMedia('(pointer: coarse)').matches;
+  const needsTooltip = !!account?.id && !isTouchDevice;
 
   const accountRow = (
     <View

--- a/upcoming-release-notes/5362.md
+++ b/upcoming-release-notes/5362.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [passabilities]
+---
+
+Disable sidebar tooltip on touchscreen device. Related to #5352


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

This is an addition to my previous PR #5352 that only checks the hover media query:
```ts
window.matchMedia('(hover: none)').matches
```
but this does not work for some touchscreen devices (i.e. newer Samsung phones/tablets)

however this does work
```ts
window.matchMedia('(pointer: coarse)').matches
```

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#coarse