### PR TITLE
:scroll: Cache image folder

### DIFF
--- a/packages/docs/static/_headers
+++ b/packages/docs/static/_headers
@@ -10,4 +10,3 @@
 /img/*
   Cache-Control: public
   Cache-Control: max-age=604800
-  Cache-Control: immutable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Noticed some home page assets weren't being cached. 

I've set the /img folder to cache for 1 week. Mostly everything is fingerprinted, it's only a few images.