### PR TITLE
Add button to import existing tag from transactions notes

### DIFF
--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -56,6 +56,8 @@ function RuleButton({ ruleCount, focused, onEdit, onClick }: RuleButtonProps) {
           border: '1px solid ' + theme.noticeBackground,
           color: theme.noticeTextDark,
           fontSize: 12,
+          cursor: 'pointer',
+          ':hover': { backgroundColor: theme.noticeBackgroundLight },
         }}
         onEdit={onEdit}
         onSelect={onClick}

--- a/packages/desktop-client/src/components/tags/ManageTags.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
-import { SvgAdd } from '@actual-app/components/icons/v1';
+import { SvgAdd, SvgDownload } from '@actual-app/components/icons/v1';
 import { Stack } from '@actual-app/components/stack';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
@@ -18,7 +18,10 @@ import {
   SelectedProvider,
   useSelected,
 } from '@desktop-client/hooks/useSelected';
-import { deleteAllTags } from '@desktop-client/queries/queriesSlice';
+import {
+  deleteAllTags,
+  importTags,
+} from '@desktop-client/queries/queriesSlice';
 import { useDispatch } from '@desktop-client/redux';
 import { useTags } from '@desktop-client/style/tags';
 
@@ -91,6 +94,10 @@ export function ManageTags() {
           <Button variant="bare" onPress={() => setCreate(true)}>
             <SvgAdd width={10} height={10} style={{ marginRight: 3 }} />
             <Trans>Add New</Trans>
+          </Button>
+          <Button variant="bare" onPress={() => dispatch(importTags())}>
+            <SvgDownload width={10} height={10} style={{ marginRight: 3 }} />
+            <Trans>Import existing tags</Trans>
           </Button>
           <View style={{ flex: 1 }} />
           <Search

--- a/packages/desktop-client/src/components/tags/ManageTags.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.tsx
@@ -2,7 +2,8 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
-import { SvgAdd, SvgDownload } from '@actual-app/components/icons/v1';
+import { SvgAdd } from '@actual-app/components/icons/v1';
+import { SvgSearchAlternate } from '@actual-app/components/icons/v2';
 import { Stack } from '@actual-app/components/stack';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
@@ -18,10 +19,7 @@ import {
   SelectedProvider,
   useSelected,
 } from '@desktop-client/hooks/useSelected';
-import {
-  deleteAllTags,
-  importTags,
-} from '@desktop-client/queries/queriesSlice';
+import { deleteAllTags, findTags } from '@desktop-client/queries/queriesSlice';
 import { useDispatch } from '@desktop-client/redux';
 import { useTags } from '@desktop-client/style/tags';
 
@@ -95,9 +93,13 @@ export function ManageTags() {
             <SvgAdd width={10} height={10} style={{ marginRight: 3 }} />
             <Trans>Add New</Trans>
           </Button>
-          <Button variant="bare" onPress={() => dispatch(importTags())}>
-            <SvgDownload width={10} height={10} style={{ marginRight: 3 }} />
-            <Trans>Import existing tags</Trans>
+          <Button variant="bare" onPress={() => dispatch(findTags())}>
+            <SvgSearchAlternate
+              width={10}
+              height={10}
+              style={{ marginRight: 3 }}
+            />
+            <Trans>Find Existing Tags</Trans>
           </Button>
           <View style={{ flex: 1 }} />
           <Search

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -1,10 +1,11 @@
 import React, { memo, useRef } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
-import { SvgRefreshArrow } from '@actual-app/components/icons/v2';
+import { SvgRefreshArrow, SvgViewShow } from '@actual-app/components/icons/v2';
 import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
+import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 
 import { type Tag } from 'loot-core/types/models';
@@ -16,8 +17,10 @@ import {
   Row,
   Cell,
   InputCell,
+  CellButton,
 } from '@desktop-client/components/table';
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
+import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { useProperFocus } from '@desktop-client/hooks/useProperFocus';
 import { useSelectedDispatch } from '@desktop-client/hooks/useSelected';
 import {
@@ -51,6 +54,7 @@ export const TagRow = memo(
     const triggerRef = useRef(null);
     const { setMenuOpen, menuOpen, handleContextMenu, position } =
       useContextMenu();
+    const navigate = useNavigate();
 
     const onUpdate = (description: string) => {
       dispatch(
@@ -62,6 +66,23 @@ export const TagRow = memo(
               description,
             }),
       );
+    };
+
+    const onShowActivity = () => {
+      const filterConditions = [
+        {
+          field: 'notes',
+          op: 'hasTags',
+          value: `#${tag.tag}`,
+          type: 'string',
+        },
+      ];
+      navigate('/accounts', {
+        state: {
+          goBack: true,
+          filterConditions,
+        },
+      });
     };
 
     return (
@@ -162,6 +183,30 @@ export const TagRow = memo(
             placeholder: t('No description'),
           }}
         />
+        {tag.tag !== '*' && (
+          <Cell
+            name="rule-count"
+            width="auto"
+            style={{ padding: '0 10px' }}
+            plain
+          >
+            <CellButton
+              onSelect={onShowActivity}
+              style={{
+                cursor: 'pointer',
+                fontSize: 11,
+                color: theme.tableTextLight,
+                ':hover': { borderBottom: '1px solid' },
+              }}
+              bare
+            >
+              <Text style={{ paddingRight: 5 }}>
+                <Trans>View Transactions</Trans>
+              </Text>
+              <SvgViewShow style={{ width: 10, height: 10 }} />
+            </CellButton>
+          </Cell>
+        )}
       </Row>
     );
   },

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -2,7 +2,8 @@ import React, { memo, useRef } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
-import { SvgRefreshArrow, SvgViewShow } from '@actual-app/components/icons/v2';
+import { SvgArrowThinRight } from '@actual-app/components/icons/v1';
+import { SvgRefreshArrow } from '@actual-app/components/icons/v2';
 import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
 import { Text } from '@actual-app/components/text';
@@ -184,26 +185,24 @@ export const TagRow = memo(
           }}
         />
         {tag.tag !== '*' && (
-          <Cell
-            name="rule-count"
-            width="auto"
-            style={{ padding: '0 10px' }}
-            plain
-          >
+          <Cell width="auto" style={{ padding: '0 10px' }} plain>
             <CellButton
-              onSelect={onShowActivity}
               style={{
+                borderRadius: 4,
+                padding: '3px 6px',
+                backgroundColor: theme.noticeBackground,
+                border: '1px solid ' + theme.noticeBackground,
+                color: theme.noticeTextDark,
+                fontSize: 12,
                 cursor: 'pointer',
-                fontSize: 11,
-                color: theme.tableTextLight,
-                ':hover': { borderBottom: '1px solid' },
+                ':hover': { backgroundColor: theme.noticeBackgroundLight },
               }}
-              bare
+              onSelect={onShowActivity}
             >
               <Text style={{ paddingRight: 5 }}>
                 <Trans>View Transactions</Trans>
               </Text>
-              <SvgViewShow style={{ width: 10, height: 10 }} />
+              <SvgArrowThinRight style={{ width: 8, height: 8 }} />
             </CellButton>
           </Cell>
         )}

