### PR TITLE
Add option to bank sync to update dates.

### DIFF
--- a/packages/desktop-client/src/components/banksync/BankSyncCheckboxOptions.tsx
+++ b/packages/desktop-client/src/components/banksync/BankSyncCheckboxOptions.tsx
@@ -152,6 +152,8 @@ type BankSyncCheckboxOptionsProps = {
   setReimportDeleted: (value: boolean) => void;
   importTransactions: boolean;
   setImportTransactions: (value: boolean) => void;
+  updateDates: boolean;
+  setUpdateDates: (value: boolean) => void;
   helpMode?: 'desktop' | 'mobile';
 };
 
@@ -164,6 +166,8 @@ export function BankSyncCheckboxOptions({
   setReimportDeleted,
   importTransactions,
   setImportTransactions,
+  updateDates,
+  setUpdateDates,
   helpMode = 'desktop',
 }: BankSyncCheckboxOptionsProps) {
   const { t } = useTranslation();
@@ -213,6 +217,18 @@ export function BankSyncCheckboxOptions({
         helpMode={helpMode}
       >
         <Trans>Investment Account</Trans>
+      </CheckboxOptionWithHelp>
+
+      <CheckboxOptionWithHelp
+        id="form_update_dates"
+        checked={updateDates}
+        onChange={() => setUpdateDates(!updateDates)}
+        helpText={t(
+          'By enabling this, the transaction date will be overwritten by the one provided by the bank.',
+        )}
+        helpMode={helpMode}
+      >
+        <Trans>Update Dates</Trans>
       </CheckboxOptionWithHelp>
     </>
   );

--- a/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
+++ b/packages/desktop-client/src/components/banksync/EditSyncAccount.tsx
@@ -148,6 +148,8 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
     setReimportDeleted,
     importTransactions,
     setImportTransactions,
+    updateDates,
+    setUpdateDates,
     mappings,
     setMapping,
     fields,
@@ -222,6 +224,8 @@ export function EditSyncAccount({ account }: EditSyncAccountProps) {
             setReimportDeleted={setReimportDeleted}
             importTransactions={importTransactions}
             setImportTransactions={setImportTransactions}
+            updateDates={updateDates}
+            setUpdateDates={setUpdateDates}
             helpMode="desktop"
           />
 

--- a/packages/desktop-client/src/components/banksync/useBankSyncAccountSettings.ts
+++ b/packages/desktop-client/src/components/banksync/useBankSyncAccountSettings.ts
@@ -32,6 +32,10 @@ export function useBankSyncAccountSettings(accountId: string) {
   const [savedImportTransactions = true, setSavedImportTransactions] =
     useSyncedPref(`sync-import-transactions-${accountId}`);
 
+  const [savedUpdateDates = false, setSavedUpdateDates] = useSyncedPref(
+    `sync-update-dates-${accountId}`,
+  );
+
   const [transactionDirection, setTransactionDirection] =
     useState<TransactionDirection>('payment');
   const [importPending, setImportPending] = useState(
@@ -48,6 +52,9 @@ export function useBankSyncAccountSettings(accountId: string) {
   );
   const [importTransactions, setImportTransactions] = useState(
     String(savedImportTransactions) === 'true',
+  );
+  const [updateDates, setUpdateDates] = useState(
+    String(savedUpdateDates) === 'true',
   );
 
   const transactionQuery = q('transactions')
@@ -84,6 +91,7 @@ export function useBankSyncAccountSettings(accountId: string) {
     setSavedImportNotes(String(importNotes));
     setSavedReimportDeleted(String(reimportDeleted));
     setSavedImportTransactions(String(importTransactions));
+    setSavedUpdateDates(String(updateDates));
   };
 
   const setMapping = (field: string, value: string) => {
@@ -110,6 +118,8 @@ export function useBankSyncAccountSettings(accountId: string) {
     setReimportDeleted,
     importTransactions,
     setImportTransactions,
+    updateDates,
+    setUpdateDates,
     mappings,
     setMapping,
     exampleTransaction,

--- a/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
@@ -37,6 +37,8 @@ export function MobileBankSyncAccountEditPage() {
     setReimportDeleted,
     importTransactions,
     setImportTransactions,
+    updateDates,
+    setUpdateDates,
     mappings,
     setMapping,
     fields,
@@ -146,6 +148,8 @@ export function MobileBankSyncAccountEditPage() {
               setReimportDeleted={setReimportDeleted}
               importTransactions={importTransactions}
               setImportTransactions={setImportTransactions}
+              updateDates={updateDates}
+              setUpdateDates={setUpdateDates}
               helpMode="mobile"
             />
           </View>

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -43,6 +43,7 @@ export type SyncedPrefs = Partial<
     | `sync-reimport-deleted-${string}`
     | `sync-import-notes-${string}`
     | `sync-import-transactions-${string}`
+    | `sync-update-dates-${string}`
     | `ofx-fallback-missing-payee-${string}`
     | `flip-amount-${string}-${'csv' | 'qif'}`
     | `flags.${FeatureFlag}`

--- a/upcoming-release-notes/6850.md
+++ b/upcoming-release-notes/6850.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [kleinweby]
+---
+
+Add bank sync option to allow overwriting dates with the bank's value.


### PR DESCRIPTION
Add an option to bank sync to update dates.

This is useful when the transaction date changes once it clears. This setting defaults to off and can be enabled by the user.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.47 MB → 14.47 MB (+5.36 kB) | +0.04%
loot-core | 1 | 5.84 MB → 5.84 MB (+821 B) | +0.01%
api | 1 | 4.38 MB → 4.38 MB (+737 B) | +0.02%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.47 MB → 14.47 MB (+5.36 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/BankSyncCheckboxOptions.tsx` | 📈 +1.11 kB (+10.13%) | 10.91 kB → 12.02 kB
`src/components/banksync/useBankSyncAccountSettings.ts` | 📈 +500 B (+9.03%) | 5.41 kB → 5.89 kB
`src/components/banksync/EditSyncAccount.tsx` | 📈 +172 B (+2.38%) | 7.06 kB → 7.23 kB
`src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx` | 📈 +172 B (+1.74%) | 9.66 kB → 9.83 kB
`locale/es.json` | 📈 +2.71 kB (+1.58%) | 171.21 kB → 173.92 kB
`locale/de.json` | 📈 +734 B (+0.40%) | 177.78 kB → 178.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/es.js | 171.21 kB → 173.92 kB (+2.71 kB) | +1.58%
static/js/index.js | 9.22 MB → 9.23 MB (+1.93 kB) | +0.02%
static/js/de.js | 177.78 kB → 178.5 kB (+734 B) | +0.40%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 162.91 kB | 0%
static/js/fr.js | 179.72 kB | 0%
static/js/it.js | 171.54 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 146.62 kB | 0%
static/js/ru.js | 106.97 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.11 MB | 0%
static/js/narrow.js | 641.19 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.84 MB → 5.84 MB (+821 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +821 B (+3.26%) | 24.57 kB → 25.37 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DjY5o5a4.js | 0 B → 5.84 MB (+5.84 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DE5uAdQe.js | 5.84 MB → 0 B (-5.84 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.38 MB → 4.38 MB (+737 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/server/accounts/sync.ts` | 📈 +737 B (+3.28%) | 21.93 kB → 22.65 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.38 MB → 4.38 MB (+737 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->