### PR TITLE
run schedule rules regardless of posted date

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -342,8 +342,9 @@ export async function runRules(
     // If there is a scheduleRuleID (meaning this transaction came from a schedule) then exclude rules linked to other schedules.
     if (scheduleRuleID !== '') {
       if (rules[i].id === scheduleRuleID) {
-        // if the rule has the same ID that is attached to the schedule then run it (it is the schedules rule).
-        finalTrans = rules[i].apply(finalTrans);
+        // bypass condition checking to run the rule even if the transaction date falls outside of the schedule's date range.
+        const changes = rules[i].execActions(finalTrans);
+        finalTrans = Object.assign({}, finalTrans, changes);
       } else if (RuleIdsLinkedToSchedules.includes(rules[i].id)) {
         // skip all other rules that are linked to other schedules.
         continue;

--- a/upcoming-release-notes/5870.md
+++ b/upcoming-release-notes/5870.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Run schedule rules regardless of posted date


### PR DESCRIPTION
Fixes https://github.com/actualbudget/actual/issues/5868

Test budget:
[post-early.zip](https://github.com/user-attachments/files/22725227/post-early.zip)

1. Go to Bank of America
2. Post the Dominion Power split schedule today

On edge, it does not split. On this deploy, it does.