--- a/packages/desktop-client/src/queries/queriesSlice.ts
+++ b/packages/desktop-client/src/queries/queriesSlice.ts
@@ -189,6 +189,10 @@ const queriesSlice = createSlice({
       const tagIdx = state.tags.findIndex(tag => tag.id === action.payload.id);
       state.tags[tagIdx] = action.payload;
     });
+
+    builder.addCase(importTags.fulfilled, (state, action) => {
+      state.tags = action.payload;
+    });
   },
 });
 
@@ -481,6 +485,14 @@ export const updateTag = createAppAsyncThunk(
   `${sliceName}/updateTag`,
   async (tag: Tag) => {
     const id = await send('tags-update', tag);
+    return id;
+  },
+);
+
+export const importTags = createAppAsyncThunk(
+  `${sliceName}/importTags`,
+  async () => {
+    const id = await send('tags-import');
     return id;
   },
 );

--- a/packages/desktop-client/src/queries/queriesSlice.ts
+++ b/packages/desktop-client/src/queries/queriesSlice.ts
@@ -190,7 +190,7 @@ const queriesSlice = createSlice({
       state.tags[tagIdx] = action.payload;
     });
 
-    builder.addCase(importTags.fulfilled, (state, action) => {
+    builder.addCase(findTags.fulfilled, (state, action) => {
       state.tags = action.payload;
     });
   },
@@ -489,10 +489,10 @@ export const updateTag = createAppAsyncThunk(
   },
 );
 
