### PR TITLE
Fix filter operator switching behavior

### DIFF
--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -477,38 +477,41 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-        (field !== 'payee' || !isIdOp(op)) &&
-        (field !== 'account' || !isNoValueAccountOp(op)) && (
-          <GenericInput
-            ref={inputRef}
-            // @ts-expect-error - fix me
-            field={field === 'date' || field === 'category' ? subfield : field}
-            // @ts-expect-error - fix me
-            type={
-              type === 'id' &&
-              (op === 'contains' ||
-                op === 'matches' ||
-                op === 'doesNotContain' ||
-                op === 'hasTags')
-                ? 'string'
-                : type
-            }
-            numberFormatType="currency"
-            // @ts-expect-error - fix me
-            value={
-              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-            }
-            // @ts-expect-error - fix me
-            multi={op === 'oneOf' || op === 'notOneOf'}
-            op={op}
-            options={subfieldToOptions(field, subfield)}
-            style={{ marginTop: 10 }}
-            // oxlint-disable-next-line typescript/no-explicit-any
-            onChange={(v: any) => {
-              dispatch({ type: 'set-value', value: v });
-            }}
-          />
-        )}
+          (field !== 'payee' || !isIdOp(op)) &&
+          (field !== 'account' || !isNoValueAccountOp(op)) && (
+            <GenericInput
+              ref={inputRef}
+              // @ts-expect-error - fix me
+              field={
+                field === 'date' || field === 'category' ? subfield : field
+              }
+              // @ts-expect-error - fix me
+              type={
+                type === 'id' &&
+                (op === 'contains' ||
+                  op === 'matches' ||
+                  op === 'doesNotContain' ||
+                  op === 'hasTags')
+                  ? 'string'
+                  : type
+              }
+              numberFormatType="currency"
+              // @ts-expect-error - fix me
+              value={
+                formattedValue ??
+                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+              }
+              // @ts-expect-error - fix me
+              multi={op === 'oneOf' || op === 'notOneOf'}
+              op={op}
+              options={subfieldToOptions(field, subfield)}
+              style={{ marginTop: 10 }}
+              // oxlint-disable-next-line typescript/no-explicit-any
+              onChange={(v: any) => {
+                dispatch({ type: 'set-value', value: v });
+              }}
+            />
+          )}
 
         {field === 'payee' && isIdOp(op) && (
           <PayeeFilter

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -477,42 +477,38 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-          (field !== 'payee' || !isPayeeIdOp(op)) &&
-          field !== 'account' &&
-          !isNoValueAccountOp(op) && (
-            <GenericInput
-              ref={inputRef}
-              // @ts-expect-error - fix me
-              field={
-                field === 'date' || field === 'category' ? subfield : field
-              }
-              // @ts-expect-error - fix me
-              type={
-                type === 'id' &&
-                (op === 'contains' ||
-                  op === 'matches' ||
-                  op === 'doesNotContain' ||
-                  op === 'hasTags')
-                  ? 'string'
-                  : type
-              }
-              numberFormatType="currency"
-              // @ts-expect-error - fix me
-              value={
-                formattedValue ??
-                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-              }
-              // @ts-expect-error - fix me
-              multi={op === 'oneOf' || op === 'notOneOf'}
-              op={op}
-              options={subfieldToOptions(field, subfield)}
-              style={{ marginTop: 10 }}
-              // oxlint-disable-next-line typescript/no-explicit-any
-              onChange={(v: any) => {
-                dispatch({ type: 'set-value', value: v });
-              }}
-            />
-          )}
+        (field !== 'payee' || !isPayeeIdOp(op)) &&
+        (field !== 'account' || !isNoValueAccountOp(op)) && (
+          <GenericInput
+            ref={inputRef}
+            // @ts-expect-error - fix me
+            field={field === 'date' || field === 'category' ? subfield : field}
+            // @ts-expect-error - fix me
+            type={
+              type === 'id' &&
+              (op === 'contains' ||
+                op === 'matches' ||
+                op === 'doesNotContain' ||
+                op === 'hasTags')
+                ? 'string'
+                : type
+            }
+            numberFormatType="currency"
+            // @ts-expect-error - fix me
+            value={
+              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+            }
+            // @ts-expect-error - fix me
+            multi={op === 'oneOf' || op === 'notOneOf'}
+            op={op}
+            options={subfieldToOptions(field, subfield)}
+            style={{ marginTop: 10 }}
+            // oxlint-disable-next-line typescript/no-explicit-any
+            onChange={(v: any) => {
+              dispatch({ type: 'set-value', value: v });
+            }}
+          />
+        )}
 
         {field === 'payee' && isPayeeIdOp(op) && (
           <PayeeFilter

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -35,8 +35,11 @@ import {
 } from 'date-fns';
 
 import { GenericInput } from '#components/util/GenericInput';
+import { useAccounts } from '#hooks/useAccounts';
+import { useCategories } from '#hooks/useCategories';
 import { useDateFormat } from '#hooks/useDateFormat';
 import { useFormat } from '#hooks/useFormat';
+import { usePayees } from '#hooks/usePayees';
 import { useTransactionFilters } from '#hooks/useTransactionFilters';
 
 import { CompactFiltersButton } from './CompactFiltersButton';

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -142,8 +142,8 @@ function ConfigureField<T extends RuleConditionEntity>({
     return value;
   }, [value, field, subfield, dateFormat]);
 
-  // For ops that filter based on payeeId, those use PayeeFilter, otherwise we use GenericInput
-  const isPayeeIdOp = (op: T['op']) =>
+  // For ops that filter based on IDs
+  const isIdOp = (op: T['op']) =>
     ['is', 'isNot', 'oneOf', 'notOneOf'].includes(op);
   // For ops that use exact matching with a single stored ID value
   const isSingleIdOp = (op: T['op']) => ['is', 'isNot'].includes(op);
@@ -477,43 +477,40 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-          (field !== 'payee' || !isPayeeIdOp(op)) &&
-          (field !== 'account' || !isNoValueAccountOp(op)) && (
-            <GenericInput
-              ref={inputRef}
-              // @ts-expect-error - fix me
-              field={
-                field === 'date' || field === 'category' ? subfield : field
-              }
-              // @ts-expect-error - fix me
-              type={
-                type === 'id' &&
-                (op === 'contains' ||
-                  op === 'matches' ||
-                  op === 'doesNotContain' ||
-                  op === 'hasTags')
-                  ? 'string'
-                  : type
-              }
-              numberFormatType="currency"
-              // @ts-expect-error - fix me
-              value={
-                formattedValue ??
-                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-              }
-              // @ts-expect-error - fix me
-              multi={op === 'oneOf' || op === 'notOneOf'}
-              op={op}
-              options={subfieldToOptions(field, subfield)}
-              style={{ marginTop: 10 }}
-              // oxlint-disable-next-line typescript/no-explicit-any
-              onChange={(v: any) => {
-                dispatch({ type: 'set-value', value: v });
-              }}
-            />
-          )}
+        (field !== 'payee' || !isIdOp(op)) &&
+        (field !== 'account' || !isNoValueAccountOp(op)) && (
+          <GenericInput
+            ref={inputRef}
+            // @ts-expect-error - fix me
+            field={field === 'date' || field === 'category' ? subfield : field}
+            // @ts-expect-error - fix me
+            type={
+              type === 'id' &&
+              (op === 'contains' ||
+                op === 'matches' ||
+                op === 'doesNotContain' ||
+                op === 'hasTags')
+                ? 'string'
+                : type
+            }
+            numberFormatType="currency"
+            // @ts-expect-error - fix me
+            value={
+              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+            }
+            // @ts-expect-error - fix me
+            multi={op === 'oneOf' || op === 'notOneOf'}
+            op={op}
+            options={subfieldToOptions(field, subfield)}
+            style={{ marginTop: 10 }}
+            // oxlint-disable-next-line typescript/no-explicit-any
+            onChange={(v: any) => {
+              dispatch({ type: 'set-value', value: v });
+            }}
+          />
+        )}
 
