### PR TITLE
remove useless assignments to local variables

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -361,7 +361,9 @@
     ],
     "eslint/no-useless-constructor": "error",
     "eslint/no-undef": "error",
-    "eslint/no-unused-expressions": "error"
+    "eslint/no-unused-expressions": "error",
+    "eslint/no-return-assign": "error",
+    "eslint/no-unused-vars": "error"
   },
   "overrides": [
     {

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -6,7 +6,6 @@ import { Navigate, Route, Routes, useHref, useLocation } from 'react-router';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
-import { useQuery } from '@tanstack/react-query';
 
 import * as undo from 'loot-core/platform/client/undo';
 
@@ -28,7 +27,6 @@ import { FloatableSidebar } from './sidebar';
 import { ManageTagsPage } from './tags/ManageTagsPage';
 import { Titlebar } from './Titlebar';
 
-import { accountQueries } from '@desktop-client/accounts';
 import { getLatestAppVersion, sync } from '@desktop-client/app/appSlice';
 import { ProtectedRoute } from '@desktop-client/auth/ProtectedRoute';
 import { Permissions } from '@desktop-client/auth/types';

--- a/packages/desktop-client/src/components/FixedSizeList.tsx
+++ b/packages/desktop-client/src/components/FixedSizeList.tsx
@@ -134,8 +134,7 @@ export class FixedSizeList extends PureComponent<
     const { initialScrollOffset } = this.props;
 
     if (typeof initialScrollOffset === 'number' && this._outerRef != null) {
-      let outerRef = this._outerRef;
-      outerRef = this._outerRef;
+      const outerRef = this._outerRef;
       outerRef.scrollTop = initialScrollOffset;
     }
 

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -262,7 +262,6 @@ type AccountInternalState = {
   workingHard: boolean;
   reconcileAmount: null | number;
   transactions: TransactionEntity[];
-  transactionCount: number;
   transactionsFiltered?: boolean;
   showBalances?: boolean | undefined;
   balances: Record<TransactionEntity['id'], IntegerAmount> | null;
@@ -314,7 +313,6 @@ class AccountInternal extends PureComponent<
       workingHard: false,
       reconcileAmount: null,
       transactions: [],
-      transactionCount: 0,
       showBalances: props.showBalances,
       balances: null,
       showCleared: props.showCleared,
@@ -500,7 +498,6 @@ class AccountInternal extends PureComponent<
         this.setState(
           {
             transactions: data,
-            transactionCount: this.paged?.totalCount ?? 0,
             transactionsFiltered: isFiltered,
             loading: false,
             workingHard: false,
@@ -835,7 +832,6 @@ class AccountInternal extends PureComponent<
           this.setState(
             {
               transactions: [],
-              transactionCount: 0,
               filterConditions: [],
               search: '',
               sort: null,
@@ -1551,7 +1547,6 @@ class AccountInternal extends PureComponent<
       this.setState(
         {
           transactions: [],
-          transactionCount: 0,
           filterConditions: conditions,
         },
         () => {

--- a/packages/desktop-client/src/components/filters/PayeeFilter.tsx
+++ b/packages/desktop-client/src/components/filters/PayeeFilter.tsx
@@ -32,7 +32,7 @@ export const PayeeFilter = ({ value, op, onChange }: PayeeFilterProps) => {
   const { t } = useTranslation();
   const multi = ['oneOf', 'notOneOf'].includes(op);
 
-  let coercedValue: PayeeFilterValue = value;
+  let coercedValue: PayeeFilterValue;
   if (multi) {
     coercedValue = Array.isArray(value) ? value : [];
   } else {

--- a/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
+++ b/packages/desktop-client/src/components/manager/BudgetFileSelection.tsx
@@ -203,10 +203,9 @@ function BudgetFileState({ file, currentUserId }: BudgetFileStateProps) {
       ownerName = t('You');
       break;
     case 'broken':
-      ownerName = 'unknown';
       Icon = SvgFileDouble;
       status = t('Local');
-      ownerName = t('You');
+      ownerName = t('Unknown');
       break;
     default:
       Icon = SvgCloudCheck;

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -154,7 +154,6 @@ const ActiveShapeMobile = ({
   value,
   expandInward,
   chartInnerRadius,
-  chartMidRadius,
   chartOuterRadius,
 }: ActiveShapeProps) => {
   const format = useFormat();
@@ -230,8 +229,6 @@ const ActiveShapeDesktop = ({
   value,
   expandInward,
   chartInnerRadius,
-  chartMidRadius,
-  chartOuterRadius,
 }: ActiveShapeProps) => {
   const format = useFormat();
   // Fix 2: guard against undefined payload.name  and payload.date

--- a/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
@@ -97,7 +97,7 @@ function SankeyNode({
   y,
   width,
   height,
-  index,
+  index: _index,
   payload,
   containerWidth,
   containerHeight,

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -8,12 +8,9 @@ import { SvgArrowDown, SvgList } from '@actual-app/components/icons/v1';
 import { Menu } from '@actual-app/components/menu';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { Popover } from '@actual-app/components/popover';
-import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
-import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
-import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import * as d from 'date-fns';
 import type { SankeyData } from 'recharts/types/chart/Sankey';
@@ -27,8 +24,6 @@ import type {
 } from 'loot-core/types/models';
 
 import { EditablePageHeaderTitle } from '@desktop-client/components/EditablePageHeaderTitle';
-import { AppliedFilters } from '@desktop-client/components/filters/AppliedFilters';
-import { FilterButton } from '@desktop-client/components/filters/FiltersMenu';
 import { MobileBackButton } from '@desktop-client/components/mobile/MobileBackButton';
 import {
   MobilePageHeader,

--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -9,7 +9,6 @@ import * as d from 'date-fns';
 
 import type { SankeyWidget } from 'loot-core/types/models';
 
-import { DateRange } from '@desktop-client/components/reports/DateRange';
 import { SankeyGraph } from '@desktop-client/components/reports/graphs/SankeyGraph';
 import { LoadingIndicator } from '@desktop-client/components/reports/LoadingIndicator';
 import { ReportCard } from '@desktop-client/components/reports/ReportCard';

--- a/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/custom-spreadsheet.ts
@@ -188,7 +188,7 @@ export function createCustomSpreadsheet({
                 (asset[groupByLabel] === (item.id ?? null) ||
                   (item.uncategorized_id && groupsByCategory)),
             )
-            .reduce((a, v) => (a = a + v.amount), 0);
+            .reduce((a, v) => a + v.amount, 0);
           perIntervalAssets += intervalAssets;
 
           const intervalDebts = filterHiddenItems(
@@ -205,7 +205,7 @@ export function createCustomSpreadsheet({
                 (debt[groupByLabel] === (item.id ?? null) ||
                   (item.uncategorized_id && groupsByCategory)),
             )
-            .reduce((a, v) => (a = a + v.amount), 0);
+            .reduce((a, v) => a + v.amount, 0);
           perIntervalDebts += intervalDebts;
 
           const netAmounts = intervalAssets + intervalDebts;

--- a/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
@@ -55,7 +55,7 @@ export function recalculate({
             (asset[groupByLabel] === (item.id ?? null) ||
               (item.uncategorized_id && groupsByCategory)),
         )
-        .reduce((a, v) => (a = a + v.amount), 0);
+        .reduce((a, v) => a + v.amount, 0);
       totalAssets += intervalAssets;
 
       const intervalDebts = filterHiddenItems(
@@ -72,7 +72,7 @@ export function recalculate({
             (debt[groupByLabel] === (item.id ?? null) ||
               (item.uncategorized_id && groupsByCategory)),
         )
-        .reduce((a, v) => (a = a + v.amount), 0);
+        .reduce((a, v) => a + v.amount, 0);
       totalDebts += intervalDebts;
 
       const intervalTotals = intervalAssets + intervalDebts;

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -136,7 +136,7 @@ export function createSpendingSpreadsheet({
 
     const dailyBudget =
       budgets &&
-      budgets.reduce((a, v) => (a = a + v.amount), 0) / compareInterval.length;
+      budgets.reduce((a, v) => a + v.amount, 0) / compareInterval.length;
 
     const intervals = monthUtils.dayRangeInclusive(startDate, endDate);
     if (endDateTo < startDate || startDateTo > endDate) {
@@ -182,13 +182,13 @@ export function createSpendingSpreadsheet({
             const intervalAssets = combineAssets
               .filter(e => !e.categoryIncome && !e.accountOffBudget)
               .filter(asset => asset.date === intervalItem)
-              .reduce((a, v) => (a = a + v.amount), 0);
+              .reduce((a, v) => a + v.amount, 0);
             perIntervalAssets += intervalAssets;
 
             const intervalDebts = combineDebts
               .filter(e => !e.categoryIncome && !e.accountOffBudget)
               .filter(debt => debt.date === intervalItem)
-              .reduce((a, v) => (a = a + v.amount), 0);
+              .reduce((a, v) => a + v.amount, 0);
             perIntervalDebts += intervalDebts;
 
             totalAssets += perIntervalAssets;
@@ -242,7 +242,7 @@ export function createSpendingSpreadsheet({
           b.cumulative === null ? a : b,
         ).cumulative;
 
-        const totalDaily = data.reduce((a, v) => (a = a + v.totalTotals), 0);
+        const totalDaily = data.reduce((a, v) => a + v.totalTotals, 0);
 
         return {
           date: data[0].date,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -1104,7 +1104,7 @@ describe('Transactions', () => {
       });
     }
 
-    let input = await editField(container, 'category', 0);
+    await editField(container, 'category', 0);
 
     // Make it clear that we are expected a negative transaction
     expect(getTransactions()[0].amount).toBe(-2777);
@@ -1128,7 +1128,7 @@ describe('Transactions', () => {
 
     // Enter an amount for the new split transaction and make sure the
     // toolbar updates
-    input = await editField(container, 'debit', 1);
+    let input = await editField(container, 'debit', 1);
     await userEvent.clear(input);
     await userEvent.type(input, '10.00[tab]');
     expect(toolbar.innerHTML.includes('17.77')).toBeTruthy();
@@ -1221,7 +1221,7 @@ describe('Transactions', () => {
   test('transaction with splits shows 0 in correct column', async () => {
     const { container, getTransactions } = renderTransactions();
 
-    let input = await editField(container, 'category', 0);
+    await editField(container, 'category', 0);
 
     // The first transaction should always be a negative amount
     expect(getTransactions()[0].amount).toBe(-2777);
@@ -1240,7 +1240,7 @@ describe('Transactions', () => {
     expect(queryField(container, 'credit', '', 2).textContent).toBe('');
 
     // Change it to a credit transaction
-    input = await editField(container, 'credit', 0);
+    const input = await editField(container, 'credit', 0);
     await userEvent.type(input, '55.00{Tab}');
 
     // The zeros should now display in the credit column

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -202,7 +202,7 @@ describe('SharedWorker coordinator', () => {
     });
 
     it('second tab joins existing budget as follower', () => {
-      const leader = setupBudgetGroup(coordinator, 'budget-1');
+      setupBudgetGroup(coordinator, 'budget-1');
 
       const follower = connectTab(coordinator);
       sendInit(follower);

--- a/packages/loot-core/src/platform/server/fs/index.ts
+++ b/packages/loot-core/src/platform/server/fs/index.ts
@@ -409,7 +409,7 @@ export const removeDirRecursively = async function (dirpath) {
   }
 };
 
-export const getModifiedTime = async (filepath: string): Promise<Date> => {
+export const getModifiedTime = async (_filepath: string): Promise<Date> => {
   throw new Error(
     'getModifiedTime not supported on the web (only used for backups)',
   );

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -711,7 +711,7 @@ export class CategoryTemplateContext {
     const cat = template.category.toLowerCase();
     const prev = template.previous;
     let sheetName;
-    let monthlyIncome = 1;
+    let monthlyIncome;
 
     //choose the sheet to find income for
     if (prev) {

--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -139,7 +139,6 @@ describe('Accounts', () => {
       await db.all<db.DbTransaction>('SELECT * FROM transactions'),
     );
 
-    let transaction = await db.getTransaction(id);
     await runHandler(handlers['transaction-update'], {
       ...(await db.getTransaction(id)),
       payee: 'transfer-three',
@@ -149,7 +148,7 @@ describe('Accounts', () => {
       await db.all<db.DbTransaction>('SELECT * FROM transactions'),
     );
 
-    transaction = await db.getTransaction(id);
+    const transaction = await db.getTransaction(id);
     await runHandler(handlers['transaction-delete'], transaction);
     differ.expectToMatchDiff(
       await db.all<db.DbTransaction>('SELECT * FROM transactions'),

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -772,8 +772,7 @@ function* getOneOfSetterRules(
       rule.actions[0].field === actionField &&
       (actionValue == null || rule.actions[0].value === actionValue) &&
       rule.conditions.length === 1 &&
-      (rule.conditions[0].op === 'oneOf' ||
-        rule.conditions[0].op === 'oneOf') &&
+      rule.conditions[0].op === 'oneOf' &&
       rule.conditions[0].field === condField &&
       (condValue == null || rule.conditions[0].value.indexOf(condValue) !== -1)
     ) {

--- a/packages/loot-core/vitest.config.ts
+++ b/packages/loot-core/vitest.config.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import peggyLoader from 'vite-plugin-peggy-loader';
 import { defineConfig } from 'vitest/config';
 

--- a/packages/loot-core/vitest.web.config.ts
+++ b/packages/loot-core/vitest.web.config.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import peggyLoader from 'vite-plugin-peggy-loader';
 import { defineConfig } from 'vitest/config';
 

--- a/upcoming-release-notes/7354.md
+++ b/upcoming-release-notes/7354.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix useless assignments to local variables


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Fixes issues highlighted in https://github.com/actualbudget/actual/security/quality/rules/js%2Fuseless-assignment-to-local
Not that I've seen this tab before, just wanted to see how it works!

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.28 MB → 12.28 MB (-183 B) | -0.00%
loot-core | 1 | 4.82 MB → 4.82 MB (-42 B) | -0.00%
api | 1 | 3.83 MB → 3.83 MB (-43 B) | -0.00%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.28 MB → 12.28 MB (-183 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/manager/BudgetFileSelection.tsx` | 📈 +4 B (+0.02%) | 25.01 kB → 25.02 kB
`src/components/reports/spreadsheets/custom-spreadsheet.ts` | 📉 -8 B (-0.14%) | 5.54 kB → 5.53 kB
`src/components/FixedSizeList.tsx` | 📉 -28 B (-0.27%) | 10.12 kB → 10.09 kB
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📉 -16 B (-0.28%) | 5.58 kB → 5.56 kB
`src/components/accounts/Account.tsx` | 📉 -127 B (-0.28%) | 43.79 kB → 43.66 kB
`src/components/reports/spreadsheets/recalculate.ts` | 📉 -8 B (-0.40%) | 1.98 kB → 1.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.24 MB → 3.24 MB (-123 B) | -0.00%
static/js/ReportRouter.js | 1.1 MB → 1.1 MB (-32 B) | -0.00%
static/js/useTransactionBatchActions.js | 4.29 MB → 4.29 MB (-28 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 190.11 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 172.28 kB | 0%
static/js/es.js | 182.18 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.5 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
static/js/zh-Hans.js | 93.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (-42 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/index.ts` | 📈 +1 B (+0.01%) | 7.91 kB → 7.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📉 -4 B (-0.02%) | 17.07 kB → 17.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -39 B (-0.20%) | 19.45 kB → 19.41 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DHyrsyU4.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.ChAr5vIB.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.83 MB → 3.83 MB (-43 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📉 -4 B (-0.02%) | 16.23 kB → 16.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -39 B (-0.20%) | 19.04 kB → 19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (-43 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->