### PR TITLE
[WIP] default value for amount to 0 (as displayed in the UI)

### DIFF
--- a/packages/desktop-client/src/components/util/GenericInput.tsx
+++ b/packages/desktop-client/src/components/util/GenericInput.tsx
@@ -413,7 +413,7 @@ export const GenericInput = ({
             <Input
               ref={ref}
               value={props.value || ''}
-              placeholder={t('nothing')}
+              placeholder="0.00"
               onChangeValue={newValue => props.onChange(Number(newValue))}
               style={inputStyle}
             />

--- a/upcoming-release-notes/6760.md
+++ b/upcoming-release-notes/6760.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [GBernard314]
+---
+
+When putting a rule for an amount, the ui shows 0.00 but the default value is nothing. Visually we think it is 0.00 i guess it would be more straightforward for it to be that.


### PR DESCRIPTION
---
category: Enhancements
authors: [GBernard314]
---

When putting a rule for an amount, the ui shows 0.00 but the default value is nothing. Visually we think it is 0.00 i guess it would be more straightforward for it to be that.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.41 MB → 14.41 MB (-222 B) | -0.00%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.41 MB → 14.41 MB (-222 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/util/GenericInput.tsx` | 📉 -222 B (-1.12%) | 19.27 kB → 19.06 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.24 MB → 9.24 MB (-222 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 175.37 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 160.05 kB | 0%
static/js/es.js | 171.21 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 103.35 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.24 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.05 MB | 0%
static/js/narrow.js | 640.99 kB | 0%
static/js/TransactionList.js | 101.58 kB | 0%
static/js/wide.js | 159.97 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BInehE-N.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->