### PR TITLE
Frontend plugins Support [3/10]: System-Wide Feature Flag System + Frontend plugins feature flag

### DIFF
--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -5,13 +5,14 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import type { FeatureFlag } from 'loot-core/types/prefs';
+import type { FeatureFlag, GlobalPrefs } from 'loot-core/types/prefs';
 
 import { Setting } from './UI';
 
 import { Link } from '@desktop-client/components/common/Link';
 import { Checkbox } from '@desktop-client/components/forms';
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';
+import { useGlobalPref } from '@desktop-client/hooks/useGlobalPref';
 import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 
 type FeatureToggleProps = {
@@ -38,6 +39,59 @@ function FeatureToggle({
         checked={enabled}
         onChange={() => {
           setFlagPref(String(!enabled));
+        }}
+        disabled={disableToggle}
+      />
+      <View
+        style={{ color: disableToggle ? theme.pageTextSubdued : 'inherit' }}
+      >
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+          {children}
+          {feedbackLink && (
+            <Link variant="external" to={feedbackLink}>
+              <Trans>(give feedback)</Trans>
+            </Link>
+          )}
+        </View>
+
+        {disableToggle && (
+          <Text
+            style={{
+              color: theme.errorText,
+              fontWeight: 500,
+            }}
+          >
+            {error}
+          </Text>
+        )}
+      </View>
+    </label>
+  );
+}
+
+type GlobalFeatureToggleProps = {
+  prefName: keyof GlobalPrefs;
+  disableToggle?: boolean;
+  error?: ReactNode;
+  children: ReactNode;
+  feedbackLink?: string;
+};
+
+function GlobalFeatureToggle({
+  prefName,
+  disableToggle = false,
+  feedbackLink,
+  error,
+  children,
+}: GlobalFeatureToggleProps) {
+  const [enabled, setEnabled] = useGlobalPref(prefName);
+
+  return (
+    <label style={{ display: 'flex' }}>
+      <Checkbox
+        checked={Boolean(enabled)}
+        onChange={() => {
+          setEnabled(!enabled);
         }}
         disabled={disableToggle}
       />
@@ -105,6 +159,13 @@ export function ExperimentalFeatures() {
             >
               <Trans>Currency support</Trans>
             </FeatureToggle>
+            {/* Commented out until all PR's are merged */}
+            {/* <GlobalFeatureToggle
+              prefName="plugins"
+              feedbackLink="https://github.com/actualbudget/actual/pull/4049"
+            >
+              <Trans>Client-Side plugins</Trans>
+            </GlobalFeatureToggle> */}
           </View>
         ) : (
           <Link

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -7,6 +7,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   goalTemplatesUIEnabled: false,
   actionTemplating: false,
   currency: false,
+  plugins: false
 };
 
 export function useFeatureFlag(name: FeatureFlag): boolean {

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -2,7 +2,8 @@ export type FeatureFlag =
   | 'goalTemplatesEnabled'
   | 'goalTemplatesUIEnabled'
   | 'actionTemplating'
-  | 'currency';
+  | 'currency'
+  | 'plugins';
 
 /**
  * Cross-device preferences. These sync across devices when they are changed.
@@ -81,7 +82,13 @@ export type LocalPrefs = Partial<{
   'mobile.showSpentColumn': boolean;
 }>;
 
-export type Theme = 'light' | 'dark' | 'auto' | 'midnight' | 'development';
+export type Theme =
+  | 'light'
+  | 'dark'
+  | 'auto'
+  | 'midnight'
+  | 'development'
+  | string;
 export type DarkTheme = 'dark' | 'midnight';
 
 // GlobalPrefs are the parsed global-store.json values
@@ -93,6 +100,17 @@ export type GlobalPrefs = Partial<{
   language: string;
   theme: Theme;
   preferredDarkTheme: DarkTheme;
+  plugins: boolean;
+  pluginThemes: Record<
+    string,
+    {
+      id: string;
+      displayName: string;
+      description?: string;
+      baseTheme?: 'light' | 'dark' | 'midnight';
+      colors: Record<string, string>;
+    }
+  >; // Complete plugin theme metadata
   documentDir: string; // Electron only
   serverSelfSignedCert: string; // Electron only
   syncServerConfig?: {
@@ -121,8 +139,11 @@ export type GlobalPrefsJson = Partial<{
   language?: GlobalPrefs['language'];
   theme?: GlobalPrefs['theme'];
   'preferred-dark-theme'?: GlobalPrefs['preferredDarkTheme'];
+  plugins?: string; // "true" or "false"
+  'plugin-themes'?: string; // JSON string of complete plugin theme (current selected plugin theme)
   'server-self-signed-cert'?: GlobalPrefs['serverSelfSignedCert'];
   syncServerConfig?: GlobalPrefs['syncServerConfig'];
+  pluginThemes?: GlobalPrefs['pluginThemes']; //All available plugin themes.
   notifyWhenUpdateIsAvailable?: GlobalPrefs['notifyWhenUpdateIsAvailable'];
 }>;
 


### PR DESCRIPTION
- [x] ~PR 1: Basic CORS Proxy Structure~
- [x] PR 2: Plugin Service Worker & PWA Infrastructure 
- [x] PR 3: System-Wide Feature Flag System + Frontend plugins feature flag (**This PR**)
- [ ] PR 4: Plugins Core Package
- [ ] PR 5: Update `loot-core` to reference `plugins-core`
- [ ] PR 6: Update `desktop-client` to reference `plugins-core`
- [ ] PR 7: Plugin runtime on desktop-client (module federation)
- [ ] PR 8: Plugins frontend pages
- [ ] PR 9: Plugin example
- [ ] PR 10: Integration fixes and documentation

Create a simple feature flag that is stored on the browser indexeddb, so all budgets uses this feature flag.
Also, created the structure of the plugins feature flag (but commented out the toggle)