### PR TITLE
Allow releasing without approval from codeowners of all packages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,12 @@
 # passionate about. You will be notified for any PRs there.
 
 /packages/api/                                    @MatissJanis
+/packages/api/package.json
 /packages/component-library/                      @MatissJanis
-/packages/desktop-client/src/components/mobile    @joel-jeremy 
+/packages/component-library/package.json
+/packages/desktop-client/src/components/mobile    @joel-jeremy
 /packages/desktop-electron/                       @MikesGlitch
+/packages/desktop-electron/package.json
 /packages/loot-core/src/server/budget             @youngcw
 /packages/sync-server/                            @matt-fidd
+/packages/sync-server/package.json

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,12 +3,14 @@
 # passionate about. You will be notified for any PRs there.
 
 /packages/api/                                    @MatissJanis
-/packages/api/package.json
 /packages/component-library/                      @MatissJanis
-/packages/component-library/package.json
 /packages/desktop-client/src/components/mobile    @joel-jeremy
 /packages/desktop-electron/                       @MikesGlitch
-/packages/desktop-electron/package.json
 /packages/loot-core/src/server/budget             @youngcw
 /packages/sync-server/                            @matt-fidd
+
+# So releases are possible without a stamp from everyone
+/packages/api/package.json
+/packages/component-library/package.json
+/packages/desktop-electron/package.json
 /packages/sync-server/package.json

--- a/upcoming-release-notes/5667.md
+++ b/upcoming-release-notes/5667.md
@@ -1,0 +1,7 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Allow releases without requiring approval from codeowners for all packages.
+


### PR DESCRIPTION
Looking for feedback here. IMO releases shouldn't require a stamp from everybody, but open to pushback

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
