### PR TITLE
Fix translate rule stages

### DIFF
--- a/packages/desktop-client/e2e/help-menu.test.ts
+++ b/packages/desktop-client/e2e/help-menu.test.ts
@@ -28,6 +28,7 @@ test.describe('Help menu', () => {
     await page.getByRole('button', { name: 'Help' }).click();
     expect(page.getByText('Keyboard shortcuts')).toBeVisible();
     await expect(page).toMatchThemeScreenshots();
+    await page.keyboard.press('Escape');
   });
 
   test('Check the keyboard shortcuts modal visuals', async () => {

--- a/packages/desktop-client/src/components/rules/RuleRow.tsx
+++ b/packages/desktop-client/src/components/rules/RuleRow.tsx
@@ -13,7 +13,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { v4 as uuid } from 'uuid';
 
-import { friendlyOp } from 'loot-core/shared/rules';
+import { friendlyOp, translateRuleStage } from 'loot-core/shared/rules';
 import { type RuleEntity } from 'loot-core/types/models';
 
 import { ActionExpression } from './ActionExpression';
@@ -138,7 +138,7 @@ export const RuleRow = memo(
                 padding: '3px 5px',
               }}
             >
-              {rule.stage}
+              {translateRuleStage(rule.stage)}
             </View>
           )}
         </Cell>

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -232,6 +232,17 @@ export function friendlyOp(op, type?) {
   }
 }
 
+export function translateRuleStage(stage: string): string {
+  switch (stage) {
+    case 'pre':
+      return t('Pre');
+    case 'post':
+      return t('Post');
+    default:
+      return null;
+  }
+}
+
 export function deserializeField(field) {
   if (field === 'amount-inflow') {
     return { field: 'amount', options: { inflow: true } };

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -239,7 +239,7 @@ export function translateRuleStage(stage: string): string {
     case 'post':
       return t('Post');
     default:
-      return null;
+      return '';
   }
 }
 

--- a/upcoming-release-notes/5421.md
+++ b/upcoming-release-notes/5421.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [milanalexandre]
+---
+
+add translation support for rule stages


### PR DESCRIPTION
This PR adds internationalization support for rule stage labels in the rules interface
Fixes #5338 
<img width="705" height="527" alt="Capture d’écran 2025-07-29 à 21 35 46" src="https://github.com/user-attachments/assets/ad262501-93fa-4d6a-be56-e9860b7c1b6e" />

problematic test log : 

```
[chromium] › e2e/help-menu.test.ts:33:7 › Help menu › Check the keyboard shortcuts modal visuals 

    Test timeout of 60000ms exceeded.
    Error: locator.click: Target page, context or browser has been closed
    Call log:
      - waiting for getByRole('button', { name: 'Help' })


      32 |
      33 |   test('Check the keyboard shortcuts modal visuals', async () => {
    > 34 |     await page.getByRole('button', { name: 'Help' }).click();
         |                                                      ^
      35 |     await page.getByText('Keyboard shortcuts').click();
      36 |
      37 |     const keyboardShortcutsModal = page.getByRole('dialog', {
```