### PR TITLE
[Docs] Update tags doc for clarity - fixes #7475

### DIFF
--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -5,10 +5,10 @@ An example would be to tag all transactions for a trip with `#Vacation2025`
 
 ## Syntax
 
-- A tag is a string of any characters (except `#`) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
+- A tag is a string of any characters (except `#` and ` `) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
+- Tags cannot contain a space as you can see in the screenshots below. Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead of spaces in tags.
 - It is possible to have multiple tags for a single transaction.
 - Tags are case-sensitive, meaning that `#tag` and `#TAG` are different.
-- Tags cannot contain a space as you can see in the screenshots below. Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead of spaces in tags.
 - To use the `#` symbol in the _Notes_ field without tagging, you can escape it by inputting it twice: `##do-not-tag-this`.
 
 ![Tagging a transaction](/img/tags/input.webp)
@@ -17,8 +17,9 @@ An example would be to tag all transactions for a trip with `#Vacation2025`
 
 ## Filter Transactions
 
-To view transactions with a given tag, you can either:
+To view transactions with a given tag, you can:
 
+- Use the _View Transactions_ button in the Tag management page, in the sidebar.
 - Click on a colored tag in the Account register.
 - Use the `has tags` filter on the _Notes_ field:
 
@@ -26,14 +27,13 @@ To view transactions with a given tag, you can either:
 
 ## Manage Tags
 
-Tags use a default color defined in the theme. If you use a lot of tags, it can be helpful to customize the color of the tags. You can configure this through the _Tags_ management page, located in the sidebar.
-
 ![Tag management page](/img/tags/manage.webp)
 
-On the Tag management page, you can perform the following actions:
+The Tag management page can be found in the sidebar under _More_. Here you can perform the following actions:
 
-- **Add New** tags. Do not enter the `#` when adding tags here, it will be added for you. If the tag already exists, the new color will be reflected in the existing tags.
-- **Find Existing Tags**, searches for tags already used within transactions and adds them to the list of managed tags.
-- Change the color of any tag and/or add a description.
+- Change the color. Tags use a default color defined in the theme. Change the color of any tag by clicking on the tag to bring up a color picker.
+- **Add New** tags. Do not enter the `#` when adding tags here, it will be added for you. If the tag already exists, the color you pick will be reflected in the matching existing tags.
+- **Find Existing Tags** searches for tags already used within transactions and adds them to the list of managed tags.
+- Add a description by clicking in the description field.
 - **View Transactions** which use a given tag.
 - Use the context menu (right-click menu) to delete a tag from this page. It will **not** delete the tag from the transaction notes.

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -7,7 +7,7 @@ An example would be to tag all transactions for a trip with `#Vacation2025`
 
 - A tag is a string of any characters (except `#`) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
 - It is possible to have multiple tags for a single transaction.
-- Tags are case-sensitive, meaning that `#tag` and `#TAG` are different. 
+- Tags are case-sensitive, meaning that `#tag` and `#TAG` are different.
 - Tags cannot contain a space as you can see in the screenshots below. Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead of spaces in tags.
 - To use the `#` symbol in the _Notes_ field without tagging, you can escape it by inputting it twice: `##do-not-tag-this`.
 

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -1,14 +1,15 @@
 # Tags
 
-Transactions can be easily flagged and identified in the table by tagging them through their notes.
-An example would be to tag all transactions for a trip with a tag like `#Vacation2025`
+Transactions can be easily flagged and identified in the account register by tagging them in their notes.
+An example would be to tag all transactions for a trip with `#Vacation2025`
 
 ## Syntax
 
-A tag is a string of any characters (except `#`) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
-It is possible to have multiple tags for a single transaction.
-Tags are case-sensitive, meaning that `#tag` and `#TAG` are different.
-To use the `#` symbol in the _Notes_ field without tagging, you can escape it by inputting it twice: `##do-not-tag-this`.
+- A tag is a string of any characters (except `#`) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
+- It is possible to have multiple tags for a single transaction.
+- Tags are case-sensitive, meaning that `#tag` and `#TAG` are different. 
+- Tags cannot contain a space as you can see in the screenshots below. Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead of spaces in tags.
+- To use the `#` symbol in the _Notes_ field without tagging, you can escape it by inputting it twice: `##do-not-tag-this`.
 
 ![Tagging a transaction](/img/tags/input.webp)
 
