### PR TITLE
Add ACTUAL_USER_CREATION_MODE documentation to oauth-auth.md

### DIFF
--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -114,6 +114,10 @@ When setup is done, you will be redirected to the _login_ page:
 
 ![](/img/oauth/first-login.webp)
 
+:::warning
+The first user to log in with OpenID/OAuth2 will be granted admin permissions and become the server owner. The server owner cannot be changed from the UI once set.
+:::
+
 ### Environment Variables
 
 #### `ACTUAL_OPENID_DISCOVERY_URL`
@@ -178,10 +182,6 @@ Use `oauth2` for providers like GitHub that don't fully support OpenID discovery
 #### `ACTUAL_USER_CREATION_MODE`
 
 - **Purpose:** In `manual` (default) users must be created manually with matching usernames in Actual before they are able to authenticate with OpenID/OAuth2. When set to `login`, users authenticating with OpenID/OAuth2 for the first time will be created in Actual automatically.
-
-  :::warning
-  The first user to log in with OpenID/OAuth2 will be granted admin permissions and become the server owner. The server owner cannot be changed from the UI once set.
-  :::
 
   **Possible Values:** `manual` or `login` (default is `manual`)
 


### PR DESCRIPTION
Just adds information for user creation mode, which is a recent feature and not yet documented. Took me a short while to find this feature, hopefully this makes it easier for others in the future!