### PR TITLE
Prevent path traversal in file upload by using basename

### DIFF
--- a/packages/loot-core/src/platform/server/fs/index.ts
+++ b/packages/loot-core/src/platform/server/fs/index.ts
@@ -314,7 +314,7 @@ export const init = async function () {
 
 export const basename = function (filepath) {
   const parts = filepath.split('/');
-  return parts[parts.length - 1];
+  return parts.slice(0, -1).join('/');
 };
 
 export const listDir = async function (filepath) {

--- a/packages/loot-core/src/platform/server/fs/index.ts
+++ b/packages/loot-core/src/platform/server/fs/index.ts
@@ -314,7 +314,7 @@ export const init = async function () {
 
 export const basename = function (filepath) {
   const parts = filepath.split('/');
-  return parts.slice(0, -1).join('/');
+  return parts[parts.length - 1];
 };
 
 export const listDir = async function (filepath) {

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -646,8 +646,7 @@ async function uploadFileWeb({
     return null;
   }
 
-  // eslint-disable-next-line no-control-regex
-  const safeName = filename.split(/[/\\]/).pop()?.replace(/\0/g, '');
+  const safeName = filename.split(/[/\\]/).pop()?.replaceAll('\0', '');
   if (!safeName || safeName === '.' || safeName === '..') {
     throw new Error('Invalid upload filename');
   }

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -646,8 +646,11 @@ async function uploadFileWeb({
     return null;
   }
 
-  const safeName = fs.basename(filename);
-  await fs.writeFile('/uploads/' + safeName, contents);
+  const safeName = filename.split(/[/\\]/).pop()?.replace(/\0/g, '');
+  if (!safeName || safeName === '.' || safeName === '..') {
+    throw new Error('Invalid upload filename');
+  }
+  await fs.writeFile(fs.join('/uploads', safeName), contents);
   return {};
 }
 

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -646,7 +646,8 @@ async function uploadFileWeb({
     return null;
   }
 
-  await fs.writeFile('/uploads/' + filename, contents);
+  const safeName = fs.basename(filename);
+  await fs.writeFile('/uploads/' + safeName, contents);
   return {};
 }
 

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -646,6 +646,7 @@ async function uploadFileWeb({
     return null;
   }
 
+  // eslint-disable-next-line no-control-regex
   const safeName = filename.split(/[/\\]/).pop()?.replace(/\0/g, '');
   if (!safeName || safeName === '.' || safeName === '..') {
     throw new Error('Invalid upload filename');

--- a/upcoming-release-notes/7428.md
+++ b/upcoming-release-notes/7428.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Fix path traversal vulnerability in file upload sanitization


### PR DESCRIPTION
## Description

Fixing some security vulnerabilities that claude is highlighting.

Technically I would not call this a real vulnerability since all "loot-core" operations happen on your local device.. but we can fix it nonetheless to silence the false-negative signals.

```
This PR fixes a potential path traversal vulnerability in the `uploadFileWeb` function by sanitizing the filename before writing to disk. The change uses `fs.basename()` to extract only the filename component, preventing attackers from using path traversal sequences (e.g., `../../../etc/passwd`) to write files outside the intended `/uploads/` directory.
```

## Related issue(s)

<!-- Security fix for path traversal vulnerability -->
n/a

## Testing

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_01UgQANWBxqkqVT7xGyWNAXB

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.9 MB | 0%
loot-core | 1 | 4.84 MB → 4.84 MB (+180 B) | +0.00%
api | 1 | 3.84 MB → 3.84 MB (+178 B) | +0.00%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.17 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.89 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/extends.js | 485.18 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.87 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 109.61 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB → 4.84 MB (+180 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +180 B (+1.63%) | 10.8 kB → 10.98 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.ddTTAQMt.js | 0 B → 4.84 MB (+4.84 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.2cr-I6dh.js | 4.84 MB → 0 B (-4.84 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.84 MB → 3.84 MB (+178 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +178 B (+1.66%) | 10.45 kB → 10.63 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+178 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->