### PR TITLE
Fix non-owner users being able to delete server budget files

### DIFF
--- a/upcoming-release-notes/6339.md
+++ b/upcoming-release-notes/6339.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix non-owner users being able to delete server budget files


### PR DESCRIPTION
## Summary

This PR fixes [issue #6334](https://github.com/actualbudget/actual/issues/6334) where non-owner users were able to delete shared budgets from the server.

## Problem

Previously, the `/delete-user-file` endpoint in the sync server only verified that a file exists before allowing deletion. It did not check if the requesting user is the file owner or an admin, allowing any user with access to the budget to delete it from the server.

## Solution

### Server-side
- Added ownership check to `/delete-user-file` endpoint in `app-sync.ts`
- Only the file owner or server admins can delete files from the server
- Returns 403 Forbidden with appropriate error details for non-owners

### Client-side  
- Updated `deleteBudget` action to handle permission errors and show notifications
- Added UI feedback in `DeleteFileModal`:
  - Non-owners see "Only the file owner can delete it from the server"
  - The "Delete file from all devices" button is disabled for non-owners
  - Local deletion is still allowed for everyone

### Tests
- Added test: owner can delete their file
- Added test: non-owner receives 403 forbidden
- Added test: admin can delete any file

## Testing

1. Set up multiuser mode with OpenID
2. Create a budget with user A and share it with user B
3. As user B, try to delete the budget from the server
4. Verify user B sees the disabled button and explanatory text
5. Verify user B can still delete locally
6. Verify user A (owner) can delete from server