### PR TITLE
Rename "Nest egg" to "Life Savings" in crossover report graph

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/CrossoverGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CrossoverGraph.tsx
@@ -127,11 +127,7 @@ export function CrossoverGraph({
                 })}
               >
                 <div>
-                  {payload[0].payload.isProjection ? (
-                    <Trans>Target Nest Egg:</Trans>
-                  ) : (
-                    <Trans>Nest Egg:</Trans>
-                  )}
+                  <Trans>Life savings:</Trans>
                 </div>
                 <div>{format(payload[0].payload.nestEgg, 'financial')}</div>
               </View>

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -802,7 +802,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
                 }}
               >
                 <span>
-                  <Trans>Target Nest Egg</Trans>:{' '}
+                  <Trans>Target Life Savings</Trans>:{' '}
                   <PrivacyFilter>
                     {targetNestEgg != null && !isNaN(targetNestEgg)
                       ? format(targetNestEgg, 'financial')

--- a/upcoming-release-notes/6425.md
+++ b/upcoming-release-notes/6425.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jonner]
+---
+
+Rename "Nest egg" to "Life Savings" in crossover report graph


### PR DESCRIPTION
For projected future amounts, the tooltip already contains the word "(projected)" to indicate that this is a future value, so we don't need the word 'target' here, which I find a bit confusing. See https://github.com/actualbudget/actual/pull/6384#issuecomment-3649921717 for more discussion.
