### PR TITLE
replace deprecated function in count points script

### DIFF
--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -2,7 +2,7 @@ import { Octokit } from '@octokit/rest';
 import { minimatch } from 'minimatch';
 import pLimit from 'p-limit';
 
-const limit = pLimit(30);
+const limit = pLimit(50);
 
 /** Repository-specific configuration for points calculation */
 const REPOSITORY_CONFIG = new Map([
@@ -129,13 +129,13 @@ async function countContributorPoints(repo) {
   // Get all PRs using search
   const searchQuery = `repo:${owner}/${repo} is:pr is:merged merged:${since.toISOString()}..${until.toISOString()}`;
   const recentPRs = await octokit.paginate(
-    octokit.search.issuesAndPullRequests,
+    'GET /search/issues',
     {
       q: searchQuery,
       per_page: 100,
       advanced_search: true,
     },
-    response => response.data,
+    response => response.data.filter(pr => pr.number),
   );
 
   // Get reviews and PR details for each PR

--- a/upcoming-release-notes/5791.md
+++ b/upcoming-release-notes/5791.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix deprecation warning in count-points script


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/actions/runs/17410800211/job/49427250454#step:4:8
Also ups concurrency limit, 50 should be safe and helps to speed it up.