@@ -18,21 +19,21 @@ To use the `#` symbol in the _Notes_ field without tagging, you can escape it by
 
 To view transactions with a given tag, you can either:
 
-- Click on the colored tag in the transactions table.
+- Click on a colored tag in the Account register.
 - Use the `has tags` filter on the _Notes_ field:
 
 ![Tag based filter of transactions](/img/tags/filter.webp)
 
 ## Manage Tags
 
-By default, tags use the purple brand color of Actual.
-If you use a lot of tags, it can be helpful to customize the color of the tags. You can configure this through the dedicated _Tags_ page, located in the sidebar.
+Tags use a default color defined in the theme. If you use a lot of tags, it can be helpful to customize the color of the tags. You can configure this through the _Tags_ management page, located in the sidebar.
 
 ![Tag management page](/img/tags/manage.webp)
 
 On the Tag management page, you can perform the following actions:
 
-- **Add New** tags. It doesn't matter whether any transactions with this tag already exist or not.
+- **Add New** tags. Do not enter the `#` when adding tags here, it will be added for you. If the tag already exists, the new color will be reflected in the existing tags.
 - **Find Existing Tags**, searches for tags already used within transactions and adds them to the list of managed tags.
 - Change the color of any tag and/or add a description.
 - **View Transactions** which use a given tag.
+- Use the context menu (right-click menu) to delete a tag from this page. It will **not** delete the tag from the transaction notes.

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -5,8 +5,8 @@ An example would be to tag all transactions for a trip with `#Vacation2025`
 
 ## Syntax
 
-- A tag is a string of any characters (except `#` and ` `) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
-- Tags cannot contain a space as you can see in the screenshots below. Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead of spaces in tags.
+- A tag is a string of any characters (except `#` and whitespaces) prefixed by the `#` symbol; it can be added anywhere within the _Notes_ field of a transaction.
+- Tags cannot contain whitespaces (spaces, tabs, etc.). Use `#camelText`, `#dashed-entries` or `#underscored_separators` instead.
 - It is possible to have multiple tags for a single transaction.
 - Tags are case-sensitive, meaning that `#tag` and `#TAG` are different.
 - To use the `#` symbol in the _Notes_ field without tagging, you can escape it by inputting it twice: `##do-not-tag-this`.
@@ -20,7 +20,7 @@ An example would be to tag all transactions for a trip with `#Vacation2025`
 To view transactions with a given tag, you can:
 
 - Use the _View Transactions_ button in the Tag management page, in the sidebar.
-- Click on a colored tag in the Account register.
+- Click on a colored tag in the account register.
 - Use the `has tags` filter on the _Notes_ field:
 
 ![Tag based filter of transactions](/img/tags/filter.webp)
@@ -32,7 +32,7 @@ To view transactions with a given tag, you can:
 The Tag management page can be found in the sidebar under _More_. Here you can perform the following actions:
 
 - Change the color. Tags use a default color defined in the theme. Change the color of any tag by clicking on the tag to bring up a color picker.
-- **Add New** tags. Do not enter the `#` when adding tags here, it will be added for you. If the tag already exists, the color you pick will be reflected in the matching existing tags.
+- **Add New** tags. Do not include the `#` prefix when adding tags here; it will be added automatically. If the tag already exists, this will update its color.
 - **Find Existing Tags** searches for tags already used within transactions and adds them to the list of managed tags.
 - Add a description by clicking in the description field.
 - **View Transactions** which use a given tag.


### PR DESCRIPTION
## Description

Update tag doc for clarity. Add note about white spaces and make a few changes for clarity. Add bullets. Add context menu delete for tag management page.

## Related issue(s)

Fixes #7475 

## Testing

Visual of deployed page.

## Checklist

- [x] Release notes not needed for docs
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
