### PR TITLE
[WIP] feat(currency): add currency display to rules

### DIFF
--- a/packages/component-library/src/Input.tsx
+++ b/packages/component-library/src/Input.tsx
@@ -47,6 +47,7 @@ export type InputProps = ComponentPropsWithRef<typeof ReactAriaInput> & {
     event: ChangeEvent<HTMLInputElement>,
   ) => void;
   onUpdate?: (newValue: string, event: FocusEvent<HTMLInputElement>) => void;
+  useKeyDown?: boolean;
 };
 
 export function Input({
@@ -56,6 +57,7 @@ export function Input({
   onChangeValue,
   onUpdate,
   className,
+  useKeyDown = false,
   ...props
 }: InputProps) {
   return (
@@ -67,15 +69,30 @@ export function Input({
           : cx(defaultInputClassName, className)
       }
       {...props}
+      onKeyDown={e => {
+        props.onKeyDown?.(e);
+
+        if (useKeyDown) {
+          if (e.key === 'Enter' && onEnter) {
+            onEnter(e.currentTarget.value, e);
+          }
+
+          if (e.key === 'Escape' && onEscape) {
+            onEscape(e.currentTarget.value, e);
+          }
+        }
+      }}
       onKeyUp={e => {
         props.onKeyUp?.(e);
 
-        if (e.key === 'Enter' && onEnter) {
-          onEnter(e.currentTarget.value, e);
-        }
+        if (!useKeyDown) {
+          if (e.key === 'Enter' && onEnter) {
+            onEnter(e.currentTarget.value, e);
+          }
 
-        if (e.key === 'Escape' && onEscape) {
-          onEscape(e.currentTarget.value, e);
+          if (e.key === 'Escape' && onEscape) {
+            onEscape(e.currentTarget.value, e);
+          }
         }
       }}
       onBlur={e => {

--- a/packages/desktop-client/src/components/filters/FilterExpression.tsx
+++ b/packages/desktop-client/src/components/filters/FilterExpression.tsx
@@ -9,7 +9,6 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { mapField, friendlyOp } from 'loot-core/shared/rules';
-import { integerToCurrency } from 'loot-core/shared/util';
 import { type RuleConditionEntity } from 'loot-core/types/models';
 
 import { FilterEditor } from './FiltersMenu';
@@ -139,11 +138,7 @@ export function FilterExpression<T extends RuleConditionEntity>({
         <FilterEditor
           field={originalField}
           op={op}
-          value={
-            field === 'amount' && typeof value === 'number'
-              ? integerToCurrency(value)
-              : value
-          }
+          value={value}
           options={options}
           onSave={onChange}
           onClose={() => setEditing(false)}

--- a/packages/desktop-client/src/components/filters/FiltersMenu.jsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.jsx
@@ -243,6 +243,7 @@ function ConfigureField({
                 ? 'string'
                 : type
             }
+            numberFormatType="currency"
             value={formattedValue}
             multi={op === 'oneOf' || op === 'notOneOf'}
             op={op}

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -48,11 +48,6 @@ import {
   getValidOps,
 } from 'loot-core/shared/rules';
 import {
-  integerToCurrency,
-  integerToAmount,
-  amountToInteger,
-} from 'loot-core/shared/util';
-import {
   type RuleEntity,
   type NewRuleEntity,
   type RuleActionEntity,
@@ -65,6 +60,7 @@ import { DisplayId } from '@desktop-client/components/util/DisplayId';
 import { GenericInput } from '@desktop-client/components/util/GenericInput';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';
+import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useSchedules } from '@desktop-client/hooks/useSchedules';
 import {
   useSelected,
@@ -356,20 +352,22 @@ function ConditionEditor({
   );
 }
 
-function formatAmount(amount) {
+function formatAmount(amount, format) {
   if (!amount) {
-    return integerToCurrency(0);
+    return format(0, 'financial');
   } else if (typeof amount === 'number') {
-    return integerToCurrency(amount);
+    return format(amount, 'financial');
   } else {
-    return `${integerToCurrency(amount.num1)} to ${integerToCurrency(
+    return `${format(amount.num1, 'financial')} to ${format(
       amount.num2,
+      'financial',
     )}`;
   }
 }
 
 function ScheduleDescription({ id }) {
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+  const format = useFormat();
   const scheduleQuery = useMemo(
     () => q('schedules').filter({ id }).select('*'),
     [id],
@@ -417,7 +415,7 @@ function ScheduleDescription({ id }) {
 
         <Text style={{ flexShrink: 0 }}>
           <Text> — </Text>
-          <Trans>Amount:</Trans> {formatAmount(schedule._amount)}
+          <Trans>Amount:</Trans> {formatAmount(schedule._amount, format)}
         </Text>
 
         <Text style={{ flexShrink: 0 }}>
@@ -808,13 +806,13 @@ function ConditionsList({
             // behavior and we can probably get rid of `makeValue`
             return makeValue(
               {
-                num1: amountToInteger(cond.value),
-                num2: amountToInteger(cond.value),
+                num1: cond.value,
+                num2: cond.value,
               },
               { ...cond, op: value },
             );
           } else if (cond.op === 'isbetween' && op !== 'isbetween') {
-            return makeValue(integerToAmount(cond.value.num1 || 0), {
+            return makeValue(cond.value.num1 || 0, {
               ...cond,
               op: value,
             });

--- a/packages/desktop-client/src/components/rules/Value.tsx
+++ b/packages/desktop-client/src/components/rules/Value.tsx
@@ -8,12 +8,12 @@ import { format as formatDate, parseISO } from 'date-fns';
 
 import { getMonthYearFormat } from 'loot-core/shared/months';
 import { getRecurringDescription } from 'loot-core/shared/schedules';
-import { integerToCurrency } from 'loot-core/shared/util';
 
 import { Link } from '@desktop-client/components/common/Link';
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
+import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 
@@ -38,6 +38,7 @@ export function Value<T>({
   style,
 }: ValueProps<T>) {
   const { t } = useTranslation();
+  const format = useFormat();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const payees = usePayees();
   const { list: categories } = useCategories();
@@ -73,7 +74,7 @@ export function Value<T>({
     } else {
       switch (field) {
         case 'amount':
-          return integerToCurrency(value);
+          return format(value, 'financial');
         case 'date':
           if (value) {
             if (value.frequency) {

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -7,6 +7,7 @@ import React, {
   type FocusEventHandler,
   type KeyboardEventHandler,
   type CSSProperties,
+  useCallback,
 } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -17,12 +18,8 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { css, cx } from '@emotion/css';
 
-import { evalArithmetic } from 'loot-core/shared/arithmetic';
-import { amountToInteger, appendDecimals } from 'loot-core/shared/util';
-
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useMergedRefs } from '@desktop-client/hooks/useMergedRefs';
-import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 
 type AmountInputProps = {
   id?: string;
@@ -67,14 +64,25 @@ export function AmountInput({
 
   const [isFocused, setIsFocused] = useState(focused ?? false);
 
-  const initialValueAbsolute = format(Math.abs(initialValue || 0), 'financial');
-  const [value, setValue] = useState(initialValueAbsolute);
-  useEffect(() => setValue(initialValueAbsolute), [initialValueAbsolute]);
+  const getDisplayValue = useCallback(
+    (value: number, isEditing: boolean) => {
+      const absoluteValue = Math.abs(value || 0);
+      return isEditing
+        ? format.forEdit(absoluteValue)
+        : format(absoluteValue, 'financial');
+    },
+    [format],
+  );
+
+  const [value, setValue] = useState(getDisplayValue(initialValue, false));
+  useEffect(
+    () => setValue(getDisplayValue(initialValue, isFocused)),
+    [initialValue, isFocused, getDisplayValue],
+  );
 
   const buttonRef = useRef(null);
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
-  const [hideFraction] = useSyncedPref('hideFraction');
 
   useEffect(() => {
     if (focused) {
@@ -92,15 +100,23 @@ export function AmountInput({
 
   function getAmount() {
     const signedValued = symbol === '-' ? symbol + value : value;
-    return amountToInteger(evalArithmetic(signedValued));
+    return format.fromEdit(signedValued, 0);
   }
 
   function onInputTextChange(val) {
-    val = autoDecimals
-      ? appendDecimals(val, String(hideFraction) === 'true')
-      : val;
-    setValue(val ? val : '');
-    onChangeValue?.(val);
+    let newText = val;
+    if (autoDecimals) {
+      const digits = val.replace(/\D/g, '');
+      if (digits === '') {
+        newText = '';
+      } else {
+        const intValue = parseInt(digits, 10);
+        newText = format.forEdit(intValue);
+      }
+    }
+
+    setValue(newText || '');
+    onChangeValue?.(newText);
   }
 
   function fireUpdate(amount) {
@@ -110,6 +126,7 @@ export function AmountInput({
     } else if (amount < 0) {
       setSymbol('-');
     }
+    setValue(format(Math.abs(amount), 'financial'));
   }
 
   function onInputAmountBlur(e) {
@@ -172,6 +189,7 @@ export function AmountInput({
         )}
         onFocus={e => {
           setIsFocused(true);
+          setValue(format.forEdit(Math.abs(initialValue)));
           onFocus?.(e);
         }}
         onBlur={e => {
@@ -183,6 +201,7 @@ export function AmountInput({
           const amount = getAmount();
           fireUpdate(amount);
         }}
+        useKeyDown={true}
         onChangeValue={onInputTextChange}
       />
     </View>

--- a/packages/desktop-client/src/components/util/GenericInput.jsx
+++ b/packages/desktop-client/src/components/util/GenericInput.jsx
@@ -5,7 +5,6 @@ import { Input } from '@actual-app/components/input';
 import { View } from '@actual-app/components/view';
 
 import { getMonthYearFormat } from 'loot-core/shared/months';
-import { integerToAmount, amountToInteger } from 'loot-core/shared/util';
 
 import { AmountInput } from './AmountInput';
 import { PercentInput } from './PercentInput';
@@ -48,8 +47,8 @@ export function GenericInput({
         return (
           <AmountInput
             inputRef={ref}
-            value={amountToInteger(value)}
-            onUpdate={v => onChange(integerToAmount(v))}
+            value={value}
+            onUpdate={v => onChange(v)}
           />
         );
       case 'percentage':

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -3,8 +3,6 @@ import { t } from 'i18next';
 
 import { FieldValueTypes, RuleConditionOp } from '../types/models';
 
-import { integerToAmount, amountToInteger, currencyToAmount } from './util';
-
 // For now, this info is duplicated from the backend. Figure out how
 // to share it later.
 const TYPE_INFO = {
@@ -288,22 +286,14 @@ export function sortNumbers(num1, num2) {
 export function parse(item) {
   if (item.op === 'set-split-amount') {
     if (item.options.method === 'fixed-amount') {
-      return { ...item, value: item.value && integerToAmount(item.value) };
+      return { ...item };
     }
     return item;
   }
 
   switch (item.type) {
     case 'number': {
-      let parsed = item.value;
-      if (
-        item.field === 'amount' &&
-        item.op !== 'isbetween' &&
-        parsed != null
-      ) {
-        parsed = integerToAmount(parsed);
-      }
-      return { ...item, value: parsed };
+      return { ...item };
     }
     case 'string': {
       const parsed = item.value == null ? '' : item.value;
@@ -324,7 +314,6 @@ export function unparse({ error, inputKey, ...item }) {
     if (item.options.method === 'fixed-amount') {
       return {
         ...item,
-        value: item.value && amountToInteger(item.value),
       };
     }
     if (item.options.method === 'fixed-percent') {
@@ -338,12 +327,7 @@ export function unparse({ error, inputKey, ...item }) {
 
   switch (item.type) {
     case 'number': {
-      let unparsed = item.value;
-      if (item.field === 'amount' && item.op !== 'isbetween') {
-        unparsed = amountToInteger(unparsed);
-      }
-
-      return { ...item, value: unparsed };
+      return { ...item };
     }
     case 'string': {
       const unparsed = item.value == null ? '' : item.value;
@@ -360,24 +344,14 @@ export function unparse({ error, inputKey, ...item }) {
 }
 
 export function makeValue(value, cond) {
-  switch (cond.type) {
-    case 'number': {
-      if (cond.op !== 'isbetween') {
-        return {
-          ...cond,
-          error: null,
-          value: value ? currencyToAmount(String(value)) || 0 : 0,
-        };
-      }
-      break;
-    }
-    default:
-  }
-
   const isMulti = ['oneOf', 'notOneOf'].includes(cond.op);
 
   if (isMulti) {
     return { ...cond, error: null, value: value || [] };
+  }
+
+  if (cond.type === 'number' && value == null) {
+    return { ...cond, error: null, value: 0 };
   }
 
   return { ...cond, error: null, value };

--- a/upcoming-release-notes/5536.md
+++ b/upcoming-release-notes/5536.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [misu-dev]
+---
+
+Adds currency display to the rules


### PR DESCRIPTION
This PR adds the currency display to the rules.
It also fixes https://github.com/actualbudget/actual/issues/5476 as the AmountInput got updated to handle currency specifics.

Also it now uses the number specific InputField in the Account Filter modal:
<img width="340" height="309" alt="image" src="https://github.com/user-attachments/assets/ce741dd7-7f87-4a54-a4ce-40122e4ecba2" />
This may break the visual of old field, but it is standardized for currency input and is already in use by the rules.

It also removes a lot of convertions like integerToAmount, amountToInteger, currencyToAmount