### PR TITLE
fix: losing transaction amount decimals on update

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1020,12 +1020,15 @@ const Transaction = memo(function Transaction({
     }
 
     // If entering an amount in either of the credit/debit fields, we
-    // need to clear out the other one so it's always properly
+    // need to clear out the other one or both so it's always properly
     // translated into the desired amount (see
     // `deserializeTransaction`)
     if (name === 'credit') {
       newTransaction['debit'] = '';
     } else if (name === 'debit') {
+      newTransaction['credit'] = '';
+    } else {
+      newTransaction['debit'] = '';
       newTransaction['credit'] = '';
     }
 

--- a/upcoming-release-notes/5807.md
+++ b/upcoming-release-notes/5807.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [csenel]
+---
+
+fix losing transaction amount decimals on update while "hide decimal places" setting is active


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes https://github.com/actualbudget/actual/issues/3294

Transaction amount was being updated even when `debit` and `credit` are not specifically updated. This is not a problem in general but when decimals are hidden now the serialized transaction is missing decimals. So if we don't use original amount, it also removes the decimals on any update, such as changing notes, cleared, etc.