### PR TITLE
Fix date format interfering with month filter edit

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -91,6 +91,7 @@ function ConfigureField<T extends RuleConditionEntity>({
 }: ConfigureFieldProps<T>) {
   const { t } = useTranslation();
   const format = useFormat();
+  const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [subfield, setSubfield] = useState(initialSubfield);
   const inputRef = useRef<AmountInputRef>(null);
   const prevOp = useRef<T['op'] | null>(null);
@@ -118,11 +119,13 @@ function ConfigureField<T extends RuleConditionEntity>({
       typeof value === 'string' &&
       /^\d{4}-\d{2}$/.test(value)
     ) {
-      const [year, month] = value.split('-');
-      return `${month}/${year}`;
+      const date = parseDate(value, 'yyyy-MM', new Date());
+      if (isDateValid(date)) {
+        return formatDate(date, getMonthYearFormat(dateFormat));
+      }
     }
     return value;
-  }, [value, field, subfield]);
+  }, [value, field, subfield, dateFormat]);
 
   return (
     <FocusScope>

--- a/upcoming-release-notes/6497.md
+++ b/upcoming-release-notes/6497.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Faizanq]
+---
+
+Fix month filter edit popup showing date in wrong format for non-default date formats.


### PR DESCRIPTION
## Summary
- Fix month filter edit popup showing date in wrong format for non-default date formats
- The edit popup was always displaying dates in mm/yyyy format regardless of user's date format preference
- Now respects the configured date format setting

## Test plan
- [x] Set date format to YYYY-MM-DD in Settings
- [x] Go to any account transactions
- [x] Add a Month filter (e.g., 2025-12)
- [x] Click on the filter badge to edit it
- [x] Verify the input shows "2025-12" (not "12/2025")

Fixes #6341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed month filter edit popup displaying dates in the wrong format when using non-default date format settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->