### PR TITLE
[WIP] fix: use user's date format for month filter value display

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -91,6 +91,7 @@ function ConfigureField<T extends RuleConditionEntity>({
 }: ConfigureFieldProps<T>) {
   const { t } = useTranslation();
   const format = useFormat();
+  const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [subfield, setSubfield] = useState(initialSubfield);
   const inputRef = useRef<AmountInputRef>(null);
   const prevOp = useRef<T['op'] | null>(null);
@@ -118,11 +119,13 @@ function ConfigureField<T extends RuleConditionEntity>({
       typeof value === 'string' &&
       /^\d{4}-\d{2}$/.test(value)
     ) {
-      const [year, month] = value.split('-');
-      return `${month}/${year}`;
+      const date = parseDate(value, 'yyyy-MM', new Date());
+      if (isDateValid(date)) {
+        return formatDate(date, getMonthYearFormat(dateFormat));
+      }
     }
     return value;
-  }, [value, field, subfield]);
+  }, [value, field, subfield, dateFormat]);
 
   return (
     <FocusScope>

--- a/upcoming-release-notes/6341.md
+++ b/upcoming-release-notes/6341.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [majiayu000]
+---
+
+Fix month filter using wrong date format when editing filter value


### PR DESCRIPTION
## Summary

- Fixes month filter using wrong date format when editing filter value
- Uses user's date format preference instead of hardcoded MM/yyyy format

## Changes

- Gets user's date format using `useDateFormat()` hook in `ConfigureField` component
- Uses `parseDate()` and `formatDate()` with `getMonthYearFormat(dateFormat)` to convert stored format to user's preferred format
- Adds `dateFormat` to `formattedValue` dependencies

## Test Plan

- [x] Verified `yarn typecheck` passes
- [x] Verified `yarn lint:fix` passes
- [x] Verified `yarn test` passes
- [x] Manual testing: edit month filter with different date format settings

Fixes #6341