### PR TITLE
Tracking budget api income

### DIFF
--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -1,6 +1,5 @@
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
-// @ts-strict-ignore
 import { getBankSyncError } from '#shared/errors';
 import type { ServerHandlers } from '#types/server-handlers';
 
@@ -89,9 +88,9 @@ describe('API handlers', () => {
       expect(group).toHaveProperty('received', 5000);
       expect(group).not.toHaveProperty('budgeted');
       expect(group).not.toHaveProperty('balance');
-      expect(group.categories[0]).toHaveProperty('received', 5000);
-      expect(group.categories[0]).not.toHaveProperty('budgeted');
-      expect(group.categories[0]).not.toHaveProperty('balance');
+      expect(group?.categories?.[0]).toHaveProperty('received', 5000);
+      expect(group?.categories?.[0]).not.toHaveProperty('budgeted');
+      expect(group?.categories?.[0]).not.toHaveProperty('balance');
     });
 
     it('tracking budget: income group returns budgeted, received, and balance', async () => {
@@ -115,10 +114,10 @@ describe('API handlers', () => {
       expect(group).toHaveProperty('budgeted', 6000);
       expect(group).toHaveProperty('received', 5000);
       expect(group).toHaveProperty('balance', 1000);
-      expect(group.categories[0]).toHaveProperty('budgeted', 6000);
-      expect(group.categories[0]).toHaveProperty('received', 5000);
-      expect(group.categories[0]).toHaveProperty('balance', 1000);
-      expect(group.categories[0]).toHaveProperty('carryover', false);
+      expect(group?.categories?.[0]).toHaveProperty('budgeted', 6000);
+      expect(group?.categories?.[0]).toHaveProperty('received', 5000);
+      expect(group?.categories?.[0]).toHaveProperty('balance', 1000);
+      expect(group?.categories?.[0]).toHaveProperty('carryover', false);
     });
   });
 });

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -1,9 +1,20 @@
+// @ts-strict-ignore
 import { getBankSyncError } from '#shared/errors';
 import type { ServerHandlers } from '#types/server-handlers';
 
 import { installAPI } from './api';
+import { isReflectBudget } from './budget/actions';
+import { createBudget } from './budget/base';
+import * as db from '#server/db';
+import * as sheet from '#server/sheet';
+import * as prefs from './prefs';
+
 vi.mock('#shared/errors', () => ({
   getBankSyncError: vi.fn(error => `Bank sync error: ${error}`),
+}));
+
+vi.mock('./budget/actions', () => ({
+  isReflectBudget: vi.fn().mockReturnValue(false),
 }));
 
 describe('API handlers', () => {
@@ -31,6 +42,89 @@ describe('API handlers', () => {
       ).rejects.toThrow('Bank sync error: connection-failed');
 
       expect(getBankSyncError).toHaveBeenCalledWith('connection-failed');
+    });
+  });
+
+  describe('api/budget-month', () => {
+    beforeEach(global.emptyDatabase());
+
+    beforeEach(async () => {
+      global.currentMonth = '2026-01';
+
+      await sheet.loadSpreadsheet(db);
+      await prefs.loadPrefs();
+
+      await db.insertCategoryGroup({
+        id: 'income-group',
+        name: 'Income',
+        is_income: 1,
+      });
+      await db.insertCategory({
+        id: 'income-cat',
+        name: 'Salary',
+        cat_group: 'income-group',
+        is_income: 1,
+      });
+
+      await db.insertAccount({ id: 'acct1', name: 'Checking' });
+
+      handlers['get-budget-bounds'] = vi
+        .fn()
+        .mockResolvedValue({ start: '2024-01', end: '2024-12' });
+    });
+
+    afterEach(() => {
+      global.currentMonth = null;
+      vi.mocked(isReflectBudget).mockReturnValue(false);
+    });
+
+    it('envelope budget: income group returns only received', async () => {
+      await createBudget(['2024-05', '2024-06']);
+      await db.insertTransaction({
+        id: 'tx1',
+        date: '2024-06-15',
+        account: 'acct1',
+        amount: 5000,
+        category: 'income-cat',
+      });
+      await sheet.waitOnSpreadsheet();
+
+      const result = await handlers['api/budget-month']({ month: '2024-06' });
+      const group = result.categoryGroups.find(g => g.is_income);
+
+      expect(group).toHaveProperty('received', 5000);
+      expect(group).not.toHaveProperty('budgeted');
+      expect(group).not.toHaveProperty('balance');
+      expect(group.categories[0]).toHaveProperty('received', 5000);
+      expect(group.categories[0]).not.toHaveProperty('budgeted');
+      expect(group.categories[0]).not.toHaveProperty('balance');
+    });
+
+    it('tracking budget: income group returns budgeted, received, and balance', async () => {
+      sheet.get().meta().budgetType = 'tracking';
+      vi.mocked(isReflectBudget).mockReturnValue(true);
+
+      await createBudget(['2024-05', '2024-06']);
+      sheet.get().set('budget202406!budget-income-cat', 6000);
+      await db.insertTransaction({
+        id: 'tx1',
+        date: '2024-06-15',
+        account: 'acct1',
+        amount: 5000,
+        category: 'income-cat',
+      });
+      await sheet.waitOnSpreadsheet();
+
+      const result = await handlers['api/budget-month']({ month: '2024-06' });
+      const group = result.categoryGroups.find(g => g.is_income);
+
+      expect(group).toHaveProperty('budgeted', 6000);
+      expect(group).toHaveProperty('received', 5000);
+      expect(group).toHaveProperty('balance', 1000);
+      expect(group.categories[0]).toHaveProperty('budgeted', 6000);
+      expect(group.categories[0]).toHaveProperty('received', 5000);
+      expect(group.categories[0]).toHaveProperty('balance', 1000);
+      expect(group.categories[0]).toHaveProperty('carryover', false);
     });
   });
 });

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -1,3 +1,5 @@
+import * as db from '#server/db';
+import * as sheet from '#server/sheet';
 // @ts-strict-ignore
 import { getBankSyncError } from '#shared/errors';
 import type { ServerHandlers } from '#types/server-handlers';
