### PR TITLE
increase playwright worker limit in CI

### DIFF
--- a/packages/desktop-client/playwright.config.ts
+++ b/packages/desktop-client/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   timeout: 60000, // 60 seconds
   retries: 1,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 3 : undefined,
   testDir: 'e2e/',
   reporter: process.env.CI ? 'blob' : [['html', { open: 'never' }]],
   use: {


### PR DESCRIPTION
I'm looking to speed up this job in CI and I'm not sure why the limit was hardcoded down to 1 but if anyone knows why, do chime in

- 1 worker [9m](https://github.com/actualbudget/actual/actions/runs/18701525803/job/53331291014)
- 2 workers [6m](https://github.com/actualbudget/actual/actions/runs/18701762364/job/53332001327?pr=5979)
- 3 workers
- 4 workers
