### PR TITLE
[AI] Persist custom CSS override across theme changes

### DIFF
--- a/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
@@ -433,6 +433,9 @@ describe('ThemeInstaller', () => {
       expect(mockSetCustomCssOverride).toHaveBeenCalledWith(
         ':root { --color-accent: #ff0000; }',
       );
+      // Textarea must also reflect the normalized value so the editor stays
+      // in sync with what was actually persisted.
+      expect(textarea).toHaveValue(':root { --color-accent: #ff0000; }');
     });
 
     it('clears customCssOverride when Apply is pressed with an empty textarea', async () => {

--- a/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useThemeCatalog } from '#hooks/useThemeCatalog';
+import { resetTestProviders, TestProviders } from '#mocks';
 import {
   fetchThemeCss,
   generateThemeId,
@@ -10,6 +11,9 @@ import {
 } from '#style/customThemes';
 
 import { ThemeInstaller } from './ThemeInstaller';
+
+const render: typeof rtlRender = (ui, options) =>
+  rtlRender(ui, { wrapper: TestProviders, ...options });
 
 vi.mock('#style/customThemes', async () => {
   const actual = await vi.importActual('#style/customThemes');
@@ -32,6 +36,18 @@ vi.mock('#style/customThemes', async () => {
 
 vi.mock('#hooks/useThemeCatalog', () => ({
   useThemeCatalog: vi.fn(),
+}));
+
+const mockSetCustomCssOverride = vi.fn();
+let mockCustomCssOverride: string | undefined = undefined;
+
+vi.mock('#hooks/useGlobalPref', () => ({
+  useGlobalPref: (key: string) => {
+    if (key === 'customCssOverride') {
+      return [mockCustomCssOverride, mockSetCustomCssOverride];
+    }
+    return [undefined, vi.fn()];
+  },
 }));
 
 describe('ThemeInstaller', () => {
@@ -84,8 +100,11 @@ describe('ThemeInstaller', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetTestProviders();
     mockOnInstall.mockClear();
     mockOnClose.mockClear();
+    mockSetCustomCssOverride.mockClear();
+    mockCustomCssOverride = undefined;
     vi.mocked(fetchThemeCss).mockResolvedValue(mockValidCss);
     vi.mocked(validateThemeCss).mockImplementation(css => css.trim());
     // Reset generateThemeId mock to default behavior
@@ -324,265 +343,6 @@ describe('ThemeInstaller', () => {
     });
   });
 
-  describe('pasted CSS installation', () => {
-    it('calls onInstall when valid CSS is pasted and Apply is clicked', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      await user.click(textArea);
-      await user.paste(mockValidCss);
-
-      const applyButton = screen.getByText('Apply');
-      await user.click(applyButton);
-
-      await waitFor(() => {
-        expect(validateThemeCss).toHaveBeenCalledWith(mockValidCss);
-        expect(mockOnInstall).toHaveBeenCalledTimes(1);
-        expect(mockOnInstall).toHaveBeenCalledWith(
-          expect.objectContaining({
-            name: 'Custom Theme',
-            repo: '',
-            overrideCss: mockValidCss,
-          }),
-        );
-      });
-    });
-
-    it('trims whitespace from pasted CSS before validation', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      const cssWithWhitespace = `  ${mockValidCss}  `;
-      await user.click(textArea);
-      await user.paste(cssWithWhitespace);
-
-      const applyButton = screen.getByText('Apply');
-      await user.click(applyButton);
-
-      expect(validateThemeCss).toHaveBeenCalledWith(cssWithWhitespace.trim());
-    });
-
-    it('calls onInstall with empty cssContent when Apply is clicked with empty CSS', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      const applyButton = screen.getByText('Apply');
-      expect(applyButton).not.toBeDisabled();
-
-      await user.click(applyButton);
-
-      await waitFor(() => {
-        expect(mockOnInstall).toHaveBeenCalledTimes(1);
-        expect(mockOnInstall).toHaveBeenCalledWith(
-          expect.objectContaining({
-            cssContent: '',
-          }),
-        );
-      });
-    });
-
-    it('calls onInstall with empty cssContent when Apply is clicked with whitespace-only CSS', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      await user.click(textArea);
-      await user.paste('   ');
-
-      const applyButton = screen.getByText('Apply');
-      expect(applyButton).not.toBeDisabled();
-
-      await user.click(applyButton);
-
-      await waitFor(() => {
-        expect(mockOnInstall).toHaveBeenCalledTimes(1);
-        expect(mockOnInstall).toHaveBeenCalledWith(
-          expect.objectContaining({
-            cssContent: '',
-          }),
-        );
-      });
-    });
-
-    it('populates text box with installed custom theme CSS when reopening', () => {
-      const installedCustomTheme = {
-        id: 'theme-abc123',
-        name: 'Custom Theme',
-        repo: '',
-        cssContent: mockValidCss,
-      };
-
-      render(
-        <ThemeInstaller
-          onInstall={mockOnInstall}
-          onClose={mockOnClose}
-          installedTheme={installedCustomTheme}
-        />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      expect(textArea).toHaveValue(mockValidCss);
-    });
-
-    it('does not populate text box when installed theme has a repo', () => {
-      const installedCatalogTheme = {
-        id: 'theme-xyz789',
-        name: 'Demo Theme',
-        repo: 'https://github.com/actualbudget/demo-theme',
-        cssContent: mockValidCss,
-      };
-
-      render(
-        <ThemeInstaller
-          onInstall={mockOnInstall}
-          onClose={mockOnClose}
-          installedTheme={installedCatalogTheme}
-        />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      expect(textArea).toHaveValue('');
-    });
-
-    it('clears selected catalog theme when CSS is pasted', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      // First select a theme (which should be selected/highlighted)
-      await user.click(screen.getByRole('button', { name: 'Demo Theme' }));
-      await waitFor(() => {
-        expect(fetchThemeCss).toHaveBeenCalled();
-      });
-
-      // Then paste CSS
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      await user.click(textArea);
-      await user.paste(mockValidCss);
-
-      // Selection should be cleared (we can't easily test visual state,
-      // but the handler should clear it)
-      expect(textArea).toHaveValue(mockValidCss);
-    });
-
-    it('clears error when CSS is pasted', async () => {
-      const user = userEvent.setup();
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      // First create an error
-      vi.mocked(fetchThemeCss).mockRejectedValueOnce(new Error('Test error'));
-      await user.click(screen.getByRole('button', { name: 'Demo Theme' }));
-      await waitFor(() => {
-        expect(screen.getByText('Test error')).toBeInTheDocument();
-      });
-
-      // Then paste CSS
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      await user.click(textArea);
-      await user.paste(mockValidCss);
-
-      // Error should be cleared
-      expect(screen.queryByText('Test error')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('error handling for pasted CSS', () => {
-    it('displays error when validateThemeCss throws for pasted CSS', async () => {
-      const user = userEvent.setup();
-      const validationError = 'Theme CSS must contain exactly :root';
-      vi.mocked(validateThemeCss).mockImplementation(() => {
-        throw new Error(validationError);
-      });
-
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      const textArea = screen.getByRole('textbox', {
-        name: 'Custom Theme CSS',
-      });
-      await user.click(textArea);
-      await user.paste('invalid css');
-
-      const applyButton = screen.getByText('Apply');
-      await user.click(applyButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(validationError)).toBeInTheDocument();
-      });
-
-      expect(mockOnInstall).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('loading states', () => {
-    it('disables Apply button when loading', async () => {
-      const user = userEvent.setup();
-      vi.mocked(fetchThemeCss).mockImplementation(
-        () =>
-          new Promise(resolve => {
-            setTimeout(() => resolve(mockValidCss), 100);
-          }),
-      );
-
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      await user.click(screen.getByRole('button', { name: 'Demo Theme' }));
-
-      const applyButton = screen.getByText('Apply');
-      expect(applyButton).toBeDisabled();
-    });
-
-    it('disables Apply button when pasted CSS is empty during loading', async () => {
-      const user = userEvent.setup();
-      vi.mocked(fetchThemeCss).mockImplementation(
-        () =>
-          new Promise(resolve => {
-            setTimeout(() => resolve(mockValidCss), 100);
-          }),
-      );
-
-      render(
-        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
-      );
-
-      // Trigger loading state
-      await user.click(screen.getByRole('button', { name: 'Demo Theme' }));
-
-      const applyButton = screen.getByText('Apply');
-      expect(applyButton).toBeDisabled();
-    });
-  });
-
   describe('close button', () => {
     it('calls onClose when close button is clicked', async () => {
       const user = userEvent.setup();
@@ -632,6 +392,98 @@ describe('ThemeInstaller', () => {
 
       const sourceLinks = screen.getAllByText('Source');
       expect(sourceLinks.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('customCssOverride pref binding', () => {
+    it('pre-fills the textarea from customCssOverride on mount', () => {
+      mockCustomCssOverride = ':root { --color-accent: #ff00aa; }';
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      const textarea = screen.getByLabelText(
+        'Custom Theme CSS',
+      ) as HTMLTextAreaElement;
+      expect(textarea.value).toBe(':root { --color-accent: #ff00aa; }');
+    });
+
+    it('leaves the textarea empty when customCssOverride is undefined', () => {
+      mockCustomCssOverride = undefined;
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      const textarea = screen.getByLabelText(
+        'Custom Theme CSS',
+      ) as HTMLTextAreaElement;
+      expect(textarea.value).toBe('');
+    });
+
+    it('writes validated CSS to customCssOverride when Apply is pressed', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = undefined;
+      vi.mocked(validateThemeCss).mockImplementation(css => css.trim());
+
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      const textarea = screen.getByLabelText('Custom Theme CSS');
+      await user.click(textarea);
+      await user.paste('  :root { --color-accent: #ff0000; }  ');
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      // validateThemeCss is mocked as css => css.trim(), so the setter
+      // must receive the trimmed version — not the raw pasted string.
+      // This proves the Apply path runs validation, not a raw pass-through.
+      expect(mockSetCustomCssOverride).toHaveBeenCalledWith(
+        ':root { --color-accent: #ff0000; }',
+      );
+    });
+
+    it('clears customCssOverride when Apply is pressed with an empty textarea', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = ':root { --color-accent: #ff0000; }';
+
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      const textarea = screen.getByLabelText('Custom Theme CSS');
+      await user.clear(textarea);
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetCustomCssOverride).toHaveBeenCalledWith('');
+    });
+
+    it('shows an error and does not write when CSS is invalid', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = undefined;
+      vi.mocked(validateThemeCss).mockImplementation(() => {
+        throw new Error('invalid css');
+      });
+
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      const textarea = screen.getByLabelText('Custom Theme CSS');
+      await user.type(textarea, 'not valid css');
+      await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+      expect(mockSetCustomCssOverride).not.toHaveBeenCalled();
+      expect(await screen.findByText('invalid css')).toBeInTheDocument();
+    });
+
+    it('does not touch customCssOverride when clicking a catalog theme', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = ':root { --color-accent: #ff0000; }';
+
+      render(
+        <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
+      );
+      await user.click(screen.getByRole('button', { name: 'Demo Theme' }));
+
+      await waitFor(() => {
+        expect(mockOnInstall).toHaveBeenCalled();
+      });
+      expect(mockSetCustomCssOverride).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.test.tsx
@@ -401,10 +401,9 @@ describe('ThemeInstaller', () => {
       render(
         <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
       );
-      const textarea = screen.getByLabelText(
-        'Custom Theme CSS',
-      ) as HTMLTextAreaElement;
-      expect(textarea.value).toBe(':root { --color-accent: #ff00aa; }');
+      expect(screen.getByLabelText('Custom Theme CSS')).toHaveValue(
+        ':root { --color-accent: #ff00aa; }',
+      );
     });
 
     it('leaves the textarea empty when customCssOverride is undefined', () => {
@@ -412,10 +411,7 @@ describe('ThemeInstaller', () => {
       render(
         <ThemeInstaller onInstall={mockOnInstall} onClose={mockOnClose} />,
       );
-      const textarea = screen.getByLabelText(
-        'Custom Theme CSS',
-      ) as HTMLTextAreaElement;
-      expect(textarea.value).toBe('');
+      expect(screen.getByLabelText('Custom Theme CSS')).toHaveValue('');
     });
 
     it('writes validated CSS to customCssOverride when Apply is pressed', async () => {

--- a/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
@@ -180,6 +180,7 @@ export function ThemeInstaller({
     try {
       const validated = pastedCss.trim() ? validateThemeCss(pastedCss) : '';
       setCustomCssOverride(validated);
+      setPastedCss(validated);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : t('Failed to validate theme CSS'),

--- a/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
+++ b/packages/desktop-client/src/components/settings/ThemeInstaller.tsx
@@ -14,6 +14,7 @@ import { View } from '@actual-app/components/view';
 
 import { Link } from '#components/common/Link';
 import { FixedSizeList } from '#components/FixedSizeList';
+import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useThemeCatalog } from '#hooks/useThemeCatalog';
 import {
   embedThemeFonts,
@@ -48,11 +49,12 @@ export function ThemeInstaller({
   mode,
 }: ThemeInstallerProps) {
   const { t } = useTranslation();
+  const [customCssOverride, setCustomCssOverride] =
+    useGlobalPref('customCssOverride');
   const [selectedCatalogTheme, setSelectedCatalogTheme] =
     useState<CatalogTheme | null>(null);
   const [erroringTheme, setErroringTheme] = useState<CatalogTheme | null>(null);
   const [pastedCss, setPastedCss] = useState('');
-  const [cachedCatalogCss, setCachedCatalogCss] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -63,20 +65,14 @@ export function ThemeInstaller({
     error: catalogError,
   } = useThemeCatalog();
 
-  // Initialize state from installed theme
+  // Mount-only: pref changes while the installer is open should not clobber
+  // in-progress edits to the textarea.
   useEffect(() => {
-    if (!installedTheme) return;
-
-    if (installedTheme.repo) {
-      // Catalog theme installed — restore overrideCss into text area if present
-      if (installedTheme.overrideCss) {
-        setPastedCss(installedTheme.overrideCss);
-      }
-    } else {
-      // Custom pasted CSS — restore into text area
-      setPastedCss(installedTheme.cssContent);
+    if (customCssOverride) {
+      setPastedCss(customCssOverride);
     }
-  }, [installedTheme]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Calculate theme item width based on container width (always 3 per row)
   const getItemWidth = useCallback((containerWidth: number) => {
@@ -111,7 +107,6 @@ export function ThemeInstaller({
       errorMessage: string;
       catalogTheme?: CatalogTheme | null;
       baseTheme?: 'light' | 'dark' | 'midnight';
-      overrideCss?: string;
     }) => {
       setError(null);
       setErroringTheme(null);
@@ -133,12 +128,6 @@ export function ThemeInstaller({
               : 'light'
             : options.baseTheme,
         };
-        if (options.overrideCss) {
-          newTheme.overrideCss = validateThemeCss(options.overrideCss);
-        }
-        if (options.catalogTheme) {
-          setCachedCatalogCss(validatedCss);
-        }
         onInstall(newTheme);
         // Only set selectedCatalogTheme on success if it's a catalog theme
         if (options.catalogTheme) {
@@ -174,10 +163,9 @@ export function ThemeInstaller({
         id: generateThemeId(normalizedRepo),
         errorMessage: t('Failed to load theme'),
         catalogTheme: theme,
-        overrideCss: pastedCss.trim() || undefined,
       });
     },
-    [installTheme, pastedCss, t],
+    [installTheme, t],
   );
 
   const handlePastedCssChange = useCallback((value: string) => {
@@ -186,38 +174,18 @@ export function ThemeInstaller({
     setError(null);
   }, []);
 
-  const handleInstallPastedCss = useCallback(() => {
-    // Determine the base catalog CSS: prefer the in-session selection,
-    // fall back to the previously installed catalog theme
-    const hasCatalog = selectedCatalogTheme || installedTheme?.repo;
-    const baseCss = selectedCatalogTheme
-      ? cachedCatalogCss
-      : (installedTheme?.cssContent ?? '');
-    const repo = selectedCatalogTheme
-      ? normalizeGitHubRepo(selectedCatalogTheme.repo)
-      : (installedTheme?.repo ?? '');
-
-    void installTheme({
-      css: hasCatalog ? baseCss : '',
-      name:
-        selectedCatalogTheme?.name ?? installedTheme?.name ?? t('Custom Theme'),
-      repo,
-      id: repo
-        ? generateThemeId(repo)
-        : generateThemeId(`pasted-${Date.now()}`),
-      errorMessage: t('Failed to validate theme CSS'),
-      catalogTheme: selectedCatalogTheme,
-      baseTheme: installedTheme?.baseTheme,
-      overrideCss: pastedCss.trim() || undefined,
-    });
-  }, [
-    pastedCss,
-    selectedCatalogTheme,
-    cachedCatalogCss,
-    installedTheme,
-    installTheme,
-    t,
-  ]);
+  const handleApplyOverride = useCallback(() => {
+    setError(null);
+    setErroringTheme(null);
+    try {
+      const validated = pastedCss.trim() ? validateThemeCss(pastedCss) : '';
+      setCustomCssOverride(validated);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : t('Failed to validate theme CSS'),
+      );
+    }
+  }, [pastedCss, setCustomCssOverride, t]);
 
   return (
     <View
@@ -469,11 +437,7 @@ export function ThemeInstaller({
             marginTop: 8,
           }}
         >
-          <Button
-            variant="normal"
-            onPress={handleInstallPastedCss}
-            isDisabled={isLoading}
-          >
+          <Button variant="normal" onPress={handleApplyOverride}>
             <Trans>Apply</Trans>
           </Button>
         </View>

--- a/packages/desktop-client/src/components/settings/Themes.test.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as StyleModule from '#style';
+
+import { ThemeSettings } from './Themes';
+
+const mockSwitchTheme = vi.fn();
+const mockSwitchDarkTheme = vi.fn();
+const mockSetLight = vi.fn();
+const mockSetDark = vi.fn();
+const mockSetOverride = vi.fn();
+
+let mockTheme: string = 'light';
+let mockInstalledLight: string | undefined = undefined;
+let mockInstalledDark: string | undefined = undefined;
+let mockCustomCssOverride: string | undefined = undefined;
+let mockCustomThemesEnabled = true;
+
+vi.mock('#hooks/useFeatureFlag', () => ({
+  useFeatureFlag: (flag: string) => {
+    if (flag === 'customThemes') return mockCustomThemesEnabled;
+    return false;
+  },
+}));
+
+vi.mock('#hooks/useGlobalPref', () => ({
+  useGlobalPref: (key: string) => {
+    switch (key) {
+      case 'installedCustomLightTheme':
+        return [mockInstalledLight, mockSetLight];
+      case 'installedCustomDarkTheme':
+        return [mockInstalledDark, mockSetDark];
+      case 'customCssOverride':
+        return [mockCustomCssOverride, mockSetOverride];
+      default:
+        return [undefined, vi.fn()];
+    }
+  },
+}));
+
+vi.mock('#style', async () => {
+  const actual = await vi.importActual<typeof StyleModule>('#style');
+  return {
+    ...actual,
+    useTheme: () => [mockTheme, mockSwitchTheme],
+    usePreferredDarkTheme: () => ['dark', mockSwitchDarkTheme],
+  };
+});
+
+vi.mock('#components/sidebar/SidebarProvider', () => ({
+  useSidebar: () => ({ floating: false }),
+}));
+
+vi.mock('#hooks/useThemeCatalog', () => ({
+  useThemeCatalog: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+describe('ThemeSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTheme = 'light';
+    mockInstalledLight = undefined;
+    mockInstalledDark = undefined;
+    mockCustomCssOverride = undefined;
+    mockCustomThemesEnabled = true;
+  });
+
+  describe('custom CSS override indicator', () => {
+    it('is hidden when customCssOverride is undefined', () => {
+      render(<ThemeSettings />);
+      expect(
+        screen.queryByLabelText('Custom CSS override active — click to edit'),
+      ).toBeNull();
+    });
+
+    it('is hidden when customCssOverride is an empty string', () => {
+      mockCustomCssOverride = '';
+      render(<ThemeSettings />);
+      expect(
+        screen.queryByLabelText('Custom CSS override active — click to edit'),
+      ).toBeNull();
+    });
+
+    it('is hidden when customCssOverride is only whitespace', () => {
+      mockCustomCssOverride = '   \n  ';
+      render(<ThemeSettings />);
+      expect(
+        screen.queryByLabelText('Custom CSS override active — click to edit'),
+      ).toBeNull();
+    });
+
+    it('is visible when customCssOverride has non-whitespace content', () => {
+      mockCustomCssOverride = ':root { --color-accent: #ff00aa; }';
+      render(<ThemeSettings />);
+      expect(
+        screen.getByLabelText('Custom CSS override active — click to edit'),
+      ).toBeVisible();
+    });
+
+    it('is hidden when customThemes feature flag is off', () => {
+      mockCustomThemesEnabled = false;
+      mockCustomCssOverride = ':root { --color-accent: #ff00aa; }';
+      render(<ThemeSettings />);
+      expect(
+        screen.queryByLabelText('Custom CSS override active — click to edit'),
+      ).toBeNull();
+    });
+
+    it('opens the installer when clicked', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = ':root { --color-accent: #ff00aa; }';
+      render(<ThemeSettings />);
+      await user.click(
+        screen.getByLabelText('Custom CSS override active — click to edit'),
+      );
+      // Installer heading appears on open
+      expect(screen.getByText('Install Custom Theme')).toBeVisible();
+    });
+  });
+
+  describe('built-in theme selection preserves override', () => {
+    it('does not call setCustomCssOverride when switching to a built-in theme', async () => {
+      const user = userEvent.setup();
+      mockCustomCssOverride = ':root { --color-accent: #ff00aa; }';
+      render(<ThemeSettings />);
+
+      // The Select trigger is the only "Light" button before the dropdown
+      // is opened. Click it to reveal the menu.
+      const select = screen.getByRole('button', { name: 'Light' });
+      await user.click(select);
+      // The Select component renders menu items as buttons (not options).
+      // After opening, "Dark" appears as a button in the popover.
+      const darkOption = await screen.findByRole('button', { name: 'Dark' });
+      await user.click(darkOption);
+
+      expect(mockSetOverride).not.toHaveBeenCalled();
+      expect(mockSwitchTheme).toHaveBeenCalledWith('dark');
+    });
+  });
+});

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { Button } from '@actual-app/components/button';
+import { SvgCode } from '@actual-app/components/icons/v1';
 import { Menu } from '@actual-app/components/menu';
 import { Select } from '@actual-app/components/select';
 import { Text } from '@actual-app/components/text';
@@ -32,14 +34,17 @@ const INSTALL_NEW_VALUE = '__install_new__';
 const INSTALL_CUSTOM_LIGHT = '__install_custom_light__';
 const INSTALL_CUSTOM_DARK = '__install_custom_dark__';
 
+type InstallerState = {
+  slot: 'light' | 'dark';
+  catalogMode?: 'light' | 'dark';
+} | null;
+
 export function ThemeSettings() {
   const { t } = useTranslation();
   const sidebar = useSidebar();
   const [theme, switchTheme] = useTheme();
   const [darkTheme, switchDarkTheme] = usePreferredDarkTheme();
-  const [showInstaller, setShowInstaller] = useState<
-    'single' | 'light' | 'dark' | null
-  >(null);
+  const [showInstaller, setShowInstaller] = useState<InstallerState>(null);
 
   const customThemesEnabled = useFeatureFlag('customThemes');
 
@@ -50,6 +55,8 @@ export function ThemeSettings() {
   const [installedDarkThemeJson, setInstalledDarkThemeJson] = useGlobalPref(
     'installedCustomDarkTheme',
   );
+  const [customCssOverride] = useGlobalPref('customCssOverride');
+  const hasCustomCssOverride = Boolean(customCssOverride?.trim());
 
   const installedCustomLightTheme = parseInstalledTheme(
     installedLightThemeJson,
@@ -124,7 +131,12 @@ export function ThemeSettings() {
   const handleThemeChange = useCallback(
     (value: string) => {
       if (value === INSTALL_NEW_VALUE) {
-        setShowInstaller('single');
+        // Pre-switch out of auto so the just-installed theme is immediately
+        // visible regardless of the OS color-scheme preference.
+        if (theme === 'auto') {
+          switchTheme('light');
+        }
+        setShowInstaller({ slot: 'light' });
         return;
       }
 
@@ -134,14 +146,14 @@ export function ThemeSettings() {
         switchTheme(value as Theme);
       }
     },
-    [setInstalledLightThemeJson, setInstalledDarkThemeJson, switchTheme],
+    [theme, setInstalledLightThemeJson, setInstalledDarkThemeJson, switchTheme],
   );
 
   // Handle light theme selection (auto mode)
   const handleLightThemeChange = useCallback(
     (value: string) => {
       if (value === INSTALL_CUSTOM_LIGHT) {
-        setShowInstaller('light');
+        setShowInstaller({ slot: 'light', catalogMode: 'light' });
         return;
       }
       if (value === 'light') {
@@ -155,7 +167,7 @@ export function ThemeSettings() {
   const handleDarkThemeChange = useCallback(
     (value: string) => {
       if (value === INSTALL_CUSTOM_DARK) {
-        setShowInstaller('dark');
+        setShowInstaller({ slot: 'dark', catalogMode: 'dark' });
         return;
       }
       if (!value.startsWith('custom-dark:')) {
@@ -166,32 +178,25 @@ export function ThemeSettings() {
     [setInstalledDarkThemeJson, switchDarkTheme],
   );
 
-  // Handle theme installation
   const handleInstall = useCallback(
     (newTheme: InstalledTheme) => {
-      if (showInstaller === 'light') {
-        setInstalledLightThemeJson(serializeInstalledTheme(newTheme));
-      } else if (showInstaller === 'dark') {
+      if (!showInstaller) return;
+      if (showInstaller.slot === 'dark') {
         setInstalledDarkThemeJson(serializeInstalledTheme(newTheme));
       } else {
         setInstalledLightThemeJson(serializeInstalledTheme(newTheme));
-        if (theme === 'auto') {
-          switchTheme('light');
-        }
       }
     },
-    [
-      showInstaller,
-      theme,
-      setInstalledLightThemeJson,
-      setInstalledDarkThemeJson,
-      switchTheme,
-    ],
+    [showInstaller, setInstalledLightThemeJson, setInstalledDarkThemeJson],
   );
 
   // Handle installer close
   const handleInstallerClose = useCallback(() => {
     setShowInstaller(null);
+  }, []);
+
+  const handleEditOverride = useCallback(() => {
+    setShowInstaller({ slot: 'light' });
   }, []);
 
   return (
@@ -220,17 +225,41 @@ export function ThemeSettings() {
               }}
             >
               <Column title={t('Theme')}>
-                <Select<string>
-                  onChange={handleThemeChange}
-                  value={getCurrentValue()}
-                  options={buildOptions()}
-                  className={css({
-                    '&[data-hovered]': {
-                      backgroundColor: themeStyle.buttonNormalBackgroundHover,
-                    },
-                    maxWidth: '100%',
-                  })}
-                />
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 8,
+                  }}
+                >
+                  <Select<string>
+                    onChange={handleThemeChange}
+                    value={getCurrentValue()}
+                    options={buildOptions()}
+                    className={css({
+                      '&[data-hovered]': {
+                        backgroundColor: themeStyle.buttonNormalBackgroundHover,
+                      },
+                      maxWidth: '100%',
+                    })}
+                  />
+                  {customThemesEnabled && hasCustomCssOverride && (
+                    <Button
+                      variant="bare"
+                      aria-label={t(
+                        'Custom CSS override active — click to edit',
+                      )}
+                      onPress={handleEditOverride}
+                      style={{
+                        color: themeStyle.pageTextPositive,
+                        gap: 6,
+                      }}
+                    >
+                      <Trans>Custom CSS is active</Trans>
+                      <SvgCode style={{ width: 14, height: 14 }} />
+                    </Button>
+                  )}
+                </View>
               </Column>
               {theme === 'auto' && (
                 <>
@@ -280,15 +309,11 @@ export function ThemeSettings() {
               onInstall={handleInstall}
               onClose={handleInstallerClose}
               installedTheme={
-                showInstaller === 'dark'
+                showInstaller.slot === 'dark'
                   ? installedCustomDarkTheme
                   : installedCustomLightTheme
               }
-              mode={
-                showInstaller === 'light' || showInstaller === 'dark'
-                  ? showInstaller
-                  : undefined
-              }
+              mode={showInstaller.catalogMode}
             />
           )}
         </View>

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -196,8 +196,12 @@ export function ThemeSettings() {
   }, []);
 
   const handleEditOverride = useCallback(() => {
-    setShowInstaller({ slot: 'light' });
-  }, []);
+    setShowInstaller(
+      theme === 'auto'
+        ? { slot: 'light', catalogMode: 'light' }
+        : { slot: 'light' },
+    );
+  }, [theme]);
 
   return (
     <Setting

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -37,6 +37,7 @@ const INSTALL_CUSTOM_DARK = '__install_custom_dark__';
 type InstallerState = {
   slot: 'light' | 'dark';
   catalogMode?: 'light' | 'dark';
+  switchThemeOnSuccess?: Theme;
 } | null;
 
 export function ThemeSettings() {
@@ -45,6 +46,8 @@ export function ThemeSettings() {
   const [theme, switchTheme] = useTheme();
   const [darkTheme, switchDarkTheme] = usePreferredDarkTheme();
   const [showInstaller, setShowInstaller] = useState<InstallerState>(null);
+  const showInstallerRef = useRef<InstallerState>(null);
+  showInstallerRef.current = showInstaller;
 
   const customThemesEnabled = useFeatureFlag('customThemes');
 
@@ -131,12 +134,10 @@ export function ThemeSettings() {
   const handleThemeChange = useCallback(
     (value: string) => {
       if (value === INSTALL_NEW_VALUE) {
-        // Pre-switch out of auto so the just-installed theme is immediately
-        // visible regardless of the OS color-scheme preference.
-        if (theme === 'auto') {
-          switchTheme('light');
-        }
-        setShowInstaller({ slot: 'light' });
+        setShowInstaller({
+          slot: 'light',
+          switchThemeOnSuccess: theme === 'auto' ? 'light' : undefined,
+        });
         return;
       }
 
@@ -180,14 +181,20 @@ export function ThemeSettings() {
 
   const handleInstall = useCallback(
     (newTheme: InstalledTheme) => {
-      if (!showInstaller) return;
-      if (showInstaller.slot === 'dark') {
+      // Read via ref so a late-resolving install (dialog already closed) is
+      // dropped instead of writing to a stale slot.
+      const current = showInstallerRef.current;
+      if (!current) return;
+      if (current.slot === 'dark') {
         setInstalledDarkThemeJson(serializeInstalledTheme(newTheme));
       } else {
         setInstalledLightThemeJson(serializeInstalledTheme(newTheme));
       }
+      if (current.switchThemeOnSuccess) {
+        switchTheme(current.switchThemeOnSuccess);
+      }
     },
-    [showInstaller, setInstalledLightThemeJson, setInstalledDarkThemeJson],
+    [setInstalledLightThemeJson, setInstalledDarkThemeJson, switchTheme],
   );
 
   // Handle installer close

--- a/packages/desktop-client/src/style/customThemes.test.ts
+++ b/packages/desktop-client/src/style/customThemes.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   embedThemeFonts,
+  extractLegacyOverride,
   MAX_FONT_FILE_SIZE,
+  migrateLegacyOverride,
   parseInstalledTheme,
   validateThemeCss,
 } from './customThemes';
@@ -1245,6 +1247,26 @@ describe('parseInstalledTheme', () => {
       expect(result?.cssContent).toBe(':root { --color-primary: #007bff; }');
     });
 
+    it('ignores legacy overrideCss field without rejecting the theme', () => {
+      const theme = {
+        id: 'theme-legacy',
+        name: 'Legacy Theme',
+        repo: 'owner/repo',
+        cssContent: ':root { --color-primary: #007bff; }',
+        overrideCss: ':root { --color-accent: #ff00aa; }',
+      };
+      const json = JSON.stringify(theme);
+
+      const result = parseInstalledTheme(json);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('theme-legacy');
+      expect(result?.cssContent).toBe(':root { --color-primary: #007bff; }');
+      // Legacy field is stripped from the typed result. extractLegacyOverride
+      // is the helper that reads it off the raw JSON during migration.
+      expect(result).not.toHaveProperty('overrideCss');
+    });
+
     it('should parse theme with empty string fields', () => {
       const theme: InstalledTheme = {
         id: '',
@@ -1590,5 +1612,241 @@ describe('embedThemeFonts', () => {
 
     const result = await embedThemeFonts(css, 'owner/repo');
     expect(result).toBe(css);
+  });
+});
+
+describe('extractLegacyOverride', () => {
+  it('returns the overrideCss string when present and non-empty', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+      overrideCss: ':root { --color-accent: #ff00aa; }',
+    });
+    expect(extractLegacyOverride(json)).toBe(
+      ':root { --color-accent: #ff00aa; }',
+    );
+  });
+
+  it('returns null when overrideCss is missing', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+    });
+    expect(extractLegacyOverride(json)).toBeNull();
+  });
+
+  it('returns null when overrideCss is an empty string', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+      overrideCss: '',
+    });
+    expect(extractLegacyOverride(json)).toBeNull();
+  });
+
+  it('returns null when overrideCss is only whitespace', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+      overrideCss: '   \n\t  ',
+    });
+    expect(extractLegacyOverride(json)).toBeNull();
+  });
+
+  it('trims leading and trailing whitespace from overrideCss', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+      overrideCss: '  :root { --color-accent: #ff00aa; }  ',
+    });
+    expect(extractLegacyOverride(json)).toBe(
+      ':root { --color-accent: #ff00aa; }',
+    );
+  });
+
+  it('returns null when overrideCss is not a string', () => {
+    const json = JSON.stringify({
+      id: 'theme-abc',
+      name: 'My Theme',
+      repo: 'owner/repo',
+      cssContent: ':root { --color-primary: #007bff; }',
+      overrideCss: 42,
+    });
+    expect(extractLegacyOverride(json)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(extractLegacyOverride(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string input', () => {
+    expect(extractLegacyOverride('')).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(extractLegacyOverride('{ not valid json')).toBeNull();
+  });
+
+  it('returns null when parsed value is not an object', () => {
+    expect(extractLegacyOverride(JSON.stringify('a string'))).toBeNull();
+    expect(extractLegacyOverride(JSON.stringify(null))).toBeNull();
+    expect(extractLegacyOverride(JSON.stringify([]))).toBeNull();
+  });
+});
+
+describe('migrateLegacyOverride', () => {
+  const baseTheme = {
+    id: 'theme-abc',
+    name: 'My Theme',
+    repo: 'owner/repo',
+    cssContent: ':root { --color-primary: #007bff; }',
+  };
+
+  it('returns null when existingOverride already has content', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: red; }',
+    });
+    expect(
+      migrateLegacyOverride({
+        existingOverride: ':root { --color-accent: blue; }',
+        lightJson,
+        darkJson: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when neither installed theme has legacy overrideCss', () => {
+    const lightJson = JSON.stringify(baseTheme);
+    const darkJson = JSON.stringify(baseTheme);
+    expect(
+      migrateLegacyOverride({
+        existingOverride: undefined,
+        lightJson,
+        darkJson,
+      }),
+    ).toBeNull();
+  });
+
+  it('migrates from light when only light has legacy overrideCss', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: #ff00aa; }',
+    });
+    const darkJson = JSON.stringify(baseTheme);
+    const result = migrateLegacyOverride({
+      existingOverride: undefined,
+      lightJson,
+      darkJson,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.override).toBe(':root { --color-accent: #ff00aa; }');
+    expect(result?.newLightJson).toBe(JSON.stringify(baseTheme));
+    expect(result?.newDarkJson).toBe(darkJson);
+    expect(
+      JSON.parse(result?.newLightJson ?? '{}').overrideCss,
+    ).toBeUndefined();
+  });
+
+  it('migrates from dark when only dark has legacy overrideCss', () => {
+    const lightJson = JSON.stringify(baseTheme);
+    const darkJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: #00ffaa; }',
+    });
+    const result = migrateLegacyOverride({
+      existingOverride: undefined,
+      lightJson,
+      darkJson,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.override).toBe(':root { --color-accent: #00ffaa; }');
+    expect(result?.newLightJson).toBe(lightJson);
+    expect(result?.newDarkJson).toBe(JSON.stringify(baseTheme));
+    expect(JSON.parse(result?.newDarkJson ?? '{}').overrideCss).toBeUndefined();
+  });
+
+  it('prefers light when both have legacy overrideCss (collision rule)', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: red; }',
+    });
+    const darkJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: blue; }',
+    });
+    const result = migrateLegacyOverride({
+      existingOverride: undefined,
+      lightJson,
+      darkJson,
+    });
+    expect(result?.override).toBe(':root { --color-accent: red; }');
+    expect(result?.newLightJson).toBe(JSON.stringify(baseTheme));
+    expect(result?.newDarkJson).toBe(JSON.stringify(baseTheme));
+    expect(
+      JSON.parse(result?.newLightJson ?? '{}').overrideCss,
+    ).toBeUndefined();
+    expect(JSON.parse(result?.newDarkJson ?? '{}').overrideCss).toBeUndefined();
+  });
+
+  it('migrates from light when existingOverride is an empty string', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: red; }',
+    });
+    const result = migrateLegacyOverride({
+      existingOverride: '',
+      lightJson,
+      darkJson: undefined,
+    });
+    expect(result?.override).toBe(':root { --color-accent: red; }');
+  });
+
+  it('migrates when existingOverride is only whitespace', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: red; }',
+    });
+    const result = migrateLegacyOverride({
+      existingOverride: '  \n  ',
+      lightJson,
+      darkJson: undefined,
+    });
+    expect(result?.override).toBe(':root { --color-accent: red; }');
+  });
+
+  it('handles undefined installed theme JSONs', () => {
+    const result = migrateLegacyOverride({
+      existingOverride: undefined,
+      lightJson: undefined,
+      darkJson: undefined,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns the untouched side by reference when only one side migrates', () => {
+    const lightJson = JSON.stringify({
+      ...baseTheme,
+      overrideCss: ':root { --color-accent: red; }',
+    });
+    const darkJson = JSON.stringify(baseTheme);
+    const result = migrateLegacyOverride({
+      existingOverride: undefined,
+      lightJson,
+      darkJson,
+    });
+    // The dark side had no legacy override, so it is returned unchanged
+    // (same reference, not a re-serialized copy).
+    expect(result?.newDarkJson).toBe(darkJson);
   });
 });

--- a/packages/desktop-client/src/style/customThemes.ts
+++ b/packages/desktop-client/src/style/customThemes.ts
@@ -18,7 +18,6 @@ export type InstalledTheme = {
   repo: string;
   cssContent: string; // CSS content stored when theme is installed (required)
   baseTheme?: BaseTheme; // Which built-in theme to use as base (defaults to contextual theme)
-  overrideCss?: string; // Additional free-text CSS overrides on top of cssContent
 };
 
 /**
@@ -625,21 +624,6 @@ export async function embedThemeFonts(
 }
 
 /**
- * Validate and concatenate cssContent and overrideCss into a single CSS string.
- * Returns empty string if neither is present.
- */
-export function validateAndCombineThemeCss(
-  cssContent?: string,
-  overrideCss?: string,
-): string {
-  const parts = [
-    cssContent && validateThemeCss(cssContent),
-    overrideCss && validateThemeCss(overrideCss),
-  ].filter(Boolean);
-  return parts.join('\n');
-}
-
-/**
  * Generate a unique ID for a theme based on its repo URL or direct CSS URL.
  */
 export function generateThemeId(urlOrRepo: string): string {
@@ -685,9 +669,6 @@ export function parseInstalledTheme(
       ) {
         result.baseTheme = parsed.baseTheme as BaseTheme;
       }
-      if (typeof parsed.overrideCss === 'string' && parsed.overrideCss) {
-        result.overrideCss = parsed.overrideCss;
-      }
       return result;
     }
     return null;
@@ -701,4 +682,83 @@ export function parseInstalledTheme(
  */
 export function serializeInstalledTheme(theme: InstalledTheme | null): string {
   return JSON.stringify(theme);
+}
+
+/**
+ * Extract the legacy `overrideCss` field from an installed theme JSON string.
+ * Used by the one-time migration that moves the field out of InstalledTheme
+ * and into the standalone `customCssOverride` global pref.
+ *
+ * Returns null if the JSON is missing, malformed, not an object, or does not
+ * contain a non-whitespace string `overrideCss` field. Leading/trailing
+ * whitespace is stripped from the returned value.
+ */
+export function extractLegacyOverride(json: string | undefined): string | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof parsed.overrideCss === 'string'
+    ) {
+      const trimmed = parsed.overrideCss.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One-time migration helper: moves a legacy `overrideCss` field out of the
+ * installed theme JSON blobs and into the standalone customCssOverride value.
+ *
+ * Collision rule: if both light and dark carry a legacy override, light wins.
+ * The other is silently dropped — users wrote one shared override in the UI
+ * today; two different values is a pathological case that only shows up if
+ * someone edited prefs.json by hand.
+ *
+ * Returns null when no migration is needed. Otherwise returns the migrated
+ * override plus the re-serialized installed theme JSONs (with `overrideCss`
+ * stripped). Callers write all three values back to global prefs.
+ */
+export function migrateLegacyOverride(params: {
+  existingOverride: string | undefined;
+  lightJson: string | undefined;
+  darkJson: string | undefined;
+}): {
+  override: string;
+  newLightJson: string | undefined;
+  newDarkJson: string | undefined;
+} | null {
+  const { existingOverride, lightJson, darkJson } = params;
+
+  if (existingOverride?.trim()) {
+    return null;
+  }
+
+  const lightLegacy = extractLegacyOverride(lightJson);
+  const darkLegacy = extractLegacyOverride(darkJson);
+  const legacy = lightLegacy ?? darkLegacy;
+  if (!legacy) {
+    return null;
+  }
+
+  // parseInstalledTheme strips any unknown fields (including the legacy
+  // overrideCss) by building the result from explicit field assignments.
+  const stripOverride = (json: string | undefined): string | undefined => {
+    const parsed = parseInstalledTheme(json);
+    return parsed ? serializeInstalledTheme(parsed) : json;
+  };
+
+  return {
+    override: legacy,
+    newLightJson: lightLegacy ? stripOverride(lightJson) : lightJson,
+    newDarkJson: darkLegacy ? stripOverride(darkJson) : darkJson,
+  };
 }

--- a/packages/desktop-client/src/style/theme.tsx
+++ b/packages/desktop-client/src/style/theme.tsx
@@ -6,8 +6,9 @@ import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 
 import {
+  migrateLegacyOverride,
   parseInstalledTheme,
-  validateAndCombineThemeCss,
+  validateThemeCss,
 } from './customThemes';
 import type { BaseTheme } from './customThemes';
 import * as darkTheme from './themes/dark';
@@ -41,6 +42,56 @@ export function usePreferredDarkTheme() {
   const [darkTheme = 'dark', setDarkTheme] =
     useGlobalPref('preferredDarkTheme');
   return [darkTheme, setDarkTheme] as const;
+}
+
+/**
+ * One-time migration: moves any legacy `overrideCss` field out of the
+ * installed theme JSON blobs and into the new `customCssOverride` global pref.
+ * Gated on the customThemes feature flag — users who never used the feature
+ * have nothing to migrate.
+ *
+ * TODO: remove this after v26.6.0 is released
+ */
+function useMigrateLegacyOverride() {
+  const customThemesEnabled = useFeatureFlag('customThemes');
+  const [customCssOverride, setCustomCssOverride] =
+    useGlobalPref('customCssOverride');
+  const [installedCustomLightThemeJson, setInstalledCustomLightThemeJson] =
+    useGlobalPref('installedCustomLightTheme');
+  const [installedCustomDarkThemeJson, setInstalledCustomDarkThemeJson] =
+    useGlobalPref('installedCustomDarkTheme');
+
+  useEffect(() => {
+    if (!customThemesEnabled) return;
+
+    const result = migrateLegacyOverride({
+      existingOverride: customCssOverride,
+      lightJson: installedCustomLightThemeJson,
+      darkJson: installedCustomDarkThemeJson,
+    });
+
+    if (!result) return;
+
+    setCustomCssOverride(result.override);
+    if (result.newLightJson !== installedCustomLightThemeJson) {
+      setInstalledCustomLightThemeJson(result.newLightJson);
+    }
+    if (result.newDarkJson !== installedCustomDarkThemeJson) {
+      setInstalledCustomDarkThemeJson(result.newDarkJson);
+    }
+    // Re-runs when prefs hydrate so migration isn't missed if the installed
+    // theme JSONs arrive after the first render. migrateLegacyOverride is
+    // idempotent: once customCssOverride is set (or the legacy field is
+    // stripped), subsequent invocations return null.
+  }, [
+    customThemesEnabled,
+    customCssOverride,
+    installedCustomLightThemeJson,
+    installedCustomDarkThemeJson,
+    setCustomCssOverride,
+    setInstalledCustomLightThemeJson,
+    setInstalledCustomDarkThemeJson,
+  ]);
 }
 
 function getBaseThemeColors(baseTheme: BaseTheme) {
@@ -144,6 +195,7 @@ export function ThemeStyle() {
  * injected via @media (prefers-color-scheme) rules. Otherwise, a single custom theme applies.
  */
 export function CustomThemeStyle() {
+  useMigrateLegacyOverride();
   const customThemesEnabled = useFeatureFlag('customThemes');
   const [activeTheme] = useTheme();
   const [installedCustomLightThemeJson] = useGlobalPref(
@@ -152,61 +204,57 @@ export function CustomThemeStyle() {
   const [installedCustomDarkThemeJson] = useGlobalPref(
     'installedCustomDarkTheme',
   );
+  const [customCssOverride] = useGlobalPref('customCssOverride');
 
   const validatedCss = useMemo(() => {
     if (!customThemesEnabled) return null;
 
+    const safeValidate = (css: string | undefined, errorLabel: string) => {
+      if (!css?.trim()) return '';
+      try {
+        return validateThemeCss(css);
+      } catch (error) {
+        console.error(errorLabel, { error });
+        return '';
+      }
+    };
+
+    let baseCss = '';
     if (activeTheme === 'auto') {
-      const lightTheme = parseInstalledTheme(installedCustomLightThemeJson);
-      const darkTheme = parseInstalledTheme(installedCustomDarkThemeJson);
-
-      let css = '';
-
-      try {
-        const lightCss = validateAndCombineThemeCss(
-          lightTheme?.cssContent,
-          lightTheme?.overrideCss,
-        );
-        if (lightCss) {
-          css += `@media (prefers-color-scheme: light) { ${lightCss} }\n`;
-        }
-      } catch (error) {
-        console.error('Invalid custom light theme CSS', { error });
-      }
-
-      try {
-        const darkCss = validateAndCombineThemeCss(
-          darkTheme?.cssContent,
-          darkTheme?.overrideCss,
-        );
-        if (darkCss) {
-          css += `@media (prefers-color-scheme: dark) { ${darkCss} }\n`;
-        }
-      } catch (error) {
-        console.error('Invalid custom dark theme CSS', { error });
-      }
-
-      return css || null;
-    }
-
-    const installedTheme = parseInstalledTheme(installedCustomLightThemeJson);
-
-    try {
-      return (
-        validateAndCombineThemeCss(
-          installedTheme?.cssContent,
-          installedTheme?.overrideCss,
-        ) || null
+      const lightCss = safeValidate(
+        parseInstalledTheme(installedCustomLightThemeJson)?.cssContent,
+        'Invalid custom light theme CSS',
       );
-    } catch (error) {
-      console.error('Invalid custom theme CSS', { error });
-      return null;
+      if (lightCss) {
+        baseCss += `@media (prefers-color-scheme: light) { ${lightCss} }\n`;
+      }
+      const darkCss = safeValidate(
+        parseInstalledTheme(installedCustomDarkThemeJson)?.cssContent,
+        'Invalid custom dark theme CSS',
+      );
+      if (darkCss) {
+        baseCss += `@media (prefers-color-scheme: dark) { ${darkCss} }\n`;
+      }
+    } else {
+      baseCss = safeValidate(
+        parseInstalledTheme(installedCustomLightThemeJson)?.cssContent,
+        'Invalid custom theme CSS',
+      );
     }
+
+    const overrideLayer = safeValidate(
+      customCssOverride,
+      'Invalid custom CSS override',
+    );
+
+    const combined = [baseCss, overrideLayer].filter(Boolean).join('\n');
+    return combined || null;
   }, [
     customThemesEnabled,
     activeTheme,
     installedCustomLightThemeJson,
     installedCustomDarkThemeJson,
+    customCssOverride,
   ]);
 
   if (!validatedCss) {

--- a/packages/loot-core/src/server/preferences/app.ts
+++ b/packages/loot-core/src/server/preferences/app.ts
@@ -107,6 +107,9 @@ async function saveGlobalPrefs(prefs: GlobalPrefs) {
       prefs.installedCustomDarkTheme,
     );
   }
+  if (prefs.customCssOverride !== undefined) {
+    await asyncStorage.setItem('custom-css-override', prefs.customCssOverride);
+  }
   if (prefs.serverSelfSignedCert !== undefined) {
     await asyncStorage.setItem(
       'server-self-signed-cert',
@@ -137,6 +140,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
     'preferred-dark-theme': preferredDarkTheme,
     'installed-custom-theme': installedCustomLightTheme,
     'installed-custom-dark-theme': installedCustomDarkTheme,
+    'custom-css-override': customCssOverride,
     'server-self-signed-cert': serverSelfSignedCert,
     syncServerConfig,
     notifyWhenUpdateIsAvailable,
@@ -151,6 +155,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
     'preferred-dark-theme',
     'installed-custom-theme',
     'installed-custom-dark-theme',
+    'custom-css-override',
     'server-self-signed-cert',
     'syncServerConfig',
     'notifyWhenUpdateIsAvailable',
@@ -175,6 +180,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
         : 'dark',
     installedCustomLightTheme: installedCustomLightTheme || undefined,
     installedCustomDarkTheme: installedCustomDarkTheme || undefined,
+    customCssOverride: customCssOverride || undefined,
     serverSelfSignedCert: serverSelfSignedCert || undefined,
     syncServerConfig: syncServerConfig || undefined,
     notifyWhenUpdateIsAvailable:

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -119,6 +119,7 @@ export type GlobalPrefs = Partial<{
   >; // Complete plugin theme metadata
   installedCustomLightTheme?: string; // JSON of InstalledTheme for light custom theme (also used as single custom theme in non-auto mode)
   installedCustomDarkTheme?: string; // JSON of InstalledTheme for auto-mode dark custom theme
+  customCssOverride?: string; // User-pasted CSS override applied on top of any theme. Empty string or undefined means no override.
   documentDir: string; // Electron only
   serverSelfSignedCert: string; // Electron only
   syncServerConfig?: {
@@ -149,6 +150,7 @@ export type GlobalPrefsJson = Partial<{
   'preferred-dark-theme'?: GlobalPrefs['preferredDarkTheme'];
   'installed-custom-theme'?: GlobalPrefs['installedCustomLightTheme'];
   'installed-custom-dark-theme'?: GlobalPrefs['installedCustomDarkTheme'];
+  'custom-css-override'?: GlobalPrefs['customCssOverride'];
   plugins?: string; // "true" or "false"
   'plugin-theme'?: string; // JSON string of complete plugin theme (current selected plugin theme)
   'server-self-signed-cert'?: GlobalPrefs['serverSelfSignedCert'];

--- a/upcoming-release-notes/7495.md
+++ b/upcoming-release-notes/7495.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Custom Themes: custom CSS overrides now persist across theme changes and show a visible indicator next to the Theme dropdown when active


### PR DESCRIPTION
The custom CSS the user can provide in the textbox will now never automatically clear. It will be persisted through theme changes.

Also showing a visual indicator if some custom css is being used.

https://github.com/actualbudget/actual/issues/6607

<img width="322" height="165" alt="Screenshot 2026-04-13 at 22 10 18" src="https://github.com/user-attachments/assets/7631cc74-32e1-498c-8e4e-190209e582a2" />

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 → 28 | 12.91 MB → 12.91 MB (-768 B) | -0.01%
loot-core | 1 | 4.85 MB → 4.84 MB (-655 B) | -0.01%
api | 1 | 3.88 MB → 3.88 MB (-628 B) | -0.02%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 → 28 | 12.91 MB → 12.91 MB (-768 B) | -0.01%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`src/style/theme.tsx` | 📈 +2.65 kB (+45.53%) | 5.83 kB → 8.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +71 B (+34.98%) | 203 B → 274 B
`src/components/settings/Themes.tsx` | 📈 +1.21 kB (+17.99%) | 6.75 kB → 7.97 kB
`node_modules/react-is/index.js` | 📈 +23 B (+11.79%) | 195 B → 218 B
`node_modules/@react-aria/grid/dist/useGridSelectionCheckbox.mjs` | 📈 +46 B (+5.92%) | 777 B → 823 B
`node_modules/recharts/es6/state/hooks.js` | 📈 +52 B (+5.70%) | 913 B → 965 B
`src/style/customThemes.ts` | 📈 +687 B (+5.46%) | 12.29 kB → 12.96 kB
`node_modules/recharts/es6/util/DataUtils.js` | 📈 +59 B (+2.62%) | 2.2 kB → 2.25 kB
`src/components/ServerContext.tsx` | 📈 +106 B (+1.86%) | 5.56 kB → 5.67 kB
`node_modules/@react-spring/web/dist/react-spring_web.modern.mjs` | 📈 +72 B (+1.03%) | 6.82 kB → 6.89 kB
`src/components/responsive/wide.ts` | 📈 +3 B (+1.03%) | 292 B → 295 B
`home/runner/work/actual/actual/packages/component-library/src/Label.tsx` | 📈 +4 B (+1.02%) | 394 B → 398 B
`node_modules/recharts/es6/component/ResponsiveContainer.js` | 📈 +67 B (+0.98%) | 6.67 kB → 6.73 kB
`node_modules/recharts/es6/util/useAnimationId.js` | 📈 +4 B (+0.87%) | 458 B → 462 B
`node_modules/unified/lib/index.js` | 📈 +66 B (+0.83%) | 7.77 kB → 7.84 kB
`node_modules/@react-stately/virtualizer/dist/Rect.mjs` | 📈 +20 B (+0.82%) | 2.38 kB → 2.4 kB
`src/build-shims.js` | 📈 +3 B (+0.82%) | 367 B → 370 B
`node_modules/recharts/es6/util/useId.js` | 📈 +2 B (+0.70%) | 287 B → 289 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/connection/index.ts` | 📈 +20 B (+0.59%) | 3.31 kB → 3.33 kB
`node_modules/react-dnd/dist/core/DndProvider.js` | 📈 +12 B (+0.56%) | 2.11 kB → 2.12 kB
`node_modules/lodash.debounce/index.js` | 📈 +21 B (+0.50%) | 4.08 kB → 4.1 kB
`node_modules/dnd-core/dist/reducers/index.js` | 📈 +6 B (+0.49%) | 1.19 kB → 1.19 kB
`src/components/banksync/FieldMapping.tsx` | 📈 +40 B (+0.46%) | 8.45 kB → 8.49 kB
`src/components/modals/ImportTransactionsModal/ParsedDate.tsx` | 📈 +8 B (+0.46%) | 1.71 kB → 1.71 kB
`node_modules/dnd-core/dist/reducers/dragOperation.js` | 📈 +9 B (+0.45%) | 1.94 kB → 1.95 kB
`node_modules/@radix-ui/react-id/dist/index.mjs` | 📈 +2 B (+0.45%) | 443 B → 445 B
`node_modules/@react-aria/selection/dist/useSelectableCollection.mjs` | 📈 +72 B (+0.45%) | 15.67 kB → 15.74 kB
`node_modules/@react-aria/collections/dist/CollectionBuilder.mjs` | 📈 +34 B (+0.44%) | 7.47 kB → 7.5 kB
`src/components/select/DateSelect.tsx` | 📈 +65 B (+0.43%) | 14.7 kB → 14.76 kB
`node_modules/react-i18next/dist/es/TransWithoutContext.js` | 📈 +61 B (+0.43%) | 14 kB → 14.06 kB
`src/hooks/useOnVisible.ts` | 📈 +3 B (+0.37%) | 809 B → 812 B
`src/components/rules/ActionExpression.tsx` | 📈 +32 B (+0.37%) | 8.43 kB → 8.46 kB
`src/components/modals/ImportTransactionsModal/SubLabel.tsx` | 📈 +2 B (+0.37%) | 541 B → 543 B
`node_modules/es-toolkit/dist/compat/util/toString.js` | 📈 +2 B (+0.36%) | 552 B → 554 B
`src/components/util/accountValidation.ts` | 📈 +2 B (+0.35%) | 570 B → 572 B
`src/components/rules/ConditionExpression.tsx` | 📈 +6 B (+0.29%) | 2.05 kB → 2.06 kB
`node_modules/dnd-core/dist/reducers/dragOffset.js` | 📈 +4 B (+0.28%) | 1.42 kB → 1.42 kB
`node_modules/lodash/_baseToString.js` | 📈 +2 B (+0.26%) | 772 B → 774 B
`node_modules/dnd-core/dist/utils/js_utils.js` | 📈 +2 B (+0.26%) | 773 B → 775 B
`node_modules/recharts/es6/container/ClipPathProvider.js` | 📈 +2 B (+0.24%) | 849 B → 851 B
`node_modules/recharts/es6/state/store.js` | 📈 +4 B (+0.23%) | 1.66 kB → 1.67 kB
`node_modules/hyperformula/es/parser/LexerConfig.mjs` | 📈 +12 B (+0.23%) | 5.09 kB → 5.1 kB
`src/components/budget/tracking/budgetsummary/BudgetTotal.tsx` | 📈 +6 B (+0.22%) | 2.66 kB → 2.67 kB
`src/components/payees/PayeeRuleCountLabel.tsx` | 📈 +2 B (+0.22%) | 929 B → 931 B
`src/components/filters/FiltersMenu.tsx` | 📈 +38 B (+0.21%) | 17.41 kB → 17.45 kB
`node_modules/recharts/es6/util/propsAreEqual.js` | 📈 +2 B (+0.21%) | 946 B → 948 B
`node_modules/@tanstack/query-core/build/modern/queryClient.js` | 📈 +16 B (+0.20%) | 7.65 kB → 7.66 kB
`node_modules/react-aria-components/dist/ListBox.mjs` | 📈 +32 B (+0.20%) | 15.34 kB → 15.38 kB
`node_modules/dnd-core/dist/actions/dragDrop/drop.js` | 📈 +4 B (+0.19%) | 2.05 kB → 2.06 kB
`src/components/settings/Encryption.tsx` | 📈 +10 B (+0.19%) | 5.21 kB → 5.22 kB
`src/components/ManageRules.tsx` | 📈 +26 B (+0.18%) | 14.04 kB → 14.07 kB
`src/components/settings/index.tsx` | 📈 +20 B (+0.18%) | 10.87 kB → 10.89 kB
`src/components/settings/BudgetTypeSettings.tsx` | 📈 +4 B (+0.17%) | 2.35 kB → 2.36 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +102 B (+0.16%) | 61.1 kB → 61.2 kB
`node_modules/recharts/es6/component/Label.js` | 📈 +18 B (+0.16%) | 10.79 kB → 10.81 kB
`src/components/settings/Reset.tsx` | 📈 +6 B (+0.16%) | 3.69 kB → 3.7 kB
`src/components/budget/goals/editor/WeekAutomation.tsx` | 📈 +2 B (+0.15%) | 1.29 kB → 1.29 kB
`src/components/manager/subscribe/ChangePassword.tsx` | 📈 +6 B (+0.15%) | 3.87 kB → 3.88 kB
`node_modules/recharts/es6/state/selectors/axisSelectors.js` | 📈 +61 B (+0.15%) | 39.44 kB → 39.5 kB
`src/components/settings/Backups.tsx` | 📈 +2 B (+0.15%) | 1.31 kB → 1.32 kB
`src/components/modals/manager/DeleteFileModal.tsx` | 📈 +8 B (+0.14%) | 5.48 kB → 5.49 kB
`src/components/manager/ServerURL.tsx` | 📈 +2 B (+0.14%) | 1.39 kB → 1.39 kB
`node_modules/es-toolkit/dist/compat/util/toPath.js` | 📈 +2 B (+0.14%) | 1.41 kB → 1.41 kB
`src/components/settings/AuthSettings.tsx` | 📈 +6 B (+0.14%) | 4.23 kB → 4.24 kB
`src/components/modals/manager/ConfirmChangeDocumentDir.tsx` | 📈 +8 B (+0.14%) | 5.66 kB → 5.67 kB
`src/components/modals/TransferOwnership.tsx` | 📈 +10 B (+0.13%) | 7.27 kB → 7.28 kB
`node_modules/downshift/dist/downshift.esm.mjs` | 📈 +138 B (+0.13%) | 106.11 kB → 106.24 kB
`src/components/modals/MergeUnusedPayeesModal.tsx` | 📈 +10 B (+0.13%) | 7.74 kB → 7.75 kB
`src/components/modals/EditAccess.tsx` | 📈 +6 B (+0.12%) | 4.99 kB → 5 kB
`src/components/rules/RuleRow.tsx` | 📈 +12 B (+0.12%) | 10.04 kB → 10.05 kB
`src/components/settings/Format.tsx` | 📈 +4 B (+0.12%) | 3.39 kB → 3.4 kB
`src/components/modals/EditUser.tsx` | 📈 +22 B (+0.11%) | 18.75 kB → 18.77 kB
`node_modules/react-swipeable/es/index.js` | 📈 +8 B (+0.11%) | 6.94 kB → 6.95 kB
`src/components/settings/Export.tsx` | 📈 +4 B (+0.11%) | 3.49 kB → 3.49 kB
`src/components/FatalError.tsx` | 📈 +12 B (+0.11%) | 10.58 kB → 10.59 kB
`src/components/accounts/Reconcile.tsx` | 📈 +10 B (+0.11%) | 9.11 kB → 9.12 kB
`src/components/modals/manager/FilesSettingsModal.tsx` | 📈 +8 B (+0.11%) | 7.3 kB → 7.31 kB
`src/components/filters/FilterExpression.tsx` | 📈 +6 B (+0.10%) | 5.73 kB → 5.73 kB
`src/components/schedules/PostsOfflineNotification.tsx` | 📈 +4 B (+0.10%) | 3.91 kB → 3.91 kB
`node_modules/redux/es/redux.js` | 📈 +4 B (+0.10%) | 3.94 kB → 3.95 kB
`node_modules/react-dnd-html5-backend/dist/HTML5BackendImpl.js` | 📈 +15 B (+0.10%) | 15.02 kB → 15.03 kB
`src/components/modals/ScheduledTransactionMenuModal.tsx` | 📈 +6 B (+0.10%) | 6.01 kB → 6.01 kB
`node_modules/recharts/es6/cartesian/getTicks.js` | 📈 +6 B (+0.10%) | 6.05 kB → 6.05 kB
`src/components/manager/subscribe/Error.tsx` | 📈 +2 B (+0.10%) | 2.04 kB → 2.04 kB
`src/components/manager/subscribe/OpenIdForm.tsx` | 📈 +18 B (+0.09%) | 18.68 kB → 18.69 kB
`src/components/schedules/ScheduleEditForm.tsx` | 📈 +20 B (+0.09%) | 20.94 kB → 20.96 kB
`src/components/modals/ConfirmPayeesMergeModal.tsx` | 📈 +4 B (+0.09%) | 4.27 kB → 4.27 kB
`src/components/budget/goals/editor/ScheduleAutomation.tsx` | 📈 +2 B (+0.09%) | 2.21 kB → 2.21 kB
`src/components/schedules/ScheduleLink.tsx` | 📈 +4 B (+0.09%) | 4.42 kB → 4.43 kB
`src/components/BankSyncStatus.tsx` | 📈 +2 B (+0.09%) | 2.22 kB → 2.22 kB
`src/components/banksync/BankSyncCheckboxOptions.tsx` | 📈 +10 B (+0.09%) | 11.11 kB → 11.12 kB
`src/components/filters/NameFilter.tsx` | 📈 +2 B (+0.08%) | 2.35 kB → 2.35 kB
`src/components/budget/tracking/budgetsummary/Saved.tsx` | 📈 +4 B (+0.08%) | 4.77 kB → 4.77 kB
`src/components/banksync/index.tsx` | 📈 +4 B (+0.08%) | 4.83 kB → 4.84 kB
`node_modules/cmdk/dist/index.mjs` | 📈 +12 B (+0.08%) | 14.53 kB → 14.54 kB
`src/components/accounts/AccountEmptyMessage.tsx` | 📈 +2 B (+0.08%) | 2.48 kB → 2.48 kB
`src/components/UpdateNotification.tsx` | 📈 +4 B (+0.07%) | 5.26 kB → 5.27 kB
`src/components/modals/TrackingBalanceMenuModal.tsx` | 📈 +2 B (+0.07%) | 2.71 kB → 2.71 kB
`src/components/modals/OutOfSyncMigrationsModal.tsx` | 📈 +2 B (+0.07%) | 2.73 kB → 2.73 kB
`src/components/modals/HoldBufferModal.tsx` | 📈 +2 B (+0.07%) | 2.74 kB → 2.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/chart-theme.js | 679.65 kB → 0 B (-679.65 kB) | -100%
static/js/client.js | 450.92 kB → 0 B (-450.92 kB) | -100%
static/js/TransactionEdit.js | 182.43 kB → 0 B (-182.43 kB) | -100%
static/js/ScheduleEditForm.js | 135.5 kB → 0 B (-135.5 kB) | -100%
static/js/PayeeRuleCountLabel.js | 52.12 kB → 0 B (-52.12 kB) | -100%
static/js/useFormatList.js | 9.86 kB → 0 B (-9.86 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB → 3.32 MB (+1.47 MB) | +79.71%
static/js/extends.js | 485.17 kB → 488.44 kB (+3.27 kB) | +0.67%
static/js/wide.js | 292 B → 295 B (+3 B) | +1.03%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.33 MB → 4.33 MB (-892 B) | -0.02%
static/js/en.js | 176.5 kB → 175.88 kB (-635 B) | -0.35%
static/js/narrow.js | 363.04 kB → 363.02 kB (-27 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 853.16 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.84 MB (-655 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
` @oxc-project+runtime@0.122.0/helpers/toPrimitive.js` | 🆕 +414 B | 0 B → 414 B
` @oxc-project+runtime@0.122.0/helpers/typeof.js` | 🆕 +405 B | 0 B → 405 B
` @oxc-project+runtime@0.122.0/helpers/assertClassBrand.js` | 🆕 +284 B | 0 B → 284 B
` @oxc-project+runtime@0.122.0/helpers/defineProperty.js` | 🆕 +278 B | 0 B → 278 B
` @oxc-project+runtime@0.122.0/helpers/checkPrivateRedeclaration.js` | 🆕 +242 B | 0 B → 242 B
` @oxc-project+runtime@0.122.0/helpers/toPropertyKey.js` | 🆕 +193 B | 0 B → 193 B
` @oxc-project+runtime@0.122.0/helpers/classPrivateFieldInitSpec.js` | 🆕 +191 B | 0 B → 191 B
` @oxc-project+runtime@0.122.0/helpers/classPrivateMethodInitSpec.js` | 🆕 +187 B | 0 B → 187 B
` @oxc-project+runtime@0.122.0/helpers/classPrivateFieldSet2.js` | 🆕 +181 B | 0 B → 181 B
` @oxc-project+runtime@0.122.0/helpers/classPrivateFieldGet2.js` | 🆕 +172 B | 0 B → 172 B
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +224 B (+4.56%) | 4.8 kB → 5.02 kB
`node_modules/chevrotain/lib_esm/src/scan/reg_exp.js` | 📉 -63 B (-0.84%) | 7.31 kB → 7.25 kB
`node_modules/chevrotain/lib_esm/src/parse/grammar/gast/gast_visitor_public.js` | 📉 -32 B (-1.75%) | 1.79 kB → 1.76 kB
`node_modules/regexp-to-ast/lib/regexp-to-ast.js` | 📉 -754 B (-3.72%) | 19.77 kB → 19.04 kB
`node_modules/chevrotain/lib_esm/src/api.js` | 📉 -30 B (-7.58%) | 396 B → 366 B
` @oxc-project+runtime@0.124.0/helpers/toPrimitive.js` | 🔥 -414 B (-100%) | 414 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/typeof.js` | 🔥 -405 B (-100%) | 405 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/assertClassBrand.js` | 🔥 -284 B (-100%) | 284 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/defineProperty.js` | 🔥 -278 B (-100%) | 278 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/checkPrivateRedeclaration.js` | 🔥 -242 B (-100%) | 242 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/toPropertyKey.js` | 🔥 -193 B (-100%) | 193 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/classPrivateFieldInitSpec.js` | 🔥 -191 B (-100%) | 191 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/classPrivateMethodInitSpec.js` | 🔥 -187 B (-100%) | 187 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/classPrivateFieldSet2.js` | 🔥 -181 B (-100%) | 181 B → 0 B
` @oxc-project+runtime@0.124.0/helpers/classPrivateFieldGet2.js` | 🔥 -172 B (-100%) | 172 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CrUi5S7Y.js | 0 B → 4.84 MB (+4.84 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cw2V9gWA.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (-628 B) | -0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +221 B (+4.58%) | 4.71 kB → 4.93 kB
`node_modules/chevrotain/lib_esm/src/scan/reg_exp.js` | 📉 -61 B (-0.84%) | 7.13 kB → 7.07 kB
`node_modules/chevrotain/lib_esm/src/parse/grammar/gast/gast_visitor_public.js` | 📉 -31 B (-1.73%) | 1.75 kB → 1.72 kB
`node_modules/regexp-to-ast/lib/regexp-to-ast.js` | 📉 -728 B (-3.74%) | 19.03 kB → 18.32 kB
`node_modules/chevrotain/lib_esm/src/api.js` | 📉 -29 B (-7.61%) | 381 B → 352 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (-628 B) | -0.02%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->