### PR TITLE
Remove maxHeight property on CategoryList

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -132,7 +132,6 @@ function CategoryList({
           overflowY: 'auto',
           willChange: 'transform',
           padding: '5px 0',
-          ...(!embedded && { maxHeight: 175 }),
         }}
       >
         {splitTransaction &&

--- a/upcoming-release-notes/5754.md
+++ b/upcoming-release-notes/5754.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [patmagauran]
+---
+
+Increase height of category list in transaction view


### PR DESCRIPTION
When clicking on the category for a transaction in the transactions list, the menu that appears is frustratingly short, especially if you have created a lot of categories. This removes the maxHeight style property and allows it to auto size appropriately. If there is a reason for the height to be limited in certain scenarios I can revisit to settle on a better value or responsive value. 

I am attaching some before and after screenshots below. I have added a bunch of extra "dummy" categories to highlight the change.

Before
<img width="1827" height="1336" alt="image" src="https://github.com/user-attachments/assets/3d2db72d-de4f-4507-a104-f9b2178b5cfd" />




After
<img width="1827" height="1333" alt="image" src="https://github.com/user-attachments/assets/3f1fe7ee-9107-4902-8b1a-56cefc97ef72" />



Verification in responsive mode
<img width="1237" height="883" alt="image" src="https://github.com/user-attachments/assets/d9abe39e-1781-4de5-9fb4-cb8784750ef6" />

Verification in mobile mode
<img width="1128" height="1114" alt="image" src="https://github.com/user-attachments/assets/450ab249-5213-4995-821d-fdb6404e2797" />


<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
