### PR TITLE
Revert "Fix updateTransaction corrupting split parents with partial updates"

### DIFF
--- a/packages/loot-core/src/shared/transactions.test.ts
+++ b/packages/loot-core/src/shared/transactions.test.ts
@@ -201,40 +201,6 @@ describe('Transactions', () => {
     expect(data.length).toBe(5);
   });
 
-  test('partially updating a split parent preserves amount and does not set error', () => {
-    const transactions = [
-      makeTransaction({ amount: 2001 }),
-      ...makeSplitTransaction({ id: 't1', amount: 2500 }, [
-        { id: 't2', amount: 2000 },
-        { id: 't3', amount: 500 },
-      ]),
-      makeTransaction({ amount: 3002 }),
-    ];
-
-    // Simulate a partial update (only `notes`) on the parent — this is
-    // how `api.updateTransaction(id, { notes: '...' })` calls it in
-    // `api.ts`: `updateTransaction(transactions, { id, ...fields })`.
-    const { data, diff } = updateTransaction(transactions, {
-      id: 't1',
-      notes: 'updated note',
-    } as TransactionEntity);
-
-    // The parent should get the updated notes without an error
-    const parent = data.find(d => d.id === 't1');
-    expect(parent?.notes).toBe('updated note');
-    expect(parent?.amount).toBe(2500);
-    expect(parent?.error).toBeNull();
-
-    // Children should be unchanged
-    expect(data.filter(t => t.parent_id === 't1').length).toBe(2);
-
-    expect(diff).toEqual({
-      added: [],
-      deleted: [],
-      updated: [expect.objectContaining({ id: 't1', notes: 'updated note' })],
-    });
-  });
-
   test('deleting a split transaction works', () => {
     const transactions = [
       makeTransaction({ amount: 2001 }),

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -262,8 +262,7 @@ export function updateTransaction(
 ) {
   return replaceTransactions(transactions, transaction.id, trans => {
     if (trans.is_parent) {
-      const parent =
-        trans.id === transaction.id ? { ...trans, ...transaction } : trans;
+      const parent = trans.id === transaction.id ? transaction : trans;
       const originalSubtransactions =
         parent.subtransactions ?? trans.subtransactions;
       const sub = originalSubtransactions?.map(t => {

--- a/upcoming-release-notes/7242.md
+++ b/upcoming-release-notes/7242.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [lwarrenthompson]
----
-
-Fix `api.updateTransaction()` corrupting split parent transactions when doing partial updates

--- a/upcoming-release-notes/7384.md
+++ b/upcoming-release-notes/7384.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [youngcw]
+---
+
+Revert updateTransaction changes, removing partial update handling for split parent transactions.


### PR DESCRIPTION
Reverts actualbudget/actual#7242

Will remerge later.  Was merged prematurely.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.27 MB → 12.27 MB (-28 B) | -0.00%
loot-core | 1 | 4.82 MB → 4.82 MB (-31 B) | -0.00%
api | 1 | 3.83 MB → 3.83 MB (-28 B) | -0.00%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.27 MB → 12.27 MB (-28 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -28 B (-0.33%) | 8.17 kB → 8.15 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useTransactionBatchActions.js | 4.29 MB → 4.29 MB (-28 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.24 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1.1 MB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 183.36 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.76 kB | 0%
static/js/es.js | 182.18 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.5 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
static/js/zh-Hans.js | 93.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (-31 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -31 B (-0.50%) | 6.04 kB → 6.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BzSpVXw5.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.3maKMh4x.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.83 MB → 3.83 MB (-28 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -28 B (-0.47%) | 5.85 kB → 5.83 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (-28 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->