### PR TITLE
[WIP] Update VRT screenshots workflow

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -96,6 +96,23 @@ jobs:
           download-translations: 'false'
       - name: Run VRT Tests
         run: yarn vrt --shard=${{ matrix.shard }}/5
+      - name: Validate VRT manifest vs snapshot files
+        if: success()
+        run: yarn workspace @actual-app/web run prune-vrt-snapshots -- --check
+      - name: Stage VRT manifest for merge job
+        if: success()
+        run: |
+          mkdir -p "_vrt-manifest-artifact/shard-${{ matrix.shard }}"
+          if [ -d packages/desktop-client/e2e/.vrt-manifest ]; then
+            cp -a packages/desktop-client/e2e/.vrt-manifest/. "_vrt-manifest-artifact/shard-${{ matrix.shard }}/"
+          fi
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: success()
+        with:
+          name: vrt-manifest-shard-${{ matrix.shard }}
+          path: _vrt-manifest-artifact
+          retention-days: 1
+          overwrite: true
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
@@ -115,6 +132,16 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up environment
         uses: ./.github/actions/setup
+      - name: Download VRT manifest shards
+        if: needs.vrt.result == 'success'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: packages/desktop-client/e2e/.vrt-manifest-ci
+          pattern: vrt-manifest-shard-*
+          merge-multiple: true
+      - name: Validate VRT manifest vs snapshots (all shards, strict — no extra PNGs)
+        if: needs.vrt.result == 'success'
+        run: yarn workspace @actual-app/web run prune-vrt-snapshots -- --check --strict packages/desktop-client/e2e/.vrt-manifest-ci
       - name: Download all blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/e2e-vrt-comment.yml
+++ b/.github/workflows/e2e-vrt-comment.yml
@@ -51,8 +51,57 @@ jobs:
             echo "VRT tests passed or skipped for PR #$PR_NUMBER"
           fi
 
-      - name: Comment on PR with VRT report link
+      - name: Check if VRT Update - Generate is already running
+        id: vrt_update_generate
         if: steps.metadata.outputs.should_comment == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.metadata.outputs.pr_number }}', 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const headSha = pr.head.sha;
+
+            let runs = (
+              await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'vrt-update-generate.yml',
+                head_sha: headSha,
+                per_page: 20,
+              })
+            ).data.workflow_runs;
+
+            // issue_comment-triggered runs may not match head_sha filter; fall back to branch + SHA.
+            if (runs.length === 0) {
+              runs = (
+                await github.rest.actions.listWorkflowRuns({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'vrt-update-generate.yml',
+                  branch: pr.head.ref,
+                  per_page: 20,
+                })
+              ).data.workflow_runs.filter((run) => run.head_sha === headSha);
+            }
+
+            const activeRun = runs.find(
+              (run) => run.status === 'queued' || run.status === 'in_progress',
+            );
+
+            core.setOutput('active', activeRun ? 'true' : 'false');
+            if (activeRun) {
+              core.setOutput('run_url', activeRun.html_url);
+              core.info(
+                `VRT Update - Generate is ${activeRun.status} for PR head ${headSha}: ${activeRun.html_url}`,
+              );
+            }
+
+      - name: Comment on PR with VRT report link
+        if: steps.metadata.outputs.should_comment == 'true' && steps.vrt_update_generate.outputs.active != 'true'
         uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
         with:
           number: ${{ steps.metadata.outputs.pr_number }}
@@ -64,3 +113,17 @@ jobs:
             VRT tests ❌ failed. [View the test report](${{ steps.metadata.outputs.artifact_url }}).
 
             To update the VRT screenshots, comment `/update-vrt` on this PR. The VRT update operation takes about 50 minutes.
+
+      - name: Comment on PR with VRT report link (update already running)
+        if: steps.metadata.outputs.should_comment == 'true' && steps.vrt_update_generate.outputs.active == 'true'
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3.0.2
+        with:
+          number: ${{ steps.metadata.outputs.pr_number }}
+          header: vrt-comment
+          hide_and_recreate: true
+          hide_classify: OUTDATED
+          message: |
+            <!-- vrt-comment -->
+            VRT tests ❌ failed. [View the test report](${{ steps.metadata.outputs.artifact_url }}).
+
+            [**VRT Update - Generate**](${{ steps.vrt_update_generate.outputs.run_url }}) is already running for this PR's latest commit. Open that workflow run to watch progress.

--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -73,18 +73,31 @@ jobs:
       - name: Install build tools
         run: apt-get update && apt-get install -y build-essential python3
 
