### PR TITLE
fix: make sure cumulative value can not be undefined

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
@@ -63,7 +63,7 @@ const CustomTooltip = ({
   if (active && payload && payload.length) {
     const comparison = ['average', 'budget'].includes(selection)
       ? payload[0].payload[selection] * -1
-      : payload[0].payload.months[selection]?.cumulative * -1;
+      : (payload[0].payload.months[selection]?.cumulative ?? 0) * -1;
     return (
       <div
         className={css({


### PR DESCRIPTION
The cumulative value can get undefined, which results in NaN.

I have to say that I do not fully understand this component yet. This is more or less a quick fix. The proper behavior should be generally verified.

Fixes https://github.com/actualbudget/actual/issues/5729