### PR TITLE
fix: reconcile select number on click

### DIFF
--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -170,13 +170,15 @@ export function ReconcileMenu({
             reconcile with:
           </Trans>
         </Text>
-        <InitialFocus>
-          <Input
-            value={inputValue ?? ''}
-            onChangeValue={setInputValue}
-            style={{ margin: '7px 0' }}
-          />
-        </InitialFocus>
+        {inputValue && (
+          <InitialFocus>
+            <Input
+              value={inputValue}
+              onChangeValue={setInputValue}
+              style={{ margin: '7px 0' }}
+            />
+          </InitialFocus>
+        )}
         {lastSyncedBalance != null && (
           <View>
             <Text>

--- a/upcoming-release-notes/5373.md
+++ b/upcoming-release-notes/5373.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [UnderKoen]
+---
+
+On initial click for reconcile selection of value


### PR DESCRIPTION
When just loading a page the reconcile button doesn't select the amount. The second time you click it does. This makes it work for the first click