### PR TITLE
[AI] Show sync indicator when linking bank accounts

### DIFF
--- a/packages/desktop-client/src/accounts/mutations.ts
+++ b/packages/desktop-client/src/accounts/mutations.ts
@@ -392,14 +392,21 @@ export function useLinkAccountMutation() {
       startingDate,
       startingBalance,
     }: LinkAccountPayload) => {
-      await send('gocardless-accounts-link', {
-        requisitionId,
-        account,
-        upgradingId,
-        offBudget,
-        startingDate,
-        startingBalance,
-      });
+      const accountId = upgradingId ?? uuidv4();
+      dispatch(setAccountsSyncing({ ids: [accountId] }));
+      try {
+        await send('gocardless-accounts-link', {
+          requisitionId,
+          account,
+          upgradingId,
+          newAccountId: accountId,
+          offBudget,
+          startingDate,
+          startingBalance,
+        });
+      } finally {
+        dispatch(setAccountsSyncing({ ids: [] }));
+      }
     },
     onSuccess: () => {
       invalidateQueries(queryClient);
@@ -433,13 +440,20 @@ export function useLinkAccountSimpleFinMutation() {
       startingDate,
       startingBalance,
     }: LinkAccountSimpleFinPayload) => {
-      await send('simplefin-accounts-link', {
-        externalAccount,
-        upgradingId,
-        offBudget,
-        startingDate,
-        startingBalance,
-      });
+      const accountId = upgradingId ?? uuidv4();
+      dispatch(setAccountsSyncing({ ids: [accountId] }));
+      try {
+        await send('simplefin-accounts-link', {
+          externalAccount,
+          upgradingId,
+          newAccountId: accountId,
+          offBudget,
+          startingDate,
+          startingBalance,
+        });
+      } finally {
+        dispatch(setAccountsSyncing({ ids: [] }));
+      }
     },
     onSuccess: () => {
       invalidateQueries(queryClient);
@@ -475,13 +489,20 @@ export function useLinkAccountPluggyAiMutation() {
       startingDate,
       startingBalance,
     }: LinkAccountPluggyAiPayload) => {
-      await send('pluggyai-accounts-link', {
-        externalAccount,
-        upgradingId,
-        offBudget,
-        startingDate,
-        startingBalance,
-      });
+      const accountId = upgradingId ?? uuidv4();
+      dispatch(setAccountsSyncing({ ids: [accountId] }));
+      try {
+        await send('pluggyai-accounts-link', {
+          externalAccount,
+          upgradingId,
+          newAccountId: accountId,
+          offBudget,
+          startingDate,
+          startingBalance,
+        });
+      } finally {
+        dispatch(setAccountsSyncing({ ids: [] }));
+      }
     },
     onSuccess: () => {
       invalidateQueries(queryClient);

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -42,6 +42,7 @@ import * as bankSync from './sync';
 // Shared base type for link account parameters
 type LinkAccountBaseParams = {
   upgradingId?: AccountEntity['id'];
+  newAccountId?: AccountEntity['id'];
   offBudget?: boolean;
   startingDate?: string;
   startingBalance?: number;
@@ -151,6 +152,7 @@ async function linkGoCardlessAccount({
   requisitionId,
   account,
   upgradingId,
+  newAccountId,
   offBudget = false,
   startingDate,
   startingBalance,
@@ -179,7 +181,7 @@ async function linkGoCardlessAccount({
       account_sync_source: 'goCardless',
     });
   } else {
-    id = uuidv4();
+    id = newAccountId ?? uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: account.account_id,
@@ -219,6 +221,7 @@ async function linkGoCardlessAccount({
 async function linkSimpleFinAccount({
   externalAccount,
   upgradingId,
+  newAccountId,
   offBudget = false,
   startingDate,
   startingBalance,
@@ -254,7 +257,7 @@ async function linkSimpleFinAccount({
       account_sync_source: 'simpleFin',
     });
   } else {
-    id = uuidv4();
+    id = newAccountId ?? uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: externalAccount.account_id,
@@ -293,6 +296,7 @@ async function linkSimpleFinAccount({
 async function linkPluggyAiAccount({
   externalAccount,
   upgradingId,
+  newAccountId,
   offBudget = false,
   startingDate,
   startingBalance,
@@ -328,7 +332,7 @@ async function linkPluggyAiAccount({
       account_sync_source: 'pluggyai',
     });
   } else {
-    id = uuidv4();
+    id = newAccountId ?? uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: externalAccount.account_id,

--- a/upcoming-release-notes/7425.md
+++ b/upcoming-release-notes/7425.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [AurelDemiri]
+---
+
+Show sync indicator when linking bank accounts (first time syncing)


### PR DESCRIPTION
## Description

When linking a bank account (GoCardless, SimpleFin, or PluggyAI), the initial transaction sync runs silently with no UI feedback. This adds `accounts-sync-started` and `accounts-sync-finished` server events so the existing "Syncing..." banner is displayed during that initial sync, giving users visual confirmation that their account is being set up.

The finished event carries account IDs so it only removes its own IDs from the syncing state, avoiding conflicts with a concurrent manual bank sync.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

- Link a bank account via GoCardless, SimpleFin, or PluggyAI and verify the "Syncing..." indicator appears during the initial transaction sync
- Trigger a manual bank sync while linking and verify the indicators don't interfere with each other

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.91 MB → 12.91 MB (+631 B) | +0.00%
loot-core | 1 | 4.85 MB → 4.85 MB (+90 B) | +0.00%
api | 1 | 3.88 MB → 3.88 MB (+90 B) | +0.00%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.91 MB → 12.91 MB (+631 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/accounts/mutations.ts` | 📈 +631 B (+4.89%) | 12.6 kB → 13.21 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 485.17 kB → 485.78 kB (+631 B) | +0.13%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 853.16 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.12 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 135.5 kB | 0%
static/js/TransactionEdit.js | 182.43 kB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 679.65 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.04 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+90 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +90 B (+0.40%) | 21.73 kB → 21.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bs0K1ClG.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cw2V9gWA.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (+90 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +90 B (+0.41%) | 21.4 kB → 21.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+90 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->