### PR TITLE
docs: Update API warning for clarity

### DIFF
--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -4,7 +4,7 @@ import { Method, MethodBox } from './types';
 
 :::warning
 
-Actual provide a "Code-level API". Many people mistake the term "API" for a HTTP and/or REST-full API. Actual **does not** expose HTTP endpoints that can be called. We do, however, offer a NPM package - API - that allows interacting with the product programmatically.
+Actual provides a "Code-level API". Many people mistake the term "API" for a HTTP and/or REST-full API. Actual **does not** expose HTTP endpoints that can be called. We do, however, offer a NPM package - API - that allows interacting with the product programmatically.
 
 :::
 


### PR DESCRIPTION
Clarified the definition of 'API' to emphasize that it provides a 'Code-level API' rather than HTTP endpoints.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
