### PR TITLE
make GoCardless fallback safer

### DIFF
--- a/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
+++ b/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
@@ -311,7 +311,7 @@ export const goCardlessService = {
       return await client
         .initSession({
           ...body,
-          accessValidForDays: 90,
+          accessValidForDays: 89,
           maxHistoricalDays: 89,
         })
         .catch(handleGoCardlessError);

--- a/upcoming-release-notes/7489.md
+++ b/upcoming-release-notes/7489.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix GoCardless unable to link for some banks


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

As it turns out, some banks don't play well with the 90 day limit, hopefully this should solve it for any of those cases.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/5709
https://discord.com/channels/937901803608096828/940290142579605514/1492972507941179605

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Unable, but the worst that will happen is the minimum days access we support is a day shorter

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
