### PR TITLE
[WIP] [FIX] Translate Schedule '(No payee)'

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -510,6 +510,7 @@ function PayeeCell({
   onNavigateToSchedule,
 }: PayeeCellProps) {
   const isCreatingPayee = useRef(false);
+  const { t } = useTranslation();
 
   const dispatch = useDispatch();
 
@@ -639,7 +640,7 @@ function PayeeCell({
       }}
       formatter={() => {
         if (!displayPayee && isPreview) {
-          return '(No payee)';
+          return t('(No payee)');
         }
         return displayPayee;
       }}

--- a/upcoming-release-notes/5777.md
+++ b/upcoming-release-notes/5777.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [milanalexandre]
+---
+
+Translated ‘(No payee)’ for a scheduled transaction


### PR DESCRIPTION
# Summary

Translated  ‘(No payee)’ for a scheduled transaction 
<img width="1092" height="185" alt="image" src="https://github.com/user-attachments/assets/54a439f7-8c2a-4cc3-9445-790b5d5102b9" />
