### PR TITLE
Add workflow to remove 'suspect ai generated' label when 'AI Generated' is added

### DIFF
--- a/.github/workflows/pr-ai-label-cleanup.yml
+++ b/.github/workflows/pr-ai-label-cleanup.yml
@@ -1,0 +1,25 @@
+name: Remove 'suspect ai generated' label when 'AI generated' is present
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-suspect-label:
+    if: >-
+      ${{ contains(github.event.pull_request.labels.*.name, 'AI generated') &&
+          contains(github.event.pull_request.labels.*.name, 'suspect ai generated') }}
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'suspect ai generated'
+            });

--- a/upcoming-release-notes/6810.md
+++ b/upcoming-release-notes/6810.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [StephenBrown2]
+---
+
+Remove 'suspect ai generated' label when 'AI Generated' is added


### PR DESCRIPTION
## Summary

This PR adds a new GitHub Actions workflow that automatically removes the `suspect ai generated` label from pull requests when both the `AI generated` and `suspect ai generated` labels are present.

## What

- Added new workflow file `.github/workflows/pr-ai-label-cleanup.yml`
- Triggers on `pull_request_target` labeled events
- Uses the new [`ubuntu-slim` runner](https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/) (1 vCPU, optimized for lightweight automation tasks)
- Uses `actions/github-script@v8` to call the GitHub API directly

## Why

An AI bot automatically adds the `suspect ai generated` label to PRs it suspects may be AI-generated. When a maintainer reviews the PR and confirms it is AI-generated, they add the `AI generated` label. At that point, the suspicion label is no longer needed since the PR has been explicitly marked as AI-generated by a maintainer.

## How

The workflow triggers on any label addition to a PR. After the label is added, it checks if **both** labels are present:
- `AI generated` (added by maintainers)
- `suspect ai generated` (added by AI bot)

If both exist, the `suspect ai generated` label is removed. This covers two scenarios:
1. Maintainer adds `AI generated` to a PR that already has `suspect ai generated`
2. AI bot adds `suspect ai generated` to a PR that a maintainer has already marked as `AI generated`

**Note:** This workflow only affects these two specific labels. All other label operations on the PR remain unaffected.