### PR TITLE
fix: add minimum width to value editor in ConditionEditor component

### DIFF
--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -348,7 +348,7 @@ function ConditionEditor({
       />
       <OpSelect ops={ops} value={op} type={type} onChange={onChange} />
 
-      <View style={{ flex: 1 }}>{valueEditor}</View>
+      <View style={{ flex: 1, minWidth: 80 }}>{valueEditor}</View>
 
       <Stack direction="row">
         <EditorButtons

--- a/upcoming-release-notes/5766.md
+++ b/upcoming-release-notes/5766.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Mobile rules page - set min width for value editor


### PR DESCRIPTION
This is not a _perfect_ fix, but at least it makes the form usable on smaller devices.

---

Before:
<img width="850" height="412" alt="image" src="https://github.com/user-attachments/assets/20ef5fa3-6530-4986-a060-484223233877" />


After:
<img width="423" height="613" alt="Screenshot 2025-09-22 at 11 28 45" src="https://github.com/user-attachments/assets/b13eb4b0-bb43-40be-bae8-f42b987a05f8" />
