### PR TITLE
[AI] Fix batchMessages losing nested batch messages on outer failure

### DIFF
--- a/packages/loot-core/src/server/sync/batchMessages.test.ts
+++ b/packages/loot-core/src/server/sync/batchMessages.test.ts
@@ -1,0 +1,147 @@
+import { Timestamp } from '@actual-app/crdt';
+
+import * as db from '../db';
+
+import { batchMessages, sendMessages, setSyncingMode } from './index';
+
+beforeEach(() => {
+  setSyncingMode('disabled');
+  return global.emptyDatabase()();
+});
+
+afterEach(() => {
+  global.resetTime();
+  setSyncingMode('disabled');
+});
+
+describe('batchMessages concurrency', () => {
+  it('preserves nested batch messages when outer batch fails', async () => {
+    // Regression test: nested batch messages must not be silently lost
+    // when the outer batch throws after the inner batch completes.
+    //
+    // Trace: A starts outer batch, sends msgA, yields. B starts nested
+    // batch, sends msgB, completes. A resumes and throws. Fix: messages
+    // are sent before rethrowing.
+
+    let resolveYield: () => void;
+    const yieldPromise = new Promise<void>(resolve => {
+      resolveYield = resolve;
+    });
+
+    let innerBatchReturned = false;
+
+    // Start operation A - it will yield, allowing B to interleave
+    const operationA = batchMessages(async () => {
+      await sendMessages([
+        {
+          dataset: 'transactions',
+          row: 'row-a',
+          column: 'amount',
+          value: 100,
+          timestamp: Timestamp.send(),
+        },
+      ]);
+
+      // Yield to event loop - B will run during this await
+      await yieldPromise;
+
+      // A fails after B has completed
+      throw new Error('operation A failed');
+    });
+
+    global.stepForwardInTime();
+
+    // B runs while A is yielded. IS_BATCHING is true, so B is nested.
+    await batchMessages(async () => {
+      await sendMessages([
+        {
+          dataset: 'transactions',
+          row: 'row-b',
+          column: 'amount',
+          value: 200,
+          timestamp: Timestamp.send(),
+        },
+      ]);
+    });
+    innerBatchReturned = true;
+
+    // Resume A, which will throw
+    resolveYield();
+
+    // A still fails
+    await expect(operationA).rejects.toThrow('operation A failed');
+
+    // B returned successfully
+    expect(innerBatchReturned).toBe(true);
+
+    // FIX: B's message IS applied despite outer batch failure.
+    // All accumulated messages are sent before the error is rethrown.
+    const rowB = await db.first<{ id: string }>(
+      'SELECT * FROM transactions WHERE id = ?',
+      ['row-b'],
+    );
+    expect(rowB).not.toBeNull();
+
+    // A's message is also applied (consistent with non-batched behavior
+    // where each sendMessages call applies immediately)
+    const rowA = await db.first<{ id: string }>(
+      'SELECT * FROM transactions WHERE id = ?',
+      ['row-a'],
+    );
+    expect(rowA).not.toBeNull();
+  });
+
+  it('applies all messages when outer batch succeeds', async () => {
+    let resolveYield: () => void;
+    const yieldPromise = new Promise<void>(resolve => {
+      resolveYield = resolve;
+    });
+
+    const operationA = batchMessages(async () => {
+      await sendMessages([
+        {
+          dataset: 'transactions',
+          row: 'row-a',
+          column: 'amount',
+          value: 100,
+          timestamp: Timestamp.send(),
+        },
+      ]);
+
+      // Yield to event loop
+      await yieldPromise;
+    });
+
+    global.stepForwardInTime();
+
+    // B runs as nested batch
+    await batchMessages(async () => {
+      await sendMessages([
+        {
+          dataset: 'transactions',
+          row: 'row-b',
+          column: 'amount',
+          value: 200,
+          timestamp: Timestamp.send(),
+        },
+      ]);
+    });
+
+    // Resume A (succeeds)
+    resolveYield();
+    await operationA;
+
+    // Both messages should be applied
+    const rowA = await db.first<{ id: string; amount: number }>(
+      'SELECT * FROM transactions WHERE id = ?',
+      ['row-a'],
+    );
+    expect(rowA).not.toBeNull();
+
+    const rowB = await db.first<{ id: string; amount: number }>(
+      'SELECT * FROM transactions WHERE id = ?',
+      ['row-b'],
+    );
+    expect(rowB).not.toBeNull();
+  });
+});

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -482,12 +482,14 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
 
   IS_BATCHING = true;
   let batched: Message[] = [];
-  let error: unknown = null;
+  let failed = false;
+  let caughtError = new Error();
 
   try {
     await func();
   } catch (e) {
-    error = e;
+    failed = true;
+    caughtError = e instanceof Error ? e : new Error(String(e));
   } finally {
     IS_BATCHING = false;
     batched = _BATCHED;
@@ -506,16 +508,18 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
     } catch (sendError) {
       // If _sendMessages fails and we already have an error from func(),
       // preserve the original error since it's the root cause.
-      if (!error) {
-        throw sendError;
+      if (!failed) {
+        throw sendError instanceof Error
+          ? sendError
+          : new Error(String(sendError));
       }
       captureException(sendError);
     }
   }
 
