### PR TITLE
:scroll: Redirect the .com domain to .org

### DIFF
--- a/packages/docs/static/_redirects
+++ b/packages/docs/static/_redirects
@@ -1,10 +1,6 @@
 # Redirects from pages on the classic actualbudget.com site to their new routes
 # (no broken links!)
 
-# Redirect the .com domain to the .org domain
-http://actualbudget.com/* https://actualbudget.org/:splat 301!
-https://actualbudget.com/* https://actualbudget.org/:splat 301!
-
 /account/*     https://sunset.actualbudget.com/account/:splat
 /pricing/*     /
 
@@ -45,3 +41,7 @@ https://actualbudget.com/* https://actualbudget.org/:splat 301!
 /docs/budgeting/returnsandreimbursements    /docs/budgeting/returns-and-reimbursements
 /docs/budgeting/creditcards                 /docs/budgeting/credit-cards
 /docs/budgeting/jointaccounts               /docs/budgeting/joint-accounts
+
+# Redirect the .com domain to the .org domain
+http://actualbudget.com/* https://actualbudget.org/:splat 301!
+https://actualbudget.com/* https://actualbudget.org/:splat 301!


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

`actualbudget.com` currently points to the netlify deployment.

Github Pages only supports one custom domain per repo so we can't point .com and .org to the same github pages. 

This change will keep the .com pointed at netlify, but will redirect the user to the .org domain.

A redirect is better for SEO as well, so it's a better approach than serving the same content across different domains.