### PR TITLE
Mobile payees: click handlers

### DIFF
--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
@@ -1,24 +1,28 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
+import { send } from 'loot-core/platform/client/fetch';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
-import { type PayeeEntity } from 'loot-core/types/models';
+import { type PayeeEntity, type RuleEntity } from 'loot-core/types/models';
 
 import { PayeesList } from './PayeesList';
 
 import { Search } from '@desktop-client/components/common/Search';
 import { MobilePageHeader, Page } from '@desktop-client/components/Page';
+import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useSelector } from '@desktop-client/redux';
 
 export function MobilePayeesPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const payees = usePayees();
   const [filter, setFilter] = useState('');
+  const [ruleCounts, setRuleCounts] = useState(new Map<string, number>());
   const isLoading = useSelector(
     s => s.payees.isPayeesLoading || s.payees.isCommonPayeesLoading,
   );
@@ -29,13 +33,57 @@ export function MobilePayeesPage() {
     return payees.filter(p => getNormalisedString(p.name).includes(norm));
   }, [payees, filter]);
 
+  const refetchRuleCounts = useCallback(async () => {
+    const counts = await send('payees-get-rule-counts');
+    const countsMap = new Map(Object.entries(counts));
+    setRuleCounts(countsMap);
+  }, []);
+
+  useEffect(() => {
+    refetchRuleCounts();
+  }, [refetchRuleCounts]);
+
   const onSearchChange = useCallback((value: string) => {
     setFilter(value);
   }, []);
 
-  const handlePayeePress = useCallback((_payee: PayeeEntity) => {
-    // Intentionally no-op for now
-  }, []);
+  const handlePayeePress = useCallback(
+    async (payee: PayeeEntity) => {
+      // View associated rules for the payee
+      if ((ruleCounts.get(payee.id) ?? 0) > 0) {
+        try {
+          const associatedRules: RuleEntity[] = await send('payees-get-rules', {
+            id: payee.id,
+          });
+          const ruleIds = associatedRules.map(rule => rule.id).join(',');
+          navigate(`/rules?visible-rules=${ruleIds}`);
+          return;
+        } catch (error) {
+          console.error('Failed to fetch payee rules:', error);
+          // Fallback to general rules page
+          navigate('/rules');
+          return;
+        }
+      }
+
+      // Create a new rule for the payee
+      navigate('/rules/new', {
+        state: {
+          rule: {
+            conditions: [
+              {
+                field: 'payee',
+                op: 'is',
+                value: payee.id,
+                type: 'id',
+              },
+            ],
+          },
+        },
+      });
+    },
+    [navigate, ruleCounts],
+  );
 
   return (
     <Page header={<MobilePageHeader title={t('Payees')} />} padding={0}>
@@ -65,6 +113,7 @@ export function MobilePayeesPage() {
       </View>
       <PayeesList
         payees={filteredPayees}
+        ruleCounts={ruleCounts}
         isLoading={isLoading}
         onPayeePress={handlePayeePress}
       />

--- a/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
@@ -13,12 +13,14 @@ import { MOBILE_NAV_HEIGHT } from '@desktop-client/components/mobile/MobileNavTa
 
 type PayeesListProps = {
   payees: PayeeEntity[];
+  ruleCounts: Map<string, number>;
   isLoading?: boolean;
   onPayeePress: (payee: PayeeEntity) => void;
 };
 
 export function PayeesList({
   payees,
+  ruleCounts,
   isLoading = false,
   onPayeePress,
 }: PayeesListProps) {
@@ -68,6 +70,7 @@ export function PayeesList({
         <PayeesListItem
           key={payee.id}
           payee={payee}
+          ruleCount={ruleCounts.get(payee.id) || 0}
           onPress={() => onPayeePress(payee)}
         />
       ))}

--- a/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
@@ -1,17 +1,28 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgBookmark } from '@actual-app/components/icons/v1';
+import { SpaceBetween } from '@actual-app/components/space-between';
 import { theme } from '@actual-app/components/theme';
 
 import { type PayeeEntity } from 'loot-core/types/models';
 
+import { PayeeRuleCountLabel } from '@desktop-client/components/payees/PayeeRuleCountLabel';
+
 type PayeesListItemProps = {
   payee: PayeeEntity;
+  ruleCount: number;
   onPress: () => void;
 };
 
-export function PayeesListItem({ payee, onPress }: PayeesListItemProps) {
+export function PayeesListItem({
+  payee,
+  ruleCount,
+  onPress,
+}: PayeesListItemProps) {
+  const { t } = useTranslation();
+
   return (
     <Button
       variant="bare"
@@ -41,19 +52,43 @@ export function PayeesListItem({ payee, onPress }: PayeesListItemProps) {
           }}
         />
       )}
-      <span
+      <SpaceBetween
         style={{
-          fontSize: 15,
-          fontWeight: 500,
-          color: theme.pageText,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
+          justifyContent: 'space-between',
+          flex: 1,
+          alignItems: 'flex-start',
         }}
-        title={payee.name}
       >
-        {payee.name}
-      </span>
+        <span
+          style={{
+            fontSize: 15,
+            fontWeight: 500,
+            color: payee.transfer_acct ? theme.pageTextSubdued : theme.pageText,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            flex: 1,
+            textAlign: 'left',
+          }}
+          title={payee.name}
+        >
+          {(payee.transfer_acct ? t('Transfer: ') : '') + payee.name}
+        </span>
+
+        <span
+          style={{
+            borderRadius: 4,
+            padding: '3px 6px',
+            backgroundColor: theme.noticeBackground,
+            border: '1px solid ' + theme.noticeBackground,
+            color: theme.noticeTextDark,
+            fontSize: 12,
+            flexShrink: 0,
+          }}
+        >
+          <PayeeRuleCountLabel count={ruleCount} style={{ fontSize: 12 }} />
+        </span>
+      </SpaceBetween>
     </Button>
   );
 }

