### PR TITLE
fix(schedules): prevent past missed schedule dates from being marked as upcoming

### DIFF
--- a/packages/desktop-client/src/components/mobile/schedules/SchedulesList.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/SchedulesList.tsx
@@ -6,13 +6,13 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
+import type { ScheduleStatusType } from 'loot-core/shared/schedules';
 import type { ScheduleEntity } from 'loot-core/types/models';
 
 import { SchedulesListItem } from './SchedulesListItem';
 
 import { ActionableGridListItem } from '@desktop-client/components/mobile/ActionableGridListItem';
 import { MOBILE_NAV_HEIGHT } from '@desktop-client/components/mobile/MobileNavTabs';
-import type { ScheduleStatusType } from '@desktop-client/hooks/useSchedules';
 
 type CompletedSchedulesItem = { id: 'show-completed' };
 type SchedulesListEntry = ScheduleEntity | CompletedSchedulesItem;

--- a/packages/desktop-client/src/components/mobile/schedules/SchedulesListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/SchedulesListItem.tsx
@@ -10,6 +10,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { format as monthUtilFormat } from 'loot-core/shared/months';
+import type { ScheduleStatusType } from 'loot-core/shared/schedules';
 import { getScheduledAmount } from 'loot-core/shared/schedules';
 import type { ScheduleEntity } from 'loot-core/types/models';
 import type { WithRequired } from 'loot-core/types/util';
@@ -19,7 +20,6 @@ import { StatusBadge } from '@desktop-client/components/schedules/StatusBadge';
 import { DisplayId } from '@desktop-client/components/util/DisplayId';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFormat } from '@desktop-client/hooks/useFormat';
