### PR TITLE
ci: fix vrt-generate and apply workflows

### DIFF
--- a/.github/workflows/vrt-update-apply.yml
+++ b/.github/workflows/vrt-update-apply.yml
@@ -131,18 +131,6 @@ jobs:
           git push origin "HEAD:refs/heads/$HEAD_REF"
           echo "Successfully pushed VRT updates to $HEAD_REPO@$HEAD_REF"
 
-      - name: Comment on PR - Success
-        if: steps.apply.outputs.applied == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: ${{ steps.metadata.outputs.pr_number }},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '✅ VRT screenshots have been automatically updated.'
-            });
-
       - name: Comment on PR - Failure
         if: failure() && steps.metadata.outputs.pr_number != ''
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Set up environment
         uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
 
       - name: Run VRT Tests on Desktop app
         continue-on-error: true

--- a/upcoming-release-notes/6421.md
+++ b/upcoming-release-notes/6421.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+ci: fix vrt-generate and apply workflows


### PR DESCRIPTION
This PR makes two improvements to the VRT (Visual Regression Test) workflows:

- **vrt-update-apply.yml**: Removed the success comment step that was posting to PRs when VRT screenshots were updated, reducing notification noise
- **vrt-update-generate.yml**: Disabled translation downloads in the setup step since they're not needed for VRT tests, which should improve workflow performance