### PR TITLE
[AI] Cache the reports cards

### DIFF
--- a/packages/desktop-client/src/accounts/mutations.ts
+++ b/packages/desktop-client/src/accounts/mutations.ts
@@ -30,6 +30,12 @@ import {
 } from './accountsSlice';
 import { accountQueries } from './queries';
 
+export const invalidateReportQueries = (queryClient: QueryClient) => {
+  void queryClient.invalidateQueries({
+    queryKey: ['report'],
+  });
+};
+
 const invalidateQueries = (queryClient: QueryClient, queryKey?: QueryKey) => {
   void queryClient.invalidateQueries({
     queryKey: queryKey ?? accountQueries.lists(),
@@ -73,7 +79,10 @@ export function useCreateAccountMutation() {
       });
       return id;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error creating account:', error);
       dispatchErrorNotification(
@@ -111,7 +120,10 @@ export function useCloseAccountMutation() {
         forced,
       });
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error closing account:', error);
       dispatchErrorNotification(
@@ -136,7 +148,10 @@ export function useReopenAccountMutation() {
     mutationFn: async ({ id }: ReopenAccountPayload) => {
       await send('account-reopen', { id });
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error re-opening account:', error);
       dispatchErrorNotification(
@@ -162,7 +177,10 @@ export function useUpdateAccountMutation() {
       await send('account-update', account);
       return account;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error updating account:', error);
       dispatchErrorNotification(
@@ -191,6 +209,7 @@ export function useMoveAccountMutation() {
     onSuccess: () => {
       invalidateQueries(queryClient);
       invalidateQueries(queryClient, payeeQueries.lists());
+      invalidateReportQueries(queryClient);
     },
     onError: error => {
       console.error('Error moving account:', error);
@@ -243,7 +262,10 @@ export function useImportPreviewTransactionsMutation() {
 
       return updatedPreview;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error importing preview transactions to account:', error);
       dispatchErrorNotification(
@@ -322,7 +344,10 @@ export function useImportTransactionsMutation() {
 
       return added.length > 0 || updated.length > 0;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error importing transactions to account:', error);
       dispatchErrorNotification(
@@ -403,6 +428,7 @@ export function useLinkAccountMutation() {
     onSuccess: () => {
       invalidateQueries(queryClient);
       invalidateQueries(queryClient, payeeQueries.lists());
+      invalidateReportQueries(queryClient);
     },
     onError: error => {
       console.error('Error linking account:', error);
@@ -443,6 +469,7 @@ export function useLinkAccountSimpleFinMutation() {
     onSuccess: () => {
       invalidateQueries(queryClient);
       invalidateQueries(queryClient, payeeQueries.lists());
+      invalidateReportQueries(queryClient);
     },
     onError: error => {
       console.error('Error linking account to SimpleFIN:', error);
@@ -485,6 +512,7 @@ export function useLinkAccountPluggyAiMutation() {
     onSuccess: () => {
       invalidateQueries(queryClient);
       invalidateQueries(queryClient, payeeQueries.lists());
+      invalidateReportQueries(queryClient);
     },
     onError: error => {
       console.error('Error linking account to PluggyAI:', error);
@@ -632,7 +660,10 @@ export function useSyncAccountsMutation() {
       dispatch(setAccountsSyncing({ ids: [] }));
       return isSyncSuccess;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error syncing accounts:', error);
       dispatchErrorNotification(
@@ -744,7 +775,10 @@ export function useSyncAndDownloadMutation() {
       }
       return { hasUpdated: hasDownloaded };
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error syncing accounts:', error);
       dispatchErrorNotification(

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -24,6 +24,12 @@ function invalidateQueries(queryClient: QueryClient, queryKey?: QueryKey) {
   });
 }
 
+function invalidateReportQueries(queryClient: QueryClient) {
+  void queryClient.invalidateQueries({
+    queryKey: ['report'],
+  });
+}
+
 function dispatchErrorNotification(
   dispatch: AppDispatch,
   message: string,
@@ -86,7 +92,10 @@ export function useCreateCategoryMutation() {
       });
       return id;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error creating category:', error);
       dispatchErrorNotification(
@@ -111,7 +120,10 @@ export function useUpdateCategoryMutation() {
     mutationFn: async ({ category }: UpdateCategoryPayload) => {
       await send('category-update', category);
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error updating category:', error);
       dispatchErrorNotification(
@@ -213,7 +225,10 @@ export function useDeleteCategoryMutation() {
         await deleteCategory({ id });
       }
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error deleting category:', error);
       dispatchErrorNotification(
@@ -240,7 +255,10 @@ export function useMoveCategoryMutation() {
     mutationFn: async ({ id, groupId, targetId }: MoveCategoryPayload) => {
       await send('category-move', { id, groupId, targetId });
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error moving category:', error);
       dispatchErrorNotification(
@@ -306,7 +324,10 @@ export function useCreateCategoryGroupMutation() {
       const id = await send('category-group-create', { name });
       return id;
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error creating category group:', error);
       dispatchErrorNotification(
@@ -353,7 +374,10 @@ export function useUpdateCategoryGroupMutation() {
       const { categories: _, ...groupNoCategories } = group;
       await send('category-group-update', groupNoCategories);
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error updating category group:', error);
       dispatchErrorNotification(
@@ -435,7 +459,10 @@ export function useDeleteCategoryGroupMutation() {
         await send('category-group-delete', { id });
       }
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error deleting category group:', error);
       dispatchErrorNotification(
@@ -461,7 +488,10 @@ export function useMoveCategoryGroupMutation() {
     mutationFn: async ({ id, targetId }: MoveCategoryGroupPayload) => {
       await send('category-group-move', { id, targetId });
     },
-    onSuccess: () => invalidateQueries(queryClient),
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
+    },
     onError: error => {
       console.error('Error moving category group:', error);
       dispatchErrorNotification(
@@ -651,6 +681,7 @@ type ApplyBudgetActionPayload =
     };
 
 export function useBudgetActions() {
+  const queryClient = useQueryClient();
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
@@ -789,6 +820,8 @@ export function useBudgetActions() {
           }),
         );
       }
+      invalidateQueries(queryClient);
+      invalidateReportQueries(queryClient);
     },
     onError: error => {
       console.error('Error applying budget action:', error);

--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
@@ -111,7 +111,13 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
       }),
     [start, end, conditions, conditionsOp, granularity],
   );
-  const data = useReport('age_of_money', reportParams);
+  const { data } = useReport('age_of_money', reportParams, [
+    start,
+    end,
+    conditions,
+    conditionsOp,
+    granularity,
+  ]);
 
   useEffect(() => {
     async function run() {

--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoneyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoneyCard.tsx
@@ -98,7 +98,13 @@ export function AgeOfMoneyCard({
       }),
     [start, end, meta?.conditions, meta?.conditionsOp, meta?.granularity],
   );
-  const data = useReport('age_of_money', params);
+  const { data } = useReport('age_of_money', params, [
+    start,
+    end,
+    meta?.conditions,
+    meta?.conditionsOp,
+    meta?.granularity,
+  ]);
 
   return (
     <ReportCard

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -187,7 +187,12 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
     [conditions, conditionsOp, startDate, endDate],
   );
 
-  const data = useReport('default', getGraphData);
+  const { data } = useReport('default', getGraphData, [
+    conditions,
+    conditionsOp,
+    startDate,
+    endDate,
+  ]);
   const navigate = useNavigate();
   const { isNarrowWidth } = useResponsive();
 

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
@@ -68,7 +68,12 @@ export function BudgetAnalysisCard({
     });
   }, [meta?.conditions, meta?.conditionsOp, startDate, endDate]);
 
-  const data = useReport('default', getGraphData);
+  const { data } = useReport('default', getGraphData, [
+    meta?.conditions,
+    meta?.conditionsOp,
+    startDate,
+    endDate,
+  ]);
 
   const latestInterval =
     data && data.intervalData.length > 0

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -103,7 +103,6 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   const [end, setEnd] = useState(monthUtils.currentDay());
   const [mode, setMode] = useState<TimeFrame['mode']>('full');
   const [query, setQuery] = useState<Query | undefined>(undefined);
-  const [dirty, setDirty] = useState(false);
   const [latestTransaction, setLatestTransaction] = useState('');
 
   const {
@@ -174,10 +173,6 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
   }, [widget?.meta?.conditions, onApplyFilter, parameters]);
 
   const params = useMemo(() => {
-    if (dirty === true) {
-      setDirty(false);
-    }
-
     return calendarSpreadsheet(
       start,
       end,
@@ -185,7 +180,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
       conditionsOp,
       firstDayOfWeekIdx,
     );
-  }, [start, end, conditions, conditionsOp, firstDayOfWeekIdx, dirty]);
+  }, [start, end, conditions, conditionsOp, firstDayOfWeekIdx]);
 
   const [sortField, setSortField] = useState('');
   const [ascDesc, setAscDesc] = useState<'asc' | 'desc'>('desc');
@@ -238,7 +233,13 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
     scrollbarContainer,
   ) as Ref<HTMLDivElement>;
 
-  const data = useReport('calendar', params);
+  const { data, refetch } = useReport('calendar', params, [
+    start,
+    end,
+    conditions,
+    conditionsOp,
+    firstDayOfWeekIdx,
+  ]);
 
   const [allMonths, setAllMonths] = useState<
     Array<{
@@ -682,7 +683,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
                     sortField={sortField}
                     ascDesc={ascDesc}
                     onChange={() => {}}
-                    onRefetch={() => setDirty(true)}
+                    onRefetch={refetch}
                     onCloseAddTransaction={() => {}}
                     onCreatePayee={async () => null}
                     onApplyFilter={() => {}}

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -112,7 +112,13 @@ export function CalendarCard({
     }
   });
 
-  const data = useReport('calendar', params);
+  const { data } = useReport('calendar', params, [
+    start,
+    end,
+    meta?.conditions,
+    meta?.conditionsOp,
+    firstDayOfWeekIdx,
+  ]);
 
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
 

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -106,6 +106,14 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
     setIsConcise(numDays > 31 * 3);
   }, [start, end]);
 
+  const [numberFormatPref] = useSyncedPref('numberFormat');
+  const [hideFractionPref] = useSyncedPref('hideFraction');
+  const [defaultCurrencyCodePref] = useSyncedPref('defaultCurrencyCode');
+  const [symbolPositionPref] = useSyncedPref('currencySymbolPosition');
+  const [spaceEnabledPref] = useSyncedPref(
+    'currencySpaceBetweenAmountAndSymbol',
+  );
+
   const params = useMemo(
     () =>
       cashFlowByDate(
@@ -117,9 +125,34 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
         locale,
         format,
       ),
-    [start, end, isConcise, conditions, conditionsOp, locale, format],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      start,
+      end,
+      isConcise,
+      conditions,
+      conditionsOp,
+      locale,
+      numberFormatPref,
+      hideFractionPref,
+      defaultCurrencyCodePref,
+      symbolPositionPref,
+      spaceEnabledPref,
+    ],
   );
-  const data = useReport('cash_flow', params);
+  const { data } = useReport('cash_flow', params, [
+    start,
+    end,
+    isConcise,
+    conditions,
+    conditionsOp,
+    locale,
+    numberFormatPref,
+    hideFractionPref,
+    defaultCurrencyCodePref,
+    symbolPositionPref,
+    spaceEnabledPref,
+  ]);
 
   useEffect(() => {
     async function run() {

--- a/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlowCard.tsx
@@ -137,7 +137,12 @@ export function CashFlowCard({
     () => simpleCashFlow(start, end, meta?.conditions, meta?.conditionsOp),
     [start, end, meta?.conditions, meta?.conditionsOp],
   );
-  const data = useReport('cash_flow_simple', params);
+  const { data } = useReport('cash_flow_simple', params, [
+    start,
+    end,
+    meta?.conditions,
+    meta?.conditionsOp,
+  ]);
 
   const [isCardHovered, setIsCardHovered] = useState(false);
   const onCardHover = useCallback(() => setIsCardHovered(true), []);

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -365,7 +365,19 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
     ],
   );
 
-  const data = useReport<CrossoverData>('crossover', params);
+  const { data } = useReport<CrossoverData>('crossover', params, [
+    start,
+    end,
+    swr,
+    useCustomGrowth,
+    estimatedReturn,
+    expectedContribution,
+    projectionType,
+    expenseAdjustmentFactor,
+    expenseCategoryIds,
+    selectedIncomeAccountIds,
+    selectionsInitialized,
+  ]);
 
   // Get the default estimated return from the spreadsheet data
   const historicalReturn = data?.historicalReturn ?? null;
@@ -414,7 +426,8 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
     !start ||
     !end ||
     isCategoriesLoading ||
-    accounts.length === 0
+    accounts.length === 0 ||
+    !selectionsInitialized
   ) {
     return <LoadingIndicator />;
   }

--- a/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CrossoverCard.tsx
@@ -57,6 +57,7 @@ export function CrossoverCard({
   // Calculate date range from meta or use default range
   const [start, setStart] = useState<string>('');
   const [end, setEnd] = useState<string>('');
+  const datesInitialized = !!(start && end);
 
   const format = useFormat();
 
@@ -180,7 +181,18 @@ export function CrossoverCard({
     ],
   );
 
-  const data = useReport<CrossoverData>('crossover', params);
+  const { data } = useReport<CrossoverData>('crossover', params, [
+    start,
+    end,
+    expenseCategoryIds,
+    incomeAccountIds,
+    swr,
+    estimatedReturn,
+    expectedContribution,
+    projectionType,
+    expenseAdjustmentFactor,
+    datesInitialized,
+  ]);
 
   // Get years to retire from spreadsheet data
   const yearsToRetire = data?.yearsToRetire ?? null;
@@ -259,7 +271,7 @@ export function CrossoverCard({
           )}
         </View>
 
-        {data ? (
+        {data && datesInitialized ? (
           <CrossoverGraph
             graphData={data.graphData}
             compact

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -592,8 +592,44 @@ function CustomReportInner({
     graphType,
     firstDayOfWeekIdx,
   ]);
-  const graphData = useReport('default', getGraphData);
-  const groupedData = useReport('grouped', getGroupData);
+  const { data: graphData } = useReport('default', getGraphData, [
+    startDate,
+    endDate,
+    interval,
+    budgetType,
+    balanceTypeOp,
+    categories,
+    payees,
+    accounts,
+    conditions,
+    conditionsOp,
+    showEmpty,
+    showOffBudget,
+    showHiddenCategories,
+    showUncategorized,
+    trimIntervals,
+    sortByOp,
+    graphType,
+    firstDayOfWeekIdx,
+    groupBy,
+  ]);
+  const { data: groupedData } = useReport('grouped', getGroupData, [
+    startDate,
+    endDate,
+    interval,
+    budgetType,
+    balanceTypeOp,
+    categories,
+    conditions,
+    conditionsOp,
+    showEmpty,
+    showOffBudget,
+    showHiddenCategories,
+    showUncategorized,
+    trimIntervals,
+    sortByOp,
+    firstDayOfWeekIdx,
+  ]);
 
   const data: DataEntity | null = graphData
     ? { ...graphData, groupedData }

--- a/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
+++ b/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
@@ -172,8 +172,21 @@ export function GetCardData({
     firstDayOfWeekIdx,
     budgetType,
   ]);
-  const graphData = useReport('default' + report.name, getGraphData);
-  const groupedData = useReport('grouped' + report.name, getGroupData);
+  const { data: graphData } = useReport('default' + report.name, getGraphData, [
+    report,
+    categories,
+    payees,
+    accounts,
+    startDate,
+    endDate,
+    firstDayOfWeekIdx,
+    budgetType,
+  ]);
+  const { data: groupedData } = useReport(
+    'grouped' + report.name,
+    getGroupData,
+    [report, categories, startDate, endDate, firstDayOfWeekIdx, budgetType],
+  );
 
   const data =
     graphData && groupedData ? { ...graphData, groupedData } : graphData;

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -124,6 +124,9 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
 
+  const [numberFormatPref] = useSyncedPref('numberFormat');
+  const [hideFractionPref] = useSyncedPref('hideFraction');
+
   const reportParams = useMemo(
     () =>
       netWorthSpreadsheet(
@@ -137,6 +140,7 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
         firstDayOfWeekIdx,
         format,
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       start,
       end,
@@ -146,10 +150,22 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
       locale,
       interval,
       firstDayOfWeekIdx,
-      format,
+      numberFormatPref,
+      hideFractionPref,
     ],
   );
-  const data = useReport('net_worth', reportParams);
+  const { data } = useReport('net_worth', reportParams, [
+    start,
+    end,
+    accounts,
+    conditions,
+    conditionsOp,
+    locale,
+    interval,
+    firstDayOfWeekIdx,
+    numberFormatPref,
+    hideFractionPref,
+  ]);
   useEffect(() => {
     async function run() {
       const earliestTransaction = await send('get-earliest-transaction');

--- a/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorthCard.tsx
@@ -53,6 +53,13 @@ export function NetWorthCard({
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
   const format = useFormat();
+  const [numberFormatPref] = useSyncedPref('numberFormat');
+  const [hideFractionPref] = useSyncedPref('hideFraction');
+  const [defaultCurrencyCodePref] = useSyncedPref('defaultCurrencyCode');
+  const [symbolPositionPref] = useSyncedPref('currencySymbolPosition');
+  const [spaceEnabledPref] = useSyncedPref(
+    'currencySpaceBetweenAmountAndSymbol',
+  );
 
   const [latestTransaction, setLatestTransaction] = useState<string>('');
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
@@ -92,6 +99,7 @@ export function NetWorthCard({
         firstDayOfWeekIdx,
         format,
       ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       start,
       end,
@@ -101,10 +109,28 @@ export function NetWorthCard({
       locale,
       meta?.interval,
       firstDayOfWeekIdx,
-      format,
+      numberFormatPref,
+      hideFractionPref,
+      defaultCurrencyCodePref,
+      symbolPositionPref,
+      spaceEnabledPref,
     ],
   );
-  const data = useReport('net_worth', params);
+  const { data } = useReport('net_worth', params, [
+    start,
+    end,
+    accounts,
+    meta?.conditions,
+    meta?.conditionsOp,
+    locale,
+    meta?.interval,
+    firstDayOfWeekIdx,
+    numberFormatPref,
+    hideFractionPref,
+    defaultCurrencyCodePref,
+    symbolPositionPref,
+    spaceEnabledPref,
+  ]);
 
   return (
     <ReportCard

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -331,7 +331,17 @@ function SankeyInner({ widget }: SankeyInnerProps) {
     setData: (data: SankeyData) => void,
   ) => setData({ nodes: [], links: [] });
 
-  const data = useReport('sankey', reportParams ?? defaultGetData);
+  const { data } = useReport('sankey', reportParams ?? defaultGetData, [
+    start,
+    end,
+    groupedCategories,
+    conditions,
+    conditionsOp,
+    graphMode,
+    topNcategories,
+    categorySort,
+    !!reportParams,
+  ]);
 
   useEffect(() => {
     async function run() {

--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -68,8 +68,15 @@ export function SankeyCard({
       ),
     [start, end, groupedCategories, meta?.conditions, meta?.conditionsOp, mode],
   );
-  const data = useReport('sankey', params);
 
+  const { data } = useReport('sankey', params, [
+    start,
+    end,
+    groupedCategories,
+    meta?.conditions,
+    meta?.conditionsOp,
+    mode,
+  ]);
   const HEADER_HEIGHT = 82;
   const PX_PER_NODE = 50;
   const topN = Math.max(

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -149,7 +149,13 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
     [conditions, conditionsOp, compare, compareTo, budgetType],
   );
 
-  const data = useReport('default', getGraphData);
+  const { data } = useReport('default', getGraphData, [
+    conditions,
+    conditionsOp,
+    compare,
+    compareTo,
+    budgetType,
+  ]);
   const navigate = useNavigate();
   const { isNarrowWidth } = useResponsive();
 

--- a/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SpendingCard.tsx
@@ -67,7 +67,13 @@ export function SpendingCard({
     });
   }, [meta?.conditions, meta?.conditionsOp, compare, compareTo, budgetType]);
 
-  const data = useReport('default', getGraphData);
+  const { data } = useReport('default', getGraphData, [
+    meta?.conditions,
+    meta?.conditionsOp,
+    compare,
+    compareTo,
+    budgetType,
+  ]);
   const todayDay =
     compare !== monthUtils.currentMonth()
       ? 27

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -134,7 +134,14 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     ],
   );
 
-  const data = useReport('summary', params);
+  const { data } = useReport('summary', params, [
+    start,
+    end,
+    dividendFilters.conditions,
+    dividendFilters.conditionsOp,
+    content,
+    locale,
+  ]);
 
   useEffect(() => {
     setContent(prev => ({

--- a/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SummaryCard.tsx
@@ -93,7 +93,14 @@ export function SummaryCard({
     [start, end, meta?.conditions, meta?.conditionsOp, content, locale],
   );
 
-  const data = useReport('summary', params);
+  const { data } = useReport('summary', params, [
+    start,
+    end,
+    meta?.conditions,
+    meta?.conditionsOp,
+    content,
+    locale,
+  ]);
 
   return (
     <ReportCard

--- a/packages/desktop-client/src/components/reports/useReport.ts
+++ b/packages/desktop-client/src/components/reports/useReport.ts
@@ -1,33 +1,43 @@
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type {
+  QueryObserverResult,
+  RefetchOptions,
+} from '@tanstack/react-query';
 
 import { useSpreadsheet } from '#hooks/useSpreadsheet';
+
+export type UseReportValue<T> = {
+  data: T | null;
+  refetch: (options?: RefetchOptions) => Promise<QueryObserverResult<T, Error>>;
+};
 
 export function useReport<T>(
   sheetName: string,
   getData: (
     spreadsheet: ReturnType<typeof useSpreadsheet>,
     setData: (results: T) => void,
-  ) => Promise<void>,
-): T | null {
+  ) => Promise<void> | void,
+  queryKey: unknown[],
+): UseReportValue<T> {
   const spreadsheet = useSpreadsheet();
-  const [results, setResults] = useState<T | null>(null);
 
-  useEffect(() => {
-    let didCancel = false;
+  const { data, refetch } = useQuery({
+    queryKey: queryKey
+      ? ['report', sheetName, ...queryKey]
+      : ['report', sheetName],
+    queryFn: () => {
+      return new Promise<T>((resolve, reject) => {
+        try {
+          const result = getData(spreadsheet, resolve);
+          if (result instanceof Promise) {
+            result.catch(reject);
+          }
+        } catch (e) {
+          reject(e);
+        }
+      });
+    },
+  });
 
-    // Reset results whenever a new data function is provided so callers
-    // can reliably show a loading state instead of stale/partial data.
-    setResults(null);
-
-    void getData(spreadsheet, results => {
-      if (!didCancel) {
-        setResults(results);
-      }
-    });
-
-    return () => {
-      didCancel = true;
-    };
-  }, [getData, spreadsheet]);
-  return results;
+  return { data: data ?? null, refetch };
 }

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -82,6 +82,22 @@ export function handleGlobalEvents(store: AppStore, queryClient: QueryClient) {
       );
     }
 
+    if (
+      tables.includes('transactions') ||
+      tables.includes('categories') ||
+      tables.includes('category_groups') ||
+      tables.includes('category_mapping') ||
+      tables.includes('accounts') ||
+      tables.includes('payees') ||
+      tables.includes('payee_mapping')
+    ) {
+      promises.push(
+        queryClient.invalidateQueries({
+          queryKey: ['report'],
+        }),
+      );
+    }
+
     const tagged = undo.getTaggedState(undoTag);
 
     if (tagged) {

--- a/packages/desktop-client/src/payees/mutations.ts
+++ b/packages/desktop-client/src/payees/mutations.ts
@@ -17,6 +17,9 @@ function invalidateQueries(queryClient: QueryClient, queryKey?: QueryKey) {
   void queryClient.invalidateQueries({
     queryKey: queryKey ?? payeeQueries.lists(),
   });
+  void queryClient.invalidateQueries({
+    queryKey: ['report'],
+  });
 }
 
 function dispatchErrorNotification(

--- a/packages/desktop-client/src/sync-events.ts
+++ b/packages/desktop-client/src/sync-events.ts
@@ -90,6 +90,23 @@ export function listenForSyncEvent(store: AppStore, queryClient: QueryClient) {
           queryKey: accountQueries.lists(),
         });
       }
+
+      if (
+        tables.includes('transactions') ||
+        tables.includes('categories') ||
+        tables.includes('category_groups') ||
+        tables.includes('category_mapping') ||
+        tables.includes('accounts') ||
+        tables.includes('payees') ||
+        tables.includes('payee_mapping') ||
+        tables.includes('tags') ||
+        tables.includes('tag_mapping') ||
+        tables.includes('tag_groups')
+      ) {
+        void queryClient.invalidateQueries({
+          queryKey: ['report'],
+        });
+      }
     } else if (event.type === 'error') {
       let notif: Notification | null = null;
       const learnMore = `[${t('Learn more')}](https://actualbudget.org/docs/getting-started/sync/#debugging-sync-issues)`;

--- a/packages/desktop-client/src/tags/mutations.ts
+++ b/packages/desktop-client/src/tags/mutations.ts
@@ -16,6 +16,9 @@ function invalidateQueries(queryClient: QueryClient, queryKey?: QueryKey) {
   void queryClient.invalidateQueries({
     queryKey: queryKey ?? tagQueries.lists(),
   });
+  void queryClient.invalidateQueries({
+    queryKey: ['report'],
+  });
 }
 
 function dispatchErrorNotification(

--- a/upcoming-release-notes/7510.md
+++ b/upcoming-release-notes/7510.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [mnil]
+---
+
+Cache the report cards to avoid the loading circle each time the reports are opened.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

When selecting the reports page, for me the cards take a few seconds for me to load. This change adds caching so that the old data are reused while the fetching of new data happens asynchronously and the card updates when it is fetched.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

In a larger budget select the reports page. Also tested by going to the reports page, adding some new data to some account, and then going back to the reports page and watch the card update after a few seconds.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.92 MB → 12.93 MB (+9.96 kB) | +0.08%
loot-core | 1 | 4.85 MB | 0%
api | 1 | 3.88 MB | 0%
cli | 1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.92 MB → 12.93 MB (+9.96 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/useReport.ts` | 📈 +109 B (+23.54%) | 463 B → 572 B
`src/components/reports/reports/GetCardData.tsx` | 📈 +980 B (+12.28%) | 7.79 kB → 8.75 kB
`src/components/reports/reports/CrossoverCard.tsx` | 📈 +929 B (+9.39%) | 9.66 kB → 10.57 kB
`src/global-events.ts` | 📈 +317 B (+9.05%) | 3.42 kB → 3.73 kB
`src/components/reports/reports/SummaryCard.tsx` | 📈 +434 B (+6.64%) | 6.39 kB → 6.81 kB
`src/components/reports/reports/CashFlow.tsx` | 📈 +581 B (+6.12%) | 9.27 kB → 9.83 kB
`src/components/reports/reports/SankeyCard.tsx` | 📈 +453 B (+5.95%) | 7.43 kB → 7.87 kB
`src/components/reports/reports/CustomReport.tsx` | 📈 +2.41 kB (+5.77%) | 41.78 kB → 44.19 kB
`src/components/reports/reports/SpendingCard.tsx` | 📈 +427 B (+5.48%) | 7.61 kB → 8.02 kB
`src/accounts/mutations.ts` | 📈 +682 B (+5.29%) | 12.6 kB → 13.26 kB
`src/components/reports/reports/BudgetAnalysisCard.tsx` | 📈 +372 B (+5.15%) | 7.05 kB → 7.41 kB
`src/budget/mutations.ts` | 📈 +631 B (+4.99%) | 12.36 kB → 12.97 kB
`src/sync-events.ts` | 📈 +397 B (+4.88%) | 7.95 kB → 8.34 kB
`src/components/reports/reports/AgeOfMoneyCard.tsx` | 📈 +400 B (+4.80%) | 8.13 kB → 8.52 kB
`src/components/reports/reports/CashFlowCard.tsx` | 📈 +328 B (+3.07%) | 10.44 kB → 10.76 kB
`src/payees/mutations.ts` | 📈 +58 B (+2.72%) | 2.08 kB → 2.14 kB
`src/components/reports/reports/Sankey.tsx` | 📈 +762 B (+2.60%) | 28.58 kB → 29.32 kB
`src/components/reports/reports/Crossover.tsx` | 📈 +996 B (+2.36%) | 41.27 kB → 42.25 kB
`src/components/reports/reports/AgeOfMoney.tsx` | 📈 +403 B (+2.23%) | 17.68 kB → 18.07 kB
`src/tags/mutations.ts` | 📈 +58 B (+2.07%) | 2.74 kB → 2.8 kB
`src/components/reports/reports/Summary.tsx` | 📈 +523 B (+2.00%) | 25.57 kB → 26.08 kB
`src/components/reports/reports/Spending.tsx` | 📈 +421 B (+1.80%) | 22.8 kB → 23.21 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +358 B (+1.76%) | 19.92 kB → 20.27 kB
`src/components/reports/reports/NetWorth.tsx` | 📈 +229 B (+1.58%) | 14.16 kB → 14.38 kB
`src/components/reports/reports/CalendarCard.tsx` | 📈 +88 B (+0.67%) | 12.9 kB → 12.99 kB
`src/components/reports/reports/Calendar.tsx` | 📉 -32 B (-0.11%) | 27.61 kB → 27.58 kB
`src/components/reports/reports/NetWorthCard.tsx` | 📉 -3.1 kB (-39.38%) | 7.87 kB → 4.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.18 MB → 1.18 MB (+7.87 kB) | +0.65%
static/js/index.js | 1.85 MB → 1.85 MB (+772 B) | +0.04%
static/js/extends.js | 486.5 kB → 487.23 kB (+740 B) | +0.15%
static/js/Value.js | 4.34 MB → 4.34 MB (+631 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.12 kB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 705.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dtv5lNQw.js | 4.85 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->