### PR TITLE
fix runImport failing when ACTUAL_DATA_DIR environment variable is not set

### DIFF
--- a/packages/loot-core/src/platform/server/fs/index.api.ts
+++ b/packages/loot-core/src/platform/server/fs/index.api.ts
@@ -6,6 +6,8 @@ import promiseRetry from 'promise-retry';
 
 import { logger } from '#platform/server/log';
 
+import { getDocumentDir } from './shared';
+
 import type * as T from './index';
 
 export { getDocumentDir, getBudgetDir, _setDocumentDir } from './shared';
@@ -14,12 +16,7 @@ export const init: typeof T.init = async () => {
   // Nothing to do
 };
 
-export const getDataDir: typeof T.getDataDir = () => {
-  if (!process.env.ACTUAL_DATA_DIR) {
-    throw new Error('ACTUAL_DATA_DIR env variable is required');
-  }
-  return process.env.ACTUAL_DATA_DIR;
-};
+export const getDataDir: typeof T.getDataDir = () => getDocumentDir();
 
 export const bundledDatabasePath: typeof T.bundledDatabasePath = path.join(
   __dirname,

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -2,7 +2,7 @@
 import SQL from 'better-sqlite3';
 import { v4 as uuidv4 } from 'uuid';
 
-import { readFile, removeFile } from '#platform/server/fs';
+import { getDataDir, readFile, removeFile } from '#platform/server/fs';
 import { logger } from '#platform/server/log';
 
 import { normalise } from './normalise';
@@ -123,7 +123,7 @@ export function closeDatabase(db: SQL.Database) {
 export async function exportDatabase(db: SQL.Database) {
   // electron does not support better-sqlite serialize since v21
   // save to file and read in the raw data.
-  const name = `${process.env.ACTUAL_DATA_DIR}/backup-for-export-${uuidv4()}.db`;
+  const name = `${getDataDir()}/backup-for-export-${uuidv4()}.db`;
 
   await db.backup(name);
 

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -329,8 +329,8 @@ handlers['api/finish-import'] = async function () {
   await handlers['get-budget-bounds']();
   await sheet.waitOnSpreadsheet();
 
-  await cloudStorage.upload().catch(() => {
-    // Ignore errors
+  await cloudStorage.upload().catch(err => {
+    logger.warn('cloudStorage.upload failed during finish-import', err);
   });
 
   connection.send('finish-import');

--- a/upcoming-release-notes/7522.md
+++ b/upcoming-release-notes/7522.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix runImport failing when ACTUAL_DATA_DIR environment variable is not set


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

The environment variable was hard coded, meaning that even if dataDir was set in the `init` call, it was sometimes not respected.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes #4326

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.92 MB | 0%
loot-core | 1 | 4.85 MB → 4.85 MB (+78 B) | +0.00%
api | 1 | 3.88 MB → 3.88 MB (-59 B) | -0.00%
cli | 1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.92 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.12 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 705.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 486.5 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 177.18 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+78 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +78 B (+0.34%) | 22.54 kB → 22.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BLXvyUAG.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dtv5lNQw.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (-59 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +76 B (+0.34%) | 21.96 kB → 22.03 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/index.electron.ts` | 📉 -15 B (-0.73%) | 2.02 kB → 2 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/index.api.ts` | 📉 -120 B (-2.87%) | 4.08 kB → 3.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (-59 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->