### PR TITLE
fix(reports): enable include current month option for last month

### DIFF
--- a/packages/desktop-client/src/components/reports/disabledList.ts
+++ b/packages/desktop-client/src/components/reports/disabledList.ts
@@ -39,10 +39,6 @@ const currentIntervalOptions = [
     disableInclude: true,
   },
   {
-    description: t('Last month'),
-    disableInclude: true,
-  },
-  {
     description: t('Last year'),
     disableInclude: true,
   },

--- a/upcoming-release-notes/6577.md
+++ b/upcoming-release-notes/6577.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [csenel]
+---
+
+Enable include current month option for last month


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
This option is already taken into account where you can toggle it on and off by switching to another date range. So it's better to enable it.

Fixes https://github.com/actualbudget/actual/issues/6576