### PR TITLE
[AI] Strengthen schedule rule types in loot-core (remove ts-expect-error)

### DIFF
--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -258,16 +258,20 @@ export function getRecurringDescription(
   return `${desc}${suffix}`.trim();
 }
 
+type ScheduleRuleOptions = IRuleOptions & {
+  frequency: string;
+  interval?: number;
+  byHourOfDay?: number[];
+};
+
 export function recurConfigToRSchedule(config) {
-  const base: IRuleOptions = {
+  const base: ScheduleRuleOptions = {
     start: monthUtils.parseDate(config.start),
-    // @ts-expect-error: issues with https://gitlab.com/john.carroll.p/rschedule/-/issues/86
     frequency: config.frequency.toUpperCase(),
     byHourOfDay: [12],
   };
 
   if (config.interval) {
-    // @ts-expect-error: issues with https://gitlab.com/john.carroll.p/rschedule/-/issues/86
     base.interval = config.interval;
   }
 

--- a/upcoming-release-notes/7051.md
+++ b/upcoming-release-notes/7051.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+TypeScript: strengthen schedule type


### PR DESCRIPTION
Extracted from https://github.com/actualbudget/actual/pull/6809

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB → 14.85 MB (-93 B) | -0.00%
loot-core | 1 | 5.82 MB → 5.82 MB (-97 B) | -0.00%
api | 1 | 4.43 MB → 4.43 MB (-93 B) | -0.00%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB → 14.85 MB (-93 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📉 -93 B (-0.74%) | 12.22 kB → 12.13 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.54 MB → 9.54 MB (-93 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.15 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.37 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/nl.js | 106.37 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/pt-BR.js | 154.22 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/uk.js | 214.74 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 637.68 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB → 5.82 MB (-97 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📉 -97 B (-1.56%) | 6.08 kB → 5.98 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BwrdDDMW.js | 5.82 MB → 5.82 MB (-97 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB → 4.43 MB (-93 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/shared/schedules.ts` | 📉 -93 B (-1.68%) | 5.42 kB → 5.32 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB → 4.43 MB (-93 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->