### PR TITLE
Only use fund from local group during cleanup.

### DIFF
--- a/upcoming-release-notes/5377.md
+++ b/upcoming-release-notes/5377.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kleinweby]
+---
+
+Local cleanup groups will only use money from inside the group itself.


### PR DESCRIPTION
When using local group cleanup, currently all funds available in To Budget are distributed into the sinks. This behaviour seems somwhat odd and also results in all later groups or the "global" cleanup run to possibly have no funds as they've been distributed before.

This patch now changes the group usage of cleanup, to only distribute funds made available by the group itself. If one also wants to sink money from To Budget into the category, a simple addtional `#cleanup sink`, will achieve this.

Fixes #5374

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
