### PR TITLE
Fix: Update methods to match TypeScript type for aqlQuery

### DIFF
--- a/packages/api/app/query.js
+++ b/packages/api/app/query.js
@@ -97,6 +97,14 @@ class Query {
   serialize() {
     return this.state;
   }
+
+  reset() {
+    return q(this.state.table);
+  }
+
+  serializeAsString() {
+    return JSON.stringify(this.serialize());
+  }
 }
 
 export function q(table) {

--- a/upcoming-release-notes/6331.md
+++ b/upcoming-release-notes/6331.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [BHChen24]
+---
+
+Updates the `Query` class in `packages/api/app/query.js` to include the missing `reset()` and `serializeAsString()` methods.


### PR DESCRIPTION
Fixes #6290 

Hi actual team,

According to the issue I added two more methods: "reset" and "serializeAsString" to class "Query."

Tested by:
1. cd to api folder
2. Create a test file with the code from the issue (maybe need a mock `tx` object)
3. Run `npx tsc {your test file name}.ts --noEmit --skipLibCheck`
4. Verify no TypeScript errors (previously would fail with "missing properties: reset, serializeAsString")

This is my first time contributing to actual, any feedback or guidance would be greatly appreciated. Thanks!