### PR TITLE
Fix mobile budget amount inputs when hide decimal places is enabled

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -460,7 +460,7 @@ const ChildTransactionEdit = forwardRef<
                   onClearActiveEdit();
                 }
               }}
-              autoDecimals={!hideFraction}
+              autoDecimals={String(hideFraction) !== 'true'}
             />
           </View>
         </View>

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -24,6 +24,7 @@ import {
 import { AmountInput } from '@desktop-client/components/util/AmountInput';
 import { useCategories } from '@desktop-client/hooks/useCategories';
 import { useInitialMount } from '@desktop-client/hooks/useInitialMount';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import type { Modal as ModalType } from '@desktop-client/modals/modalsSlice';
 import { useDispatch } from '@desktop-client/redux';
@@ -39,6 +40,7 @@ export function CoverModal({
   onSubmit,
 }: CoverModalProps) {
   const { t } = useTranslation();
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =
     useCategories();
@@ -107,7 +109,7 @@ export function CoverModal({
             <InitialFocus>
               <AmountInput
                 value={amount}
-                autoDecimals
+                autoDecimals={String(hideFraction) !== 'true'}
                 style={{
                   marginLeft: styles.mobileEditingPadding,
                   marginRight: styles.mobileEditingPadding,

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@desktop-client/components/common/Modal';
 import { FieldLabel } from '@desktop-client/components/mobile/MobileForms';
 import { AmountInput } from '@desktop-client/components/util/AmountInput';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import type { Modal as ModalType } from '@desktop-client/modals/modalsSlice';
 import { envelopeBudget } from '@desktop-client/spreadsheet/bindings';
 
@@ -24,6 +25,7 @@ type HoldBufferModalProps = Extract<
 
 export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
   const { t } = useTranslation(); // Initialize i18next
+  const [hideFraction] = useSyncedPref('hideFraction');
   const available = useEnvelopeSheetValue(envelopeBudget.toBudget) ?? 0;
   const [amount, setAmount] = useState<number>(0);
 
@@ -49,8 +51,8 @@ export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
             <FieldLabel title={t('Hold this amount:')} />{' '}
             <InitialFocus>
               <AmountInput
-                value={available}
-                autoDecimals
+                value={amount}
+                autoDecimals={String(hideFraction) !== 'true'}
                 zeroSign="+"
                 style={{
                   marginLeft: styles.mobileEditingPadding,

--- a/packages/desktop-client/src/components/modals/TransferModal.tsx
+++ b/packages/desktop-client/src/components/modals/TransferModal.tsx
@@ -23,6 +23,7 @@ import {
 } from '@desktop-client/components/mobile/MobileForms';
 import { AmountInput } from '@desktop-client/components/util/AmountInput';
 import { useCategories } from '@desktop-client/hooks/useCategories';
+import { useSyncedPref } from '@desktop-client/hooks/useSyncedPref';
 import { pushModal } from '@desktop-client/modals/modalsSlice';
 import type { Modal as ModalType } from '@desktop-client/modals/modalsSlice';
 import { useDispatch } from '@desktop-client/redux';
@@ -38,6 +39,7 @@ export function TransferModal({
   onSubmit,
 }: TransferModalProps) {
   const { t } = useTranslation();
+  const [hideFraction] = useSyncedPref('hideFraction');
 
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =
     useCategories();
@@ -99,8 +101,8 @@ export function TransferModal({
               <FieldLabel title={t('Transfer this amount:')} />
               <InitialFocus>
                 <AmountInput
-                  value={initialAmount}
-                  autoDecimals
+                  value={amount}
+                  autoDecimals={String(hideFraction) !== 'true'}
                   style={{
                     marginLeft: styles.mobileEditingPadding,
                     marginRight: styles.mobileEditingPadding,

--- a/upcoming-release-notes/6945.md
+++ b/upcoming-release-notes/6945.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [piyush-1337]
+---
+
+Fix mobile budget amount inputs when hide decimal places is enabled


### PR DESCRIPTION
Fixes #6778

use ```useSyncedPref``` in the ```TransferModal```, ```CoverModal```, ```HoldBufferModal``` to respect the hide decimal checkbox

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.65 MB → 14.65 MB (+395 B) | +0.00%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.65 MB → 14.65 MB (+395 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/HoldBufferModal.tsx` | 📈 +86 B (+3.20%) | 2.62 kB → 2.71 kB
`src/components/modals/CoverModal.tsx` | 📈 +135 B (+2.20%) | 5.99 kB → 6.12 kB
`src/components/modals/TransferModal.tsx` | 📈 +74 B (+1.33%) | 5.42 kB → 5.49 kB
`locale/en.json` | 📈 +82 B (+0.05%) | 164.55 kB → 164.63 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +18 B (+0.03%) | 61.47 kB → 61.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.48 MB → 9.48 MB (+313 B) | +0.00%
static/js/en.js | 164.55 kB → 164.63 kB (+82 B) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 180.44 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.62 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.13 MB | 0%
static/js/narrow.js | 637.46 kB | 0%
static/js/TransactionList.js | 106.13 kB | 0%
static/js/wide.js | 164.05 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.05 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.NVz4zlvh.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.39 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.39 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->