### PR TITLE
[WIP] [AI] Fix FIXED function to return number instead of string

### DIFF
--- a/packages/loot-core/src/server/rules/customFunctions.ts
+++ b/packages/loot-core/src/server/rules/customFunctions.ts
@@ -22,7 +22,7 @@ export class CustomFunctionsPlugin extends FunctionPlugin {
       state,
       this.metadata('FIXED'),
       (number: number, decimals: number = 0) => {
-        return Number(number).toFixed(decimals);
+        return Number(Number(number).toFixed(decimals));
       },
     );
   }


### PR DESCRIPTION
This PR fixes the FIXED function to return number instead of string.

The FIXED function in spreadsheet formulas was returning a string instead of a number, which could cause type mismatches when the result was used in further calculations.

Modified the FIXED function implementation to wrap the toFixed result with Number, ensuring the function returns a numeric value that can be safely used in subsequent calculations within formulas.

Testing: All existing tests pass with this change.

Related Issue: Fixes #7213

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 26 | 11.81 MB → 11.81 MB (+8 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+8 B) | +0.00%
api | 4 | 4.05 MB → 4.05 MB (+8 B) | +0.00%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
26 | 11.81 MB → 11.81 MB (+8 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/customFunctions.ts` | 📈 +8 B (+0.74%) | 1.05 kB → 1.06 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useTransactionBatchActions.js | 4.27 MB → 4.27 MB (+8 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.21 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 716.38 kB | 0%
static/js/ReportRouter.js | 1002.19 kB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 185.62 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 177.63 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 169.04 kB | 0%
static/js/es.js | 172.13 kB | 0%
static/js/fr.js | 177.63 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.79 kB | 0%
static/js/narrow.js | 353.32 kB | 0%
static/js/nb-NO.js | 154.72 kB | 0%
static/js/nl.js | 111.58 kB | 0%
static/js/pl.js | 88.31 kB | 0%
static/js/pt-BR.js | 180.55 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+8 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/customFunctions.ts` | 📈 +8 B (+0.73%) | 1.07 kB → 1.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.5ttfLvFC.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bu63xj1l.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.05 MB → 4.05 MB (+8 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/customFunctions.ts` | 📈 +8 B (+0.74%) | 1.05 kB → 1.06 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (+8 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->