### PR TITLE
add a 'dryRun' option to transactions import API

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -96,20 +96,21 @@ export function addTransactions(
 
 export interface ImportTransactionsOpts {
   defaultCleared?: boolean;
+  dryRun?: boolean;
 }
 
 export function importTransactions(
   accountId: string,
   transactions: ImportTransactionEntity[],
-  dryRun?: boolean,
   opts: ImportTransactionsOpts = {
     defaultCleared: true,
+    dryRun: false,
   },
 ) {
   return send('api/transactions-import', {
     accountId,
     transactions,
-    isPreview: dryRun,
+    isPreview: opts.dryRun,
     opts,
   });
 }

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -101,6 +101,7 @@ export interface ImportTransactionsOpts {
 export function importTransactions(
   accountId: string,
   transactions: ImportTransactionEntity[],
+  dryRun?: boolean,
   opts: ImportTransactionsOpts = {
     defaultCleared: true,
   },
@@ -108,6 +109,7 @@ export function importTransactions(
   return send('api/transactions-import', {
     accountId,
     transactions,
+    isPreview: dryRun,
     opts,
   });
 }

--- a/upcoming-release-notes/5758.md
+++ b/upcoming-release-notes/5758.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [amrawadk]
+---
+
+Add 'dryRun' option to importTransactions API.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

This allows previewing imported transactions ahead of importing. This is useful for import scripts like https://github.com/lunchflow/actual-flow, where the users will preview the transactions ahead of the import then confirm.

<img width="4721" height="2160" alt="image" src="https://github.com/user-attachments/assets/8d9d4d5d-170e-48aa-82d9-b06ec1fa1296" />


The name `isPreview` wasn't very self explanatory, so I'm proposing `dryRun`, similar to what's used in AWS CLI ([example](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#options)), but open to feedback on this 😄 I also didn't rename across the board to keep the PR focused, but happy to do so as well.
