### PR TITLE
fix(qif): import transaction categories from QIF files

### DIFF
--- a/packages/loot-core/src/mocks/files/data-with-categories.qif
+++ b/packages/loot-core/src/mocks/files/data-with-categories.qif
@@ -1,0 +1,16 @@
+!Type:Bank
+D12/19/18
+POutlet
+T-100.58
+LUsual Expenses:Shopping
+^
+D12/19/18
+PGroceriesYou
+T-20.15
+LGroceries
+^
+D12/19/18
+PRestaurantExample
+T-40.60
+LFood
+^

--- a/packages/loot-core/src/server/transactions/import/parse-file.test.ts
+++ b/packages/loot-core/src/server/transactions/import/parse-file.test.ts
@@ -221,4 +221,30 @@ describe('File import', () => {
     expect(errors.length).toBe(0);
     expect(await getTransactions('one')).toMatchSnapshot();
   });
+
+  test('qif import preserves categories from L lines', async () => {
+    const { errors, transactions } = await parseFile(
+      __dirname + '/../../../mocks/files/data-with-categories.qif',
+    );
+    expect(errors.length).toBe(0);
+    expect(transactions).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const txns = transactions as Array<Record<string, unknown>>;
+    expect(txns[0].category).toBe('Usual Expenses:Shopping');
+    expect(txns[1].category).toBe('Groceries');
+    expect(txns[2].category).toBe('Food');
+  });
+
+  test('qif import handles missing category gracefully', async () => {
+    const { errors, transactions } = await parseFile(
+      __dirname + '/../../../mocks/files/data.qif',
+      { importNotes: true },
+    );
+    expect(errors.length).toBe(0);
+    expect(transactions).toBeTruthy();
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const txns = transactions as Array<Record<string, unknown>>;
+    // Existing data.qif has no L lines - category should be null
+    expect(txns.every(t => t.category === null)).toBe(true);
+  });
 });

--- a/packages/loot-core/src/server/transactions/import/parse-file.ts
+++ b/packages/loot-core/src/server/transactions/import/parse-file.ts
@@ -51,6 +51,7 @@ type StructuredTransaction = {
   payee_name: string;
   imported_payee: string;
   notes: string;
+  category?: string;
 };
 
 // CSV files return raw data that are not guaranteed to be StructuredTransactions
@@ -183,6 +184,11 @@ async function parseQIF(
         const memoSource = swap ? trans.payee : trans.memo;
         const fallbackUsed = !payeeSource && swap;
 
+        const importedCategory =
+          trans.category && trans.subcategory
+            ? `${trans.category}:${trans.subcategory}`
+            : trans.category || trans.subcategory || null;
+
         return {
           amount:
             trans.amount != null ? looselyParseAmount(trans.amount) : null,
@@ -191,6 +197,7 @@ async function parseQIF(
           imported_payee: payeeSource || (fallbackUsed ? memoSource : null),
           notes:
             options.importNotes && !fallbackUsed ? memoSource || null : null,
+          category: importedCategory,
         };
       })
       .filter(trans => trans.date != null && trans.amount != null),

--- a/upcoming-release-notes/7315.md
+++ b/upcoming-release-notes/7315.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Muhammad-Nur-Alamsyah-Anwar]
+---
+
+Fix transaction categories not being imported from QIF files


### PR DESCRIPTION
## Description

QIF files use `L` lines to specify transaction categories, and `qif2json` already parses them correctly into `category`/`subcategory` fields. The problem was in `parseQIF` — it was just dropping those values instead of mapping them through to the returned transaction.

## Related issue(s)

Fixes #3910

## Testing

Added a QIF fixture with a few different `L` line formats and unit tests in `parse-file.test.ts` to cover the main cases (category only, category + subcategory, and no `L` line at all). To reproduce the original bug, import a QIF file containing `L` lines and check that the category column is populated in the import modal.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 12.09 MB | 0%
loot-core | 1 | 4.83 MB → 4.83 MB (+188 B) | +0.00%
api | 4 | 4.06 MB → 4.06 MB (+186 B) | +0.00%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 12.09 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.23 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1.02 MB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 182.91 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.76 kB | 0%
static/js/es.js | 182.09 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.27 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/useTransactionBatchActions.js | 4.29 MB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+188 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +188 B (+3.32%) | 5.53 kB → 5.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.0MJZX4St.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CwpE34S5.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.06 MB → 4.06 MB (+186 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +186 B (+3.27%) | 5.56 kB → 5.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+186 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->