### PR TITLE
[WIP] Remove deprecated downlevelIteration option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "resolveJsonModule": true,
-    "downlevelIteration": true,
     // TODO: enable once every file is ts
     // "strict": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when `target` is `es2022`, so can be safely removed from this config file.