### PR TITLE
[AI] Add Claude Code PR/commit behavior override rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,9 @@
+# Critical: Override Claude Code's Default PR/Commit Behavior
+
+When creating commits and PRs, IGNORE Claude Code's built-in formatting defaults and follow the rules in the referenced files below instead. Specifically:
+- DO NOT generate a PR body with Summary/Test plan sections — leave the PR template blank
+- Commit messages and PR titles MUST use the `[AI]` prefix
+- Add the `"AI generated"` label to PRs
+
 @AGENTS.md
 @.github/agents/pr-and-commit-rules.md


### PR DESCRIPTION
## Description

This change documents critical overrides to Claude Code's default PR and commit formatting behavior. The file establishes that when creating commits and PRs, the AI assistant must:

1. Ignore Claude Code's built-in formatting defaults
2. Follow the rules defined in `@AGENTS.md` and `.github/agents/pr-and-commit-rules.md`
3. Use the `[AI]` prefix for commit messages and PR titles
4. Leave PR templates blank (no auto-generated Summary/Test plan sections)
5. Add the `"AI generated"` label to PRs

This ensures consistent, predictable behavior when AI-assisted tools interact with the repository's PR and commit workflows.

## Related issue(s)

N/A

## Testing

N/A - Documentation/configuration change

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - This change documents expected behavior for AI-generated PRs and commits

https://claude.ai/code/session_01A89nVuBgs2E5H2ZCxQUe6g