### PR TITLE
[WIP] fix: remove hidden decimals check in amount input

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -17,6 +17,7 @@ import { css } from '@emotion/css';
 
 import {
   amountToCurrency,
+  amountToCurrencyWithDecimal,
   appendDecimals,
   currencyToAmount,
   reapplyThousandSeparators,
@@ -50,7 +51,6 @@ const AmountInput = memo(function AmountInput({
   const [text, setText] = useState('');
   const [value, setValue] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [hideFraction] = useSyncedPref('hideFraction');
 
   const mergedInputRef = useMergedRefs<HTMLInputElement>(
     props.inputRef,
@@ -125,7 +125,7 @@ const AmountInput = memo(function AmountInput({
     <input
       type="text"
       ref={mergedInputRef}
-      value={amountToCurrency(value)}
+      value={amountToCurrencyWithDecimal(value)}
       inputMode="decimal"
       autoCapitalize="none"
       onChange={e => onChangeText(e.target.value)}

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -115,7 +115,7 @@ const AmountInput = memo(function AmountInput({
 
   const onChangeText = (text: string) => {
     text = reapplyThousandSeparators(text);
-    text = appendDecimals(text, String(hideFraction) === 'true');
+    text = appendDecimals(text);
     setEditing(true);
     setText(text);
     props.onChangeValue?.(text);

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -125,7 +125,7 @@ const AmountInput = memo(function AmountInput({
     <input
       type="text"
       ref={mergedInputRef}
-      value={text}
+      value={amountToCurrency(value)}
       inputMode="decimal"
       autoCapitalize="none"
       onChange={e => onChangeText(e.target.value)}

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.jsx
@@ -393,7 +393,6 @@ const ChildTransactionEdit = forwardRef(
                   onClearActiveEdit();
                 }
               }}
-              autoDecimals={true}
             />
           </View>
         </View>

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -50,7 +50,6 @@ export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
             <InitialFocus>
               <AmountInput
                 value={available}
-                autoDecimals={true}
                 zeroSign="+"
                 style={{
                   marginLeft: styles.mobileEditingPadding,

--- a/packages/desktop-client/src/components/modals/TransferModal.tsx
+++ b/packages/desktop-client/src/components/modals/TransferModal.tsx
@@ -99,7 +99,6 @@ export function TransferModal({
               <InitialFocus>
                 <AmountInput
                   value={initialAmount}
-                  autoDecimals={true}
                   style={{
                     marginLeft: styles.mobileEditingPadding,
                     marginRight: styles.mobileEditingPadding,

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -94,7 +94,7 @@ export function AmountInput({
   }
 
   function onInputTextChange(val) {
-    val = appendDecimals(val)
+    val = appendDecimals(val);
     setValue(val ? val : '');
     onChangeValue?.(val);
   }

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -72,7 +72,6 @@ export function AmountInput({
   const buttonRef = useRef(null);
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
-  const [hideFraction] = useSyncedPref('hideFraction');
 
   useEffect(() => {
     if (focused) {

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -39,7 +39,6 @@ type AmountInputProps = {
   inputClassName?: string;
   focused?: boolean;
   disabled?: boolean;
-  autoDecimals?: boolean;
 };
 
 export function AmountInput({
@@ -57,7 +56,6 @@ export function AmountInput({
   inputClassName,
   focused,
   disabled = false,
-  autoDecimals = false,
 }: AmountInputProps) {
   const { t } = useTranslation();
   const format = useFormat();
@@ -96,9 +94,7 @@ export function AmountInput({
   }
 
   function onInputTextChange(val) {
-    val = autoDecimals
-      ? appendDecimals(val, String(hideFraction) === 'true')
-      : val;
+    val = appendDecimals(val)
     setValue(val ? val : '');
     onChangeValue?.(val);
   }

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -441,7 +441,9 @@ export function amountToCurrencyNoDecimal(amount: Amount): CurrencyAmount {
   }).formatter.format(amount);
 }
 
-export function currencyToAmount(currencyAmount: CurrencyAmount): Amount | null {
+export function currencyToAmount(
+  currencyAmount: CurrencyAmount,
+): Amount | null {
   let integer, fraction;
 
   // match the last dot or comma in the string

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -441,7 +441,7 @@ export function amountToCurrencyNoDecimal(amount: Amount): CurrencyAmount {
   }).formatter.format(amount);
 }
 
-export function currencyToAmount(currencyAmount: string): Amount | null {
+export function currencyToAmount(currencyAmount: CurrencyAmount): Amount | null {
   let integer, fraction;
 
   // match the last dot or comma in the string

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -434,10 +434,10 @@ export function amountToCurrency(amount: Amount): CurrencyAmount {
   return getNumberFormat().formatter.format(amount);
 }
 
-export function amountToCurrencyNoDecimal(amount: Amount): CurrencyAmount {
+export function amountToCurrencyWithDecimal(amount: Amount): CurrencyAmount {
   return getNumberFormat({
     ...numberFormatConfig,
-    hideFraction: true,
+    hideFraction: false,
   }).formatter.format(amount);
 }
 

--- a/upcoming-release-notes/5763.md
+++ b/upcoming-release-notes/5763.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [csenel]
+---
+
+remove hidden decimals check in amount input


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
Fixes https://github.com/actualbudget/actual/issues/3294

Attempt to fix the bug above. The code looked a bit cryptic to me but it seems like the `hideFraction` setting is applied while editing the text. This in turn changes the amount for the transaction. Removing this check should show the actual value while editing.