### PR TITLE
[WIP] fix(GenericInput): handle null date value to prevent crash on blur

### DIFF
--- a/packages/desktop-client/src/components/util/GenericInput.tsx
+++ b/packages/desktop-client/src/components/util/GenericInput.tsx
@@ -345,7 +345,7 @@ export const GenericInput = ({
           break;
 
         default:
-          if (typeof props.value !== 'string') {
+          if (props.value != null && typeof props.value !== 'string') {
             content = (
               <RecurringSchedulePicker
                 value={props.value}
@@ -357,7 +357,7 @@ export const GenericInput = ({
             content = (
               <DateSelect
                 ref={ref}
-                value={props.value}
+                value={typeof props.value === 'string' ? props.value : ''}
                 dateFormat={dateFormat}
                 openOnFocus={false}
                 inputProps={{ placeholder: dateFormat.toLowerCase() }}


### PR DESCRIPTION
## Summary
Fixes #6885 - Crash when rule has empty date field

## Problem
When creating a rule with a "set date" action:
1. Clicking the date entry field and then clicking elsewhere without entering a value
2. Triggers DateSelect's onBlur handler which calls `onSelect(null)` for empty values
3. GenericInput's condition `typeof props.value !== 'string'` evaluates to true for null (since `typeof null === 'object'`)
4. This causes RecurringSchedulePicker to render with a null value
5. RecurringSchedulePicker calls `getRecurringDescription(null, ...)` which crashes accessing `config.interval`

## Solution
- Add null check: `props.value != null && typeof props.value !== 'string'` before rendering RecurringSchedulePicker
- Ensure DateSelect receives an empty string instead of null: `typeof props.value === 'string' ? props.value : ''`

This ensures:
- RecurringSchedulePicker only renders for actual RecurConfig objects
- DateSelect handles null values gracefully by falling back to empty string

## Testing
Verified the fix prevents the crash when:
1. Creating a new rule
2. Changing action to "set date"
3. Clicking the date field then clicking elsewhere without entering a value