### PR TITLE
fix: resolve issue with banksync table borders

### DIFF
--- a/packages/desktop-client/src/components/banksync/index.tsx
+++ b/packages/desktop-client/src/components/banksync/index.tsx
@@ -115,6 +115,7 @@ export function BankSync() {
     <Page
       header={t('Bank Sync')}
       style={{
+        minHeight: 'initial',
         marginInline: floatingSidebar && !isNarrowWidth ? 'auto' : 0,
         paddingBottom: MOBILE_NAV_HEIGHT,
       }}
@@ -129,7 +130,7 @@ export function BankSync() {
         )}
         {Object.entries(groupedAccounts).map(([syncProvider, accounts]) => {
           return (
-            <View key={syncProvider} style={{ marginBottom: '1em' }}>
+            <View key={syncProvider} style={{ minHeight: 'initial' }}>
               {Object.keys(groupedAccounts).length > 1 && (
                 <Text
                   style={{ fontWeight: 500, fontSize: 20, margin: '.5em 0' }}

--- a/upcoming-release-notes/6825.md
+++ b/upcoming-release-notes/6825.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [aelxxs]
+---
+
+Fix bank sync table borders.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Resolve issue with banksync table borders

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.46 MB → 14.46 MB (+367 B) | +0.00%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.46 MB → 14.46 MB (+367 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/index.tsx` | 📈 +29 B (+0.54%) | 5.2 kB → 5.23 kB
`locale/nl.json` | 📈 +338 B (+0.32%) | 103.49 kB → 103.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/nl.js | 103.49 kB → 103.82 kB (+338 B) | +0.32%
static/js/wide.js | 160.04 kB → 160.07 kB (+29 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.22 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 177.78 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 162.91 kB | 0%
static/js/es.js | 171.21 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.35 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.11 MB | 0%
static/js/narrow.js | 641.19 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DE5uAdQe.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->