### PR TITLE
improve cleanup when opening multiple budgets through the API

### DIFF
--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -206,6 +206,7 @@ async function downloadBudget({
   }
 
   const id = result.id;
+  await closeBudget();
   await loadBudget({ id });
   result = await syncBudget();
 
@@ -262,7 +263,7 @@ async function closeBudget() {
   sheet.unloadSpreadsheet();
 
   clearFullSyncTimeout();
-  await app.stopServices();
+  await mainApp.stopServices();
 
   await db.closeDatabase();
 

--- a/upcoming-release-notes/5760.md
+++ b/upcoming-release-notes/5760.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Improve cleanup when opening multiple budgets through the API


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5441