### PR TITLE
Fix undefined points error in contributor points

### DIFF
--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -236,16 +236,20 @@ async function countContributorPoints(repo) {
         ) {
           const remover = event.actor.login;
           const userStats = stats.get(remover);
-          userStats.labelRemovals.push(issue.number.toString());
-          userStats.points += config.POINTS_PER_ISSUE_TRIAGE_ACTION;
+          if (userStats) {
+            userStats.labelRemovals.push(issue.number.toString());
+            userStats.points += config.POINTS_PER_ISSUE_TRIAGE_ACTION;
+          }
         }
 
         // Check if the issue was closed with "no planned" status
         if (event.event === 'closed' && event.state_reason === 'not_planned') {
           const closer = event.actor.login;
           const userStats = stats.get(closer);
-          userStats.issueClosings.push(issue.number.toString());
-          userStats.points += config.POINTS_PER_ISSUE_CLOSING_ACTION;
+          if (userStats) {
+            userStats.issueClosings.push(issue.number.toString());
+            userStats.points += config.POINTS_PER_ISSUE_CLOSING_ACTION;
+          }
         }
       });
   }


### PR DESCRIPTION
```
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fix: Prevent `TypeError: Cannot read properties of undefined (reading 'points')` in `count-points.mjs`

This error occurred when non-organization members performed actions (like removing "needs triage" labels or closing issues). The script attempted to access `userStats.points` for these users, but `stats.get(login)` returned `undefined` for non-members, causing the crash.

This PR adds null checks (`if (userStats)`) before attempting to update user statistics, ensuring that points are only processed for recognized organization members and gracefully ignoring actions by non-members without error.
```

---

[Open in Web](https://cursor.com/agents?id=bc-0fa87c24-91ba-420b-9bdf-faeaa2f7c6de) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0fa87c24-91ba-420b-9bdf-faeaa2f7c6de)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)