### PR TITLE
fix: isConcise state handling for CashFlow report

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -100,13 +100,15 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
   );
   const [latestTransaction, setLatestTransaction] = useState('');
 
-  const [isConcise, setIsConcise] = useState(() => {
+  const [isConcise, setIsConcise] = useState(false);
+
+  useEffect(() => {
     const numDays = d.differenceInCalendarDays(
       d.parseISO(end),
       d.parseISO(start),
     );
-    return numDays > 31 * 3;
-  });
+    setIsConcise(numDays > 31 * 3);
+  }, [start, end]);
 
   const params = useMemo(
     () =>
@@ -177,16 +179,9 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
   }, [latestTransaction, widget?.meta?.timeFrame]);
 
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
-    const numDays = d.differenceInCalendarDays(
-      d.parseISO(end),
-      d.parseISO(start),
-    );
-    const isConcise = numDays > 31 * 3;
-
     setStart(start);
     setEnd(end);
     setMode(mode);
-    setIsConcise(isConcise);
   }
 
   const navigate = useNavigate();

--- a/upcoming-release-notes/6765.md
+++ b/upcoming-release-notes/6765.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatthiasBenaets]
+---
+
+Simplified compact view handling for more consistent CashFlow behavior


### PR DESCRIPTION
Previously, isConcise was calculated in two separate places in the CashFlow report, which caused inconsistencies.
For example, when the time frame was more than 3 months, the x-axis should show months, but on page refresh/initial load it would incorrectly show days.
This change moves the logic into a useEffect so it is always derived correctly.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.47 MB → 14.47 MB (+3.32 kB) | +0.02%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.47 MB → 14.47 MB (+3.32 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/es.json` | 📈 +2.71 kB (+1.58%) | 171.21 kB → 173.92 kB
`locale/de.json` | 📈 +734 B (+0.40%) | 177.78 kB → 178.5 kB
`src/components/reports/reports/CashFlow.tsx` | 📉 -105 B (-1.13%) | 9.07 kB → 8.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/es.js | 171.21 kB → 173.92 kB (+2.71 kB) | +1.58%
static/js/de.js | 177.78 kB → 178.5 kB (+734 B) | +0.40%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.11 MB → 1.11 MB (-105 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.22 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 162.91 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.62 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/narrow.js | 641.19 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DE5uAdQe.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->