### PR TITLE
:scroll:  Add Flathub link on downloads page

### DIFF
--- a/packages/docs/src/pages/download.md
+++ b/packages/docs/src/pages/download.md
@@ -56,16 +56,16 @@ icon={<Linuxsvg width="100" height="100" fill="#6B46C1" />}
 platform="Linux"
 links={[
 {
+label: 'Flathub',
+url: 'https://flathub.org/en/apps/com.actualbudget.actual'
+},
+{
 label: 'AppImage (x64)',
 url: 'https://github.com/actualbudget/actual/releases/latest/download/Actual-linux-x86_64.AppImage'
 },
 {
 label: 'AppImage (arm64)',
 url: 'https://github.com/actualbudget/actual/releases/latest/download/Actual-linux-arm64.AppImage'
-},
-{
-label: 'Flatpak',
-url: 'https://github.com/actualbudget/actual/releases/latest/download/Actual-linux-x86_64.flatpak'
 }
 ]}
 />


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

The next release includes our first publish to Flathub. Including the link to Flathub on the Downloads page.

Should be merged around the same time as the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux download options: Flathub is now available as a package manager option, replacing Flatpak. AppImage packages for x64 and arm64 remain available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->