### PR TITLE
Fix feedback link for budget analysis report experimental flag

### DIFF
--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -210,7 +210,7 @@ export function ExperimentalFeatures() {
             </FeatureToggle>
             <FeatureToggle
               flag="budgetAnalysisReport"
-              feedbackLink="https://github.com/actualbudget/actual/pull/6137"
+              feedbackLink="https://github.com/actualbudget/actual/pull/6742"
             >
               <Trans>Budget Analysis Report</Trans>
             </FeatureToggle>
@@ -218,7 +218,7 @@ export function ExperimentalFeatures() {
               <ServerFeatureToggle
                 prefName="flags.plugins"
                 disableToggle
-                feedbackLink="https://github.com/actualbudget/actual/issues/6742"
+                feedbackLink="https://github.com/actualbudget/actual/issues/5950"
               >
                 <Trans>Client-Side plugins (soon)</Trans>
               </ServerFeatureToggle>

--- a/upcoming-release-notes/6914.md
+++ b/upcoming-release-notes/6914.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [diepala]
+---
+
+Fix feedback link for budget analysis report experimental flag.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

In #6137, when updating the experimental flag feedback link, the update was done in the incorrect line (https://github.com/actualbudget/actual/pull/6137/changes/65ae6fe56e2bdefc64f563b567e4e98a434ce877#diff-4eab7da5f878e8fc5049222c5c177f9a604c35c8de8c96cd5aec0dcd3b379a13L221). This PR updates the feedback links to point to the correct issues.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.47 MB | 0%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.47 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.33 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 178.39 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 164.55 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.62 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.11 MB | 0%
static/js/narrow.js | 640.46 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.G2jIa5TY.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.39 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->