### PR TITLE
Adds multi-select component for field mappings

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -36,6 +36,7 @@
     "./input": "./src/Input.tsx",
     "./label": "./src/Label.tsx",
     "./menu": "./src/Menu.tsx",
+    "./multi-select": "./src/MultiSelect.tsx",
     "./paragraph": "./src/Paragraph.tsx",
     "./popover": "./src/Popover.tsx",
     "./select": "./src/Select.tsx",

--- a/packages/component-library/src/MultiSelect.tsx
+++ b/packages/component-library/src/MultiSelect.tsx
@@ -1,0 +1,155 @@
+import { useRef, useState, type CSSProperties } from 'react';
+
+import { Button } from './Button';
+import { SvgExpandArrow } from './icons/v0';
+import { Menu } from './Menu';
+import { Popover } from './Popover';
+import { View } from './View';
+
+function isValueOption<Value>(
+  option: readonly [Value, string] | typeof Menu.line,
+): option is [Value, string] {
+  return option !== Menu.line;
+}
+
+export type MultiSelectOption<Value = string> =
+  | [Value, string]
+  | typeof Menu.line;
+
+type MultiSelectProps<Value> = {
+  id?: string;
+  bare?: boolean;
+  options: Array<readonly [Value, string] | typeof Menu.line>;
+  value: Value[];
+  defaultLabel?: string;
+  onChange?: (newValue: Value[]) => void;
+  disabled?: boolean;
+  disabledKeys?: Value[];
+  style?: CSSProperties;
+  popoverStyle?: CSSProperties;
+  className?: string;
+};
+
+/**
+ * @param {Array<[string, string]>} options - An array of options value-label pairs.
+ * @param {string[]} value - The currently selected option values.
+ * @param {string} [defaultLabel] - The label to display when no values are selected.
+ * @param {function} [onChange] - A callback function invoked when the selected values change.
+ * @param {CSSProperties} [style] - Custom styles to apply to the selected button.
+ * @param {string[]} [disabledKeys] - An array of option values to disable.
+ *
+ * @example
+ * // Usage:
+ * // <MultiSelect options={[['1', 'Option 1'], ['2', 'Option 2']]} value={['1']} onChange={handleOnChange} />
+ * // <MultiSelect options={[['1', 'Option 1'], ['2', 'Option 2']]} value={[]} defaultLabel="Select options"  onChange={handleOnChange} />
+ */
+export function MultiSelect<const Value = string>({
+  id,
+  bare,
+  options,
+  value,
+  defaultLabel = '',
+  onChange,
+  disabled = false,
+  disabledKeys = [],
+  style = {},
+  popoverStyle = {},
+  className,
+}: MultiSelectProps<Value>) {
+  const triggerRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Create a map for quick lookup of labels by value
+  const optionMap = new Map(
+    options.filter(isValueOption).map(opt => [opt[0], opt[1]]),
+  );
+
+  // Build display text in the order of selection (value array order)
+  const displayText =
+    value.length > 0
+      ? value
+          .map(v => optionMap.get(v))
+          .filter(label => label != null)
+          .join(', ')
+      : defaultLabel;
+
+  const handleItemSelect = (item: Value) => {
+    const newValue = value.includes(item)
+      ? value.filter(v => v !== item)
+      : [...value, item];
+    onChange?.(newValue);
+    // Keep the popover open for multiple selections
+  };
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        id={id}
+        variant={bare ? 'bare' : 'normal'}
+        isDisabled={disabled}
+        onPress={() => {
+          setIsOpen(true);
+        }}
+        style={style}
+        className={className}
+      >
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 5,
+            width: '100%',
+          }}
+        >
+          <span
+            style={{
+              textAlign: 'left',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              width: 'calc(100% - 7px)',
+            }}
+          >
+            {displayText}
+          </span>
+          <SvgExpandArrow
+            style={{
+              width: 7,
+              height: 7,
+              color: 'inherit',
+            }}
+          />
+        </View>
+      </Button>
+
+      <Popover
+        triggerRef={triggerRef}
+        placement="bottom start"
+        isOpen={isOpen}
+        onOpenChange={() => setIsOpen(false)}
+        style={popoverStyle}
+      >
+        <Menu
+          onMenuSelect={handleItemSelect}
+          items={options.map(item =>
+            item === Menu.line
+              ? Menu.line
+              : {
+                  name: item[0],
+                  text: item[1],
+                  disabled: disabledKeys.includes(item[0]),
+                },
+          )}
+          getItemStyle={option => {
+            if (value.includes(option.name)) {
+              return { fontWeight: 'bold' };
+            }
+            return {};
+          }}
+        />
+      </Popover>
+    </>
+  );
+}

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/FieldMappings.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/FieldMappings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Stack } from '@actual-app/components/stack';
 import { View } from '@actual-app/components/view';
 
