### PR TITLE
feature: crossover point widget to add inflation adjustment

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/CrossoverGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CrossoverGraph.tsx
@@ -85,7 +85,9 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
               })}
             >
               <div>
-                <Trans>Monthly expenses:</Trans>
+                <Trans>
+                  Target monthly expenses (no adjustment/inflation):
+                </Trans>
               </div>
               <div>
                 <FinancialText>
@@ -101,7 +103,7 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
                 })}
               >
                 <div>
-                  <Trans>Target income:</Trans>
+                  <Trans>Target monthly expenses:</Trans>
                 </div>
                 <div>
                   <FinancialText>
@@ -231,9 +233,8 @@ export function CrossoverGraph({
             type="monotone"
             dataKey="adjustedExpenses"
             dot={false}
-            stroke={theme.reportsNumberNegative}
+            stroke={theme.reportsBlue}
             strokeWidth={2}
-            strokeDasharray="5 5"
             {...animationProps}
           />
         </LineChart>

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -120,6 +120,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
     'hampel' | 'median' | 'mean'
   >('hampel');
   const [expenseAdjustmentFactor, setExpenseAdjustmentFactor] = useState(1.0);
+  const [inflationRate, setInflationRate] = useState<number | null>(null);
   const [showHiddenCategories, setShowHiddenCategories] = useState(false);
   const [selectionsInitialized, setSelectionsInitialized] = useState(false);
 
@@ -159,6 +160,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
     setExpectedContribution(initialExpectedContribution);
     setProjectionType(widget?.meta?.projectionType ?? 'hampel');
     setExpenseAdjustmentFactor(widget?.meta?.expenseAdjustmentFactor ?? 1.0);
+    setInflationRate(widget?.meta?.inflationRate ?? null);
     setShowHiddenCategories(widget?.meta?.showHiddenCategories ?? false);
 
     setSelectionsInitialized(true);
@@ -302,6 +304,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
               : null,
             projectionType,
             expenseAdjustmentFactor,
+            inflationRate,
             showHiddenCategories,
             timeFrame: { start, end, mode },
           },
@@ -353,6 +356,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
           : null,
         projectionType,
         expenseAdjustmentFactor,
+        inflationRate,
       });
       await crossoverSpreadsheet(spreadsheet, setData);
     },
@@ -365,6 +369,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
       expectedContribution,
       projectionType,
       expenseAdjustmentFactor,
+      inflationRate,
       expenseCategoryIds,
       selectedIncomeAccountIds,
     ],
@@ -1026,6 +1031,64 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
                     </Trans>
                   </div>
                 )}
+              </View>
+
+              <View style={{ marginBottom: 12 }}>
+                <div style={{ fontWeight: 600, marginBottom: 8 }}>
+                  <View
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                    }}
+                  >
+                    <Text>{t('Inflation rate (annual %, optional)')}</Text>
+                    <Tooltip
+                      content={
+                        <View style={{ maxWidth: 300 }}>
+                          <Text>
+                            <Trans>
+                              The expected annual inflation rate, used to adjust
+                              projected expenses for inflation. If not
+                              specified, expenses will be projected without
+                              inflation adjustment.
+                              <br />
+                              <br />
+                              Example: 3% annual inflation means expenses will
+                              grow by approximately 3% per year to maintain the
+                              same purchasing power.
+                            </Trans>
+                          </Text>
+                        </View>
+                      }
+                      placement="right top"
+                      style={{
+                        ...styles.tooltip,
+                      }}
+                    >
+                      <SvgQuestion height={12} width={12} cursor="pointer" />
+                    </Tooltip>
+                  </View>
+                </div>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.1}
+                  value={
+                    inflationRate == null
+                      ? ''
+                      : Number((inflationRate * 100).toFixed(2))
+                  }
+                  onChange={e =>
+                    setInflationRate(
+                      isNaN(e.target.valueAsNumber)
+                        ? null
+                        : e.target.valueAsNumber / 100,
+                    )
+                  }
+                  style={{ width: 120 }}
+                />
               </View>
             </View>
           </View>

