### PR TITLE
docs: update api reference for incorrect category parameter

### DIFF
--- a/upcoming-release-notes/6123.md
+++ b/upcoming-release-notes/6123.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [mstill3]
----
-
-docs: update api reference for incorrect category parameter


### PR DESCRIPTION
Rename `category_id` attribute to `category` since thats the expected field and how it is stored in the database.

### Discovery
I noticed this when trying the example listed on the api documentation and received the following error:
```text
actual/myapp/node_modules/@actual-app/api/dist/app/bundle.api.js:14112
            throw new Error(`Field “${field}” does not exist on table ${table}: ${JSON.stringify(obj)}`);
                  ^

Error: Field “category_id” does not exist on table transactions: {"id":"abc123-def456-ghi789","category_id":"ghi123-def456-abc789"}`
```

### Solution
When looking at the local `db.sqlite` file the `transactions` table has a field not named `category_id`, but a `category` `TEXT` field (which by the way is not a foreign key, which may be another issue).

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
