### PR TITLE
Allow Docker image build by workflow dispatch on forks

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -22,9 +22,9 @@ permissions:
 
 env:
   IMAGES: |
-    actualbudget/actual-server
-    ghcr.io/actualbudget/actual-server
-    ghcr.io/actualbudget/actual
+    ${{ !github.event.repository.fork && 'actualbudget/actual-server' || '' }}
+    ghcr.io/${{ github.repository_owner }}/actual-server
+    ghcr.io/${{ github.repository_owner }}/actual
 
   # Creates the following tags:
   # - actual-server:edge
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build:
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event_name == 'workflow_dispatch' || !github.event.repository.fork
     name: Build Docker image
     runs-on: ubuntu-latest
     strategy:
@@ -60,7 +60,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && !github.event.repository.fork
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/upcoming-release-notes/5404.md
+++ b/upcoming-release-notes/5404.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [Jackenmen]
+---
+
+Allow running the GitHub Actions workflow for building the Docker edge image on forks when using the workflow dispatch


### PR DESCRIPTION
I can understand not wanting to auto-trigger Docker builds on forks on schedule or whenever a push to master or a pull request is made *but* I think there's no reason to limit the ability for the fork owner to trigger a build manually through a workflow dispatch. As long as we exclude the push to DockerHub (which, unlike GitHub Packages, requires credentials not auto-generated by GH Actions), it can work just fine.