### PR TITLE
Fix bundle stats comment markdown formatting

### DIFF
--- a/packages/ci-actions/bin/bundle-stats-comment.mjs
+++ b/packages/ci-actions/bin/bundle-stats-comment.mjs
@@ -589,7 +589,7 @@ function printChunkModulesTable(statsDiff) {
   const summarySuffix =
     changedModules.length > 100 ? ' (largest 100 files by percent change)' : '';
 
-  return `<details>\n<summary>Changeset${summarySuffix}</summary>\n${CHUNK_TABLE_HEADERS}\n${rows}\n</details>`;
+  return `<details>\n<summary>Changeset${summarySuffix}</summary>\n\n${CHUNK_TABLE_HEADERS}\n${rows}\n</details>`;
 }
 
 function printTotalAssetTable(statsDiff) {
@@ -607,7 +607,7 @@ function renderSection(title, statsDiff, chunkModuleDiff) {
 
   parts.push(
     '',
-    `<details>\n<summary>View detailed bundle breakdown</summary>\n<div>\n${printAssetTablesByGroup(
+    `<details>\n<summary>View detailed bundle breakdown</summary>\n<div>\n\n${printAssetTablesByGroup(
       groups,
     )}\n</div>\n</details>`,
   );

--- a/upcoming-release-notes/6152.md
+++ b/upcoming-release-notes/6152.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Fix bundle stats comment - broken markdown in some places


### PR DESCRIPTION
## Summary

Fixes broken markdown rendering in bundle stats comments by adding missing newlines after `<summary>` tags.

## Changes

- Added newline after `<summary>` tag in `printChunkModulesTable` function
- Added newline after `<summary>` tag in `renderSection` function

These changes ensure proper markdown rendering in GitHub comments when the bundle stats are displayed.

## Testing

The markdown formatting should now render correctly in GitHub PR comments when bundle stats are generated.