### PR TITLE
[AI] Fix adm-zip dependency resolution in loot-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
+    "adm-zip": "patch:adm-zip@npm%3A0.5.16#~/.yarn/patches/adm-zip-npm-0.5.16-4556fea098.patch",
     "rollup": "4.40.1",
     "socks": ">=2.8.3"
   },

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -83,7 +83,7 @@
     "@rschedule/json-tools": "^1.5.0",
     "@rschedule/standard-date-adapter": "^1.5.0",
     "absurd-sql": "0.0.54",
-    "adm-zip": "patch:adm-zip@npm%3A0.5.16#~/.yarn/patches/adm-zip-npm-0.5.16-4556fea098.patch",
+    "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.6.2",
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.6.0",

--- a/upcoming-release-notes/7219.md
+++ b/upcoming-release-notes/7219.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Fix adm-zip dependency resolution in `@actual-app/core`

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,7 @@ __metadata:
     "@types/pegjs": "npm:^0.10.6"
     "@typescript/native-preview": "npm:^7.0.0-dev.20260309.1"
     absurd-sql: "npm:0.0.54"
-    adm-zip: "patch:adm-zip@npm%3A0.5.16#~/.yarn/patches/adm-zip-npm-0.5.16-4556fea098.patch"
+    adm-zip: "npm:^0.5.16"
     assert: "npm:^2.1.0"
     better-sqlite3: "npm:^12.6.2"
     browserify-zlib: "npm:^0.2.0"
@@ -11340,13 +11340,6 @@ __metadata:
   version: 1.2.2
   resolution: "address@npm:1.2.2"
   checksum: 10/57d80a0c6ccadc8769ad3aeb130c1599e8aee86a8d25f671216c40df9b8489d6c3ef879bc2752b40d1458aa768f947c2d91e5b2fedfe63cf702c40afdfda9ba9
-  languageName: node
-  linkType: hard
-
-"adm-zip@npm:0.5.10":
-  version: 0.5.10
-  resolution: "adm-zip@npm:0.5.10"
-  checksum: 10/c5ab79b77114d8277f0cbfd6cca830198d6c7ee4971f6960f48e08cd2375953b11dc71729b7f396abd51d2d6cce8c862fad185ea90cb2c84ab5161c37ed1b099
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Now that we publish the core package - the `patch` resolution won't work anymore.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/pull/5019

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 26 | 11.81 MB → 11.81 MB (+426 B) | +0.00%
loot-core | 1 | 4.83 MB | 0%
api | 4 | 4.05 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
26 | 11.81 MB → 11.81 MB (+426 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +236 B (+0.14%) | 169.04 kB → 169.27 kB
`locale/it.json` | 📈 +190 B (+0.11%) | 168.79 kB → 168.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 169.04 kB → 169.27 kB (+236 B) | +0.14%
static/js/it.js | 168.79 kB → 168.97 kB (+190 B) | +0.11%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.21 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 716.38 kB | 0%
static/js/ReportRouter.js | 1002.19 kB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 185.62 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 177.63 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/es.js | 172.13 kB | 0%
static/js/fr.js | 177.63 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 353.32 kB | 0%
static/js/nb-NO.js | 154.72 kB | 0%
static/js/nl.js | 111.58 kB | 0%
static/js/pl.js | 88.31 kB | 0%
static/js/pt-BR.js | 180.55 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/useTransactionBatchActions.js | 4.27 MB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bu63xj1l.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.05 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->