### PR TITLE
Fix API init() silently ignoring authentication failures

### DIFF
--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -259,9 +259,12 @@ export async function init(config: InitConfig) {
     setServer(serverURL);
 
     if (config.password) {
-      await runHandler(handlers['subscribe-sign-in'], {
+      const result = await runHandler(handlers['subscribe-sign-in'], {
         password: config.password,
       });
+      if (result?.error) {
+        throw new Error(`Authentication failed: ${result.error}`);
+      }
     }
   } else {
     // This turns off all server URLs. In this mode we don't want any

--- a/upcoming-release-notes/6337.md
+++ b/upcoming-release-notes/6337.md
@@ -1,0 +1,7 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix API `downloadBudget` failing with "Could not get remote files" error when authentication fails silently during `init()`.
+


### PR DESCRIPTION
## Summary

When using the `@actual-app/api` package, if authentication failed during `init()` (e.g., wrong password, network issue), the error was silently ignored. This led to confusing "Could not get remote files" errors later when calling `downloadBudget()`.

## Changes

- Modified `init()` in `packages/loot-core/src/server/main.ts` to check the result of the sign-in handler and throw an error if authentication fails

## Before

```javascript
await actual.init({
  serverURL: 'https://example.com',
  password: 'wrong-password',
});
// No error thrown, init() appears to succeed

await actual.downloadBudget('sync-id');
// Error: Could not get remote files (confusing!)
```

## After

```javascript
await actual.init({
  serverURL: 'https://example.com', 
  password: 'wrong-password',
});
// Error: Authentication failed: invalid-password (clear feedback!)
```

Maybe fixes #6320