### PR TITLE
Fix/i18n translate status and date

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -34,6 +34,7 @@ import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import * as Platform from 'loot-core/shared/platform';
 import { q } from 'loot-core/shared/query';
+import { getStatusLabel } from 'loot-core/shared/schedules';
 import {
   ungroupTransactions,
   updateTransaction,
@@ -164,8 +165,10 @@ export function Status({ status, isSplit }) {
       }}
     >
       {isSplit
-        ? t('{{status}} (Split)', { status: titleFirst(status) })
-        : titleFirst(status)}
+        ? t('{{status}} (Split)', {
+            status: titleFirst(getStatusLabel(status)),
+          })
+        : titleFirst(getStatusLabel(status))}
     </Text>
   );
 }

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.jsx
@@ -579,7 +579,7 @@ export function ImportTransactionsModal({
       if (date == null) {
         errorMessage = t(
           'Unable to parse date {{date}} with given date format',
-          { date: trans.date || '(empty)' },
+          { date: trans.date || t('(empty)') },
         );
         break;
       }

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -14,6 +14,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
+import { getStatusLabel } from 'loot-core/shared/schedules';
 import { titleFirst } from 'loot-core/shared/util';
 
 import { type ScheduleStatusType } from '@desktop-client/hooks/useSchedules';
@@ -113,7 +114,9 @@ export function StatusBadge({ status }: { status: ScheduleStatusType }) {
           marginRight: 7,
         }}
       />
-      <Text style={{ lineHeight: '1em' }}>{titleFirst(status)}</Text>
+      <Text style={{ lineHeight: '1em' }}>
+        {titleFirst(getStatusLabel(status))}
+      </Text>
     </View>
   );
 }

--- a/packages/desktop-client/src/components/settings/AuthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/AuthSettings.tsx
@@ -53,7 +53,7 @@ export function AuthSettings() {
                   )
                 }
               >
-                Start using OpenID
+                {t('Start using OpenID')}
               </Button>
               <Label
                 style={{ paddingTop: 5 }}

--- a/packages/desktop-client/src/components/settings/AuthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/AuthSettings.tsx
@@ -53,7 +53,7 @@ export function AuthSettings() {
                   )
                 }
               >
