### PR TITLE
delete docs-only release notes

### DIFF
--- a/upcoming-release-notes/6103.md
+++ b/upcoming-release-notes/6103.md
@@ -1,7 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Docs: update faq - document that Actual enforces upload size limits via configurable environment variables.
-

--- a/upcoming-release-notes/6105.md
+++ b/upcoming-release-notes/6105.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Docs: update incorrect function usage

--- a/upcoming-release-notes/6106.md
+++ b/upcoming-release-notes/6106.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Docs: remove account type reference

--- a/upcoming-release-notes/6113.md
+++ b/upcoming-release-notes/6113.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Docs - remove references to the old docs repository


### PR DESCRIPTION
These are no longer required, dropping them before they're collected for release notes.

I've opted not to include a release note in this PR, I don't see any value in a release note for a release note change 😅