### PR TITLE
testing preview still works

### DIFF
--- a/packages/desktop-client/src/components/manager/ConfigServer.tsx
+++ b/packages/desktop-client/src/components/manager/ConfigServer.tsx
@@ -1,9 +1,22 @@
+// @ts-strict-ignore
+import React, { useCallback, useEffect, useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
 import { Button, ButtonWithLoading } from '@actual-app/components/button';
 import { BigInput } from '@actual-app/components/input';
 import { Label } from '@actual-app/components/label';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
+import { css } from '@emotion/css';
+
+import {
+  isElectron,
+  isNonProductionEnvironment,
+} from 'loot-core/shared/environment';
+
+import { Title } from './subscribe/common';
+
 import { createBudget } from '@desktop-client/budgetfiles/budgetfilesSlice';
 import { Link } from '@desktop-client/components/common/Link';
 import {
@@ -15,16 +28,6 @@ import { useNavigate } from '@desktop-client/hooks/useNavigate';
 import { saveGlobalPrefs } from '@desktop-client/prefs/prefsSlice';
 import { useDispatch } from '@desktop-client/redux';
 import { loggedIn, signOut } from '@desktop-client/users/usersSlice';
-import { css } from '@emotion/css';
-import {
-  isElectron,
-  isNonProductionEnvironment,
-} from 'loot-core/shared/environment';
-// @ts-strict-ignore
-import React, { useCallback, useEffect, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
-
-import { Title } from './subscribe/common';
 
 export function ElectronServerConfig({
   onDoNotUseServer,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.41 MB → 14.41 MB (+268 B) | +0.00%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.41 MB → 14.41 MB (+268 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/manager/ConfigServer.tsx` | 📈 +268 B (+1.13%) | 23.18 kB → 23.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.24 MB → 9.24 MB (+268 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 176.28 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 159.4 kB | 0%
static/js/es.js | 171.98 kB | 0%
static/js/fr.js | 180.63 kB | 0%
static/js/it.js | 172.42 kB | 0%
static/js/nb-NO.js | 158.09 kB | 0%
static/js/nl.js | 103.35 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.32 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.28 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 216.34 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.05 MB | 0%
static/js/narrow.js | 640.99 kB | 0%
static/js/TransactionList.js | 101.58 kB | 0%
static/js/wide.js | 159.96 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BInehE-N.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->