### PR TITLE
[WIP] fix: prevent crash when editing filter to 'one of' / 'not one of'

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -693,7 +693,10 @@ function MultiAutocomplete<T extends AutocompleteItem>({
   ...props
 }: MultiAutocompleteProps<T>) {
   const [focused, setFocused] = useState(false);
-  const selectedItemIds = selectedItems.map(getItemId);
+  // Ensure selectedItems is always an array to prevent crashes when
+  // switching filter types (e.g., from "contains" to "one of")
+  const normalizedItems = Array.isArray(selectedItems) ? selectedItems : [];
+  const selectedItemIds = normalizedItems.map(getItemId);
   const inputRef = useRef(null);
   useProperFocus(inputRef, focused);
 
@@ -714,7 +717,7 @@ function MultiAutocomplete<T extends AutocompleteItem>({
     prevOnKeyDown?: ComponentProps<typeof Input>['onKeyDown'],
   ) {
     if (e.key === 'Backspace' && e.currentTarget.value === '') {
-      onRemoveItem(selectedItemIds[selectedItems.length - 1]);
+      onRemoveItem(selectedItemIds[normalizedItems.length - 1]);
     }
 
     prevOnKeyDown?.(e);
@@ -749,7 +752,7 @@ function MultiAutocomplete<T extends AutocompleteItem>({
             }),
           }}
         >
-          {selectedItems.map((item, idx) => {
+          {normalizedItems.map((item, idx) => {
             item = findItem(strict, suggestions, item);
             return (
               item && (


### PR DESCRIPTION
## Summary

Fixes #6325

## Problem

When editing an existing filter on the Notes field and changing the filter type to `one of` or `not one of`, the app crashes with:

`
 TypeError: l.map is not a function
    Autocomplete.tsx:696
`

## Root Cause

The `MultiAutocomplete` component expects `selectedItems` to be an array, but when switching filter types (e.g., from `contains` to `one of`), the previous value (a string) is passed instead.

Line 696:
`	sx
const selectedItemIds = selectedItems.map(getItemId);
`

When `selectedItems` is a string, `.map()` fails.

## Solution

Normalize `selectedItems` to always be an array before any array operations:

`	sx
const normalizedItems = Array.isArray(selectedItems) ? selectedItems : [];
const selectedItemIds = normalizedItems.map(getItemId);
`

## Testing

1. Open any account overview
2. Create a filter on Notes using `contains`
3. Apply the filter
4. Edit the filter and change to `one of`
5. App no longer crashes