### PR TITLE
Add conditional to schedules logic in rules page - improve VRT stability

### DIFF
--- a/packages/desktop-client/src/components/ManageRules.tsx
+++ b/packages/desktop-client/src/components/ManageRules.tsx
@@ -21,7 +21,11 @@ import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { q } from 'loot-core/shared/query';
 import { mapField, friendlyOp } from 'loot-core/shared/rules';
 import { describeSchedule } from 'loot-core/shared/schedules';
-import { type RuleEntity, type NewRuleEntity } from 'loot-core/types/models';
+import {
+  type RuleEntity,
+  type NewRuleEntity,
+  type ScheduleEntity,
+} from 'loot-core/types/models';
 
 import { InfiniteScrollWrapper } from './common/InfiniteScrollWrapper';
 import { Link } from './common/Link';
@@ -45,12 +49,7 @@ export type FilterData = {
   payees?: Array<{ id: string; name: string }>;
   categories?: Array<{ id: string; name: string }>;
   accounts?: Array<{ id: string; name: string }>;
-  schedules?: readonly {
-    id: string;
-    rule: string;
-    _payee: string;
-    completed: boolean;
-  }[];
+  schedules?: readonly ScheduleEntity[];
 };
 
 export function mapValue(
@@ -98,10 +97,12 @@ export function ruleToString(rule: RuleEntity, data: FilterData) {
       const schedule = data.schedules?.find(s => s.id === String(action.value));
       return [
         friendlyOp(action.op),
-        describeSchedule(
-          schedule,
-          data.payees?.find(p => p.id === schedule?._payee),
-        ),
+        schedule
+          ? describeSchedule(
+              schedule,
+              data.payees?.find(p => p.id === schedule._payee),
+            )
+          : '-',
       ];
     } else if (action.op === 'prepend-notes' || action.op === 'append-notes') {
       const noteValue = String(action.value || '');

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -4,6 +4,8 @@ import * as d from 'date-fns';
 import { Locale } from 'date-fns';
 import { t } from 'i18next';
 
+import { type PayeeEntity, type ScheduleEntity } from 'loot-core/types/models';
+
 import { Condition } from '../server/rules';
 
 import * as monthUtils from './months';
@@ -394,7 +396,10 @@ export function getScheduledAmount(
   return inverse ? -Math.round(avg) : Math.round(avg);
 }
 
-export function describeSchedule(schedule, payee) {
+export function describeSchedule(
+  schedule: ScheduleEntity,
+  payee?: PayeeEntity,
+) {
   if (payee) {
     return `${payee.name} (${schedule.next_date})`;
   } else {

--- a/upcoming-release-notes/5600.md
+++ b/upcoming-release-notes/5600.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Add missing conditional for describing schedules in rules page


### PR DESCRIPTION
Refactor schedule handling in ManageRules component

- Updated the ManageRules component to use ScheduleEntity type for schedules.
- Improved the describeSchedule function to include type annotations for better clarity.
- Added a conditional check to handle cases where the schedule may not exist, ensuring robust functionality.

**This has been making the rules VRT tests flaky. For example: https://github.com/actualbudget/actual/actions/runs/17114788611/job/48543539731?pr=5587**