### PR TITLE
[AI] Remove unused TypeScript from root package.json devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "p-limit": "^7.3.0",
     "prompts": "^2.4.2",
     "source-map-support": "^0.5.21",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "ts-node": "^10.9.2"
   },
   "resolutions": {
     "rollup": "4.40.1",

--- a/upcoming-release-notes/7212.md
+++ b/upcoming-release-notes/7212.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove unused old TypeScript dependency

--- a/yarn.lock
+++ b/yarn.lock
@@ -11512,7 +11512,6 @@ __metadata:
     prompts: "npm:^2.4.2"
     source-map-support: "npm:^0.5.21"
     ts-node: "npm:^10.9.2"
-    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -28734,7 +28733,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4, typescript@npm:^5.9.3":
+"typescript@npm:^5.0.4":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -28754,7 +28753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.0.4#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Turns out "typescript" is not necessary to run "ts-node". TIL :) 

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x]  No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 14.94 MB | 0%
loot-core | 1 | 5.76 MB | 0%
api | 3 | 4.63 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 14.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 9.81 MB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 12.94 kB | 0%
static/js/workbox-window.prod.es5.js | 5.64 kB | 0%
static/js/ca.js | 187.85 kB | 0%
static/js/da.js | 106.13 kB | 0%
static/js/de.js | 179.82 kB | 0%
static/js/en-GB.js | 7.18 kB | 0%
static/js/en.js | 171.28 kB | 0%
static/js/es.js | 174.29 kB | 0%
static/js/fr.js | 179.34 kB | 0%
static/js/it.js | 170.91 kB | 0%
static/js/nb-NO.js | 156.74 kB | 0%
static/js/nl.js | 113.03 kB | 0%
static/js/pl.js | 89.61 kB | 0%
static/js/pt-BR.js | 182.82 kB | 0%
static/js/th.js | 181.54 kB | 0%
static/js/uk.js | 215.25 kB | 0%
static/js/resize-observer.js | 18.37 kB | 0%
static/js/BackgroundImage.js | 120.54 kB | 0%
static/js/ReportRouter.js | 1.16 MB | 0%
static/js/narrow.js | 423.11 kB | 0%
static/js/TransactionList.js | 106.52 kB | 0%
static/js/wide.js | 164.37 kB | 0%
static/js/AppliedFilters.js | 9.99 kB | 0%
static/js/usePayeeRuleCounts.js | 11.57 kB | 0%
static/js/useTransactionBatchActions.js | 13.24 kB | 0%
static/js/FormulaEditor.js | 1.04 MB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.76 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.d3q7AChe.js | 5.76 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
3 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 4.34 MB | 0%
index-BKGP2w5F.js | 285.56 kB | 0%
multipart-parser-DwddZ4BH.js | 9.33 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->