### PR TITLE
fix tag colors when using the light theme as system default

### DIFF
--- a/packages/desktop-client/src/style/tags.ts
+++ b/packages/desktop-client/src/style/tags.ts
@@ -25,6 +25,12 @@ export function useTags() {
 }
 
 function getTagCSSColors(theme: Theme, color?: string | null) {
+  if (theme === 'auto') {
+    theme = window.matchMedia('(prefers-color-scheme: light)').matches
+      ? 'light'
+      : 'dark';
+  }
+
   if (theme === 'light') {
     return [
       color ? `${color} !important` : themeStyle.noteTagText,

--- a/upcoming-release-notes/5457.md
+++ b/upcoming-release-notes/5457.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix tag colors when using the light theme as system default


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5463
First reported in Discord
https://discord.com/channels/937901803608096828/1273368072555729098/1401321211291631728


Reproduction instructions:
1) Set system to light theme
2) Set theme in actual to "system default"
3) Observe that tags use the dark mode colourings instead of light