### PR TITLE
Add blog post: Next Steps for Funding Contributors

### DIFF
--- a/packages/docs/blog/2026-01-17-next-steps-for-funding-contributors.md
+++ b/packages/docs/blog/2026-01-17-next-steps-for-funding-contributors.md
@@ -1,6 +1,6 @@
 ---
 title: Next Steps for Funding Contributors
-description: Expanding upon our successful contributor compensation system, we're exploring new ways to reward broader project involvement—including feature work, bug fixes, and active community participation—while ensuring transparency, fairness, and ongoing support in funding for all meaningful contributions.
+description: Expanding upon our successful contributor compensation system, we're exploring new ways to reward broader project involvement — including feature work, bug fixes, and active community participation — while ensuring transparency, fairness, and ongoing support in funding for all meaningful contributions.
 date: 2026-01-17T10:00
 slug: next-steps-for-funding-contributors
 tags: [announcement]


### PR DESCRIPTION
This blog post was extracted from PR #6481 as I would like to publish the blog post first. And then merge the points calculation update in February (since we are counting the new points only from start of feb, not start of jan).