### PR TITLE
[WIP] Disallow the updating of transactions in a closed account which changes its balance

### DIFF
--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -436,8 +436,6 @@ async function closeAccount({
         throw APIError('balance is non-zero: transferAccountId is required');
       }
 
-      await db.update('accounts', { id, closed: 1 });
-
       // If there is a balance we need to transfer it to the specified
       // account (and possibly categorize it)
       if (balance !== 0 && transferAccountId) {
@@ -462,6 +460,8 @@ async function closeAccount({
           category: categoryId,
         });
       }
+
+      await db.update('accounts', { id, closed: 1 });
     }
   });
 }


### PR DESCRIPTION
This PR disallows the updating of transactions in closed accounts in ways it would affect its balance.

The changes are two-part. There is the enforcement on the API level to ensure this can't happen. Then there is the UI / UX to prevent the end-user from updating "attributes" of a transaction which may affect the balance of the account.

Currently I'm working under the assumption the primary ways this may happen is by updating the amount of a transaction or even updating the account which a transaction belongs to.

---

Fixes #5413