### PR TITLE
[AI] lint: convert oxlint rules from warn to error

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -20,72 +20,72 @@
   "rules": {
     // Import sorting
     "perfectionist/sort-named-imports": [
-      "warn",
+      "error",
       {
         "groups": ["value-import", "type-import"]
       }
     ],
 
     // Actual rules
-    "actual/typography": "warn",
+    "actual/typography": "error",
     "actual/no-untranslated-strings": "error",
     "actual/prefer-trans-over-t": "error",
-    "actual/prefer-if-statement": "warn",
+    "actual/prefer-if-statement": "error",
     "actual/prefer-logger-over-console": "error",
-    "actual/object-shorthand-properties": "warn",
-    "actual/prefer-const": "warn",
-    "actual/no-anchor-tag": "warn",
-    "actual/no-react-default-import": "warn",
+    "actual/object-shorthand-properties": "error",
+    "actual/prefer-const": "error",
+    "actual/no-anchor-tag": "error",
+    "actual/no-react-default-import": "error",
 
     // JSX A11y rules
     "jsx-a11y/no-autofocus": [
-      "warn",
+      "error",
       {
         "ignoreNonDOM": true
       }
     ],
-    "jsx-a11y/alt-text": "warn",
-    "jsx-a11y/anchor-has-content": "warn",
+    "jsx-a11y/alt-text": "error",
+    "jsx-a11y/anchor-has-content": "error",
     "jsx-a11y/anchor-is-valid": [
-      "warn",
+      "error",
       {
         "aspects": ["noHref", "invalidHref"]
       }
     ],
-    "jsx-a11y/aria-activedescendant-has-tabindex": "warn",
-    "jsx-a11y/aria-props": "warn",
-    "jsx-a11y/aria-proptypes": "warn",
+    "jsx-a11y/aria-activedescendant-has-tabindex": "error",
+    "jsx-a11y/aria-props": "error",
+    "jsx-a11y/aria-proptypes": "error",
     "jsx-a11y/aria-role": [
-      "warn",
+      "error",
       {
         "ignoreNonDOM": true
       }
     ],
-    "jsx-a11y/aria-unsupported-elements": "warn",
-    "jsx-a11y/heading-has-content": "warn",
-    "jsx-a11y/iframe-has-title": "warn",
-    "jsx-a11y/img-redundant-alt": "warn",
-    "jsx-a11y/no-access-key": "warn",
-    "jsx-a11y/no-distracting-elements": "warn",
-    "jsx-a11y/no-redundant-roles": "warn",
-    "jsx-a11y/role-has-required-aria-props": "warn",
-    "jsx-a11y/role-supports-aria-props": "warn",
-    "jsx-a11y/scope": "warn",
+    "jsx-a11y/aria-unsupported-elements": "error",
+    "jsx-a11y/heading-has-content": "error",
+    "jsx-a11y/iframe-has-title": "error",
+    "jsx-a11y/img-redundant-alt": "error",
+    "jsx-a11y/no-access-key": "error",
+    "jsx-a11y/no-distracting-elements": "error",
+    "jsx-a11y/no-redundant-roles": "error",
+    "jsx-a11y/role-has-required-aria-props": "error",
+    "jsx-a11y/role-supports-aria-props": "error",
+    "jsx-a11y/scope": "error",
 
     // Typescript rules
-    "typescript/ban-ts-comment": ["warn"],
-    "typescript/consistent-type-definitions": ["warn", "type"],
+    "typescript/ban-ts-comment": ["error"],
+    "typescript/consistent-type-definitions": ["error", "type"],
     "typescript/consistent-type-imports": [
-      "warn",
+      "error",
       {
         "prefer": "type-imports",
         "fixStyle": "inline-type-imports"
       }
     ],
-    "typescript/no-implied-eval": "warn",
-    "typescript/no-explicit-any": "warn",
+    "typescript/no-implied-eval": "error",
+    "typescript/no-explicit-any": "error",
     "typescript/no-restricted-types": [
-      "warn",
+      "error",
       {
         "types": {
           // forbid FC as superfluous
@@ -98,19 +98,19 @@
         }
       }
     ],
-    "typescript/no-var-requires": "warn",
+    "typescript/no-var-requires": "error",
 
     // Import rules
-    "import/consistent-type-specifier-style": "warn",
+    "import/consistent-type-specifier-style": "error",
     "import/first": "error",
     "import/no-amd": "error",
-    "import/no-default-export": "warn",
+    "import/no-default-export": "error",
     "import/no-webpack-loader-syntax": "error",
-    "import/no-useless-path-segments": "warn",
-    "import/no-unresolved": "warn",
-    "import/no-unused-modules": "warn",
+    "import/no-useless-path-segments": "error",
+    "import/no-unresolved": "error",
+    "import/no-unused-modules": "error",
     "import/no-duplicates": [
-      "warn",
+      "error",
       {
         "prefer-inline": false
       }
@@ -118,122 +118,122 @@
 
     // React rules
     "react/exhaustive-deps": [
-      "warn",
+      "error",
       {
         "additionalHooks": "(^useQuery$|^useEffectAfterMount$)"
       }
     ],
-    "react/jsx-curly-brace-presence": "warn",
+    "react/jsx-curly-brace-presence": "error",
     "react/jsx-filename-extension": [
-      "warn",
+      "error",
       {
         "extensions": [".jsx", ".tsx"],
         "allow": "as-needed"
       }
     ],
-    "react/jsx-no-comment-textnodes": "warn",
-    "react/jsx-no-duplicate-props": "warn",
-    "react/jsx-no-target-blank": "warn",
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-duplicate-props": "error",
+    "react/jsx-no-target-blank": "error",
     "react/jsx-no-undef": "error",
-    "react/jsx-no-useless-fragment": "warn",
+    "react/jsx-no-useless-fragment": "error",
     "react/jsx-pascal-case": [
-      "warn",
+      "error",
       {
         "allowAllCaps": true,
         "ignore": []
       }
     ],
-    "react/no-danger-with-children": "warn",
-    "react/no-direct-mutation-state": "warn",
-    "react/no-is-mounted": "warn",
-    "react/no-unstable-nested-components": "warn",
+    "react/no-danger-with-children": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/no-is-mounted": "error",
+    "react/no-unstable-nested-components": "error",
     "react/require-render-return": "error",
     "react/rules-of-hooks": "error",
-    "react/self-closing-comp": "warn",
-    "react/style-prop-object": "warn",
-    "react/jsx-boolean-value": "warn",
+    "react/self-closing-comp": "error",
+    "react/style-prop-object": "error",
+    "react/jsx-boolean-value": "error",
 
     // ESLint rules
-    "eslint/array-callback-return": "warn",
-    "eslint/curly": ["warn", "multi-line", "consistent"],
+    "eslint/array-callback-return": "error",
+    "eslint/curly": ["error", "multi-line", "consistent"],
     "eslint/default-case": [
-      "warn",
+      "error",
       {
         "commentPattern": "^no default$"
       }
     ],
-    "eslint/eqeqeq": ["warn", "smart"],
-    "eslint/no-array-constructor": "warn",
-    "eslint/no-caller": "warn",
-    "eslint/no-cond-assign": ["warn", "except-parens"],
-    "eslint/no-const-assign": "warn",
-    "eslint/no-control-regex": "warn",
-    "eslint/no-delete-var": "warn",
-    "eslint/no-dupe-class-members": "warn",
-    "eslint/no-dupe-keys": "warn",
-    "eslint/no-duplicate-case": "warn",
-    "eslint/no-empty-character-class": "warn",
-    "eslint/no-empty-function": "warn",
-    "eslint/no-empty-pattern": "warn",
-    "eslint/no-eval": "warn",
-    "eslint/no-ex-assign": "warn",
-    "eslint/no-extend-native": "warn",
-    "eslint/no-extra-bind": "warn",
-    "eslint/no-extra-label": "warn",
-    "eslint/no-fallthrough": "warn",
-    "eslint/no-func-assign": "warn",
-    "eslint/no-invalid-regexp": "warn",
-    "eslint/no-iterator": "warn",
-    "eslint/no-label-var": "warn",
-    "eslint/no-var": "warn",
+    "eslint/eqeqeq": ["error", "smart"],
+    "eslint/no-array-constructor": "error",
+    "eslint/no-caller": "error",
+    "eslint/no-cond-assign": ["error", "except-parens"],
+    "eslint/no-const-assign": "error",
+    "eslint/no-control-regex": "error",
+    "eslint/no-delete-var": "error",
+    "eslint/no-dupe-class-members": "error",
+    "eslint/no-dupe-keys": "error",
+    "eslint/no-duplicate-case": "error",
+    "eslint/no-empty-character-class": "error",
+    "eslint/no-empty-function": "error",
+    "eslint/no-empty-pattern": "error",
+    "eslint/no-eval": "error",
+    "eslint/no-ex-assign": "error",
+    "eslint/no-extend-native": "error",
+    "eslint/no-extra-bind": "error",
+    "eslint/no-extra-label": "error",
+    "eslint/no-fallthrough": "error",
+    "eslint/no-func-assign": "error",
+    "eslint/no-invalid-regexp": "error",
+    "eslint/no-iterator": "error",
+    "eslint/no-label-var": "error",
+    "eslint/no-var": "error",
     "eslint/no-labels": [
-      "warn",
+      "error",
       {
         "allowLoop": true,
         "allowSwitch": false
       }
     ],
-    "eslint/no-new-func": "warn",
-    "eslint/no-script-url": "warn",
-    "eslint/no-self-assign": "warn",
-    "eslint/no-self-compare": "warn",
-    "eslint/no-sequences": "warn",
-    "eslint/no-shadow-restricted-names": "warn",
-    "eslint/no-sparse-arrays": "warn",
-    "eslint/no-template-curly-in-string": "warn",
-    "eslint/no-this-before-super": "warn",
-    "eslint/no-throw-literal": "warn",
-    "eslint/no-unreachable": "warn",
-    "eslint/no-obj-calls": "warn",
-    "eslint/no-new-wrappers": "warn",
-    "eslint/no-unsafe-negation": "warn",
-    "eslint/no-multi-str": "warn",
-    "eslint/no-global-assign": "warn",
-    "eslint/no-lone-blocks": "warn",
-    "eslint/no-unused-labels": "warn",
-    "eslint/no-object-constructor": "warn",
-    "eslint/no-new-native-nonconstructor": "warn",
-    "eslint/no-redeclare": "warn",
-    "eslint/no-useless-computed-key": "warn",
-    "eslint/no-useless-concat": "warn",
-    "eslint/no-useless-escape": "warn",
-    "eslint/require-yield": "warn",
-    "eslint/getter-return": "warn",
-    "eslint/unicode-bom": ["warn", "never"],
-    "eslint/no-use-isnan": "warn",
-    "eslint/valid-typeof": "warn",
+    "eslint/no-new-func": "error",
+    "eslint/no-script-url": "error",
+    "eslint/no-self-assign": "error",
+    "eslint/no-self-compare": "error",
+    "eslint/no-sequences": "error",
+    "eslint/no-shadow-restricted-names": "error",
+    "eslint/no-sparse-arrays": "error",
+    "eslint/no-template-curly-in-string": "error",
+    "eslint/no-this-before-super": "error",
+    "eslint/no-throw-literal": "error",
+    "eslint/no-unreachable": "error",
+    "eslint/no-obj-calls": "error",
+    "eslint/no-new-wrappers": "error",
+    "eslint/no-unsafe-negation": "error",
+    "eslint/no-multi-str": "error",
+    "eslint/no-global-assign": "error",
+    "eslint/no-lone-blocks": "error",
+    "eslint/no-unused-labels": "error",
+    "eslint/no-object-constructor": "error",
+    "eslint/no-new-native-nonconstructor": "error",
+    "eslint/no-redeclare": "error",
+    "eslint/no-useless-computed-key": "error",
+    "eslint/no-useless-concat": "error",
+    "eslint/no-useless-escape": "error",
+    "eslint/require-yield": "error",
+    "eslint/getter-return": "error",
+    "eslint/unicode-bom": ["error", "never"],
+    "eslint/no-use-isnan": "error",
+    "eslint/valid-typeof": "error",
     "eslint/no-useless-rename": [
-      "warn",
+      "error",
       {
         "ignoreDestructuring": false,
         "ignoreImport": false,
         "ignoreExport": false
       }
     ],
-    "eslint/no-with": "warn",
-    "eslint/no-regex-spaces": "warn",
+    "eslint/no-with": "error",
+    "eslint/no-regex-spaces": "error",
     "eslint/no-restricted-globals": [
-      "warn",
+      "error",
 
       // https://github.com/facebook/create-react-app/tree/main/packages/confusing-browser-globals
       "addEventListener",
@@ -295,7 +295,7 @@
       "top"
     ],
     "eslint/no-restricted-imports": [
-      "warn",
+      "error",
       {
         "paths": [
           {
@@ -345,9 +345,9 @@
         ]
       }
     ],
-    "eslint/no-useless-constructor": "warn",
-    "eslint/no-undef": "warn",
-    "eslint/no-unused-expressions": "warn"
+    "eslint/no-useless-constructor": "error",
+    "eslint/no-undef": "error",
+    "eslint/no-unused-expressions": "error"
   },
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "vrt:docker": "./bin/run-vrt",
     "rebuild-electron": "./node_modules/.bin/electron-rebuild -m ./packages/loot-core",
     "rebuild-node": "yarn workspace loot-core rebuild",
-    "lint": "oxfmt --check . && oxlint --deny-warnings",
-    "lint:fix": "oxfmt . && oxlint --deny-warnings --fix",
+    "lint": "oxfmt --check . && oxlint",
+    "lint:fix": "oxfmt . && oxlint --fix",
     "install:server": "yarn workspaces focus @actual-app/sync-server --production",
     "typecheck": "yarn tsc --incremental && tsc-strict",
     "jq": "./node_modules/node-jq/bin/jq",
@@ -95,7 +95,7 @@
       "oxfmt --no-error-on-unmatched-pattern"
     ],
     "*.{js,mjs,jsx,ts,tsx}": [
-      "oxlint --deny-warnings --fix"
+      "oxlint --fix"
     ]
   },
   "browserslist": [

--- a/upcoming-release-notes/6970.md
+++ b/upcoming-release-notes/6970.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+lint: convert warnings to errors


### PR DESCRIPTION
This PR converts existing oxlint rules from `warn` to `error` to establish a strict baseline.

**Reason / follow-up intent:** I want to add more eslint/oxlint rules that act as **recommendations** (i.e. `warn`) rather than mandatory. For example: enforcing no manual type coercions (`x as Type`) — those should be warns so we can improve the codebase gradually without blocking. Having a clear split (current rules = error, new style rules = warn) makes this easier.

Made with [Cursor](https://cursor.com)

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.75 MB → 14.77 MB (+15.68 kB) | +0.10%
loot-core | 1 | 5.86 MB → 5.86 MB (+977 B) | +0.02%
api | 1 | 4.4 MB → 4.4 MB (+889 B) | +0.02%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.75 MB → 14.77 MB (+15.68 kB) | +0.10%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/accounts/mutations.ts` | 🆕 +21.82 kB | 0 B → 21.82 kB
`src/accounts/queries.ts` | 🆕 +1.02 kB | 0 B → 1.02 kB
`src/hooks/useClosedAccounts.ts` | 📈 +100 B (+31.35%) | 319 B → 419 B
`src/hooks/useOffBudgetAccounts.ts` | 📈 +76 B (+21.78%) | 349 B → 425 B
`src/hooks/useOnBudgetAccounts.ts` | 📈 +75 B (+21.55%) | 348 B → 423 B
`src/hooks/useAccount.ts` | 📈 +46 B (+11.17%) | 412 B → 458 B
`src/modals/modalsSlice.ts` | 📈 +96 B (+4.49%) | 2.09 kB → 2.18 kB
`src/components/accounts/Account.tsx` | 📈 +1.2 kB (+2.47%) | 48.75 kB → 49.96 kB
`src/components/modals/CreateLocalAccountModal.tsx` | 📈 +141 B (+2.15%) | 6.4 kB → 6.54 kB
`src/components/banksync/EditSyncAccount.tsx` | 📈 +133 B (+1.80%) | 7.23 kB → 7.36 kB
`src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx` | 📈 +142 B (+1.41%) | 9.83 kB → 9.97 kB
`src/components/mobile/accounts/AccountPage.tsx` | 📈 +140 B (+1.38%) | 9.93 kB → 10.07 kB
`src/global-events.ts` | 📈 +49 B (+1.26%) | 3.79 kB → 3.83 kB
`src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx` | 📈 +355 B (+1.23%) | 28.1 kB → 28.45 kB
`src/components/sidebar/Account.tsx` | 📈 +164 B (+1.21%) | 13.21 kB → 13.37 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +456 B (+1.05%) | 42.6 kB → 43.05 kB
`src/components/modals/CloseAccountModal.tsx` | 📈 +104 B (+0.87%) | 11.68 kB → 11.79 kB
`src/components/accounts/AccountSyncCheck.tsx` | 📈 +59 B (+0.63%) | 9.2 kB → 9.26 kB
`src/components/mobile/accounts/AccountTransactions.tsx` | 📈 +60 B (+0.62%) | 9.51 kB → 9.57 kB
`src/sync-events.ts` | 📈 +53 B (+0.52%) | 9.86 kB → 9.92 kB
`src/components/FinancesApp.tsx` | 📈 +94 B (+0.50%) | 18.5 kB → 18.59 kB
`src/budget/mutations.ts` | 📈 +92 B (+0.42%) | 21.48 kB → 21.57 kB
`src/components/mobile/accounts/AccountsPage.tsx` | 📈 +58 B (+0.26%) | 21.43 kB → 21.49 kB
`src/components/sidebar/Accounts.tsx` | 📈 +17 B (+0.20%) | 8.46 kB → 8.48 kB
`src/components/rules/RuleEditor.tsx` | 📉 -2 B (-0.00%) | 49.43 kB → 49.43 kB
`src/components/rules/RuleRow.tsx` | 📉 -2 B (-0.02%) | 10.83 kB → 10.83 kB
`src/hooks/useFailedAccounts.ts` | 📉 -2 B (-0.54%) | 367 B → 365 B
`src/app/appSlice.ts` | 📉 -605 B (-18.19%) | 3.25 kB → 2.66 kB
`src/hooks/useAccounts.ts` | 📉 -407 B (-50.00%) | 814 B → 407 B
`src/accounts/accountsSlice.ts` | 📉 -9.83 kB (-88.27%) | 11.13 kB → 1.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.49 MB → 9.5 MB (+14.22 kB) | +0.15%
static/js/wide.js | 164.05 kB → 165.25 kB (+1.2 kB) | +0.73%
static/js/narrow.js | 638.5 kB → 638.75 kB (+258 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 96.92 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 180.44 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 165.58 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.97 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.13 MB | 0%
static/js/TransactionList.js | 106.13 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.05 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB → 5.86 MB (+977 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +966 B (+3.58%) | 26.34 kB → 27.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +11 B (+0.04%) | 25.94 kB → 25.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D5WUU_Sw.js | 0 B → 5.86 MB (+5.86 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hYlRL2CV.js | 5.86 MB → 0 B (-5.86 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.4 MB → 4.4 MB (+889 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/server/accounts/app.ts` | 📈 +878 B (+3.82%) | 22.47 kB → 23.33 kB
`src/server/api.ts` | 📈 +11 B (+0.05%) | 22.7 kB → 22.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.4 MB → 4.4 MB (+889 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->