### PR TITLE
Add contributions to crossover report

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
@@ -171,6 +171,7 @@ export function CrossoverCard({
 
   const swr = meta?.safeWithdrawalRate ?? 0.04;
   const estimatedReturn = meta?.estimatedReturn ?? null;
+  const expectedContribution = meta?.expectedContribution ?? null;
   const projectionType: 'hampel' | 'median' | 'mean' =
     meta?.projectionType ?? 'hampel';
   const expenseAdjustmentFactor = meta?.expenseAdjustmentFactor ?? 1.0;
@@ -183,7 +184,8 @@ export function CrossoverCard({
         expenseCategoryIds,
         incomeAccountIds,
         safeWithdrawalRate: swr,
-        estimatedReturn: estimatedReturn == null ? null : estimatedReturn,
+        estimatedReturn,
+        expectedContribution,
         projectionType,
         expenseAdjustmentFactor,
       }),
@@ -194,6 +196,7 @@ export function CrossoverCard({
       incomeAccountIds,
       swr,
       estimatedReturn,
+      expectedContribution,
       projectionType,
       expenseAdjustmentFactor,
     ],

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -80,6 +80,7 @@ export type CrossoverWidget = AbstractWidget<
     timeFrame?: TimeFrame;
     safeWithdrawalRate?: number; // 0.04 default
     estimatedReturn?: number | null; // annual
+    expectedContribution?: number | null; // monthly dollar amount
     projectionType?: 'hampel' | 'median' | 'mean'; // expense projection method
     showHiddenCategories?: boolean; // show hidden categories in selector
     expenseAdjustmentFactor?: number; // multiplier for expenses (default 1.0)

--- a/upcoming-release-notes/6639.md
+++ b/upcoming-release-notes/6639.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jonner]
+---
+
+Add the ability to specify expected contributions to the crossover point report.


### PR DESCRIPTION
Add the ability to specify expected monthly contributions to the crossover report. This will allow users to estimate the growth of their investments more accurately instead of treating all account growth as exponential investment returns. When the checkbox is unclicked, the automatically calculated historical return value will be used. When the checkbox is clicked, it will display two input fields. One for expected investment growth, and one for expected monthly contributions to your retirement accounts.

Note that I am not a js developer and UI is not my strong suit, so I've used claude code to assist with this patch. Any help in making this more polished would be welcome.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.4 MB → 14.41 MB (+5.22 kB) | +0.04%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.4 MB → 14.41 MB (+5.22 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Crossover.tsx` | 📈 +4.93 kB (+13.71%) | 35.94 kB → 40.86 kB
`src/components/reports/spreadsheets/crossover-spreadsheet.ts` | 📈 +181 B (+1.93%) | 9.14 kB → 9.32 kB
`src/components/reports/reports/CrossoverCard.tsx` | 📈 +118 B (+1.10%) | 10.5 kB → 10.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.05 MB → 1.05 MB (+5.22 kB) | +0.49%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.24 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 176.28 kB | 0%
static/js/en-GB.js | 6.98 kB | 0%
static/js/en.js | 159.37 kB | 0%
static/js/es.js | 171.98 kB | 0%
static/js/fr.js | 180.63 kB | 0%
static/js/it.js | 172.42 kB | 0%
static/js/nb-NO.js | 158.09 kB | 0%
static/js/nl.js | 103.35 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.32 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.28 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 216.34 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/narrow.js | 640.86 kB | 0%
static/js/TransactionList.js | 101.58 kB | 0%
static/js/wide.js | 159.96 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BInehE-N.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->