--- a/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
@@ -151,6 +151,7 @@ export function CrossoverCard({
   const projectionType: 'hampel' | 'median' | 'mean' =
     meta?.projectionType ?? 'hampel';
   const expenseAdjustmentFactor = meta?.expenseAdjustmentFactor ?? 1.0;
+  const inflationRate = meta?.inflationRate ?? null;
 
   const params = useMemo(
     () =>
@@ -164,6 +165,7 @@ export function CrossoverCard({
         expectedContribution,
         projectionType,
         expenseAdjustmentFactor,
+        inflationRate,
       }),
     [
       start,
@@ -175,6 +177,7 @@ export function CrossoverCard({
       expectedContribution,
       projectionType,
       expenseAdjustmentFactor,
+      inflationRate,
     ],
   );
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/crossover-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/crossover-spreadsheet.test.ts
@@ -1,0 +1,532 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCrossoverSpreadsheet } from './crossover-spreadsheet';
+import type { CrossoverData } from './crossover-spreadsheet';
+
+import { aqlQuery } from '@desktop-client/queries/aqlQuery';
+
+// Mock the aqlQuery function
+vi.mock('@desktop-client/queries/aqlQuery', () => ({
+  aqlQuery: vi.fn(),
+}));
+
+describe('crossover-spreadsheet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('inflation adjustment', () => {
+    it('should apply inflation to projected expenses with hampel method', async () => {
+      const mockAqlQuery = aqlQuery as unknown as ReturnType<typeof vi.fn>;
+
+      // Mock expense data - $1000/month
+      mockAqlQuery.mockImplementation((query: unknown) => {
+        const queryObj = query as { state?: { filterExpressions?: unknown[] } };
+
+        // Check if this is an expense query
+        if (queryObj.state?.filterExpressions) {
+          return Promise.resolve({
+            data: [
+              { date: '2024-01', amount: -1000 },
+              { date: '2024-02', amount: -1000 },
+              { date: '2024-03', amount: -1000 },
+            ],
+          });
+        }
+
+        // Account balance query - return starting balance and monthly data
+        return Promise.resolve({
+          data: 100000, // Starting balance
+        });
+      });
+
+      const params = {
+        start: '2024-01',
+        end: '2024-03',
+        expenseCategoryIds: ['cat1'],
+        incomeAccountIds: ['acc1'],
+        safeWithdrawalRate: 0.04,
+        estimatedReturn: 0.05,
+        projectionType: 'hampel' as const,
+        inflationRate: 0.03, // 3% annual inflation
+      };
+
+      const spreadsheet = createCrossoverSpreadsheet(params);
+
+      let capturedData: CrossoverData | null = null;
+      const setData = (data: CrossoverData) => {
+        capturedData = data;
+      };
+
+      // Mock spreadsheet object - we don't actually use it
+      const mockSpreadsheet = {} as Parameters<typeof spreadsheet>[0];
+
+      await spreadsheet(mockSpreadsheet, setData);
+
+      expect(capturedData).not.toBeNull();
+
+      // Find projected data points
+      const projectedData = capturedData!.graphData.data.filter(
+        d => d.isProjection,
+      );
+
+      if (projectedData.length >= 2) {
+        // First projected month should have base expense
+        const firstProjected = projectedData[0];
+        const secondProjected = projectedData[1];
+
+        // adjustedExpenses should increase due to inflation
+        // Note: actual implementation rounds to nearest integer
+        expect(secondProjected.adjustedExpenses).toBeGreaterThan(
+          firstProjected.adjustedExpenses!,
+        );
+
+        // Base expenses should remain flat
+        expect(firstProjected.expenses).toBe(secondProjected.expenses);
+
+        // Verify the increase is reasonable for 3% annual inflation
+        // Monthly increase should be approximately 0.25%
+        const percentIncrease =
+          (secondProjected.adjustedExpenses! -
+            firstProjected.adjustedExpenses!) /
+          firstProjected.adjustedExpenses!;
+        expect(percentIncrease).toBeGreaterThan(0.001); // At least 0.1% increase
+        expect(percentIncrease).toBeLessThan(0.005); // Less than 0.5% increase
+      }
+    });
+
+    it('should apply inflation to projected expenses with trend method', async () => {
+      const mockAqlQuery = aqlQuery as unknown as ReturnType<typeof vi.fn>;
+
+      // Mock expense data with a trend - increasing expenses
+      mockAqlQuery.mockImplementation((query: unknown) => {
+        const queryObj = query as { state?: { filterExpressions?: unknown[] } };
+
+        if (queryObj.state?.filterExpressions) {
+          return Promise.resolve({
+            data: [
+              { date: '2024-01', amount: -1000 },
+              { date: '2024-02', amount: -1050 },
+              { date: '2024-03', amount: -1100 },
+            ],
+          });
+        }
+
+        return Promise.resolve({
+          data: 100000,
+        });
+      });
+
+      const params = {
+        start: '2024-01',
+        end: '2024-03',
+        expenseCategoryIds: ['cat1'],
+        incomeAccountIds: ['acc1'],
+        safeWithdrawalRate: 0.04,
+        estimatedReturn: 0.05,
+        projectionType: 'median' as const,
+        inflationRate: 0.03,
+      };
+
+      const spreadsheet = createCrossoverSpreadsheet(params);
+
+      let capturedData: CrossoverData | null = null;
+      const setData = (data: CrossoverData) => {
+        capturedData = data;
+      };
+
+      const mockSpreadsheet = {} as Parameters<typeof spreadsheet>[0];
+
+      await spreadsheet(mockSpreadsheet, setData);
+
+      expect(capturedData).not.toBeNull();
+
+      const projectedData = capturedData!.graphData.data.filter(
+        d => d.isProjection,
+      );
+
+      if (projectedData.length >= 2) {
+        // adjustedExpenses should be increasing due to inflation
+        const firstProjected = projectedData[0];
+        const secondProjected = projectedData[1];
+
+        expect(secondProjected.adjustedExpenses).toBeGreaterThan(
+          firstProjected.adjustedExpenses!,
+        );
+
+        // Base expenses should remain constant (median of flat expenses)
+        expect(firstProjected.expenses).toBe(secondProjected.expenses);
+      }
+    });
+
+    it('should not apply inflation when inflationRate is null', async () => {
+      const mockAqlQuery = aqlQuery as unknown as ReturnType<typeof vi.fn>;
+
+      mockAqlQuery.mockImplementation((query: unknown) => {
+        const queryObj = query as { state?: { filterExpressions?: unknown[] } };
+
+        if (queryObj.state?.filterExpressions) {
+          return Promise.resolve({
+            data: [
+              { date: '2024-01', amount: -1000 },
+              { date: '2024-02', amount: -1000 },
+              { date: '2024-03', amount: -1000 },
+            ],
+          });
+        }
+
+        return Promise.resolve({
+          data: 100000,
+        });
+      });
+
+      const params = {
+        start: '2024-01',
+        end: '2024-03',
+        expenseCategoryIds: ['cat1'],
+        incomeAccountIds: ['acc1'],
+        safeWithdrawalRate: 0.04,
+        estimatedReturn: 0.05,
+        projectionType: 'hampel' as const,
+        inflationRate: null, // No inflation
+      };
+
+      const spreadsheet = createCrossoverSpreadsheet(params);
+
+      let capturedData: CrossoverData | null = null;
+      const setData = (data: CrossoverData) => {
+        capturedData = data;
+      };
+
+      const mockSpreadsheet = {} as Parameters<typeof spreadsheet>[0];
+
+      await spreadsheet(mockSpreadsheet, setData);
+
+      expect(capturedData).not.toBeNull();
+
+      const projectedData = capturedData!.graphData.data.filter(
+        d => d.isProjection,
+      );
+
+      if (projectedData.length >= 2) {
+        // With hampel and no inflation, expenses should be flat
+        const firstProjected = projectedData[0];
+        const secondProjected = projectedData[1];
+
+        expect(firstProjected.expenses).toBe(secondProjected.expenses);
+      }
+    });
+
+    it('should calculate correct monthly inflation rate from annual rate', async () => {
+      const mockAqlQuery = aqlQuery as unknown as ReturnType<typeof vi.fn>;
+
+      mockAqlQuery.mockImplementation((query: unknown) => {
+        const queryObj = query as { state?: { filterExpressions?: unknown[] } };
+
+        if (queryObj.state?.filterExpressions) {
+          return Promise.resolve({
+            data: [{ date: '2024-01', amount: -1200 }],
+          });
+        }
+
+        return Promise.resolve({
+          data: 100000,
+        });
+      });
+
+      const params = {
+        start: '2024-01',
+        end: '2024-01',
+        expenseCategoryIds: ['cat1'],
+        incomeAccountIds: ['acc1'],
+        safeWithdrawalRate: 0.04,
+        estimatedReturn: 0.05,
+        projectionType: 'hampel' as const,
+        inflationRate: 0.03, // 3% annual
+      };
+
+      const spreadsheet = createCrossoverSpreadsheet(params);
+
+      let capturedData: CrossoverData | null = null;
+      const setData = (data: CrossoverData) => {
+        capturedData = data;
+      };
+
+      const mockSpreadsheet = {} as Parameters<typeof spreadsheet>[0];
+
+      await spreadsheet(mockSpreadsheet, setData);
+
+      expect(capturedData).not.toBeNull();
+
+      const projectedData = capturedData!.graphData.data.filter(
+        d => d.isProjection,
+      );
+
+      if (projectedData.length >= 12) {
+        // After 12 months, adjustedExpenses should be approximately 3% higher
+        const firstMonth = projectedData[0];
+        const twelfthMonth = projectedData[11];
+
+        // Due to Math.round() in implementation, we can't expect exact values
+        // Just verify that adjustedExpenses have increased over 12 months
+        expect(twelfthMonth.adjustedExpenses).toBeGreaterThan(
+          firstMonth.adjustedExpenses!,
+        );
+
+        // Calculate the actual increase percentage
+        const percentIncrease =
+          (twelfthMonth.adjustedExpenses! - firstMonth.adjustedExpenses!) /
+          firstMonth.adjustedExpenses!;
+
+        // Should be roughly 3% (allowing for rounding errors)
+        // Since each month compounds and rounds, we expect 2-4% range
+        expect(percentIncrease).toBeGreaterThan(0.02); // At least 2%
+        expect(percentIncrease).toBeLessThan(0.04); // Less than 4%
+
+        // Base expenses should remain flat
+        expect(firstMonth.expenses).toBe(twelfthMonth.expenses);
+      }
+    });
+
+    it('should handle zero inflation rate', async () => {
+      const mockAqlQuery = aqlQuery as unknown as ReturnType<typeof vi.fn>;
+
+      mockAqlQuery.mockImplementation((query: unknown) => {
+        const queryObj = query as { state?: { filterExpressions?: unknown[] } };
+
+        if (queryObj.state?.filterExpressions) {
+          return Promise.resolve({
+            data: [{ date: '2024-01', amount: -1000 }],
+          });
+        }
+
+        return Promise.resolve({
+          data: 100000,
+        });
+      });
+
+      const params = {
+        start: '2024-01',
+        end: '2024-01',
+        expenseCategoryIds: ['cat1'],
+        incomeAccountIds: ['acc1'],
+        safeWithdrawalRate: 0.04,
+        estimatedReturn: 0.05,
+        projectionType: 'hampel' as const,
+        inflationRate: 0, // Zero inflation
+      };
+
+      const spreadsheet = createCrossoverSpreadsheet(params);
+
+      let capturedData: CrossoverData | null = null;
+      const setData = (data: CrossoverData) => {
+        capturedData = data;
+      };
+
+      const mockSpreadsheet = {} as Parameters<typeof spreadsheet>[0];
+
+      await spreadsheet(mockSpreadsheet, setData);
+
+      expect(capturedData).not.toBeNull();
+
+      const projectedData = capturedData!.graphData.data.filter(
+        d => d.isProjection,
+      );
+
+      if (projectedData.length >= 2) {
+        // With zero inflation, hampel expenses should remain constant
+        const firstProjected = projectedData[0];
+        const secondProjected = projectedData[1];
+
+        expect(firstProjected.expenses).toBe(secondProjected.expenses);
+      }
+    });
+  });
+
+  describe('monthly inflation rate conversion', () => {
+    it('should use compound formula, not simple division', () => {
+      const annualInflation = 0.03;
+      const baseExpense = 1000;
+
+      // WRONG WAY: Simple division
+      const simpleDivision = annualInflation / 12; // 0.0025
+      const resultSimple = baseExpense * Math.pow(1 + simpleDivision, 12);
+
+      // RIGHT WAY: Compound formula
+      const compoundFormula = Math.pow(1 + annualInflation, 1 / 12) - 1; // 0.002466
+      const resultCompound = baseExpense * Math.pow(1 + compoundFormula, 12);
+
+      // Simple division gives ~3.04% instead of exactly 3%
+      expect(resultSimple).toBeCloseTo(1030.42, 2);
+
+      // Compound formula gives exactly 3%
+      expect(resultCompound).toBeCloseTo(1030.0, 2);
+
+      // The difference matters!
+      expect(resultSimple).toBeGreaterThan(resultCompound);
+    });
+
+    it('should convert 3% annual inflation to monthly rate correctly', () => {
+      const annualInflation = 0.03;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // Monthly inflation should be approximately 0.2466% (0.002466)
+      // NOT 0.25% (0.0025) which would be simple division
+      expect(monthlyInflation).toBeCloseTo(0.002466, 5);
+    });
+
+    it('should convert 0% annual inflation to 0% monthly rate', () => {
+      const annualInflation = 0;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      expect(monthlyInflation).toBe(0);
+    });
+
+    it('should convert 10% annual inflation to monthly rate correctly', () => {
+      const annualInflation = 0.1;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // Monthly inflation should be approximately 0.7974% (0.007974)
+      expect(monthlyInflation).toBeCloseTo(0.007974, 5);
+    });
+  });
+
+  describe('expense inflation over time', () => {
+    it('should compound monthly inflation correctly over 12 months', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.03;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // After 12 months, should be approximately 3% higher
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 12);
+
+      // Should be close to $1030
+      expect(inflatedExpense).toBeCloseTo(1030, 0);
+    });
+
+    it('should handle zero inflation correctly', () => {
+      const baseExpense = 1000;
+      const monthlyInflation = 0;
+
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 12);
+
+      expect(inflatedExpense).toBe(1000);
+    });
+
+    it('should compound correctly over multiple years', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.03;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // After 24 months (2 years), should be approximately (1.03)^2 = 1.0609 times higher
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 24);
+
+      // Should be close to $1060.90
+      expect(inflatedExpense).toBeCloseTo(1060.9, 0);
+    });
+
+    it('should handle high inflation rates', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.2; // 20% annual inflation
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // After 12 months, should be 20% higher
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 12);
+
+      expect(inflatedExpense).toBeCloseTo(1200, 0);
+    });
+
+    it('should apply inflation correctly to projected expenses in sequence', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.03;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      const projectedExpenses: number[] = [];
+
+      // Project for 6 months
+      for (let i = 1; i <= 6; i++) {
+        const expense = baseExpense * Math.pow(1 + monthlyInflation, i);
+        projectedExpenses.push(expense);
+      }
+
+      // Each month should be higher than the previous
+      for (let i = 1; i < projectedExpenses.length; i++) {
+        expect(projectedExpenses[i]).toBeGreaterThan(projectedExpenses[i - 1]);
+      }
+
+      // First month should be approximately $1002.47
+      expect(projectedExpenses[0]).toBeCloseTo(1002.47, 1);
+
+      // Sixth month should be approximately $1014.89
+      expect(projectedExpenses[5]).toBeCloseTo(1014.89, 1);
+    });
+  });
+
+  describe('inflation disabled behavior', () => {
+    it('should not inflate expenses when inflation rate is null', () => {
+      const baseExpense = 1000;
+      const inflationRate = null;
+
+      // When inflation is null, monthlyInflationRate should be 0
+      const monthlyInflationRate = inflationRate
+        ? Math.pow(1 + inflationRate, 1 / 12) - 1
+        : 0;
+
+      const inflatedExpense =
+        baseExpense * Math.pow(1 + monthlyInflationRate, 12);
+
+      expect(inflatedExpense).toBe(1000);
+    });
+
+    it('should handle undefined inflation rate as no inflation', () => {
+      const baseExpense = 1000;
+      const inflationRate = undefined;
+
+      const monthlyInflationRate = inflationRate
+        ? Math.pow(1 + inflationRate, 1 / 12) - 1
+        : 0;
+
+      const inflatedExpense =
+        baseExpense * Math.pow(1 + monthlyInflationRate, 12);
+
+      expect(inflatedExpense).toBe(1000);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very small inflation rates', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.001; // 0.1% annual
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 12);
+
+      // Should be very close to $1001
+      expect(inflatedExpense).toBeCloseTo(1001, 0);
+    });
+
+    it('should handle negative inflation (deflation)', () => {
+      const baseExpense = 1000;
+      const annualInflation = -0.02; // -2% annual (deflation)
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 12);
+
+      // Should be close to $980
+      expect(inflatedExpense).toBeCloseTo(980, 0);
+    });
+
+    it('should maintain precision over long projection periods', () => {
+      const baseExpense = 1000;
+      const annualInflation = 0.03;
+      const monthlyInflation = Math.pow(1 + annualInflation, 1 / 12) - 1;
+
+      // Project 10 years (120 months)
+      const inflatedExpense = baseExpense * Math.pow(1 + monthlyInflation, 120);
+
+      // After 10 years at 3% annual, should be (1.03)^10 = 1.3439 times higher
+      // $1000 * 1.3439 = $1343.90
+      expect(inflatedExpense).toBeCloseTo(1343.9, 0);
+    });
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/crossover-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/crossover-spreadsheet.ts
@@ -7,9 +7,15 @@ import type { AccountEntity } from 'loot-core/types/models';
 import type { useSpreadsheet } from '@desktop-client/hooks/useSpreadsheet';
 import { aqlQuery } from '@desktop-client/queries/aqlQuery';
 
