### PR TITLE
[AI] lint: introduce type-aware linting

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -99,6 +99,8 @@
       }
     ],
     "typescript/no-var-requires": "error",
+    // we want to allow unions such as "{ name: DbAccount['name'] | DbPayee['name'] }"
+    "typescript/no-duplicate-type-constituents": "off",
 
     // Import rules
     "import/consistent-type-specifier-style": "error",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "vrt:docker": "./bin/run-vrt",
     "rebuild-electron": "./node_modules/.bin/electron-rebuild -m ./packages/loot-core",
     "rebuild-node": "yarn workspace loot-core rebuild",
-    "lint": "oxfmt --check . && oxlint",
-    "lint:fix": "oxfmt . && oxlint --fix",
+    "lint": "oxfmt --check . && oxlint --type-aware",
+    "lint:fix": "oxfmt . && oxlint --fix --type-aware",
     "install:server": "yarn workspaces focus @actual-app/sync-server --production",
     "typecheck": "yarn tsc --incremental && tsc-strict",
     "jq": "./node_modules/node-jq/bin/jq",
@@ -79,6 +79,7 @@
     "npm-run-all": "^4.1.5",
     "oxfmt": "^0.32.0",
     "oxlint": "^1.47.0",
+    "oxlint-tsgolint": "^0.13.0",
     "p-limit": "^7.2.0",
     "prompts": "^2.4.2",
     "source-map-support": "^0.5.21",
@@ -95,7 +96,7 @@
       "oxfmt --no-error-on-unmatched-pattern"
     ],
     "*.{js,mjs,jsx,ts,tsx}": [
-      "oxlint --fix"
+      "oxlint --fix --type-aware"
     ]
   },
   "browserslist": [

--- a/upcoming-release-notes/6984.md
+++ b/upcoming-release-notes/6984.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+lint: introduce type-aware linting

--- a/yarn.lock
+++ b/yarn.lock
@@ -5279,6 +5279,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxlint-tsgolint/darwin-arm64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/darwin-arm64@npm:0.13.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/darwin-x64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/darwin-x64@npm:0.13.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/linux-arm64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/linux-arm64@npm:0.13.0"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/linux-x64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/linux-x64@npm:0.13.0"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/win32-arm64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/win32-arm64@npm:0.13.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@oxlint-tsgolint/win32-x64@npm:0.13.0":
+  version: 0.13.0
+  resolution: "@oxlint-tsgolint/win32-x64@npm:0.13.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@oxlint/binding-android-arm-eabi@npm:1.47.0":
   version: 1.47.0
   resolution: "@oxlint/binding-android-arm-eabi@npm:1.47.0"
@@ -10587,6 +10629,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     oxfmt: "npm:^0.32.0"
     oxlint: "npm:^1.47.0"
+    oxlint-tsgolint: "npm:^0.13.0"
     p-limit: "npm:^7.2.0"
     prompts: "npm:^2.4.2"
     source-map-support: "npm:^0.5.21"
@@ -21698,6 +21741,35 @@ __metadata:
   bin:
     oxfmt: bin/oxfmt
   checksum: 10/0ace6d6512056982ea94aeb6c199eeba0f74488fbe9dcba723e1ae8666f66034fb88c29c2fca7bd197aef2e2fefa97652ef5d7e86558510019fd7c78eea8b0e3
+  languageName: node
+  linkType: hard
+
+"oxlint-tsgolint@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "oxlint-tsgolint@npm:0.13.0"
+  dependencies:
+    "@oxlint-tsgolint/darwin-arm64": "npm:0.13.0"
+    "@oxlint-tsgolint/darwin-x64": "npm:0.13.0"
+    "@oxlint-tsgolint/linux-arm64": "npm:0.13.0"
+    "@oxlint-tsgolint/linux-x64": "npm:0.13.0"
+    "@oxlint-tsgolint/win32-arm64": "npm:0.13.0"
+    "@oxlint-tsgolint/win32-x64": "npm:0.13.0"
+  dependenciesMeta:
+    "@oxlint-tsgolint/darwin-arm64":
+      optional: true
+    "@oxlint-tsgolint/darwin-x64":
+      optional: true
+    "@oxlint-tsgolint/linux-arm64":
+      optional: true
+    "@oxlint-tsgolint/linux-x64":
+      optional: true
+    "@oxlint-tsgolint/win32-arm64":
+      optional: true
+    "@oxlint-tsgolint/win32-x64":
+      optional: true
+  bin:
+    tsgolint: bin/tsgolint.js
+  checksum: 10/f5187ab239a201c2578c378e194ee074b37c2c9232d48d50b8a6d17a17016cd140aa9e1e35822e70f9ad31f8bf371fcf32513cfdda74bb996ef745d5fdda7048
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This will result in ~800 new **warnings** being reported. I'll be slowly churning through them in follow up PRs.. unfortunately these are not auto-fixable, but most should be relatively easy to fix.

This will make the linter slightly slower (7s vs 14s), but it will allow us to catch a lot more issues.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 14.78 MB → 14.8 MB (+19.88 kB) | +0.13%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.4 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 14.78 MB → 14.8 MB (+19.88 kB) | +0.13%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/ca.json` | 📈 +18.21 kB (+18.79%) | 96.92 kB → 115.14 kB
`locale/en.json` | 📈 +1.67 kB (+1.01%) | 165.58 kB → 167.25 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ca.js | 96.92 kB → 115.14 kB (+18.21 kB) | +18.79%
static/js/en.js | 165.58 kB → 167.25 kB (+1.67 kB) | +1.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.52 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/da.js | 106.62 kB | 0%
static/js/de.js | 180.44 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/es.js | 173.83 kB | 0%
static/js/fr.js | 179.97 kB | 0%
static/js/it.js | 171.44 kB | 0%
static/js/nb-NO.js | 157.23 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 88.64 kB | 0%
static/js/pt-BR.js | 154.57 kB | 0%
static/js/sv.js | 78.2 kB | 0%
static/js/th.js | 182.35 kB | 0%
static/js/uk.js | 215.11 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.13 MB | 0%
static/js/narrow.js | 638.75 kB | 0%
static/js/TransactionList.js | 106.13 kB | 0%
static/js/wide.js | 165.25 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.05 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.92NpqIpU.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.4 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.4 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->