### PR TITLE
fix loot-core version bump in generate script

### DIFF
--- a/.github/workflows/generate-release-pr.yml
+++ b/.github/workflows/generate-release-pr.yml
@@ -34,7 +34,7 @@ jobs:
             [sync]="sync-server"
             [api]="api"
             [cli]="cli"
-            [core]="core"
+            [core]="loot-core"
           )
 
           for key in "${!packages[@]}"; do


### PR DESCRIPTION
No release note for this one, unless you think it's necessary.