### PR TITLE
fix: prevent unnecessary formula recalculation

### DIFF
--- a/packages/desktop-client/src/hooks/useFormulaExecution.ts
+++ b/packages/desktop-client/src/hooks/useFormulaExecution.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import { send } from 'loot-core/platform/client/fetch';
 import * as monthUtils from 'loot-core/shared/months';
@@ -35,6 +35,11 @@ export function useFormulaExecution(
   const [result, setResult] = useState<number | string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const queriesRef = useRef(queries);
+
+  useEffect(() => {
+    queriesRef.current = queries;
+  }, [queries]);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,7 +68,7 @@ export function useFormulaExecution(
 
         for (const match of queryMatches) {
           const queryName = match[1];
-          const queryConfig = queries[queryName];
+          const queryConfig = queriesRef.current[queryName];
 
           if (!queryConfig) {
             console.warn(`Query “${queryName}” not found in queries config`);
@@ -159,7 +164,7 @@ export function useFormulaExecution(
     return () => {
       cancelled = true;
     };
-  }, [formula, queriesVersion, locale, queries, namedExpressions]);
+  }, [formula, queriesVersion, locale, namedExpressions]);
 
   return { result, isLoading, error };
 }

--- a/upcoming-release-notes/6147.md
+++ b/upcoming-release-notes/6147.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatthiasBenaets]
+---
+
+Prevent unnecessary formula recalculation for the formula report card


### PR DESCRIPTION
I noticed that the formula report card value kept flickering, especially when resizing the window.

The flickering happened because the formula execution hook was re-running on every render because a new queries object was being created, triggering the recalculation. This led to the constant toggling of the loading state.

I don't think it's a big issue to just remove queries from the dependencies, but then the linter isn't too happy (exhaustive-deps); so I just used a useRef.
So now the recalculation triggers when inputs actually change. Even if queries updates, it should still be tracked using queriesVersion.