### PR TITLE
[AI] Respect user notes when rules append or prepend on new transactions (#7303)

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -55,6 +55,7 @@ import {
   groupById,
   integerToAmount,
   integerToCurrency,
+  shouldApplyRuleDiffField,
   titleFirst,
 } from 'loot-core/shared/util';
 import type {
@@ -1507,15 +1508,13 @@ function TransactionEditUnconnected({
         if (diff) {
           Object.keys(diff).forEach(key => {
             const field = key as keyof TransactionEntity;
-            // Update "empty" fields in general
-            // Or update all fields if the payee changes (assists location-based entry by
-            // applying rules to prefill category, notes, etc. based on the selected payee)
             if (
-              newTransaction[field] == null ||
-              newTransaction[field] === '' ||
-              newTransaction[field] === 0 ||
-              newTransaction[field] === false ||
-              updatedField === 'payee'
+              shouldApplyRuleDiffField(
+                key,
+                newTransaction[field],
+                diff[field],
+                updatedField,
+              )
             ) {
               (newTransaction as Record<string, unknown>)[field] = diff[field];
             }

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -18,7 +18,11 @@ import {
   splitTransaction,
   updateTransaction,
 } from 'loot-core/shared/transactions';
-import { applyChanges, getChangedValues } from 'loot-core/shared/util';
+import {
+  applyChanges,
+  getChangedValues,
+  shouldApplyRuleDiffField,
+} from 'loot-core/shared/util';
 import type {
   AccountEntity,
   CategoryEntity,
@@ -535,10 +539,12 @@ export function TransactionList({
       if (diff) {
         Object.keys(diff).forEach(field => {
           if (
-            newTransaction[field] == null ||
-            newTransaction[field] === '' ||
-            newTransaction[field] === 0 ||
-            newTransaction[field] === false
+            shouldApplyRuleDiffField(
+              field,
+              newTransaction[field],
+              diff[field],
+              updatedFieldName,
+            )
           ) {
             newTransaction[field] = diff[field];
           }

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -3,6 +3,7 @@ import {
   getNumberFormat,
   looselyParseAmount,
   setNumberFormat,
+  shouldApplyRuleDiffField,
   stringToInteger,
   titleFirst,
 } from './util';
@@ -236,5 +237,22 @@ describe('utility functions', () => {
     expect(stringToInteger('-3')).toBe(-3);
     // Unicode minus
     expect(stringToInteger('−3')).toBe(-3);
+  });
+
+  test('shouldApplyRuleDiffField applies append/prepend notes (#7303)', () => {
+    expect(
+      shouldApplyRuleDiffField('notes', 'hello', 'hello world', null),
+    ).toBe(true);
+    expect(shouldApplyRuleDiffField('notes', 'hello', 'worldhello', null)).toBe(
+      true,
+    );
+    expect(shouldApplyRuleDiffField('notes', 'hello', 'world', null)).toBe(
+      false,
+    );
+    expect(shouldApplyRuleDiffField('notes', 'hello', 'hi', null)).toBe(false);
+    expect(shouldApplyRuleDiffField('notes', '', 'note', null)).toBe(true);
+    expect(shouldApplyRuleDiffField('category', 'a', 'b', null)).toBe(false);
+    expect(shouldApplyRuleDiffField('category', null, 'b', null)).toBe(true);
+    expect(shouldApplyRuleDiffField('notes', 'x', 'y', 'payee')).toBe(true);
   });
 });

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -246,13 +246,20 @@ describe('utility functions', () => {
     expect(shouldApplyRuleDiffField('notes', 'hello', 'worldhello', null)).toBe(
       true,
     );
+    expect(shouldApplyRuleDiffField('notes', 'a', 'ab', null)).toBe(true);
+    expect(shouldApplyRuleDiffField('notes', 'b', 'ab', null)).toBe(true);
     expect(shouldApplyRuleDiffField('notes', 'hello', 'world', null)).toBe(
       false,
     );
+    expect(shouldApplyRuleDiffField('notes', 'hello', 'helXlo', null)).toBe(
+      false,
+    );
     expect(shouldApplyRuleDiffField('notes', 'hello', 'hi', null)).toBe(false);
+    expect(shouldApplyRuleDiffField('notes', 'foo', 'bar', null)).toBe(false);
     expect(shouldApplyRuleDiffField('notes', '', 'note', null)).toBe(true);
     expect(shouldApplyRuleDiffField('category', 'a', 'b', null)).toBe(false);
     expect(shouldApplyRuleDiffField('category', null, 'b', null)).toBe(true);
     expect(shouldApplyRuleDiffField('notes', 'x', 'y', 'payee')).toBe(true);
+    expect(shouldApplyRuleDiffField('category', 'a', 'b', 'payee')).toBe(true);
   });
 });

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -29,6 +29,42 @@ export function getChangedValues<T extends { id?: string }>(obj1: T, obj2: T) {
   return hasChanged ? diff : null;
 }
 
+/**
+ * Whether a field from `getChangedValues(before, afterRules)` should be merged
+ * into the working transaction after rules run (e.g. when saving a new row).
+ * Empty fields always accept rule output; when the payee was just updated, all
+ * diffs apply (prefill). For non-empty `notes`, only apply when the rule result
+ * clearly extends the existing text (append / prepend), so arbitrary `set notes`
+ * rules still respect user-entered notes (see issue #7303).
+ */
+export function shouldApplyRuleDiffField(
+  field: string,
+  prev: unknown,
+  next: unknown,
+  updatedFieldName: string | null = null,
+): boolean {
+  if (updatedFieldName === 'payee') {
+    return true;
+  }
+
+  if (prev == null || prev === '' || prev === 0 || prev === false) {
+    return true;
+  }
+
+  if (
+    field === 'notes' &&
+    typeof prev === 'string' &&
+    typeof next === 'string'
+  ) {
+    return (
+      next.length > prev.length &&
+      (next.startsWith(prev) || next.endsWith(prev))
+    );
+  }
+
+  return false;
+}
+
 export function hasFieldsChanged<T extends object>(
   obj1: T,
   obj2: T,

--- a/packages/sync-server/src/app-sync.test.ts
+++ b/packages/sync-server/src/app-sync.test.ts
@@ -472,9 +472,11 @@ describe('/upload-user-file', () => {
       ],
     );
 
-    fs.writeFile(getPathForUserFile(fileId), oldFileContent, err => {
-      if (err) throw err;
-    });
+    await fs.promises.writeFile(
+      getPathForUserFile(fileId),
+      oldFileContent,
+      'utf8',
+    );
 
     const res = await request(app)
       .post('/upload-user-file')

--- a/upcoming-release-notes/7320.md
+++ b/upcoming-release-notes/7320.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [pranayseela]
+---
+
+When saving a new transaction, rules that append or prepend notes apply without overwriting notes you already typed; other fields still follow the existing empty-or-payee-changed merge rules.

--- a/upcoming-release-notes/7320.md
+++ b/upcoming-release-notes/7320.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [pranayseela]
 ---
 
-When saving a new transaction, rules that append or prepend notes apply without overwriting notes you already typed; other fields still follow the existing empty-or-payee-changed merge rules.
+Fix rule merge on new transactions so append-only and prepend-only notes from rules apply without wiping user-typed notes, leaving other fields’ empty-or-payee-changed behavior unchanged.


### PR DESCRIPTION
Fixes #7303

Made with [Cursor](https://cursor.com)

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 12.09 MB → 12.09 MB (-118 B) | -0.00%
loot-core | 1 | 4.83 MB | 0%
api | 4 | 4.06 MB | 0%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 12.09 MB → 12.09 MB (-118 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📈 +388 B (+4.27%) | 8.87 kB → 9.25 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📉 -76 B (-0.13%) | 58.28 kB → 58.2 kB
`src/components/transactions/TransactionList.tsx` | 📉 -42 B (-0.24%) | 17.15 kB → 17.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.23 MB → 3.23 MB (-76 B) | -0.00%
static/js/useTransactionBatchActions.js | 4.29 MB → 4.29 MB (-42 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1.02 MB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 182.91 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.76 kB | 0%
static/js/es.js | 182.09 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.27 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CwpE34S5.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.06 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->