+import { MultiSelectField } from './MultiSelectField';
 import { SelectField } from './SelectField';
 import { SubLabel } from './SubLabel';
 import {
@@ -17,11 +18,15 @@ import { SectionLabel } from '@desktop-client/components/forms';
 type FieldMappingsProps = {
   transactions: ImportTransaction[];
   mappings?: FieldMapping;
-  onChange: (field: keyof FieldMapping, newValue: string) => void;
+  onChange: (field: keyof FieldMapping, newValue: string | string[]) => void;
   splitMode: boolean;
   inOutMode: boolean;
   hasHeaderRow: boolean;
 };
+
+function toArray<T>(value: T | T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : value ? [value] : [];
+}
 
 export function FieldMappings({
   transactions,
@@ -69,20 +74,20 @@ export function FieldMappings({
         </View>
         <View style={{ flex: 1, marginRight: 10 }}>
           <SubLabel title={t('Payee')} />
-          <SelectField
+          <MultiSelectField
             options={options}
-            value={mappings.payee}
-            onChange={name => onChange('payee', name)}
+            value={toArray(mappings.payee)}
+            onChange={values => onChange('payee', values)}
             hasHeaderRow={hasHeaderRow}
             firstTransaction={transactions[0]}
           />
         </View>
         <View style={{ flex: 1, marginRight: 10 }}>
           <SubLabel title={t('Notes')} />
-          <SelectField
+          <MultiSelectField
             options={options}
-            value={mappings.notes}
-            onChange={name => onChange('notes', name)}
+            value={toArray(mappings.notes)}
+            onChange={values => onChange('notes', values)}
             hasHeaderRow={hasHeaderRow}
             firstTransaction={transactions[0]}
           />

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -532,7 +532,12 @@ export function ImportTransactionsModal({
   function onUpdateFields(field, name) {
     const newFieldMappings = {
       ...fieldMappings,
-      [field]: name === '' ? null : name,
+      [field]:
+        name === ''
+          ? null
+          : Array.isArray(name) && name.length === 0
+            ? null
+            : name,
     };
     setFieldMappings(newFieldMappings);
     runImportPreview();

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/MultiSelectField.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/MultiSelectField.tsx
@@ -1,0 +1,44 @@
+import React, { type CSSProperties } from 'react';
+
+import { MultiSelect } from '@actual-app/components/multi-select';
+
+type MultiSelectFieldProps = {
+  style?: CSSProperties;
+  options: string[];
+  value: string[];
+  onChange: (newValue: string[]) => void;
+  hasHeaderRow: boolean;
+  firstTransaction: Record<string, unknown>;
+};
+
+export function MultiSelectField({
+  style,
+  options,
+  value,
+  onChange,
+  hasHeaderRow,
+  firstTransaction,
+}: MultiSelectFieldProps) {
+  const columns = options.map(
+    option =>
+      [
+        option,
+        hasHeaderRow
+          ? option
+          : `Column ${parseInt(option) + 1} (${firstTransaction[option]})`,
+      ] as const,
+  );
+
+  // Filter out any selected columns that don't exist in the transaction sheet
+  const validValue = value.filter(v => columns.find(col => col[0] === v));
+
+  return (
+    <MultiSelect
+      options={columns}
+      value={validValue}
+      onChange={onChange}
+      defaultLabel="Choose field(s)..."
+      style={style}
+    />
+  );
+}

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
@@ -143,8 +143,8 @@ export type ImportTransaction = {
 export type FieldMapping = {
   date: string | null;
   amount: string | null;
-  payee: string | null;
-  notes: string | null;
+  payee: string | string[] | null;
+  notes: string | string[] | null;
   inOut: string | null;
   category: string | null;
   outflow: string | null;
@@ -158,7 +158,18 @@ export function applyFieldMappings(
   const result: Partial<ImportTransaction> = {};
   for (const [originalField, target] of Object.entries(mappings)) {
     const field = originalField === 'payee' ? 'payee_name' : originalField;
-    result[field] = transaction[target || field];
+
+    // Handle multi-column fields (payee and notes)
+    if (Array.isArray(target)) {
+      // Merge multiple columns with space separator
+      const values = target
+        .map(col => transaction[col])
+        .filter(val => val != null && val !== '')
+        .map(val => String(val).trim());
+      result[field] = values.join(' ');
+    } else {
+      result[field] = transaction[target || field];
+    }
   }
   // Keep preview fields on the mapped transactions
   result.trx_id = transaction.trx_id;


### PR DESCRIPTION
It has been requested a couple times in Discord recently, to combine multiple columns upon importing from bank files.

This PR introduces a multi-select component based on the existing Select component to allow users to map multiple columns to a single field during transaction import.

Currently only Payee and Notes fields are affected. The column values are merged upon import, joined with a space. This is not yet configurable, though could be perhaps as a future enhancement.