--- a/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
-import { useParams } from 'react-router';
+import { useLocation, useParams } from 'react-router';
 
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
@@ -21,6 +21,7 @@ export function MobileRuleEditPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { id } = useParams<{ id?: string }>();
+  const location = useLocation();
   const dispatch = useDispatch();
 
   const [rule, setRule] = useState<RuleEntity | null>(null);
@@ -70,6 +71,7 @@ export function MobileRuleEditPage() {
         type: 'id',
       },
     ],
+    ...(location.state.rule || {}),
   };
 
   const handleSave = () => {
@@ -78,7 +80,7 @@ export function MobileRuleEditPage() {
   };
 
   const handleCancel = () => {
-    navigate('/rules');
+    navigate(-1);
   };
 
   const handleDelete = () => {

--- a/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
@@ -21,12 +21,14 @@ import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useSchedules } from '@desktop-client/hooks/useSchedules';
+import { useUrlParam } from '@desktop-client/hooks/useUrlParam';
 
 const PAGE_SIZE = 50;
 
 export function MobileRulesPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [visibleRulesParam] = useUrlParam('visible-rules');
   const [allRules, setAllRules] = useState<RuleEntity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasMoreRules, setHasMoreRules] = useState(true);
@@ -48,8 +50,17 @@ export function MobileRulesPage() {
     [payees, accounts, schedules, categories],
   );
 
+  const visibleRules = useMemo(() => {
+    if (!visibleRulesParam || visibleRulesParam.trim() === '') {
+      return allRules;
+    }
+
+    const visibleRuleIds = visibleRulesParam.split(',').map(id => id.trim());
+    return allRules.filter(rule => visibleRuleIds.includes(rule.id));
+  }, [allRules, visibleRulesParam]);
+
   const filteredRules = useMemo(() => {
-    const rules = allRules.filter(rule => {
+    const rules = visibleRules.filter(rule => {
       const schedule = schedules.find(schedule => schedule.rule === rule.id);
       return schedule ? schedule.completed === false : true;
     });
@@ -61,7 +72,7 @@ export function MobileRulesPage() {
             getNormalisedString(filter),
           ),
         );
-  }, [allRules, filter, filterData, schedules]);
+  }, [visibleRules, filter, filterData, schedules]);
 
   const loadRules = useCallback(async (append = false) => {
     try {

--- a/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
@@ -1,0 +1,24 @@
+import { type CSSProperties } from 'react';
+import { Trans } from 'react-i18next';
+
+import { Text } from '@actual-app/components/text';
+
+type PayeeRuleCountLabelProps = {
+  count: number;
+  style?: CSSProperties;
+};
+
+export function PayeeRuleCountLabel({
+  count,
+  style,
+}: PayeeRuleCountLabelProps) {
+  return (
+    <Text style={style}>
+      {count > 0 ? (
+        <Trans count={count}>{{ count }} associated rules</Trans>
+      ) : (
+        <Trans>Create rule</Trans>
+      )}
+    </Text>
+  );
+}

--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 import { memo, useRef, useMemo, type CSSProperties } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import {
   SvgArrowThinRight,
@@ -9,11 +9,12 @@ import {
 } from '@actual-app/components/icons/v1';
 import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
-import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 
 import { type PayeeEntity } from 'loot-core/types/models';
+
+import { PayeeRuleCountLabel } from './PayeeRuleCountLabel';
 
 import {
   Cell,
@@ -38,8 +39,6 @@ type RuleButtonProps = {
 };
 
 function RuleButton({ ruleCount, focused, onEdit, onClick }: RuleButtonProps) {
-  const count = ruleCount;
-
   return (
     <Cell
       name="rule-count"
@@ -62,13 +61,7 @@ function RuleButton({ ruleCount, focused, onEdit, onClick }: RuleButtonProps) {
         onEdit={onEdit}
         onSelect={onClick}
       >
-        <Text style={{ paddingRight: 5 }}>
-          {ruleCount > 0 ? (
-            <Trans count={ruleCount}>{{ count }} associated rules</Trans>
-          ) : (
-            <Trans>Create rule</Trans>
-          )}
-        </Text>
+        <PayeeRuleCountLabel count={ruleCount} style={{ paddingRight: 5 }} />
         <SvgArrowThinRight style={{ width: 8, height: 8 }} />
       </CellButton>
     </Cell>

--- a/packages/desktop-client/src/hooks/useUrlParam.ts
+++ b/packages/desktop-client/src/hooks/useUrlParam.ts
@@ -1,0 +1,17 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router';
+
+/**
+ * Hook to get and set a specific URL search parameter value
+ */
+export function useUrlParam(name: string) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setParam = useCallback(
+    (value: string) => {
+      setSearchParams({ [name]: value });
+    },
+    [name, setSearchParams],
+  );
+
+  return [searchParams.get(name), setParam] as const;
+}

--- a/upcoming-release-notes/5776.md
+++ b/upcoming-release-notes/5776.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Mobile payees - clicking takes to appropriate pages


### PR DESCRIPTION
Next step for https://github.com/actualbudget/actual/pull/5767

Enhance Mobile Payees Page with Rule Counts and Navigation

- Added functionality to fetch and display rule counts for each payee.
- Implemented navigation to associated rules or creation of new rules based on payee selection.
- Updated PayeesList and PayeesListItem components to show rule counts.
- Improved MobileRuleEditPage to handle navigation state more effectively.

