### PR TITLE
make payeeName fall back to default if the custom mapped bank sync field is missing

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -407,7 +407,7 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
     const mapping = mappings.get(trans.amount <= 0 ? 'payment' : 'deposit');
 
     const date = trans[mapping.get('date')] ?? trans.date;
-    const payeeName = trans[mapping.get('payee')];
+    const payeeName = trans[mapping.get('payee')] ?? trans.payeeName;
     const notes = trans[mapping.get('notes')];
 
     // Validate the date because we do some stuff with it. The db

--- a/upcoming-release-notes/5460.md
+++ b/upcoming-release-notes/5460.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Make payee fall back to default if the custom mapped field is missing


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5367