### PR TITLE
fix: limit custom css textarea to resize vertically

### DIFF
--- a/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
@@ -375,6 +375,7 @@ export function ThemeInstaller({
           aria-label={t('Custom Theme CSS')}
           style={{
             height: 120,
+            resize: 'vertical',
           }}
         />
         <View

--- a/upcoming-release-notes/6695.md
+++ b/upcoming-release-notes/6695.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatthiasBenaets]
+---
+
+Limit custom css textarea to resize vertically


### PR DESCRIPTION
Title.

Otherwise, the text area can be resized to outside the View.