+      # Web VRT: manifest under e2e/.vrt-manifest records expected PNGs; prune (below) removes orphans only.
+      # Manifest reset + Electron baseline clear run before --update-snapshots so regeneration starts from a known state.
+      - name: Prepare VRT snapshot manifest
+        run: rm -rf packages/desktop-client/e2e/.vrt-manifest
+
       - name: Run VRT Tests on Desktop app
+        id: run_desktop
         continue-on-error: true
         run: |
           yarn rebuild-electron
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" -- yarn e2e:desktop --update-snapshots
 
       - name: Run VRT Tests
+        id: run_vrt
         continue-on-error: true
         run: yarn vrt --update-snapshots
 
+      # Prune and patch only when both snapshot updates succeeded (continue-on-error still runs both steps).
+      - name: Prune orphaned web VRT snapshots
+        if: ${{ steps.run_desktop.outcome == 'success' && steps.run_vrt.outcome == 'success' }}
+        run: yarn vrt:prune
+
       - name: Create patch with PNG changes only
         id: create-patch
+        if: ${{ steps.run_desktop.outcome == 'success' && steps.run_vrt.outcome == 'success' }}
         run: |
           # Trust the repository directory (required for container environments)
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -92,10 +105,18 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Stage only PNG files
-          git add "**/*.png"
+          # Stage VRT snapshot changes
+          git add --no-ignore-removal -- packages/desktop-client/e2e packages/desktop-electron/e2e
 
-          # Check if there are any changes
+          # Unstage non-PNG files (not included in VRT patch)
+          mapfile -t non_png < <(git diff --cached --name-only | grep -vE '\.png$' || true)
+          if [ "${#non_png[@]}" -gt 0 ]; then
+            echo "Unstaging non-PNG files (not included in VRT patch):"
+            printf '  %s\n' "${non_png[@]}"
+            git reset HEAD -- "${non_png[@]}"
+          fi
+
+          # Check if there are any real changes
           if git diff --staged --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No VRT changes to commit"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "e2e:desktop": "yarn build:desktop --skip-exe-build --skip-translations && yarn workspace desktop-electron e2e",
     "playwright": "yarn workspace @actual-app/web run playwright",
     "vrt": "yarn workspace @actual-app/web run vrt",
+    "vrt:prune": "yarn workspace @actual-app/web run prune-vrt-snapshots",
     "vrt:docker": "./bin/run-vrt",
     "rebuild-electron": "./node_modules/.bin/electron-rebuild -m ./packages/loot-core && ./node_modules/.bin/electron-rebuild  -m ./packages/desktop-electron -o better-sqlite3,bcrypt",
     "rebuild-node": "yarn workspace @actual-app/core rebuild",

--- a/packages/desktop-client/README.md
+++ b/packages/desktop-client/README.md
@@ -59,6 +59,9 @@ yarn vrt:docker
 
     # To update snapshots, use the following command:
     yarn vrt:docker --e2e-start-url https://ip:port --update-snapshots
