### PR TITLE
fix crash when enter is used to submit empty date in date picker

### DIFF
--- a/packages/desktop-client/src/components/select/DateSelect.tsx
+++ b/packages/desktop-client/src/components/select/DateSelect.tsx
@@ -346,11 +346,13 @@ export function DateSelect({
         onUpdate?.(defaultValue);
       }
     } else if (shouldSaveFromKey(e)) {
-      setValue(selectedValue);
-      setOpen(false);
+      if (selectedValue) {
+        setValue(selectedValue);
+        const date = parse(selectedValue, dateFormat, new Date());
+        onSelect(format(date, 'yyyy-MM-dd'));
+      }
 
-      const date = parse(selectedValue, dateFormat, new Date());
-      onSelect(format(date, 'yyyy-MM-dd'));
+      setOpen(false);
 
       if (open && e.key === 'Enter') {
         // This stops the event from propagating up

--- a/upcoming-release-notes/5423.md
+++ b/upcoming-release-notes/5423.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Serializator]
+---
+
+Fix crash when the enter key is used to submit an empty date to the date picker


### PR DESCRIPTION
This change is related to #5095.

Fixes #5304 