### PR TITLE
show full decimals while editing

### DIFF
--- a/upcoming-release-notes/5808.md
+++ b/upcoming-release-notes/5808.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [csenel]
+---
+
+show full decimals while editing regardless of hide decimals setting


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes https://github.com/actualbudget/actual/issues/3053

Depending on hide decimals setting, the decimals were removed from the input cell. Instead, we can keep the decimals if they exist and show/hide them using formatter.