### PR TITLE
Fix payee/category is nothing rules not applying correctly

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1090,7 +1090,7 @@ export async function prepareTransactionForRules(
       r._category_name = category.name;
     }
   }
-  
+
   return r;
 }
 

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1045,6 +1045,24 @@ export async function prepareTransactionForRules(
   accounts: Map<string, db.DbAccount> | null = null,
 ): Promise<TransactionForRules> {
   const r: TransactionForRules = { ...trans };
+  // normalize undefined payee/category to null so "is nothing" rules can match
+  const normalizedRuleFields: string[] = [];
+
+  if (r.payee === undefined) {
+    r.payee = null;
+    normalizedRuleFields.push('payee');
+  }
+
+  if (r.category === undefined) {
+    r.category = null;
+    normalizedRuleFields.push('category');
+  }
+
+  if (normalizedRuleFields.length > 0) {
+    (
+      r as TransactionForRules & { _normalizedRuleFields?: string[] }
+    )._normalizedRuleFields = normalizedRuleFields;
+  }
   if (trans.payee) {
     const payee = await getPayee(trans.payee);
     if (payee) {
@@ -1072,7 +1090,7 @@ export async function prepareTransactionForRules(
       r._category_name = category.name;
     }
   }
-
+  
   return r;
 }
 
@@ -1122,6 +1140,22 @@ export async function finalizeTransactionForRules(
         delete stx.parent_amount;
       }
     });
+  }
+
+  // remove temporary normalization used for "is nothing" rules
+  const normalizedRuleFields = (
+    trans as TransactionEntity & { _normalizedRuleFields?: string[] }
+  )._normalizedRuleFields;
+
+  if (normalizedRuleFields) {
+    normalizedRuleFields.forEach(field => {
+      if (trans[field] === null) {
+        delete trans[field];
+      }
+    });
+
+    delete (trans as TransactionEntity & { _normalizedRuleFields?: string[] })
+      ._normalizedRuleFields;
   }
 
   return trans;

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -1143,19 +1143,17 @@ export async function finalizeTransactionForRules(
   }
 
   // remove temporary normalization used for "is nothing" rules
-  const normalizedRuleFields = (
-    trans as TransactionEntity & { _normalizedRuleFields?: string[] }
-  )._normalizedRuleFields;
-
-  if (normalizedRuleFields) {
-    normalizedRuleFields.forEach(field => {
-      if (trans[field] === null) {
-        delete trans[field];
+  if (
+    '_normalizedRuleFields' in trans &&
+    Array.isArray(trans._normalizedRuleFields)
+  ) {
+    trans._normalizedRuleFields.forEach(field => {
+      if ((trans as Record<string, unknown>)[field] === null) {
+        delete (trans as Record<string, unknown>)[field];
       }
     });
 
-    delete (trans as TransactionEntity & { _normalizedRuleFields?: string[] })
-      ._normalizedRuleFields;
+    delete trans._normalizedRuleFields;
   }
 
   return trans;

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -967,6 +967,8 @@ export type TransactionForRules = TransactionEntity & {
   parent_amount?: number;
   /** Prefetched cent balances for BALANCE_OF("…") in rule formulas; cleared in finalize */
   _balanceOfPrefetched?: Map<string, number>;
+  /** Fields normalized from undefined→null for rule matching; cleared in finalize */
+  _normalizedRuleFields?: string[];
 };
 
 /**
@@ -1059,9 +1061,7 @@ export async function prepareTransactionForRules(
   }
 
   if (normalizedRuleFields.length > 0) {
-    (
-      r as TransactionForRules & { _normalizedRuleFields?: string[] }
-    )._normalizedRuleFields = normalizedRuleFields;
+    r._normalizedRuleFields = normalizedRuleFields;
   }
   if (trans.payee) {
     const payee = await getPayee(trans.payee);

--- a/upcoming-release-notes/7531.md
+++ b/upcoming-release-notes/7531.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [sk10727-a11y]
+---
+
+Fixes an issue where "payee is blank, set payee" or "category is blank, set category" were not being enforced correctly.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes an issue where "payee is blank, set payee" or "category is blank, set category" were not being enforced correctly. Transactions missing those fields were not matching the rule condition as expected, causing the action to be skipped.

This change normalizes missing ID fields during rule matching, so blank payee and blank category conditions are handled consistently. 

## Related issue(s)

Fixes #5724

## Testing

Tested rule behavior for "is nothing" conditions across different flows by creating two rules: payee is nothing → set payee and category is nothing → set category. Tested both rules in both the All Accounts view and individual account views.

Verified that the rules applied automatically for new transactions in both views. No regressions observed for other rule conditions.

## Notes

- As a result of this fix, rules targeting blank fields (e.g. "payee is blank") will now correctly apply during manual transaction entry, since missing values are normalized during rule evaluation.

- For testing:
  - In "All Accounts", rules trigger as long as required fields like date and account are set.
  - In a specific account view, transactions must have a nonzero amount before rules are applied.

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.87 MB | 0%
loot-core | 1 | 5.27 MB → 5.27 MB (+553 B) | +0.01%
api | 2 | 3.89 MB → 3.89 MB (+537 B) | +0.01%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.86 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+553 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +553 B (+2.57%) | 21.02 kB → 21.56 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D2pXlvdi.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.JKo6NKKa.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.89 MB (+537 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +537 B (+2.56%) | 20.52 kB → 21.04 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.89 MB (+537 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->