### PR TITLE
Crossover report: Remove leftover help text referring to linear trend

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -698,10 +698,6 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
                               How past expenses are projected into the future.
                               <br />
                               <br />
-                              Linear Trend: Projects expenses using a linear
-                              regression of historical data.
-                              <br />
-                              <br />
                               Hampel Filtered Median: Filters out outliers
                               before calculating the median expense.
                               <br />

--- a/upcoming-release-notes/6638.md
+++ b/upcoming-release-notes/6638.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jonner]
+---
+
+Remove obsolete help text after removing linear trend from crossover report


### PR DESCRIPTION
Accidentally forgotten in https://github.com/actualbudget/actual/pull/6589
