### PR TITLE
:scroll: Allow browser to cache docs assets

### DIFF
--- a/packages/docs/static/_headers
+++ b/packages/docs/static/_headers
@@ -1,0 +1,8 @@
+
+# /assets folder contain processed assets with a file hash
+# They are safe for immutable caching, as filename change when content change
+
+/assets/*
+  Cache-Control: public
+  Cache-Control: max-age=365000000
+  Cache-Control: immutable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

When on netlify allow the browser to keep a cache of /assets folder. 

Should reduce both **web requests and bandwidth**.

Even if we're on github pages - this may still be useful for preview builds.

<img width="839" height="306" alt="image" src="https://github.com/user-attachments/assets/938584b7-efc6-4d2e-b132-9730d4d41e72" />
