### PR TITLE
improvements to release PR points counting logic

### DIFF
--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -173,15 +173,17 @@ async function countContributorPoints(repo) {
       config.PR_REVIEW_POINT_TIERS.find(tier => totalChanges >= tier.minChanges)
         ?.points ?? 0;
 
-    // Award points to the PR creator if it's a release PR
-    if (isReleasePR && stats.has(pr.user.login)) {
-      const creatorStats = stats.get(pr.user.login);
-      creatorStats.reviews.push({
-        pr: pr.number.toString(),
-        points: config.POINTS_PER_RELEASE_PR,
-        isReleaseCreator: true,
-      });
-      creatorStats.points += config.POINTS_PER_RELEASE_PR;
+    if (isReleasePR) {
+      // Award points to the PR creator if it's a release PR
+      if (stats.has(pr.user.login)) {
+        const creatorStats = stats.get(pr.user.login);
+        creatorStats.reviews.push({
+          pr: pr.number.toString(),
+          points: config.POINTS_PER_RELEASE_PR,
+          isReleaseCreator: true,
+        });
+        creatorStats.points += config.POINTS_PER_RELEASE_PR;
+      }
     } else {
       // Add points to the reviewers
       const uniqueReviewers = new Set();

--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -166,7 +166,7 @@ async function countContributorPoints(repo) {
       .reduce((sum, file) => sum + file.additions + file.deletions, 0);
 
     // Check if this is a release PR
-    const isReleasePR = pr.title.match(/^🔖 \(\d+\.\d+\.\d+\)/);
+    const isReleasePR = pr.title.match(/🔖.*\d+\.\d+\.\d+/);
 
     // Calculate points for reviewers based on PR size
     const prPoints =


### PR DESCRIPTION
1) Reviewers of release PRs created by the bot were being credited for the review.
https://github.com/actualbudget/actual/actions/runs/16696074125/job/47260378227
> matt-fidd: 24 (PRs: ... #5272 (2pts) ...)

2) Release regex too strict to consider below PR title as release
https://github.com/actualbudget/docs/pull/740