### PR TITLE
Hide refresh button when not connected to sync server

### DIFF
--- a/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
@@ -59,6 +59,7 @@ import {
 import { useMultiuserEnabled } from '@desktop-client/components/ServerContext';
 import { useInitialMount } from '@desktop-client/hooks/useInitialMount';
 import { useMetadataPref } from '@desktop-client/hooks/useMetadataPref';
+import { useSyncServerStatus } from '@desktop-client/hooks/useSyncServerStatus';
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import { useSelector, useDispatch } from '@desktop-client/redux';
 import { getUserData } from '@desktop-client/users/usersSlice';
@@ -495,7 +496,7 @@ function SettingsButton({ onOpenSettings }: SettingsButtonProps) {
 
 type BudgetFileSelectionHeaderProps = {
   quickSwitchMode: boolean;
-  onRefresh: () => void;
+  onRefresh?: () => void;
   onOpenSettings: () => void;
 };
 
@@ -526,7 +527,7 @@ function BudgetFileSelectionHeader({
             gap: '0.2rem',
           }}
         >
-          <RefreshButton onRefresh={onRefresh} />
+          {onRefresh && <RefreshButton onRefresh={onRefresh} />}
           {isElectron() && <SettingsButton onOpenSettings={onOpenSettings} />}
         </View>
       )}
@@ -549,6 +550,7 @@ export function BudgetFileSelection({
   const [id] = useMetadataPref('id');
   const [currentUserId, setCurrentUserId] = useState('');
   const userData = useSelector(state => state.user.data);
+  const serverStatus = useSyncServerStatus();
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -636,7 +638,7 @@ export function BudgetFileSelection({
       {showHeader && (
         <BudgetFileSelectionHeader
           quickSwitchMode={quickSwitchMode}
-          onRefresh={refresh}
+          onRefresh={serverStatus === 'online' ? refresh : undefined}
           onOpenSettings={() =>
             dispatch(pushModal({ modal: { name: 'files-settings' } }))
           }

--- a/upcoming-release-notes/5940.md
+++ b/upcoming-release-notes/5940.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Budget selection page: do not show refresh button for non-server users


### PR DESCRIPTION
This PR hides the refresh button in the budget file selection screen when the user is not connected to a sync server instance.

It doesn't make much sense to show it as it will not really do anything for offline users.

<img width="403" height="581" alt="Screenshot 2025-10-16 at 21 30 30" src="https://github.com/user-attachments/assets/34cf676c-788c-4e28-82ec-f7006156be2c" />
