### PR TITLE
Use ACTIONS_UPDATE_TOKEN for workflows that push to forks

### DIFF
--- a/.github/workflows/ai-generated-release-notes.yml
+++ b/.github/workflows/ai-generated-release-notes.yml
@@ -72,7 +72,7 @@ jobs:
         if: steps.check-first-comment.outputs.result == 'true' && steps.check-release-notes-exists.outputs.result == 'false' && steps.generate-summary.outputs.result != 'null' && steps.determine-category.outputs.result != 'null' && steps.determine-category.outputs.result != ''
         run: node .github/actions/ai-generated-release-notes/create-release-notes-file.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           SUMMARY_DATA: ${{ steps.generate-summary.outputs.result }}

--- a/.github/workflows/vrt-update-apply.yml
+++ b/.github/workflows/vrt-update-apply.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           repository: ${{ steps.metadata.outputs.head_repo }}
           ref: ${{ steps.metadata.outputs.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           fetch-depth: 0
 
       - name: Validate and apply patch

--- a/upcoming-release-notes/6349.md
+++ b/upcoming-release-notes/6349.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Change to personal access token on vrt update workflow to trigger ci


### PR DESCRIPTION
## Summary
`GITHUB_TOKEN` doesn't have permission to push to fork branches in `workflow_run` and `issue_comment` triggered workflows. This PR switches to using a PAT stored as `ACTIONS_UPDATE_TOKEN` for workflows that need cross-fork push access.

## Changes
- **VRT update workflow**: Use `ACTIONS_UPDATE_TOKEN` for checkout token when pushing VRT screenshot updates to contributor fork branches
- **AI-generated release notes**: Pass `ACTIONS_UPDATE_TOKEN` as environment variable when committing release notes files to PR branches

## Notes
- The `ACTIONS_UPDATE_TOKEN` secret must be configured in repository settings with appropriate permissions (`contents: write`)
- Static analysis may show "Context access might be invalid" warnings for custom secrets - this is expected and informational only