### PR TITLE
Fix missing translations

### DIFF
--- a/packages/desktop-client/src/components/budget/SidebarGroup.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarGroup.tsx
@@ -150,7 +150,7 @@ export function SidebarGroup({
                   { name: 'rename', text: t('Rename') },
                   !group.is_income && {
                     name: 'toggle-visibility',
-                    text: group.hidden ? 'Show' : 'Hide',
+                    text: group.hidden ? t('Show') : t('Hide'),
                   },
                   onDelete && { name: 'delete', text: t('Delete') },
                   ...(isGoalTemplatesEnabled

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -294,7 +294,7 @@ function AdditionalCategoryGroupMenu({ group, onDelete, onToggleVisibility }) {
                 [
                   {
                     name: 'toggleVisibility',
-                    text: group.hidden ? 'Show' : 'Hide',
+                    text: group.hidden ? t('Show') : t('Hide'),
                     icon: group.hidden ? SvgViewShow : SvgViewHide,
                     iconSize: 16,
                   },
@@ -302,7 +302,7 @@ function AdditionalCategoryGroupMenu({ group, onDelete, onToggleVisibility }) {
                     Menu.line,
                     {
                       name: 'delete',
-                      text: 'Delete',
+                      text: t('Delete'),
                       icon: SvgTrash,
                       iconSize: 15,
                     },

--- a/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryGroupMenuModal.tsx
@@ -162,7 +162,7 @@ export function CategoryGroupMenuModal({
               }}
             >
               <Notes
-                notes={notes?.length > 0 ? notes : 'No notes'}
+                notes={notes?.length > 0 ? notes : t('No notes')}
                 editable={false}
                 focused={false}
                 getStyle={() => ({

--- a/packages/desktop-client/src/components/reports/SaveReport.tsx
+++ b/packages/desktop-client/src/components/reports/SaveReport.tsx
@@ -1,4 +1,5 @@
 import React, { createRef, useRef, useState } from 'react';
+import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgExpandArrow } from '@actual-app/components/icons/v0';
@@ -199,7 +200,7 @@ export function SaveReport({
             flexShrink: 0,
           }}
         >
-          {!report.id ? 'Unsaved report' : report.name}&nbsp;
+          {!report.id ? <Trans>Unsaved report</Trans> : report.name}&nbsp;
         </Text>
         {savedStatus === 'modified' && <Text>(modified)&nbsp;</Text>}
         <SvgExpandArrow width={8} height={8} style={{ marginRight: 5 }} />

--- a/upcoming-release-notes/5396.md
+++ b/upcoming-release-notes/5396.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [milanalexandre]
+---
+
+add missing translations for UI texts (Show, Hide, Delete, Unsaved report)


### PR DESCRIPTION
This PR updates the UI to add missing translations for several user-facing texts, including :

"Show" / "Hide" in category group menus
"Delete" in modals
"Unsaved report" in the reports section
<img width="520" height="539" alt="Capture d’écran 2025-07-26 à 14 01 56" src="https://github.com/user-attachments/assets/60d6027f-3160-44b6-ba41-3cea0af559c8" />
<img width="1141" height="133" alt="Capture d’écran 2025-07-26 à 14 05 21" src="https://github.com/user-attachments/assets/54ed86c9-c75b-4501-a1c8-9b2621df5135" />
<img width="618" height="420" alt="Capture d’écran 2025-07-26 à 14 06 40" src="https://github.com/user-attachments/assets/59908d31-c1d5-45cb-9b02-88505aad43cd" />
