### PR TITLE
Fix merged transfer losing linkage when imported transaction is kept

### DIFF
--- a/packages/loot-core/src/server/transactions/merge.test.ts
+++ b/packages/loot-core/src/server/transactions/merge.test.ts
@@ -284,6 +284,58 @@ describe('Merging success', () => {
     });
   });
 
+  it('preserves transfer linkage when imported transaction is kept', async () => {
+    const transferPayee = await db.insertPayee({
+      name: 'Transfer to two',
+      transfer_acct: 'two',
+    });
+
+    // Manual transfer in account one (linked to counterpart in account two)
+    const manualTransfer = await db.insertTransaction({
+      account: 'one',
+      amount: 20,
+      date: '2025-01-01',
+      payee: transferPayee,
+      category: null,
+    });
+
+    const transferCounterpart = await db.insertTransaction({
+      account: 'two',
+      amount: 20,
+      date: '2025-01-01',
+      payee: transferPayee,
+      category: null,
+      transfer_id: manualTransfer,
+    });
+
+    await db.updateTransaction({
+      id: manualTransfer,
+      transfer_id: transferCounterpart,
+    });
+
+    // Imported duplicate that should be kept by merge logic
+    const imported = await db.insertTransaction({
+      account: 'one',
+      amount: 20,
+      date: '2025-01-02',
+      imported_id: 'imported_transfer_1',
+      category: null,
+    });
+
+    const keptId = await mergeTransactions([
+      { id: manualTransfer },
+      { id: imported },
+    ]);
+
+    expect(keptId).toBe(imported);
+
+    const keptTransaction = await db.getTransaction(imported);
+    expect(keptTransaction?.transfer_id).toBe(transferCounterpart);
+
+    const counterpart = await db.getTransaction(transferCounterpart);
+    expect(counterpart?.transfer_id).toBe(imported);
+  });
+
   it('preserves split categories when merging split transaction with uncategorized imported transaction', async () => {
     // Create a manual transaction with splits
     const manualParent = await db.insertTransaction({

--- a/packages/loot-core/src/server/transactions/merge.ts
+++ b/packages/loot-core/src/server/transactions/merge.ts
@@ -61,6 +61,8 @@ export async function mergeTransactions(
   const keepHasSubtransactions = keepSubtransactions.length > 0;
   const dropHasSubtransactions = dropSubtransactions.length > 0;
 
+  const mergedTransferId = keep.transfer_id || drop.transfer_id || null;
+
   // If keep doesn't have subtransactions but drop does, transfer them
   if (!keepHasSubtransactions && dropHasSubtransactions) {
     // Update each subtransaction to point to the kept parent
@@ -81,6 +83,7 @@ export async function mergeTransactions(
       notes: keep.notes || drop.notes,
       cleared: keep.cleared || drop.cleared,
       reconciled: keep.reconciled || drop.reconciled,
+      transfer_id: mergedTransferId,
     } as unknown as TransactionEntity);
   } else {
     // Normal merge without subtransactions
@@ -91,7 +94,20 @@ export async function mergeTransactions(
       notes: keep.notes || drop.notes,
       cleared: keep.cleared || drop.cleared,
       reconciled: keep.reconciled || drop.reconciled,
+      transfer_id: mergedTransferId,
     } as TransactionEntity);
+  }
+
+  // If transfer linkage was inherited from dropped transaction, relink
+  // counterpart transaction to the kept transaction id.
+  if (drop.transfer_id && drop.transfer_id !== keep.transfer_id) {
+    const transferCounterpart = await db.getTransaction(drop.transfer_id);
+    if (transferCounterpart) {
+      await db.updateTransaction({
+        id: transferCounterpart.id,
+        transfer_id: keep.id,
+      } as TransactionEntity);
+    }
   }
 
   // Delete the dropped transaction using shared deleteTransaction to


### PR DESCRIPTION
## Summary
Fixes transfer merge behavior when merging a manual transfer transaction with an imported duplicate.

When merge keeps the imported transaction, it should preserve transfer linkage from the dropped manual transfer transaction. Previously, transfer linkage could be lost, leaving the counterpart transfer transaction pointing at a deleted id.

Closes #5000.

## Reproduction
1. Create a transfer from account A -> B (so A tx and B counterpart are linked via `transfer_id`).
2. Import a duplicate of the A-side transaction.
3. Merge manual transfer tx + imported tx.

### Before
- Imported transaction is kept.
- Kept transaction may lose `transfer_id`.
- Counterpart transaction can keep `transfer_id` pointing to dropped (deleted) transaction.
- Result is no longer a valid linked transfer pair.

### After
- Kept transaction receives merged `transfer_id`.
- Counterpart transaction is relinked to kept transaction id.
- Transfer relationship remains consistent after merge.

## Code changes
- `packages/loot-core/src/server/transactions/merge.ts`
  - Preserve `transfer_id` during merge update.
  - Relink counterpart transaction when transfer linkage came from dropped transaction.
- `packages/loot-core/src/server/transactions/merge.test.ts`
  - Add regression test: `preserves transfer linkage when imported transaction is kept`.

## Validation
- Added focused regression test covering issue path.
- Full test run was not completed in this environment because workspace dependency install (`yarn install --immutable`) stalled during fetch.
