### PR TITLE
Add backend logic to support automations UI

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/BudgetAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/BudgetAutomation.tsx
@@ -26,9 +26,10 @@ type BudgetAutomationProps = {
 };
 
 const DEFAULT_TEMPLATE: Template = {
-  directive: '',
+  directive: 'template',
   type: 'simple',
   monthly: 0,
+  priority: 0,
 };
 
 export const BudgetAutomation = ({

--- a/packages/desktop-client/src/components/budget/goals/BudgetAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/BudgetAutomation.tsx
@@ -12,7 +12,7 @@ import { type Template } from 'loot-core/types/models/templates';
 import { type Action } from './actions';
 import { BudgetAutomationEditor } from './BudgetAutomationEditor';
 import { BudgetAutomationReadOnly } from './BudgetAutomationReadOnly';
-import { getInitialState, templateReducer } from './reducer';
+import { DEFAULT_PRIORITY, getInitialState, templateReducer } from './reducer';
 
 type BudgetAutomationProps = {
   categories: CategoryGroupEntity[];
@@ -29,7 +29,7 @@ const DEFAULT_TEMPLATE: Template = {
   directive: 'template',
   type: 'simple',
   monthly: 0,
-  priority: 0,
+  priority: DEFAULT_PRIORITY,
 };
 
 export const BudgetAutomation = ({

--- a/packages/desktop-client/src/components/budget/goals/actions.ts
+++ b/packages/desktop-client/src/components/budget/goals/actions.ts
@@ -14,7 +14,7 @@ type SET_TEMPLATE = {
 
 type UPDATE_TEMPLATE = {
   type: 'update-template';
-  payload: Partial<Template>;
+  payload: Partial<Template> & Pick<Template, 'type'>;
 };
 
 export const setType = (type: DisplayTemplateType): SET_TYPE => ({
@@ -28,7 +28,7 @@ export const setTemplate = (template: Template): SET_TEMPLATE => ({
 });
 
 export const updateTemplate = (
-  template: Partial<Template>,
+  template: Partial<Template> & Pick<Template, 'type'>,
 ): UPDATE_TEMPLATE => ({
   type: 'update-template' as const,
   payload: template,

--- a/packages/desktop-client/src/components/budget/goals/editor/HistoricalAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/HistoricalAutomation.tsx
@@ -62,8 +62,8 @@ export const HistoricalAutomation = ({
             dispatch(
               updateTemplate(
                 template.type === 'average'
-                  ? { numMonths: value }
-                  : { lookBack: value },
+                  ? { type: 'average', numMonths: value }
+                  : { type: 'copy', lookBack: value },
               ),
             )
           }

--- a/packages/desktop-client/src/components/budget/goals/reducer.ts
+++ b/packages/desktop-client/src/components/budget/goals/reducer.ts
@@ -136,7 +136,7 @@ const changeType = (
 
 function mapTemplateTypesForUpdate(
   state: ReducerState,
-  template: Partial<Template>,
+  template: Partial<Template> & Pick<Template, 'type'>,
 ): ReducerState {
   switch (state.template.type) {
     case 'average':
@@ -179,7 +179,7 @@ function mapTemplateTypesForUpdate(
       break;
   }
 
-  if (!template.type || state.template.type === template.type) {
+  if (state.template.type === template.type) {
     const { type: _1, directive: _2, ...rest } = template;
     return {
       ...state,

--- a/packages/desktop-client/src/components/budget/goals/reducer.ts
+++ b/packages/desktop-client/src/components/budget/goals/reducer.ts
@@ -58,9 +58,10 @@ const changeType = (
       return {
         displayType: visualType,
         template: {
-          directive: '',
+          directive: 'template',
           type: 'simple',
           monthly: 500,
+          priority: 0,
         },
       };
     case 'percentage':
@@ -70,11 +71,12 @@ const changeType = (
       return {
         displayType: visualType,
         template: {
-          directive: '',
+          directive: 'template',
           type: 'percentage',
           percent: 15,
           previous: false,
           category: 'total',
+          priority: 0,
         },
       };
     case 'schedule':
@@ -84,9 +86,10 @@ const changeType = (
       return {
         displayType: visualType,
         template: {
-          directive: '',
+          directive: 'template',
           type: 'schedule',
           name: '',
+          priority: 0,
         },
       };
     case 'week':
@@ -96,7 +99,7 @@ const changeType = (
       return {
         displayType: visualType,
         template: {
-          directive: '',
+          directive: 'template',
           type: 'periodic',
           amount: 500,
           period: {
@@ -104,6 +107,7 @@ const changeType = (
             amount: 1,
           },
           starting: '',
+          priority: 0,
         },
       };
     case 'historical':
@@ -116,9 +120,10 @@ const changeType = (
       return {
         displayType: visualType,
         template: {
-          directive: '',
+          directive: 'template',
           type: 'average',
           numMonths: 3,
+          priority: 0,
         },
       };
     default:
@@ -140,9 +145,10 @@ function mapTemplateTypesForUpdate(
             displayType: 'historical',
             template: {
               ...template,
-              directive: '',
+              directive: 'template',
               type: 'copy',
               lookBack: state.template.numMonths,
+              priority: state.template.priority,
             },
           };
         default:
@@ -157,9 +163,10 @@ function mapTemplateTypesForUpdate(
             displayType: 'historical',
             template: {
               ...template,
-              directive: '',
+              directive: 'template',
               type: 'average',
               numMonths: state.template.lookBack,
+              priority: state.template.priority,
             },
           };
         default:
@@ -171,7 +178,7 @@ function mapTemplateTypesForUpdate(
   }
 
   if (!template.type || state.template.type === template.type) {
-    const { type: _, ...rest } = template;
+    const { type: _1, directive: _2, ...rest } = template;
     return {
       ...state,
       ...getInitialState({

--- a/packages/desktop-client/src/components/budget/goals/reducer.ts
+++ b/packages/desktop-client/src/components/budget/goals/reducer.ts
@@ -3,6 +3,8 @@ import { type Template } from 'loot-core/types/models/templates';
 import { type Action } from './actions';
 import { type ReducerState, type DisplayTemplateType } from './constants';
 
+export const DEFAULT_PRIORITY = 1;
+
 export const getInitialState = (template: Template | null): ReducerState => {
   const type = template?.type;
   switch (type) {
@@ -61,7 +63,7 @@ const changeType = (
           directive: 'template',
           type: 'simple',
           monthly: 500,
-          priority: 0,
+          priority: DEFAULT_PRIORITY,
         },
       };
     case 'percentage':
@@ -76,7 +78,7 @@ const changeType = (
           percent: 15,
           previous: false,
           category: 'total',
-          priority: 0,
+          priority: DEFAULT_PRIORITY,
         },
       };
     case 'schedule':
@@ -89,7 +91,7 @@ const changeType = (
           directive: 'template',
           type: 'schedule',
           name: '',
-          priority: 0,
+          priority: DEFAULT_PRIORITY,
         },
       };
     case 'week':
@@ -107,7 +109,7 @@ const changeType = (
             amount: 1,
           },
           starting: '',
-          priority: 0,
+          priority: DEFAULT_PRIORITY,
         },
       };
     case 'historical':
@@ -123,7 +125,7 @@ const changeType = (
           directive: 'template',
           type: 'average',
           numMonths: 3,
-          priority: 0,
+          priority: DEFAULT_PRIORITY,
         },
       };
     default:

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
@@ -29,7 +29,8 @@ export function BudgetAutomationsModal() {
     {
       type: 'average',
       numMonths: 3,
-      directive: '',
+      directive: 'template',
+      priority: 0,
       id: uniqueId(),
     },
   ]);
@@ -44,7 +45,13 @@ export function BudgetAutomationsModal() {
   const onAdd = () => {
     setTemplates([
       ...templates,
-      { type: 'average', numMonths: 3, directive: '', id: uniqueId() },
+      {
+        type: 'average',
+        numMonths: 3,
+        directive: 'template',
+        priority: 0,
+        id: uniqueId(),
+      },
     ]);
   };
   const onSave = () => {};

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal.tsx
@@ -10,6 +10,7 @@ import { q } from 'loot-core/shared/query';
 import { type Template } from 'loot-core/types/models/templates';
 
 import { BudgetAutomation } from '@desktop-client/components/budget/goals/BudgetAutomation';
+import { DEFAULT_PRIORITY } from '@desktop-client/components/budget/goals/reducer';
 import { useBudgetAutomationCategories } from '@desktop-client/components/budget/goals/useBudgetAutomationCategories';
 import {
   Modal,
@@ -30,7 +31,7 @@ export function BudgetAutomationsModal() {
       type: 'average',
       numMonths: 3,
       directive: 'template',
-      priority: 0,
+      priority: DEFAULT_PRIORITY,
       id: uniqueId(),
     },
   ]);
@@ -49,7 +50,7 @@ export function BudgetAutomationsModal() {
         type: 'average',
         numMonths: 3,
         directive: 'template',
-        priority: 0,
+        priority: DEFAULT_PRIORITY,
         id: uniqueId(),
       },
     ]);

--- a/packages/loot-core/migrations/1754611200000_add_category_template_settings.sql
+++ b/packages/loot-core/migrations/1754611200000_add_category_template_settings.sql
@@ -1,0 +1,5 @@
+-- Add a column to track where a category's automation templates come from
+-- Allowed values for source (by convention): 'notes' | 'ui'
+ALTER TABLE categories ADD COLUMN template_settings JSON DEFAULT '{"source": "notes"}';
+
+UPDATE categories SET template_settings = '{"source": "ui"}' WHERE template_settings IS NULL;

--- a/packages/loot-core/migrations/1754611200000_add_category_template_source.sql
+++ b/packages/loot-core/migrations/1754611200000_add_category_template_source.sql
@@ -1,3 +1,0 @@
--- Add a column to track where a category's automation templates come from
--- Allowed values (by convention): 'notes' | 'ui'
-ALTER TABLE categories ADD COLUMN template_source TEXT DEFAULT 'notes';

--- a/packages/loot-core/migrations/1754611200000_add_category_template_source.sql
+++ b/packages/loot-core/migrations/1754611200000_add_category_template_source.sql
@@ -1,0 +1,3 @@
+-- Add a column to track where a category's automation templates come from
+-- Allowed values (by convention): 'notes' | 'ui'
+ALTER TABLE categories ADD COLUMN template_source TEXT DEFAULT 'notes';

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -85,7 +85,7 @@ export const schema = {
     hidden: f('boolean'),
     group: f('id', { ref: 'category_groups' }),
     goal_def: f('string'),
-    template_source: f('string'),
+    template_settings: f('json'),
     sort_order: f('float'),
     tombstone: f('boolean'),
   },

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -85,6 +85,7 @@ export const schema = {
     hidden: f('boolean'),
     group: f('id', { ref: 'category_groups' }),
     goal_def: f('string'),
+    template_source: f('string'),
     sort_order: f('float'),
     tombstone: f('boolean'),
   },

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -85,7 +85,7 @@ export const schema = {
     hidden: f('boolean'),
     group: f('id', { ref: 'category_groups' }),
     goal_def: f('string'),
-    template_settings: f('json'),
+    template_settings: f('json', { default: { source: 'notes' } }),
     sort_order: f('float'),
     tombstone: f('boolean'),
   },

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -54,6 +54,8 @@ export interface BudgetHandlers {
   'category-group-move': typeof moveCategoryGroup;
   'category-group-delete': typeof deleteCategoryGroup;
   'must-category-transfer': typeof isCategoryTransferRequired;
+  'budget/get-category-automations': typeof goalActions.getTemplatesForCategory;
+  'budget/set-category-automations': typeof goalActions.storeTemplates;
 }
 
 export const app = createApp<BudgetHandlers>();
@@ -139,6 +141,12 @@ app.method('category-group-update', mutator(undoable(updateCategoryGroup)));
 app.method('category-group-move', mutator(undoable(moveCategoryGroup)));
 app.method('category-group-delete', mutator(undoable(deleteCategoryGroup)));
 app.method('must-category-transfer', isCategoryTransferRequired);
+
+app.method(
+  'budget/get-category-automations',
+  goalActions.getTemplatesForCategory,
+);
+app.method('budget/set-category-automations', goalActions.storeTemplates);
 
 // Server must return AQL entities not the raw DB data
 async function getCategories() {

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -146,7 +146,10 @@ app.method(
   'budget/get-category-automations',
   goalActions.getTemplatesForCategory,
 );
-app.method('budget/set-category-automations', goalActions.storeTemplates);
+app.method(
+  'budget/set-category-automations',
+  mutator(undoable(goalActions.storeTemplates)),
+);
 
 // Server must return AQL entities not the raw DB data
 async function getCategories() {

--- a/packages/loot-core/src/server/budget/category-template-context.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.test.ts
@@ -771,6 +771,7 @@ describe('CategoryTemplateContext', () => {
           type: 'remainder',
           weight: 2,
           directive: 'template',
+          priority: null,
         },
       ];
       const instance = new TestCategoryTemplateContext(
@@ -796,6 +797,7 @@ describe('CategoryTemplateContext', () => {
           type: 'remainder',
           weight: 1,
           directive: 'template',
+          priority: null,
         },
       ];
       const instance = new TestCategoryTemplateContext(
@@ -821,6 +823,7 @@ describe('CategoryTemplateContext', () => {
           type: 'remainder',
           weight: 1,
           directive: 'template',
+          priority: null,
         },
       ];
       const instance = new TestCategoryTemplateContext(
@@ -860,6 +863,7 @@ describe('CategoryTemplateContext', () => {
           type: 'remainder',
           weight: 1,
           directive: 'template',
+          priority: null,
         },
       ];
 
@@ -983,6 +987,7 @@ describe('CategoryTemplateContext', () => {
           type: 'remainder',
           weight: 1,
           directive: 'template',
+          priority: null,
         },
       ];
 

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -133,7 +133,12 @@ export class CategoryTemplateContext {
     if (!this.priorities.has(priority)) return 0;
     if (this.limitMet) return 0;
 
-    const t = this.templates.filter(t => t.priority === priority);
+    const t = this.templates.filter(
+      t =>
+        t.directive === 'template' &&
+        t.type !== 'remainder' &&
+        t.priority === priority,
+    );
     let available = budgetAvail || 0;
     let toBudget = 0;
     let byFlag = false;

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -134,10 +134,7 @@ export class CategoryTemplateContext {
     if (this.limitMet) return 0;
 
     const t = this.templates.filter(
-      t =>
-        t.directive === 'template' &&
-        t.type !== 'remainder' &&
-        t.priority === priority,
+      t => t.directive === 'template' && t.priority === priority,
     );
     let available = budgetAvail || 0;
     let toBudget = 0;

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -4,11 +4,12 @@ import { q } from '../../shared/query';
 import { CategoryEntity, CategoryGroupEntity } from '../../types/models';
 import { Template } from '../../types/models/templates';
 import { aqlQuery } from '../aql';
+import * as db from '../db';
 import { batchMessages } from '../sync';
 
 import { isReflectBudget, getSheetValue, setGoal, setBudget } from './actions';
 import { CategoryTemplateContext } from './category-template-context';
-import { checkTemplates, storeTemplates } from './template-notes';
+import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
 
 type Notification = {
   type?: 'message' | 'error' | 'warning' | undefined;
@@ -18,12 +19,33 @@ type Notification = {
   sticky?: boolean | undefined;
 };
 
+export async function storeTemplates({
+  categoriesWithTemplates,
+  source,
+}: {
+  categoriesWithTemplates: {
+    id: string;
+    templates: Template[];
+  }[];
+  source: 'notes' | 'ui';
+}): Promise<void> {
+  for (const { id, templates } of categoriesWithTemplates) {
+    const goalDefs = JSON.stringify(templates);
+
+    await db.update('categories', {
+      id,
+      goal_def: goalDefs,
+      template_source: source,
+    });
+  }
+}
+
 export async function applyTemplate({
   month,
 }: {
   month: string;
 }): Promise<Notification> {
-  await storeTemplates();
+  await storeNoteTemplates();
   const categoryTemplates = await getTemplates();
   const ret = await processTemplate(month, false, categoryTemplates);
   return ret;
@@ -34,7 +56,7 @@ export async function overwriteTemplate({
 }: {
   month: string;
 }): Promise<Notification> {
-  await storeTemplates();
+  await storeNoteTemplates();
   const categoryTemplates = await getTemplates();
   const ret = await processTemplate(month, true, categoryTemplates);
   return ret;
@@ -52,7 +74,7 @@ export async function applyMultipleCategoryTemplates({
       .filter({ id: { $oneof: categoryIds } })
       .select('*'),
   );
-  await storeTemplates();
+  await storeNoteTemplates();
   const categoryTemplates = await getTemplates(c => categoryIds.includes(c.id));
   const ret = await processTemplate(
     month,
@@ -73,7 +95,7 @@ export async function applySingleCategoryTemplate({
   const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
     q('categories').filter({ id: category }).select('*'),
   );
-  await storeTemplates();
+  await storeNoteTemplates();
   const categoryTemplates = await getTemplates(c => c.id === category);
   const ret = await processTemplate(
     month,
@@ -85,7 +107,7 @@ export async function applySingleCategoryTemplate({
 }
 
 export function runCheckTemplates() {
-  return checkTemplates();
+  return checkTemplateNotes();
 }
 
 async function getCategories(): Promise<CategoryEntity[]> {
@@ -113,6 +135,12 @@ async function getTemplates(
     );
   }
   return categoryTemplates;
+}
+
+export async function getTemplatesForCategory(
+  categoryId: CategoryEntity['id'],
+): Promise<Record<CategoryEntity['id'], Template[]>> {
+  return getTemplates(c => c.id === categoryId);
 }
 
 type TemplateBudget = {

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -29,15 +29,17 @@ export async function storeTemplates({
   }[];
   source: 'notes' | 'ui';
 }): Promise<void> {
-  for (const { id, templates } of categoriesWithTemplates) {
-    const goalDefs = JSON.stringify(templates);
+  await batchMessages(async () => {
+    for (const { id, templates } of categoriesWithTemplates) {
+      const goalDefs = JSON.stringify(templates);
 
-    await db.updateWithSchema('categories', {
-      id,
-      goal_def: goalDefs,
-      template_settings: { source },
-    });
-  }
+      await db.updateWithSchema('categories', {
+        id,
+        goal_def: goalDefs,
+        template_settings: { source },
+      });
+    }
+  });
 }
 
 export async function applyTemplate({

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -32,10 +32,10 @@ export async function storeTemplates({
   for (const { id, templates } of categoriesWithTemplates) {
     const goalDefs = JSON.stringify(templates);
 
-    await db.update('categories', {
+    await db.updateWithSchema('categories', {
       id,
       goal_def: goalDefs,
-      template_source: source,
+      template_settings: { source },
     });
   }
 }

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -27,7 +27,8 @@ describe('runSchedule', () => {
       {
         type: 'schedule',
         name: 'Test Schedule',
-        directive: '#template schedule Test Schedule',
+        priority: 0,
+        directive: 'template',
       } as const,
     ];
     const current_month = '2024-08-01';
@@ -97,7 +98,8 @@ describe('runSchedule', () => {
       {
         type: 'schedule',
         name: 'Test Schedule',
-        directive: '#template schedule Test Schedule',
+        directive: 'template',
+        priority: 0,
       } as const,
     ];
     const current_month = '2024-09-01';

--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -13,7 +13,8 @@ export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
                        FROM notes n
                        WHERE lower(note) LIKE '%${TEMPLATE_PREFIX}%'
                           OR lower(note) LIKE '%${GOAL_PREFIX}%')
-        AND template_source <> 'ui'
+        AND JSON_EXTRACT(template_settings, '$.source') IS NOT NULL
+        AND JSON_EXTRACT(template_settings, '$.source') <> 'ui'
     `,
   );
 }
@@ -38,7 +39,8 @@ export async function getCategoriesWithTemplateNotes(): Promise<
              JOIN categories c ON n.id = c.id
       WHERE c.id = n.id
         AND c.tombstone = 0
-        AND c.template_source <> 'ui'
+        AND JSON_EXTRACT(c.template_settings, '$.source') IS NOT NULL
+        AND JSON_EXTRACT(c.template_settings, '$.source') <> 'ui'
         AND (lower(note) LIKE '%${TEMPLATE_PREFIX}%'
         OR lower(note) LIKE '%${GOAL_PREFIX}%')
     `,

--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -13,8 +13,7 @@ export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
                        FROM notes n
                        WHERE lower(note) LIKE '%${TEMPLATE_PREFIX}%'
                           OR lower(note) LIKE '%${GOAL_PREFIX}%')
-        AND JSON_EXTRACT(template_settings, '$.source') IS NOT NULL
-        AND JSON_EXTRACT(template_settings, '$.source') <> 'ui'
+        AND COALESCE(JSON_EXTRACT(template_settings, '$.source'), 'notes') <> 'ui'
     `,
   );
 }
@@ -39,8 +38,7 @@ export async function getCategoriesWithTemplateNotes(): Promise<
              JOIN categories c ON n.id = c.id
       WHERE c.id = n.id
         AND c.tombstone = 0
-        AND JSON_EXTRACT(c.template_settings, '$.source') IS NOT NULL
-        AND JSON_EXTRACT(c.template_settings, '$.source') <> 'ui'
+        AND COALESCE(JSON_EXTRACT(c.template_settings, '$.source'), 'notes') <> 'ui'
         AND (lower(note) LIKE '%${TEMPLATE_PREFIX}%'
         OR lower(note) LIKE '%${GOAL_PREFIX}%')
     `,

--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -13,6 +13,7 @@ export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
                        FROM notes n
                        WHERE lower(note) LIKE '%${TEMPLATE_PREFIX}%'
                           OR lower(note) LIKE '%${GOAL_PREFIX}%')
+        AND template_source <> 'ui'
     `,
   );
 }
@@ -37,6 +38,7 @@ export async function getCategoriesWithTemplateNotes(): Promise<
              JOIN categories c ON n.id = c.id
       WHERE c.id = n.id
         AND c.tombstone = 0
+        AND c.template_source <> 'ui'
         AND (lower(note) LIKE '%${TEMPLATE_PREFIX}%'
         OR lower(note) LIKE '%${GOAL_PREFIX}%')
     `,

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -6,7 +6,7 @@ import {
   getCategoriesWithTemplateNotes,
   resetCategoryGoalDefsWithNoTemplates,
 } from './statements';
-import { checkTemplates, storeTemplates } from './template-notes';
+import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
 
 vi.mock('../db');
 vi.mock('./statements');
@@ -25,7 +25,7 @@ function mockDbUpdate() {
   vi.mocked(db.update).mockResolvedValue(undefined);
 }
 
-describe('storeTemplates', () => {
+describe('storeNoteTemplates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -131,7 +131,7 @@ describe('storeTemplates', () => {
       mockDbUpdate();
 
       // When
-      await storeTemplates();
+      await storeNoteTemplates();
 
       // Then
       if (expectedTemplates.length === 0) {
@@ -266,7 +266,7 @@ describe('checkTemplates', () => {
       mockGetActiveSchedules(mockSchedules);
 
       // When
-      const result = await checkTemplates();
+      const result = await checkTemplateNotes();
 
       // Then
       expect(result).toEqual(expected);

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -22,7 +22,7 @@ function mockGetActiveSchedules(schedules: db.DbSchedule[]) {
 }
 
 function mockDbUpdate() {
-  vi.mocked(db.update).mockResolvedValue(undefined);
+  vi.mocked(db.updateWithSchema).mockResolvedValue(undefined);
 }
 
 describe('storeNoteTemplates', () => {
@@ -135,13 +135,13 @@ describe('storeNoteTemplates', () => {
 
       // Then
       if (expectedTemplates.length === 0) {
-        expect(db.update).not.toHaveBeenCalled();
+        expect(db.updateWithSchema).not.toHaveBeenCalled();
         expect(resetCategoryGoalDefsWithNoTemplates).toHaveBeenCalled();
         return;
       }
 
       mockTemplateNotes.forEach(({ id }) => {
-        expect(db.update).toHaveBeenCalledWith('categories', {
+        expect(db.updateWithSchema).toHaveBeenCalledWith('categories', {
           id,
           goal_def: JSON.stringify(expectedTemplates),
           template_settings: { source: 'notes' },

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -144,7 +144,7 @@ describe('storeNoteTemplates', () => {
         expect(db.update).toHaveBeenCalledWith('categories', {
           id,
           goal_def: JSON.stringify(expectedTemplates),
-          template_source: 'notes',
+          template_settings: { source: 'notes' },
         });
       });
       expect(resetCategoryGoalDefsWithNoTemplates).toHaveBeenCalled();

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -144,6 +144,7 @@ describe('storeNoteTemplates', () => {
         expect(db.update).toHaveBeenCalledWith('categories', {
           id,
           goal_def: JSON.stringify(expectedTemplates),
+          template_source: 'notes',
         });
       });
       expect(resetCategoryGoalDefsWithNoTemplates).toHaveBeenCalled();

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -1,6 +1,6 @@
-import { Template } from '../../types/models/templates';
-import * as db from '../db';
+import type { Template } from '../../types/models/templates';
 
+import { storeTemplates } from './goal-template';
 import { parse } from './goal-template.pegjs';
 import {
   CategoryWithTemplateNote,
@@ -19,28 +19,21 @@ type Notification = {
 export const TEMPLATE_PREFIX = '#template';
 export const GOAL_PREFIX = '#goal';
 
-export async function storeTemplates(): Promise<void> {
+export async function storeNoteTemplates(): Promise<void> {
   const categoriesWithTemplates = await getCategoriesWithTemplates();
 
-  for (const { id, templates } of categoriesWithTemplates) {
-    const goalDefs = JSON.stringify(templates);
-
-    await db.update('categories', {
-      id,
-      goal_def: goalDefs,
-    });
-  }
+  await storeTemplates({ categoriesWithTemplates, source: 'notes' });
 
   await resetCategoryGoalDefsWithNoTemplates();
 }
 
-type CategoryWithTemplates = {
+type CategoryWithTemplateNotes = {
   id: string;
   name: string;
   templates: Template[];
 };
 
-export async function checkTemplates(): Promise<Notification> {
+export async function checkTemplateNotes(): Promise<Notification> {
   const categoryWithTemplates = await getCategoriesWithTemplates();
   const schedules = await getActiveSchedules();
   const scheduleNames = schedules.map(({ name }) => name);
@@ -78,8 +71,10 @@ export async function checkTemplates(): Promise<Notification> {
   };
 }
 
-async function getCategoriesWithTemplates(): Promise<CategoryWithTemplates[]> {
-  const templatesForCategory: CategoryWithTemplates[] = [];
+async function getCategoriesWithTemplates(): Promise<
+  CategoryWithTemplateNotes[]
+> {
+  const templatesForCategory: CategoryWithTemplateNotes[] = [];
   const templateNotes = await getCategoriesWithTemplateNotes();
 
   templateNotes.forEach(({ id, name, note }: CategoryWithTemplateNote) => {

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -39,6 +39,7 @@ export type DbCategory = {
   sort_order: number;
   hidden: 1 | 0;
   goal_def?: JsonString | null;
+  template_source?: 'notes' | 'ui' | null;
   tombstone: 1 | 0;
 };
 

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -39,7 +39,7 @@ export type DbCategory = {
   sort_order: number;
   hidden: 1 | 0;
   goal_def?: JsonString | null;
-  template_source?: 'notes' | 'ui' | null;
+  template_settings?: { source: 'notes' | 'ui' };
   tombstone: 1 | 0;
 };
 

--- a/packages/loot-core/src/types/models/category.ts
+++ b/packages/loot-core/src/types/models/category.ts
@@ -6,6 +6,7 @@ export interface CategoryEntity {
   is_income?: boolean;
   group: CategoryGroupEntity['id'];
   goal_def?: string;
+  template_source?: 'notes' | 'ui';
   sort_order?: number;
   tombstone?: boolean;
   hidden?: boolean;

--- a/packages/loot-core/src/types/models/category.ts
+++ b/packages/loot-core/src/types/models/category.ts
@@ -6,7 +6,7 @@ export interface CategoryEntity {
   is_income?: boolean;
   group: CategoryGroupEntity['id'];
   goal_def?: string;
-  template_source?: 'notes' | 'ui';
+  template_settings?: { source: 'notes' | 'ui' };
   sort_order?: number;
   tombstone?: boolean;
   hidden?: boolean;

--- a/packages/loot-core/src/types/models/templates.ts
+++ b/packages/loot-core/src/types/models/templates.ts
@@ -86,6 +86,7 @@ export interface RemainderTemplate extends BaseTemplate {
     start?: string;
   };
   directive: 'template';
+  priority: null;
 }
 
 export interface GoalTemplate extends BaseTemplate {

--- a/packages/loot-core/src/types/models/templates.ts
+++ b/packages/loot-core/src/types/models/templates.ts
@@ -1,17 +1,20 @@
 interface BaseTemplate {
   type: string;
-  priority?: number;
-  directive: string;
+  directive: 'template' | 'goal' | 'error';
+}
+interface BaseTemplateWithPriority extends BaseTemplate {
+  priority: number;
+  directive: 'template';
 }
 
-export interface PercentageTemplate extends BaseTemplate {
+export interface PercentageTemplate extends BaseTemplateWithPriority {
   type: 'percentage';
   percent: number;
   previous: boolean;
   category: string;
 }
 
-export interface PeriodicTemplate extends BaseTemplate {
+export interface PeriodicTemplate extends BaseTemplateWithPriority {
   type: 'periodic';
   amount: number;
   period: {
@@ -27,7 +30,7 @@ export interface PeriodicTemplate extends BaseTemplate {
   };
 }
 
-export interface ByTemplate extends BaseTemplate {
+export interface ByTemplate extends BaseTemplateWithPriority {
   type: 'by';
   amount: number;
   month: string;
@@ -36,7 +39,7 @@ export interface ByTemplate extends BaseTemplate {
   from?: string;
 }
 
-export interface SpendTemplate extends BaseTemplate {
+export interface SpendTemplate extends BaseTemplateWithPriority {
   type: 'spend';
   amount: number;
   month: string;
@@ -45,7 +48,7 @@ export interface SpendTemplate extends BaseTemplate {
   repeat?: number;
 }
 
-export interface SimpleTemplate extends BaseTemplate {
+export interface SimpleTemplate extends BaseTemplateWithPriority {
   type: 'simple';
   monthly?: number;
   limit?: {
@@ -56,11 +59,21 @@ export interface SimpleTemplate extends BaseTemplate {
   };
 }
 
-export interface ScheduleTemplate extends BaseTemplate {
+export interface ScheduleTemplate extends BaseTemplateWithPriority {
   type: 'schedule';
   name: string;
   full?: boolean;
   adjustment?: number;
+}
+
+export interface AverageTemplate extends BaseTemplateWithPriority {
+  type: 'average';
+  numMonths: number;
+}
+
+export interface CopyTemplate extends BaseTemplateWithPriority {
+  type: 'copy';
+  lookBack: number;
 }
 
 export interface RemainderTemplate extends BaseTemplate {
@@ -72,27 +85,20 @@ export interface RemainderTemplate extends BaseTemplate {
     period?: 'daily' | 'weekly' | 'monthly';
     start?: string;
   };
-}
-
-export interface AverageTemplate extends BaseTemplate {
-  type: 'average';
-  numMonths: number;
+  directive: 'template';
 }
 
 export interface GoalTemplate extends BaseTemplate {
   type: 'goal';
   amount: number;
-}
-
-export interface CopyTemplate extends BaseTemplate {
-  type: 'copy';
-  lookBack: number;
+  directive: 'goal';
 }
 
 interface ErrorTemplate extends BaseTemplate {
   type: 'error';
   line: string;
   error: string;
+  directive: 'error';
 }
 
 export type Template =

--- a/upcoming-release-notes/5532.md
+++ b/upcoming-release-notes/5532.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jfdoming]
+---
+
+Add backend logic to support automations UI


### PR DESCRIPTION
## WARNING: This PR contains a migration—don't connect it to a server you care about.

My current migration plan is:
1. Roll out automations UI and let users opt in on a per-category basis. In a future PR I'll add a "migration" modal for both directions; for now notes-based templates will get displayed in the UI, and if you hit 'Save' they are converted to UI automations.
2. At some point in a future release once we have full support in the UI and expect most users have migrated to the UI, remove the ability to populate notes-based templates during application. This means effectively you can't create notes-based templates and can only migrate them to the UI. We could potentially release both experimental features at this point.
3. At some point far in the future, remove the ability to migrate. At this point anyone with unmigrated notes-based templates will need to upgrade to an intermediate release, migrate, and then move to the latest release.

Three changes here to facilitate Step 1:
1. Marked `priority` and `directive` as required, because without them templates don't actually get run.
2. Added a `template_source` attribute to categories and updated database logic in `resetCategoryGoalDefsWithNoTemplates`/`getCategoriesWithTemplateNotes` to ignore non-notes-based templates.
3. Extracted some notes-specific logic into separate functions and exposed non-notes-specific logic via `send`.

Looking for feedback on the migration plan as well as the shape of changes added here! Also check out [this PR](https://github.com/actualbudget/actual/pull/5533) and [this preview link](https://deploy-preview-5533.demo.actualbudget.org/budget) for the usage of the logic added to this PR. Note that you will need to run `localStorage.setItem("devEnableGoalTemplatesUI", "true")` in the console AND enable both experimental features in order to see the updated logic.