### PR TITLE
Unlock split subtransactions when un-reconciling parent

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2764,7 +2764,7 @@ export const TransactionTable = forwardRef(
       async (
         transaction: TransactionEntity,
         subtransactions: TransactionEntity[] | null = null,
-        updatedFieldName: keyof TransactionEntity | null = null,
+        updatedFieldName: string | null = null,
       ) => {
         savePending.current = true;
 

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2014,7 +2014,7 @@ type TransactionTableInnerProps = {
   onSave: (
     transaction: TransactionEntity,
     subtransactions?: TransactionEntity[] | null,
-    updatedFieldName?: keyof TransactionEntity | null,
+    updatedFieldName?: string | null,
   ) => Promise<void> | void;
   onApplyRules: (
     transaction: TransactionEntity,
@@ -2367,7 +2367,7 @@ export type TransactionTableProps = {
   onSave: (
     transaction: TransactionEntity,
     subtransactions?: TransactionEntity[] | null,
-    updatedFieldName?: keyof TransactionEntity | null,
+    updatedFieldName?: string | null,
   ) => Promise<void> | void;
   onApplyRules: (
     transaction: TransactionEntity,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2011,7 +2011,11 @@ type TransactionTableInnerProps = {
   dateFormat: string | undefined;
   hideFraction: boolean;
   renderEmpty: ReactNode | (() => ReactNode);
-  onSave: (transaction: TransactionEntity) => void;
+  onSave: (
+    transaction: TransactionEntity,
+    subtransactions?: TransactionEntity[] | null,
+    updatedFieldName?: keyof TransactionEntity | null,
+  ) => Promise<void> | void;
   onApplyRules: (
     transaction: TransactionEntity,
     field: string,
@@ -2360,7 +2364,11 @@ export type TransactionTableProps = {
   dateFormat: string | undefined;
   hideFraction: boolean;
   renderEmpty: ReactNode | (() => ReactNode);
-  onSave: (transaction: TransactionEntity) => void;
+  onSave: (
+    transaction: TransactionEntity,
+    subtransactions?: TransactionEntity[] | null,
+    updatedFieldName?: keyof TransactionEntity | null,
+  ) => Promise<void> | void;
   onApplyRules: (
     transaction: TransactionEntity,
     field: string | null,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1007,7 +1007,10 @@ const Transaction = memo(function Transaction({
             name: 'confirm-transaction-edit',
             options: {
               onConfirm: () => {
-                const unlockedTransaction = { ...transaction, reconciled: false };
+                const unlockedTransaction = {
+                  ...transaction,
+                  reconciled: false,
+                };
                 const unlockedSubtransactions =
                   subtransactions?.map(subtransaction => ({
                     ...subtransaction,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1007,7 +1007,22 @@ const Transaction = memo(function Transaction({
             name: 'confirm-transaction-edit',
             options: {
               onConfirm: () => {
-                onUpdateAfterConfirm('reconciled', false);
+                const unlockedTransaction = { ...transaction, reconciled: false };
+                const unlockedSubtransactions =
+                  subtransactions?.map(subtransaction => ({
+                    ...subtransaction,
+                    reconciled: false,
+                  })) ?? null;
+
+                const deserialized = deserializeTransaction(
+                  unlockedTransaction,
+                  originalTransaction,
+                );
+
+                setTransaction(
+                  serializeTransaction(deserialized, showZeroInDeposit),
+                );
+                onSave(deserialized, unlockedSubtransactions, 'reconciled');
               },
               confirmReason: 'unlockReconciled',
             },

--- a/upcoming-release-notes/6994.md
+++ b/upcoming-release-notes/6994.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [HadiAyache]
+---
+
+Unlocking a reconciled split transaction now also unlocks its subtransactions so follow-up edits behave consistently.


### PR DESCRIPTION
## Summary
- when unlocking a reconciled parent transaction, also set child split transactions to unreconciled
- persist parent + child unreconciled state in the same save action
- keep UI row state in sync after confirmation

## Why
Unlocking a split transaction currently leaves child subtransactions reconciled, which triggers reconciled-edit warnings when editing child amounts. This keeps split state consistent after unlock.

Fixes #6859

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB → 14.85 MB (+527 B) | +0.00%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB → 14.85 MB (+527 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📈 +527 B (+0.60%) | 86.2 kB → 86.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.54 MB → 9.54 MB (+527 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.15 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.37 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/nl.js | 106.37 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/pt-BR.js | 154.22 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/uk.js | 214.74 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 637.68 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BwrdDDMW.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->