### PR TITLE
[AI] Refactor IS_GENERIC_BROWSER env var to --mode=browser

### DIFF
--- a/packages/desktop-client/bin/build-browser
+++ b/packages/desktop-client/bin/build-browser
@@ -7,10 +7,9 @@ echo "Building the browser..."
 
 rm -fr build
 
-export IS_GENERIC_BROWSER=1
 export REACT_APP_BACKEND_WORKER_HASH=`ls "$ROOT"/../public/kcab/kcab.worker.*.js |  sed 's/.*kcab\.worker\.\(.*\)\.js/\1/'`
 
-yarn build
+yarn build --mode=browser
 
 rm -fr build-stats
 mkdir build-stats

--- a/packages/desktop-client/bin/watch-browser
+++ b/packages/desktop-client/bin/watch-browser
@@ -3,8 +3,7 @@
 ROOT=`dirname $0`
 cd "$ROOT/.."
 
-export IS_GENERIC_BROWSER=1
 export PORT=3001
 export REACT_APP_BACKEND_WORKER_HASH="dev"
 
-yarn start
+yarn start --mode=browser

--- a/packages/desktop-client/src/build-shims.js
+++ b/packages/desktop-client/src/build-shims.js
@@ -3,7 +3,7 @@ const global = globalThis || this || self;
 const process = {
   env: {
     ...import.meta.env,
-    NODE_ENV: import.meta.env.MODE,
+    NODE_ENV: import.meta.env.DEV ? 'development' : 'production',
     PUBLIC_URL: import.meta.env.BASE_URL.slice(0, -1),
   },
 };

--- a/packages/desktop-client/vite.config.ts
+++ b/packages/desktop-client/vite.config.ts
@@ -164,7 +164,7 @@ export default defineConfig(async ({ mode }) => {
       },
     },
     resolve: {
-      ...(!env.IS_GENERIC_BROWSER && {
+      ...(mode !== 'browser' && {
         conditions: ['electron-renderer', 'module', 'browser', 'default'],
       }),
       tsconfigPaths: true,

--- a/packages/desktop-client/vite.config.ts
+++ b/packages/desktop-client/vite.config.ts
@@ -152,7 +152,7 @@ export default defineConfig(async ({ mode }) => {
     },
     server: {
       host: true,
-      headers: mode === 'development' ? devHeaders : undefined,
+      headers: devHeaders,
       port: +env.PORT || 5173,
       open: env.BROWSER
         ? ['chrome', 'firefox', 'edge', 'browser', 'browserPrivate'].includes(

--- a/upcoming-release-notes/7466.md
+++ b/upcoming-release-notes/7466.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Refactor browser mode configuration to use `--mode=browser` instead of an environment variable.


### PR DESCRIPTION
Replace `IS_GENERIC_BROWSER` with `--mode` param usage: simplifying the build process.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.9 MB → 12.9 MB (-3 B) | -0.00%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.9 MB → 12.9 MB (-3 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/build-shims.js` | 📉 -3 B (-0.81%) | 370 B → 367 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 485.17 kB → 485.17 kB (-3 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.17 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.89 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.95 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.05 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.2cr-I6dh.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->