### PR TITLE
Fix tags not syncing properly

### DIFF
--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -818,9 +818,7 @@ export function insertTag(tag): Promise<DbTag['id']> {
 }
 
 export async function deleteTag(tag) {
-  return transaction(() => {
-    runQuery(`DELETE FROM tags WHERE id = ?`, [tag.id]);
-  });
+  return delete_('tags', tag.id);
 }
 
 export function updateTag(tag) {

--- a/upcoming-release-notes/5387.md
+++ b/upcoming-release-notes/5387.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix tags not syncing properly


### PR DESCRIPTION
So far this should fix deleting tags.  We can add other fixes as needed.
