### PR TITLE
[Docs] Tour: Move the Tour to website top level and add a sidebar for the tour

### DIFF
--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -29,23 +29,6 @@ const sidebars = {
     'releases',
     {
       type: 'category',
-      label: 'A Tour of Actual',
-      link: {
-        type: 'doc',
-        id: 'tour/index',
-      },
-      items: [
-        'tour/user-interface',
-        'tour/budget',
-        'tour/accounts',
-        'tour/reports',
-        'tour/schedules',
-        'tour/payees',
-        'tour/rules',
-      ],
-    },
-    {
-      type: 'category',
       label: 'Getting Started',
       collapsible: false,
       className: 'no-indent',

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -13,6 +13,16 @@
 
 /** @type {import('@docusaurus/plugin-content-docs').SidebarsConfig} */
 const sidebars = {
+  tourSidebar: [
+    'tour/index',
+    'tour/user-interface',
+    'tour/budget',
+    'tour/accounts',
+    'tour/reports',
+    'tour/schedules',
+    'tour/payees',
+    'tour/rules',
+  ],
   docs: [
     'index',
     'vision',

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -83,6 +83,12 @@ module.exports = {
             position: 'left',
           },
           {
+            type: 'docSidebar',
+            sidebarId: 'tourSidebar',
+            label: 'Tour Actual',
+            position: 'left',
+          },
+          {
             type: 'doc',
             docId: 'index',
             label: 'Docs',

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -85,7 +85,7 @@ module.exports = {
           {
             type: 'docSidebar',
             sidebarId: 'tourSidebar',
-            label: 'Tour Actual',
+            label: 'Tour',
             position: 'left',
           },
           {


### PR DESCRIPTION
## Description

Moves the tour out of the docs and into it's own top level menu. This should be less confusing when perusing the docs.

## Related issue(s)

Fixes #6189 

## Testing

View resulting website deploy.

## Checklist

- [x] Release notes not needed for docs.
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
