### PR TITLE
[AI] feat: Add option to reorder accounts in stacked net worth graph

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/NetWorthGraph.tsx
@@ -27,6 +27,7 @@ import {
 } from '@desktop-client/components/reports/chart-theme';
 import { Container } from '@desktop-client/components/reports/Container';
 import { numberFormatterTooltip } from '@desktop-client/components/reports/numberFormatter';
+import { sortAccountsByOrder } from '@desktop-client/components/reports/util';
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import type { UseFormatResult } from '@desktop-client/hooks/useFormat';
 import { usePrivacyMode } from '@desktop-client/hooks/usePrivacyMode';
@@ -236,6 +237,7 @@ type NetWorthGraphProps = {
   showTooltip?: boolean;
   interval?: string;
   mode?: 'trend' | 'stacked';
+  accountOrder?: string[];
 };
 
 export function NetWorthGraph({
@@ -246,6 +248,7 @@ export function NetWorthGraph({
   showTooltip = true,
   interval = 'Monthly',
   mode = 'trend',
+  accountOrder,
 }: NetWorthGraphProps) {
   const privacyMode = usePrivacyMode();
   const id = useId();
@@ -292,6 +295,10 @@ export function NetWorthGraph({
   const sortedAccounts = useMemo(() => {
     if (!accounts || mode !== 'stacked') return [];
 
+    if (accountOrder && accountOrder.length > 0) {
+      return sortAccountsByOrder(accounts, accountOrder, true);
+    }
+
     const totals = accounts.reduce(
       (acc, account) => {
         acc[account.id] = graphData.data.reduce((sum, point) => {
@@ -305,7 +312,7 @@ export function NetWorthGraph({
     return [...accounts].sort((a, b) => {
       return totals[a.id] - totals[b.id];
     });
-  }, [accounts, graphData.data, mode]);
+  }, [accounts, graphData.data, mode, accountOrder]);
 
   // Assign colors to accounts
   const colors = useMemo(() => {
@@ -354,6 +361,7 @@ export function NetWorthGraph({
             }}
           >
             <AreaChart
+              key={`${mode}-${sortedAccounts.map(a => a.id).join(',')}`}
               responsive
               width={width}
               height={height}

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -5,16 +5,23 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import type { KeyboardEvent } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
-import { SvgCalendar, SvgChart } from '@actual-app/components/icons/v1';
+import {
+  SvgCalendar,
+  SvgChart,
+  SvgDotsHorizontalTriple,
+  SvgMenu,
+} from '@actual-app/components/icons/v1';
 import { Menu } from '@actual-app/components/menu';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { Popover } from '@actual-app/components/popover';
 import { styles } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
@@ -40,9 +47,22 @@ import { ReportOptions } from '@desktop-client/components/reports/ReportOptions'
 import { calculateTimeRange } from '@desktop-client/components/reports/reportRanges';
 import { createSpreadsheet as netWorthSpreadsheet } from '@desktop-client/components/reports/spreadsheets/net-worth-spreadsheet';
 import { useReport } from '@desktop-client/components/reports/useReport';
-import { fromDateRepr } from '@desktop-client/components/reports/util';
+import {
+  fromDateRepr,
+  sortAccountsByOrder,
+} from '@desktop-client/components/reports/util';
+import {
+  DropHighlight,
+  useDraggable,
+  useDroppable,
+} from '@desktop-client/components/sort';
+import type {
+  DropPosition,
+  OnDropCallback,
+} from '@desktop-client/components/sort';
 import { useAccounts } from '@desktop-client/hooks/useAccounts';
 import { useDashboardWidget } from '@desktop-client/hooks/useDashboardWidget';
+import { useDragRef } from '@desktop-client/hooks/useDragRef';
 import { useFormat } from '@desktop-client/hooks/useFormat';
 import { useLocale } from '@desktop-client/hooks/useLocale';
 import { useNavigate } from '@desktop-client/hooks/useNavigate';
@@ -63,7 +83,7 @@ export function NetWorth() {
     return <LoadingIndicator />;
   }
 
-  return <NetWorthInner widget={widget} />;
+  return <NetWorthInner key={widget?.id || 'new'} widget={widget} />;
 }
 
 type NetWorthInnerProps = {
@@ -113,6 +133,10 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
   const [graphMode, setGraphMode] = useState<'trend' | 'stacked'>(
     widget?.meta?.mode || 'trend',
   );
+  const [accountOrder, setAccountOrder] = useState<string[]>(
+    widget?.meta?.accountOrder || [],
+  );
+
   // Combined setter: set mode and update interval (unless interval was set in widget meta)
   const setModeAndInterval = useCallback(
     (newMode: TimeFrame['mode']) => {
@@ -155,6 +179,62 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
     ],
   );
   const data = useReport('net_worth', reportParams);
+
+  const sortedAccountsForReorder = useMemo(() => {
+    if (!data?.accounts) return [];
+
+    if (accountOrder.length > 0) {
+      return sortAccountsByOrder(data.accounts, accountOrder);
+    }
+
+    const graphData = data.graphData?.data;
+    if (!Array.isArray(graphData)) {
+      return data.accounts;
+    }
+
+    const totals = data.accounts.reduce(
+      (acc, account) => {
+        acc[account.id] = graphData.reduce((sum, point) => {
+          return (
+            sum + (Number((point as Record<string, unknown>)[account.id]) || 0)
+          );
+        }, 0);
+        return acc;
+      },
+      {} as Record<string, number>,
+    );
+
+    return [...data.accounts].sort((a, b) => {
+      return totals[b.id] - totals[a.id];
+    });
+  }, [data?.accounts, data?.graphData?.data, accountOrder]);
+
+  const onReorderAccounts = useCallback(
+    (id: string, dropPos: DropPosition | null, targetId: string) => {
+      if (dropPos === null || id === targetId) return;
+
+      const currentOrder =
+        accountOrder.length > 0
+          ? [
+              ...accountOrder,
+              ...sortedAccountsForReorder
+                .map(a => a.id)
+                .filter(accountId => !accountOrder.includes(accountId)),
+            ]
+          : sortedAccountsForReorder.map(a => a.id);
+      const newOrder = [...currentOrder];
+
+      const fromIndex = newOrder.indexOf(id);
+      if (fromIndex === -1) return;
+      newOrder.splice(fromIndex, 1);
+      const toIndex = newOrder.indexOf(targetId);
+      if (toIndex === -1) return;
+      newOrder.splice(dropPos === 'top' ? toIndex : toIndex + 1, 0, id);
+
+      setAccountOrder(newOrder);
+    },
+    [accountOrder, sortedAccountsForReorder],
+  );
   useEffect(() => {
     async function run() {
       const earliestTransaction = await send('get-earliest-transaction');
@@ -243,6 +323,7 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
             conditionsOp,
             interval,
             mode: graphMode,
+            accountOrder,
             timeFrame: {
               start,
               end,
@@ -339,6 +420,12 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
           <>
             <IntervalSelector interval={interval} onChange={setInterval} />
             <ModeSelector mode={graphMode} onChange={setGraphMode} />
+            {graphMode === 'stacked' && (
+              <ReorderSelector
+                accounts={sortedAccountsForReorder}
+                onReorder={onReorderAccounts}
+              />
+            )}
           </>
         }
       >
@@ -384,6 +471,7 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
           showTooltip={!isNarrowWidth}
           interval={interval}
           mode={graphMode}
+          accountOrder={accountOrder}
         />
 
         <View style={{ marginTop: 30, userSelect: 'none' }}>
@@ -507,5 +595,155 @@ function ModeSelector({
         />
       </Popover>
     </>
+  );
+}
+
+function ReorderSelector({
+  accounts,
+  onReorder,
+}: {
+  accounts: Array<{ id: string; name: string }>;
+  onReorder: OnDropCallback;
+}) {
+  const { t } = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        variant="bare"
+        onPress={() => setIsOpen(true)}
+        aria-label={t('Reorder accounts')}
+      >
+        <SvgMenu style={{ width: 12, height: 12 }} />
+        <span style={{ marginLeft: 5 }}>
+          <Trans>Reorder</Trans>
+        </span>
+      </Button>
+
+      <Popover
+        triggerRef={triggerRef}
+        placement="bottom start"
+        isOpen={isOpen}
+        onOpenChange={() => setIsOpen(false)}
+        style={{ width: 300 }}
+      >
+        <View style={{ padding: 10 }}>
+          <View
+            style={{
+              ...styles.smallText,
+              fontWeight: 'bold',
+              marginBottom: 10,
+              color: theme.pageText,
+            }}
+          >
+            <Trans>Reorder accounts (top to bottom)</Trans>
+          </View>
+          <AccountReorderer accounts={accounts} onReorder={onReorder} />
+        </View>
+      </Popover>
+    </>
+  );
+}
+
+function AccountReorderer({
+  accounts,
+  onReorder,
+}: {
+  accounts: Array<{ id: string; name: string }>;
+  onReorder: OnDropCallback;
+}) {
+  return (
+    <View style={{ maxHeight: 300, overflowY: 'auto' }}>
+      {accounts.map((account, index) => (
+        <AccountItem
+          key={account.id}
+          account={account}
+          onReorder={onReorder}
+          previousAccount={accounts[index - 1]}
+          nextAccount={accounts[index + 1]}
+        />
+      ))}
+    </View>
+  );
+}
+
+function AccountItem({
+  account,
+  onReorder,
+  previousAccount,
+  nextAccount,
+}: {
+  account: { id: string; name: string };
+  onReorder: OnDropCallback;
+  previousAccount?: { id: string; name: string };
+  nextAccount?: { id: string; name: string };
+}) {
+  const { t } = useTranslation();
+  const { dragRef } = useDraggable({
+    type: 'account-reorder',
+    item: { id: account.id },
+    canDrag: true,
+    onDragChange: () => {
+      // noop
+    },
+  });
+  const handleDragRef = useDragRef(dragRef);
+
+  const { dropRef, dropPos } = useDroppable({
+    types: 'account-reorder',
+    id: account.id,
+    onDrop: onReorder,
+  });
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowUp' && previousAccount) {
+      e.preventDefault();
+      onReorder(account.id, 'top', previousAccount.id);
+    } else if (e.key === 'ArrowDown' && nextAccount) {
+      e.preventDefault();
+      onReorder(account.id, 'bottom', nextAccount.id);
+    }
+  };
+
+  return (
+    <View
+      innerRef={dropRef}
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: '8px 10px',
+        backgroundColor: theme.menuBackground,
+        borderBottom: `1px solid ${theme.tableBorder}`,
+        position: 'relative',
+        cursor: 'default',
+        userSelect: 'none',
+      }}
+    >
+      <DropHighlight pos={dropPos} />
+      <View
+        innerRef={handleDragRef}
+        role="button"
+        tabIndex={0}
+        aria-label={t('Reorder {{accountName}}', { accountName: account.name })}
+        onKeyDown={onKeyDown}
+        style={{
+          cursor: 'grab',
+          marginRight: 10,
+          color: theme.menuItemText,
+          padding: 2,
+          outline: 'none',
+          ':focus': {
+            backgroundColor: theme.menuItemBackgroundHover,
+            borderRadius: 2,
+          },
+        }}
+      >
+        <SvgDotsHorizontalTriple width={12} height={12} />
+      </View>
+      <Text style={{ color: theme.menuItemText, flex: 1 }}>{account.name}</Text>
+    </View>
   );
 }

--- a/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
@@ -185,6 +185,7 @@ export function NetWorthCard({
             showTooltip={!isEditing && !isNarrowWidth}
             interval={meta?.interval || 'Monthly'}
             mode={meta?.mode || 'trend'}
+            accountOrder={meta?.accountOrder}
             style={{ height: 'auto', flex: 1 }}
           />
         ) : (

--- a/packages/desktop-client/src/components/reports/util.ts
+++ b/packages/desktop-client/src/components/reports/util.ts
@@ -120,3 +120,20 @@ export function calculateHasWarning(
   }
   return false;
 }
+
+export function sortAccountsByOrder<T extends { id: string }>(
+  accounts: T[],
+  accountOrder: string[],
+  reverse = false,
+): T[] {
+  return [...accounts].sort((a, b) => {
+    const indexA = accountOrder.indexOf(a.id);
+    const indexB = accountOrder.indexOf(b.id);
+
+    if (indexA === -1 && indexB === -1) return 0;
+    if (indexA === -1) return reverse ? -1 : 1;
+    if (indexB === -1) return reverse ? 1 : -1;
+
+    return reverse ? indexB - indexA : indexA - indexB;
+  });
+}

--- a/packages/desktop-client/src/components/sort.tsx
+++ b/packages/desktop-client/src/components/sort.tsx
@@ -150,7 +150,7 @@ type ItemPosition = 'first' | 'last' | null;
 export const DropHighlightPosContext = createContext<ItemPosition>(null);
 
 type DropHighlightProps = {
-  pos: DropPosition;
+  pos: DropPosition | null;
   offset?: {
     top?: number;
     bottom?: number;

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -44,6 +44,7 @@ export type NetWorthWidget = AbstractWidget<
     timeFrame?: TimeFrame;
     interval?: 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
     mode?: 'trend' | 'stacked';
+    accountOrder?: string[];
   } | null
 >;
 

--- a/upcoming-release-notes/7162.md
+++ b/upcoming-release-notes/7162.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [mnil]
+---
+
+Add ability to reorder accounts in the stacked net worth graph.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Add ability to reorder accounts in the stacked net worth graph.

<img width="569" height="291" alt="image" src="https://github.com/user-attachments/assets/a52e43db-1fa2-4af1-b159-d629f471b42e" />

## Related issue(s)

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested by creating a stacked net worth graph and reordering the accounts.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.92 MB → 14.93 MB (+10.67 kB) | +0.07%
loot-core | 1 | 5.83 MB | 0%
api | 1 | 4.44 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.92 MB → 14.93 MB (+10.67 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/Menu.tsx` | 🆕 +798 B | 0 B → 798 B
`src/components/reports/reports/NetWorth.tsx` | 📈 +9.38 kB (+62.37%) | 15.03 kB → 24.41 kB
`src/components/reports/util.ts` | 📈 +416 B (+19.75%) | 2.06 kB → 2.46 kB
`src/components/reports/graphs/NetWorthGraph.tsx` | 📈 +466 B (+1.95%) | 23.36 kB → 23.82 kB
`src/components/reports/reports/NetWorthCard.tsx` | 📈 +98 B (+1.11%) | 8.62 kB → 8.71 kB
`locale/en.json` | 📈 +353 B (+0.20%) | 170.86 kB → 171.21 kB
`src/reports/mutations.ts` | 📈 +4 B (+0.03%) | 14.15 kB → 14.15 kB
`locale/th.json` | 📉 -40 B (-0.02%) | 181.58 kB → 181.54 kB
`locale/nl.json` | 📉 -29 B (-0.03%) | 113.06 kB → 113.03 kB
`locale/pt-BR.json` | 📉 -74 B (-0.04%) | 182.89 kB → 182.82 kB
`locale/pl.json` | 📉 -38 B (-0.04%) | 89.65 kB → 89.61 kB
`locale/nb-NO.json` | 📉 -67 B (-0.04%) | 156.8 kB → 156.74 kB
`locale/it.json` | 📉 -74 B (-0.04%) | 170.98 kB → 170.91 kB
`locale/de.json` | 📉 -78 B (-0.04%) | 179.89 kB → 179.82 kB
`locale/fr.json` | 📉 -78 B (-0.04%) | 179.41 kB → 179.34 kB
`locale/ca.json` | 📉 -82 B (-0.04%) | 187.93 kB → 187.85 kB
`locale/uk.json` | 📉 -94 B (-0.04%) | 215.35 kB → 215.25 kB
`locale/es.json` | 📉 -82 B (-0.05%) | 174.37 kB → 174.29 kB
`locale/da.json` | 📉 -74 B (-0.07%) | 106.2 kB → 106.13 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.16 MB → 1.17 MB (+11.12 kB) | +0.93%
static/js/en.js | 170.86 kB → 171.21 kB (+353 B) | +0.20%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/uk.js | 215.35 kB → 215.25 kB (-94 B) | -0.04%
static/js/ca.js | 187.93 kB → 187.85 kB (-82 B) | -0.04%
static/js/es.js | 174.37 kB → 174.29 kB (-82 B) | -0.05%
static/js/de.js | 179.89 kB → 179.82 kB (-78 B) | -0.04%
static/js/fr.js | 179.41 kB → 179.34 kB (-78 B) | -0.04%
static/js/da.js | 106.2 kB → 106.13 kB (-74 B) | -0.07%
static/js/it.js | 170.98 kB → 170.91 kB (-74 B) | -0.04%
static/js/pt-BR.js | 182.89 kB → 182.82 kB (-74 B) | -0.04%
static/js/nb-NO.js | 156.8 kB → 156.74 kB (-67 B) | -0.04%
static/js/th.js | 181.58 kB → 181.54 kB (-40 B) | -0.02%
static/js/pl.js | 89.65 kB → 89.61 kB (-38 B) | -0.04%
static/js/nl.js | 113.06 kB → 113.03 kB (-29 B) | -0.03%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.57 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/narrow.js | 638.11 kB | 0%
static/js/TransactionList.js | 106.48 kB | 0%
static/js/wide.js | 164.15 kB | 0%
static/js/AppliedFilters.js | 9.71 kB | 0%
static/js/usePayeeRuleCounts.js | 11.57 kB | 0%
static/js/useTransactionBatchActions.js | 13.23 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BJYv72EV.js | 5.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.44 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
bundle.api.js | 4.44 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->