### PR TITLE
:bug: fix template limit checker

### DIFF
--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -434,10 +434,6 @@ export class CategoryTemplateContext {
         t.type === 'limit' ||
         t.type === 'remainder',
     )) {
-      if (this.limitCheck) {
-        throw new Error('Only one `up to` allowed per category');
-      }
-
       let limitDef;
       if (template.type === 'limit') {
         limitDef = template;
@@ -447,6 +443,10 @@ export class CategoryTemplateContext {
         } else {
           continue; // may not have a limit defined in the template
         }
+      }
+
+      if (this.limitCheck) {
+        throw new Error('Only one `up to` allowed per category');
       }
 
       if (limitDef.period === 'daily') {

--- a/upcoming-release-notes/5835.md
+++ b/upcoming-release-notes/5835.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix template limit checker incorrectly claiming there are multiple limits


### PR DESCRIPTION
To test put the following templates in a category.  This will fail on edge claiming there are multiple limits.
```
#template 10 up to 100
#template 10