-  if (error) {
-    void errorHandler(error as Error);
-    throw error;
+  if (failed) {
+    void errorHandler(caughtError);
+    throw caughtError;
   }
 }
 

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -482,20 +482,40 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
 
   IS_BATCHING = true;
   let batched: Message[] = [];
+  let error: unknown = null;
 
   try {
     await func();
   } catch (e) {
-    void errorHandler(e);
-    throw e;
+    error = e;
   } finally {
     IS_BATCHING = false;
     batched = _BATCHED;
     _BATCHED = [];
   }
 
+  // Always send accumulated messages, even if func threw. This prevents
+  // silently losing messages from successfully-completed nested batches
+  // that were coalesced into this outer batch. Without this, if the
+  // outer batch fails, all nested batch messages are discarded even
+  // though their callers received no error. This is consistent with
+  // non-batched behavior where each sendMessages call applies immediately.
   if (batched.length > 0) {
-    await _sendMessages(batched);
+    try {
+      await _sendMessages(batched);
+    } catch (sendError) {
+      // If _sendMessages fails and we already have an error from func(),
+      // preserve the original error since it's the root cause.
+      if (!error) {
+        throw sendError;
+      }
+      captureException(sendError);
+    }
+  }
+
+  if (error) {
+    void errorHandler(error as Error);
+    throw error;
   }
 }
 

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -482,14 +482,12 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
 
   IS_BATCHING = true;
   let batched: Message[] = [];
-  let failed = false;
-  let caughtError = new Error();
+  let error: unknown = null;
 
   try {
     await func();
   } catch (e) {
-    failed = true;
-    caughtError = e instanceof Error ? e : new Error(String(e));
+    error = e;
   } finally {
     IS_BATCHING = false;
     batched = _BATCHED;
@@ -508,7 +506,7 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
     } catch (sendError) {
       // If _sendMessages fails and we already have an error from func(),
       // preserve the original error since it's the root cause.
-      if (!failed) {
+      if (!error) {
         throw sendError instanceof Error
           ? sendError
           : new Error(String(sendError));
@@ -517,9 +515,10 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
     }
   }
 
-  if (failed) {
-    void errorHandler(caughtError);
-    throw caughtError;
+  if (error) {
+    void errorHandler(error as Error);
+    // eslint-disable-next-line no-throw-literal -- rethrowing the original caught value
+    throw error;
   }
 }
 

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -482,12 +482,12 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
 
   IS_BATCHING = true;
   let batched: Message[] = [];
-  let error: unknown = null;
+  let error: Error | undefined;
 
   try {
     await func();
   } catch (e) {
-    error = e;
+    error = e instanceof Error ? e : new Error(String(e));
   } finally {
     IS_BATCHING = false;
     batched = _BATCHED;
@@ -516,8 +516,8 @@ export async function batchMessages(func: () => Promise<void>): Promise<void> {
   }
 
   if (error) {
-    void errorHandler(error as Error);
-    // eslint-disable-next-line no-throw-literal -- rethrowing the original caught value
+    void errorHandler(error);
+    // eslint-disable-next-line no-throw-literal -- oxlint can't narrow Error|undefined
     throw error;
   }
 }

--- a/upcoming-release-notes/7225.md
+++ b/upcoming-release-notes/7225.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [dearlordylord]
+---
+
+Fix batchMessages silently losing nested batch messages when outer batch fails


### PR DESCRIPTION
## Description

`batchMessages` uses module-level globals `IS_BATCHING` and `_BATCHED` shared across async operations. When two async callers interleave (cooperative scheduling via await), a nested batch's messages get silently lost if the outer batch throws - the catch block ran before `_sendMessages`, discarding everything in `_BATCHED`.

Fix moves `_sendMessages` call outside try/catch so accumulated messages are always sent regardless of whether `func()` threw.

## Related issue(s)

None (found via code audit)

## Testing

Added `batchMessages.test.ts` with two tests:
- Outer batch fails after inner completes - verifies inner messages are preserved
- Both batches succeed - positive control

Both tests use promise-based yield control to deterministically reproduce the interleaving.

## Checklist

- [ ] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 26 | 11.81 MB | 0%
loot-core | 1 | 4.83 MB → 4.83 MB (+259 B) | +0.01%
api | 4 | 4.05 MB → 4.05 MB (+250 B) | +0.01%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
26 | 11.81 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.21 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 716.38 kB | 0%
static/js/ReportRouter.js | 1002.19 kB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 185.62 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 177.63 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 169.27 kB | 0%
static/js/es.js | 172.13 kB | 0%
static/js/fr.js | 177.63 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.97 kB | 0%
static/js/narrow.js | 353.32 kB | 0%
static/js/nb-NO.js | 154.72 kB | 0%
static/js/nl.js | 111.58 kB | 0%
static/js/pl.js | 88.31 kB | 0%
static/js/pt-BR.js | 180.55 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/useTransactionBatchActions.js | 4.27 MB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+259 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +259 B (+1.84%) | 13.74 kB → 14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BYOYYYBz.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bu63xj1l.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.05 MB → 4.05 MB (+250 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +250 B (+1.83%) | 13.35 kB → 13.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (+250 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->