### PR TITLE
[AI] Allow var(--name) in custom theme CSS

### DIFF
--- a/packages/docs/docs/experimental/custom-themes.md
+++ b/packages/docs/docs/experimental/custom-themes.md
@@ -62,8 +62,20 @@ Custom themes must be written as CSS using the `:root` selector with CSS custom 
 
 - The CSS must contain **exactly** `:root { ... }` and nothing else
 - Only custom properties starting with `--` are allowed; Actual uses `--color-*` variables for theming
+- **Values** may use `var(--custom-property-name)` to reference other variables (e.g. to reuse existing theme variables). Only this form is allowed; fallbacks like `var(--name, value)` are not supported.
 - No other selectors, at-rules (@import, @media, etc.), or nested blocks are allowed
 - Comments are allowed and will be stripped during validation
+
+Example using variables:
+
+```css
+:root {
+  --color-pageBackground: #1a1a1a;
+  --color-pageText: #ffffff;
+  /* Reuse another variable */
+  --color-buttonPrimaryBackground: var(--color-pageTextLink);
+}
+```
 
 ### Available CSS Variables
 
@@ -125,9 +137,10 @@ When you paste CSS or install from a catalog, the theme is validated to ensure i
 
 1. Must contain exactly `:root { ... }`
 2. Only custom properties starting with `--` are allowed; Actual uses `--color-*` variables for theming
-3. No at-rules (@import, @media, @keyframes, etc.)
-4. No nested selectors or blocks
-5. No content outside the `:root` block
+3. Values may be literals (colors, lengths, etc.) or `var(--name)` references (no fallbacks)
+4. No at-rules (@import, @media, @keyframes, etc.)
+5. No nested selectors or blocks
+6. No content outside the `:root` block
 
 If validation fails, you'll see an error message explaining what's wrong.
 

--- a/upcoming-release-notes/7018.md
+++ b/upcoming-release-notes/7018.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Custom themes: allow using simple CSS variables


### PR DESCRIPTION
A relatively small change that IMO is safe. We allow simple CSS variables, but no fallbacks. Since the CSS vars themselves are already enforced to be colors only - this should be safe.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.81 MB → 14.81 MB (+306 B) | +0.00%
loot-core | 1 | 5.86 MB | 0%
api | 1 | 4.4 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.81 MB → 14.81 MB (+306 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/style/customThemes.ts` | 📈 +306 B (+5.23%) | 5.71 kB → 6.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.52 MB → 9.52 MB (+306 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 182.95 kB | 0%
static/js/da.js | 106.46 kB | 0%
static/js/de.js | 180.27 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 168.47 kB | 0%
static/js/es.js | 173.67 kB | 0%
static/js/fr.js | 179.8 kB | 0%
static/js/it.js | 171.27 kB | 0%
static/js/nb-NO.js | 157.07 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 88.48 kB | 0%
static/js/pt-BR.js | 154.41 kB | 0%
static/js/th.js | 182.04 kB | 0%
static/js/uk.js | 214.89 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.15 MB | 0%
static/js/narrow.js | 637.33 kB | 0%
static/js/TransactionList.js | 106.18 kB | 0%
static/js/wide.js | 164 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Zwjv9l4n.js | 5.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.4 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.4 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->