### PR TITLE
[WIP] Fix copy last month's budget including hidden categories

### DIFF
--- a/upcoming-release-notes/5735.md
+++ b/upcoming-release-notes/5735.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mgibson-scottlogic]
+---
+
+Exclude hidden categories from "Copy last month's budget" when copying whole month


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes #5720 

Update getBudgetData to include the 'hidden' state of a category.
Skip hidden categories when copying last months budget.
