### PR TITLE
[WIP] Fix rule matching when id fields are undefined (payee/category "is nothing")

### DIFF
--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -239,8 +239,6 @@ export class Condition {
 
     if (type === 'string') {
       fieldValue ??= '';
-    } else if (type === 'id') {
-      fieldValue ??= null;
     }
 
     if (fieldValue === undefined) {

--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -239,6 +239,8 @@ export class Condition {
 
     if (type === 'string') {
       fieldValue ??= '';
+    } else if (type === 'id') {
+      fieldValue ??= null;
     }
 
     if (fieldValue === undefined) {

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1045,6 +1045,14 @@ export async function prepareTransactionForRules(
   accounts: Map<string, db.DbAccount> | null = null,
 ): Promise<TransactionForRules> {
   const r: TransactionForRules = { ...trans };
+  // Normalize optional id fields so "is nothing" rules can match
+  if (r.payee === undefined) {
+    r.payee = null;
+  }
+  if (r.category === undefined) {
+    r.category = null;
+  }
+  
   if (trans.payee) {
     const payee = await getPayee(trans.payee);
     if (payee) {

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1052,7 +1052,7 @@ export async function prepareTransactionForRules(
   if (r.category === undefined) {
     r.category = null;
   }
-  
+
   if (trans.payee) {
     const payee = await getPayee(trans.payee);
     if (payee) {

--- a/upcoming-release-notes/7516.md
+++ b/upcoming-release-notes/7516.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [sk10727-a11y]
+---
+
+Fixes an issue where rules like "payee is nothing" or "category is nothing" fail to match when the field is undefined.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes an issue where rules like **"payee is nothing"** or **"category is nothing"** fail to match when the field is `undefined`.

Previously, `Condition.eval` returned `false` when a field was `undefined`, even though for id fields (like payee and category), `undefined` should be treated the same as `null` (i.e. “no value”). This caused rules to not apply for new transactions where these fields were not yet set.

This change normalizes `undefined` to `null` for id fields during evaluation, ensuring consistent rule behavior.

## Related issue(s)

Fixes #5724 

## Testing

Tested rule behavior for id fields (`payee`, `category`) using separate rules:

- Rule 1: `payee is nothing → set category`
- Rule 2: `category is nothing → set notes`

Tested in both:
- All Accounts view  
- Specific account register  

Verified:
- Rules correctly apply when fields are initially unset
- Behavior is consistent across both views
- No regressions observed for other rule conditions

**Notes:**
- Since these are default rules, manually created transactions are automatically populated with the rule-applied values during entry (before the transaction is saved).
- For rules to apply during manual entry:
  - In a specific account register: payment/deposit must be non-zero
  - In All Accounts: an account must be selected  
  
## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.91 MB | 0%
loot-core | 1 | 4.85 MB → 4.85 MB (+90 B) | +0.00%
api | 1 | 3.88 MB → 3.88 MB (+88 B) | +0.00%
cli | 1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 853.16 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.12 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 135.5 kB | 0%
static/js/TransactionEdit.js | 182.43 kB | 0%
static/js/TransactionList.js | 82.49 kB | 0%
static/js/Value.js | 4.33 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 679.65 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 485.17 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.04 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+90 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +90 B (+0.42%) | 20.92 kB → 21.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dm2zp-s1.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cw2V9gWA.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (+88 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +88 B (+0.42%) | 20.52 kB → 20.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+88 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.89 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->