### PR TITLE
Mobile rules - update default stage to be "default" instead of "pre"

### DIFF
--- a/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
@@ -52,7 +52,7 @@ export function MobileRuleEditPage() {
 
   // If no rule is provided, create a new one
   const defaultRule: NewRuleEntity = rule || {
-    stage: 'pre',
+    stage: null,
     conditionsOp: 'and',
     conditions: [
       {

--- a/upcoming-release-notes/5587.md
+++ b/upcoming-release-notes/5587.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+mobile rules - change default new rule stage to be "default" instead of "pre"


### PR DESCRIPTION
This is to match the desktop experience.