### PR TITLE
Add workflow to auto-assign maintainers to PRs on comment/review

### DIFF
--- a/.github/actions/pr-auto-assign/assign-maintainer.js
+++ b/.github/actions/pr-auto-assign/assign-maintainer.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+import { Octokit } from '@octokit/rest';
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+const prNumber = process.env.PR_NUMBER;
+const userLogin = process.env.USER_LOGIN;
+
+if (!token || !repo || !prNumber || !userLogin) {
+  console.log('Missing required environment variables');
+  console.log(
+    'Required: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, USER_LOGIN',
+  );
+  process.exit(1);
+}
+
+const [owner, repoName] = repo.split('/');
+const octokit = new Octokit({ auth: token });
+const orgName = 'actualbudget';
+
+async function assignMaintainer() {
+  try {
+    console.log(
+      `Checking if ${userLogin} should be assigned to PR #${prNumber}...`,
+    );
+
+    // Get PR details to check if user is the author
+    const { data: pr } = await octokit.rest.pulls.get({
+      owner,
+      repo: repoName,
+      pull_number: prNumber,
+    });
+
+    // Skip if user is the PR author
+    if (pr.user.login === userLogin) {
+      console.log(
+        `Skipping: ${userLogin} is the PR author, not assigning to own PR`,
+      );
+      return;
+    }
+
+    // Check if user is a member of the organization
+    try {
+      await octokit.rest.orgs.checkMembershipForUser({
+        org: orgName,
+        username: userLogin,
+      });
+      console.log(`${userLogin} is a member of ${orgName} organization`);
+    } catch (error) {
+      if (error.status === 404) {
+        console.log(
+          `Skipping: ${userLogin} is not a member of ${orgName} organization`,
+        );
+        return;
+      }
+      // If we get a 403, it might be due to insufficient permissions
+      // Log but don't fail - this prevents the workflow from breaking
+      if (error.status === 403) {
+        console.log(
+          `Warning: Cannot verify organization membership (403). This may be due to insufficient token permissions. Skipping assignment.`,
+        );
+        return;
+      }
+      throw error;
+    }
+
+    // Get current assignees
+    const { data: issue } = await octokit.rest.issues.get({
+      owner,
+      repo: repoName,
+      issue_number: prNumber,
+    });
+
+    const currentAssignees = issue.assignees.map(assignee => assignee.login);
+
+    // Skip if user is already assigned
+    if (currentAssignees.includes(userLogin)) {
+      console.log(
+        `Skipping: ${userLogin} is already assigned to PR #${prNumber}`,
+      );
+      return;
+    }
+
+    // Add user as assignee
+    console.log(`Adding ${userLogin} as assignee to PR #${prNumber}...`);
+    await octokit.rest.issues.addAssignees({
+      owner,
+      repo: repoName,
+      issue_number: prNumber,
+      assignees: [userLogin],
+    });
+
+    console.log(`Successfully assigned ${userLogin} to PR #${prNumber}`);
+  } catch (error) {
+    console.log('Error assigning maintainer:', error.message);
+    if (error.response) {
+      console.log('Response status:', error.response.status);
+      console.log(
+        'Response data:',
+        JSON.stringify(error.response.data, null, 2),
+      );
+    }
+    console.log('Stack:', error.stack);
+    process.exit(1);
+  }
+}
+
+assignMaintainer().catch(error => {
+  console.log('Unhandled error:', error.message);
+  console.log('Stack:', error.stack);
+  process.exit(1);
+});

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,28 @@
+name: PR Auto-Assign Maintainers
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign-maintainer:
+    # Only run on PRs, not issues
+    if: github.event.issue.pull_request || github.event.pull_request
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Assign maintainer
+        run: node .github/actions/pr-auto-assign/assign-maintainer.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          USER_LOGIN: ${{ github.event.review.user.login || github.event.comment.user.login }}

--- a/upcoming-release-notes/6156.md
+++ b/upcoming-release-notes/6156.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Auto assign maintainers after they interact in a PR


### PR DESCRIPTION
## Overview

This PR adds a GitHub Actions workflow that automatically assigns maintainers (organization members) to pull requests when they comment or submit a review.

Demo: https://github.com/MatissJanis/actual/pull/17

## Changes

- **New workflow** (): Triggers on `pull_request_review` (submitted) and `issue_comment` (created) events
- **New script** (): Node.js script that:
  - Checks if the user is a member of the `actualbudget` organization
  - Skips if user is the PR author (prevents self-assignment)
  - Skips if user is already assigned (idempotent)
  - Adds the user as an assignee without removing existing assignees

## Features

- ✅ Multiple assignees supported - adds without removing existing ones
- ✅ Organization membership verification - only assigns members of `actualbudget`
- ✅ Self-assignment prevention - skips if user is the PR author
- ✅ Idempotent - gracefully skips if already assigned
- ✅ Error handling - handles permission errors gracefully
- ✅ Secure - uses safe event types (`issue_comment`/`pull_request_review` not `pull_request_target`)

## Security

- Uses safe event types that run in base repository context
- Verifies organization membership before assigning
- Handles permission errors gracefully (403 errors)
- Follows existing workflow patterns and security best practices

## Testing

The workflow will automatically trigger when:
1. A maintainer comments on a PR
2. A maintainer submits a review on a PR

It will only assign if the user is an organization member and not already assigned.