### PR TITLE
[AI] Fix unrecoverable UI error after login (#7341)

### DIFF
--- a/packages/desktop-client/src/components/CommandBar.tsx
+++ b/packages/desktop-client/src/components/CommandBar.tsx
@@ -246,7 +246,7 @@ export function CommandBar() {
   const filteredSections = sections.map(section => ({
     ...section,
     items: section.items.filter(item =>
-      item.name?.toLowerCase().includes(searchLower),
+      item.name.toLowerCase().includes(searchLower),
     ),
   }));
   const hasResults = filteredSections.some(section => !!section.items.length);

--- a/packages/desktop-client/src/reports/queries.ts
+++ b/packages/desktop-client/src/reports/queries.ts
@@ -51,7 +51,7 @@ export const dashboardQueries = {
         const { data }: { data: DashboardPageEntity[] } = await aqlQuery(
           q('dashboard_pages').select('*'),
         );
-        return data;
+        return data.map(page => ({ ...page, name: page.name ?? '' }));
       },
     }),
 };

--- a/packages/loot-core/src/server/reports/app.ts
+++ b/packages/loot-core/src/server/reports/app.ts
@@ -31,7 +31,7 @@ export const reportModel = {
   toJS(row: CustomReportData): CustomReportEntity {
     return {
       id: row.id,
-      name: row.name,
+      name: row.name ?? '',
       startDate: row.start_date,
       endDate: row.end_date,
       isDateStatic: row.date_static === 1,


### PR DESCRIPTION
Fixes #7341

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.17 MB → 12.17 MB (+63 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+6 B) | +0.00%
api | 4 | 4.06 MB → 4.06 MB (+6 B) | +0.00%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.17 MB → 12.17 MB (+63 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/reports/queries.ts` | 📈 +63 B (+6.01%) | 1.02 kB → 1.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useTransactionBatchActions.js | 4.29 MB → 4.29 MB (+63 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.23 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1.02 MB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 182.91 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.76 kB | 0%
static/js/es.js | 182.18 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.5 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
static/js/zh-Hans.js | 86.32 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+6 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +6 B (+0.16%) | 3.63 kB → 3.63 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B--GR9z4.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CwpE34S5.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
4 | 4.06 MB → 4.06 MB (+6 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +6 B (+0.17%) | 3.55 kB → 3.55 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+6 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
from-Bl-Hslp4.js | 167.73 kB | 0%
multipart-parser-BnDysoMr.js | 8.1 kB | 0%
src-iMkUmuwR.js | 43.64 kB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->