### PR TITLE
Add BTC currency

### DIFF
--- a/packages/desktop-client/src/components/settings/Currency.tsx
+++ b/packages/desktop-client/src/components/settings/Currency.tsx
@@ -25,6 +25,7 @@ export function CurrencySettings() {
         ['ARS', t('Argentinian Peso')],
         ['AUD', t('Australian Dollar')],
         ['BRL', t('Brazilian Real')],
+        ['BTC', t('Bitcoin')],
         ['BYN', t('Belarusian Ruble')],
         ['CAD', t('Canadian Dollar')],
         ['CHF', t('Swiss Franc')],

--- a/packages/desktop-client/src/hooks/useFormat.ts
+++ b/packages/desktop-client/src/hooks/useFormat.ts
@@ -164,24 +164,14 @@ export function useFormat(): UseFormatResult {
 
   const formatDisplay = useCallback(
     (value: unknown, type: FormatType = 'string'): string => {
-      const isFinancialType =
-        type === 'financial' ||
-        type === 'financial-with-sign' ||
-        type === 'financial-no-decimals';
-
-      let displayDecimalPlaces: number | undefined;
-
-      if (isFinancialType) {
-        if (type === 'financial-no-decimals' || hideFractionPref === 'true') {
-          displayDecimalPlaces = 0;
-        } else {
-          displayDecimalPlaces = activeCurrency.decimalPlaces;
-        }
-      }
-
+      const isFinancialType = type.startsWith('financial');
+      const noDecimals =
+        type === 'financial-no-decimals' || hideFractionPref === 'true';
+      const hideFraction = isFinancialType && noDecimals;
       const intlFormatter = getNumberFormat({
         format: numberFormatConfig.format,
-        decimalPlaces: displayDecimalPlaces,
+        hideFraction,
+        decimalPlaces: hideFraction ? 0 : activeCurrency.decimalPlaces,
       }).formatter;
 
       const { numericValue, formattedString } = format(
@@ -233,6 +223,7 @@ export function useFormat(): UseFormatResult {
         hideFractionPref === 'true' ? 0 : activeCurrency.decimalPlaces;
       const editFormatter = getNumberFormat({
         format: numberFormatConfig.format,
+        hideFraction: hideFractionPref === 'true',
         decimalPlaces,
       }).formatter;
       return editFormatter.format(amount);

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -25,7 +25,7 @@ export const currencies: Currency[] = [
   { code: 'ARS', name: 'Argentinian Peso', symbol: 'Arg$', decimalPlaces: 2, numberFormat: 'dot-comma', symbolFirst: true },
   { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
   { code: 'BRL', name: 'Brazilian Real', symbol: 'R$', decimalPlaces: 2, numberFormat: 'dot-comma', symbolFirst: true },
-  { code: 'BTC', name: 'Bitcoin', symbol: '₿', decimalPlaces: 8, numberFormat: 'comma-dot', symbolFirst: false },
+  { code: 'BTC', name: 'Bitcoin', symbol: '₿', decimalPlaces: 8, numberFormat: 'sat-comma', symbolFirst: false },
   { code: 'BYN', name: 'Belarusian Ruble', symbol: 'Br', decimalPlaces: 2, numberFormat: 'space-comma', symbolFirst: false },
   { code: 'CAD', name: 'Canadian Dollar', symbol: 'CA$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
   { code: 'CHF', name: 'Swiss Franc', symbol: 'Fr.', decimalPlaces: 2, numberFormat: 'apostrophe-dot', symbolFirst: true },

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -25,6 +25,7 @@ export const currencies: Currency[] = [
   { code: 'ARS', name: 'Argentinian Peso', symbol: 'Arg$', decimalPlaces: 2, numberFormat: 'dot-comma', symbolFirst: true },
   { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
   { code: 'BRL', name: 'Brazilian Real', symbol: 'R$', decimalPlaces: 2, numberFormat: 'dot-comma', symbolFirst: true },
+  { code: 'BTC', name: 'Bitcoin', symbol: '₿', decimalPlaces: 8, numberFormat: 'comma-dot', symbolFirst: false },
   { code: 'BYN', name: 'Belarusian Ruble', symbol: 'Br', decimalPlaces: 2, numberFormat: 'space-comma', symbolFirst: false },
   { code: 'CAD', name: 'Canadian Dollar', symbol: 'CA$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
   { code: 'CHF', name: 'Swiss Franc', symbol: 'Fr.', decimalPlaces: 2, numberFormat: 'apostrophe-dot', symbolFirst: true },

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -5,6 +5,9 @@ import {
   currencyToAmount,
   stringToInteger,
   titleFirst,
+  integerToCurrency,
+  amountToCurrency,
+  amountToCurrencyNoDecimal,
 } from './util';
 
 describe('utility functions', () => {
@@ -102,6 +105,19 @@ describe('utility functions', () => {
     expect(formatter.format(Number('1234.56'))).toBe('1.235');
   });
 
+  test('number formatting works with sat-comma format', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    let formatter = getNumberFormat().formatter;
+    // grouping separator space char is a narrow non-breaking space (U+202F)
+    expect(formatter.format(Number('1.23456789'))).toBe(
+      '1.23\u202F456\u202F789',
+    );
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    formatter = getNumberFormat().formatter;
+    expect(formatter.format(Number('1.23456789'))).toBe('123,456,789');
+  });
+
   test('number formatting works with space-comma format', () => {
     setNumberFormat({ format: 'space-comma', hideFraction: false });
     let formatter = getNumberFormat().formatter;
@@ -186,6 +202,25 @@ describe('utility functions', () => {
     expect(currencyToAmount('3.000,')).toBe(3000);
   });
 
+  test('currencyToAmount works with sat-comma format (round-trip precision)', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // Test round-trip: format -> parse -> should equal original value
+    // The formatted string contains U+202F narrow no-break spaces in the fraction
+    // which must be stripped for proper parsing
+    const formatted1 = '1.23\u202F456\u202F789';
+    expect(currencyToAmount(formatted1)).toBe(1.23456789);
+
+    const formatted2 = '0.00\u202F000\u202F001';
+    expect(currencyToAmount(formatted2)).toBe(0.00000001);
+
+    const formatted3 = '123.45\u202F600\u202F000';
+    expect(currencyToAmount(formatted3)).toBe(123.456);
+
+    // Test with grouping separators in integer part
+    const formatted4 = '1,234,567.89\u202F012\u202F345';
+    expect(currencyToAmount(formatted4)).toBe(1234567.89012345);
+  });
+
   test('titleFirst works with all inputs', () => {
     expect(titleFirst('')).toBe('');
     expect(titleFirst(undefined)).toBe('');
@@ -198,5 +233,198 @@ describe('utility functions', () => {
     expect(stringToInteger('-3')).toBe(-3);
     // Unicode minus
     expect(stringToInteger('−3')).toBe(-3);
+  });
+
+  test('integerToCurrency works with sat-comma format', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // 12345 satoshis = 0.00012345 BTC with 8 decimal places
+    expect(integerToCurrency(12345)).toBe('0.00\u202F012\u202F345');
+    // 123456789 satoshis = 1.23456789 BTC
+    expect(integerToCurrency(123456789)).toBe('1.23\u202F456\u202F789');
+    // 100000000 satoshis = 1 BTC
+    expect(integerToCurrency(100000000)).toBe('1.00\u202F000\u202F000');
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    // With hideFraction, still displays as satoshis (the amount is converted to BTC then back to sats)
+    // 12345 sats -> 0.00012345 BTC -> 12,345 sats displayed
+    expect(integerToCurrency(12345)).toBe('12,345');
+    // 123456789 sats -> 1.23456789 BTC -> 123,456,789 sats displayed
+    expect(integerToCurrency(123456789)).toBe('123,456,789');
+    // 100000000 sats -> 1 BTC -> 100,000,000 sats displayed
+    expect(integerToCurrency(100000000)).toBe('100,000,000');
+  });
+
+  test('amountToCurrency works with sat-comma format', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // 8 decimal places with special grouping
+    expect(amountToCurrency(1.23456789)).toBe('1.23\u202F456\u202F789');
+    expect(amountToCurrency(0.00000001)).toBe('0.00\u202F000\u202F001');
+    expect(amountToCurrency(123.456)).toBe('123.45\u202F600\u202F000');
+    expect(amountToCurrency(1234567.89012345)).toBe(
+      '1,234,567.89\u202F012\u202F345',
+    );
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    // Convert to satoshis (multiply by 100 million)
+    expect(amountToCurrency(1.23456789)).toBe('123,456,789');
+    expect(amountToCurrency(0.00000001)).toBe('1');
+    expect(amountToCurrency(21)).toBe('2,100,000,000');
+  });
+  test('amountToCurrencyNoDecimal works with sat-comma format', () => {
+    // This function always uses hideFraction: true
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // Should still convert to satoshis even though base format has hideFraction: false
+    expect(amountToCurrencyNoDecimal(1.23456789)).toBe('123,456,789');
+    expect(amountToCurrencyNoDecimal(0.00000001)).toBe('1');
+    expect(amountToCurrencyNoDecimal(21)).toBe('2,100,000,000');
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    expect(amountToCurrencyNoDecimal(1.23456789)).toBe('123,456,789');
+  });
+
+  test('amountToCurrency preserves negative sign for values between -1 and 0', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // Regression test for negative values between -1 and 0
+    // -0.00000001 BTC (the smallest unit: -1 satoshi)
+    expect(amountToCurrency(-0.00000001)).toBe('-0.00\u202F000\u202F001');
+    // -0.5 BTC
+    expect(amountToCurrency(-0.5)).toBe('-0.50\u202F000\u202F000');
+    // -0.00012345 BTC
+    expect(amountToCurrency(-0.00012345)).toBe('-0.00\u202F012\u202F345');
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    // With hideFraction, show as negative satoshis
+    expect(amountToCurrency(-0.00000001)).toBe('-1');
+    expect(amountToCurrency(-0.5)).toBe('-50,000,000');
+    expect(amountToCurrency(-0.00012345)).toBe('-12,345');
+  });
+
+  test('integerToCurrency preserves negative sign for negative satoshi values', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // Negative satoshis converted to BTC
+    expect(integerToCurrency(-1)).toBe('-0.00\u202F000\u202F001');
+    expect(integerToCurrency(-12345)).toBe('-0.00\u202F012\u202F345');
+    expect(integerToCurrency(-100000000)).toBe('-1.00\u202F000\u202F000');
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    // Display as negative satoshis
+    expect(integerToCurrency(-1)).toBe('-1');
+    expect(integerToCurrency(-12345)).toBe('-12,345');
+    expect(integerToCurrency(-100000000)).toBe('-100,000,000');
+  });
+
+  test('amountToCurrency handles non-finite numbers (NaN, Infinity)', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    // NaN should be formatted as "NaN" by native Intl.NumberFormat
+    expect(amountToCurrency(NaN)).toBe('NaN');
+    // Infinity should be formatted as "∞" by native Intl.NumberFormat
+    expect(amountToCurrency(Infinity)).toBe('∞');
+    expect(amountToCurrency(-Infinity)).toBe('-∞');
+
+    setNumberFormat({ format: 'sat-comma', hideFraction: true });
+    // Non-finite numbers should still work with hideFraction
+    expect(amountToCurrency(NaN)).toBe('NaN');
+    expect(amountToCurrency(Infinity)).toBe('∞');
+    expect(amountToCurrency(-Infinity)).toBe('-∞');
+  });
+
+  test('number formatting supports formatRangeToParts with locale-aware approximation', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    const formatter = getNumberFormat().formatter;
+
+    // When start and end are different, should have separate parts with range separator
+    const diffParts = formatter.formatRangeToParts(1.0, 2.0);
+    expect(diffParts.some(p => p.source === 'startRange')).toBe(true);
+    expect(diffParts.some(p => p.source === 'endRange')).toBe(true);
+    expect(diffParts.some(p => p.value === '–')).toBe(true);
+
+    // When start and end format to the same string, all parts should be 'shared'
+    const sameParts = formatter.formatRangeToParts(1.23456789, 1.23456789);
+    expect(sameParts.every(p => p.source === 'shared')).toBe(true);
+
+    // The approximatelySign should be locale-aware, not hard-coded
+    // In en-US locale, the native formatter may or may not include it
+    // TypeScript types may not include 'approximatelySign', so check dynamically
+    const hasApproxSign = sameParts.some(
+      p => (p as { type: string }).type === 'approximatelySign',
+    );
+    if (hasApproxSign) {
+      // If present, it should be the first part
+      expect((sameParts[0] as { type: string }).type).toBe('approximatelySign');
+      expect(sameParts[0].source).toBe('shared');
+    }
+  });
+
+  test('formatRange produces correct string output', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    const formatter = getNumberFormat().formatter;
+
+    // Different values should produce a range with separator
+    const range1 = formatter.formatRange(1.0, 2.0);
+    expect(range1).toContain('–');
+    expect(range1).toMatch(/1\.00.*–.*2\.00/);
+
+    // Same values should produce single value (possibly with approximation sign)
+    const range2 = formatter.formatRange(1.23456789, 1.23456789);
+    expect(range2).toMatch(/1\.23\u202F456\u202F789/);
+    // Should not have range separator
+    expect(range2).not.toContain('–');
+  });
+
+  test('formatRangeToParts uses locale-specific approximatelySign when available', () => {
+    setNumberFormat({ format: 'sat-comma', hideFraction: false });
+    const formatter = getNumberFormat().formatter;
+
+    // Test with a locale that typically includes approximatelySign (e.g., ja-JP)
+    // First check if native formatter for the test locale supports approximatelySign
+    const testLocale = 'ja-JP';
+    const nativeFormatter = new Intl.NumberFormat(testLocale);
+
+    if (typeof nativeFormatter.formatRangeToParts === 'function') {
+      // Check if this locale uses approximatelySign
+      const nativeParts = nativeFormatter.formatRangeToParts(1, 1);
+      // TypeScript types may not include 'approximatelySign', so check dynamically
+      const nativeHasApprox = nativeParts.some(
+        p => (p as { type: string }).type === 'approximatelySign',
+      );
+
+      if (nativeHasApprox) {
+        // If the native formatter includes approximatelySign, our custom formatter should too
+        // Note: SatNumberFormat uses the locale passed to its constructor
+        const sameParts = formatter.formatRangeToParts(1.0, 1.0);
+
+        // The approximatelySign behavior depends on the locale used by the formatter
+        // Since formatter uses 'en-US' for sat-comma, check en-US behavior
+        const enUsFormatter = new Intl.NumberFormat('en-US');
+        if (typeof enUsFormatter.formatRangeToParts === 'function') {
+          const enUsParts = enUsFormatter.formatRangeToParts(1, 1);
+          const enUsHasApprox = enUsParts.some(
+            p => (p as { type: string }).type === 'approximatelySign',
+          );
+
+          if (enUsHasApprox) {
+            // en-US includes approximatelySign, so our formatter should too
+            const approxPart = sameParts.find(
+              p => (p as { type: string }).type === 'approximatelySign',
+            );
+            expect(approxPart).toBeDefined();
+            expect(approxPart?.source).toBe('shared');
+            expect((sameParts[0] as { type: string }).type).toBe(
+              'approximatelySign',
+            );
+          }
+        }
+      }
+    }
+
+    // Verify that when approximatelySign is present, it comes first
+    const parts = formatter.formatRangeToParts(1.0, 1.0);
+    const approxIndex = parts.findIndex(
+      p => (p as { type: string }).type === 'approximatelySign',
+    );
+    if (approxIndex !== -1) {
+      // If approximatelySign exists, it should be the first part
+      expect(approxIndex).toBe(0);
+    }
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,8 @@
   ],
   "compilerOptions": {
     // "composite": true,
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,

--- a/upcoming-release-notes/6044.md
+++ b/upcoming-release-notes/6044.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [StephenBrown2]
+---
+
+Add BTC currency to supported list


### PR DESCRIPTION
This pull request adds support for Bitcoin (BTC) as a currency, including custom formatting for Bitcoin and satoshi amounts using the Satcomma standard. It introduces a new number format ("sat-comma") that improves readability for Bitcoin fractions and ensures correct display in both the UI and formatting utilities. Comprehensive tests have been added to verify the new formatting logic and currency handling.

The "Satcomma" formatting is for convenience, but if it adds too much complexity since I wanted a full drop-in replacement for Intl.NumberFormat, we can drop all commits but the first and rely on the regular comma-dot format instead.

**Bitcoin currency support and formatting:**

* Added Bitcoin (`BTC`) to the currency selection UI (`CurrencySettings` component) and to the `currencies` list with appropriate symbol, 8 decimal places, and the new `sat-comma` number format. [[1]](diffhunk://#diff-9b0bd6bc744bfd4afac03d8e6db423fa69216ff2dac2272f2a5dba73494e14ccR28) [[2]](diffhunk://#diff-e58604b34393a62d237d3e6c3c8f02502c9c3857eabb3be763b2e5a47c185068R28)
* Introduced the `sat-comma` number format to the available formats and UI labels, following the Satcomma standard for grouping fractional digits in Bitcoin amounts. [[1]](diffhunk://#diff-38e21533cdabf107724be33472d5cca2ebda693ca957e11885b3a515e5f355cfL263-R263) [[2]](diffhunk://#diff-38e21533cdabf107724be33472d5cca2ebda693ca957e11885b3a515e5f355cfR287-R291)

**Custom number formatting for Bitcoin:**

* Implemented the `SatNumberFormat` class to handle Bitcoin/Satoshi formatting, including grouping fractional digits with narrow non-breaking spaces and converting amounts to satoshis when fractions are hidden.
* Updated the `getNumberFormat` function to use `SatNumberFormat` for `sat-comma` formatting and ensured correct integration with existing formatting logic. [[1]](diffhunk://#diff-38e21533cdabf107724be33472d5cca2ebda693ca957e11885b3a515e5f355cfR497-R501) [[2]](diffhunk://#diff-38e21533cdabf107724be33472d5cca2ebda693ca957e11885b3a515e5f355cfR523-R533)

**Formatting logic and utility updates:**

* Adjusted formatting utilities (`integerToCurrency`, `integerToCurrencyWithDecimal`) to support 8 decimal places for Bitcoin and correctly handle sat-comma formatting.
* Refactored formatting logic in `useFormat` hook to properly use the new `hideFraction` and decimal place rules for financial types, including support for Bitcoin. [[1]](diffhunk://#diff-4d927b5c3d05bf6ad49d88bb4c2d0fe771895e381ef4b5746846055871b73959L167-R174) [[2]](diffhunk://#diff-4d927b5c3d05bf6ad49d88bb4c2d0fe771895e381ef4b5746846055871b73959R226)

**Testing enhancements:**

* Added comprehensive tests for sat-comma formatting, Bitcoin currency display, and related utility functions to ensure correctness across various scenarios. [[1]](diffhunk://#diff-80112f2782bc3272bb7e0252d315d508cc0e449e7a6f4cf077d11c03245b5dc7R7-R9) [[2]](diffhunk://#diff-80112f2782bc3272bb7e0252d315d508cc0e449e7a6f4cf077d11c03245b5dc7R100-R112) [[3]](diffhunk://#diff-80112f2782bc3272bb7e0252d315d508cc0e449e7a6f4cf077d11c03245b5dc7R200-R247)

**Bitcoin compatibility with existing MAX_SAFE_NUMBER**

The app's existing architecture using **2^51 - 1** (approximately **2.25 quadrillion**) as MAX_SAFE_NUMBER is sufficient for Bitcoin without modification.

**Key Facts:**
- 1 BTC = 100,000,000 satoshis (smallest unit: 0.00000001 BTC)
- Bitcoin total supply = 21 million BTC = 2.1 quadrillion satoshis
- App can handle: 2.25 quadrillion satoshis = **22.5 million BTC**

**Conclusion:** The existing MAX_SAFE_NUMBER exceeds Bitcoin's total supply by ~7%, providing adequate headroom. No changes to MAX_SAFE_NUMBER are required.

**Screenshots**

With just the basic currency details added ([88045c4](https://github.com/actualbudget/actual/pull/6044/commits/88045c465c309a3f482a884c339f73bad5561855)):
<img width="778" height="416" alt="Screenshot from 2025-11-03 12-10-22" src="https://github.com/user-attachments/assets/41b935dc-4010-46ce-a320-8def3b4b726f" />

With the custom SatComma formatting, which adds spaces among the fractional part:
<img width="778" height="416" alt="Screenshot from 2025-11-03 12-11-37" src="https://github.com/user-attachments/assets/30ceef8a-0f36-4ee7-8bc4-bcfc4257fcaf" />
<img width="269" height="178" alt="Screenshot from 2025-11-03 12-12-32" src="https://github.com/user-attachments/assets/fc3eacab-c18a-41e9-bb32-c5f6c40399cb" />