### PR TITLE
Fix bug where total selected balance is not shown when it is zero

### DIFF
--- a/packages/desktop-client/src/components/accounts/Balance.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.test.tsx
@@ -67,6 +67,18 @@ describe('SelectedBalance – normal transactions', () => {
     expect(screen.getByText('Selected balance:')).toBeInTheDocument();
     expect(screen.getByText('-50.00')).toBeInTheDocument();
   });
+
+  test('shows balance when balance is falsy', () => {
+    vi.mocked(useSheetValue).mockReturnValueOnce(null).mockReturnValueOnce(0);
+
+    render(
+      <TestProviders>
+        <SelectedBalance selectedItems={new Set(['tx-123'])} />
+      </TestProviders>,
+    );
+
+    expect(screen.getByText('Selected balance:')).toBeInTheDocument();
+  });
 });
 
 describe('SelectedBalance – preview (scheduled) transactions', () => {

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -116,7 +116,7 @@ export function SelectedBalance({
     }
   }
 
-  if (!balance && !scheduleBalance) {
+  if (typeof balance !== 'number' && !scheduleBalance) {
     return null;
   } else {
     balance = (balance ?? 0) + scheduleBalance;

--- a/upcoming-release-notes/7460.md
+++ b/upcoming-release-notes/7460.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [Kennedy242]
+---
+
+Fix bug where total selected balance is not shown when it is zero


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fix bug where total selected balance is not shown when it is zero   

## Related issue(s)

Fixes ##7452

## Testing

See the issue: 

- Use the current demo build add a payment transaction that is equal the to account balance. Select all transactions, expect to see 'Selected balance' but it is not there.
- Run the updated tests with out the fix. See them fail

See the fix:

- Use the this PR's demo build add a payment transaction that is equal the to account balance. Select all transactions, see 'Selected balance'. Yaya!
- run the updated tests with the fix, see them pass!


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.9 MB → 12.9 MB (+19 B) | +0.00%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.84 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.9 MB → 12.9 MB (+19 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Balance.tsx` | 📈 +19 B (+0.18%) | 10.13 kB → 10.15 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB → 3.32 MB (+19 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.17 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.89 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/extends.js | 485.18 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.87 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 109.61 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.2cr-I6dh.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->