+/** Aggregated monthly transaction data */
 type MonthlyAgg = { date: string; amount: number };
 
-// Utility functions for Hampel identifier
+/**
+ * Calculates the median value of a numeric array.
+ *
+ * @param values - Array of numbers to calculate median from
+ * @returns The median value, or 0 if array is empty
+ */
 function calculateMedian(values: number[]): number {
   if (values.length === 0) return 0;
   if (values.length === 1) return values[0];
@@ -27,11 +33,33 @@ function calculateMean(values: number[]): number {
   return sum / values.length;
 }
 
+/**
+ * Calculates the Median Absolute Deviation (MAD) from a given median.
+ *
+ * MAD is a robust measure of variability that is less sensitive to outliers
+ * than standard deviation.
+ *
+ * @param values - Array of numbers
+ * @param median - The median of the values array
+ * @returns The median absolute deviation
+ */
 function calculateMAD(values: number[], median: number): number {
   const deviations = values.map(v => Math.abs(v - median));
   return calculateMedian(deviations);
 }
 
+/**
+ * Applies Hampel filter to calculate a robust median, removing outliers.
+ *
+ * The Hampel identifier detects outliers using the median and MAD (Median Absolute Deviation).
+ * Values outside of median ± threshold × MAD × 1.4826 are considered outliers and excluded.
+ *
+ * This is useful for expense projection when historical data contains anomalies
+ * (e.g., one-time large purchases, vacations, medical emergencies).
+ *
+ * @param expenses - Array of expense values
+ * @returns The median of the filtered (non-outlier) expenses
+ */
 function calculateHampelFilteredMedian(expenses: number[]): number {
   if (expenses.length === 0) return 0;
   if (expenses.length === 1) return expenses[0];
@@ -49,42 +77,87 @@ function calculateHampelFilteredMedian(expenses: number[]): number {
   return calculateMedian(filteredExpenses);
 }
 
-// Type for the return value of the recalculate function
 export type CrossoverData = {
+  /** Graph visualization data */
   graphData: {
+    /** Array of data points for chart display */
     data: Array<{
+      /** Month label (e.g., "Jan 2024") */
       x: string;
+      /** Monthly investment income based on safe withdrawal rate */
       investmentIncome: number;
+      /** Monthly expenses (actual or projected with inflation and adjustment factor) */
       expenses: number;
+      /** Total investment balance (nest egg) */
       nestEgg: number;
+      /** Expenses adjusted by the expenseAdjustmentFactor (without inflation) for reference */
       adjustedExpenses?: number;
+      /** Whether this data point is projected vs historical */
       isProjection?: boolean;
     }>;
+    /** Start month of the data range */
     start: string;
+    /** End month of the data range */
     end: string;
+    /** Month label where crossover occurs, or null if not yet achieved */
     crossoverXLabel: string | null;
   };
+  /** Most recent known investment balance */
   lastKnownBalance: number;
+  /** Most recent monthly investment income */
   lastKnownMonthlyIncome: number;
+  /** Most recent monthly expenses */
   lastKnownMonthlyExpenses: number;
+  /** Calculated historical annual return rate, or null if cannot be calculated */
   historicalReturn: number | null;
+  /** Estimated years until financial independence, or null if already achieved or not calculable */
   yearsToRetire: number | null;
+  /** Target monthly income needed at crossover point */
   targetMonthlyIncome: number | null;
+  /** Target nest egg amount needed to achieve crossover */
   targetNestEgg: number | null;
 };
 
 export type CrossoverParams = {
+  /** Start month in YYYY-MM format */
   start: string;
+  /** End month in YYYY-MM format */
   end: string;
-  expenseCategoryIds: string[]; // which categories count as expenses
-  incomeAccountIds: AccountEntity['id'][]; // selected accounts for both historical returns and projections
-  safeWithdrawalRate: number; // annual percent, e.g. 0.04 for 4%
-  estimatedReturn?: number | null; // optional annual return to project future balances
-  expectedContribution?: number | null; // optional monthly contribution to project future balances
-  projectionType: 'hampel' | 'median' | 'mean'; // expense projection method
+
   expenseAdjustmentFactor?: number; // multiplier for expenses (default 1.0)
+  /** Category IDs that count as expenses */
+  expenseCategoryIds: string[];
+  /** Selected Account IDs for investment/retirement accounts */
+  incomeAccountIds: AccountEntity['id'][];
+  /** Annual safe withdrawal rate (e.g., 0.04 for 4%) */
+  safeWithdrawalRate: number;
+  /** Optional annual return rate for projections (e.g., 0.05 for 5%) */
+  estimatedReturn?: number | null;
+  /** Optional monthly contribution to project future balances */
+  expectedContribution?: number | null;
+  /** Method for projecting expenses: 'trend' uses linear regression, 'hampel' uses outlier-filtered median */
+  projectionType: 'hampel' | 'median' | 'mean';
+  /** Optional annual inflation rate for adjusting projected expenses (e.g., 0.03 for 3%) */
+  inflationRate?: number | null;
 };
 
+/**
+ * Creates a spreadsheet calculation function for the crossover point analysis.
+ *
+ * This function generates both historical data and future projections to determine
+ * when investment income will exceed living expenses (the "crossover point").
+ *
+ * The calculation includes:
+ * - Historical expense and balance tracking
+ * - Expense projection using trend analysis or Hampel filtering
+ * - Optional inflation adjustment for realistic long-term projections
+ * - Investment growth projections based on historical or estimated returns
+ * - Crossover point detection and time-to-FI calculation
+ *
+ * @param params - Configuration parameters for the crossover calculation
+ * @returns An async function that performs the spreadsheet calculation
+ *
+ */
 export function createCrossoverSpreadsheet({
   start,
   end,
@@ -95,6 +168,7 @@ export function createCrossoverSpreadsheet({
   expectedContribution,
   projectionType,
   expenseAdjustmentFactor,
+  inflationRate,
 }: CrossoverParams) {
   return async (
     _spreadsheet: ReturnType<typeof useSpreadsheet>,
@@ -204,12 +278,39 @@ export function createCrossoverSpreadsheet({
           expectedContribution,
           projectionType,
           expenseAdjustmentFactor,
+          inflationRate,
         },
         expenses,
         historicalBalances,
       ),
     );
   };
+}
+
+/**
+ * Calculate monthly inflation rate from annual rate.
+ *
+ * Uses compound interest formula: (1 + annual)^(1/12) - 1
+ * This ensures that 12 months of monthly inflation equals the annual rate.
+ */
+function calculateMonthlyInflationRate(
+  params: Pick<
+    CrossoverParams,
+    | 'start'
+    | 'end'
+    | 'expenseCategoryIds'
+    | 'incomeAccountIds'
+    | 'safeWithdrawalRate'
+    | 'estimatedReturn'
+    | 'expectedContribution'
+    | 'projectionType'
+    | 'expenseAdjustmentFactor'
+    | 'inflationRate'
+  >,
+) {
+  return params.inflationRate
+    ? Math.pow(1 + params.inflationRate, 1 / 12) - 1
+    : 0;
 }
 
 function recalculate(
@@ -224,6 +325,7 @@ function recalculate(
     | 'expectedContribution'
     | 'projectionType'
     | 'expenseAdjustmentFactor'
+    | 'inflationRate'
   >,
   expenses: MonthlyAgg[],
   historicalAccounts: Array<{
@@ -368,6 +470,8 @@ function recalculate(
       flatExpense = calculateMean(y);
     }
 
+    const monthlyInflationRate = calculateMonthlyInflationRate(params);
+
     for (let i = 1; i <= maxProjectionMonths; i++) {
       monthCursor = d.addMonths(monthCursor, 1);
 
@@ -383,22 +487,27 @@ function recalculate(
 
       const projectedExpenses = Math.max(0, flatExpense);
 
-      // Calculate adjusted expenses
-      const adjustedProjectedExpenses = projectedExpenses * adjustmentFactor;
+      // Apply adjustment factor to inflation-adjusted expenses for the target
+      let inflationAdjustedTarget = projectedExpenses * adjustmentFactor;
+
+      if (monthlyInflationRate > 0) {
+        inflationAdjustedTarget =
+          inflationAdjustedTarget * Math.pow(1 + monthlyInflationRate, i);
+      }
 
       data.push({
         x: d.format(monthCursor, 'MMM yyyy'),
         investmentIncome: Math.round(projectedIncome),
         expenses: Math.round(projectedExpenses),
         nestEgg: Math.round(projectedBalance),
-        adjustedExpenses: Math.round(adjustedProjectedExpenses),
+        adjustedExpenses: Math.round(inflationAdjustedTarget),
         isProjection: true,
       });
 
-      // Check crossover against ADJUSTED expenses
+      // Check crossover against inflation-adjusted expenses
       if (
         crossoverIndex == null &&
-        Math.round(projectedIncome) >= Math.round(adjustedProjectedExpenses)
+        Math.round(projectedIncome) >= Math.round(inflationAdjustedTarget)
       ) {
         crossoverIndex = months.length + (i - 1);
         break;

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -98,6 +98,7 @@ export type CrossoverWidget = AbstractWidget<
     projectionType?: 'hampel' | 'median' | 'mean'; // expense projection method
     showHiddenCategories?: boolean; // show hidden categories in selector
     expenseAdjustmentFactor?: number; // multiplier for expenses (default 1.0)
+    inflationRate?: number | null; // annual inflation rate (e.g., 0.03 for 3%)
   } | null
 >;
 export type MarkdownWidget = AbstractWidget<

--- a/upcoming-release-notes/6495.md
+++ b/upcoming-release-notes/6495.md
@@ -1,0 +1,6 @@
+---
+category: Enhancement
+authors: [math29]
+---
+
+Add inflation adjustment to Crossover Point projections for more realistic long-term financial independence planning.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add an annual "Inflation rate" input (percentage) to Crossover Point reports with tooltip; value is saved with the widget and applied to projections using monthly compounding, updating projected expenses, crossover charts, and summary metrics (years to retire, target nest egg).

* **Tests**
  * Add comprehensive tests covering annual→monthly conversion, compound monthly projections, zero/null/negative rates, precision over long horizons, and multiple projection modes.

* **Documentation**
  * Add release-note entry describing the inflation adjustment feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB → 14.85 MB (+2.64 kB) | +0.02%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB → 14.85 MB (+2.64 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Crossover.tsx` | 📈 +2.14 kB (+5.09%) | 42 kB → 44.14 kB
`src/components/reports/spreadsheets/crossover-spreadsheet.ts` | 📈 +382 B (+4.00%) | 9.33 kB → 9.7 kB
`src/components/reports/reports/CrossoverCard.tsx` | 📈 +128 B (+1.16%) | 10.74 kB → 10.86 kB
`src/components/reports/graphs/CrossoverGraph.tsx` | 📈 +9 B (+0.08%) | 10.43 kB → 10.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.16 MB → 1.16 MB (+2.64 kB) | +0.22%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.54 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.15 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.37 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/nl.js | 106.37 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/pt-BR.js | 154.22 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/uk.js | 214.74 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/narrow.js | 637.68 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BwrdDDMW.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->