### PR TITLE
Change minimum transaction date from 2000 to 1995

### DIFF
--- a/packages/loot-core/src/server/aql/schema-helpers.test.ts
+++ b/packages/loot-core/src/server/aql/schema-helpers.test.ts
@@ -210,15 +210,15 @@ describe('schema-helpers', () => {
     }).toThrow('Can’t convert to integer');
   });
 
-  test('dates before 2000-01-01 are rejected', () => {
+  test('dates before 1995-01-01 are rejected', () => {
     expect(() => {
       convertForInsert(basicSchema, {}, 'transactions', {
         id: 't1',
         account: 'foo',
         amount: 5,
-        date: '1999-12-31',
+        date: '1994-12-31',
       });
-    }).toThrow('Invalid date: 1999-12-31');
+    }).toThrow('Invalid date: 1994-12-31');
 
     expect(() => {
       convertForInsert(basicSchema, {}, 'transactions', {
@@ -230,13 +230,13 @@ describe('schema-helpers', () => {
     }).toThrow('Invalid date: 1900-01-01');
   });
 
-  test('dates on or after 2000-01-01 are accepted', () => {
+  test('dates on or after 1995-01-01 are accepted', () => {
     const trans = convertForInsert(basicSchema, {}, 'transactions', {
       id: 't1',
       account: 'foo',
       amount: 5,
-      date: '2000-01-01',
+      date: '1995-01-01',
     });
-    expect(trans.date).toBe(20000101);
+    expect(trans.date).toBe(19950101);
   });
 });

--- a/packages/loot-core/src/server/aql/schema-helpers.ts
+++ b/packages/loot-core/src/server/aql/schema-helpers.ts
@@ -25,7 +25,7 @@ export function convertInputType(value, type) {
         return toDateRepr(dayFromDate(value));
       } else if (
         value.match(/^\d{4}-\d{2}-\d{2}$/) == null ||
-        value < '2000-01-01'
+        value < '1995-01-01'
       ) {
         throw new Error('Invalid date: ' + value);
       }

--- a/upcoming-release-notes/6440.md
+++ b/upcoming-release-notes/6440.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Change minimum transaction year from 2000 to 1995


### PR DESCRIPTION
## Summary

This PR changes the minimum allowed date for transactions from 2000-01-01 to 1995-01-01, allowing users to enter older transaction dates without crashes.

## Changes

- Updated date validation in `schema-helpers.ts` to accept dates from 1995-01-01 onwards
- Updated corresponding tests in `schema-helpers.test.ts` to reflect the new minimum date

## Context

This addresses the date validation bug mentioned in PR #5970 that was causing crashes with old dates. By lowering the minimum year from 2000 to 1995, users can now enter transactions from 1995 onwards.

## Testing

- Updated unit tests to verify dates before 1995-01-01 are rejected
- Updated unit tests to verify dates on or after 1995-01-01 are accepted