### PR TITLE
fix error when clearing the payee field of a transaction

### DIFF
--- a/packages/loot-core/src/server/aql/schema-helpers.test.ts
+++ b/packages/loot-core/src/server/aql/schema-helpers.test.ts
@@ -201,6 +201,18 @@ describe('schema-helpers', () => {
     });
   });
 
+  test('undefined values are skipped when updating', () => {
+    const trans = convertForUpdate(basicSchema, {}, 'transactions', {
+      id: 'id',
+      notes: undefined,
+      cleared: false,
+    });
+    expect(trans).toEqual({
+      id: 'id',
+      cleared: 0,
+    });
+  });
+
   test('floats are not allowed as input types to integers', () => {
     expect(() => {
       convertForUpdate(basicSchema, {}, 'transactions', {

--- a/packages/loot-core/src/server/aql/schema-helpers.ts
+++ b/packages/loot-core/src/server/aql/schema-helpers.ts
@@ -132,6 +132,11 @@ export function conform(
           );
         }
 
+        // treat undefined as missing
+        if (obj[field] === undefined) {
+          return null;
+        }
+
         // This option removes null values (see `convertForInsert`)
         if (skipNull && obj[field] == null) {
           return null;

--- a/upcoming-release-notes/7532.md
+++ b/upcoming-release-notes/7532.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix error when clearing the payee field of a transaction


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

The blast radius of this one might be quite big, but it seems like the sensible fix as undefined was a no-op anyway, and definitely fixes the reported issue. In all honesty I can't understand why we haven't hit this before

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes https://github.com/actualbudget/actual/issues/7530

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Follow repro steps in the linked issue

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.93 MB | 0%
loot-core | 1 | 4.85 MB → 4.85 MB (+43 B) | +0.00%
api | 1 | 3.88 MB → 3.88 MB (+42 B) | +0.00%
cli | 1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.93 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.13 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 709.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 484.53 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.49 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 9.86 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+43 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema-helpers.ts` | 📈 +43 B (+1.06%) | 3.95 kB → 3.99 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DlizRlNG.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.iwwnFvvZ.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (+42 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema-helpers.ts` | 📈 +42 B (+1.06%) | 3.87 kB → 3.91 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+42 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->