-export const importTags = createAppAsyncThunk(
-  `${sliceName}/importTags`,
+export const findTags = createAppAsyncThunk(
+  `${sliceName}/findTags`,
   async () => {
-    const id = await send('tags-import');
+    const id = await send('tags-find');
     return id;
   },
 );

--- a/packages/desktop-client/src/style/tags.ts
+++ b/packages/desktop-client/src/style/tags.ts
@@ -56,8 +56,8 @@ export function useTagCSS() {
         theme,
         // fallback strategy: options color > tag color > default color > theme color (undefined)
         options.color ??
-          tags.find(t => t.tag === tag)?.color ??
-          tags.find(t => t.tag === '*')?.color,
+          (tags.find(t => t.tag === tag)?.color ||
+            tags.find(t => t.tag === '*')?.color),
       );
 
       return css({

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -826,3 +826,14 @@ export async function deleteTag(tag) {
 export function updateTag(tag) {
   return update('tags', tag);
 }
+
+export function importTags() {
+  return all<{ notes: string }>(
+    `
+    SELECT notes
+    FROM transactions
+    WHERE notes LIKE ?
+  `,
+    ['%#%'],
+  );
+}

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -827,7 +827,7 @@ export function updateTag(tag) {
   return update('tags', tag);
 }
 
-export function importTags() {
+export function findTags() {
   return all<{ notes: string }>(
     `
     SELECT notes

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -64,7 +64,7 @@ async function importTags(): Promise<Tag[]> {
 
   const tags = await getTags();
   for (const { notes } of taggedNotes) {
-    for (const [_, tag] of notes.matchAll(/#([^#\s]+)/g)) {
+    for (const [_, tag] of notes.matchAll(/(?<!#)#([^#\s]+)/g)) {
       if (!tags.find(t => t.tag === tag)) {
         tags.push(await createTag({ tag, color: '' }));
       }

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -11,7 +11,7 @@ export type TagsHandlers = {
   'tags-delete': typeof deleteTag;
   'tags-delete-all': typeof deleteAllTags;
   'tags-update': typeof updateTag;
-  'tags-import': typeof importTags;
+  'tags-find': typeof findTags;
 };
 
 export const app = createApp<TagsHandlers>();
@@ -20,7 +20,7 @@ app.method('tags-create', mutator(undoable(createTag)));
 app.method('tags-delete', mutator(undoable(deleteTag)));
 app.method('tags-delete-all', mutator(deleteAllTags));
 app.method('tags-update', mutator(undoable(updateTag)));
-app.method('tags-import', mutator(importTags));
+app.method('tags-find', mutator(findTags));
 
 async function getTags(): Promise<Tag[]> {
   return await db.getTags();
@@ -59,8 +59,8 @@ async function updateTag(tag: Tag): Promise<Tag> {
   return tag;
 }
 
-async function importTags(): Promise<Tag[]> {
-  const taggedNotes = await db.importTags();
+async function findTags(): Promise<Tag[]> {
+  const taggedNotes = await db.findTags();
 
   const tags = await getTags();
   for (const { notes } of taggedNotes) {

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -11,6 +11,7 @@ export type TagsHandlers = {
   'tags-delete': typeof deleteTag;
   'tags-delete-all': typeof deleteAllTags;
   'tags-update': typeof updateTag;
+  'tags-import': typeof importTags;
 };
 
 export const app = createApp<TagsHandlers>();
@@ -19,6 +20,7 @@ app.method('tags-create', mutator(undoable(createTag)));
 app.method('tags-delete', mutator(undoable(deleteTag)));
 app.method('tags-delete-all', mutator(deleteAllTags));
 app.method('tags-update', mutator(undoable(updateTag)));
+app.method('tags-import', mutator(importTags));
 
 async function getTags(): Promise<Tag[]> {
   return await db.getTags();
@@ -55,4 +57,27 @@ async function deleteAllTags(ids: Array<Tag['id']>): Promise<Array<Tag['id']>> {
 async function updateTag(tag: Tag): Promise<Tag> {
   await db.updateTag(tag);
   return tag;
+}
+
+async function importTags(): Promise<Tag[]> {
+  const taggedNotes = await db.importTags();
+
+  const tags = await getTags();
+  for (const { notes } of taggedNotes) {
+    for (const [_, tag] of notes.matchAll(/#([^#\s]+)/g)) {
+      if (!tags.find(t => t.tag === tag)) {
+        tags.push(await createTag({ tag, color: '' }));
+      }
+    }
+  }
+
+  return tags.sort(function (a, b) {
+    if (a.tag < b.tag) {
+      return -1;
+    }
+    if (a.tag > b.tag) {
+      return 1;
+    }
+    return 0;
+  });
 }

--- a/upcoming-release-notes/5368.md
+++ b/upcoming-release-notes/5368.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [pogman-code]
 ---
 
-Add button to import existing tag from transactions notes
+Add button to find existing tag from transactions notes

--- a/upcoming-release-notes/5368.md
+++ b/upcoming-release-notes/5368.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [pogman-code]
+---
+
+Add button to import existing tag from transactions notes


### PR DESCRIPTION
I guess everything is in the title :D

Adds a button in the "tags" page to import/extract existing tags from notes.

<img width="464" height="251" alt="image" src="https://github.com/user-attachments/assets/39d02493-e239-48d5-b611-c5c7fe1f5d9f" />
