### PR TITLE
Hide hold for next month option when "to budget" is negative

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
@@ -43,7 +43,7 @@ export function ToBudgetMenu({
           },
         ]
       : []),
-    ...(autoBuffered === 0
+    ...(autoBuffered === 0 && toBudget > 0
       ? [
           {
             name: 'buffer',

--- a/upcoming-release-notes/5496.md
+++ b/upcoming-release-notes/5496.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Hide hold for next month option when "to budget" is negative


### PR DESCRIPTION
It keeps confusing me when I go to cover overspend "to budget", I think it must have changed at some point! You can't hold a negative amount, so the menu option doesn't do anything.