-import type { ScheduleStatusType } from '@desktop-client/hooks/useSchedules';
 
 type SchedulesListItemProps = {
   onDelete: () => void;

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -40,6 +40,7 @@ import {
   parse,
   unparse,
 } from 'loot-core/shared/rules';
+import type { ScheduleStatusType } from 'loot-core/shared/schedules';
 import type {
   NewRuleEntity,
   RuleActionEntity,
@@ -58,7 +59,6 @@ import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFeatureFlag } from '@desktop-client/hooks/useFeatureFlag';
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useSchedules } from '@desktop-client/hooks/useSchedules';
-import type { ScheduleStatusType } from '@desktop-client/hooks/useSchedules';
 import {
   SelectedProvider,
   useSelected,

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -16,6 +16,10 @@ import { View } from '@actual-app/components/view';
 import { format as monthUtilFormat } from 'loot-core/shared/months';
 import { getNormalisedString } from 'loot-core/shared/normalisation';
 import { getScheduledAmount } from 'loot-core/shared/schedules';
+import type {
+  ScheduleStatuses,
+  ScheduleStatusType,
+} from 'loot-core/shared/schedules';
 import type { ScheduleEntity } from 'loot-core/types/models';
 
 import { StatusBadge } from './StatusBadge';
@@ -35,11 +39,6 @@ import { useContextMenu } from '@desktop-client/hooks/useContextMenu';
 import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import { usePayees } from '@desktop-client/hooks/usePayees';
-import type {
-  ScheduleStatuses,
-  ScheduleStatusType,
-} from '@desktop-client/hooks/useSchedules';
-
 type SchedulesTableProps = {
   isLoading?: boolean;
   schedules: readonly ScheduleEntity[];

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -15,9 +15,8 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { getStatusLabel } from 'loot-core/shared/schedules';
+import type { ScheduleStatusType } from 'loot-core/shared/schedules';
 import { titleFirst } from 'loot-core/shared/util';
-
-import type { ScheduleStatusType } from '@desktop-client/hooks/useSchedules';
 
 // Consists of Schedule Statuses + Transaction statuses
 export type StatusTypes =

--- a/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
+++ b/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplateIndicator.ts
@@ -6,11 +6,11 @@ import type { TFunction } from 'i18next';
 
 import * as monthUtils from 'loot-core/shared/months';
 import { getUpcomingDays } from 'loot-core/shared/schedules';
+import type { ScheduleStatusType } from 'loot-core/shared/schedules';
 import type { CategoryEntity, ScheduleEntity } from 'loot-core/types/models';
 
 import { useCategoryScheduleGoalTemplates } from './useCategoryScheduleGoalTemplates';
 import { useLocale } from './useLocale';
-import type { ScheduleStatusType } from './useSchedules';
 import { useSyncedPref } from './useSyncedPref';
 
 type UseCategoryScheduleGoalTemplateProps = {

--- a/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplates.ts
+++ b/packages/desktop-client/src/hooks/useCategoryScheduleGoalTemplates.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 
+import type { ScheduleStatuses } from 'loot-core/shared/schedules';
 import type { CategoryEntity, ScheduleEntity } from 'loot-core/types/models';
 
 import { useCachedSchedules } from './useCachedSchedules';
 import { useFeatureFlag } from './useFeatureFlag';
-import type { ScheduleStatuses, ScheduleStatusLabels } from './useSchedules';
+import type { ScheduleStatusLabels } from './useSchedules';
 
 type ScheduleGoalDefinition = {
   type: 'schedule';

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -1,22 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import * as d from 'date-fns';
-
 import { send } from 'loot-core/platform/client/fetch';
-import { addDays, currentDay, parseDate } from 'loot-core/shared/months';
-import {
-  extractScheduleConds,
-  getNextDate,
-  getScheduledAmount,
-  getUpcomingDays,
-  scheduleIsRecurring,
-} from 'loot-core/shared/schedules';
+import { computeSchedulePreviewTransactions } from 'loot-core/shared/schedules';
 import { ungroupTransactions } from 'loot-core/shared/transactions';
 import type { IntegerAmount } from 'loot-core/shared/util';
 import type { ScheduleEntity, TransactionEntity } from 'loot-core/types/models';
 
 import { useCachedSchedules } from './useCachedSchedules';
-import type { ScheduleStatuses } from './useSchedules';
 import { useSyncedPref } from './useSyncedPref';
 import { calculateRunningBalancesBottomUp } from './useTransactions';
 
@@ -74,76 +64,12 @@ export function usePreviewTransactions({
       return [];
     }
 
-    const schedulesForPreview = schedules
-      .filter(s => isForPreview(s, statuses))
-      .filter(filter ? filter : () => true);
-
-    const today = d.startOfDay(parseDate(currentDay()));
-
-    const upcomingPeriodEnd = d.startOfDay(
-      parseDate(addDays(today, getUpcomingDays(upcomingLength))),
+    return computeSchedulePreviewTransactions(
+      schedules,
+      statuses,
+      upcomingLength,
+      filter,
     );
-
-    return schedulesForPreview
-      .map(schedule => {
-        const { date: dateConditions } = extractScheduleConds(
-          schedule._conditions,
-        );
-
-        const status = statuses.get(schedule.id);
-        const isRecurring = scheduleIsRecurring(dateConditions);
-
-        const dates: string[] = [schedule.next_date];
-        let day = d.startOfDay(parseDate(schedule.next_date));
-        if (isRecurring) {
-          while (day <= upcomingPeriodEnd) {
-            const nextDate = getNextDate(dateConditions, day);
-
-            if (d.startOfDay(parseDate(nextDate)) > upcomingPeriodEnd) break;
-
-            if (dates.includes(nextDate)) {
-              day = d.startOfDay(parseDate(addDays(day, 1)));
-              continue;
-            }
-
-            dates.push(nextDate);
-            day = d.startOfDay(parseDate(addDays(nextDate, 1)));
-          }
-        }
-
-        if (status === 'paid') {
-          dates.shift();
-        }
-
-        const schedules: {
-          id: string;
-          payee: string;
-          account: string;
-          amount: number;
-          date: string;
-          schedule: string;
-          forceUpcoming: boolean;
-        }[] = [];
-        dates.forEach(date => {
-          schedules.push({
-            id: 'preview/' + schedule.id + `/${date}`,
-            payee: schedule._payee,
-            account: schedule._account,
-            amount: getScheduledAmount(schedule._amount),
-            date,
-            schedule: schedule.id,
-            forceUpcoming: date !== schedule.next_date || status === 'paid',
-          });
-        });
-
-        return schedules;
-      })
-      .flat()
-      .sort(
-        (a, b) =>
-          parseDate(b.date).getTime() - parseDate(a.date).getTime() ||
-          a.amount - b.amount,
-      );
   }, [filter, isSchedulesLoading, schedules, statuses, upcomingLength]);
 
   useEffect(() => {
@@ -220,12 +146,4 @@ export function usePreviewTransactions({
     isLoading: isLoading || isSchedulesLoading,
     ...(returnError && { error: returnError }),
   };
-}
-
-function isForPreview(schedule: ScheduleEntity, statuses: ScheduleStatuses) {
-  const status = statuses.get(schedule.id);
-  return (
-    !schedule.completed &&
-    ['due', 'upcoming', 'missed', 'paid'].includes(status!)
-  );
 }

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -7,6 +7,7 @@ import {
   getStatus,
   getStatusLabel,
 } from 'loot-core/shared/schedules';
+import type { ScheduleStatuses } from 'loot-core/shared/schedules';
 import type {
   AccountEntity,
   ScheduleEntity,
@@ -18,9 +19,6 @@ import { useSyncedPref } from './useSyncedPref';
 import { accountFilter } from '@desktop-client/queries';
 import { liveQuery } from '@desktop-client/queries/liveQuery';
 import type { LiveQuery } from '@desktop-client/queries/liveQuery';
-
-export type ScheduleStatusType = ReturnType<typeof getStatus>;
-export type ScheduleStatuses = Map<ScheduleEntity['id'], ScheduleStatusType>;
 
 export type ScheduleStatusLabelType = ReturnType<typeof getStatusLabel>;
 export type ScheduleStatusLabels = Map<

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -469,3 +469,93 @@ export function scheduleIsRecurring(dateCond: Condition | null) {
 
   return value.type === 'recur';
 }
+
+export type ScheduleStatusType = ReturnType<typeof getStatus>;
+export type ScheduleStatuses = Map<ScheduleEntity['id'], ScheduleStatusType>;
+
+export function isForPreview(
+  schedule: ScheduleEntity,
+  statuses: ScheduleStatuses,
+) {
+  const status = statuses.get(schedule.id);
+  return (
+    !schedule.completed &&
+    ['due', 'upcoming', 'missed', 'paid'].includes(status!)
+  );
+}
+
+export function computeSchedulePreviewTransactions(
+  schedules: readonly ScheduleEntity[],
+  statuses: ScheduleStatuses,
+  upcomingLength?: string,
+  filter?: (schedule: ScheduleEntity) => boolean,
+) {
+  const schedulesForPreview = schedules
+    .filter(s => isForPreview(s, statuses))
+    .filter(filter ? filter : () => true);
+
+  const today = d.startOfDay(monthUtils.parseDate(monthUtils.currentDay()));
+
+  const upcomingPeriodEnd = d.startOfDay(
+    monthUtils.parseDate(
+      monthUtils.addDays(today, getUpcomingDays(upcomingLength)),
+    ),
+  );
+
+  return schedulesForPreview
+    .flatMap(schedule => {
+      const { date: dateConditions } = extractScheduleConds(
+        schedule._conditions,
+      );
+
+      const status = statuses.get(schedule.id);
+      const isRecurring = scheduleIsRecurring(dateConditions);
+
+      const dates = [schedule.next_date];
+      let day = d.startOfDay(monthUtils.parseDate(schedule.next_date));
+      if (isRecurring) {
+        while (day <= upcomingPeriodEnd) {
+          const nextDate = getNextDate(dateConditions, day);
+
+          if (
+            d.startOfDay(monthUtils.parseDate(nextDate)) > upcomingPeriodEnd
+          ) {
+            break;
+          }
+
+          if (dates.includes(nextDate)) {
+            day = d.startOfDay(
+              monthUtils.parseDate(monthUtils.addDays(day, 1)),
+            );
+            continue;
+          }
+
+          dates.push(nextDate);
+          day = d.startOfDay(
+            monthUtils.parseDate(monthUtils.addDays(nextDate, 1)),
+          );
+        }
+      }
+
+      if (status === 'paid') {
+        dates.shift();
+      }
+
+      return dates.map(date => ({
+        id: 'preview/' + schedule.id + `/${date}`,
+        payee: schedule._payee,
+        account: schedule._account,
+        amount: getScheduledAmount(schedule._amount),
+        date,
+        schedule: schedule.id,
+        forceUpcoming:
+          (date !== schedule.next_date || status === 'paid') &&
+          date >= monthUtils.currentDay(),
+      }));
+    })
+    .sort(
+      (a, b) =>
+        monthUtils.parseDate(b.date).getTime() -
+          monthUtils.parseDate(a.date).getTime() || a.amount - b.amount,
+    );
+}

--- a/upcoming-release-notes/6925.md
+++ b/upcoming-release-notes/6925.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [rznn7]
+---
+
+Prevent past missed schedule dates from being marked as upcoming


### PR DESCRIPTION
Fixes a bug where past missed recurring schedule dates were incorrectly shown as "upcoming" in preview transactions. Added a date check so only future dates can be forced to upcoming status.

Also moved the preview transaction logic from `usePreviewTransactions` into a shared `computeSchedulePreviewTransactions` function in loot-core so it can be tested, and added tests for the `forceUpcoming` flag behavior.

Fixes #6872.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.64 MB → 14.64 MB (+70 B) | +0.00%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.64 MB → 14.64 MB (+70 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.81 kB (+17.43%) | 10.4 kB → 12.22 kB
`src/hooks/usePreviewTransactions.ts` | 📉 -1.75 kB (-37.13%) | 4.7 kB → 2.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.48 MB → 9.48 MB (+1.81 kB) | +0.02%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/usePayeeRuleCounts.js | 11.79 kB → 10.05 kB (-1.75 kB) | -14.80%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 178.39 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 164.55 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.62 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.12 MB | 0%
static/js/narrow.js | 640.46 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BmGAOUic.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.39 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->