### PR TITLE
[Goals] fix up to only templates and negative carryover

### DIFF
--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -548,7 +548,7 @@ export class CategoryTemplateContext {
         templateContext.currency.decimalPlaces,
       );
     } else {
-      return templateContext.limitAmount;
+      return templateContext.limitAmount - templateContext.fromLastMonth;
     }
   }
 

--- a/upcoming-release-notes/6566.md
+++ b/upcoming-release-notes/6566.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix refill templates not handling negative carryover properly


### PR DESCRIPTION
fixes #6522.

A template like `#template up to 150` should get the category balance up to 150 no matter how much was rolled forward, even if it was a negative amount.
