### PR TITLE
only show schedule name in notes for upcoming transactions

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1376,7 +1376,7 @@ const Transaction = memo(function Transaction({
         textAlign="flex"
         exposed={focusedField === 'notes'}
         focused={focusedField === 'notes'}
-        value={notes ?? schedule?.name ?? ''}
+        value={notes ?? (isPreview ? schedule?.name : null) ?? ''}
         valueStyle={valueStyle}
         formatter={value =>
           NotesTagFormatter({ notes: value, onNotesTagClick })

--- a/upcoming-release-notes/5580.md
+++ b/upcoming-release-notes/5580.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Only show schedule name in notes for upcoming transactions


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5578