### PR TITLE
ci: improve vrt-update UX

### DIFF
--- a/.github/workflows/e2e-vrt-comment.yml
+++ b/.github/workflows/e2e-vrt-comment.yml
@@ -53,17 +53,14 @@ jobs:
 
       - name: Comment on PR with VRT report link
         if: steps.metadata.outputs.should_comment == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        env:
-          PR_NUMBER: ${{ steps.metadata.outputs.pr_number }}
-          ARTIFACT_URL: ${{ steps.metadata.outputs.artifact_url }}
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          script: |
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
-            const artifactUrl = process.env.ARTIFACT_URL;
-            await github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `VRT tests ❌ failed. [View the test report](${artifactUrl}).\n\nTo update the VRT screenshots, comment \`/update-vrt\` on this PR.`
-            });
+          number: ${{ steps.metadata.outputs.pr_number }}
+          header: vrt-comment
+          hide_and_recreate: true
+          hide_classify: OUTDATED
+          message: |
+            <!-- vrt-comment -->
+            VRT tests ❌ failed. [View the test report](${{ steps.metadata.outputs.artifact_url }}).
+
+            To update the VRT screenshots, comment `/update-vrt` on this PR. The VRT update operation takes about 50 minutes.

--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -15,6 +15,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  add-reaction:
+    name: Add 👀 Reaction
+    runs-on: ubuntu-latest
+    # Only run on PR comments containing /update-vrt
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/update-vrt')
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add 👀 reaction to comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
   generate-vrt-updates:
     name: Generate VRT Updates
     runs-on: ubuntu-latest

--- a/upcoming-release-notes/6439.md
+++ b/upcoming-release-notes/6439.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+ci: improve vrt-update UX


### PR DESCRIPTION
- Use sticky-pull-request-comment action for better comment management (hide old VRT comments)
- Add 👀 reaction to /update-vrt comments for immediate feedback
- Add note about 50-minute duration in VRT comment