-        {field === 'payee' && isPayeeIdOp(op) && (
+        {field === 'payee' && isIdOp(op) && (
           <PayeeFilter
             // @ts-expect-error - fix me
             value={formattedValue}

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -296,37 +296,43 @@ function ConfigureField<T extends RuleConditionEntity>({
           });
         }}
       >
-        {type !== 'boolean' && (field !== 'payee' || !isPayeeIdOp(op)) && (
-          <GenericInput
-            ref={inputRef}
-            // @ts-expect-error - fix me
-            field={field === 'date' || field === 'category' ? subfield : field}
-            // @ts-expect-error - fix me
-            type={
-              type === 'id' &&
-              (op === 'contains' ||
-                op === 'matches' ||
-                op === 'doesNotContain' ||
-                op === 'hasTags')
-                ? 'string'
-                : type
-            }
-            numberFormatType="currency"
-            // @ts-expect-error - fix me
-            value={
-              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-            }
-            // @ts-expect-error - fix me
-            multi={op === 'oneOf' || op === 'notOneOf'}
-            op={op}
-            options={subfieldToOptions(field, subfield)}
-            style={{ marginTop: 10 }}
-            // oxlint-disable-next-line typescript/no-explicit-any
-            onChange={(v: any) => {
-              dispatch({ type: 'set-value', value: v });
-            }}
-          />
-        )}
+        {type !== 'boolean' &&
+          (field !== 'payee' || !isPayeeIdOp(op)) &&
+          field !== 'account' &&
+          !isNoValueAccountOp(op) && (
+            <GenericInput
+              ref={inputRef}
+              // @ts-expect-error - fix me
+              field={
+                field === 'date' || field === 'category' ? subfield : field
+              }
+              // @ts-expect-error - fix me
+              type={
+                type === 'id' &&
+                (op === 'contains' ||
+                  op === 'matches' ||
+                  op === 'doesNotContain' ||
+                  op === 'hasTags')
+                  ? 'string'
+                  : type
+              }
+              numberFormatType="currency"
+              // @ts-expect-error - fix me
+              value={
+                formattedValue ??
+                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+              }
+              // @ts-expect-error - fix me
+              multi={op === 'oneOf' || op === 'notOneOf'}
+              op={op}
+              options={subfieldToOptions(field, subfield)}
+              style={{ marginTop: 10 }}
+              // oxlint-disable-next-line typescript/no-explicit-any
+              onChange={(v: any) => {
+                dispatch({ type: 'set-value', value: v });
+              }}
+            />
+          )}
 
         {field === 'payee' && isPayeeIdOp(op) && (
           <PayeeFilter

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -297,42 +297,38 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-          (field !== 'payee' || !isPayeeIdOp(op)) &&
-          field !== 'account' &&
-          !isNoValueAccountOp(op) && (
-            <GenericInput
-              ref={inputRef}
-              // @ts-expect-error - fix me
-              field={
-                field === 'date' || field === 'category' ? subfield : field
-              }
-              // @ts-expect-error - fix me
-              type={
-                type === 'id' &&
-                (op === 'contains' ||
-                  op === 'matches' ||
-                  op === 'doesNotContain' ||
-                  op === 'hasTags')
-                  ? 'string'
-                  : type
-              }
-              numberFormatType="currency"
-              // @ts-expect-error - fix me
-              value={
-                formattedValue ??
-                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-              }
-              // @ts-expect-error - fix me
-              multi={op === 'oneOf' || op === 'notOneOf'}
-              op={op}
-              options={subfieldToOptions(field, subfield)}
-              style={{ marginTop: 10 }}
-              // oxlint-disable-next-line typescript/no-explicit-any
-              onChange={(v: any) => {
-                dispatch({ type: 'set-value', value: v });
-              }}
-            />
-          )}
+        (field !== 'payee' || !isPayeeIdOp(op)) &&
+        (field !== 'account' && !isNoValueAccountOp(op)) && (
+          <GenericInput
+            ref={inputRef}
+            // @ts-expect-error - fix me
+            field={field === 'date' || field === 'category' ? subfield : field}
+            // @ts-expect-error - fix me
+            type={
+              type === 'id' &&
+              (op === 'contains' ||
+                op === 'matches' ||
+                op === 'doesNotContain' ||
+                op === 'hasTags')
+                ? 'string'
+                : type
+            }
+            numberFormatType="currency"
+            // @ts-expect-error - fix me
+            value={
+              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+            }
+            // @ts-expect-error - fix me
+            multi={op === 'oneOf' || op === 'notOneOf'}
+            op={op}
+            options={subfieldToOptions(field, subfield)}
+            style={{ marginTop: 10 }}
+            // oxlint-disable-next-line typescript/no-explicit-any
+            onChange={(v: any) => {
+              dispatch({ type: 'set-value', value: v });
+            }}
+          />
+        )}
 
         {field === 'payee' && isPayeeIdOp(op) && (
           <PayeeFilter

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -50,13 +50,6 @@ import { subfieldFromFilter } from './subfieldFromFilter';
 import { subfieldToOptions } from './subfieldToOptions';
 import { updateFilterReducer } from './updateFilterReducer';
 
-import { GenericInput } from '@desktop-client/components/util/GenericInput';
-import { useAccounts } from '@desktop-client/hooks/useAccounts';
-import { useCategories } from '@desktop-client/hooks/useCategories';
-import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
-import { useFormat } from '@desktop-client/hooks/useFormat';
-import { usePayees } from '@desktop-client/hooks/usePayees';
-import { useTransactionFilters } from '@desktop-client/hooks/useTransactionFilters';
 
 type FilterReducerState<T extends RuleConditionEntity> = Pick<
   T,

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -50,6 +50,14 @@ import { subfieldFromFilter } from './subfieldFromFilter';
 import { subfieldToOptions } from './subfieldToOptions';
 import { updateFilterReducer } from './updateFilterReducer';
 
+import { GenericInput } from '@desktop-client/components/util/GenericInput';
+import { useAccounts } from '@desktop-client/hooks/useAccounts';
+import { useCategories } from '@desktop-client/hooks/useCategories';
+import { useDateFormat } from '@desktop-client/hooks/useDateFormat';
+import { useFormat } from '@desktop-client/hooks/useFormat';
+import { usePayees } from '@desktop-client/hooks/usePayees';
+import { useTransactionFilters } from '@desktop-client/hooks/useTransactionFilters';
+
 type FilterReducerState<T extends RuleConditionEntity> = Pick<
   T,
   'value' | 'op' | 'field'
@@ -95,6 +103,9 @@ function ConfigureField<T extends RuleConditionEntity>({
   const { t } = useTranslation();
   const format = useFormat();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+  const accounts = useAccounts();
+  const categories = useCategories();
+  const payees = usePayees();
   const field = initialField === 'category_group' ? 'category' : initialField;
   const [subfield, setSubfield] = useState(initialSubfield);
   const inputRef = useRef<AmountInputRef>(null);
@@ -141,7 +152,181 @@ function ConfigureField<T extends RuleConditionEntity>({
 
   // For ops that filter based on payeeId, those use PayeeFilter, otherwise we use GenericInput
   const isPayeeIdOp = (op: T['op']) =>
-    ['is', 'is not', 'one of', 'not one of'].includes(op);
+    ['is', 'isNot', 'oneOf', 'notOneOf'].includes(op);
+  // For ops that use exact matching with a single stored ID value
+  const isSingleIdOp = (op: T['op']) => ['is', 'isNot'].includes(op);
+  // For ops that use exact matching with multiple stored ID values
+  const isMultiIdOp = (op: T['op']) => ['oneOf', 'notOneOf'].includes(op);
+  // For ops that use text matching and expect a string input
+  const isTextOp = (op: T['op']) =>
+    ['contains', 'matches', 'doesNotContain'].includes(op);
+  // For account ops that do not use an input value but should preserve the current value in state
+  const isNoValueAccountOp = (op: T['op']) =>
+    ['onBudget', 'offBudget'].includes(op);
+
+  // Convert stored ID value into text
+  const resolveIdToText = (field: string, subfield: string, value: unknown) => {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    if (field === 'account') {
+      const account = accounts.data?.find(account => account.id === value);
+      return account?.name ?? '';
+    }
+    if (field === 'payee') {
+      const payee = payees.data?.find(payee => payee.id === value);
+      return payee?.name ?? '';
+    }
+    if (field === 'category' && subfield === 'category_group') {
+      const group = categories.data?.grouped.find(group => group.id === value);
+      return group?.name ?? '';
+    }
+    if (field === 'category' && subfield === 'category') {
+      for (const group of categories.data?.grouped || []) {
+        const category = group.categories?.find(
+          category => category.id === value,
+        );
+        if (category) {
+          return category.name;
+        }
+      }
+    }
+    return '';
+  };
+
+  // Convert text into stored ID value
+  const resolveTextToId = (field: string, subfield: string, value: unknown) => {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    if (field === 'account') {
+      const matches =
+        accounts.data?.filter(account => account.name === value) ?? [];
+      return matches.length === 1 ? matches[0].id : null;
+    }
+    if (field === 'payee') {
+      const matches = payees.data?.filter(payee => payee.name === value) ?? [];
+      return matches.length === 1 ? matches[0].id : null;
+    }
+    if (field === 'category' && subfield === 'category_group') {
+      const matches =
+        categories.data?.grouped.filter(group => group.name === value) ?? [];
+      return matches.length === 1 ? matches[0].id : null;
+    }
+    if (field === 'category' && subfield === 'category') {
+      const matches = [];
+      for (const group of categories.data?.grouped || []) {
+        for (const category of group.categories || []) {
+          if (category.name === value) {
+            matches.push(category);
+          }
+        }
+      }
+      return matches.length === 1 ? matches[0].id : null;
+    }
+    return null;
+  };
+
+  const isIdField =
+    field === 'account' || field === 'payee' || field === 'category';
+
+  // Converting values when switching between ops is a bit tricky, so we have some specific rules:
+  const setOp = (nextOp: T['op']) => {
+    // Single ID -> Text: Convert stored ID to text with one to one mapping
+    if (isIdField && isSingleIdOp(op) && isTextOp(nextOp)) {
+      dispatch({
+        type: 'set-value',
+        value: resolveIdToText(field, subfield, value),
+      });
+    }
+    // Text -> Single ID: Only convert if there is a single exact match
+    if (isIdField && isTextOp(op) && isSingleIdOp(nextOp)) {
+      const resolvedValue = resolveTextToId(field, subfield, value);
+      if (resolvedValue) {
+        dispatch({
+          type: 'set-value',
+          value: resolvedValue,
+        });
+      }
+    }
+    // Multi ID -> Text: If there is exactly one selected ID, convert it to text; otherwise clear the value
+    if (isIdField && isMultiIdOp(op) && isTextOp(nextOp)) {
+      if (Array.isArray(value) && value.length === 1) {
+        dispatch({
+          type: 'set-value',
+          value: resolveIdToText(field, subfield, value[0]) || '',
+        });
+      } else {
+        dispatch({
+          type: 'set-value',
+          value: '',
+        });
+      }
+    }
+    // Text -> Multi ID: Only convert if there is a single exact match and wrap in array
+    if (isIdField && isTextOp(op) && isMultiIdOp(nextOp)) {
+      const resolvedValue = resolveTextToId(field, subfield, value);
+      if (resolvedValue) {
+        dispatch({
+          type: 'set-value',
+          value: resolvedValue ? [resolvedValue] : [],
+        });
+      }
+    }
+    // No-value Account -> Text: Preserve the old value while the no-value op is selected,
+    // then convert when switching back to text
+    if (field === 'account' && isNoValueAccountOp(op) && isTextOp(nextOp)) {
+      if (Array.isArray(value)) {
+        dispatch({
+          type: 'set-value',
+          value:
+            value.length === 1
+              ? resolveIdToText(field, subfield, value[0]) || ''
+              : '',
+        });
+      } else {
+        dispatch({
+          type: 'set-value',
+          value: resolveIdToText(field, subfield, value) || '',
+        });
+      }
+    }
+    // No-value Account -> Single-ID: If preserved value is text, resolve to an ID;
+    // If it is already a single ID string, keep as-is
+    if (field === 'account' && isNoValueAccountOp(op) && isSingleIdOp(nextOp)) {
+      if (typeof value === 'string') {
+        const resolvedValue = resolveTextToId(field, subfield, value);
+        dispatch({
+          type: 'set-value',
+          value: resolvedValue || value,
+        });
+      } else {
+        dispatch({
+          type: 'set-value',
+          value: '',
+        });
+      }
+    }
+    // No-value Account -> Multi-ID: If the preserved value is text, resolve to a single ID and wrap;
+    // if the preserved value is already a single ID string, wrap it directly;
+    // otherwise clear
+    if (field === 'account' && isNoValueAccountOp(op) && isMultiIdOp(nextOp)) {
+      if (typeof value === 'string') {
+        const resolvedValue = resolveTextToId(field, subfield, value);
+
+        dispatch({
+          type: 'set-value',
+          value: resolvedValue ? [resolvedValue] : [value],
+        });
+      } else {
+        dispatch({
+          type: 'set-value',
+          value: [],
+        });
+      }
+    }
+    dispatch({ type: 'set-op', op: nextOp });
+  };
 
   const subfieldSelectOptions = (
     field: 'amount' | 'date' | 'category',
@@ -244,7 +429,7 @@ function ConfigureField<T extends RuleConditionEntity>({
                 key={currOp}
                 op={currOp}
                 isSelected={currOp === op}
-                onPress={() => dispatch({ type: 'set-op', op: currOp })}
+                onPress={() => setOp(currOp)}
               />
             ))}
             {ops.slice(3, ops.length).map(currOp => (
@@ -252,7 +437,7 @@ function ConfigureField<T extends RuleConditionEntity>({
                 key={currOp}
                 op={currOp}
                 isSelected={currOp === op}
-                onPress={() => dispatch({ type: 'set-op', op: currOp })}
+                onPress={() => setOp(currOp)}
               />
             ))}
           </>

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -50,7 +50,6 @@ import { subfieldFromFilter } from './subfieldFromFilter';
 import { subfieldToOptions } from './subfieldToOptions';
 import { updateFilterReducer } from './updateFilterReducer';
 
-
 type FilterReducerState<T extends RuleConditionEntity> = Pick<
   T,
   'value' | 'op' | 'field'
@@ -478,38 +477,42 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-        (field !== 'payee' || !isPayeeIdOp(op)) &&
-        (field !== 'account' && !isNoValueAccountOp(op)) && (
-          <GenericInput
-            ref={inputRef}
-            // @ts-expect-error - fix me
-            field={field === 'date' || field === 'category' ? subfield : field}
-            // @ts-expect-error - fix me
-            type={
-              type === 'id' &&
-              (op === 'contains' ||
-                op === 'matches' ||
-                op === 'doesNotContain' ||
-                op === 'hasTags')
-                ? 'string'
-                : type
-            }
-            numberFormatType="currency"
-            // @ts-expect-error - fix me
-            value={
-              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-            }
-            // @ts-expect-error - fix me
-            multi={op === 'oneOf' || op === 'notOneOf'}
-            op={op}
-            options={subfieldToOptions(field, subfield)}
-            style={{ marginTop: 10 }}
-            // oxlint-disable-next-line typescript/no-explicit-any
-            onChange={(v: any) => {
-              dispatch({ type: 'set-value', value: v });
-            }}
-          />
-        )}
+          (field !== 'payee' || !isPayeeIdOp(op)) &&
+          field !== 'account' &&
+          !isNoValueAccountOp(op) && (
+            <GenericInput
+              ref={inputRef}
+              // @ts-expect-error - fix me
+              field={
+                field === 'date' || field === 'category' ? subfield : field
+              }
+              // @ts-expect-error - fix me
+              type={
+                type === 'id' &&
+                (op === 'contains' ||
+                  op === 'matches' ||
+                  op === 'doesNotContain' ||
+                  op === 'hasTags')
+                  ? 'string'
+                  : type
+              }
+              numberFormatType="currency"
+              // @ts-expect-error - fix me
+              value={
+                formattedValue ??
+                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+              }
+              // @ts-expect-error - fix me
+              multi={op === 'oneOf' || op === 'notOneOf'}
+              op={op}
+              options={subfieldToOptions(field, subfield)}
+              style={{ marginTop: 10 }}
+              // oxlint-disable-next-line typescript/no-explicit-any
+              onChange={(v: any) => {
+                dispatch({ type: 'set-value', value: v });
+              }}
+            />
+          )}
 
         {field === 'payee' && isPayeeIdOp(op) && (
           <PayeeFilter

--- a/packages/desktop-client/src/components/filters/FiltersMenu.tsx
+++ b/packages/desktop-client/src/components/filters/FiltersMenu.tsx
@@ -477,38 +477,41 @@ function ConfigureField<T extends RuleConditionEntity>({
         }}
       >
         {type !== 'boolean' &&
-        (field !== 'payee' || !isPayeeIdOp(op)) &&
-        (field !== 'account' || !isNoValueAccountOp(op)) && (
-          <GenericInput
-            ref={inputRef}
-            // @ts-expect-error - fix me
-            field={field === 'date' || field === 'category' ? subfield : field}
-            // @ts-expect-error - fix me
-            type={
-              type === 'id' &&
-              (op === 'contains' ||
-                op === 'matches' ||
-                op === 'doesNotContain' ||
-                op === 'hasTags')
-                ? 'string'
-                : type
-            }
-            numberFormatType="currency"
-            // @ts-expect-error - fix me
-            value={
-              formattedValue ?? (op === 'oneOf' || op === 'notOneOf' ? [] : '')
-            }
-            // @ts-expect-error - fix me
-            multi={op === 'oneOf' || op === 'notOneOf'}
-            op={op}
-            options={subfieldToOptions(field, subfield)}
-            style={{ marginTop: 10 }}
-            // oxlint-disable-next-line typescript/no-explicit-any
-            onChange={(v: any) => {
-              dispatch({ type: 'set-value', value: v });
-            }}
-          />
-        )}
+          (field !== 'payee' || !isPayeeIdOp(op)) &&
+          (field !== 'account' || !isNoValueAccountOp(op)) && (
+            <GenericInput
+              ref={inputRef}
+              // @ts-expect-error - fix me
+              field={
+                field === 'date' || field === 'category' ? subfield : field
+              }
+              // @ts-expect-error - fix me
+              type={
+                type === 'id' &&
+                (op === 'contains' ||
+                  op === 'matches' ||
+                  op === 'doesNotContain' ||
+                  op === 'hasTags')
+                  ? 'string'
+                  : type
+              }
+              numberFormatType="currency"
+              // @ts-expect-error - fix me
+              value={
+                formattedValue ??
+                (op === 'oneOf' || op === 'notOneOf' ? [] : '')
+              }
+              // @ts-expect-error - fix me
+              multi={op === 'oneOf' || op === 'notOneOf'}
+              op={op}
+              options={subfieldToOptions(field, subfield)}
+              style={{ marginTop: 10 }}
+              // oxlint-disable-next-line typescript/no-explicit-any
+              onChange={(v: any) => {
+                dispatch({ type: 'set-value', value: v });
+              }}
+            />
+          )}
 
         {field === 'payee' && isPayeeIdOp(op) && (
           <PayeeFilter

--- a/upcoming-release-notes/7304.md
+++ b/upcoming-release-notes/7304.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [sk10727-a11y]
+---
+
+Fix UUID showing when switching filter operators


### PR DESCRIPTION
## Description
Fixes an issue where switching filter operators between exact-match (is, one of) and text-based operators (contains, matches) would populate the input with UUIDs instead of human-readable names.

This PR adds logic to correctly transform values when switching between operator types for ID-based fields (accounts, categories, category groups, payees):
- Single-ID → text: Converts stored ID → text, since there is a one-to-one mapping
- Text → Single-ID: Converts text → ID (if uniquely matched), ensuring correctness without guessing
- Multi-ID → text: If the array size is 1, resolves ID to text (if uniquely matched); otherwise, clears the value, since multiple IDs cannot be reliably represented as a single string
- Text → Multi-ID: Resolves text to a single ID (if uniquely matched) and wraps it in an array, matching the expected multi-value format

**Unique to the accounts filter, there are account no-value operators (is on budget, is off budget):**
- No-value → text: Converts preserved ID(s) → text when possible
- No-value → Single-ID: Converts preserved text → ID when a unique match exists
- No-value → Multi-ID: Resolves preserved text to a single ID (if uniquely matched) and wraps it in an array; otherwise clears the value

**Note:**
- Single-ID exact-match operators: is, is not → store a single ID value
- Multi-ID exact-match operators: one of, not one of → store an array of IDs
- Text-based operators: contains, matches, does not contain → store plain strings
- Account no-value operators: is on budget, is off budget → do not use input values but preserve state for future conversions

This ensures the input always matches the expected format for the selected operator and prevents UUID leakage in the UI.

## Related issue(s)
Fixes #7123.

## Testing
Tested the following transitions across accounts, categories, category groups, and payees:
- is → contains, matches, does not contain: ID correctly converted to text
- is not → text operators: same behavior as above
- contains / matches → is, is not: text converted back to ID when an exact match exists
- contains / matches → one of: text converted to single ID and wrapped in array
- one of / not one of → text operators: prevented invalid conversion (cleared value)
- is → one of: single ID preserved and wrapped in array

**Account-specific cases:**
- is → is on budget / is off budget → contains: correctly converts back to text
- one of → is on budget / is off budget → text: clears or converts appropriately
- text → is on budget / is off budget → is: attempts to resolve back to ID

## How to test
1. Navigate to an account
2. Create or edit a filter on an ID-based field (accounts, category, category group, payees)
3. Switch between operators
4. Verify the input remains human-readable and matches the outlined behavior

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.93 MB → 12.94 MB (+4 kB) | +0.03%
loot-core | 1 | 4.85 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.93 MB → 12.94 MB (+4 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/filters/FiltersMenu.tsx` | 📈 +4 kB (+22.96%) | 17.41 kB → 21.41 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/chart-theme.js | 705.55 kB → 709.55 kB (+4 kB) | +0.57%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.12 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 486.5 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.49 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BLXvyUAG.js | 4.85 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->