### PR TITLE
[WIP] fix: close non-modal popover on pointer down outside

### DIFF
--- a/packages/component-library/src/Popover.tsx
+++ b/packages/component-library/src/Popover.tsx
@@ -24,14 +24,29 @@ export const Popover = ({
     [props],
   );
 
+  const handlePointerDownOutside = useCallback(
+    (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        props.onOpenChange?.(false);
+      }
+    },
+    [props],
+  );
+
   useEffect(() => {
     if (!props.isNonModal) return;
     if (props.isOpen) {
       ref.current?.addEventListener('focusout', handleFocus);
+      document.addEventListener('pointerdown', handlePointerDownOutside);
     } else {
       ref.current?.removeEventListener('focusout', handleFocus);
+      document.removeEventListener('pointerdown', handlePointerDownOutside);
     }
-  }, [handleFocus, props.isNonModal, props.isOpen]);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDownOutside);
+    };
+  }, [handleFocus, handlePointerDownOutside, props.isNonModal, props.isOpen]);
 
   return (
     <ReactAriaPopover


### PR DESCRIPTION
## Summary
- When editing a transaction field (payee, note, etc.) and right-clicking to open the context menu, the menu stays open indefinitely because it never receives focus — the existing `focusout`-based close mechanism never fires.
- Added a document-level `pointerdown` listener for non-modal Popovers that closes the menu when clicking outside, regardless of focus state.

## Root Cause
The `Popover` component in `isNonModal` mode relies solely on `focusout` events to close. When the context menu is triggered while an input field has focus, the Popover opens but never gains focus itself, so `focusout` never fires and the menu cannot be dismissed.

## Fix
Register a `pointerdown` event listener on `document` when a non-modal Popover is open. If the click target is outside the Popover, trigger `onOpenChange(false)` to close it. The listener is properly cleaned up when the Popover closes or unmounts.

## Test plan
- [ ] Open a transaction for editing (click on payee, note, or any editable field)
- [ ] While the field is focused, right-click on the transaction row
- [ ] Click anywhere outside the context menu
- [ ] Verify the context menu closes properly
- [ ] Verify normal context menu behavior still works (right-click → select item)
- [ ] Verify other non-modal Popovers (payee table, sidebar, budget categories) still close correctly

Fixes #7113

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.85 MB → 14.88 MB (+36.58 kB) | +0.24%
loot-core | 1 | 5.82 MB | 0%
api | 1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.85 MB → 14.88 MB (+36.58 kB) | +0.24%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/component-library/src/Popover.tsx` | 📈 +647 B (+28.28%) | 2.23 kB → 2.87 kB
`locale/pt-BR.json` | 📈 +28.97 kB (+18.78%) | 154.22 kB → 183.19 kB
`locale/nl.json` | 📈 +6.84 kB (+6.44%) | 106.37 kB → 113.21 kB
`locale/uk.json` | 📈 +139 B (+0.06%) | 214.74 kB → 214.88 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pt-BR.js | 154.22 kB → 183.19 kB (+28.97 kB) | +18.78%
static/js/nl.js | 106.37 kB → 113.21 kB (+6.84 kB) | +6.44%
static/js/index.js | 9.54 MB → 9.54 MB (+647 B) | +0.01%
static/js/uk.js | 214.74 kB → 214.88 kB (+139 B) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 188.11 kB | 0%
static/js/da.js | 106.35 kB | 0%
static/js/de.js | 180.07 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 170.33 kB | 0%
static/js/es.js | 174.55 kB | 0%
static/js/fr.js | 179.6 kB | 0%
static/js/it.js | 171.16 kB | 0%
static/js/nb-NO.js | 156.96 kB | 0%
static/js/pl.js | 88.37 kB | 0%
static/js/th.js | 181.87 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 637.77 kB | 0%
static/js/TransactionList.js | 106.22 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 10.04 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C2vnwNMt.js | 5.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.43 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.43 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->