### PR TITLE
[AI] Move ImportTransactionsOpts from api package to loot-core

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -8,6 +8,7 @@ import type {
   APITagEntity,
 } from 'loot-core/server/api-models';
 import type { Query } from 'loot-core/shared/query';
+import type { ImportTransactionsOpts } from 'loot-core/types/api-handlers';
 import type { Handlers } from 'loot-core/types/handlers';
 import type {
   ImportTransactionEntity,
@@ -125,11 +126,6 @@ export function addTransactions(
     runTransfers,
   });
 }
-
-export type ImportTransactionsOpts = {
-  defaultCleared?: boolean;
-  dryRun?: boolean;
-};
 
 export function importTransactions(
   accountId: APIAccountEntity['id'],

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -1,6 +1,4 @@
 // @ts-strict-ignore
-import type { ImportTransactionsOpts } from '@actual-app/api';
-
 import type { ImportTransactionsResult } from '../server/accounts/app';
 import type {
   APIAccountEntity,
@@ -22,6 +20,11 @@ import type {
   ScheduleEntity,
   TransactionEntity,
 } from './models';
+
+export type ImportTransactionsOpts = {
+  defaultCleared?: boolean;
+  dryRun?: boolean;
+};
 
 export type ApiHandlers = {
   'api/batch-budget-start': () => Promise<void>;

--- a/upcoming-release-notes/7053.md
+++ b/upcoming-release-notes/7053.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+TypeScript: move ImportTransactionsOpts from the api package to loot-core


### PR DESCRIPTION
Extracted from https://github.com/actualbudget/actual/pull/6809

TypeScript: move `ImportTransactionsOpts` from the api package to loot-core.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB | 0%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.54 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.15 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.37 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/nl.js | 106.37 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/pt-BR.js | 154.22 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/uk.js | 214.74 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 637.68 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BwrdDDMW.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->