### PR TITLE
[WIP] Fix: Prevent single-slash paths like /word from being parsed as filepath

### DIFF
--- a/packages/desktop-client/src/notes/linkParser.ts
+++ b/packages/desktop-client/src/notes/linkParser.ts
@@ -13,7 +13,7 @@ export type ParsedSegment =
 const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\(([^)]+)\)/;
 const FULL_URL_REGEX = /https?:\/\/[^\s]+/;
 const WWW_URL_REGEX = /www\.[^\s]+/;
-const UNIX_PATH_REGEX = /^\/(?:[^\s/]+\/)*[^\s/]+$/;
+const UNIX_PATH_REGEX = /^\/[^\s\/]+\/[^\s]*$/;
 const WINDOWS_PATH_REGEX = /^[A-Z]:\\(?:[^\s\\]+\\)*[^\s\\]+$/i;
 
 // Common trailing punctuation that should not be part of URLs


### PR DESCRIPTION
The previous UNIX_PATH_REGEX pattern matched any string starting with '/' followed by one or more path segments. This caused simple words like '/transaction' or '/word' in transaction notes to be incorrectly parsed as file paths and rendered as clickable buttons.

This change updates the regex to require at least two path segments (e.g., '/usr/bin' or '/home/user/file.txt'), preventing single-segment paths like '/word' from being treated as filepaths.

**Changes:**
- Updated UNIX_PATH_REGEX from `/^\/(?:[^\s\/]+\/)*[^\s\/]+$/` to `/^\/[^\s\/]+\/[^\s]*$/`
- New pattern requires: start with '/', at least one non-whitespace/non-slash segment, another '/', then any non-whitespace characters
- This prevents '/word' from matching while still allowing legitimate paths like '/usr/bin' or '/home/user/file.txt'

**Result:**
Words like '/transaction' in notes will now display as regular text instead of being converted to underlined, pink button elements.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.65 MB → 14.65 MB (-5 B) | -0.00%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.65 MB → 14.65 MB (-5 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/notes/linkParser.ts` | 📉 -5 B (-0.11%) | 4.26 kB → 4.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.48 MB → 9.48 MB (-5 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 180.44 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 164.55 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.62 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.13 MB | 0%
static/js/narrow.js | 641.33 kB | 0%
static/js/TransactionList.js | 106.13 kB | 0%
static/js/wide.js | 164.05 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.05 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.NVz4zlvh.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.39 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->