### PR TITLE
fix payee autocomplete hovering randomly

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -186,7 +186,7 @@ function PayeeList({
         return acc;
       },
       {
-        newPayee: null as PayeeAutocompleteItem,
+        newPayee: null as PayeeAutocompleteItem | null,
         suggestedPayees: [] as Array<PayeeAutocompleteItem>,
         payees: [] as Array<PayeeAutocompleteItem>,
         transferPayees: [] as Array<PayeeAutocompleteItem>,

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -171,34 +171,54 @@ function PayeeList({
   // entered
 
   const { newPayee, suggestedPayees, payees, transferPayees } = useMemo(() => {
-    return items.reduce(
-      (acc, item, index) => {
+    let currentIndex = 0;
+    const result = items.reduce(
+      (acc, item) => {
         if (item.id === 'new') {
-          acc.newPayee = { ...item, highlightedIndex: index };
+          acc.newPayee = { ...item };
         } else if (item.itemType === 'common_payee') {
-          acc.suggestedPayees.push({ ...item, highlightedIndex: index });
+          acc.suggestedPayees.push({ ...item });
         } else if (item.itemType === 'payee') {
-          acc.payees.push({ ...item, highlightedIndex: index });
+          acc.payees.push({ ...item });
         } else if (item.itemType === 'account') {
-          acc.transferPayees.push({ ...item, highlightedIndex: index });
+          acc.transferPayees.push({ ...item });
         }
         return acc;
       },
       {
-        newPayee: null as PayeeAutocompleteItem & {
-          highlightedIndex: number;
-        },
-        suggestedPayees: [] as Array<
-          PayeeAutocompleteItem & { highlightedIndex: number }
-        >,
-        payees: [] as Array<
-          PayeeAutocompleteItem & { highlightedIndex: number }
-        >,
-        transferPayees: [] as Array<
-          PayeeAutocompleteItem & { highlightedIndex: number }
-        >,
+        newPayee: null as PayeeAutocompleteItem,
+        suggestedPayees: [] as Array<PayeeAutocompleteItem>,
+        payees: [] as Array<PayeeAutocompleteItem>,
+        transferPayees: [] as Array<PayeeAutocompleteItem>,
       },
     );
+
+    // assign indexes in render order
+    const newPayeeWithIndex = result.newPayee
+      ? { ...result.newPayee, highlightedIndex: currentIndex++ }
+      : null;
+
+    const suggestedPayeesWithIndex = result.suggestedPayees.map(item => ({
+      ...item,
+      highlightedIndex: currentIndex++,
+    }));
+
+    const payeesWithIndex = result.payees.map(item => ({
+      ...item,
+      highlightedIndex: currentIndex++,
+    }));
+
+    const transferPayeesWithIndex = result.transferPayees.map(item => ({
+      ...item,
+      highlightedIndex: currentIndex++,
+    }));
+
+    return {
+      newPayee: newPayeeWithIndex,
+      suggestedPayees: suggestedPayeesWithIndex,
+      payees: payeesWithIndex,
+      transferPayees: transferPayeesWithIndex,
+    };
   }, [items]);
 
   // We limit the number of payees shown to 100.

--- a/upcoming-release-notes/5817.md
+++ b/upcoming-release-notes/5817.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix highlighting bug when hovering over the payee dropdown


### PR DESCRIPTION
The indexes assigned were not being generated in the same order as it is rendered, that was messing up the hover indexes when the list was filtered and changed order