### PR TITLE
Align amount conversion utilities between api and loot-core

### DIFF
--- a/packages/api/utils.js
+++ b/packages/api/utils.js
@@ -1,7 +1,9 @@
-export function amountToInteger(n) {
-  return Math.round(n * 100);
+export function amountToInteger(amount, decimalPlaces = 2) {
+  const multiplier = Math.pow(10, decimalPlaces);
+  return Math.round(amount * multiplier);
 }
 
-export function integerToAmount(n) {
-  return parseFloat((n / 100).toFixed(2));
+export function integerToAmount(integerAmount, decimalPlaces = 2) {
+  const divisor = Math.pow(10, decimalPlaces);
+  return parseFloat((integerAmount / divisor).toFixed(decimalPlaces));
 }

--- a/packages/api/utils.js
+++ b/packages/api/utils.js
@@ -1,9 +1,0 @@
-export function amountToInteger(amount, decimalPlaces = 2) {
-  const multiplier = Math.pow(10, decimalPlaces);
-  return Math.round(amount * multiplier);
-}
-
-export function integerToAmount(integerAmount, decimalPlaces = 2) {
-  const divisor = Math.pow(10, decimalPlaces);
-  return parseFloat((integerAmount / divisor).toFixed(decimalPlaces));
-}

--- a/packages/api/utils.ts
+++ b/packages/api/utils.ts
@@ -1,0 +1,1 @@
+export { amountToInteger, integerToAmount } from 'loot-core/shared/util';

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -5,14 +5,13 @@
 // entire backend bundle from the API
 import { send } from '@actual-app/api/injected';
 import * as actual from '@actual-app/api/methods';
-import { amountToInteger } from '@actual-app/api/utils';
 import AdmZip from 'adm-zip';
 import normalizePathSep from 'slash';
 import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '../../platform/server/log';
 import * as monthUtils from '../../shared/months';
-import { groupBy, sortByKey } from '../../shared/util';
+import { amountToInteger, groupBy, sortByKey } from '../../shared/util';
 
 import * as YNAB4 from './ynab4-types';
 

--- a/upcoming-release-notes/5747.md
+++ b/upcoming-release-notes/5747.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [StephenBrown2]
+---
+
+Align amount conversion utilities between api and loot-core


### PR DESCRIPTION
Updates api amount conversion utilities to use the loot-core versions.

- Removed duplicate implementations: Deleted the local amountToInteger and integerToAmount function implementations
- Added re-exports: Used a single export statement to re-export both functions from the loot-core module
- Maintained API compatibility: The public API remains exactly the same - consumers of this module won't need to change anything