### PR TITLE
Fix merging split transactions (#5781)

### DIFF
--- a/packages/desktop-client/e2e/page-models/mobile-rules-page.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-rules-page.ts
@@ -40,17 +40,14 @@ export class MobileRulesPage {
    * Get the nth rule item (0-based index)
    */
   getNthRule(index: number) {
-    return this.page
-      .getByRole('button')
-      .filter({ hasText: /IF|THEN/ })
-      .nth(index);
+    return this.getAllRules().nth(index);
   }
 
   /**
    * Get all visible rule items
    */
   getAllRules() {
-    return this.page.getByRole('button').filter({ hasText: /IF|THEN/ });
+    return this.page.getByRole('grid', { name: 'Rules' }).getByRole('row');
   }
 
   /**
@@ -112,7 +109,7 @@ export class MobileRulesPage {
    */
   async getRuleStage(index: number) {
     const rule = this.getNthRule(index);
-    const stageBadge = rule.locator('span').first();
+    const stageBadge = rule.getByTestId('rule-stage-badge');
     return await stageBadge.textContent();
   }
 }

--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -14,6 +14,7 @@ import { PayeesList } from './PayeesList';
 import { Search } from '@desktop-client/components/common/Search';
 import { MobilePageHeader, Page } from '@desktop-client/components/Page';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
+import { usePayeeRuleCounts } from '@desktop-client/hooks/usePayeeRuleCounts';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useSelector } from '@desktop-client/redux';
 
@@ -22,7 +23,7 @@ export function MobilePayeesPage() {
   const navigate = useNavigate();
   const payees = usePayees();
   const [filter, setFilter] = useState('');
-  const [ruleCounts, setRuleCounts] = useState(new Map<string, number>());
+  const { ruleCounts, isLoading: isRuleCountsLoading } = usePayeeRuleCounts();
   const isLoading = useSelector(
     s => s.payees.isPayeesLoading || s.payees.isCommonPayeesLoading,
   );
@@ -32,16 +33,6 @@ export function MobilePayeesPage() {
     const norm = getNormalisedString(filter);
     return payees.filter(p => getNormalisedString(p.name).includes(norm));
   }, [payees, filter]);
