### PR TITLE
Remove inactive community repository links from docs

### DIFF
--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -13,16 +13,9 @@ for it to be added, your project must have a proper README file.
 The following are implementations of bank syncing using the Actual API. For instructions on using them, see the respective repositories.
 
 - **Akahu and Up bank sync to Actual Budget** - https://github.com/tim-smart/actualbudget-sync
-- **Caju Brazil bank exporter to OFX** - https://github.com/Kasama/caju-actual-budget-importer
-- **Credit Suisse, Cembra Money Bank, DKB, ZKB, and Interactive Brokers CVS import** - https://github.com/wirhabenzeit/actual-budget-cli
 - **ICS Cards Holland CVS exporter** - https://github.com/IeuanK/ICS-Exporter/
-- **ING bank CSV import** - https://github.com/jvmap/ActualBudgetTransformer
 - **Lunch Flow: Import transactions from GoCardless, MX, Finicity, Finverse, and more** - https://github.com/lunchflow/actual-flow
 - **MoneyMan an israel banks importer** - https://github.com/daniel-hauser/moneyman
-- **Monobank bank sync** - https://github.com/dnullproject/mono-to-actualbudget
-- **My Edenred and Coverfelx Portugal bank sync** - https://github.com/rodriguestiago0/myedenred-actual
-- **Norwegian Trumf Visa PDF invoice to Actual Budget friendly CSV converter** - https://github.com/RubenOlsen/TrumfVisa2ActualBudget
-- **Plaid bank sync** - https://github.com/youngcw/actualplaid
 - **ANZ Plus bank PDF to OFX converter** - [PDFtoOFX](https://github.com/spydisec/PDFtoOFX/)
 
 ## Other Importers
@@ -30,8 +23,6 @@ The following are implementations of bank syncing using the Actual API. For inst
 Actual is used by some people to track money not necessarily found in bank accounts. This can be crypto currency
 tracking, loyalty card paybacks, prepaid cards, etc.
 
-- **Coinbase data puller** - https://github.com/SwadeDotExe/Coinbase-To-ActualBudget
-  - _This script pulls data from a USD and BTC wallet in Coinbase and keeps a wallet in Actual Budget synchronized with this balance._
 - **Portuguese meal cards from My Edenred and Coverflex** - https://github.com/rodriguestiago0/actual-mealcards
   - _This script will track Portuguese prepaid meal cards from My Edenred and Coverflex providers_
 
@@ -39,11 +30,8 @@ tracking, loyalty card paybacks, prepaid cards, etc.
 
 Actual currently has official support for migrating budgets from YNAB4 and nYNAB. The following are available for migrating from other budget apps.
 
-- **Mint.com** - https://github.com/youngcw/actual_mint_importer
 - **MoneyMoney** - https://github.com/NikxDa/actual-moneymoney
-- **Financier.io** - https://github.com/jat255/financier-to-actual
 - **Quicken on Mac** - https://github.com/slimslickner/quicken-mac-to-actual-budget
-- **Priotecs MoneyControl (Primoco)** - https://github.com/SimonMayerhofer/primoco-to-actual-migrator
 
 ## Various utilities to enhance Actual's functionality
 
@@ -57,8 +45,6 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
   - _Collection of helper scripts to track home prices and car values, add loan interest transactions, track investment accounts, etc._
 - **Actual Tasks** - https://github.com/rodriguestiago0/actual_task
   - _Two utilities to help fix payees and calculate mortgages._
-- **Easy category archive function** - https://github.com/rvisharma/actual-archive-category
-  - _This tool moves transactions over to an *archive* category, and then deletes the category._
 - **Actual Budget Backup** - https://github.com/rodriguestiago0/actualbudget-backup
   - _Tool which will back up Actual Budget and upload it to the configurable destination using the clone utility._
 - **Actual Budget Prometheus Exporter** - https://github.com/sakowicz/actual-budget-prometheus-exporter
@@ -74,8 +60,6 @@ Actual currently has official support for migrating budgets from YNAB4 and nYNAB
 
 - **Amazon orders CSV exporter user script** - https://github.com/IeuanK/AmazonExporter/
   - _Allows you to capture your Amazon orders, then store them as CSV or JSON file_
-- **Actual Budget CLI** - https://github.com/wirhabenzeit/actual-budget-cli
-  - _CLI to interact with the Actual Budget API._
 - **Local REST API** - https://github.com/jhonderson/actual-http-api
   - _This is a bridging API between REST and the internal Actual APIs._
 - **Actual Python API** - https://github.com/bvanelli/actualpy

--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -16,6 +16,7 @@ The following are implementations of bank syncing using the Actual API. For inst
 - **ICS Cards Holland CVS exporter** - https://github.com/IeuanK/ICS-Exporter/
 - **Lunch Flow: Import transactions from GoCardless, MX, Finicity, Finverse, and more** - https://github.com/lunchflow/actual-flow
 - **MoneyMan an israel banks importer** - https://github.com/daniel-hauser/moneyman
+- **Plaid bank sync** - https://github.com/youngcw/actualplaid
 - **ANZ Plus bank PDF to OFX converter** - [PDFtoOFX](https://github.com/spydisec/PDFtoOFX/)
 
 ## Other Importers

--- a/upcoming-release-notes/7500.md
+++ b/upcoming-release-notes/7500.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Remove inactive community repository links from documentation for improved clarity and relevance.

--- a/upcoming-release-notes/7500.md
+++ b/upcoming-release-notes/7500.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Remove inactive community repository links from documentation for improved clarity and relevance.


### PR DESCRIPTION
## Description

Removing some community links to repos that are either unmaintained (>1 year) or simply removed (404).

## Related issue(s)

<!-- If there's a related issue, reference it here -->

n/a

## Testing

N/A - Documentation-only change

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed
