### PR TITLE
Avoid negative zero in budget summary amounts

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
@@ -9,8 +9,35 @@ import { View } from '@actual-app/components/view';
 
 import { EnvelopeCellValue } from '@desktop-client/components/budget/envelope/EnvelopeBudgetComponents';
 import { CellValueText } from '@desktop-client/components/spreadsheet/CellValue';
-import { useFormat } from '@desktop-client/hooks/useFormat';
+import { useFormat, type FormatType } from '@desktop-client/hooks/useFormat';
 import { envelopeBudget } from '@desktop-client/spreadsheet/bindings';
+
+/**
+ * Creates a formatter that displays values with explicit +/- signs.
+ * Uses Math.abs to avoid double-negative display (e.g., "--$0.00").
+ *
+ * @param format - The format function from useFormat hook
+ * @param invert - If true, shows '-' for positive and '+' for negative
+ */
+function makeSignedFormatter(
+  format: ReturnType<typeof useFormat>,
+  invert = false,
+) {
+  return (value: number, type?: FormatType) => {
+    const v = format(Math.abs(value), type);
+    if (value === 0) {
+      return '-' + v;
+    }
+    const isPositive = value > 0;
+    return invert
+      ? isPositive
+        ? '-' + v
+        : '+' + v
+      : isPositive
+        ? '+' + v
+        : '-' + v;
+  };
+}
 
 type TotalsListProps = {
   prevMonthName: string;
@@ -19,6 +46,8 @@ type TotalsListProps = {
 
 export function TotalsList({ prevMonthName, style }: TotalsListProps) {
   const format = useFormat();
+  const signedFormatter = makeSignedFormatter(format);
+  const invertedSignedFormatter = makeSignedFormatter(format, true);
   return (
     <View
       style={{
@@ -78,10 +107,7 @@ export function TotalsList({ prevMonthName, style }: TotalsListProps) {
             <CellValueText
               {...props}
               style={{ fontWeight: 600 }}
-              formatter={(value, type) => {
-                const v = format(value, type);
-                return value > 0 ? '+' + v : value === 0 ? '-' + v : v;
-              }}
+              formatter={signedFormatter}
             />
           )}
         </EnvelopeCellValue>
@@ -94,10 +120,7 @@ export function TotalsList({ prevMonthName, style }: TotalsListProps) {
             <CellValueText
               {...props}
               style={{ fontWeight: 600 }}
-              formatter={(value, type) => {
-                const v = format(value, type);
-                return value > 0 ? '+' + v : value === 0 ? '-' + v : v;
-              }}
+              formatter={signedFormatter}
             />
           )}
         </EnvelopeCellValue>
@@ -110,10 +133,7 @@ export function TotalsList({ prevMonthName, style }: TotalsListProps) {
             <CellValueText
               {...props}
               style={{ fontWeight: 600 }}
-              formatter={(value, type) => {
-                const v = format(Math.abs(value), type);
-                return value >= 0 ? '-' + v : '+' + v;
-              }}
+              formatter={invertedSignedFormatter}
             />
           )}
         </EnvelopeCellValue>

--- a/upcoming-release-notes/6843.md
+++ b/upcoming-release-notes/6843.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [StephenBrown2]
+---
+
+Fix double negative sign in budget summary amounts


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

# Fix double negative sign in budget summary amounts

## Summary

Fixes a display issue where budget summary amounts could show double negative signs (e.g., `--0.00`) when the value is negative zero.

Fixes <https://discord.com/channels/937901803608096828/940290142579605514/1465437617364668591>

I could have just added `Math.abs` to the two formatter functions that didn't use it already, but I figured a single function might be reusable elsewhere. Just not sure where it should go yet. Can be moved anywhere it's needed.

## Problem

The budget summary tooltip (showing "Overspent in [month]", "Budgeted", and "For next month") could display malformed amounts like `--0.00` due to how JavaScript handles negative zero (`-0`). When formatting a value of `-0`, the format function would return `-0.00`, and then the code would prepend another `-` sign, resulting in `--0.00`.

## Solution

Extracted a `makeSignedFormatter` helper function that:

1. Uses `Math.abs(value)` to always format a positive number
2. Explicitly adds the appropriate `+` or `-` sign based on the value
3. Handles zero consistently (always shows `-` prefix for zero amounts)

This ensures the sign is always controlled explicitly rather than relying on the formatter's handling of negative values.

## Changes

- Added `makeSignedFormatter()` helper function with JSDoc documentation
- Replaced three inline formatter functions with the shared helper
- Added `invert` parameter to handle the "For next month" case where sign logic is reversed

## Test plan

- [ ] Open the budget page
- [ ] Click on the "To Budget" amount to see the tooltip
- [ ] Verify "Overspent in [month]", "Budgeted", and "For next month" display correctly
- [ ] Verify zero amounts show as `-0.00` (not `--0.00`)
- [ ] Verify positive amounts show with `+` prefix
- [ ] Verify negative amounts show with `-` prefix

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.47 MB → 14.47 MB (+401 B) | +0.00%
loot-core | 1 | 5.84 MB | 0%
api | 1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.47 MB → 14.47 MB (+401 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/envelope/budgetsummary/TotalsList.tsx` | 📈 +401 B (+7.11%) | 5.51 kB → 5.9 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.22 MB → 9.22 MB (+401 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 177.78 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 162.91 kB | 0%
static/js/es.js | 171.21 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.62 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.11 MB | 0%
static/js/narrow.js | 641.19 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DE5uAdQe.js | 5.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->