### PR TITLE
Add maketransfer to uncategorized transactions

### DIFF
--- a/packages/desktop-client/src/components/mobile/budget/UncategorizedTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/UncategorizedTransactions.tsx
@@ -62,6 +62,7 @@ export function UncategorizedTransactions() {
         isLoadingMore={isLoadingMoreTransactions}
         onLoadMore={fetchMoreTransactions}
         onOpenTransaction={onOpenTransaction}
+        showMakeTransfer
       />
     </SchedulesProvider>
   );

--- a/upcoming-release-notes/7496.md
+++ b/upcoming-release-notes/7496.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [tempiz]
+---
+
+Fixes inconsistency between web UI and mobile UI where maketransfer is not available on uncategorized transaction menu.


### PR DESCRIPTION

## Description

This change resolves a inconsistency between the desktop UI and the mobile UI. Within the uncategorized transactions menu, the desktop UI displays the Make Transfer button on transactions that meet transfer conditions, but on mobile the make transfer button is only available from the All Accounts menu. It does not display in the uncategorized transactions menu. I primarily use the mobile UI for budgeting, so this will make my daily flow much easier.

## Related issue(s)

N/A

## Testing

Open the mobile UI and and the desktop UI. Create two transactions between two accounts with the same value, one a deposit and the other a withdraw so it meets conditions to be a transfer. Open the uncategorized transactions menu on both interfaces and attempt to select them and make transfer. The desktop displays the button but the mobile does not. It is available under all accounts, but not uncategorized transactions.

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.91 MB → 12.91 MB (+27 B) | +0.00%
loot-core | 1 | 4.84 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.91 MB → 12.91 MB (+27 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/budget/UncategorizedTransactions.tsx` | 📈 +27 B (+1.07%) | 2.46 kB → 2.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/narrow.js | 363.02 kB → 363.04 kB (+27 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 3.32 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 852.77 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.98 kB | 0%
static/js/da.js | 104.66 kB | 0%
static/js/de.js | 174.38 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 175.89 kB | 0%
static/js/es.js | 181.8 kB | 0%
static/js/extends.js | 485.17 kB | 0%
static/js/fr.js | 177.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.95 kB | 0%
static/js/nb-NO.js | 151.85 kB | 0%
static/js/nl.js | 108.93 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.44 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 179.3 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.6 kB | 0%
static/js/wide.js | 295 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DZcmk4OR.js | 4.84 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->