### PR TITLE
Bring back i18n extraction ci job

### DIFF
--- a/.github/workflows/i18n-string-extract-master.yml
+++ b/.github/workflows/i18n-string-extract-master.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   extract-and-upload-i18n-strings:
     runs-on: ubuntu-latest
-    if: false # Temporarily disabled
+    if: github.repository == 'actualbudget/actual'
     steps:
       - name: Check out main repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/upcoming-release-notes/6460.md
+++ b/upcoming-release-notes/6460.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Bring back i18n extraction ci job


### PR DESCRIPTION
Temporarily disabled in https://github.com/actualbudget/actual/pull/6454