### PR TITLE
Warn before delete when transfer counterpart is reconciled

### DIFF
--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useTransactionBatchActions } from './useTransactionBatchActions';
 
@@ -25,36 +24,6 @@ vi.mock('@desktop-client/queries/aqlQuery', () => ({
   aqlQuery: aqlQueryMock,
 }));
 
-function collectOneOfIds(node: unknown): string[] {
-  if (!node || typeof node !== 'object') {
-    return [];
-  }
-
-  if (
-    'id' in node &&
-    node.id &&
-    typeof node.id === 'object' &&
-    '$oneof' in node.id &&
-    Array.isArray(node.id.$oneof)
-  ) {
-    return node.id.$oneof as string[];
-  }
-
-  return Object.values(node).flatMap(value => collectOneOfIds(value));
-}
-
-function includesReconciledTrue(node: unknown): boolean {
-  if (!node || typeof node !== 'object') {
-    return false;
-  }
-
-  if ('reconciled' in node && node.reconciled === true) {
-    return true;
-  }
-
-  return Object.values(node).some(value => includesReconciledTrue(value));
-}
-
 describe('useTransactionBatchActions', () => {
   beforeEach(() => {
     dispatchMock.mockReset();
@@ -63,23 +32,13 @@ describe('useTransactionBatchActions', () => {
   });
 
   it('warns before delete when transfer pair contains a reconciled transaction', async () => {
-    aqlQueryMock.mockImplementation(async query => {
-      const serialized = query.serialize();
-      const ids = collectOneOfIds(serialized.filter);
-
-      if (includesReconciledTrue(serialized.filter)) {
-        return {
-          data: ids.includes('tx-peer')
-            ? [{ id: 'tx-peer', reconciled: true }]
-            : [],
-          dependencies: [],
-        };
-      }
-
-      return {
-        data: [{ id: 'tx-1', transfer_id: 'tx-peer' }],
-        dependencies: [],
-      };
+    aqlQueryMock.mockResolvedValueOnce({
+      data: [{ id: 'tx-1', transfer_id: 'tx-peer' }],
+      dependencies: [],
+    });
+    aqlQueryMock.mockResolvedValueOnce({
+      data: [{ id: 'tx-peer', reconciled: true }],
+      dependencies: [],
     });
 
     const { result } = renderHook(() => useTransactionBatchActions());

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTransactionBatchActions } from './useTransactionBatchActions';
+
+const { dispatchMock, pushModalMock, aqlQueryMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+  pushModalMock: vi.fn((payload: { modal: { name: string } }) => payload.modal),
+  aqlQueryMock: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (value: string) => value }),
+}));
+
+vi.mock('@desktop-client/redux', () => ({
+  useDispatch: () => dispatchMock,
+}));
+
+vi.mock('@desktop-client/modals/modalsSlice', () => ({
+  pushModal: pushModalMock,
+}));
+
+vi.mock('@desktop-client/queries/aqlQuery', () => ({
+  aqlQuery: aqlQueryMock,
+}));
+
+function collectOneOfIds(node: unknown): string[] {
+  if (!node || typeof node !== 'object') {
+    return [];
+  }
+
+  if (
+    'id' in node &&
+    node.id &&
+    typeof node.id === 'object' &&
+    '$oneof' in node.id &&
+    Array.isArray(node.id.$oneof)
+  ) {
+    return node.id.$oneof as string[];
+  }
+
+  return Object.values(node).flatMap(value => collectOneOfIds(value));
+}
+
+function includesReconciledTrue(node: unknown): boolean {
+  if (!node || typeof node !== 'object') {
+    return false;
+  }
+
+  if ('reconciled' in node && node.reconciled === true) {
+    return true;
+  }
+
+  return Object.values(node).some(value => includesReconciledTrue(value));
+}
+
+describe('useTransactionBatchActions', () => {
+  beforeEach(() => {
+    dispatchMock.mockReset();
+    pushModalMock.mockClear();
+    aqlQueryMock.mockReset();
+  });
+
+  it('warns before delete when transfer pair contains a reconciled transaction', async () => {
+    aqlQueryMock.mockImplementation(async query => {
+      const serialized = query.serialize();
+      const ids = collectOneOfIds(serialized.filter);
+
+      if (includesReconciledTrue(serialized.filter)) {
+        return {
+          data: ids.includes('tx-peer') ? [{ id: 'tx-peer', reconciled: true }] : [],
+          dependencies: [],
+        };
+      }
+
+      return {
+        data: [{ id: 'tx-1', transfer_id: 'tx-peer' }],
+        dependencies: [],
+      };
+    });
+
+    const { result } = renderHook(() => useTransactionBatchActions());
+
+    await result.current.onBatchDelete({ ids: ['tx-1'] });
+
+    expect(aqlQueryMock).toHaveBeenCalledTimes(2);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'confirm-transaction-edit' }),
+    );
+  });
+});

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts
@@ -69,7 +69,9 @@ describe('useTransactionBatchActions', () => {
 
       if (includesReconciledTrue(serialized.filter)) {
         return {
-          data: ids.includes('tx-peer') ? [{ id: 'tx-peer', reconciled: true }] : [],
+          data: ids.includes('tx-peer')
+            ? [{ id: 'tx-peer', reconciled: true }]
+            : [],
           dependencies: [],
         };
       }

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -328,11 +328,13 @@ export function useTransactionBatchActions() {
     const { data } = await aqlQuery(
       q('transactions')
         .filter({ id: { $oneof: ids } })
-        .select('*'),
+        .select('*')
+        .options({ splits: 'grouped' }),
     );
 
-    const transferIds = (data as TransactionEntity[])
-      .flatMap(transaction => transaction.transfer_id)
+    const transactions = ungroupTransactions(data as TransactionEntity[]);
+    const transferIds = transactions
+      .map(transaction => transaction.transfer_id)
       .filter((transferId): transferId is string => !!transferId);
 
     return Array.from(new Set([...ids, ...transferIds]));

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -322,6 +322,22 @@ export function useTransactionBatchActions() {
     );
   };
 
+  const getIdsForDeleteReconciledCheck = async (
+    ids: Array<TransactionEntity['id']>,
+  ) => {
+    const { data } = await aqlQuery(
+      q('transactions')
+        .filter({ id: { $oneof: ids } })
+        .select('*'),
+    );
+
+    const transferIds = (data as TransactionEntity[])
+      .flatMap(transaction => transaction.transfer_id)
+      .filter((transferId): transferId is string => !!transferId);
+
+    return Array.from(new Set([...ids, ...transferIds]));
+  };
+
   const onBatchDelete = async ({ ids, onSuccess }: BatchDeleteProps) => {
     const onConfirmDelete = (ids: Array<TransactionEntity['id']>) => {
       dispatch(
@@ -395,10 +411,12 @@ export function useTransactionBatchActions() {
       );
     };
 
+    const idsForReconciledCheck = await getIdsForDeleteReconciledCheck(ids);
+
     await checkForReconciledTransactions(
-      ids,
+      idsForReconciledCheck,
       'batchDeleteWithReconciled',
-      onConfirmDelete,
+      () => onConfirmDelete(ids),
     );
   };
 

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -325,14 +325,14 @@ export function useTransactionBatchActions() {
   const getIdsForDeleteReconciledCheck = async (
     ids: Array<TransactionEntity['id']>,
   ) => {
-    const { data } = await aqlQuery(
+    const { data }: { data: TransactionEntity[] } = await aqlQuery(
       q('transactions')
         .filter({ id: { $oneof: ids } })
         .select('*')
         .options({ splits: 'grouped' }),
     );
 
-    const transactions = ungroupTransactions(data as TransactionEntity[]);
+    const transactions = ungroupTransactions(data);
     const transferIds = transactions
       .map(transaction => transaction.transfer_id)
       .filter((transferId): transferId is string => !!transferId);

--- a/upcoming-release-notes/6787.md
+++ b/upcoming-release-notes/6787.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [HadiAyache]
+---
+
+Warn before deleting transactions when a linked transfer counterpart is reconciled.

--- a/upcoming-release-notes/7064.md
+++ b/upcoming-release-notes/7064.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [HadiAyache]
+---
+
+Warn before deleting transactions when a linked transfer counterpart is reconciled.


### PR DESCRIPTION
## Summary
Fixes missing delete warning when a selected transaction is part of a transfer and the linked counterpart is reconciled/locked.

## Repro
- Select transaction "tx-1" (not reconciled)
- Linked transfer peer "tx-peer" is reconciled
- Trigger delete batch action
- Before this change, no reconciled warning was shown

## Root cause
Reconciled precheck only inspected selected IDs and did not include transfer counterpart IDs (transfer_id).

## Fix
- Expand warning precheck IDs to include transfer-linked counterpart IDs
- Keep actual delete execution scoped to originally selected IDs

## Test
Added regression test:
- warns before delete when transfer pair contains a reconciled transaction

## Validation
- corepack yarn workspace @actual-app/web test src/hooks/useTransactionBatchActions.test.ts
- corepack yarn workspace @actual-app/web test src/hooks/useMetaThemeColor.test.ts src/hooks/useTransactionBatchActions.test.ts
- corepack yarn oxlint packages/desktop-client/src/hooks/useTransactionBatchActions.ts packages/desktop-client/src/hooks/useTransactionBatchActions.test.ts

Closes #6787

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB → 14.85 MB (+682 B) | +0.00%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB → 14.85 MB (+682 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useTransactionBatchActions.ts` | 📈 +682 B (+5.17%) | 12.87 kB → 13.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useTransactionBatchActions.js | 13.23 kB → 13.89 kB (+682 B) | +5.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.54 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.15 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.37 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/nl.js | 106.37 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/pt-BR.js | 154.22 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/uk.js | 214.74 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 637.77 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BwrdDDMW.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->