### PR TITLE
fix filter transactions by closed account transfer payee

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -457,6 +457,7 @@ export default pluginTypescript.config(
         'warn',
         {
           varsIgnorePattern: '^(_|React)',
+          argsIgnorePattern: '^(_|React)',
           ignoreRestSiblings: true,
           caughtErrors: 'none',
         },

--- a/packages/desktop-client/src/components/FixedSizeList.tsx
+++ b/packages/desktop-client/src/components/FixedSizeList.tsx
@@ -477,7 +477,6 @@ export class FixedSizeList extends PureComponent<
     return style;
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _getItemStyleCache = memoizeOne((_, __, ___) => ({}));
 
   _getRangeToRender() {

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -88,16 +88,13 @@ function getPayeeSuggestions(
 
 function filterActivePayees(
   payees: PayeeAutocompleteItem[],
-  focusTransferPayees: boolean,
   accounts: AccountEntity[],
 ) {
-  let activePayees = accounts ? getActivePayees(payees, accounts) : payees;
+  return accounts ? getActivePayees(payees, accounts) : payees;
+}
 
-  if (focusTransferPayees && activePayees) {
-    activePayees = activePayees.filter(p => !!p.transfer_acct);
-  }
-
-  return activePayees || [];
+function filterTransferPayees(payees: PayeeAutocompleteItem[]) {
+  return payees.filter(payee => !!payee.transfer_acct);
 }
 
 function makeNew(id, rawPayee) {
@@ -256,6 +253,7 @@ function PayeeList({
 export type PayeeAutocompleteProps = ComponentProps<
   typeof Autocomplete<PayeeAutocompleteItem>
 > & {
+  showInactivePayees?: boolean;
   showMakeTransfer?: boolean;
   showManagePayees?: boolean;
   embedded?: boolean;
@@ -276,6 +274,7 @@ export type PayeeAutocompleteProps = ComponentProps<
 export function PayeeAutocomplete({
   value,
   inputProps,
+  showInactivePayees = false,
   showMakeTransfer = true,
   showManagePayees = false,
   clearOnBlur = true,
@@ -307,18 +306,30 @@ export function PayeeAutocomplete({
   const hasPayeeInput = !!rawPayee;
   const payeeSuggestions: PayeeAutocompleteItem[] = useMemo(() => {
     const suggestions = getPayeeSuggestions(commonPayees, payees);
-    const filteredSuggestions = filterActivePayees(
-      suggestions,
-      focusTransferPayees,
-      accounts,
-    );
+
+    let filteredSuggestions: PayeeAutocompleteItem[] = [...suggestions];
+
+    if (!showInactivePayees) {
+      filteredSuggestions = filterActivePayees(filteredSuggestions, accounts);
+    }
+
+    if (focusTransferPayees) {
+      filteredSuggestions = filterTransferPayees(filteredSuggestions);
+    }
 
     if (!hasPayeeInput) {
       return filteredSuggestions;
     }
 
     return [{ id: 'new', favorite: false, name: '' }, ...filteredSuggestions];
-  }, [commonPayees, payees, focusTransferPayees, accounts, hasPayeeInput]);
+  }, [
+    commonPayees,
+    payees,
+    focusTransferPayees,
+    accounts,
+    hasPayeeInput,
+    showInactivePayees,
+  ]);
 
   const dispatch = useDispatch();
 

--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -35,6 +35,7 @@ import { titleFirst } from 'loot-core/shared/util';
 import { CompactFiltersButton } from './CompactFiltersButton';
 import { FiltersButton } from './FiltersButton';
 import { OpButton } from './OpButton';
+import { PayeeFilter } from './PayeeFilter';
 import { subfieldFromFilter } from './subfieldFromFilter';
 import { subfieldToOptions } from './subfieldToOptions';
 import { updateFilterReducer } from './updateFilterReducer';
@@ -229,7 +230,7 @@ function ConfigureField({
           });
         }}
       >
-        {type !== 'boolean' && (
+        {type !== 'boolean' && field !== 'payee' && (
           <GenericInput
             ref={inputRef}
             field={field}
@@ -250,6 +251,14 @@ function ConfigureField({
             onChange={v => {
               dispatch({ type: 'set-value', value: v });
             }}
+          />
+        )}
+
+        {field === 'payee' && (
+          <PayeeFilter
+            value={formattedValue}
+            op={op}
+            onChange={v => dispatch({ type: 'set-value', value: v })}
           />
         )}
 

--- a/packages/desktop-client/src/components/filters/PayeeFilter.tsx
+++ b/packages/desktop-client/src/components/filters/PayeeFilter.tsx
@@ -39,10 +39,11 @@ export const PayeeFilter = ({ value, op, onChange }: PayeeFilterProps) => {
   if (multi) {
     coercedValue = Array.isArray(value) ? value : [];
   } else {
-    coercedValue = Array.isArray(value) ? value[0] ?? null : value;
+    coercedValue = Array.isArray(value) ? (value[0] ?? null) : value;
   }
 
-  const placeholder = multi && coercedValue.length > 0 ? undefined : t('nothing');
+  const placeholder =
+    multi && coercedValue.length > 0 ? undefined : t('nothing');
 
   return (
     // @ts-ignore: typing is not playing nicely with the union type of AutocompleteProps.

--- a/packages/desktop-client/src/components/filters/PayeeFilter.tsx
+++ b/packages/desktop-client/src/components/filters/PayeeFilter.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  PayeeAutocomplete,
+  type PayeeAutocompleteItem,
+} from '@desktop-client/components/autocomplete/PayeeAutocomplete';
+
+type PayeeFilterValue =
+  | PayeeAutocompleteItem['id']
+  | PayeeAutocompleteItem['id'][];
+
+/** This component only supports single- or multi-select operations. */
+type PayeeFilterOp = 'is' | 'isNot' | 'oneOf' | 'notOneOf';
+
+type PayeeFilterProps = {
+  /** The selected value(s) of the filter. This is a controlled component. */
+  value: PayeeFilterValue;
+
+  /** To determine the use of a single- or multi-select input. */
+  op: PayeeFilterOp;
+
+  /** Called whenever the selected value(s) of the filter change. */
+  onChange: (value: PayeeFilterValue) => void;
+};
+
+/**
+ * Component to filter on payee.
+ *
+ * This component also shows "inactive" payees, specifically meant for transfer payees
+ * whose account are closed. This lets the end-user filter transactions (among others)
+ * based on transfer payees of closed accounts.
+ */
+export const PayeeFilter = ({ value, op, onChange }: PayeeFilterProps) => {
+  const { t } = useTranslation();
+  const multi = ['oneOf', 'notOneOf'].includes(op);
+
+  let coercedValue: PayeeFilterValue = value;
+  if (multi) {
+    coercedValue = Array.isArray(value) ? value : [];
+  } else {
+    coercedValue = Array.isArray(value) ? value[0] ?? null : value;
+  }
+
+  const placeholder = multi && coercedValue.length > 0 ? undefined : t('nothing');
+
+  return (
+    // @ts-ignore: typing is not playing nicely with the union type of AutocompleteProps.
+    <PayeeAutocomplete
+      type={multi ? 'multi' : 'single'}
+      showInactivePayees={true}
+      showMakeTransfer={false}
+      openOnFocus={true}
+      value={coercedValue}
+      inputProps={{ placeholder }}
+      onSelect={(payeeIdOrIds: string | string[], _: string) =>
+        onChange(payeeIdOrIds)
+      }
+    />
+  );
+};

--- a/upcoming-release-notes/5438.md
+++ b/upcoming-release-notes/5438.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Serializator]
+---
+
+Allow filter based on transfer payee from closed account


### PR DESCRIPTION
The `GenericInput` component automatically filters transfer payees from closed accounts.

This behavior is desirable  when payees to be selected must exist (e.g. set the payee of a transaction) but less so when you want to filter on a transfer payee from a closed account.

I decided not to "hack" this into the existing `GenericInput` component but create a `PayeeFilter` component. Hacking it into the `GenericInput` component would've required prop drilling from `FiltersMenu` into the `GenericInput` to the `PayeeAutocomplete` component. Adding yet another property to the `GenericInput` which is only meant for **one** type, as already done with the `multi` property which is only relevant for autocomplete.

This PR also contains the slight refactoring of `filterActivePayees` to extract logic about transfer payees which now needs to be independent of whether the transfer payee is active or not.

I decided to keep `filterActivePayees` even though in reality it only wraps another function. The reason for this decision is to make the intent immediately obvious, to filter. This can of course be changed if preferred.

**What about the TypeScript ignore?** 💥 

Yes... Hiding from your problems does not make them go away! This is different, as always... Typing is not playing nice with the union type of `AutocompleteProps` which is a union of `SingleAutocompleteProps` and `MultiAutocompleteProps` where the `type` and `onSelect` are problematic.

I wasn't able to get this to work nicely and I tried to do so for hours.

```
yarn packages/desktop-client/src/components/filters/PayeeFilter.tsx:39:11 - error TS2322: Type '{ type: "single" | "multi"; showInactivePayees: true; showMakeTransfer: false; openOnFocus: true; value: PayeeFilterValue; inputProps: { placeholder: string; }; onSelect: (payeeIdOrIds: string | string[], _: string) => void; }' is not assignable to type 'IntrinsicAttributes & PayeeAutocompleteProps'.
  Type '{ type: "single" | "multi"; showInactivePayees: true; showMakeTransfer: false; openOnFocus: true; value: PayeeFilterValue; inputProps: { placeholder: string; }; onSelect: (payeeIdOrIds: string | string[], _: string) => void; }' is not assignable to type '{ type: "multi"; onSelect: (ids: string[], id?: string) => void; value: string[] | PayeeEntity[]; }'.
    Types of property 'type' are incompatible.
      Type '"single" | "multi"' is not assignable to type '"multi"'.
        Type '"single"' is not assignable to type '"multi"'.

39   return <PayeeAutocomplete
```

----

Fixes #5370