### PR TITLE
Handle fork PRs gracefully in release notes generation

### DIFF
--- a/.github/actions/ai-generated-release-notes/create-release-notes-file.js
+++ b/.github/actions/ai-generated-release-notes/create-release-notes-file.js
@@ -2,19 +2,20 @@
 
 import { Octokit } from '@octokit/rest';
 
-const token = process.env.GITHUB_TOKEN;
+const githubToken = process.env.GITHUB_TOKEN;
+const actionsUpdateToken = process.env.ACTIONS_UPDATE_TOKEN;
 const repo = process.env.GITHUB_REPOSITORY;
 const issueNumber = process.env.GITHUB_EVENT_ISSUE_NUMBER;
 const summaryDataJson = process.env.SUMMARY_DATA;
 const category = process.env.CATEGORY;
 
-if (!token || !repo || !issueNumber || !summaryDataJson || !category) {
+if (!githubToken || !repo || !issueNumber || !summaryDataJson || !category) {
   console.log('Missing required environment variables');
   process.exit(1);
 }
 
 const [owner, repoName] = repo.split('/');
-const octokit = new Octokit({ auth: token });
+const readOctokit = new Octokit({ auth: githubToken });
 
 async function createReleaseNotesFile() {
   try {
@@ -55,8 +56,8 @@ ${summaryData.summary}
     console.log('File content:');
     console.log(fileContent);
 
-    // Get PR info
-    const { data: pr } = await octokit.rest.pulls.get({
+    // Get PR info (use GITHUB_TOKEN - has read access in the repo where the workflow runs)
+    const { data: pr } = await readOctokit.rest.pulls.get({
       owner,
       repo: repoName,
       pull_number: issueNumber,
@@ -65,13 +66,28 @@ ${summaryData.summary}
     const prBranch = pr.head.ref;
     const headOwner = pr.head.repo.owner.login;
     const headRepo = pr.head.repo.name;
+    const headRepoFull = `${headOwner}/${headRepo}`;
+
+    // PR from fork: head repo !== this repo → we must write to the fork; use ACTIONS_UPDATE_TOKEN
+    //   (workflow runs in base repo and has the PAT). Same repo (branch PR): use GITHUB_TOKEN.
+    // If this workflow runs in a fork (e.g. contributor’s copy), PAT isn’t set; same-repo writes
+    // still work via GITHUB_TOKEN.
+    const writeToken = headRepoFull !== repo ? actionsUpdateToken : githubToken;
+    if (!writeToken) {
+      console.log(
+        'Cannot write to fork: ACTIONS_UPDATE_TOKEN is required for cross-repo writes and is not available (e.g. workflow running in a fork).',
+      );
+      process.exit(1);
+    }
 
     console.log(
       `Committing to PR branch: ${headOwner}/${headRepo}:${prBranch}`,
     );
 
+    const writeOctokit = new Octokit({ auth: writeToken });
+
     // Create the file via GitHub API on the PR branch
-    await octokit.rest.repos.createOrUpdateFileContents({
+    await writeOctokit.rest.repos.createOrUpdateFileContents({
       owner: headOwner,
       repo: headRepo,
       path: fileName,

--- a/.github/workflows/ai-generated-release-notes.yml
+++ b/.github/workflows/ai-generated-release-notes.yml
@@ -78,7 +78,8 @@ jobs:
         if: steps.check-first-comment.outputs.result == 'true' && steps.check-release-notes-exists.outputs.result == 'false' && steps.generate-summary.outputs.result != 'null' && steps.determine-category.outputs.result != 'null' && steps.determine-category.outputs.result != ''
         run: node .github/actions/ai-generated-release-notes/create-release-notes-file.js
         env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTIONS_UPDATE_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
           SUMMARY_DATA: ${{ steps.generate-summary.outputs.result }}

--- a/upcoming-release-notes/6817.md
+++ b/upcoming-release-notes/6817.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [StephenBrown2]
+---
+
+Enable Release Notes generation for PRs from forks


### PR DESCRIPTION
## Summary

This PR fixes the AI-generated release notes workflow so it can create and commit the release-notes file on fork PR branches. The workflow was unable to write to fork branches; this change fixes the permission context by passing both tokens and choosing the correct one in the script.

## What changed

- **Workflow** (`.github/workflows/ai-generated-release-notes.yml`): The step that creates/commits the release notes file now receives both `GITHUB_TOKEN` and `ACTIONS_UPDATE_TOKEN` (previously only `ACTIONS_UPDATE_TOKEN` was passed).
- **Script** (`.github/actions/ai-generated-release-notes/create-release-notes-file.js`): Uses `GITHUB_TOKEN` for reading PR details. For writing the file via the Contents API, it chooses the token by repo:
  - **PR from fork** (head repo ≠ current repo): use `ACTIONS_UPDATE_TOKEN` so the workflow (running in the base repo) can write to the fork.
  - **Same-repo PR**: use `GITHUB_TOKEN`.
  If the script needs to write to a different repo and `ACTIONS_UPDATE_TOKEN` is not set, it exits with a clear error (e.g. when the workflow runs in a contributor’s fork and they don’t have the PAT).

## Permissions and context

- For a **fork PR** (e.g. `contributor/actual` → `actualbudget/actual`), the `issue_comment` event runs in the **base** repo, so the job has access to `ACTIONS_UPDATE_TOKEN` and can write to the fork’s branch via the chosen token.
- For a **same-repo** branch PR, the write targets the current repo, so `GITHUB_TOKEN` is used.
- If the workflow runs **inside a fork** (e.g. a PR within the fork), the fork has no `ACTIONS_UPDATE_TOKEN`; same-repo writes still work via `GITHUB_TOKEN`.

## Comparison to VRT Update workflows

The **VRT Update** flow is split into two workflows:

1. **VRT Update - Generate** (triggered by `issue_comment`): generates a patch and uploads it as an artifact.
2. **VRT Update - Apply** (triggered by `workflow_run` when Generate completes): runs in the **base** repo, so it always has `ACTIONS_UPDATE_TOKEN` and can push to the fork.

That split guarantees the write step runs in the base repo. For release notes we kept a **single workflow** and fixed token selection. If fork PRs still cannot create files (e.g. if GitHub restricts secrets for this trigger), the next step would be to split into Generate + Apply via `workflow_run` like VRT so the commit step always runs in the base repo.

## Test plan

- Run workflow on a fork PR and confirm the release-notes file is created on the PR branch when CodeRabbit’s first comment is posted and the PR targets `master`.
- Confirm same-repo PRs still get the file (using `GITHUB_TOKEN`).
