### PR TITLE
feat: show/hide balance graph in side nav

### DIFF
--- a/packages/component-library/src/SpaceBetween.tsx
+++ b/packages/component-library/src/SpaceBetween.tsx
@@ -1,5 +1,6 @@
-import React, { type CSSProperties, type ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
+import { type CSSProperties } from './styles';
 import { View } from './View';
 
 type SpaceBetweenProps = {

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -1,13 +1,9 @@
 // @ts-strict-ignore
 import React, { type CSSProperties, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { AlignedText } from '@actual-app/components/aligned-text';
 import { Button } from '@actual-app/components/button';
-import {
-  SvgCheveronDown,
-  SvgCheveronUp,
-} from '@actual-app/components/icons/v1';
 import {
   SvgArrowButtonDown1,
   SvgArrowButtonUp1,

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -1,11 +1,18 @@
 // @ts-strict-ignore
 import React, { type CSSProperties, useRef, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { AlignedText } from '@actual-app/components/aligned-text';
+import { Button } from '@actual-app/components/button';
+import {
+  SvgCheveronDown,
+  SvgCheveronUp,
+} from '@actual-app/components/icons/v1';
 import { InitialFocus } from '@actual-app/components/initial-focus';
 import { Input } from '@actual-app/components/input';
 import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
+import { SpaceBetween } from '@actual-app/components/space-between';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
@@ -31,6 +38,7 @@ import { CellValue } from '@desktop-client/components/spreadsheet/CellValue';
 import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
 import { useDragRef } from '@desktop-client/hooks/useDragRef';
 import { useNotes } from '@desktop-client/hooks/useNotes';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { openAccountCloseModal } from '@desktop-client/modals/modalsSlice';
 import {
   reopenAccount,
@@ -83,6 +91,7 @@ export function Account<FieldName extends SheetFields<'account'>>({
   onDrop,
   titleAccount,
 }: AccountProps<FieldName>) {
+  const { t } = useTranslation();
   const type = account
     ? account.closed
       ? 'account-closed'
@@ -108,6 +117,10 @@ export function Account<FieldName extends SheetFields<'account'>>({
     id: account && account.id,
     onDrop,
   });
+
+  const [showBalanceHistory, setShowBalanceHistory] = useSyncedPref(
+    `side-nav.show-balance-history-${account?.id}`,
+  );
 
   const dispatch = useDispatch();
 
@@ -281,14 +294,35 @@ export function Account<FieldName extends SheetFields<'account'>>({
             padding: 10,
           }}
         >
-          <Text
-            style={{
-              fontWeight: 'bold',
-            }}
-          >
-            {name}
-          </Text>
-          {account && <BalanceHistoryGraph accountId={account.id} />}
+          <SpaceBetween style={{ justifyContent: 'space-between' }}>
+            <Text
+              style={{
+                fontWeight: 'bold',
+              }}
+            >
+              {name}
+            </Text>
+            <Button
+              aria-label={t('Toggle balance history')}
+              onClick={() =>
+                setShowBalanceHistory(
+                  showBalanceHistory === 'true' ? 'false' : 'true',
+                )
+              }
+            >
+              <SpaceBetween gap={3}>
+                {showBalanceHistory === 'true' ? (
+                  <SvgCheveronUp width={14} height={14} />
+                ) : (
+                  <SvgCheveronDown width={14} height={14} />
+                )}
+                <Trans>Balance graph</Trans>
+              </SpaceBetween>
+            </Button>
+          </SpaceBetween>
+          {showBalanceHistory === 'true' && account && (
+            <BalanceHistoryGraph accountId={account.id} />
+          )}
           {accountNote && (
             <Notes
               getStyle={() => ({

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -8,6 +8,10 @@ import {
   SvgCheveronDown,
   SvgCheveronUp,
 } from '@actual-app/components/icons/v1';
+import {
+  SvgArrowButtonDown1,
+  SvgArrowButtonUp1,
+} from '@actual-app/components/icons/v2';
 import { InitialFocus } from '@actual-app/components/initial-focus';
 import { Input } from '@actual-app/components/input';
 import { Menu } from '@actual-app/components/menu';
@@ -294,7 +298,19 @@ export function Account<FieldName extends SheetFields<'account'>>({
             padding: 10,
           }}
         >
-          <SpaceBetween style={{ justifyContent: 'space-between' }}>
+          <SpaceBetween
+            gap={5}
+            style={{
+              justifyContent: 'space-between',
+              '& .hover-visible': {
+                opacity: 0,
+                transition: 'opacity .25s',
+              },
+              '&:hover .hover-visible': {
+                opacity: 1,
+              },
+            }}
+          >
             <Text
               style={{
                 fontWeight: 'bold',
@@ -304,19 +320,20 @@ export function Account<FieldName extends SheetFields<'account'>>({
             </Text>
             <Button
               aria-label={t('Toggle balance history')}
+              variant="bare"
               onClick={() =>
                 setShowBalanceHistory(
                   showBalanceHistory === 'true' ? 'false' : 'true',
                 )
               }
+              className="hover-visible"
             >
               <SpaceBetween gap={3}>
                 {showBalanceHistory === 'true' ? (
-                  <SvgCheveronUp width={14} height={14} />
+                  <SvgArrowButtonUp1 width={10} height={10} />
                 ) : (
-                  <SvgCheveronDown width={14} height={14} />
+                  <SvgArrowButtonDown1 width={10} height={10} />
                 )}
-                <Trans>Balance graph</Trans>
               </SpaceBetween>
             </Button>
           </SpaceBetween>

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -20,6 +20,7 @@ export type SyncedPrefs = Partial<
     | 'currencySymbolPosition'
     | 'currencySpaceBetweenAmountAndSymbol'
     | 'defaultCurrencyCode'
+    | `side-nav.show-balance-history-${string}`
     | `show-balances-${string}`
     | `show-extra-balances-${string}`
     | `hide-cleared-${string}`

--- a/upcoming-release-notes/5452.md
+++ b/upcoming-release-notes/5452.md
@@ -1,0 +1,7 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Add toggle feature to show/hide balance history graph in sidebar account tooltip.
+


### PR DESCRIPTION
Improving the balance graph in side nav by making it less intrusive - ability to toggle it on/off per account. By default it is off.

Let me know if you have any feedback and/or thoughts.

<img width="663" height="213" alt="Screenshot 2025-08-02 at 21 41 01" src="https://github.com/user-attachments/assets/60a6a3d0-c318-412f-b2ce-8a24132d2fbf" />
