### PR TITLE
fix live report time ranges

### DIFF
--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -186,9 +186,13 @@ export function calculateTimeRange(
   const mode = timeFrame?.mode ?? defaultTimeFrame?.mode ?? 'sliding-window';
 
   if (mode === 'full') {
-    const fullEnd = latestTransaction 
+    const latestTransactionMonth = latestTransaction 
       ? monthUtils.monthFromDate(latestTransaction)
-      : end;
+      : null;
+    const currentMonth = monthUtils.currentMonth();
+    const fullEnd = latestTransactionMonth && monthUtils.isAfter(latestTransactionMonth, currentMonth)
+      ? latestTransactionMonth
+      : currentMonth;
     return getFullRange(start, fullEnd);
   }
   if (mode === 'sliding-window') {

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -175,6 +175,7 @@ export function getLatestRange(offset: number) {
 export function calculateTimeRange(
   timeFrame?: Partial<TimeFrame>,
   defaultTimeFrame?: TimeFrame,
+  latestTransaction?: string,
 ) {
   const start =
     timeFrame?.start ??
@@ -185,7 +186,10 @@ export function calculateTimeRange(
   const mode = timeFrame?.mode ?? defaultTimeFrame?.mode ?? 'sliding-window';
 
   if (mode === 'full') {
-    return getFullRange(start, end);
+    const fullEnd = latestTransaction 
+      ? monthUtils.monthFromDate(latestTransaction)
+      : end;
+    return getFullRange(start, fullEnd);
   }
   if (mode === 'sliding-window') {
     const offset = monthUtils.differenceInCalendarMonths(end, start);

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -186,13 +186,15 @@ export function calculateTimeRange(
   const mode = timeFrame?.mode ?? defaultTimeFrame?.mode ?? 'sliding-window';
 
   if (mode === 'full') {
-    const latestTransactionMonth = latestTransaction 
+    const latestTransactionMonth = latestTransaction
       ? monthUtils.monthFromDate(latestTransaction)
       : null;
     const currentMonth = monthUtils.currentMonth();
-    const fullEnd = latestTransactionMonth && monthUtils.isAfter(latestTransactionMonth, currentMonth)
-      ? latestTransactionMonth
-      : currentMonth;
+    const fullEnd =
+      latestTransactionMonth &&
+      monthUtils.isAfter(latestTransactionMonth, currentMonth)
+        ? latestTransactionMonth
+        : currentMonth;
     return getFullRange(start, fullEnd);
   }
   if (mode === 'sliding-window') {

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -106,7 +106,9 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const { t } = useTranslation();
   const format = useFormat();
 
-  const [start, setStart] = useState(monthUtils.dayFromDate(monthUtils.currentMonth()));
+  const [start, setStart] = useState(
+    monthUtils.dayFromDate(monthUtils.currentMonth()),
+  );
   const [end, setEnd] = useState(monthUtils.currentDay());
   const [mode, setMode] = useState<TimeFrame['mode']>('full');
   const [query, setQuery] = useState<Query | undefined>(undefined);

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -106,19 +106,12 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const { t } = useTranslation();
   const format = useFormat();
 
-  const [initialStart, initialEnd, initialMode] = calculateTimeRange(
-    widget?.meta?.timeFrame,
-    {
-      start: monthUtils.dayFromDate(monthUtils.currentMonth()),
-      end: monthUtils.currentDay(),
-      mode: 'full',
-    },
-  );
-  const [start, setStart] = useState(initialStart);
-  const [end, setEnd] = useState(initialEnd);
-  const [mode, setMode] = useState(initialMode);
+  const [start, setStart] = useState(monthUtils.dayFromDate(monthUtils.currentMonth()));
+  const [end, setEnd] = useState(monthUtils.currentDay());
+  const [mode, setMode] = useState<TimeFrame['mode']>('full');
   const [query, setQuery] = useState<Query | undefined>(undefined);
   const [dirty, setDirty] = useState(false);
+  const [latestTransaction, setLatestTransaction] = useState('');
 
   const { transactions: transactionsGrouped, loadMore: loadMoreTransactions } =
     useTransactions({ query });
@@ -304,6 +297,23 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
     }
     run();
   }, [locale]);
+
+  useEffect(() => {
+    if (latestTransaction) {
+      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+        widget?.meta?.timeFrame,
+        {
+          start: monthUtils.dayFromDate(monthUtils.currentMonth()),
+          end: monthUtils.currentDay(),
+          mode: 'full',
+        },
+        latestTransaction,
+      );
+      setStart(initialStart);
+      setEnd(initialEnd);
+      setMode(initialMode);
+    }
+  }, [latestTransaction, widget?.meta?.timeFrame]);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -492,7 +502,6 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   );
 
   const [earliestTransaction, setEarliestTransaction] = useState('');
-  const [latestTransaction, setLatestTransaction] = useState('');
 
   return (
     <Page

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -66,6 +66,7 @@ export function CalendarCard({
 }: CalendarCardProps) {
   const { t } = useTranslation();
   const format = useFormat();
+
   const [latestTransaction, setLatestTransaction] = useState<string>('');
 
   useEffect(() => {

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -24,6 +24,7 @@ import { View } from '@actual-app/components/view';
 import { format as formatDate } from 'date-fns';
 import debounce from 'lodash/debounce';
 
+import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import { type CalendarWidget } from 'loot-core/types/models';
 import { type SyncedPrefs } from 'loot-core/types/prefs';
@@ -65,12 +66,27 @@ export function CalendarCard({
 }: CalendarCardProps) {
   const { t } = useTranslation();
   const format = useFormat();
+  const [latestTransaction, setLatestTransaction] = useState<string>('');
 
-  const [start, end] = calculateTimeRange(meta?.timeFrame, {
-    start: monthUtils.dayFromDate(monthUtils.currentMonth()),
-    end: monthUtils.currentDay(),
-    mode: 'full',
-  });
+  useEffect(() => {
+    async function fetchLatestTransaction() {
+      const latestTrans = await send('get-latest-transaction');
+      setLatestTransaction(
+        latestTrans ? latestTrans.date : monthUtils.currentDay(),
+      );
+    }
+    fetchLatestTransaction();
+  }, []);
+
+  const [start, end] = calculateTimeRange(
+    meta?.timeFrame,
+    {
+      start: monthUtils.dayFromDate(monthUtils.currentMonth()),
+      end: monthUtils.currentDay(),
+      mode: 'full',
+    },
+    latestTransaction,
+  );
   const params = useMemo(
     () =>
       calendarSpreadsheet(

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -91,16 +91,13 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
     pretty: string;
   }>>(null);
 
-  const [initialStart, initialEnd, initialMode] = calculateTimeRange(
-    widget?.meta?.timeFrame,
-    defaultTimeFrame,
-  );
-  const [start, setStart] = useState(initialStart);
-  const [end, setEnd] = useState(initialEnd);
-  const [mode, setMode] = useState(initialMode);
+  const [start, setStart] = useState(monthUtils.currentMonth());
+  const [end, setEnd] = useState(monthUtils.currentMonth());
+  const [mode, setMode] = useState<TimeFrame['mode']>('sliding-window');
   const [showBalance, setShowBalance] = useState(
     widget?.meta?.showBalance ?? true,
   );
+  const [latestTransaction, setLatestTransaction] = useState('');
 
   const [isConcise, setIsConcise] = useState(() => {
     const numDays = d.differenceInCalendarDays(
@@ -158,6 +155,19 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
     }
     run();
   }, [locale]);
+
+  useEffect(() => {
+    if (latestTransaction) {
+      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+        widget?.meta?.timeFrame,
+        defaultTimeFrame,
+        latestTransaction,
+      );
+      setStart(initialStart);
+      setEnd(initialEnd);
+      setMode(initialMode);
+    }
+  }, [latestTransaction, widget?.meta?.timeFrame]);
 
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     const numDays = d.differenceInCalendarDays(
@@ -221,7 +231,6 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
   };
 
   const [earliestTransaction, setEarliestTransaction] = useState('');
-  const [latestTransaction, setLatestTransaction] = useState('');
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
 

--- a/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   useMemo,
   useCallback,
+  useEffect,
   type SVGAttributes,
 } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +11,8 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { Bar, BarChart, LabelList, ResponsiveContainer } from 'recharts';
 
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 import { type CashFlowWidget } from 'loot-core/types/models';
 
 import { defaultTimeFrame } from './CashFlow';
@@ -108,8 +111,23 @@ export function CashFlowCard({
   onRemove,
 }: CashFlowCardProps) {
   const { t } = useTranslation();
+  const [latestTransaction, setLatestTransaction] = useState<string>('');
 
-  const [start, end] = calculateTimeRange(meta?.timeFrame, defaultTimeFrame);
+  useEffect(() => {
+    async function fetchLatestTransaction() {
+      const latestTrans = await send('get-latest-transaction');
+      setLatestTransaction(
+        latestTrans ? latestTrans.date : monthUtils.currentDay(),
+      );
+    }
+    fetchLatestTransaction();
+  }, []);
+
+  const [start, end] = calculateTimeRange(
+    meta?.timeFrame,
+    defaultTimeFrame,
+    latestTransaction,
+  );
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
   const params = useMemo(

--- a/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
@@ -112,6 +112,7 @@ export function CashFlowCard({
 }: CashFlowCardProps) {
   const { t } = useTranslation();
   const [latestTransaction, setLatestTransaction] = useState<string>('');
+  const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
   useEffect(() => {
     async function fetchLatestTransaction() {
@@ -128,7 +129,6 @@ export function CashFlowCard({
     defaultTimeFrame,
     latestTransaction,
   );
-  const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
   const params = useMemo(
     () => simpleCashFlow(start, end, meta?.conditions, meta?.conditionsOp),

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -86,13 +86,11 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
     pretty: string;
   }> | null>(null);
 
-  const [initialStart, initialEnd, initialMode] = calculateTimeRange(
-    widget?.meta?.timeFrame,
-  );
-  const [start, setStart] = useState(initialStart);
-  const [end, setEnd] = useState(initialEnd);
-  const [mode, setMode] = useState(initialMode);
+  const [start, setStart] = useState(monthUtils.currentMonth());
+  const [end, setEnd] = useState(monthUtils.currentMonth());
+  const [mode, setMode] = useState<TimeFrame['mode']>('sliding-window');
   const [interval, setInterval] = useState(widget?.meta?.interval || 'Monthly');
+  const [latestTransaction, setLatestTransaction] = useState('');
 
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
@@ -170,6 +168,19 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
     run();
   }, [locale]);
 
+  useEffect(() => {
+    if (latestTransaction) {
+      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+        widget?.meta?.timeFrame,
+        undefined,
+        latestTransaction,
+      );
+      setStart(initialStart);
+      setEnd(initialEnd);
+      setMode(initialMode);
+    }
+  }, [latestTransaction, widget?.meta?.timeFrame]);
+
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     setStart(start);
     setEnd(end);
@@ -225,7 +236,6 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
   };
 
   const [earliestTransaction, setEarliestTransaction] = useState('');
-  const [latestTransaction, setLatestTransaction] = useState('');
 
   if (!allMonths || !data) {
     return null;

--- a/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Block } from '@actual-app/components/block';
@@ -6,6 +6,8 @@ import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { styles } from '@actual-app/components/styles';
 import { View } from '@actual-app/components/view';
 
+import { send } from 'loot-core/platform/client/fetch';
+import * as monthUtils from 'loot-core/shared/months';
 import {
   type AccountEntity,
   type NetWorthWidget,
@@ -49,10 +51,25 @@ export function NetWorthCard({
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
 
   const format = useFormat();
+  const [latestTransaction, setLatestTransaction] = useState<string>('');
+
+  useEffect(() => {
+    async function fetchLatestTransaction() {
+      const latestTrans = await send('get-latest-transaction');
+      setLatestTransaction(
+        latestTrans ? latestTrans.date : monthUtils.currentDay(),
+      );
+    }
+    fetchLatestTransaction();
+  }, []);
 
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
-  const [start, end] = calculateTimeRange(meta?.timeFrame);
+  const [start, end] = calculateTimeRange(
+    meta?.timeFrame,
+    undefined,
+    latestTransaction,
+  );
   const [isCardHovered, setIsCardHovered] = useState(false);
   const onCardHover = useCallback(() => setIsCardHovered(true), []);
   const onCardHoverEnd = useCallback(() => setIsCardHovered(false), []);

--- a/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
@@ -49,9 +49,11 @@ export function NetWorthCard({
   const { isNarrowWidth } = useResponsive();
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
-
   const format = useFormat();
+
   const [latestTransaction, setLatestTransaction] = useState<string>('');
+  const [nameMenuOpen, setNameMenuOpen] = useState(false);
+  const [isCardHovered, setIsCardHovered] = useState(false);
 
   useEffect(() => {
     async function fetchLatestTransaction() {
@@ -63,14 +65,11 @@ export function NetWorthCard({
     fetchLatestTransaction();
   }, []);
 
-  const [nameMenuOpen, setNameMenuOpen] = useState(false);
-
   const [start, end] = calculateTimeRange(
     meta?.timeFrame,
     undefined,
     latestTransaction,
   );
-  const [isCardHovered, setIsCardHovered] = useState(false);
   const onCardHover = useCallback(() => setIsCardHovered(true), []);
   const onCardHoverEnd = useCallback(() => setIsCardHovered(false), []);
 

--- a/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
@@ -38,12 +38,11 @@ export function SpendingCard({
   const { t } = useTranslation();
   const format = useFormat();
 
-  const [compare, compareTo] = calculateSpendingReportTimeRange(meta ?? {});
-
   const [isCardHovered, setIsCardHovered] = useState(false);
+  const [nameMenuOpen, setNameMenuOpen] = useState(false);
   const spendingReportMode = meta?.mode ?? 'single-month';
 
-  const [nameMenuOpen, setNameMenuOpen] = useState(false);
+  const [compare, compareTo] = calculateSpendingReportTimeRange(meta ?? {});
 
   const selection =
     spendingReportMode === 'single-month' ? 'compareTo' : spendingReportMode;

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -76,17 +76,9 @@ function SummaryInner({ widget }: SummaryInnerProps) {
   const { t } = useTranslation();
   const format = useFormat();
 
-  const [initialStart, initialEnd, initialMode] = calculateTimeRange(
-    widget?.meta?.timeFrame,
-    {
-      start: monthUtils.dayFromDate(monthUtils.currentMonth()),
-      end: monthUtils.currentDay(),
-      mode: 'full',
-    },
-  );
-  const [start, setStart] = useState(initialStart);
-  const [end, setEnd] = useState(initialEnd);
-  const [mode, setMode] = useState(initialMode);
+  const [start, setStart] = useState(monthUtils.dayFromDate(monthUtils.currentMonth()));
+  const [end, setEnd] = useState(monthUtils.currentDay());
+  const [mode, setMode] = useState<TimeFrame['mode']>('full');
 
   const dividendFilters: FilterObject = useRuleConditionFilters(
     widget?.meta?.conditions ?? [],
@@ -211,6 +203,23 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     }
     run();
   }, [locale]);
+
+  useEffect(() => {
+    if (latestTransaction) {
+      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+        widget?.meta?.timeFrame,
+        {
+          start: monthUtils.dayFromDate(monthUtils.currentMonth()),
+          end: monthUtils.currentDay(),
+          mode: 'full',
+        },
+        latestTransaction,
+      );
+      setStart(initialStart);
+      setEnd(initialEnd);
+      setMode(initialMode);
+    }
+  }, [latestTransaction, widget?.meta?.timeFrame]);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -76,7 +76,9 @@ function SummaryInner({ widget }: SummaryInnerProps) {
   const { t } = useTranslation();
   const format = useFormat();
 
-  const [start, setStart] = useState(monthUtils.dayFromDate(monthUtils.currentMonth()));
+  const [start, setStart] = useState(
+    monthUtils.dayFromDate(monthUtils.currentMonth()),
+  );
   const [end, setEnd] = useState(monthUtils.currentDay());
   const [mode, setMode] = useState<TimeFrame['mode']>('full');
 

--- a/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
@@ -38,6 +38,7 @@ export function SummaryCard({
   const locale = useLocale();
   const { t } = useTranslation();
   const [latestTransaction, setLatestTransaction] = useState<string>('');
+  const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
   useEffect(() => {
     async function fetchLatestTransaction() {
@@ -88,8 +89,6 @@ export function SummaryCard({
   );
 
   const data = useReport('summary', params);
-
-  const [nameMenuOpen, setNameMenuOpen] = useState(false);
 
   return (
     <ReportCard

--- a/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { View } from '@actual-app/components/view';
 
+import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
 import {
   type SummaryContent,
@@ -36,12 +37,27 @@ export function SummaryCard({
 }: SummaryCardProps) {
   const locale = useLocale();
   const { t } = useTranslation();
+  const [latestTransaction, setLatestTransaction] = useState<string>('');
 
-  const [start, end] = calculateTimeRange(meta?.timeFrame, {
-    start: monthUtils.dayFromDate(monthUtils.currentMonth()),
-    end: monthUtils.currentDay(),
-    mode: 'full',
-  });
+  useEffect(() => {
+    async function fetchLatestTransaction() {
+      const latestTrans = await send('get-latest-transaction');
+      setLatestTransaction(
+        latestTrans ? latestTrans.date : monthUtils.currentDay(),
+      );
+    }
+    fetchLatestTransaction();
+  }, []);
+
+  const [start, end] = calculateTimeRange(
+    meta?.timeFrame,
+    {
+      start: monthUtils.dayFromDate(monthUtils.currentMonth()),
+      end: monthUtils.currentDay(),
+      mode: 'full',
+    },
+    latestTransaction,
+  );
 
   const content = useMemo(
     () =>

--- a/upcoming-release-notes/5790.md
+++ b/upcoming-release-notes/5790.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix live report time ranges


### PR DESCRIPTION
Fixes https://discord.com/channels/937901803608096828/1389677350215618623/1420520966295126036

This was a balance between retaining the existing behaviour and keeping the changes from https://github.com/actualbudget/actual/pull/5753. I settled on this way because I imagine most people will not add transactions in future months, so they wouldn't see a difference. If you do though, the ranges will push on to the month with the furthest ahead transaction in it, which I can only assume is what you wanted if you added transactions to them.

WDYT? We could also just revert the behaviour so the live ranges just push to the current month and ignore the future transactions but IMO that would go against https://github.com/actualbudget/actual/pull/5753.