### PR TITLE
Fix transaction hooks and improve transactions loading experience in mobile

### DIFF
--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -241,6 +241,12 @@ function TransactionListWithPreviews({
   readonly accountName: AccountEntity['name'] | string;
 }) {
   const { t } = useTranslation();
+
+  const balanceQueries = useMemo(
+    () => queriesFromAccountId(accountId, account),
+    [accountId, account],
+  );
+
   const baseTransactionsQuery = useCallback(
     () =>
       queries.transactions(accountId).options({ splits: 'all' }).select('*'),
@@ -352,11 +358,6 @@ function TransactionListWithPreviews({
       }
     },
     [dispatch, navigate],
-  );
-
-  const balanceQueries = useMemo(
-    () => queriesFromAccountId(accountId, account),
-    [accountId, account],
   );
 
   const transactionsToDisplay = !isSearching

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -90,7 +90,7 @@ function TransactionListWithPreviews({
   );
   const {
     transactions,
-    isLoading,
+    isLoading: isTransactionsLoading,
     isLoadingMore,
     loadMore: loadMoreTransactions,
     reload: reloadTransactions,
@@ -138,10 +138,11 @@ function TransactionListWithPreviews({
     month,
   );
 
-  const { previewTransactions } = useCategoryPreviewTransactions({
-    categoryId: category.id,
-    month,
-  });
+  const { previewTransactions, isLoading: isPreviewTransactionsLoading } =
+    useCategoryPreviewTransactions({
+      categoryId: category.id,
+      month,
+    });
 
   const transactionsToDisplay = !isSearching
     ? previewTransactions.concat(transactions)
@@ -149,7 +150,9 @@ function TransactionListWithPreviews({
 
   return (
     <TransactionListWithBalances
-      isLoading={isLoading}
+      isLoading={
+        isSearching ? isTransactionsLoading : isPreviewTransactionsLoading
+      }
       transactions={transactionsToDisplay}
       balance={balance}
       balanceCleared={balanceCleared}
@@ -159,8 +162,6 @@ function TransactionListWithPreviews({
       isLoadingMore={isLoadingMore}
       onLoadMore={loadMoreTransactions}
       onOpenTransaction={onOpenTransaction}
-      onRefresh={undefined}
-      account={undefined}
     />
   );
 }

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -148,30 +148,34 @@ export function TransactionList({
     }
   });
 
-  if (isLoading) {
-    return <Loading aria-label={t('Loading transactions...')} />;
-  }
-
   return (
     <>
+      {isLoading && (
+        <Loading
+          style={{ paddingBottom: 8 }}
+          aria-label={t('Loading transactions...')}
+        />
+      )}
       <ListBox
         aria-label={t('Transaction list')}
         selectionMode={selectedTransactions.size > 0 ? 'multiple' : 'single'}
         selectedKeys={selectedTransactions}
         dependencies={[selectedTransactions]}
-        renderEmptyState={() => (
-          <View
-            style={{
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: theme.mobilePageBackground,
-            }}
-          >
-            <Text style={{ fontSize: 15 }}>
-              <Trans>No transactions</Trans>
-            </Text>
-          </View>
-        )}
+        renderEmptyState={() =>
+          !isLoading && (
+            <View
+              style={{
+                alignItems: 'center',
+                justifyContent: 'center',
+                backgroundColor: theme.mobilePageBackground,
+              }}
+            >
+              <Text style={{ fontSize: 15 }}>
+                <Trans>No transactions</Trans>
+              </Text>
+            </View>
+          )
+        }
         items={sections}
       >
         {section => (

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -38,7 +38,7 @@ import {
   type TransactionEntity,
 } from 'loot-core/types/models';
 
-import { TransactionListItem } from './TransactionListItem';
+import { ROW_HEIGHT, TransactionListItem } from './TransactionListItem';
 
 import { FloatingActionBar } from '@desktop-client/components/mobile/FloatingActionBar';
 import { useScrollListener } from '@desktop-client/components/ScrollProvider';
@@ -221,7 +221,7 @@ export function TransactionList({
           aria-label={t('Loading more transactions...')}
           style={{
             // Same height as transaction list item
-            height: 60,
+            height: ROW_HEIGHT,
           }}
         />
       )}

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListItem.tsx
@@ -47,7 +47,7 @@ import { usePayee } from '@desktop-client/hooks/usePayee';
 import { NotesTagFormatter } from '@desktop-client/notes/NotesTagFormatter';
 import { useSelector } from '@desktop-client/redux';
 
-const ROW_HEIGHT = 60;
+export const ROW_HEIGHT = 60;
 
 const getTextStyle = ({
   isPreview,

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -142,7 +142,7 @@ export function TransactionListWithBalances({
           />
         </View>
         <PullToRefresh
-          isPullable={!!onRefresh}
+          isPullable={!isLoading && !!onRefresh}
           onRefresh={async () => onRefresh?.()}
         >
           <TransactionList

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -109,7 +109,9 @@ export function useAccountPreviewTransactions({
 
     const transactionIds = new Set(previewTransactions.map(t => t.id));
     const runningBalances = new Map(
-      [...previewRunningBalances.entries()].filter(([id]) => transactionIds.has(id)),
+      [...previewRunningBalances.entries()].filter(([id]) =>
+        transactionIds.has(id),
+      ),
     );
 
     return {

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -98,12 +98,9 @@ export function useAccountPreviewTransactions({
     });
 
     const transactionIds = new Set(previewTransactions.map(t => t.id));
-    const runningBalances = allRunningBalances;
-    for (const transactionId of runningBalances.keys()) {
-      if (!transactionIds.has(transactionId)) {
-        runningBalances.delete(transactionId);
-      }
-    }
+    const runningBalances = new Map(
+      [...allRunningBalances].filter(([id]) => transactionIds.has(id)),
+    );
 
     return {
       isLoading,
@@ -114,11 +111,11 @@ export function useAccountPreviewTransactions({
   }, [
     accountId,
     allPreviewTransactions,
-    allRunningBalances,
-    error,
     getPayeeByTransferAccount,
     getTransferAccountByPayee,
+    allRunningBalances,
     isLoading,
+    error,
   ]);
 }
 

--- a/packages/desktop-client/src/hooks/useCategoryPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useCategoryPreviewTransactions.ts
@@ -66,8 +66,8 @@ export function useCategoryPreviewTransactions({
       return {
         previewTransactions: [],
         runningBalances: new Map(),
-        isLoading: false,
-        error: undefined,
+        isLoading,
+        error,
       };
     }
 
@@ -77,12 +77,9 @@ export function useCategoryPreviewTransactions({
     );
 
     const transactionIds = new Set(previewTransactions.map(t => t.id));
-    const runningBalances = allRunningBalances;
-    for (const transactionId of runningBalances.keys()) {
-      if (!transactionIds.has(transactionId)) {
-        runningBalances.delete(transactionId);
-      }
-    }
+    const runningBalances = new Map(
+      [...allRunningBalances].filter(([id]) => transactionIds.has(id)),
+    );
 
     return {
       previewTransactions,

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -27,7 +27,12 @@ type UsePreviewTransactionsProps = {
   filter?: (schedule: ScheduleEntity) => boolean;
   options?: {
     /**
+     * Whether to calculate running balances.
+     */
+    calculateRunningBalances?: boolean;
+    /**
      * The starting balance to start the running balance calculation from.
+     * This is ignored if `calculateRunningBalances` is false.
      */
     startingBalance?: IntegerAmount;
   };
@@ -181,18 +186,20 @@ export function usePreviewTransactions({
           const ungroupedTransactions = ungroupTransactions(withDefaults);
           setPreviewTransactions(ungroupedTransactions);
 
-          setRunningBalances(
-            // We always use the bottom up calculation for preview transactions
-            // because the hook controls the order of the transactions. We don't
-            // need to provide a custom way for consumers to calculate the running
-            // balances, at least as of writing.
-            calculateRunningBalancesBottomUp(
-              ungroupedTransactions,
-              // Preview transactions are behaves like 'all' splits
-              'all',
-              optionsRef.current?.startingBalance,
-            ),
-          );
+          if (optionsRef.current?.calculateRunningBalances) {
+            setRunningBalances(
+              // We always use the bottom up calculation for preview transactions
+              // because the hook controls the order of the transactions. We don't
+              // need to provide a custom way for consumers to calculate the running
+              // balances, at least as of writing.
+              calculateRunningBalancesBottomUp(
+                ungroupedTransactions,
+                // Preview transactions are behaves like 'all' splits
+                'all',
+                optionsRef.current?.startingBalance,
+              ),
+            );
+          }
 
           setIsLoading(false);
         }

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import { useEffect, useState, useMemo, useRef } from 'react';
 
 import * as d from 'date-fns';
 
 import { send } from 'loot-core/platform/client/fetch';
 import { currentDay, addDays, parseDate } from 'loot-core/shared/months';
-import { type Query } from 'loot-core/shared/query';
 import {
   getUpcomingDays,
   extractScheduleConds,
@@ -22,197 +21,7 @@ import {
 import { useCachedSchedules } from './useCachedSchedules';
 import { type ScheduleStatuses } from './useSchedules';
 import { useSyncedPref } from './useSyncedPref';
-
-import {
-  pagedQuery,
-  type PagedQuery,
-} from '@desktop-client/queries/pagedQuery';
-
-// Mirrors the `splits` AQL option from the server
-type TransactionSplitsOption = 'all' | 'inline' | 'grouped' | 'none';
-
-type CalculateRunningBalancesOption =
-  | ((
-      transactions: TransactionEntity[],
-      splits: TransactionSplitsOption,
-    ) => Map<TransactionEntity['id'], IntegerAmount>)
-  | boolean;
-
-type UseTransactionsProps = {
-  /**
-   * The Query class is immutable so it is important to memoize the query object
-   * to prevent unnecessary re-renders i.e. `useMemo`, `useState`, etc.
-   */
-  query?: Query;
-  /**
-   * The options to configure the hook behavior.
-   */
-  options?: {
-    /**
-     * The number of transactions to load at a time.
-     * This is used for pagination and should be set to a reasonable number
-     * to avoid loading too many transactions at once.
-     * The default is 50.
-     * @default 50
-     */
-    pageCount?: number;
-    /**
-     * Whether to calculate running balances for the transactions returned by the query.
-     * This can be set to `true` to calculate running balances for all transactions
-     * (using the default running balance calculation), or a function that takes the
-     * transactions and the query state and returns a map of transaction IDs to running balances.
-     * The function will be called with the transactions and the query state
-     * whenever the transactions are loaded or reloaded.
-     *
-     * The default running balance calculation is a simple sum of the transaction amounts
-     * in reverse order (bottom up). This works well if the transactions are ordered by
-     * date in descending order. If the query orders the transactions differently,
-     * a custom `calculateRunningBalances` function should be used instead.
-     * @default false
-     */
-    calculateRunningBalances?: CalculateRunningBalancesOption;
-  };
-};
-
-type UseTransactionsResult = {
-  /**
-   * The transactions returned by the query.
-   */
-  transactions: ReadonlyArray<TransactionEntity>;
-  /**
-   * The running balances for the transactions returned by the query.
-   * This is only populated if `calculateRunningBalances` is either set to `true`
-   * or a function that implements the calculation in the options.
-   */
-  runningBalances: Map<TransactionEntity['id'], IntegerAmount>;
-  /**
-   * Whether the transactions are currently being loaded.
-   */
-  isLoading: boolean;
-  /**
-   * An error that occurred while loading the transactions.
-   */
-  error?: Error;
-  /**
-   * Reload the transactions.
-   */
-  reload: () => void;
-  /**
-   * Load more transactions.
-   */
-  loadMore: () => void;
-  /**
-   * Whether more transactions are currently being loaded.
-   */
-  isLoadingMore: boolean;
-};
-
-export function useTransactions({
-  query,
-  options = { pageCount: 50, calculateRunningBalances: false },
-}: UseTransactionsProps): UseTransactionsResult {
-  const [isLoading, setIsLoading] = useState(true);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [error, setError] = useState<Error | undefined>(undefined);
-  const [transactions, setTransactions] = useState<
-    ReadonlyArray<TransactionEntity>
-  >([]);
-  const [runningBalances, setRunningBalances] = useState<
-    Map<TransactionEntity['id'], IntegerAmount>
-  >(new Map());
-
-  const pagedQueryRef = useRef<PagedQuery<TransactionEntity> | null>(null);
-
-  // We don't want to re-render if options changes.
-  // Putting options in a ref will prevent that and
-  // allow us to use the latest options on next render.
-  const optionsRef = useRef(options);
-  optionsRef.current = options;
-
-  useEffect(() => {
-    let isUnmounted = false;
-
-    setError(undefined);
-
-    if (!query) {
-      return;
-    }
-
-    function onError(error: Error) {
-      if (!isUnmounted) {
-        setError(error);
-        setIsLoading(false);
-      }
-    }
-
-    if (query.state.table !== 'transactions') {
-      onError(new Error('Query must be a transactions query.'));
-      return;
-    }
-
-    setIsLoading(true);
-
-    pagedQueryRef.current = pagedQuery<TransactionEntity>(query, {
-      onData: data => {
-        if (!isUnmounted) {
-          setTransactions(data);
-
-          const calculateFn = getCalculateRunningBalancesFn(
-            optionsRef.current?.calculateRunningBalances,
-          );
-          if (calculateFn) {
-            setRunningBalances(
-              calculateFn(
-                data,
-                query.state.tableOptions?.splits as TransactionSplitsOption,
-              ),
-            );
-          }
-
-          setIsLoading(false);
-        }
-      },
-      onError,
-      options: optionsRef.current.pageCount
-        ? { pageCount: optionsRef.current.pageCount }
-        : {},
-    });
-
-    return () => {
-      isUnmounted = true;
-      pagedQueryRef.current?.unsubscribe();
-    };
-  }, [query]);
-
-  const loadMore = useCallback(async () => {
-    if (!pagedQueryRef.current) {
-      return;
-    }
-
-    setIsLoadingMore(true);
-
-    await pagedQueryRef.current
-      .fetchNext()
-      .catch(setError)
-      .finally(() => {
-        setIsLoadingMore(false);
-      });
-  }, []);
-
-  const reload = useCallback(() => {
-    pagedQueryRef.current?.run();
-  }, []);
-
-  return {
-    transactions,
-    runningBalances,
-    isLoading,
-    ...(error && { error }),
-    reload,
-    loadMore,
-    isLoadingMore,
-  };
-}
+import { calculateRunningBalancesBottomUp } from './useTransactions';
 
 type UsePreviewTransactionsProps = {
   filter?: (schedule: ScheduleEntity) => boolean;
@@ -409,61 +218,10 @@ export function usePreviewTransactions({
   };
 }
 
-export function isForPreview(
-  schedule: ScheduleEntity,
-  statuses: ScheduleStatuses,
-) {
+function isForPreview(schedule: ScheduleEntity, statuses: ScheduleStatuses) {
   const status = statuses.get(schedule.id);
   return (
     !schedule.completed &&
     ['due', 'upcoming', 'missed', 'paid'].includes(status!)
-  );
-}
-
-function getCalculateRunningBalancesFn(
-  calculateRunningBalances: CalculateRunningBalancesOption = false,
-) {
-  return calculateRunningBalances === true
-    ? calculateRunningBalancesBottomUp
-    : typeof calculateRunningBalances === 'function'
-      ? calculateRunningBalances
-      : undefined;
-}
-
-export function calculateRunningBalancesBottomUp(
-  transactions: TransactionEntity[],
-  splits: TransactionSplitsOption,
-  startingBalance: IntegerAmount = 0,
-) {
-  return (
-    transactions
-      .filter(t => {
-        switch (splits) {
-          case 'all':
-            // Only calculate parent/non-split amounts
-            return !t.parent_id;
-          default:
-            // inline
-            // grouped
-            // none
-            return true;
-        }
-      })
-      // We're using `reduceRight` here to calculate the running balance in reverse order (bottom up).
-      .reduceRight((acc, transaction, index, arr) => {
-        const previousTransactionIndex = index + 1;
-        if (previousTransactionIndex >= arr.length) {
-          // This is the last transaction in the list,
-          // so we set the running balance to the starting balance + the amount of the transaction
-          acc.set(transaction.id, startingBalance + transaction.amount);
-          return acc;
-        }
-        const previousTransaction = arr[previousTransactionIndex];
-        const previousRunningBalance = acc.get(previousTransaction.id) ?? 0;
-        const currentRunningBalance =
-          previousRunningBalance + transaction.amount;
-        acc.set(transaction.id, currentRunningBalance);
-        return acc;
-      }, new Map<TransactionEntity['id'], IntegerAmount>())
   );
 }

--- a/packages/desktop-client/src/hooks/useTransactions.ts
+++ b/packages/desktop-client/src/hooks/useTransactions.ts
@@ -1,12 +1,23 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 
-import type { Query } from 'loot-core/shared/query';
-import type { TransactionEntity } from 'loot-core/types/models';
+import { type Query } from 'loot-core/shared/query';
+import { type IntegerAmount } from 'loot-core/shared/util';
+import { type TransactionEntity } from 'loot-core/types/models';
 
 import {
-  type PagedQuery,
   pagedQuery,
+  type PagedQuery,
 } from '@desktop-client/queries/pagedQuery';
+
+// Mirrors the `splits` AQL option from the server
+type TransactionSplitsOption = 'all' | 'inline' | 'grouped' | 'none';
+
+type CalculateRunningBalancesOption =
+  | ((
+      transactions: TransactionEntity[],
+      splits: TransactionSplitsOption,
+    ) => Map<TransactionEntity['id'], IntegerAmount>)
+  | boolean;
 
 type UseTransactionsProps = {
   /**
@@ -14,22 +25,72 @@ type UseTransactionsProps = {
    * to prevent unnecessary re-renders i.e. `useMemo`, `useState`, etc.
    */
   query?: Query;
+  /**
+   * The options to configure the hook behavior.
+   */
   options?: {
+    /**
+     * The number of transactions to load at a time.
+     * This is used for pagination and should be set to a reasonable number
+     * to avoid loading too many transactions at once.
+     * The default is 50.
+     * @default 50
+     */
     pageCount?: number;
+    /**
+     * Whether to calculate running balances for the transactions returned by the query.
+     * This can be set to `true` to calculate running balances for all transactions
+     * (using the default running balance calculation), or a function that takes the
+     * transactions and the query state and returns a map of transaction IDs to running balances.
+     * The function will be called with the transactions and the query state
+     * whenever the transactions are loaded or reloaded.
+     *
+     * The default running balance calculation is a simple sum of the transaction amounts
+     * in reverse order (bottom up). This works well if the transactions are ordered by
+     * date in descending order. If the query orders the transactions differently,
+     * a custom `calculateRunningBalances` function should be used instead.
+     * @default false
+     */
+    calculateRunningBalances?: CalculateRunningBalancesOption;
   };
 };
+
 type UseTransactionsResult = {
+  /**
+   * The transactions returned by the query.
+   */
   transactions: ReadonlyArray<TransactionEntity>;
+  /**
+   * The running balances for the transactions returned by the query.
+   * This is only populated if `calculateRunningBalances` is either set to `true`
+   * or a function that implements the calculation in the options.
+   */
+  runningBalances: Map<TransactionEntity['id'], IntegerAmount>;
+  /**
+   * Whether the transactions are currently being loaded.
+   */
   isLoading: boolean;
+  /**
+   * An error that occurred while loading the transactions.
+   */
   error?: Error;
+  /**
+   * Reload the transactions.
+   */
   reload: () => void;
+  /**
+   * Load more transactions.
+   */
   loadMore: () => void;
+  /**
+   * Whether more transactions are currently being loaded.
+   */
   isLoadingMore: boolean;
 };
 
 export function useTransactions({
   query,
-  options = { pageCount: 50 },
+  options = { pageCount: 50, calculateRunningBalances: false },
 }: UseTransactionsProps): UseTransactionsResult {
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -37,6 +98,9 @@ export function useTransactions({
   const [transactions, setTransactions] = useState<
     ReadonlyArray<TransactionEntity>
   >([]);
+  const [runningBalances, setRunningBalances] = useState<
+    Map<TransactionEntity['id'], IntegerAmount>
+  >(new Map());
 
   const pagedQueryRef = useRef<PagedQuery<TransactionEntity> | null>(null);
 
@@ -73,6 +137,19 @@ export function useTransactions({
       onData: data => {
         if (!isUnmounted) {
           setTransactions(data);
+
+          const calculateFn = getCalculateRunningBalancesFn(
+            optionsRef.current?.calculateRunningBalances,
+          );
+          if (calculateFn) {
+            setRunningBalances(
+              calculateFn(
+                data,
+                query.state.tableOptions?.splits as TransactionSplitsOption,
+              ),
+            );
+          }
+
           setIsLoading(false);
         }
       },
@@ -109,10 +186,59 @@ export function useTransactions({
 
   return {
     transactions,
+    runningBalances,
     isLoading,
     ...(error && { error }),
     reload,
     loadMore,
     isLoadingMore,
   };
+}
+
+function getCalculateRunningBalancesFn(
+  calculateRunningBalances: CalculateRunningBalancesOption = false,
+) {
+  return calculateRunningBalances === true
+    ? calculateRunningBalancesBottomUp
+    : typeof calculateRunningBalances === 'function'
+      ? calculateRunningBalances
+      : undefined;
+}
+
+export function calculateRunningBalancesBottomUp(
+  transactions: TransactionEntity[],
+  splits: TransactionSplitsOption,
+  startingBalance: IntegerAmount = 0,
+) {
+  return (
+    transactions
+      .filter(t => {
+        switch (splits) {
+          case 'all':
+            // Only calculate parent/non-split amounts
+            return !t.parent_id;
+          default:
+            // inline
+            // grouped
+            // none
+            return true;
+        }
+      })
+      // We're using `reduceRight` here to calculate the running balance in reverse order (bottom up).
+      .reduceRight((acc, transaction, index, arr) => {
+        const previousTransactionIndex = index + 1;
+        if (previousTransactionIndex >= arr.length) {
+          // This is the last transaction in the list,
+          // so we set the running balance to the starting balance + the amount of the transaction
+          acc.set(transaction.id, startingBalance + transaction.amount);
+          return acc;
+        }
+        const previousTransaction = arr[previousTransactionIndex];
+        const previousRunningBalance = acc.get(previousTransaction.id) ?? 0;
+        const currentRunningBalance =
+          previousRunningBalance + transaction.amount;
+        acc.set(transaction.id, currentRunningBalance);
+        return acc;
+      }, new Map<TransactionEntity['id'], IntegerAmount>())
+  );
 }

--- a/upcoming-release-notes/5415.md
+++ b/upcoming-release-notes/5415.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [joel-jeremy]
+---
+
+Fix transaction hooks and improve transactions loading experience in mobile


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fix reverted changes on some hooks (could be due to incorrect rebase/merge), this PR aims to fix that + a change on the loading experience on mobile to display transactions as they load.

Meaning, normal transactions would be displayed even when the preview transactions are not yet loaded, and display the preview transactions as they load (a loading indicator would be displayed to indicate the preview transactions are still being loaded). This should improve the user experience because the preview transactions are slower to load than the normal transactions.