### PR TITLE
Fix display of link schedules condition

### DIFF
--- a/packages/component-library/src/View.tsx
+++ b/packages/component-library/src/View.tsx
@@ -23,7 +23,11 @@ export const View = forwardRef<HTMLDivElement, ViewProps>((props, ref) => {
       {...restProps}
       ref={innerRef ?? ref}
       style={nativeStyle}
-      className={cx('view', className, css(style))}
+      className={cx(
+        'view',
+        className,
+        style && Object.keys(style).length > 0 ? css(style) : undefined,
+      )}
     />
   );
 });

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -406,7 +406,7 @@ function ScheduleDescription({ id }) {
           marginRight: 15,
         }}
       >
-        <SpaceBetween gap={5} style={{ flexWrap: 'no-wrap' }}>
+        <SpaceBetween gap={5} style={{ flexWrap: 'nowrap' }}>
           <Trans>Payee:</Trans>
           <DisplayId
             type="payees"

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -22,6 +22,7 @@ import {
 } from '@actual-app/components/icons/v1';
 import { Menu } from '@actual-app/components/menu';
 import { Select } from '@actual-app/components/select';
+import { SpaceBetween } from '@actual-app/components/space-between';
 import { Stack } from '@actual-app/components/stack';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
@@ -391,33 +392,41 @@ function ScheduleDescription({ id }) {
   const status = schedule && statusLabels.get(schedule.id);
 
   return (
-    <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center' }}>
-      <View style={{ marginRight: 15, flexDirection: 'row' }}>
-        <Text
-          style={{
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          <Trans>Payee:</Trans>{' '}
+    <View
+      style={{
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      }}
+    >
+      <SpaceBetween
+        gap={5}
+        style={{
+          marginRight: 15,
+        }}
+      >
+        <SpaceBetween gap={5} style={{ flexWrap: 'no-wrap' }}>
+          <Trans>Payee:</Trans>
           <DisplayId
             type="payees"
             id={schedule._payee}
             noneColor={theme.pageTextLight}
           />
-        </Text>
-        <Text style={{ margin: '0 5px' }}> — </Text>
+        </SpaceBetween>
+
         <Text style={{ flexShrink: 0 }}>
+          <Text> — </Text>
           <Trans>Amount:</Trans> {formatAmount(schedule._amount)}
         </Text>
-        <Text style={{ margin: '0 5px' }}> — </Text>
+
         <Text style={{ flexShrink: 0 }}>
+          <Text> — </Text>
           <Trans>
             Next: {{ month: monthUtils.format(schedule.next_date, dateFormat) }}
           </Trans>
         </Text>
-      </View>
+      </SpaceBetween>
       {/* @ts-expect-error fix this */}
       <StatusBadge status={status} />
     </View>

--- a/upcoming-release-notes/5529.md
+++ b/upcoming-release-notes/5529.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix the display of 'link schedules' condition


### PR DESCRIPTION
Split off from: https://github.com/actualbudget/actual/pull/5516

Originally broken due to: https://github.com/actualbudget/actual/pull/5489

Before:
<img width="988" height="693" alt="Screenshot 2025-08-09 at 11 33 13" src="https://github.com/user-attachments/assets/b09d7354-ea78-4856-b21f-3f36cae0e3e7" />

After:
<img width="995" height="588" alt="Screenshot 2025-08-09 at 11 32 55" src="https://github.com/user-attachments/assets/606150f3-83a6-450d-99f8-1fe0e45de7ed" />
