### PR TITLE
Fix transactions table context menu bug

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1321,8 +1321,8 @@ const Transaction = memo(function Transaction({
           triggerRef={triggerRef}
           placement="bottom start"
           isOpen={menuOpen}
-          onOpenChange={(isOpen) => {
-            if(!isOpen) setMenuOpen(false);
+          onOpenChange={isOpen => {
+            if (!isOpen) setMenuOpen(false);
           }}
           {...position}
           style={{ width: 200, margin: 1 }}

--- a/upcoming-release-notes/7264.md
+++ b/upcoming-release-notes/7264.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [nathaliaacouto]
+---
+
+This PR fixes a bug where the transaction context menu (right-click) would remain stuck on the screen if opened while a transaction cell was in edit mode.


### PR DESCRIPTION
## Description

This PR fixes a bug where the transaction context menu (right-click) would remain stuck on the screen if opened while a transaction cell was in edit mode.

## Related issue(s)

Fixes #7113 

## Testing
1. Focus into a transaction field as to edit it (payee, note, ...).
2. Right click anywhere on the transaction.
3. Click somewhere else.
4. The menu should disappear 

Before:

https://github.com/user-attachments/assets/b2c53a40-8898-4107-a9c8-30a58ed320b3


After:

https://github.com/user-attachments/assets/13e8d96f-0ecc-4ecd-82ff-71a612460344


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 12.51 MB → 12.51 MB (+38 B) | +0.00%
loot-core | 1 | 4.83 MB | 0%
api | 4 | 4.06 MB | 0%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 12.51 MB → 12.51 MB (+38 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📈 +38 B (+0.04%) | 85.09 kB → 85.12 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useTransactionBatchActions.js | 4.29 MB → 4.29 MB (+38 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.23 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1021.25 kB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 185.57 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 177.58 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.68 kB | 0%
static/js/es.js | 172.13 kB | 0%
static/js/fr.js | 177.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.97 kB | 0%
static/js/narrow.js | 354.12 kB | 0%
static/js/nb-NO.js | 154.72 kB | 0%
static/js/nl.js | 111.58 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 180.5 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 484.67 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dmj0rSrb.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.06 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->