### PR TITLE
Fix range calculator on the MonthPicker component

### DIFF
--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -50,11 +50,11 @@ export const MonthPicker = ({
   const range = monthUtils.rangeInclusive(
     monthUtils.subMonths(
       firstSelectedMonth,
-      Math.ceil(targetMonthCount / 2 - numDisplayed / 2),
+      Math.floor(targetMonthCount / 2 - numDisplayed / 2),
     ),
     monthUtils.addMonths(
       lastSelectedMonth,
-      Math.ceil(targetMonthCount / 2 - numDisplayed / 2),
+      Math.floor(targetMonthCount / 2 - numDisplayed / 2),
     ),
   );
 

--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -50,11 +50,11 @@ export const MonthPicker = ({
   const range = monthUtils.rangeInclusive(
     monthUtils.subMonths(
       firstSelectedMonth,
-      targetMonthCount / 2 - numDisplayed / 2,
+      Math.ceil(targetMonthCount / 2 - numDisplayed / 2),
     ),
     monthUtils.addMonths(
       lastSelectedMonth,
-      targetMonthCount / 2 - numDisplayed / 2,
+      Math.ceil(targetMonthCount / 2 - numDisplayed / 2),
     ),
   );
 

--- a/upcoming-release-notes/5622.md
+++ b/upcoming-release-notes/5622.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [itsbekas]
+---
+
+Fix range calculator on the MonthPicker component


### PR DESCRIPTION
Fixes #5621 

There's a weird behavior I can't seem to pinpoint with `monthUtils.subMonth` and float values, where sometimes the subtraction matches the result's ceiling, and other times it matches its floor, which I suspect is related to date-fns/date-fns#4061. In the meantime, I've simply made the operation always return the result's floor, in order to make the behavior predictable.

Example:
`monthUtils.subMonths('2023-01', 4)` = 2022-09
`monthUtils.subMonths('2023-01', 4.5)` = 2022-09

`monthUtils.subMonths('2024-11', 4)` = 2024-07
`monthUtils.subMonths('2024-11', 4.5)` = 2024-06
