### PR TITLE
React Query - clear cache when closing budget (similar to resetApp redux action)

### DIFF
--- a/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
+++ b/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
@@ -100,10 +100,11 @@ export const loadBudget = createAppAsyncThunk(
 
 export const closeBudget = createAppAsyncThunk(
   `${sliceName}/closeBudget`,
-  async (_, { dispatch, getState }) => {
+  async (_, { dispatch, getState, extra: { queryClient } }) => {
     const prefs = getState().prefs.local;
     if (prefs && prefs.id) {
       await dispatch(resetApp());
+      queryClient.clear()
       await dispatch(setAppState({ loadingText: t('Closing...') }));
       await send('close-budget');
       await dispatch(setAppState({ loadingText: null }));
@@ -116,10 +117,11 @@ export const closeBudget = createAppAsyncThunk(
 
 export const closeBudgetUI = createAppAsyncThunk(
   `${sliceName}/closeBudgetUI`,
-  async (_, { dispatch, getState }) => {
+  async (_, { dispatch, getState, extra: { queryClient } }) => {
     const prefs = getState().prefs.local;
     if (prefs && prefs.id) {
       await dispatch(resetApp());
+      queryClient.clear();
     }
   },
 );

--- a/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
+++ b/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
@@ -104,7 +104,7 @@ export const closeBudget = createAppAsyncThunk(
     const prefs = getState().prefs.local;
     if (prefs && prefs.id) {
       await dispatch(resetApp());
-      queryClient.clear()
+      queryClient.clear();
       await dispatch(setAppState({ loadingText: t('Closing...') }));
       await send('close-budget');
       await dispatch(setAppState({ loadingText: null }));

--- a/upcoming-release-notes/6929.md
+++ b/upcoming-release-notes/6929.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [joel-jeremy]
+---
+
+Clear React Query cache upon closing a budget, enhancing data freshness and application performance.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.48 MB → 14.48 MB (+114 B) | +0.00%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.48 MB → 14.48 MB (+114 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budgetfiles/budgetfilesSlice.ts` | 📈 +114 B (+0.94%) | 11.85 kB → 11.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.33 MB → 9.33 MB (+114 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 178.39 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 164.55 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.62 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.12 MB | 0%
static/js/narrow.js | 640.46 kB | 0%
static/js/TransactionList.js | 105.97 kB | 0%
static/js/wide.js | 160.07 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.79 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BmGAOUic.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.39 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->