### PR TITLE
Fix: custom reports - persist "show uncategorized" field

### DIFF
--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -228,7 +228,7 @@ export type DbCustomReport = {
   show_empty: 1 | 0;
   show_offbudget: 1 | 0;
   show_hidden: 1 | 0;
-  show_uncateogorized: 1 | 0;
+  show_uncategorized: 1 | 0;
   selected_categories: string;
   graph_type: string;
   conditions: JsonString;

--- a/packages/loot-core/src/server/reports/app.ts
+++ b/packages/loot-core/src/server/reports/app.ts
@@ -54,7 +54,7 @@ export const reportModel = {
     };
   },
 
-  fromJS(report: CustomReportEntity) {
+  fromJS(report: CustomReportEntity): CustomReportData {
     return {
       id: report.id,
       name: report.name,
@@ -64,12 +64,13 @@ export const reportModel = {
       date_range: report.dateRange,
       mode: report.mode,
       group_by: report.groupBy,
-      sort_by: report.sortBy,
+      sort_by: report.sortBy ?? 'desc',
       interval: report.interval,
       balance_type: report.balanceType,
       show_empty: report.showEmpty ? 1 : 0,
       show_offbudget: report.showOffBudget ? 1 : 0,
       show_hidden: report.showHiddenCategories ? 1 : 0,
+      show_uncategorized: report.showUncategorized ? 1 : 0,
       trim_intervals: report.trimIntervals ? 1 : 0,
       include_current: report.includeCurrentInterval ? 1 : 0,
       graph_type: report.graphType,

--- a/upcoming-release-notes/6005.md
+++ b/upcoming-release-notes/6005.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Custom reports - persist "show_uncategorized" in DB


### PR DESCRIPTION
Related: https://github.com/actualbudget/actual/issues/6004

The "show uncategorized" field was not being saved to the DB.
