### PR TITLE
fix: crash on filtering by amount

### DIFF
--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -340,7 +340,18 @@ export function unparse({ error, inputKey, ...item }) {
     case 'number': {
       let unparsed = item.value;
       if (item.field === 'amount' && item.op !== 'isbetween') {
-        unparsed = amountToInteger(unparsed);
+        // Handle both string (formatted) and number inputs
+        if (typeof unparsed === 'string') {
+          // Convert formatted string back to number first
+          unparsed = currencyToAmount(unparsed);
+          if (unparsed !== null && !isNaN(unparsed)) {
+            unparsed = amountToInteger(unparsed);
+          } else {
+            unparsed = null;
+          }
+        } else {
+          unparsed = amountToInteger(unparsed);
+        }
       }
 
       return { ...item, value: unparsed };


### PR DESCRIPTION
Fixes Issue https://github.com/actualbudget/actual/issues/5476, as there was no more work done in https://github.com/actualbudget/actual/pull/5515.
I also don't know if I can finish https://github.com/actualbudget/actual/pull/5536 (most likely not) before merge freeze.

As I don't have a lot of time, some testing of the rules should be done to make sure it does not introduce new bugs.