### PR TITLE
Change formatting of reconcile form for clarity and ease of use

### DIFF
--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -189,7 +189,7 @@ export function ReconcileMenu({
         )}
         {lastSyncedBalance != null && (
           <View>
-            <Text style={{ margin: '8px 8px 8px 0', textAlign: 'right' }}>
+            <Text style={{ margin: '0 6px 8px 0', textAlign: 'right' }}>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
             </Text>

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -190,9 +190,9 @@ export function ReconcileMenu({
         {lastSyncedBalance != null && (
           <View>
             <Text>
+              <Text style={{ marginRight: '8px', textAlign: 'right' }}>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
-              style={{ margin: '0 8px', textAlign: 'right' }}
             </Text>
             <Button
               onPress={() =>

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -189,7 +189,7 @@ export function ReconcileMenu({
         )}
         {lastSyncedBalance != null && (
           <View>
-            <Text style={{ marginRight: '8px', textAlign: 'right' }}>
+            <Text style={{ margin: '8px 8px 8px 0', textAlign: 'right' }}>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
             </Text>
@@ -206,7 +206,7 @@ export function ReconcileMenu({
         <Button type="submit" variant="primary">
           <Trans>Reconcile</Trans>
         </Button>
-        <Text style={{ color: theme.pageTextLight, paddingBottom: 6 }}>
+        <Text style={{ color: theme.pageTextLight, marginTop: 8px  }}>
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -192,7 +192,7 @@ export function ReconcileMenu({
             <Text>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
-              style={{ marginRight: '8px', textAlign: 'right' }}
+              style={{ margin: '0 8px', textAlign: 'right' }}
             </Text>
             <Button
               onPress={() =>

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -189,8 +189,7 @@ export function ReconcileMenu({
         )}
         {lastSyncedBalance != null && (
           <View>
-            <Text>
-              <Text style={{ marginRight: '8px', textAlign: 'right' }}>
+            <Text style={{ marginRight: '8px', textAlign: 'right' }}>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
             </Text>

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -183,7 +183,7 @@ export function ReconcileMenu({
             <Input
               value={inputValue}
               onChangeValue={setInputValue}
-              style={{ margin: '7px 0' }}
+              style={{ margin: '7px 0', textAlign: 'right' }}
             />
           </InitialFocus>
         )}
@@ -192,6 +192,7 @@ export function ReconcileMenu({
             <Text>
               <Trans>Last Balance from Bank: </Trans>
               {format(lastSyncedBalance, 'financial')}
+              style={{ marginRight: '8px', textAlign: 'right' }}
             </Text>
             <Button
               onPress={() =>

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -206,7 +206,13 @@ export function ReconcileMenu({
         <Button type="submit" variant="primary">
           <Trans>Reconcile</Trans>
         </Button>
-        <Text style={{ color: theme.pageTextLight, marginTop: '8px', textAlign: 'center' }}>
+        <Text
+          style={{
+            color: theme.pageTextLight,
+            marginTop: '8px',
+            textAlign: 'center',
+          }}
+        >
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -206,7 +206,7 @@ export function ReconcileMenu({
         <Button type="submit" variant="primary">
           <Trans>Reconcile</Trans>
         </Button>
-        <Text style={{ color: theme.pageTextLight, marginTop: '8px'  }}>
+        <Text style={{ color: theme.pageTextLight, marginTop: '8px' }}>
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -206,7 +206,7 @@ export function ReconcileMenu({
         <Button type="submit" variant="primary">
           <Trans>Reconcile</Trans>
         </Button>
-        <Text style={{ color: theme.pageTextLight, marginTop: '8px' }}>
+        <Text style={{ color: theme.pageTextLight, marginTop: '8px', textAlign: 'center' }}>
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -206,7 +206,7 @@ export function ReconcileMenu({
         <Button type="submit" variant="primary">
           <Trans>Reconcile</Trans>
         </Button>
-        <Text style={{ color: theme.pageTextLight, marginTop: 8px  }}>
+        <Text style={{ color: theme.pageTextLight, marginTop: '8px'  }}>
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(

--- a/packages/desktop-client/src/components/accounts/Reconcile.tsx
+++ b/packages/desktop-client/src/components/accounts/Reconcile.tsx
@@ -204,7 +204,10 @@ export function ReconcileMenu({
             </Button>
           </View>
         )}
-        <Text style={{ color: theme.pageTextSubdued, paddingBottom: 6 }}>
+        <Button type="submit" variant="primary">
+          <Trans>Reconcile</Trans>
+        </Button>
+        <Text style={{ color: theme.pageTextLight, paddingBottom: 6 }}>
           {account?.last_reconciled
             ? t('Reconciled {{ relativeTimeAgo }} ({{ absoluteDate }})', {
                 relativeTimeAgo: tsToRelativeTime(
@@ -219,9 +222,6 @@ export function ReconcileMenu({
               })
             : t('Not yet reconciled')}
         </Text>
-        <Button type="submit" variant="primary">
-          <Trans>Reconcile</Trans>
-        </Button>
       </View>
     </Form>
   );

--- a/upcoming-release-notes/7423.md
+++ b/upcoming-release-notes/7423.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Juulz]
+---
+
+Change formatting of reconcile form for clarity and ease of use.


### PR DESCRIPTION
## Description

Change the reconcile form box numbers to align to the right to make it easier to parse the cleared balance and the last bank balance in relation to each other.

This has been bugging me for a while and I find it very difficult to make sure that the values match when one is left and the other is right, especially when you have a lot of accounts.

Change the order of the last reconcile date to the bottom, center the text and use pageTextLight instead of subdued so it is easier to read in all themes. Using subdued text for anything other than null feels like an unreadable choice.

Before:

<img width=50% alt="Screenshot 2026-04-08 131656" src="https://github.com/user-attachments/assets/bd7d1760-db78-4408-8dfb-1bf270e20ee4" />

<img width=50%  alt="Screenshot 2026-04-08 131712" src="https://github.com/user-attachments/assets/41255346-305f-43ea-b7f6-4372d7a275b8" />

After:

<img width=50% alt="Screenshot 2026-04-08 131553" src="https://github.com/user-attachments/assets/d76907db-3faf-4e70-9bf1-3deff79ca9c7" />

<img width=50%  alt="Screenshot 2026-04-08 131609" src="https://github.com/user-attachments/assets/531365c5-edd6-4a29-9419-b34f4602b0c4" />

<img width=50%  alt="Screenshot 2026-04-08 131638" src="https://github.com/user-attachments/assets/1c53f801-a53b-422e-98e1-1f67f7ce3221" />

## Related issue(s)

None

## Testing

I reconciled an account with cleared and uncleared transactions.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 12.41 MB → 12.41 MB (+126 B) | +0.00%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.84 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 12.41 MB → 12.41 MB (+126 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Reconcile.tsx` | 📈 +126 B (+1.37%) | 9 kB → 9.12 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.31 MB → 3.31 MB (+126 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.17 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/ca.js | 189.75 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.65 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.87 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/useTransactionBatchActions.js | 4.33 MB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 94.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DOvC4GKD.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->