### PR TITLE
Revert "[AI] fix: preserve explicit category on imported transactions"

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -477,46 +477,6 @@ describe('Account sync', () => {
     ]);
   });
 
-  test('addTransactions does not override explicitly provided category', async () => {
-    const { id: acctId } = await prepareDatabase();
-
-    await db.insertCategoryGroup({
-      id: 'group2',
-      name: 'group2',
-    });
-    const explicitCategoryId = await db.insertCategory({
-      id: 'api-cat',
-      name: 'API Category',
-      cat_group: 'group2',
-    });
-    const ruleCategoryId = await db.insertCategory({
-      id: 'rule-cat',
-      name: 'Rule Category',
-      cat_group: 'group2',
-    });
-
-    const payeeId = await db.insertPayee({ name: 'P' });
-    await insertRule({
-      stage: null,
-      conditionsOp: 'and',
-      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
-      actions: [{ op: 'set', field: 'category', value: ruleCategoryId }],
-    });
-
-    await addTransactions(acctId, [
-      {
-        date: '2017-10-21',
-        payee_name: 'P',
-        amount: -2947,
-        category: explicitCategoryId,
-      },
-    ]);
-
-    const [addedTransaction] = await getAllTransactions();
-    expect(addedTransaction.category).toBe(explicitCategoryId);
-    expect(addedTransaction.category).not.toBe(ruleCategoryId);
-  });
-
   test("reconcile does not merge transactions with different 'imported_id' values", async () => {
     const { id } = await prepareDatabase();
 

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -350,9 +350,6 @@ async function normalizeTransactions(
     // Strip off the irregular properties
     const { payee_name: originalPayeeName, subtransactions, ...rest } = trans;
     trans = rest;
-    const explicitFields = Object.entries(rest)
-      .filter(([, value]) => value != null)
-      .map(([field]) => field);
 
     let payee_name = originalPayeeName;
     if (payee_name) {
@@ -379,7 +376,6 @@ async function normalizeTransactions(
 
     normalized.push({
       payee_name,
-      explicitFields,
       subtransactions: subtransactions
         ? subtransactions.map(t => ({ ...t, account: acctId }))
         : null,
@@ -880,28 +876,15 @@ export async function addTransactions(
   const accounts: db.DbAccount[] = await db.getAccounts();
   const accountsMap = new Map(accounts.map(account => [account.id, account]));
 
-  for (const {
-    trans: originalTrans,
-    subtransactions,
-    explicitFields,
-  } of normalized) {
+  for (const { trans: originalTrans, subtransactions } of normalized) {
     // Run the rules
     const trans = await runRules(originalTrans, accountsMap);
 
-    // Rules should enrich missing fields but not override explicit values provided by API clients.
-    const transWithExplicitFields = { ...trans };
-    for (const field of explicitFields) {
-      transWithExplicitFields[field] = originalTrans[field];
-    }
-
     const finalTransaction = {
       id: uuidv4(),
-      ...transWithExplicitFields,
+      ...trans,
       account: acctId,
-      cleared:
-        transWithExplicitFields.cleared != null
-          ? transWithExplicitFields.cleared
-          : true,
+      cleared: trans.cleared != null ? trans.cleared : true,
     };
 
     // Add split transactions if they are given

--- a/upcoming-release-notes/7185.md
+++ b/upcoming-release-notes/7185.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [api2062]
----
-
-Preserve explicitly provided transaction category when importing transactions with matching payee rules.

--- a/upcoming-release-notes/7388.md
+++ b/upcoming-release-notes/7388.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [youngcw]
+---
+
+Remove logic preserving explicit transaction categories during normalization and delete related test cases.

--- a/upcoming-release-notes/7388.md
+++ b/upcoming-release-notes/7388.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [youngcw]
----
-
-Remove logic preserving explicit transaction categories during normalization and delete related test cases.


### PR DESCRIPTION
Reverts actualbudget/actual#7185

fixes #7302.  Can remerge after the release when there is time to debug.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.27 MB | 0%
loot-core | 1 | 4.82 MB → 4.82 MB (-318 B) | -0.01%
api | 1 | 3.83 MB → 3.83 MB (-315 B) | -0.01%
cli | 1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.24 MB | 0%
static/js/BackgroundImage.js | 119.98 kB | 0%
static/js/FormulaEditor.js | 846.44 kB | 0%
static/js/ReportRouter.js | 1.1 MB | 0%
static/js/TransactionList.js | 81.29 kB | 0%
static/js/ca.js | 183.36 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.79 kB | 0%
static/js/en-GB.js | 7.16 kB | 0%
static/js/en.js | 170.76 kB | 0%
static/js/es.js | 182.18 kB | 0%
static/js/fr.js | 177.47 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 166.25 kB | 0%
static/js/narrow.js | 354.5 kB | 0%
static/js/nb-NO.js | 152.2 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.84 kB | 0%
static/js/resize-observer.js | 18.03 kB | 0%
static/js/sv.js | 80.58 kB | 0%
static/js/th.js | 179.94 kB | 0%
static/js/theme.js | 30.68 kB | 0%
static/js/uk.js | 213.14 kB | 0%
static/js/useTransactionBatchActions.js | 4.29 MB | 0%
static/js/wide.js | 418 B | 0%
static/js/workbox-window.prod.es5.js | 7.28 kB | 0%
static/js/zh-Hans.js | 93.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (-318 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -318 B (-1.39%) | 22.42 kB → 22.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bm7V74Ca.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.3maKMh4x.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.83 MB → 3.83 MB (-315 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -315 B (-1.40%) | 22.04 kB → 21.73 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (-315 B) | -0.01%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.88 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->