### PR TITLE
Mobile payees - add loading indicator to rules count label

### DIFF
--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -14,6 +14,7 @@ import { PayeesList } from './PayeesList';
 import { Search } from '@desktop-client/components/common/Search';
 import { MobilePageHeader, Page } from '@desktop-client/components/Page';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { usePayeeRuleCounts } from '@desktop-client/hooks/usePayeeRuleCounts';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useSelector } from '@desktop-client/redux';
 
@@ -22,7 +23,7 @@ export function MobilePayeesPage() {
   const navigate = useNavigate();
   const payees = usePayees();
   const [filter, setFilter] = useState('');
-  const [ruleCounts, setRuleCounts] = useState(new Map<string, number>());
+  const { ruleCounts, isLoading: isRuleCountsLoading } = usePayeeRuleCounts();
   const isLoading = useSelector(
     s => s.payees.isPayeesLoading || s.payees.isCommonPayeesLoading,
   );
@@ -32,16 +33,6 @@ export function MobilePayeesPage() {
     const norm = getNormalisedString(filter);
     return payees.filter(p => getNormalisedString(p.name).includes(norm));
   }, [payees, filter]);
-
-  const refetchRuleCounts = useCallback(async () => {
-    const counts = await send('payees-get-rule-counts');
-    const countsMap = new Map(Object.entries(counts));
-    setRuleCounts(countsMap);
-  }, []);
-
-  useEffect(() => {
-    refetchRuleCounts();
-  }, [refetchRuleCounts]);
 
   const onSearchChange = useCallback((value: string) => {
     setFilter(value);
@@ -114,6 +105,7 @@ export function MobilePayeesPage() {
       <PayeesList
         payees={filteredPayees}
         ruleCounts={ruleCounts}
+        isRuleCountsLoading={isRuleCountsLoading}
         isLoading={isLoading}
         onPayeePress={handlePayeePress}
       />

--- a/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
@@ -78,7 +78,7 @@ export function PayeesList({
           paddingBottom: MOBILE_NAV_HEIGHT,
           overflow: 'auto',
         }}
-        dependencies={[isRuleCountsLoading]}
+        dependencies={[ruleCounts, isRuleCountsLoading]}
       >
         {payee => (
           <PayeesListItem

--- a/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
@@ -15,6 +15,7 @@ import { MOBILE_NAV_HEIGHT } from '@desktop-client/components/mobile/MobileNavTa
 type PayeesListProps = {
   payees: PayeeEntity[];
   ruleCounts: Map<string, number>;
+  isRuleCountsLoading?: boolean;
   isLoading?: boolean;
   onPayeePress: (payee: PayeeEntity) => void;
 };
@@ -22,6 +23,7 @@ type PayeesListProps = {
 export function PayeesList({
   payees,
   ruleCounts,
+  isRuleCountsLoading = false,
   isLoading = false,
   onPayeePress,
 }: PayeesListProps) {
@@ -76,11 +78,13 @@ export function PayeesList({
           paddingBottom: MOBILE_NAV_HEIGHT,
           overflow: 'auto',
         }}
+        dependencies={[isRuleCountsLoading]}
       >
         {payee => (
           <PayeesListItem
             value={payee}
             ruleCount={ruleCounts.get(payee.id) ?? 0}
+            isRuleCountLoading={isRuleCountsLoading}
             onAction={() => onPayeePress(payee)}
           />
         )}

--- a/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
@@ -14,11 +14,13 @@ import { PayeeRuleCountLabel } from '@desktop-client/components/payees/PayeeRule
 type PayeesListItemProps = {
   value: PayeeEntity;
   ruleCount: number;
+  isRuleCountLoading?: boolean;
 } & Omit<GridListItemProps<PayeeEntity>, 'value'>;
 
 export const PayeesListItem = memo(function PayeeListItem({
   value: payee,
   ruleCount,
+  isRuleCountLoading,
   ...props
 }: PayeesListItemProps) {
   const { t } = useTranslation();
@@ -84,7 +86,11 @@ export const PayeesListItem = memo(function PayeeListItem({
               flexShrink: 0,
             }}
           >
-            <PayeeRuleCountLabel count={ruleCount} style={{ fontSize: 12 }} />
+            <PayeeRuleCountLabel
+              count={ruleCount}
+              isLoading={isRuleCountLoading}
+              style={{ fontSize: 12 }}
+            />
           </span>
         </SpaceBetween>
       </SpaceBetween>

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -8,6 +8,7 @@ import { type NewRuleEntity, type PayeeEntity } from 'loot-core/types/models';
 
 import { ManagePayees } from './ManagePayees';
 
+import { usePayeeRuleCounts } from '@desktop-client/hooks/usePayeeRuleCounts';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import { getPayees, reloadPayees } from '@desktop-client/payees/payeesSlice';
@@ -22,8 +23,8 @@ export function ManagePayeesWithData({
 }: ManagePayeesWithDataProps) {
   const payees = usePayees();
   const dispatch = useDispatch();
+  const { ruleCounts, refetch: refetchRuleCounts } = usePayeeRuleCounts();
 
-  const [ruleCounts, setRuleCounts] = useState({ value: new Map() });
   const [orphans, setOrphans] = useState<Array<Pick<PayeeEntity, 'id'>>>([]);
 
   const refetchOrphanedPayees = useCallback(async () => {
@@ -31,16 +32,9 @@ export function ManagePayeesWithData({
     setOrphans(orphs);
   }, []);
 
-  const refetchRuleCounts = useCallback(async () => {
-    const counts = await send('payees-get-rule-counts');
-    const countsMap = new Map(Object.entries(counts));
-    setRuleCounts({ value: countsMap });
-  }, []);
-
   useEffect(() => {
     async function loadData() {
       await dispatch(getPayees());
-      await refetchRuleCounts();
       await refetchOrphanedPayees();
     }
     loadData();
@@ -119,7 +113,7 @@ export function ManagePayeesWithData({
   return (
     <ManagePayees
       payees={payees}
-      ruleCounts={ruleCounts.value}
+      ruleCounts={ruleCounts}
       orphanedPayees={orphans}
       initialSelectedIds={initialSelectedIds}
       onBatchChange={async (changes: Diff<PayeeEntity>) => {
@@ -141,17 +135,11 @@ export function ManagePayeesWithData({
         }
         filtedOrphans = filtedOrphans.filter(o => !mergeIds.includes(o.id));
 
-        mergeIds.forEach(id => {
-          const count = ruleCounts.value.get(id) || 0;
-          ruleCounts.value.set(
-            targetId,
-            (ruleCounts.value.get(targetId) || 0) + count,
-          );
-        });
+        // Refetch rule counts after merging
+        await refetchRuleCounts();
 
         await dispatch(reloadPayees());
         setOrphans(filtedOrphans);
-        setRuleCounts({ value: ruleCounts.value });
       }}
       onViewRules={onViewRules}
       onCreateRule={onCreateRule}

--- a/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
@@ -1,20 +1,28 @@
 import { type CSSProperties } from 'react';
 import { Trans } from 'react-i18next';
 
+import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { Text } from '@actual-app/components/text';
+import { View } from '@actual-app/components/view';
 
 type PayeeRuleCountLabelProps = {
   count: number;
+  isLoading?: boolean;
   style?: CSSProperties;
 };
 
 export function PayeeRuleCountLabel({
   count,
+  isLoading,
   style,
 }: PayeeRuleCountLabelProps) {
   return (
     <Text style={style}>
-      {count > 0 ? (
+      {isLoading ? (
+        <View>
+          <AnimatedLoading style={{ width: 12, height: 12 }} />
+        </View>
+      ) : count > 0 ? (
         <Trans count={count}>{{ count }} associated rules</Trans>
       ) : (
         <Trans>Create rule</Trans>

--- a/packages/desktop-client/src/hooks/usePayeeRuleCounts.ts
+++ b/packages/desktop-client/src/hooks/usePayeeRuleCounts.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { send } from 'loot-core/platform/client/fetch';
+
+type PayeeRuleCounts = Map<string, number>;
+
+type UsePayeeRuleCountsResult = {
+  ruleCounts: PayeeRuleCounts;
+  isLoading: boolean;
+  refetch: () => Promise<void>;
+};
+
+export function usePayeeRuleCounts(): UsePayeeRuleCountsResult {
+  const [ruleCounts, setRuleCounts] = useState<PayeeRuleCounts>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const counts = await send('payees-get-rule-counts');
+      const countsMap = new Map(Object.entries(counts));
+      setRuleCounts(countsMap);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { ruleCounts, isLoading, refetch };
+}

--- a/upcoming-release-notes/5842.md
+++ b/upcoming-release-notes/5842.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Mobile Payees - add loading indicator to rules count label


### PR DESCRIPTION
Added a loading indicator to the rules count label.

Also extracted the rules-count fetching logic into a reusable hook and implemented it in all the necessary places.