### PR TITLE
Do not search tags in deleted transactions

### DIFF
--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -839,7 +839,7 @@ export function findTags() {
     `
     SELECT notes
     FROM transactions
-    WHERE notes LIKE ?
+    WHERE tombstone = 0 AND notes LIKE ?
   `,
     ['%#%'],
   );

--- a/upcoming-release-notes/5409.md
+++ b/upcoming-release-notes/5409.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [pogman-code]
+---
+
+Do not search tags in deleted transactions


### PR DESCRIPTION
Do not search tags in deleted (tombstoned) transactions