-                {t('Start using OpenID')}
+                <Trans>Start using OpenID</Trans>
               </Button>
               <Label
                 style={{ paddingTop: 5 }}

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -115,6 +115,7 @@ function IDName({ children }: { children: ReactNode }) {
 function AdvancedAbout() {
   const [budgetId] = useMetadataPref('id');
   const [groupId] = useMetadataPref('groupId');
+  const { t } = useTranslation();
 
   return (
     <Setting>
@@ -133,15 +134,15 @@ function AdvancedAbout() {
       </Text>
       <Text style={{ color: theme.pageText }}>
         <Trans>
-          <IDName>Sync ID:</IDName> {{ syncId: groupId || '(none)' }}
+          <IDName>Sync ID:</IDName> {{ syncId: groupId || t('(none)') }}
         </Trans>
       </Text>
       {/* low priority todo: eliminate some or all of these, or decide when/if to show them */}
       {/* <Text>
-        <IDName>Cloud File ID:</IDName> {prefs.cloudFileId || '(none)'}
+        <IDName>Cloud File ID:</IDName> {prefs.cloudFileId || t('(none)')}
       </Text>
       <Text>
-        <IDName>User ID:</IDName> {prefs.userId || '(none)'}
+        <IDName>User ID:</IDName> {prefs.userId || t('(none)')}
       </Text> */}
     </Setting>
   );

--- a/packages/desktop-client/src/components/sidebar/BalanceHistoryGraph.tsx
+++ b/packages/desktop-client/src/components/sidebar/BalanceHistoryGraph.tsx
@@ -175,19 +175,19 @@ export function BalanceHistoryGraph({ accountId }: BalanceHistoryGraphProps) {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        <LineChart data={balanceData} width={CHART_WIDTH} height={CHART_HEIGHT}>
+        <LineChart
+          data={balanceData}
+          width={CHART_WIDTH}
+          height={CHART_HEIGHT}
+          onMouseMove={state => {
+            if (state && state.activePayload && state.activePayload[0]) {
+              setHoveredValue(state.activePayload[0].payload);
+            }
+          }}
+        >
           <YAxis domain={['dataMin', 'dataMax']} hide={true} />
           <RechartsTooltip
-            contentStyle={{
-              display: 'none',
-            }}
-            labelFormatter={(label, items) => {
-              const data = items[0]?.payload;
-              if (data) {
-                setHoveredValue(data);
-              }
-              return '';
-            }}
+            contentStyle={{ display: 'none' }}
             isAnimationActive={false}
           />
           <Line

--- a/packages/desktop-client/src/components/sidebar/BalanceHistoryGraph.tsx
+++ b/packages/desktop-client/src/components/sidebar/BalanceHistoryGraph.tsx
@@ -5,7 +5,7 @@ import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
-import { subMonths, format, eachMonthOfInterval, parseISO } from 'date-fns';
+import { subMonths, format, eachMonthOfInterval } from 'date-fns';
 import { LineChart, Line, YAxis, Tooltip as RechartsTooltip } from 'recharts';
 
 import * as monthUtils from 'loot-core/shared/months';
@@ -14,6 +14,7 @@ import { integerToCurrency } from 'loot-core/shared/util';
 
 import { PrivacyFilter } from '@desktop-client/components/PrivacyFilter';
 import { LoadingIndicator } from '@desktop-client/components/reports/LoadingIndicator';
+import { useLocale } from '@desktop-client/hooks/useLocale';
 import { aqlQuery } from '@desktop-client/queries/aqlQuery';
 
 const CHART_HEIGHT = 70;
@@ -31,6 +32,7 @@ type Balance = {
 };
 
 export function BalanceHistoryGraph({ accountId }: BalanceHistoryGraphProps) {
+  const locale = useLocale();
   const [balanceData, setBalanceData] = useState<
     Array<{ date: string; balance: number }>
   >([]);
@@ -139,7 +141,7 @@ export function BalanceHistoryGraph({ accountId }: BalanceHistoryGraphProps) {
         .map(t => {
           return {
             balance: t.balance,
-            date: format(parseISO(t.date), 'MMM yyyy'),
+            date: monthUtils.format(t.date, 'MMM yyyy', locale),
           };
         });
 
@@ -149,7 +151,7 @@ export function BalanceHistoryGraph({ accountId }: BalanceHistoryGraphProps) {
     }
 
     fetchBalanceHistory();
-  }, [accountId]);
+  }, [accountId, locale]);
 
   // State to track if the chart is hovered (used to conditionally render PrivacyFilter)
   const [isHovered, setIsHovered] = useState(false);

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -44,6 +44,7 @@ import { View } from '@actual-app/components/view';
 import { format as formatDate, parseISO } from 'date-fns';
 
 import * as monthUtils from 'loot-core/shared/months';
+import { getStatusLabel } from 'loot-core/shared/schedules';
 import {
   addSplitTransaction,
   deleteTransaction,
@@ -1416,7 +1417,7 @@ const Transaction = memo(function Transaction({
                 display: 'inline-block',
               }}
             >
-              {titleFirst(previewStatus ?? '')}
+              {titleFirst(getStatusLabel(previewStatus ?? ''))}
             </View>
           )}
           <CellButton

--- a/upcoming-release-notes/5411.md
+++ b/upcoming-release-notes/5411.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [milanalexandre]
+---
+
+Add status label translations for 'Schedules' and others


### PR DESCRIPTION
This branch adds 
- Translation of the labels for *Schedules* elements
- Translation of the date in the price preview popup (with a fix to calculate  display the date) 
- Translation in the settings
    
<img width="521" height="710" alt="Capture d’écran 2025-07-26 à 18 51 09" src="https://github.com/user-attachments/assets/2140c66f-f87b-45e3-890c-29e7784718e8" />
<img width="521" height="247" alt="Capture d’écran 2025-07-26 à 18 51 45" src="https://github.com/user-attachments/assets/2e4f5358-24c6-4af9-b716-d1f146d9662f" />
<img width="560" height="247" alt="Capture d’écran 2025-07-26 à 18 52 24" src="https://github.com/user-attachments/assets/41bd243d-1b5a-4507-b34e-4c4ed5d08d50" />
<img width="416" height="363" alt="Capture d’écran 2025-07-28 à 13 57 14" src="https://github.com/user-attachments/assets/2c75fa1f-0a4c-4e52-8875-597940cece27" />
