### PR TITLE
test: improve help-menu e2e test stability

### DIFF
--- a/packages/desktop-client/e2e/help-menu.test.ts
+++ b/packages/desktop-client/e2e/help-menu.test.ts
@@ -26,7 +26,8 @@ test.describe('Help menu', () => {
 
   test('Check the help menu visuals', async () => {
     await page.getByRole('button', { name: 'Help' }).click();
-    expect(page.getByText('Keyboard shortcuts')).toBeVisible();
+    await expect(page.locator('[data-popover]')).toBeVisible();
+    await expect(page.getByText('Keyboard shortcuts')).toBeVisible();
     await expect(page).toMatchThemeScreenshots();
     await page.keyboard.press('Escape');
   });

--- a/upcoming-release-notes/6489.md
+++ b/upcoming-release-notes/6489.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+test: improve help-menu e2e test stability


### PR DESCRIPTION
The help-menu e2e test is rather unstable. As can be seen here: https://github.com/actualbudget/actual/actions/runs/20443708807/job/58742418792?pr=6234

Making it more reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved help menu end-to-end test stability with enhanced assertion checks for popover visibility and keyboard shortcuts functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->