### PR TITLE
fix live report date mode not supporting a 2 month window

### DIFF
--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -160,7 +160,7 @@ export function Header({
             {show1Month && (
               <Button
                 variant="bare"
-                onPress={() => onChangeDates(...getLatestRange(1))}
+                onPress={() => onChangeDates(...getLatestRange(0))}
               >
                 <Trans>1 month</Trans>
               </Button>

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -161,10 +161,8 @@ export function getFullRange(start: string) {
 
 export function getLatestRange(offset: number) {
   const end = monthUtils.currentMonth();
-  let start = end;
-  if (offset !== 1) {
-    start = monthUtils.subMonths(end, offset);
-  }
+  const start = monthUtils.subMonths(end, offset);
+
   return [start, end, 'sliding-window'] as const;
 }
 

--- a/upcoming-release-notes/5495.md
+++ b/upcoming-release-notes/5495.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix live report date mode not supporting a 2 month window


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/3988

I'm not sure what this if statement was originally in there to catch, but I'd imagine it was because the one month window was using a positive offset instead of 0.