### PR TITLE
[BUG] Fix incorrect mathematic calculation in reconcile window

### DIFF
--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { generateAccount } from 'loot-core/mocks';
+import { q } from 'loot-core/shared/query';
 import { type AccountEntity } from 'loot-core/types/models';
 
 import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
@@ -26,9 +28,9 @@ describe('ReconcilingMessage math & UI', () => {
 
   function makeBalanceQuery() {
     return {
-      name: 'balance-query-test',
-      query: { filter: () => ({}) },
-    } as const;
+      name: 'balance-query-test' as const,
+      query: q('transactions'),
+    };
   }
 
   test('shows "All reconciled!" when target matches cleared', async () => {
@@ -121,14 +123,8 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     vi.clearAllMocks();
   });
 
-  const baseAccount = {
-    id: 'acct-1',
-    name: 'Checking',
-    last_reconciled: null,
-    offbudget: false,
-    closed: false,
-    balance_current: 5555, // 55.55
-  } as const;
+  // Create a valid offline account entity
+  const baseAccount: AccountEntity = generateAccount('Checking', false, false);
 
   test('defaults input to cleared balance and submits evaluated integer amount', async () => {
     // clearedBalance = 123.45
@@ -169,7 +165,11 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     render(
       <TestProvider>
         <ReconcileMenu
-          account={{ ...baseAccount, balance_current: 4321 } as AccountEntity}
+          account={{
+            // Use a connected account shape so balance_current is allowed
+            ...generateAccount('Checking', true, false),
+            balance_current: 4321,
+          }}
           onReconcile={onReconcile}
           onClose={onClose}
         />

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
+
+import { TestProvider } from '@desktop-client/redux/mock';
+import { useSheetValue } from '../../hooks/useSheetValue';
+
+vi.mock('../../hooks/useSheetValue', () => ({
+  useSheetValue: vi.fn(),
+}));
+
+// Use actual arithmetic and util functions for real math behavior
+// (we rely on default decimalPlaces=2 semantics for integer amounts)
+
+describe('ReconcilingMessage math & UI', () => {
+  // useSheetValue is mocked above via relative path
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeBalanceQuery() {
+    return {
+      name: 'balance-query-test',
+      query: { filter: () => ({}) },
+    } as const;
+  }
+
+  test('shows "All reconciled!" when target matches cleared', async () => {
+    vi.mocked(useSheetValue).mockReturnValue(5000);
+
+    const onDone = vi.fn();
+    const onCreateTransaction = vi.fn();
+
+    render(
+      <TestProvider>
+        <ReconcilingMessage
+          balanceQuery={makeBalanceQuery()}
+          targetBalance={5000}
+          onDone={onDone}
+          onCreateTransaction={onCreateTransaction}
+        />
+      </TestProvider>,
+    );
+
+    expect(screen.getByText('All reconciled!')).toBeInTheDocument();
+    // No reconciliation transaction button when diff is zero
+    expect(
+      screen.queryByText('Create reconciliation transaction'),
+    ).not.toBeInTheDocument();
+
+    // Done button triggers callback
+    await userEvent.click(screen.getByText('Done reconciling'));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  test('computes positive difference and passes correct amount', async () => {
+    // cleared = 30.00, bank = 100.00 => diff = +70.00
+    vi.mocked(useSheetValue).mockReturnValue(3000);
+    const onCreateTransaction = vi.fn();
+
+    render(
+      <TestProvider>
+        <ReconcilingMessage
+          balanceQuery={makeBalanceQuery()}
+          targetBalance={10000}
+          onDone={() => {}}
+          onCreateTransaction={onCreateTransaction}
+        />
+      </TestProvider>,
+    );
+
+    // Formatted amounts present
+    expect(screen.getByText('30.00')).toBeInTheDocument();
+    expect(screen.getByText('100.00')).toBeInTheDocument();
+    // Positive diff shows plus sign
+    expect(screen.getByText('+70.00')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Create reconciliation transaction'));
+    expect(onCreateTransaction).toHaveBeenCalledWith(7000);
+  });
+
+  test('computes negative difference and passes correct amount', async () => {
+    // cleared = 120.00, bank = 100.00 => diff = -20.00
+    vi.mocked(useSheetValue).mockReturnValue(12000);
+    const onCreateTransaction = vi.fn();
+
+    render(
+      <TestProvider>
+        <ReconcilingMessage
+          balanceQuery={makeBalanceQuery()}
+          targetBalance={10000}
+          onDone={() => {}}
+          onCreateTransaction={onCreateTransaction}
+        />
+      </TestProvider>,
+    );
+
+    expect(screen.getByText('120.00')).toBeInTheDocument();
+    expect(screen.getByText('100.00')).toBeInTheDocument();
+    expect(screen.getByText('-20.00')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Create reconciliation transaction'));
+    expect(onCreateTransaction).toHaveBeenCalledWith(-2000);
+  });
+});
+
+describe('ReconcileMenu arithmetic evaluation', () => {
+  // useSheetValue is mocked above via relative path
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseAccount = {
+    id: 'acct-1',
+    name: 'Checking',
+    last_reconciled: null,
+    offbudget: false,
+    closed: false,
+    balance_current: 5555, // 55.55
+  } as const;
+
+  test('defaults input to cleared balance and submits evaluated integer amount', async () => {
+    // clearedBalance = 123.45
+    vi.mocked(useSheetValue).mockReturnValue(12345);
+    const onReconcile = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <TestProvider>
+        <ReconcileMenu
+          account={baseAccount as any}
+          onReconcile={onReconcile}
+          onClose={onClose}
+        />
+      </TestProvider>,
+    );
+
+    const input = screen.getByRole('textbox');
+    // Replace with arithmetic expression
+    await userEvent.clear(input);
+    await userEvent.type(input, '100+25.50-10');
+
+    // Submit
+    await userEvent.click(screen.getByRole('button', { name: 'Reconcile' }));
+
+    // 100 + 25.50 - 10 = 115.50 -> 11550 integer
+    expect(onReconcile).toHaveBeenCalledWith(11550);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking "Use last synced total" fills and submits that amount', async () => {
+    // clearedBalance present so input renders
+    vi.mocked(useSheetValue).mockReturnValue(1000);
+
+    const onReconcile = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <TestProvider>
+        <ReconcileMenu
+          account={{ ...baseAccount, balance_current: 4321 } as any}
+          onReconcile={onReconcile}
+          onClose={onClose}
+        />
+      </TestProvider>,
+    );
+
+    // Fill from last synced value (43.21)
+    await userEvent.click(screen.getByText('Use last synced total'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reconcile' }));
+    expect(onReconcile).toHaveBeenCalledWith(4321);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('submitting with empty input does not reconcile', async () => {
+    vi.mocked(useSheetValue).mockReturnValue(2222);
+
+    const onReconcile = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <TestProvider>
+        <ReconcileMenu
+          account={baseAccount as any}
+          onReconcile={onReconcile}
+          onClose={onClose}
+        />
+      </TestProvider>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await userEvent.clear(input);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reconcile' }));
+    expect(onReconcile).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('when cleared balance is not available, submits null', async () => {
+    // No cleared balance -> input is not rendered
+    vi.mocked(useSheetValue).mockReturnValue(null);
+
+    const onReconcile = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <TestProvider>
+        <ReconcileMenu
+          account={baseAccount as any}
+          onReconcile={onReconcile}
+          onClose={onClose}
+        />
+      </TestProvider>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Reconcile' }));
+    expect(onReconcile).toHaveBeenCalledWith(null);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { generateAccount } from 'loot-core/mocks';
 import { q } from 'loot-core/shared/query';
-import { type AccountEntity, type _SyncFields } from 'loot-core/types/models';
+import { type AccountEntity } from 'loot-core/types/models';
 
 import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
 
@@ -163,9 +163,11 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     const onClose = vi.fn();
 
     // Ensure the account is the connected variant so balance_current is a number
-    const connectedAccount =
-      generateAccount('Checking', true, false) as AccountEntity &
-        _SyncFields<true>;
+    const connectedAccount = generateAccount(
+      'Checking',
+      true,
+      false,
+    ) as AccountEntity;
     connectedAccount.balance_current = 4321;
 
     render(

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+import { type AccountEntity } from 'loot-core/types/models';
 
 import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
 
+
+import { useSheetValue } from '@desktop-client/hooks/useSheetValue';
 import { TestProvider } from '@desktop-client/redux/mock';
-import { useSheetValue } from '../../hooks/useSheetValue';
 
 vi.mock('../../hooks/useSheetValue', () => ({
   useSheetValue: vi.fn(),
@@ -136,7 +140,7 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     render(
       <TestProvider>
         <ReconcileMenu
-          account={baseAccount as any}
+          account={baseAccount as AccountEntity}
           onReconcile={onReconcile}
           onClose={onClose}
         />
@@ -166,7 +170,7 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     render(
       <TestProvider>
         <ReconcileMenu
-          account={{ ...baseAccount, balance_current: 4321 } as any}
+          account={{ ...baseAccount, balance_current: 4321 } as AccountEntity}
           onReconcile={onReconcile}
           onClose={onClose}
         />
@@ -189,7 +193,7 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     render(
       <TestProvider>
         <ReconcileMenu
-          account={baseAccount as any}
+          account={baseAccount as AccountEntity}
           onReconcile={onReconcile}
           onClose={onClose}
         />
@@ -213,7 +217,7 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     render(
       <TestProvider>
         <ReconcileMenu
-          account={baseAccount as any}
+          account={baseAccount as AccountEntity}
           onReconcile={onReconcile}
           onClose={onClose}
         />

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { generateAccount } from 'loot-core/mocks';
 import { q } from 'loot-core/shared/query';
-import { type AccountEntity } from 'loot-core/types/models';
+import { type AccountEntity, type _SyncFields } from 'loot-core/types/models';
 
 import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
 
@@ -162,14 +162,16 @@ describe('ReconcileMenu arithmetic evaluation', () => {
     const onReconcile = vi.fn();
     const onClose = vi.fn();
 
+    // Ensure the account is the connected variant so balance_current is a number
+    const connectedAccount =
+      generateAccount('Checking', true, false) as AccountEntity &
+        _SyncFields<true>;
+    connectedAccount.balance_current = 4321;
+
     render(
       <TestProvider>
         <ReconcileMenu
-          account={{
-            // Use a connected account shape so balance_current is allowed
-            ...generateAccount('Checking', true, false),
-            balance_current: 4321,
-          }}
+          account={connectedAccount}
           onReconcile={onReconcile}
           onClose={onClose}
         />

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -7,7 +7,6 @@ import { type AccountEntity } from 'loot-core/types/models';
 
 import { ReconcilingMessage, ReconcileMenu } from './Reconcile';
 
-
 import { useSheetValue } from '@desktop-client/hooks/useSheetValue';
 import { TestProvider } from '@desktop-client/redux/mock';
 

--- a/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.test.tsx
@@ -78,7 +78,9 @@ describe('ReconcilingMessage math & UI', () => {
     // Positive diff shows plus sign
     expect(screen.getByText('+70.00')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Create reconciliation transaction'));
+    await userEvent.click(
+      screen.getByText('Create reconciliation transaction'),
+    );
     expect(onCreateTransaction).toHaveBeenCalledWith(7000);
   });
 
@@ -102,7 +104,9 @@ describe('ReconcilingMessage math & UI', () => {
     expect(screen.getByText('100.00')).toBeInTheDocument();
     expect(screen.getByText('-20.00')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('Create reconciliation transaction'));
+    await userEvent.click(
+      screen.getByText('Create reconciliation transaction'),
+    );
     expect(onCreateTransaction).toHaveBeenCalledWith(-2000);
   });
 });

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -13,7 +13,8 @@ import { View } from '@actual-app/components/view';
 import { t } from 'i18next';
 
 import { type Query } from 'loot-core/shared/query';
-import { currencyToInteger, tsToRelativeTime } from 'loot-core/shared/util';
+import { evalArithmetic } from 'loot-core/shared/arithmetic';
+import { currencyToInteger, tsToRelativeTime, amountToInteger } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 
@@ -154,8 +155,8 @@ export function ReconcileMenu({
       return;
     }
 
-    const amount =
-      inputValue != null ? currencyToInteger(inputValue) : clearedBalance;
+    const evaluatedAmount = inputValue != null ? evalArithmetic(inputValue) : null;
+    const amount = evaluatedAmount != null ? amountToInteger(evaluatedAmount) : clearedBalance;
 
     onReconcile(amount);
     onClose();

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -12,13 +12,9 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { t } from 'i18next';
 
-import { type Query } from 'loot-core/shared/query';
 import { evalArithmetic } from 'loot-core/shared/arithmetic';
-import {
-  currencyToInteger,
-  tsToRelativeTime,
-  amountToInteger,
-} from 'loot-core/shared/util';
+import { type Query } from 'loot-core/shared/query';
+import { tsToRelativeTime, amountToInteger } from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -14,7 +14,11 @@ import { t } from 'i18next';
 
 import { type Query } from 'loot-core/shared/query';
 import { evalArithmetic } from 'loot-core/shared/arithmetic';
-import { currencyToInteger, tsToRelativeTime, amountToInteger } from 'loot-core/shared/util';
+import {
+  currencyToInteger,
+  tsToRelativeTime,
+  amountToInteger,
+} from 'loot-core/shared/util';
 import { type AccountEntity } from 'loot-core/types/models';
 import { type TransObjectLiteral } from 'loot-core/types/util';
 
@@ -155,8 +159,12 @@ export function ReconcileMenu({
       return;
     }
 
-    const evaluatedAmount = inputValue != null ? evalArithmetic(inputValue) : null;
-    const amount = evaluatedAmount != null ? amountToInteger(evaluatedAmount) : clearedBalance;
+    const evaluatedAmount =
+      inputValue != null ? evalArithmetic(inputValue) : null;
+    const amount =
+      evaluatedAmount != null
+        ? amountToInteger(evaluatedAmount)
+        : clearedBalance;
 
     onReconcile(amount);
     onClose();

--- a/upcoming-release-notes/5528.md
+++ b/upcoming-release-notes/5528.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [junyuanz1]
+---
+
+Fix incorrect mathematical equation calculations in the  reconcile window (Bug #5527)


### PR DESCRIPTION
  Purpose: Fix incorrect mathematical equation calculations in the
  reconcile window (Bug #5527)

  Key Changes:
  1. Fixed arithmetic evaluation in Reconcile.tsx:155-163:
    - Replaced currencyToInteger() with proper arithmetic evaluation using
  evalArithmetic()
    - Added amountToInteger() for correct amount conversion
    - Now properly evaluates mathematical expressions (e.g.,
  "100+25.50-10") instead of treating them as literal strings
  2. Added comprehensive test coverage in Reconcile.test.tsx:
    - 231 lines of new tests covering reconciliation math scenarios
    - Tests for positive/negative differences, arithmetic expressions, edge
   cases
    - Validates that reconciliation amounts are correctly calculated and
  passed

  Impact: Users can now enter mathematical expressions in reconcile inputs
  and have them properly evaluated, fixing the core calculation bug