### PR TITLE
⬆️ straggler dependencies (react-spring!)

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -47,7 +47,7 @@
     "usehooks-ts": "^3.1.1"
   },
   "devDependencies": {
-    "@chromatic-com/storybook": "^5.0.0",
+    "@chromatic-com/storybook": "^5.0.1",
     "@storybook/addon-a11y": "^10.2.7",
     "@storybook/addon-docs": "^10.2.7",
     "@storybook/react-vite": "^10.2.7",

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -82,7 +82,7 @@
     "react-redux": "^9.2.0",
     "react-router": "7.13.0",
     "react-simple-pull-to-refresh": "^1.3.4",
-    "react-spring": "10.0.0",
+    "react-spring": "^10.0.3",
     "react-swipeable": "^7.0.2",
     "react-virtualized-auto-sizer": "^2.0.2",
     "recharts": "^3.7.0",

--- a/packages/desktop-client/src/components/Notifications.tsx
+++ b/packages/desktop-client/src/components/Notifications.tsx
@@ -153,22 +153,27 @@ function Notification({
   const yOffset = index * Y_OFFSET_PER_LEVEL;
 
   const [isSwiped, setIsSwiped] = useState(false);
-  const [spring, api] = useSpring(() => ({
-    x: 0,
-    y: yOffset,
-    opacity: stackOpacity,
-    scale,
-  }));
+  const [spring, api] = useSpring(
+    () => ({
+      from: {
+        x: 0,
+        y: yOffset,
+        opacity: stackOpacity,
+        scale,
+      },
+    }),
+    [],
+  );
 
   // Update scale, opacity, and y-position when index changes
   useEffect(() => {
-    void api.start({ scale, opacity: stackOpacity, y: yOffset });
+    void api.start({ to: { scale, opacity: stackOpacity, y: yOffset } });
   }, [index, scale, stackOpacity, yOffset, api]);
 
   const swipeHandlers = useSwipeable({
     onSwiping: ({ deltaX }) => {
       if (!isSwiped) {
-        void api.start({ x: deltaX });
+        void api.start({ to: { x: deltaX } });
       }
     },
     onSwiped: ({ velocity, deltaX }) => {
@@ -179,14 +184,13 @@ function Notification({
       if (Math.abs(deltaX) > threshold || velocity > 0.5) {
         // Animate out & remove item after animation
         void api.start({
-          x: direction * 1000,
-          opacity: 0,
+          to: { x: direction * 1000, opacity: 0 },
           onRest: onRemove,
         });
         setIsSwiped(true);
       } else {
         // Reset position if not swiped far enough
-        void api.start({ x: 0 });
+        void api.start({ to: { x: 0 } });
       }
     },
     trackMouse: true,

--- a/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetSummaries.tsx
@@ -24,10 +24,13 @@ export function BudgetSummaries() {
   const [firstMonth] = months;
 
   const [widthState, setWidthState] = useState(0);
-  const [styles, spring] = useSpring(() => ({
-    x: 0,
-    config: { mass: 3, tension: 600, friction: 80 },
-  }));
+  const [styles, spring] = useSpring(
+    () => ({
+      from: { x: 0 },
+      config: { mass: 3, tension: 600, friction: 80 },
+    }),
+    [],
+  );
 
   const containerRef = useResizeObserver<HTMLDivElement>(
     useCallback(rect => {
@@ -55,7 +58,7 @@ export function BudgetSummaries() {
     }
 
     const to = -offsetX;
-    spring.start({ from: { x: from }, x: to });
+    spring.start({ from: { x: from }, to: { x: to } });
   }, [spring, firstMonth, monthWidth, allMonths]);
 
   useLayoutEffect(() => {

--- a/packages/desktop-client/src/components/mobile/ActionableGridListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/ActionableGridListItem.tsx
@@ -34,10 +34,13 @@ export function ActionableGridListItem<T extends object>({
   const hasActions = !!actions;
 
   // Spring animation for the swipe
-  const [{ x }, api] = useSpring(() => ({
-    x: 0,
-    config: config.stiff,
-  }));
+  const [{ x }, api] = useSpring(
+    () => ({
+      from: { x: 0 },
+      config: config.stiff,
+    }),
+    [],
+  );
 
   // Handle drag gestures
   const bind = useDrag(
@@ -48,7 +51,7 @@ export function ActionableGridListItem<T extends object>({
       if (active) {
         dragStartedRef.current = true;
         api.start({
-          x: Math.max(-actionsWidth, Math.min(0, currentX)),
+          to: { x: Math.max(-actionsWidth, Math.min(0, currentX)) },
           onRest: () => {
             dragStartedRef.current = false;
           },
@@ -62,7 +65,7 @@ export function ActionableGridListItem<T extends object>({
         (vx < -0.5 && currentX < -actionsWidth / 5);
 
       api.start({
-        x: shouldReveal ? -actionsWidth : 0,
+        to: { x: shouldReveal ? -actionsWidth : 0 },
         onRest: () => {
           dragStartedRef.current = false;
           setIsRevealed(shouldReveal);

--- a/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
+++ b/packages/desktop-client/src/components/mobile/MobileNavTabs.tsx
@@ -52,7 +52,7 @@ export function MobileNavTabs() {
     maxWidth: `${100 / COLUMN_COUNT}%`,
   };
 
-  const [{ y }, api] = useSpring(() => ({ y: OPEN_DEFAULT_Y }));
+  const [{ y }, api] = useSpring(() => ({ from: { y: OPEN_DEFAULT_Y } }), []);
 
   const openFull = useCallback(
     ({ canceled }: { canceled?: boolean }) => {
@@ -60,7 +60,7 @@ export function MobileNavTabs() {
       // so we change the spring config to create a nice wobbly effect
       setNavbarState('open');
       api.start({
-        y: OPEN_FULL_Y,
+        to: { y: OPEN_FULL_Y },
         immediate: isTestEnv,
         config: canceled ? config.wobbly : config.stiff,
       });
@@ -72,7 +72,7 @@ export function MobileNavTabs() {
     (velocity = 0) => {
       setNavbarState('default');
       api.start({
-        y: OPEN_DEFAULT_Y,
+        to: { y: OPEN_DEFAULT_Y },
         immediate: isTestEnv,
         config: { ...config.stiff, velocity },
       });
@@ -84,7 +84,7 @@ export function MobileNavTabs() {
     (velocity = 0) => {
       setNavbarState('hidden');
       api.start({
-        y: HIDDEN_Y,
+        to: { y: HIDDEN_Y },
         immediate: isTestEnv,
         config: { ...config.stiff, velocity },
       });

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -447,15 +447,18 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const openY = 0;
   const [mobileTransactionsOpen, setMobileTransactionsOpen] = useState(false);
 
-  const [{ y }, api] = useSpring(() => ({
-    y: closeY.current,
-    immediate: false,
-  }));
+  const [{ y }, api] = useSpring(
+    () => ({
+      from: { y: closeY.current },
+      immediate: false,
+    }),
+    [],
+  );
 
   useEffect(() => {
     closeY.current = totalHeight;
     void api.start({
-      y: mobileTransactionsOpen ? openY : closeY.current,
+      to: { y: mobileTransactionsOpen ? openY : closeY.current },
       immediate: false,
     });
   }, [totalHeight, mobileTransactionsOpen, api]);
@@ -463,7 +466,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const open = useCallback(
     ({ canceled }: { canceled: boolean }) => {
       void api.start({
-        y: openY,
+        to: { y: openY },
         immediate: false,
         config: canceled ? config.wobbly : config.stiff,
       });
@@ -475,7 +478,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const close = useCallback(
     (velocity = 0) => {
       void api.start({
-        y: closeY.current,
+        to: { y: closeY.current },
         config: { ...config.stiff, velocity },
       });
       setMobileTransactionsOpen(false);
@@ -487,7 +490,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
     ({ offset: [, oy], cancel }) => {
       if (oy < 0) {
         cancel();
-        void api.start({ y: 0, immediate: true });
+        void api.start({ to: { y: 0 }, immediate: true });
         return;
       }
 
@@ -501,7 +504,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
           open({ canceled: true });
           setMobileTransactionsOpen(true);
         } else {
-          void api.start({ y: oy, immediate: true });
+          void api.start({ to: { y: oy }, immediate: true });
         }
       }
     },

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@electron/notarize": "3.1.1",
-    "@electron/rebuild": "4.0.2",
+    "@electron/rebuild": "4.0.3",
     "@playwright/test": "1.58.2",
     "@types/copyfiles": "^2",
     "@types/fs-extra": "^11",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.52.3",
     "@mdx-js/react": "^3.1.1",
-    "@r74tech/docusaurus-plugin-panzoom": "^2.4.0",
+    "@r74tech/docusaurus-plugin-panzoom": "^2.4.2",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.4",

--- a/upcoming-release-notes/7027.md
+++ b/upcoming-release-notes/7027.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Bump some more dependencies

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,7 +46,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/components@workspace:packages/component-library"
   dependencies:
-    "@chromatic-com/storybook": "npm:^5.0.0"
+    "@chromatic-com/storybook": "npm:^5.0.1"
     "@emotion/css": "npm:^11.13.5"
     "@storybook/addon-a11y": "npm:^10.2.7"
     "@storybook/addon-docs": "npm:^10.2.7"
@@ -2107,9 +2107,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chromatic-com/storybook@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@chromatic-com/storybook@npm:5.0.0"
+"@chromatic-com/storybook@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@chromatic-com/storybook@npm:5.0.1"
   dependencies:
     "@neoconfetti/react": "npm:^1.0.0"
     chromatic: "npm:^13.3.4"
@@ -2118,7 +2118,7 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
   peerDependencies:
     storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0
-  checksum: 10/4964c1086f4aaaf5a0db80063801fafd0595546e22914dff1e6e0869dad9cf9f9cae66bd41133f1bbd0d59696923ca65e9734b76ca4a6ca13f1f97e9d4286e64
+  checksum: 10/10a3dc8dbd1f7d9d523f71bf739a61488415e30c51a9a45effc422e246c95758ce9784a5c1206acb71fdfccebea987e5a91810396a079e01ed2bdb65ac8ec394
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3488,7 +3488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.9.2, @docusaurus/utils-validation@npm:^2 || ^3, @docusaurus/utils-validation@npm:^3.7.0":
+"@docusaurus/utils-validation@npm:3.9.2, @docusaurus/utils-validation@npm:^2 || ^3, @docusaurus/utils-validation@npm:^3.9.2":
   version: 3.9.2
   resolution: "@docusaurus/utils-validation@npm:3.9.2"
   dependencies:
@@ -5537,10 +5537,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@panzoom/panzoom@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "@panzoom/panzoom@npm:4.6.0"
-  checksum: 10/9b0aa0defcaab0a4f5a924ff6055c0428b97130bf31b6f53e6a1476d9d4a289caea580cd18308a76c48faaaea5528d137bee64cdefe19515ffa3a7029d1018c7
+"@panzoom/panzoom@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "@panzoom/panzoom@npm:4.6.1"
+  checksum: 10/e7c47009aa75e5e06863684c24edc63140823c5d26264b0053c0d7e9154e34b7f72bee8595c3bd4fb96946f0350e1c28664eb806b153eef7a33a6a56fa8934e0
   languageName: node
   linkType: hard
 
@@ -5758,13 +5758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@r74tech/docusaurus-plugin-panzoom@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@r74tech/docusaurus-plugin-panzoom@npm:2.4.0"
+"@r74tech/docusaurus-plugin-panzoom@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "@r74tech/docusaurus-plugin-panzoom@npm:2.4.2"
   dependencies:
-    "@docusaurus/utils-validation": "npm:^3.7.0"
-    "@panzoom/panzoom": "npm:^4.6.0"
-  checksum: 10/869cf91af518448827c79855daa678d2ef060b31531e98acbcad9f835e02890e2f5bf137d59c8e9b234a5c3f27dc6140bdd9e58b9873899ff752cb03be20efc3
+    "@docusaurus/utils-validation": "npm:^3.9.2"
+    "@panzoom/panzoom": "npm:^4.6.1"
+  checksum: 10/7825504924c4fe59d32486a1ac620b11ac79b188c48e7e8782b079852405611ec546941ba0d9e2e9aa21c1036b74fdd16a65567eb9c4df120b27ea3385c4aa7b
   languageName: node
   linkType: hard
 
@@ -14598,7 +14598,7 @@ __metadata:
     "@docusaurus/theme-mermaid": "npm:^3.9.2"
     "@easyops-cn/docusaurus-search-local": "npm:^0.52.3"
     "@mdx-js/react": "npm:^3.1.1"
-    "@r74tech/docusaurus-plugin-panzoom": "npm:^2.4.0"
+    "@r74tech/docusaurus-plugin-panzoom": "npm:^2.4.2"
     "@types/react": "npm:^19.2.5"
     clsx: "npm:^2.1.1"
     prism-react-renderer: "npm:^2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,9 +3679,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron/rebuild@npm:4.0.2":
-  version: 4.0.2
-  resolution: "@electron/rebuild@npm:4.0.2"
+"@electron/rebuild@npm:4.0.3":
+  version: 4.0.3
+  resolution: "@electron/rebuild@npm:4.0.3"
   dependencies:
     "@malept/cross-spawn-promise": "npm:^2.0.0"
     debug: "npm:^4.1.1"
@@ -3694,14 +3694,14 @@ __metadata:
     ora: "npm:^5.1.0"
     read-binary-file-arch: "npm:^1.0.6"
     semver: "npm:^7.3.5"
-    tar: "npm:^6.0.5"
+    tar: "npm:^7.5.6"
     yargs: "npm:^17.0.1"
   dependenciesMeta:
     electron:
       built: true
   bin:
     electron-rebuild: lib/cli.js
-  checksum: 10/41e1d7f6d68292f0a97425fc0d2b12fe0beb6b2f2ed47ceb3741bc90ce3704eca373cde95613c0aaca2c39dd97c9cc2d2afb8f6541c18266627165b2ecc202d7
+  checksum: 10/24626c53eebd0d8bb47b1ea628e0c3c97096c2f0a8fbdbac774f29350d855aca53abcfd9bd6e1bf7655b2b6739a09ddb281f25089a5287a08725e30f8fba1331
   languageName: node
   linkType: hard
 
@@ -14402,7 +14402,7 @@ __metadata:
   dependencies:
     "@actual-app/sync-server": "workspace:*"
     "@electron/notarize": "npm:3.1.1"
-    "@electron/rebuild": "npm:4.0.2"
+    "@electron/rebuild": "npm:4.0.3"
     "@playwright/test": "npm:1.58.2"
     "@types/copyfiles": "npm:^2"
     "@types/fs-extra": "npm:^11"
@@ -27058,6 +27058,19 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10/4848cd2fa2fcaf0734cf54e14bc685056eb43a74d7cc7f954c3ac88fea88c85d95b1d7896619f91aab6f2234c5eec731c18aaa201a78fcf86985bdc824ed7a00
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.6":
+  version: 7.5.9
+  resolution: "tar@npm:7.5.9"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10/1213cdde9c22d6acf8809ba5d2a025212ce3517bc99c4a4c6981b7dc0489bf3b164db9c826c9517680889194c9ba57448c8ff0da35eca9a60bb7689bf0b3897d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,7 +204,7 @@ __metadata:
     react-redux: "npm:^9.2.0"
     react-router: "npm:7.13.0"
     react-simple-pull-to-refresh: "npm:^1.3.4"
-    react-spring: "npm:10.0.0"
+    react-spring: "npm:^10.0.3"
     react-swipeable: "npm:^7.0.2"
     react-virtualized-auto-sizer: "npm:^2.0.2"
     recharts: "npm:^3.7.0"
@@ -6997,133 +6997,133 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/animated@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/animated@npm:10.0.0"
+"@react-spring/animated@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/animated@npm:10.0.3"
   dependencies:
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/1f1cf60d768b6d125d3c4da13a32bfc2314683dbbf5c985688c133ea6f1010718c9c77c04af79d3fe3652c9e4480471d1d7109c2ae4dd30f3c045dab3352fb4d
+  checksum: 10/473b4d2a6e9c4477e3806623d8581352db73cabd200f6fc4899dc98525ff155645ac5a758f21f0ccae443cfd4e96a1f2512fd7bb8bb0dd7b614915a500e7889a
   languageName: node
   linkType: hard
 
-"@react-spring/core@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/core@npm:10.0.0"
+"@react-spring/core@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/core@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/317ddb8345fc4722f70527872053c87a88c9093f1e97c9691673324fc6ebfe005f62c17afe4198c0f1c949ff2a18cd4fbc5f2c08400e41dc740db0c0cfc00a43
+  checksum: 10/43493d9f96fa1e7ca55be41bffbaca970df46fb1164ff8da4c99b8a4962893bbac685d50926b7d22ba5d32b985f1880ccd1dd825d7a55311ed787c0fe24cfea8
   languageName: node
   linkType: hard
 
-"@react-spring/konva@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/konva@npm:10.0.0"
+"@react-spring/konva@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/konva@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     konva: ">=2.6"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-konva: ^19
-  checksum: 10/bc97ece79583694effde8a9749537b306c3ae3b0f1f924d3aa8751dddac41d43553d05cc1af5cb6b1f8cbddfed7df096f78fc84a4fb33d5fc438bf044c512903
+  checksum: 10/538f6c5aa491658bc753f473fd3afc5b409618156f4342e88a05b74d481acbdb6bce89d04216ee84cec402ced4da0d8dc80d9ccd40eca866c27d9e34c7fccbdb
   languageName: node
   linkType: hard
 
-"@react-spring/native@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/native@npm:10.0.0"
+"@react-spring/native@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/native@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-native: ">=0.78"
-  checksum: 10/130faf30cc00fcea33cbc0ffc1d8ee962dd674643f8c64319089e74d450f966940e51851c1a8c3a673168dfe30e551ffa6618af779072caa80ff48b799b8f1e8
+  checksum: 10/6c176ab19cfd898564d7b2dd2330fa56433238c70f8be7ef6daaf5b07f6b22c860619e846bd3a3d784ad75e2b361ee9ad79e8664ae015279998825502b3a1d61
   languageName: node
   linkType: hard
 
-"@react-spring/rafz@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/rafz@npm:10.0.0"
-  checksum: 10/d8961c853aef489fce4956084d368d994a3dcb5f9f8b848d5ccd32e7f7fb86247fae502e369e0134f97dd9dc515853b30df8ec76c8c2a39b2009db2ddc936376
+"@react-spring/rafz@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/rafz@npm:10.0.3"
+  checksum: 10/b3884747db544e2e630383e01f423b93f503799c318a01bd438eefac38c9beaa58ec10d701e042e0902164b1aefa42a4a50c0ff09d01b87135bb8242e560b786
   languageName: node
   linkType: hard
 
-"@react-spring/shared@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/shared@npm:10.0.0"
+"@react-spring/shared@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/shared@npm:10.0.3"
   dependencies:
-    "@react-spring/rafz": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/rafz": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/64a86386a9e8fbaa834be64b43bb29f378b44d63ce8c26577126f9cb5ffdd6d840f4ae8ca4d3032d89ee8fad75eea768a13ed79bc9002796e4b203dadb0c3a4c
+  checksum: 10/6193944a30139b830ad188ac9322bb492d59405f2909346c23b2c08a4b15ed81977d2e919bdc33815bfff55e64d88d1e74072800fa99b4a6b762aef72a2ebfb2
   languageName: node
   linkType: hard
 
-"@react-spring/three@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/three@npm:10.0.0"
+"@react-spring/three@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/three@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     "@react-three/fiber": ">=6.0"
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     three: ">=0.126"
-  checksum: 10/cf871c2aa6bbc4404af0eb5d915ad5d8e022c55ad91e82c0d67373d9cfd53bea1b058725fd88e806933c228fe6415e9d0e2af1e31d7aaa5a4205ac1f0362089e
+  checksum: 10/c1732cb01ab5b4f9bad2e1e3c4352ffe89069415a5c3209fb63f7201980913457e1fae61705abd2604533aba4e12f63d79b6cd9e9590e3d03440506f444910b8
   languageName: node
   linkType: hard
 
-"@react-spring/types@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/types@npm:10.0.0"
-  checksum: 10/b0cd524db137a75f12909959c5d97d7f8d4f9697a56ce779e3a1b7aa54bbf31dd44535f640a60ac3150960cde512c8b893e9c54866afe361f8637f17c3dd76f9
+"@react-spring/types@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/types@npm:10.0.3"
+  checksum: 10/162a21857c1af3388f40ea86b3560e2a360937d47a187d3275e2e5105f5f4d4696fc890e6761af67aef9017c872847ba2f328cb8e76357c88d82525842d7ab17
   languageName: node
   linkType: hard
 
-"@react-spring/web@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/web@npm:10.0.0"
+"@react-spring/web@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/web@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/61cea16b4c295cf64390e3e03ecd7d37e59eb534159f0b53e9b0a0a31d96546923dd87bcb5c6ed1bd055573ee3f448ff695bc3743d9f3e01c57f544f0b5ba322
+  checksum: 10/1d8af3f23b45ee7ab5efa5907530cb2b8ee3dab9b8ae2e3b80778d2df36455cd4815a285cf8b8a9572116ad13e7c9d561e356ec35db1eb0bc5d288a756845150
   languageName: node
   linkType: hard
 
-"@react-spring/zdog@npm:~10.0.0":
-  version: 10.0.0
-  resolution: "@react-spring/zdog@npm:10.0.0"
+"@react-spring/zdog@npm:~10.0.3":
+  version: 10.0.3
+  resolution: "@react-spring/zdog@npm:10.0.3"
   dependencies:
-    "@react-spring/animated": "npm:~10.0.0"
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/shared": "npm:~10.0.0"
-    "@react-spring/types": "npm:~10.0.0"
+    "@react-spring/animated": "npm:~10.0.3"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/shared": "npm:~10.0.3"
+    "@react-spring/types": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-zdog: ">=1.0"
     zdog: ">=1.0"
-  checksum: 10/2aa4fd69aa0df36ba010c125e77cd525ebe2e33b5528cec16f72f391e34c4f09d47cd99fbc33197751fabe4b3e48b10ec22487ede351e5f6b2ad8672285151a5
+  checksum: 10/1765e31fa5dba06b7d9a115749950030406f8ee895b4518327c97502c774a688b9ffc9d188d744fe3dda4800cd73fbca07ab7d8989e000a726930d44f13a9ee3
   languageName: node
   linkType: hard
 
@@ -24490,20 +24490,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-spring@npm:10.0.0":
-  version: 10.0.0
-  resolution: "react-spring@npm:10.0.0"
+"react-spring@npm:^10.0.3":
+  version: 10.0.3
+  resolution: "react-spring@npm:10.0.3"
   dependencies:
-    "@react-spring/core": "npm:~10.0.0"
-    "@react-spring/konva": "npm:~10.0.0"
-    "@react-spring/native": "npm:~10.0.0"
-    "@react-spring/three": "npm:~10.0.0"
-    "@react-spring/web": "npm:~10.0.0"
-    "@react-spring/zdog": "npm:~10.0.0"
+    "@react-spring/core": "npm:~10.0.3"
+    "@react-spring/konva": "npm:~10.0.3"
+    "@react-spring/native": "npm:~10.0.3"
+    "@react-spring/three": "npm:~10.0.3"
+    "@react-spring/web": "npm:~10.0.3"
+    "@react-spring/zdog": "npm:~10.0.3"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/e4612f3f9d57d08d2b66fab182a793458701d0eca8627636df7cbdbe0c8461f79bed49a03a71fbfca88e3948034e087b8b14d6a3636a61d658be818909987ec5
+  checksum: 10/db2f0811006dee8a1589081cee47046f5253b65cb3a4b35314e1c293b02ac4c2a585e9441a71266a709effedfb8e72d885bfcb560a4c85d43fa51ac0be955904
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With the help of https://github.com/pmndrs/react-spring/issues/2385#issuecomment-3041393446, I finally managed to get us up to `react-spring` 10.0.3! Also grabbed other stragglers that updated since my other while I was on it.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.78 MB → 14.83 MB (+54.5 kB) | +0.36%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.36 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.78 MB → 14.83 MB (+54.5 kB) | +0.36%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/recharts/es6/cartesian/getCartesianPosition.js` | 🆕 +7.36 kB | 0 B → 7.36 kB
`node_modules/recharts/es6/state/selectors/combiners/combineAllBarPositions.js` | 🆕 +4.18 kB | 0 B → 4.18 kB
`node_modules/recharts/es6/util/scale/RechartsScale.js` | 🆕 +2.98 kB | 0 B → 2.98 kB
`node_modules/recharts/es6/util/propsAreEqual.js` | 🆕 +2.65 kB | 0 B → 2.65 kB
`node_modules/recharts/es6/cartesian/BarStack.js` | 🆕 +2.13 kB | 0 B → 2.13 kB
`node_modules/recharts/es6/util/scale/CartesianScaleHelper.js` | 🆕 +1.84 kB | 0 B → 1.84 kB
`node_modules/recharts/es6/util/axisPropsAreEqual.js` | 🆕 +1.78 kB | 0 B → 1.78 kB
`node_modules/recharts/es6/state/selectors/combiners/combineBarSizeList.js` | 🆕 +1.29 kB | 0 B → 1.29 kB
`node_modules/recharts/es6/state/selectors/combiners/combineCheckedDomain.js` | 🆕 +1.17 kB | 0 B → 1.17 kB
`node_modules/recharts/es6/util/round.js` | 🆕 +1.08 kB | 0 B → 1.08 kB
`node_modules/recharts/es6/state/selectors/graphicalItemSelectors.js` | 🆕 +825 B | 0 B → 825 B
`node_modules/recharts/es6/util/getEveryNth.js` | 🆕 +795 B | 0 B → 795 B
`node_modules/recharts/es6/state/selectors/combiners/combineStackedData.js` | 🆕 +567 B | 0 B → 567 B
`node_modules/recharts/es6/util/getAxisTypeBasedOnLayout.js` | 🆕 +446 B | 0 B → 446 B
`node_modules/recharts/es6/state/selectors/combiners/combineBarPosition.js` | 🆕 +379 B | 0 B → 379 B
`node_modules/recharts/es6/state/reduxDevtoolsJsonStringifyReplacer.js` | 🆕 +375 B | 0 B → 375 B
`node_modules/recharts/es6/util/getClassNameFromUnknown.js` | 🆕 +171 B | 0 B → 171 B
`node_modules/recharts/es6/component/responsiveContainerUtils.js` | 🆕 +98 B | 0 B → 98 B
`node_modules/recharts/es6/component/Cell.js` | 📈 +437 B (+514.12%) | 85 B → 522 B
`node_modules/recharts/es6/util/LogUtils.js` | 📈 +527 B (+259.61%) | 203 B → 730 B
`node_modules/recharts/es6/chart/PieChart.js` | 📈 +1.39 kB (+229.73%) | 619 B → 1.99 kB
`node_modules/recharts/es6/state/externalEventsMiddleware.js` | 📈 +1.41 kB (+188.40%) | 767 B → 2.16 kB
`node_modules/recharts/es6/cartesian/getEquidistantTicks.js` | 📈 +2.67 kB (+156.60%) | 1.71 kB → 4.38 kB
`node_modules/recharts/es6/state/selectors/combiners/combineActiveTooltipIndex.js` | 📈 +1.26 kB (+130.71%) | 990 B → 2.23 kB
`node_modules/recharts/es6/state/SetLegendPayload.js` | 📈 +926 B (+104.63%) | 885 B → 1.77 kB
`node_modules/recharts/es6/state/SetTooltipEntrySettings.js` | 📈 +468 B (+82.39%) | 568 B → 1.01 kB
`node_modules/recharts/es6/hooks.js` | 📈 +527 B (+42.13%) | 1.22 kB → 1.74 kB
`node_modules/recharts/es6/state/mouseEventsMiddleware.js` | 📈 +791 B (+41.96%) | 1.84 kB → 2.61 kB
`node_modules/recharts/es6/shape/Dot.js` | 📈 +265 B (+37.86%) | 700 B → 965 B
`node_modules/recharts/es6/polar/defaultPolarRadiusAxisProps.js` | 📈 +65 B (+35.91%) | 181 B → 246 B
`node_modules/recharts/es6/state/cartesianAxisSlice.js` | 📈 +1.32 kB (+33.32%) | 3.95 kB → 5.27 kB
`node_modules/recharts/es6/chart/AreaChart.js` | 📈 +121 B (+30.48%) | 397 B → 518 B
`node_modules/recharts/es6/util/types.js` | 📈 +1.31 kB (+30.25%) | 4.32 kB → 5.62 kB
`node_modules/recharts/es6/chart/LineChart.js` | 📈 +121 B (+30.17%) | 401 B → 522 B
`node_modules/recharts/es6/chart/ComposedChart.js` | 📈 +121 B (+29.88%) | 405 B → 526 B
`node_modules/recharts/es6/chart/BarChart.js` | 📈 +121 B (+29.73%) | 407 B → 528 B
`node_modules/recharts/es6/cartesian/XAxis.js` | 📈 +1.44 kB (+25.13%) | 5.71 kB → 7.15 kB
`node_modules/recharts/es6/state/selectors/polarAxisSelectors.js` | 📈 +1.2 kB (+24.89%) | 4.81 kB → 6 kB
`node_modules/recharts/es6/state/legendSlice.js` | 📈 +365 B (+22.59%) | 1.58 kB → 1.93 kB
`node_modules/recharts/es6/container/Layer.js` | 📈 +279 B (+22.09%) | 1.23 kB → 1.51 kB
`node_modules/recharts/es6/cartesian/YAxis.js` | 📈 +1.44 kB (+20.32%) | 7.07 kB → 8.5 kB
`node_modules/recharts/es6/state/touchEventsMiddleware.js` | 📈 +391 B (+20.20%) | 1.89 kB → 2.27 kB
`node_modules/recharts/es6/util/ReduceCSSCalc.js` | 📈 +868 B (+18.74%) | 4.52 kB → 5.37 kB
`node_modules/recharts/es6/state/store.js` | 📈 +438 B (+18.34%) | 2.33 kB → 2.76 kB
`node_modules/recharts/es6/state/hooks.js` | 📈 +245 B (+17.92%) | 1.33 kB → 1.57 kB
`node_modules/recharts/es6/shape/Rectangle.js` | 📈 +1.5 kB (+16.71%) | 8.95 kB → 10.45 kB
`node_modules/recharts/es6/state/selectors/areaSelectors.js` | 📈 +603 B (+15.35%) | 3.84 kB → 4.43 kB
`node_modules/recharts/es6/state/selectors/dataSelectors.js` | 📈 +229 B (+15.32%) | 1.46 kB → 1.68 kB
`node_modules/recharts/es6/util/getActiveCoordinate.js` | 📈 +963 B (+15.24%) | 6.17 kB → 7.11 kB
`node_modules/recharts/es6/shape/Curve.js` | 📈 +738 B (+14.07%) | 5.12 kB → 5.84 kB
`node_modules/recharts/es6/component/DefaultTooltipContent.js` | 📈 +702 B (+13.79%) | 4.97 kB → 5.66 kB
`node_modules/recharts/es6/cartesian/ReferenceLine.js` | 📈 +1 kB (+13.13%) | 7.61 kB → 8.61 kB
`node_modules/recharts/es6/state/tooltipSlice.js` | 📈 +854 B (+12.79%) | 6.52 kB → 7.36 kB
`node_modules/recharts/es6/state/selectors/rootPropsSelectors.js` | 📈 +74 B (+12.33%) | 600 B → 674 B
`node_modules/recharts/es6/container/Surface.js` | 📈 +207 B (+11.68%) | 1.73 kB → 1.93 kB
`node_modules/recharts/es6/state/selectors/combiners/combineTooltipPayloadConfigurations.js` | 📈 +168 B (+11.59%) | 1.42 kB → 1.58 kB
`node_modules/recharts/es6/shape/Trapezoid.js` | 📈 +649 B (+11.58%) | 5.47 kB → 6.11 kB
`node_modules/recharts/es6/context/tooltipContext.js` | 📈 +126 B (+11.06%) | 1.11 kB → 1.24 kB
`node_modules/recharts/es6/component/Tooltip.js` | 📈 +714 B (+10.96%) | 6.36 kB → 7.06 kB
`node_modules/recharts/es6/cartesian/Area.js` | 📈 +2.38 kB (+10.35%) | 22.95 kB → 25.32 kB
`node_modules/recharts/es6/state/selectors/tooltipSelectors.js` | 📈 +1.02 kB (+10.30%) | 9.91 kB → 10.93 kB
`node_modules/recharts/es6/state/ReportMainChartProps.js` | 📈 +104 B (+10.08%) | 1.01 kB → 1.11 kB
`node_modules/recharts/es6/component/ResponsiveContainer.js` | 📈 +19 B (+9.55%) | 199 B → 218 B
`node_modules/recharts/es6/cartesian/Line.js` | 📈 +1.95 kB (+9.38%) | 20.84 kB → 22.8 kB
`node_modules/recharts/es6/util/ChartUtils.js` | 📈 +1.41 kB (+9.13%) | 15.44 kB → 16.85 kB
`node_modules/recharts/es6/state/rootPropsSlice.js` | 📈 +114 B (+8.76%) | 1.27 kB → 1.38 kB
`node_modules/recharts/es6/state/polarOptionsSlice.js` | 📈 +26 B (+8.75%) | 297 B → 323 B
`node_modules/react-redux/dist/react-redux.mjs` | 📈 +647 B (+8.55%) | 7.39 kB → 8.02 kB
`node_modules/recharts/es6/cartesian/getTicks.js` | 📈 +526 B (+8.23%) | 6.24 kB → 6.75 kB
`node_modules/recharts/es6/animation/easing.js` | 📈 +292 B (+7.80%) | 3.66 kB → 3.94 kB
`node_modules/recharts/es6/util/svgPropertiesAndEvents.js` | 📈 +131 B (+7.36%) | 1.74 kB → 1.87 kB
`node_modules/recharts/es6/state/types/StackedGraphicalItem.js` | 📈 +30 B (+7.19%) | 417 B → 447 B
`node_modules/recharts/es6/polar/Pie.js` | 📈 +1.49 kB (+7.11%) | 20.92 kB → 22.4 kB
`node_modules/recharts/es6/chart/RechartsWrapper.js` | 📈 +775 B (+6.49%) | 11.66 kB → 12.42 kB
`node_modules/recharts/es6/state/selectors/combiners/combineTooltipPayload.js` | 📈 +420 B (+6.45%) | 6.36 kB → 6.77 kB
`node_modules/recharts/es6/shape/Sector.js` | 📈 +463 B (+6.41%) | 7.05 kB → 7.51 kB
`node_modules/recharts/es6/polar/defaultPolarAngleAxisProps.js` | 📈 +15 B (+6.22%) | 241 B → 256 B
`node_modules/recharts/es6/state/selectors/polarSelectors.js` | 📈 +162 B (+6.16%) | 2.57 kB → 2.73 kB
`node_modules/recharts/es6/state/SetGraphicalItem.js` | 📈 +99 B (+5.99%) | 1.62 kB → 1.71 kB
`node_modules/recharts/es6/context/chartLayoutContext.js` | 📈 +354 B (+5.88%) | 5.88 kB → 6.22 kB
`node_modules/recharts/es6/animation/JavascriptAnimate.js` | 📈 +87 B (+5.75%) | 1.48 kB → 1.56 kB
`node_modules/recharts/es6/cartesian/Bar.js` | 📈 +1.13 kB (+4.98%) | 22.68 kB → 23.81 kB
`src/components/budget/BudgetSummaries.tsx` | 📈 +201 B (+4.23%) | 4.64 kB → 4.83 kB
`src/components/mobile/ActionableGridListItem.tsx` | 📈 +231 B (+3.83%) | 5.9 kB → 6.12 kB
`node_modules/recharts/es6/state/keyboardEventsMiddleware.js` | 📈 +97 B (+3.60%) | 2.63 kB → 2.73 kB
`node_modules/recharts/es6/chart/PolarChart.js` | 📈 +140 B (+3.60%) | 3.8 kB → 3.94 kB
`node_modules/recharts/es6/animation/configUpdate.js` | 📈 +193 B (+3.54%) | 5.33 kB → 5.52 kB
`node_modules/recharts/es6/chart/CartesianChart.js` | 📈 +85 B (+3.38%) | 2.46 kB → 2.54 kB
`node_modules/recharts/es6/state/selectors/lineSelectors.js` | 📈 +85 B (+3.17%) | 2.62 kB → 2.7 kB
`node_modules/recharts/es6/util/LRUCache.js` | 📈 +40 B (+3.05%) | 1.28 kB → 1.32 kB
`node_modules/recharts/es6/state/selectors/axisSelectors.js` | 📈 +1.46 kB (+3.00%) | 48.47 kB → 49.92 kB
`node_modules/recharts/es6/component/TooltipBoundingBox.js` | 📈 +143 B (+2.85%) | 4.9 kB → 5.04 kB
`node_modules/recharts/es6/component/ActivePoints.js` | 📈 +76 B (+2.31%) | 3.21 kB → 3.29 kB
`src/components/mobile/MobileNavTabs.tsx` | 📈 +253 B (+2.14%) | 11.53 kB → 11.78 kB
`node_modules/recharts/es6/zIndex/DefaultZIndexes.js` | 📈 +44 B (+1.98%) | 2.17 kB → 2.22 kB
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +283 B (+1.93%) | 14.32 kB → 14.59 kB
`src/components/Notifications.tsx` | 📈 +308 B (+1.90%) | 15.87 kB → 16.17 kB
`node_modules/recharts/es6/util/svgPropertiesNoEvents.js` | 📈 +117 B (+1.77%) | 6.45 kB → 6.56 kB
`node_modules/recharts/es6/component/Text.js` | 📈 +124 B (+1.42%) | 8.51 kB → 8.63 kB
`node_modules/recharts/es6/state/chartDataSlice.js` | 📈 +25 B (+1.39%) | 1.76 kB → 1.78 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.49 MB → 9.52 MB (+40.36 kB) | +0.42%
static/js/ReportRouter.js | 1.15 MB → 1.16 MB (+13.91 kB) | +1.18%
static/js/narrow.js | 637.68 kB → 637.91 kB (+231 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 182.95 kB | 0%
static/js/da.js | 106.46 kB | 0%
static/js/de.js | 180.27 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 168.59 kB | 0%
static/js/es.js | 173.67 kB | 0%
static/js/fr.js | 179.8 kB | 0%
static/js/it.js | 171.27 kB | 0%
static/js/nb-NO.js | 157.07 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 88.48 kB | 0%
static/js/pt-BR.js | 154.41 kB | 0%
static/js/th.js | 182.04 kB | 0%
static/js/uk.js | 214.89 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C2MZfWzQ.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.36 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.36 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->