### PR TITLE
ForceReload: update service worker refresh logic

### DIFF
--- a/packages/desktop-client/src/components/settings/Reset.tsx
+++ b/packages/desktop-client/src/components/settings/Reset.tsx
@@ -96,17 +96,19 @@ export function ForceReload() {
   async function onForceReload() {
     setReloading(true);
     try {
-      if (isElectron()) {
-        window.location.reload();
-      } else {
-        if (window.Actual?.applyAppUpdate) {
-          await window.Actual.applyAppUpdate();
-        } else {
-          window.location.reload();
+      if (!isElectron()) {
+        const registration =
+          await window.navigator.serviceWorker.getRegistration('/');
+        if (registration) {
+          await registration.update();
+          if (registration.waiting) {
+            registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+          }
         }
       }
     } catch (error) {
-      // If reload fails, fall back to location.reload()
+      // Do nothing
+    } finally {
       window.location.reload();
     }
   }

--- a/upcoming-release-notes/6162.md
+++ b/upcoming-release-notes/6162.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Force reload: update logic for service worker data refresh


### PR DESCRIPTION

Implements the proposed changes from [PR #6119 comment](https://github.com/actualbudget/actual/pull/6119#issuecomment-3527972145) to improve the force reload functionality for web applications.
