### PR TITLE
[AI] Add Sankey report toggle to view values as percentages

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SankeyGraph.tsx
@@ -24,6 +24,7 @@ type SankeyGraphNode = SankeyData['nodes'][number] & {
   toBudget?: number;
   isNegative?: boolean;
   actualValue?: number;
+  percentageLabel?: string;
   targetLinks?: Array<Record<string, unknown>>;
   sourceLinks?: Array<Record<string, unknown>>;
 };
@@ -91,6 +92,7 @@ type SankeyNodeProps = {
   payload: SankeyGraphNode;
   containerWidth: number;
   containerHeight: number;
+  showPercentages?: boolean;
 };
 function SankeyNode({
   x,
@@ -101,6 +103,7 @@ function SankeyNode({
   payload,
   containerWidth,
   containerHeight,
+  showPercentages,
 }: SankeyNodeProps) {
   const privacyMode = usePrivacyMode();
   const format = useFormat();
@@ -162,7 +165,9 @@ function SankeyNode({
         ))}
       {renderText(payload.name || '', height / 2)}
       {renderText(
-        format(payload.value, 'financial'),
+        showPercentages && payload.percentageLabel
+          ? payload.percentageLabel
+          : format(payload.value, 'financial'),
         height / 2 + 13,
         11,
         0.5,
@@ -195,11 +200,13 @@ type SankeyGraphProps = {
   data: SankeyData;
   showTooltip?: boolean;
   collapsedNodes?: string[];
+  showPercentages?: boolean;
 };
 export function SankeyGraph({
   style,
   data,
   showTooltip = true,
+  showPercentages = false,
 }: SankeyGraphProps) {
   const privacyMode = usePrivacyMode();
   const format = useFormat();
@@ -229,6 +236,7 @@ export function SankeyGraph({
                 {...props}
                 containerWidth={width}
                 containerHeight={height}
+                showPercentages={showPercentages}
               />
             )}
             link={props => (

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -31,7 +31,10 @@ import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
 import { ModeButton } from '#components/reports/ModeButton';
 import { calculateTimeRange } from '#components/reports/reportRanges';
-import { createSpreadsheet as sankeySpreadsheet } from '#components/reports/spreadsheets/sankey-spreadsheet';
+import {
+  createSpreadsheet as sankeySpreadsheet,
+  withPercentageLabels,
+} from '#components/reports/spreadsheets/sankey-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { useCategories } from '#hooks/useCategories';
@@ -197,6 +200,46 @@ function GraphModeSelector({ mode, onChange }: GraphModeSelectorProps) {
   );
 }
 
+type OptionsButtonProps = {
+  showPercentages: boolean;
+  onTogglePercentages: () => void;
+};
+
+function OptionsButton({
+  showPercentages,
+  onTogglePercentages,
+}: OptionsButtonProps) {
+  const { t } = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button ref={triggerRef} onPress={() => setIsOpen(true)}>
+        <Trans>Options</Trans>
+      </Button>
+      <Popover
+        triggerRef={triggerRef}
+        placement="bottom end"
+        isOpen={isOpen}
+        onOpenChange={() => setIsOpen(false)}
+      >
+        <Menu
+          onMenuSelect={item => {
+            if (item === 'show-percentages') onTogglePercentages();
+          }}
+          items={[
+            {
+              name: 'show-percentages',
+              text: t('Show as percentages'),
+              toggle: showPercentages,
+            },
+          ]}
+        />
+      </Popover>
+    </>
+  );
+}
+
 type SankeyInnerProps = {
   widget?: SankeyWidget;
 };
@@ -248,6 +291,10 @@ function SankeyInner({ widget }: SankeyInnerProps) {
   const [categorySort, setCategorySort] = useState<
     'per-group' | 'global' | 'budget-order'
   >(widget?.meta?.categorySort ?? 'per-group');
+
+  const [showPercentages, setShowPercentages] = useState(
+    widget?.meta?.showPercentages ?? false,
+  );
 
   const { data: { grouped: groupedCategories = [] } = { grouped: [] } } =
     useCategories();
@@ -370,6 +417,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
             mode: graphMode,
             topNcategories,
             categorySort,
+            showPercentages,
             timeFrame: {
               start,
               end,
@@ -504,6 +552,12 @@ function SankeyInner({ widget }: SankeyInnerProps) {
           </>
         }
       >
+        <View style={{ marginRight: 4 }}>
+          <OptionsButton
+            showPercentages={showPercentages}
+            onTogglePercentages={() => setShowPercentages(v => !v)}
+          />
+        </View>
         {widget && (
           <Button variant="primary" onPress={onSaveWidget}>
             <Trans>Save widget</Trans>
@@ -552,7 +606,12 @@ function SankeyInner({ widget }: SankeyInnerProps) {
                 {data && data.links && data.links.length > 0 ? (
                   <SankeyGraph
                     style={{ flexGrow: 1 }}
-                    data={data as SankeyData}
+                    data={
+                      showPercentages
+                        ? withPercentageLabels(data as SankeyData)
+                        : (data as SankeyData)
+                    }
+                    showPercentages={showPercentages}
                   />
                 ) : (
                   <View

--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -16,6 +16,7 @@ import { calculateTimeRange } from '#components/reports/reportRanges';
 import {
   compactSankeyData,
   createSpreadsheet as sankeySpreadsheet,
+  withPercentageLabels,
 } from '#components/reports/spreadsheets/sankey-spreadsheet';
 import { useDashboardWidgetCopyMenu } from '#components/reports/useDashboardWidgetCopyMenu';
 import { useReport } from '#components/reports/useReport';
@@ -153,7 +154,12 @@ export function SankeyCard({
 
         {compactData ? (
           <SankeyGraph
-            data={compactData}
+            data={
+              meta?.showPercentages
+                ? withPercentageLabels(compactData)
+                : compactData
+            }
+            showPercentages={meta?.showPercentages}
             showTooltip={!isEditing}
             style={{ height: 'auto', flex: 1 }}
           />

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -763,10 +763,10 @@ export function withPercentageLabels(data: SankeyData): SankeyData {
 
   const nodes = data.nodes.map((node, i) => {
     const total = layerTotal.get(depth[i]) ?? 0;
-    if (total === 0) return node;
     return {
       ...node,
-      percentageLabel: `${((nodeValue(i) / total) * 100).toFixed(1)}%`,
+      percentageLabel:
+        total === 0 ? '0%' : `${((nodeValue(i) / total) * 100).toFixed(1)}%`,
     };
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -41,6 +41,7 @@ type SankeyNode = {
   name: string;
   toBudget?: number;
   isNegative?: boolean;
+  percentageLabel?: string;
 };
 
 type SankeyLink = {
@@ -727,4 +728,47 @@ export function compactSankeyData(
   }
 
   return compactedData;
+}
+
+export function withPercentageLabels(data: SankeyData): SankeyData {
+  // Assign a layer depth to each node, starting from the root (node 0 = depth 0).
+  const depth = new Array<number>(data.nodes.length).fill(-1);
+  depth[0] = 0;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const link of data.links) {
+      const src = link.source as number;
+      const tgt = link.target as number;
+      if (depth[src] >= 0 && depth[tgt] < 0) {
+        depth[tgt] = depth[src] + 1;
+        changed = true;
+      }
+    }
+  }
+
+  // Each node's value is the sum of its incoming links.
+  // The root has no incoming links, so use its outgoing links instead.
+  const nodeValue = (i: number) =>
+    data.links
+      .filter(l => (depth[i] === 0 ? l.source === i : l.target === i))
+      .reduce((sum, l) => sum + l.value, 0);
+
+  // Compute the total value per layer so percentages within each layer sum to 100%.
+  const layerTotal = new Map<number, number>();
+  data.nodes.forEach((_, i) => {
+    const d = depth[i];
+    if (d >= 0) layerTotal.set(d, (layerTotal.get(d) ?? 0) + nodeValue(i));
+  });
+
+  const nodes = data.nodes.map((node, i) => {
+    const total = layerTotal.get(depth[i]) ?? 0;
+    if (total === 0) return node;
+    return {
+      ...node,
+      percentageLabel: `${((nodeValue(i) / total) * 100).toFixed(1)}%`,
+    };
+  });
+
+  return { ...data, nodes };
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -738,8 +738,8 @@ export function withPercentageLabels(data: SankeyData): SankeyData {
   while (changed) {
     changed = false;
     for (const link of data.links) {
-      const src = link.source as number;
-      const tgt = link.target as number;
+      const src = link.source;
+      const tgt = link.target;
       if (depth[src] >= 0 && depth[tgt] < 0) {
         depth[tgt] = depth[src] + 1;
         changed = true;

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -222,5 +222,6 @@ export type SankeyWidget = AbstractWidget<
     mode?: 'budgeted' | 'spent';
     topNcategories?: number;
     categorySort?: 'per-group' | 'global' | 'budget-order';
+    showPercentages?: boolean;
   } | null
 >;

--- a/upcoming-release-notes/7476.md
+++ b/upcoming-release-notes/7476.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [emiltb]
 ---
 
-Add Options button to allow customization of Sankey chart properties. Add toggle for viewing values in Sankey chart as percentages instead of absolute values.
+Added a new Sankey Options menu with a toggle to view values as percentages.

--- a/upcoming-release-notes/7476.md
+++ b/upcoming-release-notes/7476.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [emiltb]
 ---
 
-Add Options button to allow customization of Sankey chart properties. Add toggle for viewing values in Sankey chart as percentages instead of absolute values. 
+Add Options button to allow customization of Sankey chart properties. Add toggle for viewing values in Sankey chart as percentages instead of absolute values.

--- a/upcoming-release-notes/7476.md
+++ b/upcoming-release-notes/7476.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [emiltb]
+---
+
+Add Options button to allow customization of Sankey chart properties. Add toggle for viewing values in Sankey chart as percentages instead of absolute values. 


### PR DESCRIPTION
## Description

Adds requested option to view values as percentages instead of absolute values. Each layer in the Sankey chart sums to 100%. In the anticipation, that more options for customization will be requested, the toggle for viewing as percentages has been placed behind an Options button, which leaves room for more toggles to be added later.

## Related issue(s)

Relates to #1919. 

## Testing

Tested and verified that values can be viewed as percentages. The toggle option can be saved and takes effect on both the report and the card. 

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.9 MB → 12.91 MB (+4.8 kB) | +0.04%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.9 MB → 12.91 MB (+4.8 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Sankey.tsx` | 📈 +3.37 kB (+13.36%) | 25.21 kB → 28.58 kB
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📈 +932 B (+7.06%) | 12.9 kB → 13.81 kB
`src/components/reports/graphs/SankeyGraph.tsx` | 📈 +367 B (+3.82%) | 9.38 kB → 9.74 kB
`src/components/reports/reports/SankeyCard.tsx` | 📈 +171 B (+2.30%) | 7.26 kB → 7.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.17 MB → 1.18 MB (+4.8 kB) | +0.40%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.89 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/extends.js | 485.17 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.95 kB | 0%
static/js/narrow.js | 363.02 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.05 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.ddTTAQMt.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->