@@ -5,8 +7,6 @@ import type { ServerHandlers } from '#types/server-handlers';
 import { installAPI } from './api';
 import { isReflectBudget } from './budget/actions';
 import { createBudget } from './budget/base';
-import * as db from '#server/db';
-import * as sheet from '#server/sheet';
 import * as prefs from './prefs';
 
 vi.mock('#shared/errors', () => ({

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -5,16 +5,11 @@ import { getBankSyncError } from '#shared/errors';
 import type { ServerHandlers } from '#types/server-handlers';
 
 import { installAPI } from './api';
-import { isReflectBudget } from './budget/actions';
 import { createBudget } from './budget/base';
 import * as prefs from './prefs';
 
 vi.mock('#shared/errors', () => ({
   getBankSyncError: vi.fn(error => `Bank sync error: ${error}`),
-}));
-
-vi.mock('./budget/actions', () => ({
-  isReflectBudget: vi.fn().mockReturnValue(false),
 }));
 
 describe('API handlers', () => {
@@ -75,7 +70,6 @@ describe('API handlers', () => {
 
     afterEach(() => {
       global.currentMonth = null;
-      vi.mocked(isReflectBudget).mockReturnValue(false);
     });
 
     it('envelope budget: income group returns only received', async () => {
@@ -102,7 +96,7 @@ describe('API handlers', () => {
 
     it('tracking budget: income group returns budgeted, received, and balance', async () => {
       sheet.get().meta().budgetType = 'tracking';
-      vi.mocked(isReflectBudget).mockReturnValue(true);
+      await db.update('preferences', { id: 'budgetType', value: 'tracking' });
 
       await createBudget(['2024-05', '2024-06']);
       sheet.get().set('budget202406!budget-income-cat', 6000);

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -64,7 +64,7 @@ describe('API handlers', () => {
 
       handlers['get-budget-bounds'] = vi
         .fn()
-        .mockResolvedValue({ start: '2024-01', end: '2024-12' });
+        .mockResolvedValue({ start: '2026-01', end: '2026-12' });
     });
 
     afterEach(() => {
@@ -72,18 +72,19 @@ describe('API handlers', () => {
     });
 
     it('envelope budget: income group returns only received', async () => {
-      await createBudget(['2024-05', '2024-06']);
+      await createBudget(['2026-02', '2026-03']);
       await db.insertTransaction({
         id: 'tx1',
-        date: '2024-06-15',
+        date: '2026-03-15',
         account: 'acct1',
         amount: 5000,
         category: 'income-cat',
       });
       await sheet.waitOnSpreadsheet();
 
-      const result = await handlers['api/budget-month']({ month: '2024-06' });
+      const result = await handlers['api/budget-month']({ month: '2026-03' });
       const group = result.categoryGroups.find(g => g.is_income);
+      assert(group, 'Expected income category group to exist');
 
       expect(group).toHaveProperty('received', 5000);
       expect(group).not.toHaveProperty('budgeted');
@@ -97,19 +98,20 @@ describe('API handlers', () => {
       sheet.get().meta().budgetType = 'tracking';
       await db.update('preferences', { id: 'budgetType', value: 'tracking' });
 
-      await createBudget(['2024-05', '2024-06']);
-      sheet.get().set('budget202406!budget-income-cat', 6000);
+      await createBudget(['2026-02', '2026-03']);
+      sheet.get().set('budget202603!budget-income-cat', 6000);
       await db.insertTransaction({
         id: 'tx1',
-        date: '2024-06-15',
+        date: '2026-03-15',
         account: 'acct1',
         amount: 5000,
         category: 'income-cat',
       });
       await sheet.waitOnSpreadsheet();
 
-      const result = await handlers['api/budget-month']({ month: '2024-06' });
+      const result = await handlers['api/budget-month']({ month: '2026-03' });
       const group = result.categoryGroups.find(g => g.is_income);
+      assert(group, 'Expected income category group to exist');
 
       expect(group).toHaveProperty('budgeted', 6000);
       expect(group).toHaveProperty('received', 5000);

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -371,6 +371,7 @@ handlers['api/budget-month'] = async function ({ month }) {
     q('category_groups').select('*'),
   );
   const sheetName = monthUtils.sheetForMonth(month);
+  const isTrackingBudget = isReflectBudget();
 
   function value(name) {
     const v = sheet.get().getCellValue(sheetName, name);
@@ -394,7 +395,7 @@ handlers['api/budget-month'] = async function ({ month }) {
 
     categoryGroups: groups.map(group => {
       if (group.is_income) {
-        if (isReflectBudget()) {
+        if (isTrackingBudget) {
           return {
             ...categoryGroupModel.toExternal(group),
             budgeted: value(`group-budget-${group.id}`),

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -26,6 +26,7 @@ import type {
 import type { ServerHandlers } from '#types/server-handlers';
 
 import { addTransactions } from './accounts/sync';
+import { isReflectBudget } from './budget/actions';
 import {
   accountModel,
   budgetModel,
@@ -393,6 +394,23 @@ handlers['api/budget-month'] = async function ({ month }) {
 
     categoryGroups: groups.map(group => {
       if (group.is_income) {
+        if (isReflectBudget()) {
+          return {
+            ...categoryGroupModel.toExternal(group),
+            budgeted: value(`group-budget-${group.id}`),
+            received: value(`group-sum-amount-${group.id}`),
+            balance: value(`group-leftover-${group.id}`),
+
+            categories: group.categories.map(cat => ({
+              ...categoryModel.toExternal(cat),
+              budgeted: value(`budget-${cat.id}`),
+              received: value(`sum-amount-${cat.id}`),
+              balance: value(`leftover-${cat.id}`),
+              carryover: value(`carryover-${cat.id}`),
+            })),
+          };
+        }
+
         return {
           ...categoryGroupModel.toExternal(group),
           received: value('total-income'),

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -26,7 +26,6 @@ import type {
 import type { ServerHandlers } from '#types/server-handlers';
 
 import { addTransactions } from './accounts/sync';
-import { isReflectBudget } from './budget/actions';
 import {
   accountModel,
   budgetModel,
@@ -39,6 +38,7 @@ import {
 } from './api-models';
 import type { AmountOPType, APIScheduleEntity } from './api-models';
 import { aqlQuery } from './aql';
+import { isReflectBudget } from './budget/actions';
 import * as cloudStorage from './cloud-storage';
 import type { RemoteFile } from './cloud-storage';
 import * as db from './db';

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -38,7 +38,7 @@ import {
 } from './api-models';
 import type { AmountOPType, APIScheduleEntity } from './api-models';
 import { aqlQuery } from './aql';
-import { isReflectBudget } from './budget/actions';
+import { isTrackingBudget } from './budget/actions';
 import * as cloudStorage from './cloud-storage';
 import type { RemoteFile } from './cloud-storage';
 import * as db from './db';
@@ -371,7 +371,6 @@ handlers['api/budget-month'] = async function ({ month }) {
     q('category_groups').select('*'),
   );
   const sheetName = monthUtils.sheetForMonth(month);
-  const isTrackingBudget = isReflectBudget();
 
   function value(name) {
     const v = sheet.get().getCellValue(sheetName, name);
@@ -395,7 +394,7 @@ handlers['api/budget-month'] = async function ({ month }) {
 
     categoryGroups: groups.map(group => {
       if (group.is_income) {
-        if (isTrackingBudget) {
+        if (isTrackingBudget()) {
           return {
             ...categoryGroupModel.toExternal(group),
             budgeted: value(`group-budget-${group.id}`),

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -71,7 +71,9 @@ export type ApiHandlers = {
     totalIncome: number;
     totalSpent: number;
     totalBalance: number;
-    categoryGroups: Record<string, unknown>[];
+    categoryGroups: Array<
+      Record<string, unknown> & { categories?: Record<string, unknown>[] }
+    >;
   }>;
 
   'api/budget-set-amount': (arg: {

--- a/packages/loot-core/typings/window.ts
+++ b/packages/loot-core/typings/window.ts
@@ -59,4 +59,6 @@ declare global {
   var IS_TESTING: boolean;
 
   var currentMonth: string | null;
+
+  var emptyDatabase: (avoidUpdate?: boolean) => () => Promise<void>;
 }

--- a/upcoming-release-notes/7526.md
+++ b/upcoming-release-notes/7526.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [JSkinnerUK]
+---
+
+Adds budgeted, received, balance and carryover to api for tracking budget


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

From investigating this issue, I concluded that it must be that the reporter was using a tracking budget, as the missing fields, budgeted and balance are not relevant to an envelope budget, so create a test and fixed on that assumption, so that these fields get returned from the api when this budget type is in use.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

Fixes #3387
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Added a new test for this.
<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.96 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+557 B) | +0.01%
api | 2 | 3.9 MB → 3.9 MB (+542 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.96 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.92 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/narrow.js | 363.89 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+557 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +557 B (+2.37%) | 22.92 kB → 23.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CnsLtsAM.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BgC9bktg.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+542 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +542 B (+2.37%) | 22.31 kB → 22.84 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+542 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->