### PR TITLE
Fix incorrect month selected in Budget Header

### DIFF
--- a/packages/desktop-client/src/components/budget/MonthPicker.tsx
+++ b/packages/desktop-client/src/components/budget/MonthPicker.tsx
@@ -58,8 +58,7 @@ export const MonthPicker = ({
     ),
   );
 
-  const firstSelectedIndex =
-    Math.floor(range.length / 2) - Math.floor(numDisplayed / 2);
+  const firstSelectedIndex = range.indexOf(firstSelectedMonth);
   const lastSelectedIndex = firstSelectedIndex + numDisplayed - 1;
 
   const [size, setSize] = useState('small');


### PR DESCRIPTION
Fix incorrect selected month in Budget Header
<img width="1488" height="131" alt="Screenshot 2025-09-05 at 18 57 31" src="https://github.com/user-attachments/assets/f3665060-7ae7-4aea-860e-a9e57edfc525" />
