### PR TITLE
Dispatch github ci jobs after running update-vrt workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,11 @@ on:
     branches:
       - master
   pull_request:
+  repository_dispatch:
+    types: [vrt_updated]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -22,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build API
@@ -38,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build CRDT
@@ -54,6 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build Web
@@ -73,6 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build Server

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - master
   pull_request:
+  repository_dispatch:
+    types: [vrt_updated]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -15,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Lint
@@ -23,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Typecheck
@@ -31,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Build Web
@@ -41,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Test
@@ -51,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [master]
   pull_request:
+  repository_dispatch:
+    types: [vrt_updated]
   schedule:
     - cron: '23 11 * * 6'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.client_payload.pr_number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -23,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/update-vrt.yml
+++ b/.github/workflows/update-vrt.yml
@@ -96,6 +96,17 @@ jobs:
           fi
           git commit -m "Update VRT"
           git push origin HEAD:${BRANCH_NAME}
+      - name: Trigger CI workflows
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: vrt_updated
+          client-payload: |
+            {
+              "pr_number": "${{ github.event.issue.number }}",
+              "branch": "${{ steps.comment-branch.outputs.head_ref }}",
+              "sha": "${{ steps.comment-branch.outputs.head_sha }}"
+            }
       - name: Add finished reaction
         uses: dkershner6/reaction-action@v2
         with:

--- a/upcoming-release-notes/5586.md
+++ b/upcoming-release-notes/5586.md
@@ -1,0 +1,7 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Add repository dispatch trigger to CI workflows for improved downstream job execution.
+


### PR DESCRIPTION
Enhance CI workflows to support repository dispatch events and improve branch handling

- Added support for `repository_dispatch` events in build, check, and codeql workflows.
- Updated concurrency group to include `client_payload.pr_number` for better context.
- Modified checkout steps to reference the correct branch from `client_payload` if available.

**Important:** I have not actually fully tested this. In theory - I think it will work. But if it fails after merging (because we need to merge to test it.. and I'm a bit lazy in terms of creating a fork and all that stuff..) - I will simply roll back this PR.