-
-  const refetchRuleCounts = useCallback(async () => {
-    const counts = await send('payees-get-rule-counts');
-    const countsMap = new Map(Object.entries(counts));
-    setRuleCounts(countsMap);
-  }, []);
-
-  useEffect(() => {
-    refetchRuleCounts();
-  }, [refetchRuleCounts]);
 
   const onSearchChange = useCallback((value: string) => {
     setFilter(value);
@@ -114,6 +105,7 @@ export function MobilePayeesPage() {
       <PayeesList
         payees={filteredPayees}
         ruleCounts={ruleCounts}
+        isRuleCountsLoading={isRuleCountsLoading}
         isLoading={isLoading}
         onPayeePress={handlePayeePress}
       />

--- a/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesList.tsx
@@ -15,6 +15,7 @@ import { MOBILE_NAV_HEIGHT } from '@desktop-client/components/mobile/MobileNavTa
 type PayeesListProps = {
   payees: PayeeEntity[];
   ruleCounts: Map<string, number>;
+  isRuleCountsLoading?: boolean;
   isLoading?: boolean;
   onPayeePress: (payee: PayeeEntity) => void;
 };
@@ -22,6 +23,7 @@ type PayeesListProps = {
 export function PayeesList({
   payees,
   ruleCounts,
+  isRuleCountsLoading = false,
   isLoading = false,
   onPayeePress,
 }: PayeesListProps) {
@@ -76,11 +78,13 @@ export function PayeesList({
           paddingBottom: MOBILE_NAV_HEIGHT,
           overflow: 'auto',
         }}
+        dependencies={[ruleCounts, isRuleCountsLoading]}
       >
         {payee => (
           <PayeesListItem
             value={payee}
             ruleCount={ruleCounts.get(payee.id) ?? 0}
+            isRuleCountLoading={isRuleCountsLoading}
             onAction={() => onPayeePress(payee)}
           />
         )}

--- a/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/PayeesListItem.tsx
@@ -14,11 +14,13 @@ import { PayeeRuleCountLabel } from '@desktop-client/components/payees/PayeeRule
 type PayeesListItemProps = {
   value: PayeeEntity;
   ruleCount: number;
+  isRuleCountLoading?: boolean;
 } & Omit<GridListItemProps<PayeeEntity>, 'value'>;
 
 export const PayeesListItem = memo(function PayeeListItem({
   value: payee,
   ruleCount,
+  isRuleCountLoading,
   ...props
 }: PayeesListItemProps) {
   const { t } = useTranslation();
@@ -84,7 +86,11 @@ export const PayeesListItem = memo(function PayeeListItem({
               flexShrink: 0,
             }}
           >
-            <PayeeRuleCountLabel count={ruleCount} style={{ fontSize: 12 }} />
+            <PayeeRuleCountLabel
+              count={ruleCount}
+              isLoading={isRuleCountLoading}
+              style={{ fontSize: 12 }}
+            />
           </span>
         </SpaceBetween>
       </SpaceBetween>

--- a/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
@@ -23,15 +23,12 @@ import { usePayees } from '@desktop-client/hooks/usePayees';
 import { useSchedules } from '@desktop-client/hooks/useSchedules';
 import { useUrlParam } from '@desktop-client/hooks/useUrlParam';
 
-const PAGE_SIZE = 50;
-
 export function MobileRulesPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [visibleRulesParam] = useUrlParam('visible-rules');
   const [allRules, setAllRules] = useState<RuleEntity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [hasMoreRules, setHasMoreRules] = useState(true);
   const [filter, setFilter] = useState('');
 
   const { schedules = [] } = useSchedules({
@@ -76,16 +73,12 @@ export function MobileRulesPage() {
         );
   }, [visibleRules, filter, filterData, schedules]);
 
-  const loadRules = useCallback(async (append = false) => {
+  const loadRules = useCallback(async () => {
     try {
       setIsLoading(true);
       const result = await send('rules-get');
-      const newRules = result || [];
-
-      setAllRules(prevRules =>
-        append ? [...prevRules, ...newRules] : newRules,
-      );
-      setHasMoreRules(newRules.length === PAGE_SIZE);
+      const rules = result || [];
+      setAllRules(rules);
     } catch (error) {
       console.error('Failed to load rules:', error);
       setAllRules([]);
@@ -104,12 +97,6 @@ export function MobileRulesPage() {
     },
     [navigate],
   );
-
-  const handleLoadMore = useCallback(() => {
-    if (!isLoading && hasMoreRules && !filter) {
-      loadRules(true);
-    }
-  }, [isLoading, hasMoreRules, filter, loadRules]);
 
   const onSearchChange = useCallback(
     (value: string) => {
@@ -153,7 +140,6 @@ export function MobileRulesPage() {
         rules={filteredRules}
         isLoading={isLoading}
         onRulePress={handleRulePress}
-        onLoadMore={handleLoadMore}
       />
     </Page>
   );

--- a/packages/desktop-client/src/components/mobile/rules/RulesList.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/RulesList.tsx
@@ -1,4 +1,4 @@
-import { type UIEvent } from 'react';
+import { GridList } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 
 import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
@@ -16,15 +16,9 @@ type RulesListProps = {
   rules: RuleEntity[];
   isLoading: boolean;
   onRulePress: (rule: RuleEntity) => void;
-  onLoadMore?: () => void;
 };
 
-export function RulesList({
-  rules,
-  isLoading,
-  onRulePress,
-  onLoadMore,
-}: RulesListProps) {
+export function RulesList({ rules, isLoading, onRulePress }: RulesListProps) {
   const { t } = useTranslation();
 
   if (isLoading && rules.length === 0) {
@@ -65,32 +59,27 @@ export function RulesList({
     );
   }
 
-  const handleScroll = (event: UIEvent<HTMLDivElement>) => {
-    if (!onLoadMore) return;
-
-    const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
-    if (scrollHeight - scrollTop <= clientHeight * 1.5) {
-      onLoadMore();
-    }
-  };
-
   return (
-    <View
-      style={{ flex: 1, paddingBottom: MOBILE_NAV_HEIGHT, overflow: 'auto' }}
-      onScroll={handleScroll}
-    >
-      {rules.map(rule => (
-        <RulesListItem
-          key={rule.id}
-          rule={rule}
-          onPress={() => onRulePress(rule)}
-        />
-      ))}
+    <View style={{ flex: 1 }}>
+      <GridList
+        aria-label={t('Rules')}
+        aria-busy={isLoading || undefined}
+        items={rules}
+        style={{
+          flex: 1,
+          paddingBottom: MOBILE_NAV_HEIGHT,
+          overflow: 'auto',
+        }}
+      >
+        {rule => (
+          <RulesListItem value={rule} onAction={() => onRulePress(rule)} />
+        )}
+      </GridList>
       {isLoading && (
         <View
           style={{
             alignItems: 'center',
-            paddingVertical: 20,
+            paddingTop: 20,
           }}
         >
           <AnimatedLoading style={{ width: 20, height: 20 }} />

--- a/packages/desktop-client/src/components/mobile/rules/RulesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/RulesListItem.tsx
@@ -1,24 +1,26 @@
 import React from 'react';
+import { GridListItem, type GridListItemProps } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 
-import { Button } from '@actual-app/components/button';
+import { SpaceBetween } from '@actual-app/components/space-between';
+import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { type RuleEntity } from 'loot-core/types/models';
+import { type WithRequired } from 'loot-core/types/util';
 
 import { ActionExpression } from '@desktop-client/components/rules/ActionExpression';
 import { ConditionExpression } from '@desktop-client/components/rules/ConditionExpression';
 import { groupActionsBySplitIndex } from '@desktop-client/util/ruleUtils';
 
-const ROW_HEIGHT = 60;
+type RulesListItemProps = WithRequired<GridListItemProps<RuleEntity>, 'value'>;
 
-type RulesListItemProps = {
-  rule: RuleEntity;
-  onPress: () => void;
-};
-
-export function RulesListItem({ rule, onPress }: RulesListItemProps) {
+export function RulesListItem({
+  value: rule,
+  style,
+  ...props
+}: RulesListItemProps) {
   const { t } = useTranslation();
 
   // Group actions by splitIndex to handle split transactions
@@ -26,172 +28,160 @@ export function RulesListItem({ rule, onPress }: RulesListItemProps) {
   const hasSplits = actionSplits.length > 1;
 
   return (
-    <Button
-      variant="bare"
-      style={{
-        minHeight: ROW_HEIGHT,
-        width: '100%',
-        borderRadius: 0,
-        borderWidth: '0 0 1px 0',
-        borderColor: theme.tableBorder,
-        borderStyle: 'solid',
-        backgroundColor: theme.tableBackground,
-        flexDirection: 'row',
-        alignItems: 'flex-start',
-        justifyContent: 'flex-start',
-        padding: '8px 16px',
-        gap: 12,
-      }}
-      onPress={onPress}
+    <GridListItem
+      id={rule.id}
+      value={rule}
+      textValue={t('Rule {{id}}', { id: rule.id })}
+      style={{ ...styles.mobileListItem, padding: '8px 16px', ...style }}
+      {...props}
     >
-      {/* Column 1: PRE/POST pill */}
-      <View
-        style={{
-          flexShrink: 0,
-          paddingTop: 2, // Slight top padding to align with text baseline
-        }}
-      >
+      <SpaceBetween gap={12} style={{ alignItems: 'flex-start' }}>
+        {/* Column 1: PRE/POST pill */}
         <View
           style={{
-            backgroundColor:
-              rule.stage === 'pre'
-                ? theme.noticeBackgroundLight
-                : rule.stage === 'post'
-                  ? theme.warningBackground
-                  : theme.pillBackgroundSelected,
-            paddingLeft: 6,
-            paddingRight: 6,
-            paddingTop: 2,
-            paddingBottom: 2,
-            borderRadius: 3,
+            flexShrink: 0,
+            paddingTop: 2, // Slight top padding to align with text baseline
           }}
         >
-          <span
+          <View
             style={{
-              fontSize: 11,
-              fontWeight: 500,
-              color:
+              backgroundColor:
                 rule.stage === 'pre'
-                  ? theme.noticeTextLight
+                  ? theme.noticeBackgroundLight
                   : rule.stage === 'post'
-                    ? theme.warningText
-                    : theme.pillTextSelected,
+                    ? theme.warningBackground
+                    : theme.pillBackgroundSelected,
+              paddingLeft: 6,
+              paddingRight: 6,
+              paddingTop: 2,
+              paddingBottom: 2,
+              borderRadius: 3,
             }}
           >
-            {rule.stage === 'pre'
-              ? t('PRE')
-              : rule.stage === 'post'
-                ? t('POST')
-                : t('DEFAULT')}
-          </span>
-        </View>
-      </View>
-
-      {/* Column 2: IF and THEN blocks */}
-      <View
-        style={{
-          flex: 1,
-          flexDirection: 'column',
-          gap: 4,
-        }}
-      >
-        {/* IF conditions block */}
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            flexWrap: 'wrap',
-            gap: 6,
-          }}
-        >
-          <span
-            style={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: theme.pageTextLight,
-              marginRight: 4,
-            }}
-          >
-            {t('IF')}
-          </span>
-
-          {rule.conditions.map((condition, index) => (
-            <View key={index} style={{ marginRight: 4, marginBottom: 2 }}>
-              <ConditionExpression
-                field={condition.field}
-                op={condition.op}
-                value={condition.value}
-                options={condition.options}
-                inline={true}
-              />
-            </View>
-          ))}
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 500,
+                color:
+                  rule.stage === 'pre'
+                    ? theme.noticeTextLight
+                    : rule.stage === 'post'
+                      ? theme.warningText
+                      : theme.pillTextSelected,
+              }}
+              data-testid="rule-stage-badge"
+            >
+              {rule.stage === 'pre'
+                ? t('PRE')
+                : rule.stage === 'post'
+                  ? t('POST')
+                  : t('DEFAULT')}
+            </span>
+          </View>
         </View>
 
-        {/* THEN actions block */}
+        {/* Column 2: IF and THEN blocks */}
         <View
           style={{
+            flex: 1,
             flexDirection: 'column',
-            alignItems: 'flex-start',
             gap: 4,
           }}
         >
-          <span
+          {/* IF conditions block */}
+          <SpaceBetween gap={6}>
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: theme.pageTextLight,
+                marginRight: 4,
+              }}
+            >
+              {t('IF')}
+            </span>
+
+            {rule.conditions.map((condition, index) => (
+              <View key={index} style={{ marginRight: 4, marginBottom: 2 }}>
+                <ConditionExpression
+                  field={condition.field}
+                  op={condition.op}
+                  value={condition.value}
+                  options={condition.options}
+                  inline={true}
+                />
+              </View>
+            ))}
+          </SpaceBetween>
+
+          {/* THEN actions block */}
+          <View
             style={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: theme.pageTextLight,
-              marginBottom: 2,
+              flexDirection: 'column',
+              alignItems: 'flex-start',
+              gap: 4,
             }}
           >
-            {t('THEN')}
-          </span>
+            <span
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: theme.pageTextLight,
+                marginBottom: 2,
+              }}
+            >
+              {t('THEN')}
+            </span>
 
-          {hasSplits
-            ? actionSplits.map((split, i) => (
-                <View
-                  key={split.id}
-                  style={{
-                    width: '100%',
-                    flexDirection: 'column',
-                    alignItems: 'flex-start',
-                    marginTop: i > 0 ? 4 : 0,
-                    padding: '6px',
-                    borderColor: theme.tableBorder,
-                    borderWidth: '1px',
-                    borderRadius: '5px',
-                  }}
-                >
-                  <span
+            {hasSplits
+              ? actionSplits.map((split, i) => (
+                  <View
+                    key={i}
                     style={{
-                      fontSize: 11,
-                      fontWeight: 500,
-                      color: theme.pageTextLight,
-                      marginBottom: 4,
+                      width: '100%',
+                      flexDirection: 'column',
+                      alignItems: 'flex-start',
+                      marginTop: i > 0 ? 4 : 0,
+                      padding: '6px',
+                      borderColor: theme.tableBorder,
+                      borderWidth: '1px',
+                      borderRadius: '5px',
                     }}
                   >
-                    {i ? t('Split {{num}}', { num: i }) : t('Apply to all')}
-                  </span>
-                  {split.actions.map((action, j) => (
-                    <View
-                      key={j}
+                    <span
                       style={{
-                        marginBottom: j !== split.actions.length - 1 ? 2 : 0,
-                        maxWidth: '100%',
+                        fontSize: 11,
+                        fontWeight: 500,
+                        color: theme.pageTextLight,
+                        marginBottom: 4,
                       }}
                     >
-                      <ActionExpression {...action} />
-                    </View>
-                  ))}
-                </View>
-              ))
-            : rule.actions.map((action, index) => (
-                <View key={index} style={{ marginBottom: 2, maxWidth: '100%' }}>
-                  <ActionExpression {...action} />
-                </View>
-              ))}
+                      {i ? t('Split {{num}}', { num: i }) : t('Apply to all')}
+                    </span>
+                    {split.actions.map((action, j) => (
+                      <View
+                        key={j}
+                        style={{
+                          marginBottom: j !== split.actions.length - 1 ? 2 : 0,
+                          maxWidth: '100%',
+                        }}
+                      >
+                        <ActionExpression {...action} />
+                      </View>
+                    ))}
+                  </View>
+                ))
+              : rule.actions.map((action, index) => (
+                  <View
+                    key={index}
+                    style={{ marginBottom: 2, maxWidth: '100%' }}
+                  >
+                    <ActionExpression {...action} />
+                  </View>
+                ))}
+          </View>
         </View>
-      </View>
-    </Button>
+      </SpaceBetween>
+    </GridListItem>
   );
 }

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -8,6 +8,7 @@ import { type NewRuleEntity, type PayeeEntity } from 'loot-core/types/models';
 
 import { ManagePayees } from './ManagePayees';
 
+import { usePayeeRuleCounts } from '@desktop-client/hooks/usePayeeRuleCounts';
 import { usePayees } from '@desktop-client/hooks/usePayees';
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import { getPayees, reloadPayees } from '@desktop-client/payees/payeesSlice';
@@ -22,8 +23,8 @@ export function ManagePayeesWithData({
 }: ManagePayeesWithDataProps) {
   const payees = usePayees();
   const dispatch = useDispatch();
+  const { ruleCounts, refetch: refetchRuleCounts } = usePayeeRuleCounts();
 
-  const [ruleCounts, setRuleCounts] = useState({ value: new Map() });
   const [orphans, setOrphans] = useState<Array<Pick<PayeeEntity, 'id'>>>([]);
 
   const refetchOrphanedPayees = useCallback(async () => {
@@ -31,16 +32,9 @@ export function ManagePayeesWithData({
     setOrphans(orphs);
   }, []);
 
-  const refetchRuleCounts = useCallback(async () => {
-    const counts = await send('payees-get-rule-counts');
-    const countsMap = new Map(Object.entries(counts));
-    setRuleCounts({ value: countsMap });
-  }, []);
-
   useEffect(() => {
     async function loadData() {
       await dispatch(getPayees());
-      await refetchRuleCounts();
       await refetchOrphanedPayees();
     }
     loadData();
@@ -119,7 +113,7 @@ export function ManagePayeesWithData({
   return (
     <ManagePayees
       payees={payees}
-      ruleCounts={ruleCounts.value}
+      ruleCounts={ruleCounts}
       orphanedPayees={orphans}
       initialSelectedIds={initialSelectedIds}
       onBatchChange={async (changes: Diff<PayeeEntity>) => {
@@ -141,17 +135,11 @@ export function ManagePayeesWithData({
         }
         filtedOrphans = filtedOrphans.filter(o => !mergeIds.includes(o.id));
 
-        mergeIds.forEach(id => {
-          const count = ruleCounts.value.get(id) || 0;
-          ruleCounts.value.set(
-            targetId,
-            (ruleCounts.value.get(targetId) || 0) + count,
-          );
-        });
+        // Refetch rule counts after merging
+        await refetchRuleCounts();
 
         await dispatch(reloadPayees());
         setOrphans(filtedOrphans);
-        setRuleCounts({ value: ruleCounts.value });
       }}
       onViewRules={onViewRules}
       onCreateRule={onCreateRule}

--- a/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeRuleCountLabel.tsx
@@ -1,20 +1,28 @@
 import { type CSSProperties } from 'react';
 import { Trans } from 'react-i18next';
 
+import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { Text } from '@actual-app/components/text';
+import { View } from '@actual-app/components/view';
 
 type PayeeRuleCountLabelProps = {
   count: number;
+  isLoading?: boolean;
   style?: CSSProperties;
 };
 
 export function PayeeRuleCountLabel({
   count,
+  isLoading,
   style,
 }: PayeeRuleCountLabelProps) {
   return (
     <Text style={style}>
-      {count > 0 ? (
+      {isLoading ? (
+        <View>
+          <AnimatedLoading style={{ width: 12, height: 12 }} />
+        </View>
+      ) : count > 0 ? (
         <Trans count={count}>{{ count }} associated rules</Trans>
       ) : (
         <Trans>Create rule</Trans>

--- a/packages/desktop-client/src/hooks/usePayeeRuleCounts.ts
+++ b/packages/desktop-client/src/hooks/usePayeeRuleCounts.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { send } from 'loot-core/platform/client/fetch';
+
+type PayeeRuleCounts = Map<string, number>;
+
+type UsePayeeRuleCountsResult = {
+  ruleCounts: PayeeRuleCounts;
+  isLoading: boolean;
+  refetch: () => Promise<void>;
+};
+
+export function usePayeeRuleCounts(): UsePayeeRuleCountsResult {
+  const [ruleCounts, setRuleCounts] = useState<PayeeRuleCounts>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const counts = await send('payees-get-rule-counts');
+      const countsMap = new Map(Object.entries(counts));
+      setRuleCounts(countsMap);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { ruleCounts, isLoading, refetch };
+}

--- a/upcoming-release-notes/5804.md
+++ b/upcoming-release-notes/5804.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Mobile rules - refactor to use react-aria GridList

--- a/upcoming-release-notes/5842.md
+++ b/upcoming-release-notes/5842.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Mobile Payees - add loading indicator to rules count label

--- a/upcoming-release-notes/5861.md
+++ b/upcoming-release-notes/5861.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [willkell]
+---
+
+fix merging of split transactions


### PR DESCRIPTION
Fixes #5781 

This bug fixes an issue where, during transaction merging, if the transaction that is dropped has split transactions and the transaction that was kept does not then the dropped transaction's splits disappear and don't get re-parented to the kept transaction.

Now, the behavior is:

- If the dropped transaction is a split transaction and the kept transaction does not, the dropped transaction's splits are re-parented to the kept transaction
- If both the dropped and kept transaction are split transactions the dropped transaction's splits are properly deleted and just the kept transaction's splits are kept around

This is my first time doing this, so please feel free to let me know if anything needs to be changed. Thanks!
