### PR TITLE
Fix display of old payee name in MergeUnusedPayees modal

### DIFF
--- a/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
+++ b/packages/desktop-client/src/components/modals/MergeUnusedPayeesModal.tsx
@@ -112,7 +112,7 @@ export function MergeUnusedPayeesModal({
                 <Trans>
                   The payee{' '}
                   <Text style={highlightStyle}>
-                    {{ payee: payees[0].name } as TransObjectLiteral}
+                    {{ previousPayee: payees[0].name } as TransObjectLiteral}
                   </Text>{' '}
                   is not used by transactions any more. Would you like to merge
                   it with{' '}

--- a/upcoming-release-notes/5485.md
+++ b/upcoming-release-notes/5485.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [r1ch]
+---
+
+Display name of old payee correctly when merging


### PR DESCRIPTION
Fix for : https://github.com/actualbudget/actual/issues/5481
