### PR TITLE
 Add scoped ErrorBoundary to Rules page to contain rendering crashes

### DIFF
--- a/packages/desktop-client/src/components/FeatureErrorFallback.tsx
+++ b/packages/desktop-client/src/components/FeatureErrorFallback.tsx
@@ -8,9 +8,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-export function FeatureErrorFallback({
-  resetErrorBoundary,
-}: FallbackProps) {
+export function FeatureErrorFallback({ resetErrorBoundary }: FallbackProps) {
   return (
     <View
       style={{

--- a/packages/desktop-client/src/components/FeatureErrorFallback.tsx
+++ b/packages/desktop-client/src/components/FeatureErrorFallback.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { FallbackProps } from 'react-error-boundary';
 import { Trans } from 'react-i18next';
 
@@ -8,7 +8,14 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-export function FeatureErrorFallback({ resetErrorBoundary }: FallbackProps) {
+export function FeatureErrorFallback({
+  error,
+  resetErrorBoundary,
+}: FallbackProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
   return (
     <View
       style={{
@@ -21,6 +28,21 @@ export function FeatureErrorFallback({ resetErrorBoundary }: FallbackProps) {
       <Text style={{ ...styles.mediumText, color: theme.errorText }}>
         <Trans>Something went wrong loading this section.</Trans>
       </Text>
+      {error?.message && (
+        <Text
+          style={{
+            ...styles.smallText,
+            fontFamily: 'monospace',
+            color: theme.errorText,
+            marginTop: 10,
+            maxWidth: 600,
+            textAlign: 'center',
+            userSelect: 'text',
+          }}
+        >
+          {error.message}
+        </Text>
+      )}
       <Button onPress={resetErrorBoundary} style={{ marginTop: 15 }}>
         <Trans>Try again</Trans>
       </Button>

--- a/packages/desktop-client/src/components/FeatureErrorFallback.tsx
+++ b/packages/desktop-client/src/components/FeatureErrorFallback.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { FallbackProps } from 'react-error-boundary';
+import { Trans } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { styles } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+export function FeatureErrorFallback({
+  resetErrorBoundary,
+}: FallbackProps) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: 20,
+      }}
+    >
+      <Text style={{ ...styles.mediumText, color: theme.errorText }}>
+        <Trans>Something went wrong loading this section.</Trans>
+      </Text>
+      <Button onPress={resetErrorBoundary} style={{ marginTop: 15 }}>
+        <Trans>Try again</Trans>
+      </Button>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useEffectEvent, useRef } from 'react';
 import type { ReactElement } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes, useHref, useLocation } from 'react-router';
 
@@ -12,6 +13,7 @@ import * as undo from 'loot-core/platform/client/undo';
 import { UserAccessPage } from './admin/UserAccess/UserAccessPage';
 import { BankSyncStatus } from './BankSyncStatus';
 import { CommandBar } from './CommandBar';
+import { FeatureErrorFallback } from './FeatureErrorFallback';
 import { GlobalKeys } from './GlobalKeys';
 import { MobileBankSyncAccountEditPage } from './mobile/banksync/MobileBankSyncAccountEditPage';
 import { MobileNavTabs } from './mobile/MobileNavTabs';
@@ -287,11 +289,19 @@ export function FinancesApp() {
                 />
                 <Route
                   path="/rules"
-                  element={<NarrowAlternate name="Rules" />}
+                  element={
+                    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+                      <NarrowAlternate name="Rules" />
+                    </ErrorBoundary>
+                  }
                 />
                 <Route
                   path="/rules/:id"
-                  element={<NarrowAlternate name="RuleEdit" />}
+                  element={
+                    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+                      <NarrowAlternate name="RuleEdit" />
+                    </ErrorBoundary>
+                  }
                 />
                 <Route
                   path="/bank-sync"

--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -89,6 +89,7 @@ export function FinancesApp() {
   const { isNarrowWidth } = useResponsive();
   useMetaThemeColor(isNarrowWidth ? theme.mobileViewTheme : undefined);
 
+  const location = useLocation();
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
@@ -290,7 +291,10 @@ export function FinancesApp() {
                 <Route
                   path="/rules"
                   element={
-                    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+                    <ErrorBoundary
+                      FallbackComponent={FeatureErrorFallback}
+                      resetKeys={[location.pathname]}
+                    >
                       <NarrowAlternate name="Rules" />
                     </ErrorBoundary>
                   }
@@ -298,7 +302,10 @@ export function FinancesApp() {
                 <Route
                   path="/rules/:id"
                   element={
-                    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+                    <ErrorBoundary
+                      FallbackComponent={FeatureErrorFallback}
+                      resetKeys={[location.pathname]}
+                    >
                       <NarrowAlternate name="RuleEdit" />
                     </ErrorBoundary>
                   }

--- a/upcoming-release-notes/7437.md
+++ b/upcoming-release-notes/7437.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tmchow]
+---
+
+Add scoped ErrorBoundary to Rules page to contain rendering crashes.


### PR DESCRIPTION
Addresses #7391 (picking the Rules page area from the table).

When a Rules or RuleEdit component throws during rendering, the whole app goes to the Fatal Error screen. This wraps both `/rules` and `/rules/:id` routes in a scoped `ErrorBoundary` so crashes stay contained to that section.

**What changed:**
- New `FeatureErrorFallback` component with a retry button. Reusable for other areas later
- ErrorBoundary wrapping in `FinancesApp.tsx` for both Rules routes

The fallback uses the existing `react-error-boundary` v6 dependency and `@actual-app/components` primitives. All strings go through `Trans` for i18n.

The `FeatureErrorFallback` component follows the pattern from `GetCardData.tsx` but adds `resetErrorBoundary` support so users can retry without leaving the page.

---
*This change was made with AI assistance.*

[![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 27 | 12.86 MB → 12.86 MB (+2.12 kB) | +0.02%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.84 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
27 | 12.86 MB → 12.86 MB (+2.12 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/FeatureErrorFallback.tsx` | 🆕 +1.3 kB | 0 B → 1.3 kB
`src/components/FinancesApp.tsx` | 📈 +841 B (+4.71%) | 17.44 kB → 18.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.31 MB → 3.32 MB (+2.12 kB) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.17 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.72 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.87 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 485.18 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/useTransactionBatchActions.js | 4.33 MB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 99.27 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.2cr-I6dh.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->