### PR TITLE
[AI] Fix sync-server build not resolving subpath imports

### DIFF
--- a/packages/sync-server/bin/add-import-extensions.mjs
+++ b/packages/sync-server/bin/add-import-extensions.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, extname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -8,6 +8,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const buildDir = resolve(__dirname, '../build');
+const packageRoot = resolve(__dirname, '..');
+
+// Load the imports map from package.json
+const packageJson = JSON.parse(
+  readFileSync(join(packageRoot, 'package.json'), 'utf-8'),
+);
+const importsMap = packageJson.imports || {};
 
 async function getAllJsFiles(dir) {
   const files = [];
@@ -50,15 +57,70 @@ function resolveImportPath(importPath, fromFile) {
   return `${importPath}.js`;
 }
 
+function resolveSubpathImport(importPath, fromFile) {
+  // Try exact match first
+  if (importsMap[importPath]) {
+    const target = importsMap[importPath];
+    // Target is like "./src/account-db.js" - convert to build path
+    const buildTarget = target.replace(/^\.\/src\//, './build/src/');
+    const absoluteTarget = resolve(packageRoot, buildTarget);
+    // If the target ends with .ts, the built version will be .js
+    const jsTarget = absoluteTarget.replace(/\.ts$/, '.js');
+    let rel = relative(dirname(fromFile), jsTarget);
+    if (!rel.startsWith('.')) rel = './' + rel;
+    // Normalize to posix separators
+    return rel.split('\\').join('/');
+  }
+
+  // Try wildcard patterns (e.g., "#accounts/*" -> "./src/accounts/*.js")
+  for (const [pattern, target] of Object.entries(importsMap)) {
+    if (!pattern.includes('*')) continue;
+    const prefix = pattern.replace('*', '');
+    if (importPath.startsWith(prefix)) {
+      const wildcard = importPath.slice(prefix.length);
+      const resolvedTarget = target.replace('*', wildcard);
+      const buildTarget = resolvedTarget.replace(/^\.\/src\//, './build/src/');
+      const absoluteTarget = resolve(packageRoot, buildTarget);
+      const jsTarget = absoluteTarget.replace(/\.ts$/, '.js');
+      // Check if the file exists; if not, try adding .js
+      let finalTarget = jsTarget;
+      if (
+        !existsSync(finalTarget) &&
+        existsSync(finalTarget.replace(/\.js$/, '') + '.js')
+      ) {
+        finalTarget = finalTarget.replace(/\.js$/, '') + '.js';
+      }
+      let rel = relative(dirname(fromFile), finalTarget);
+      if (!rel.startsWith('.')) rel = './' + rel;
+      return rel.split('\\').join('/');
+    }
+  }
+
+  console.warn(
+    `Warning: Could not resolve subpath import '${importPath}' from ${relative(buildDir, fromFile)}`,
+  );
+  return null;
+}
+
 function addExtensionsToImports(content, filePath) {
-  // Match relative imports: import ... from './path' or import ... from '../path'
+  // Match relative imports AND subpath (#) imports
+  // Handles: import ... from './path', import ... from '#path'
   // Also handle: import('./path') and require('./path')
   const importRegex =
-    /(?:import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?|import\s*\(|require\s*\()['"](\.\.?\/[^'"]+)['"]/g;
+    /(?:import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?|import\s*\(|require\s*\()['"]((\.\.?\/[^'"]+)|(#[^'"]+))['"]/g;
 
   return content.replace(importRegex, (match, importPath) => {
-    // importPath is the second capture group (the path)
+    // importPath is the capture group (the path)
     if (!importPath || typeof importPath !== 'string') {
+      return match;
+    }
+
+    // Handle subpath imports (#-prefixed)
+    if (importPath.startsWith('#')) {
+      const resolved = resolveSubpathImport(importPath, filePath);
+      if (resolved) {
+        return match.replace(importPath, resolved);
+      }
       return match;
     }
 

--- a/packages/sync-server/bin/add-import-extensions.mjs
+++ b/packages/sync-server/bin/add-import-extensions.mjs
@@ -76,10 +76,10 @@ function resolveSubpathImport(importPath, fromFile) {
   }
 
   for (const [pattern, target] of wildcardEntries) {
-    const prefix = pattern.replace('*', '');
+    const prefix = pattern.replaceAll('*', '');
     if (importPath.startsWith(prefix)) {
       const wildcard = importPath.slice(prefix.length);
-      return toRelativePath(target.replace('*', wildcard), fromFile);
+      return toRelativePath(target.replaceAll('*', wildcard), fromFile);
     }
   }
 

--- a/packages/sync-server/bin/add-import-extensions.mjs
+++ b/packages/sync-server/bin/add-import-extensions.mjs
@@ -10,11 +10,17 @@ const __dirname = dirname(__filename);
 const buildDir = resolve(__dirname, '../build');
 const packageRoot = resolve(__dirname, '..');
 
-// Load the imports map from package.json
 const packageJson = JSON.parse(
   readFileSync(join(packageRoot, 'package.json'), 'utf-8'),
 );
-const importsMap = packageJson.imports || {};
+// publishConfig.imports already has ./build/src/ paths with .js extensions
+const importsMap = packageJson.publishConfig?.imports || {};
+
+// Sort wildcard patterns longest-prefix-first so more specific patterns
+// (e.g. #app-gocardless/services/tests/*) match before broader ones (#app-gocardless/*)
+const wildcardEntries = Object.entries(importsMap)
+  .filter(([p]) => p.includes('*'))
+  .sort(([a], [b]) => b.length - a.length);
 
 async function getAllJsFiles(dir) {
   const files = [];
@@ -57,42 +63,23 @@ function resolveImportPath(importPath, fromFile) {
   return `${importPath}.js`;
 }
 
+function toRelativePath(target, fromFile) {
+  const absoluteTarget = resolve(packageRoot, target);
+  let rel = relative(dirname(fromFile), absoluteTarget);
+  if (!rel.startsWith('.')) rel = './' + rel;
+  return rel.split('\\').join('/');
+}
+
 function resolveSubpathImport(importPath, fromFile) {
-  // Try exact match first
   if (importsMap[importPath]) {
-    const target = importsMap[importPath];
-    // Target is like "./src/account-db.js" - convert to build path
-    const buildTarget = target.replace(/^\.\/src\//, './build/src/');
-    const absoluteTarget = resolve(packageRoot, buildTarget);
-    // If the target ends with .ts, the built version will be .js
-    const jsTarget = absoluteTarget.replace(/\.ts$/, '.js');
-    let rel = relative(dirname(fromFile), jsTarget);
-    if (!rel.startsWith('.')) rel = './' + rel;
-    // Normalize to posix separators
-    return rel.split('\\').join('/');
+    return toRelativePath(importsMap[importPath], fromFile);
   }
 
-  // Try wildcard patterns (e.g., "#accounts/*" -> "./src/accounts/*.js")
-  for (const [pattern, target] of Object.entries(importsMap)) {
-    if (!pattern.includes('*')) continue;
+  for (const [pattern, target] of wildcardEntries) {
     const prefix = pattern.replace('*', '');
     if (importPath.startsWith(prefix)) {
       const wildcard = importPath.slice(prefix.length);
-      const resolvedTarget = target.replace('*', wildcard);
-      const buildTarget = resolvedTarget.replace(/^\.\/src\//, './build/src/');
-      const absoluteTarget = resolve(packageRoot, buildTarget);
-      const jsTarget = absoluteTarget.replace(/\.ts$/, '.js');
-      // Check if the file exists; if not, try adding .js
-      let finalTarget = jsTarget;
-      if (
-        !existsSync(finalTarget) &&
-        existsSync(finalTarget.replace(/\.js$/, '') + '.js')
-      ) {
-        finalTarget = finalTarget.replace(/\.js$/, '') + '.js';
-      }
-      let rel = relative(dirname(fromFile), finalTarget);
-      if (!rel.startsWith('.')) rel = './' + rel;
-      return rel.split('\\').join('/');
+      return toRelativePath(target.replace('*', wildcard), fromFile);
     }
   }
 
@@ -103,19 +90,14 @@ function resolveSubpathImport(importPath, fromFile) {
 }
 
 function addExtensionsToImports(content, filePath) {
-  // Match relative imports AND subpath (#) imports
-  // Handles: import ... from './path', import ... from '#path'
-  // Also handle: import('./path') and require('./path')
   const importRegex =
     /(?:import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)(?:\s*,\s*(?:\{[^}]*\}|\*\s+as\s+\w+|\w+))*\s+from\s+)?|import\s*\(|require\s*\()['"]((\.\.?\/[^'"]+)|(#[^'"]+))['"]/g;
 
   return content.replace(importRegex, (match, importPath) => {
-    // importPath is the capture group (the path)
     if (!importPath || typeof importPath !== 'string') {
       return match;
     }
 
-    // Handle subpath imports (#-prefixed)
     if (importPath.startsWith('#')) {
       const resolved = resolveSubpathImport(importPath, filePath);
       if (resolved) {

--- a/upcoming-release-notes/7478.md
+++ b/upcoming-release-notes/7478.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Resolve subpath imports when running server locally


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

After enabling subpath imports in the sync-server the `yarn start:server` operation no longer worked. Fixing it here.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

`yarn start:server`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->