+
+    # After updating, remove PNGs that are no longer referenced by tests:
+    yarn vrt:prune
 ```
 
 Run manually:

--- a/packages/desktop-client/bin/prune-vrt-snapshots.mjs
+++ b/packages/desktop-client/bin/prune-vrt-snapshots.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Remove PNGs under e2e/*-snapshots that are not listed in the VRT manifest
+ * (written during the last `yarn vrt` run). Safe to no-op when the manifest is empty.
+ *
+ * With --check: validate only (no deletes):
+ *   - Every manifest path must exist on disk (paths are relative to packages/desktop-client).
+ *   - With --strict: every PNG under e2e/*-snapshots must appear in the manifest (no extras).
+ *     Use --strict with a combined manifest directory (e.g. merge-vrt), not a single shard.
+ *
+ * Usage:
+ *   node prune-vrt-snapshots.mjs [--check] [--strict] [manifest-dir ...]
+ *
+ * Manifest dirs: if omitted, uses VRT_SNAPSHOT_MANIFEST_DIR or e2e/.vrt-manifest.
+ * Any .txt file under manifest dir(s) is scanned for path lines (recursive).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.join(__dirname, '..');
+
+const argv = process.argv.slice(2);
+const check = argv.includes('--check');
+const strict = argv.includes('--strict');
+const positional = argv.filter((a) => !a.startsWith('-'));
+
+const defaultManifestDir =
+  process.env.VRT_SNAPSHOT_MANIFEST_DIR ??
+  path.join(pkgRoot, 'e2e', '.vrt-manifest');
+
+const manifestRoots =
+  positional.length > 0
+    ? positional.map((d) => path.resolve(process.cwd(), d))
+    : [defaultManifestDir];
+
+/** @param {string} dir */
+function collectLinesFromTxtFiles(dir) {
+  const lines = new Set();
+  if (!fs.existsSync(dir)) return lines;
+
+  function walk(d) {
+    for (const ent of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, ent.name);
+      if (ent.isDirectory()) walk(p);
+      else if (ent.name.endsWith('.txt')) {
+        const text = fs.readFileSync(p, 'utf8');
+        for (const line of text.split('\n')) {
+          const t = line.trim();
+          if (t) lines.add(t);
+        }
+      }
+    }
+  }
+  walk(dir);
+  return lines;
+}
+
+const expected = new Set();
+for (const root of manifestRoots) {
+  for (const line of collectLinesFromTxtFiles(root)) expected.add(line);
+}
+
+if (check) {
+  if (expected.size === 0 && !strict) {
+    console.log('No VRT manifest entries to validate.');
+    process.exit(0);
+  }
+
+  const missing = [];
+  for (const rel of expected) {
+    const abs = path.join(pkgRoot, rel);
+    if (!fs.existsSync(abs)) missing.push(rel);
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      'VRT manifest lists paths that are not present on disk under packages/desktop-client:',
+    );
+    for (const m of missing) console.error(`  ${m}`);
+    process.exit(1);
+  }
+
+  if (strict) {
+    const e2eRoot = path.join(pkgRoot, 'e2e');
+    const extra = [];
+
+    function walkPng(dir) {
+      for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, ent.name);
+        if (ent.isDirectory()) walkPng(p);
+        else if (ent.name.endsWith('.png')) {
+          const rel = path.relative(pkgRoot, p).split(path.sep).join('/');
+          if (!expected.has(rel)) extra.push(rel);
+        }
+      }
+    }
+
+    if (fs.existsSync(e2eRoot)) {
+      for (const ent of fs.readdirSync(e2eRoot, { withFileTypes: true })) {
+        if (ent.isDirectory() && ent.name.endsWith('-snapshots')) {
+          walkPng(path.join(e2eRoot, ent.name));
+        }
+      }
+    }
+
+    if (extra.length > 0) {
+      console.error(
+        'PNG snapshot files exist that are not listed in the VRT manifest (remove them or update tests):',
+      );
+      for (const e of extra.sort()) console.error(`  ${e}`);
+      process.exit(1);
+    }
+  }
+
+  const msg =
+    strict && expected.size === 0
+      ? 'VRT manifest check OK (strict: no PNGs under e2e/*-snapshots).'
+      : `VRT manifest check OK (${expected.size} path(s) in manifest${
+          strict ? '; no extra PNGs under e2e/*-snapshots' : ''
+        }).`;
+  console.log(msg);
+  process.exit(0);
+}
+
+if (expected.size === 0) {
+  console.log('No VRT snapshot manifest entries; skipping orphan prune.');
+  process.exit(0);
+}
+
+const e2eRoot = path.join(pkgRoot, 'e2e');
+let removed = 0;
+
+function considerRemove(absPath) {
+  const rel = path.relative(pkgRoot, absPath).split(path.sep).join('/');
+  if (!expected.has(rel)) {
+    fs.unlinkSync(absPath);
+    console.log('Removed orphan snapshot:', rel);
+    removed += 1;
+  }
+}
+
+function walkPngUnderSnapshotDir(dir) {
+  for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, ent.name);
+    if (ent.isDirectory()) walkPngUnderSnapshotDir(p);
+    else if (ent.name.endsWith('.png')) considerRemove(p);
+  }
+}
+
+for (const ent of fs.readdirSync(e2eRoot, { withFileTypes: true })) {
+  if (ent.isDirectory() && ent.name.endsWith('-snapshots')) {
+    walkPngUnderSnapshotDir(path.join(e2eRoot, ent.name));
+  }
+}
+
+console.log(
+  `VRT orphan prune done (${removed} removed, ${expected.size} expected).`,
+);

--- a/packages/desktop-client/e2e/fixtures.ts
+++ b/packages/desktop-client/e2e/fixtures.ts
@@ -1,7 +1,38 @@
 import { expect as baseExpect } from '@playwright/test';
-import type { Locator } from '@playwright/test';
+import type { Locator, TestInfo } from '@playwright/test';
+
+declare global {
+  // oxlint-disable-next-line typescript/consistent-type-definitions -- merges with lib.dom Window
+  interface Window {
+    Actual: {
+      setTheme(theme: string): void;
+    };
+  }
+}
 
 export { test } from '@playwright/test';
+
+type PlaywrightGlobals = { currentTestInfo: () => TestInfo | null };
+
+let playwrightGlobalsPromise: Promise<PlaywrightGlobals> | undefined;
+
+async function getPlaywrightGlobals(): Promise<PlaywrightGlobals> {
+  playwrightGlobalsPromise ??= import('./load-playwright-globals.cjs').then(
+    m => m.default,
+  );
+  return playwrightGlobalsPromise;
+}
+
+type AppendManifest = (testInfo: TestInfo) => void;
+
+let appendManifestPromise: Promise<AppendManifest> | undefined;
+
+async function getAppendVrtSnapshotManifestLine(): Promise<AppendManifest> {
+  appendManifestPromise ??= import('./vrt-manifest.mjs').then(
+    m => m.appendVrtSnapshotManifestLine,
+  );
+  return appendManifestPromise;
+}
 
 export const expect = baseExpect.extend({
   async toMatchThemeScreenshots(locator: Locator) {
@@ -13,6 +44,15 @@ export const expect = baseExpect.extend({
         pass: true,
       };
     }
+
+    const { currentTestInfo } = await getPlaywrightGlobals();
+    const testInfo = currentTestInfo();
+    if (!testInfo) {
+      throw new Error('toMatchThemeScreenshots() must be called during a test');
+    }
+
+    const appendVrtSnapshotManifestLine =
+      await getAppendVrtSnapshotManifestLine();
 
     const config = {
       mask: [locator.locator('[data-vrt-mask="true"]')],
@@ -27,26 +67,31 @@ export const expect = baseExpect.extend({
         ? locator.page().locator('[data-theme]')
         : locator.locator('[data-theme]');
 
-    // Check lightmode
-    await locator.evaluate(() => window.Actual.setTheme('auto'));
-    await baseExpect(dataThemeLocator).toHaveAttribute('data-theme', 'auto');
-    await baseExpect(locator).toHaveScreenshot(config);
+    try {
+      // Check lightmode
+      await locator.evaluate(() => window.Actual.setTheme('auto'));
+      await baseExpect(dataThemeLocator).toHaveAttribute('data-theme', 'auto');
+      await baseExpect(locator).toHaveScreenshot(config);
+      appendVrtSnapshotManifestLine(testInfo);
 
-    // Switch to darkmode and check
-    await locator.evaluate(() => window.Actual.setTheme('dark'));
-    await baseExpect(dataThemeLocator).toHaveAttribute('data-theme', 'dark');
-    await baseExpect(locator).toHaveScreenshot(config);
+      // Switch to darkmode and check
+      await locator.evaluate(() => window.Actual.setTheme('dark'));
+      await baseExpect(dataThemeLocator).toHaveAttribute('data-theme', 'dark');
+      await baseExpect(locator).toHaveScreenshot(config);
+      appendVrtSnapshotManifestLine(testInfo);
 
-    // Switch to midnight theme and check
-    await locator.evaluate(() => window.Actual.setTheme('midnight'));
-    await baseExpect(dataThemeLocator).toHaveAttribute(
-      'data-theme',
-      'midnight',
-    );
-    await baseExpect(locator).toHaveScreenshot(config);
+      // Switch to midnight theme and check
+      await locator.evaluate(() => window.Actual.setTheme('midnight'));
+      await baseExpect(dataThemeLocator).toHaveAttribute(
+        'data-theme',
+        'midnight',
+      );
+      await baseExpect(locator).toHaveScreenshot(config);
+      appendVrtSnapshotManifestLine(testInfo);
+    } finally {
+      await locator.evaluate(() => window.Actual.setTheme('auto'));
+    }
 
-    // Switch back to lightmode
-    await locator.evaluate(() => window.Actual.setTheme('auto'));
     return {
       message: () => 'pass',
       pass: true,

--- a/packages/desktop-client/e2e/load-playwright-globals.cjs
+++ b/packages/desktop-client/e2e/load-playwright-globals.cjs
@@ -1,0 +1,13 @@
+'use strict';
+
+const { createRequire } = require('module');
+const path = require('path');
+
+const requireFromHere = createRequire(__filename);
+const playwrightRoot = path.dirname(
+  requireFromHere.resolve('playwright/package.json'),
+);
+
+module.exports = requireFromHere(
+  path.join(playwrightRoot, 'lib/common/globals.js'),
+);

--- a/packages/desktop-client/e2e/vrt-manifest.mjs
+++ b/packages/desktop-client/e2e/vrt-manifest.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const pkgRoot = path.join(import.meta.dirname, '..');
+
+/**
+ * Aligns with Playwright TestInfoImpl anonymous screenshot indexing.
+ * `testInfo.snapshotPath('', { kind: 'screenshot' })` does not advance the counter.
+ *
+ * @param {import('@playwright/test').TestInfo} testInfo
+ */
+function absolutePathForLastAnonymousScreenshot(testInfo) {
+  const last = testInfo._snapshotNames.lastAnonymousSnapshotIndex;
+  if (last < 1) {
+    throw new Error('No anonymous screenshot has been recorded yet');
+  }
+  testInfo._snapshotNames.lastAnonymousSnapshotIndex = last - 1;
+  try {
+    return testInfo._resolveSnapshotPaths(
+      'screenshot',
+      '',
+      'dontUpdateSnapshotIndex',
+      undefined,
+    ).absoluteSnapshotPath;
+  } finally {
+    testInfo._snapshotNames.lastAnonymousSnapshotIndex = last;
+  }
+}
+
+/**
+ * Append a manifest line for the most recent anonymous screenshot (VRT theme flow).
+ *
+ * @param {import('@playwright/test').TestInfo} testInfo
+ */
+export function appendVrtSnapshotManifestLine(testInfo) {
+  if (!process.env.VRT) return;
+  const absolutePath = absolutePathForLastAnonymousScreenshot(testInfo);
+  const manifestDir =
+    process.env.VRT_SNAPSHOT_MANIFEST_DIR ??
+    path.join(import.meta.dirname, '.vrt-manifest');
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const rel = path.relative(pkgRoot, absolutePath).split(path.sep).join('/');
+  const file = path.join(manifestDir, `parallel-${testInfo.parallelIndex}.txt`);
+  fs.appendFileSync(file, `${rel}\n`, 'utf8');
+}

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -103,6 +103,7 @@
     "test": "vitest --run",
     "e2e": "npx playwright test --browser=chromium",
     "vrt": "cross-env VRT=true npx playwright test --browser=chromium",
+    "prune-vrt-snapshots": "node ./bin/prune-vrt-snapshots.mjs",
     "playwright": "playwright",
     "typecheck": "tsgo -b && tsc-strict"
   },

--- a/upcoming-release-notes/7459.md
+++ b/upcoming-release-notes/7459.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [StephenBrown2]
+---
+
+VRT: prune orphan web snapshots after updates, alter VRT update comment when one is already running.


### PR DESCRIPTION
## Description

This PR improves the visual regression test (VRT) update pipeline and how contributors see status on pull requests.

**Prune orphaned web VRT snapshots.** When tests or themes change, old PNGs can remain under `e2e/*-snapshots` even though Playwright no longer references them. During VRT runs (`VRT=true`), `toMatchThemeScreenshots` records each expected snapshot path into a per-worker manifest under `e2e/.vrt-manifest/`. A new script (`yarn vrt:prune` / `prune-vrt-snapshots`) deletes PNGs in snapshot folders that are not listed in that manifest, so local and CI updates do not leave stale files behind. The VRT update workflow clears the manifest before a run, clears Electron baseline PNGs before regeneration, runs the prune step after `--update-snapshots`, and stages snapshot changes with `git add --no-ignore-removal` on the web and desktop-electron `e2e` trees so **removals** are included in the generated patch (non-PNG paths are unstaged).

**Clearer PR comments when a VRT update is already running.** The E2E VRT comment workflow checks whether **VRT Update - Generate** is already queued or in progress for the PR’s current head commit. If so, the sticky comment still links to the failing VRT report but also points to the active workflow run instead of only suggesting `/update-vrt` again.

## Related issue(s)

Extracted from the earlier PR #6954 which renamed VRT tests, and thus resulted in orphaned PNGs, still tracked in git.

## Testing

- **Prune script:** Run web VRT with `VRT=true` so `.vrt-manifest` is populated, add or rename a bogus PNG under an `e2e/*-snapshots` directory, run `yarn vrt:prune` from the repo root, and confirm only unreferenced files are removed.
- **CI workflows:** Validate on a PR where VRT fails: (1) comment posts as before when no update run is active; (2) when `/update-vrt` has already triggered **VRT Update - Generate**, the alternate sticky message includes a link to that run; (3) a full VRT update produces a patch that includes deleted baseline PNGs where appropriate.
- **E2E / fixtures:** `yarn workspace @actual-app/web exec playwright test --list` should list all tests (no load error from `fixtures.ts`). Run normal E2E (without `VRT`) in CI or locally to confirm unchanged behavior for non-VRT runs.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.91 MB → 12.91 MB (+62 B) | +0.00%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.91 MB → 12.91 MB (+62 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`package.json` | 📈 +62 B (+0.74%) | 8.19 kB → 8.25 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB → 3.32 MB (+62 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 853.16 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.88 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 485.17 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B_XN_qvd.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->