### PR TITLE
[fix] Adjust modal styles and text wrapping in TransactionError

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1184,7 +1184,12 @@ const Transaction = memo(function Transaction({
           triggerRef={triggerRef}
           isOpen
           isNonModal
-          style={{ width: 375, padding: 5, maxHeight: '38px !important' }}
+          style={{
+            maxWidth: 500,
+            minWidth: 375,
+            padding: 5,
+            maxHeight: '38px !important',
+          }}
           shouldFlip={false}
           placement="bottom end"
           UNSTABLE_portalContainer={listContainerRef.current}
@@ -1703,7 +1708,7 @@ function TransactionError({
             }}
             data-testid="transaction-error"
           >
-            <Text>
+            <Text style={{ whiteSpace: 'nowrap' }}>
               <Trans>Amount left:</Trans>{' '}
               <Text style={{ fontWeight: 500 }}>
                 {integerToCurrency(

--- a/upcoming-release-notes/5634.md
+++ b/upcoming-release-notes/5634.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [milanalexandre]
+---
+
+Adjust the size of the SplitTransactionError modal dynamically


### PR DESCRIPTION
## Context

The transactionError modal was displaying its content across two lines due to insufficient width constraints.

## Summary of Changes

- Updated the `style` property of the modal to set `maxWidth` and `minWidth`.
- Added `whiteSpace: 'nowrap'` to the `Text` component inside the `TransactionError` to ensure the text remains on a single line.

## How to test

- Create a split transaction.
- Modify the transaction value so that the amount is less than the total value.
- Confirm that the modal's width adjusts within the defined constraints.


|from|to|
|--|--|
| <img width="684" height="111" alt="Capture d’écran 2025-08-24 à 11 27 45" src="https://github.com/user-attachments/assets/cd2de29e-f5da-4727-a83f-785641b28305" /> | <img width="684" height="327" alt="Capture d’écran 2025-08-24 à 11 29 00" src="https://github.com/user-attachments/assets/f3396a79-9fa5-41c6-87a0-1b6928adc1f5" /> |