### PR TITLE
fix nuisance timestamp error in API

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -42,7 +42,11 @@ export async function init(config: InitConfig = {}) {
 
 export async function shutdown() {
   if (actualApp) {
-    await actualApp.send('sync');
+    try {
+      await actualApp.send('sync');
+    } catch (e) {
+      // most likely that no budget is loaded, so the sync failed
+    }
     await actualApp.send('close-budget');
     actualApp = null;
   }

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -625,11 +625,20 @@ async function _fullSync(
   count: number,
   prevDiffTime: number,
 ): Promise<Message[]> {
-  const { cloudFileId, groupId, lastSyncedTimestamp } = prefs.getPrefs() || {};
+  const {
+    id: currentId,
+    cloudFileId,
+    groupId,
+    lastSyncedTimestamp,
+  } = prefs.getPrefs() || {};
 
   clearFullSyncTimeout();
 
-  if (checkSyncingMode('disabled') || checkSyncingMode('offline')) {
+  if (
+    checkSyncingMode('disabled') ||
+    checkSyncingMode('offline') ||
+    !currentId
+  ) {
     return [];
   }
 

--- a/upcoming-release-notes/5759.md
+++ b/upcoming-release-notes/5759.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix timestamp error when shutting down API with no budget loaded


### PR DESCRIPTION
I _think_ there might be a race that triggers this too, because I've seen it once every 100 ish calls to the API but this should sort it out. The error is caused by the crdt clock not being set, and trying to sync regardless.

Error:
```
TypeError: Cannot read properties of undefined (reading 'timestamp')
    at _fullSync (/Users/x/actual-api-test/node_modules/@actual-app/api/dist/app/bundle.api.js:60079:35)
```

Repro script:
```js
import * as api from '@actual-app/api';

async function test() {
    await api.init({
        dataDir: './data, 
        serverURL: 'http://loaclhost:5006',
        password: 'password' 
    });

    await api.shutdown();
}
```