### PR TITLE
docs: fix incorrect ActualQL function usage in aggregate examples

### DIFF
--- a/packages/docs/docs/api/actual-ql/functions.md
+++ b/packages/docs/docs/api/actual-ql/functions.md
@@ -39,7 +39,7 @@ You can specify aggregate functions in `select` for things like sums and counts.
 ```js
 q('transactions')
   .filter({ 'category.name': 'Food' })
-  .select({ total: { $sum: 'amount' } });
+  .select({ total: { $sum: '$amount' } });
 ```
 
 This sums up the amount of all transactions with the `Food` category (usually, you will filter by date too). **Aggregate results must be named**; here we named it `total`. You will get an error if you don't name it. (In the future, we may remove this restriction)
@@ -49,7 +49,7 @@ Since it's so common to select a single aggregate expression, ActualQL provides 
 ```js
 q('transactions')
   .filter({ 'category.name': 'Food' })
-  .calculate({ $sum: 'amount' });
+  .calculate({ $sum: '$amount' });
 ```
 
 Not only did we not have to name the result, `data` in the result will also be the summed value itself. If you use `select`, data will be an array with one element. The difference is that in the above you just use `data`, but if you used `select` you'd have to use `data[0].total`.

--- a/upcoming-release-notes/6105.md
+++ b/upcoming-release-notes/6105.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Docs: update incorrect function usage


### PR DESCRIPTION
Fixed incorrect usage of amount field in  aggregate function examples.
Changed 'amount' to '' to match ActualQL syntax requirements.

Fixes https://github.com/actualbudget/actual/issues/6093
