### PR TITLE
Add tilde(~) separator to CSV parser

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -978,6 +978,7 @@ export function ImportTransactionsModal({
                           [';', ';'],
                           ['|', '|'],
                           ['\t', 'tab'],
+                          ['~', '~'],
                         ]}
                         value={delimiter}
                         onChange={value => {

--- a/upcoming-release-notes/6045.md
+++ b/upcoming-release-notes/6045.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ishanjain28]
+---
+
+Add tilde(~) separator to CSV parser


### PR DESCRIPTION
This separator is used by Credit card statements of some banks in India and it was missing in actual.