### PR TITLE
[WIP] FR 5381: Add "Group" Column to Transaction View

### DIFF
--- a/packages/desktop-client/src/budget/budgetSlice.ts
+++ b/packages/desktop-client/src/budget/budgetSlice.ts
@@ -601,6 +601,19 @@ export const applyBudgetAction = createAppAsyncThunk(
   },
 );
 
+export const getGroupByCategoryId = memoizeOne(
+  (categoryGroups: CategoryGroupEntity[] | null | undefined) => {
+    const res: { [id: CategoryEntity['id']]: CategoryGroupEntity } = {};
+    categoryGroups?.forEach(group => {
+      group.categories?.forEach(cat => {
+        res[cat.id] = group;
+      });
+    });
+
+    return res;
+  },
+);
+
 export const getCategoriesById = memoizeOne(
   (categoryGroups: CategoryGroupEntity[] | null | undefined) => {
     const res: { [id: CategoryEntity['id']]: CategoryEntity } = {};

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -86,7 +86,10 @@ import {
 import { TransactionMenu } from './TransactionMenu';
 
 import { getAccountsById } from '@desktop-client/accounts/accountsSlice';
-import { getCategoriesById } from '@desktop-client/budget/budgetSlice';
+import {
+  getCategoriesById,
+  getGroupByCategoryId,
+} from '@desktop-client/budget/budgetSlice';
 import { AccountAutocomplete } from '@desktop-client/components/autocomplete/AccountAutocomplete';
 import { CategoryAutocomplete } from '@desktop-client/components/autocomplete/CategoryAutocomplete';
 import { PayeeAutocomplete } from '@desktop-client/components/autocomplete/PayeeAutocomplete';
@@ -264,6 +267,16 @@ const TransactionHeader = memo(
             onSort('notes', selectAscDesc(field, ascDesc, 'notes', 'asc'))
           }
         />
+        {showCategory && (
+          <HeaderCell
+            value={t('Group')}
+            width="flex"
+            alignItems="flex"
+            marginLeft={-5}
+            id="group"
+            icon={field === 'group' ? ascDesc : 'clickable'}
+          />
+        )}
         {showCategory && (
           <HeaderCell
             value={t('Category')}
@@ -1406,6 +1419,14 @@ const Transaction = memo(function Transaction({
           value: notes || '',
           onUpdate: onUpdate.bind(null, 'notes'),
         }}
+      />
+
+      <Cell
+        name="group"
+        width="flex"
+        value={
+          getGroupByCategoryId(categoryGroups)[categoryId ?? '']?.name ?? ''
+        }
       />
 
       {(isPreview && !isChild) || isParent ? (

--- a/upcoming-release-notes/5381.md
+++ b/upcoming-release-notes/5381.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ngoc-minh-do]
+---
+
+Add a read-only "Group" column to the transaction view that displays the group associated with each category


### PR DESCRIPTION
Add a read-only "Group" column to the transaction view that displays the group associated with each category.
The group value should not be editable in the transaction view.
It should always reflect the group defined for the selected category.

As described in #5381, this would help reduce confusion when checking the transaction list, especially when there are categories with the same name but in different groups.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.46 MB → 14.46 MB (+980 B) | +0.01%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.46 MB → 14.46 MB (+980 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budget/budgetSlice.ts` | 📈 +219 B (+2.11%) | 10.13 kB → 10.34 kB
`src/components/transactions/TransactionsTable.tsx` | 📈 +649 B (+0.74%) | 85.88 kB → 86.52 kB
`locale/pt-BR.json` | 📈 +112 B (+0.07%) | 146.35 kB → 146.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.22 MB → 9.22 MB (+868 B) | +0.01%
static/js/pt-BR.js | 146.35 kB → 146.46 kB (+112 B) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 177.78 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 162.91 kB | 0%
static/js/es.js | 171.21 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 103.82 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.11 MB | 0%
static/js/narrow.js | 641.19 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DE5uAdQe.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->