### PR TITLE
[fix] make the StatusLabel text appear on a single line

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1432,6 +1432,7 @@ const Transaction = memo(function Transaction({
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 display: 'inline-block',
+                whiteSpace: 'nowrap',
               }}
             >
               {titleFirst(getStatusLabel(previewStatus ?? ''))}


### PR DESCRIPTION
|from|to|
|--|--|
| <img width="493" height="403" alt="Capture d’écran 2025-09-16 à 21 18 15" src="https://github.com/user-attachments/assets/7ace45ad-7d87-43e0-89ef-0c7147f28c47" /> | <img width="493" height="403" alt="Capture d’écran 2025-09-16 à 21 18 52" src="https://github.com/user-attachments/assets/8e43abe7-39ca-4fdc-8a90-4560dae9319e" />  |  

