### PR TITLE
[WIP] Fix missing margin between button and separator in spending report toolbar

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -363,6 +363,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                 height: 28,
                 backgroundColor: theme.pillBorderDark,
                 marginRight: 10,
+                marginLeft: 10,
               }}
             />
 


### PR DESCRIPTION
This fixes the missing margin between the button and the vertical separator line in the spending report toolbar.

The separator View component was missing a left margin, causing it to appear too close to the adjacent button. I added marginLeft: 10 to match the existing marginRight: 10, which creates consistent spacing on both sides of the separator.

Fixes #6003