### PR TITLE
[AI] sync-server: use workspace reference for @actual-app/crdt

### DIFF
--- a/bin/package-browser
+++ b/bin/package-browser
@@ -16,6 +16,7 @@ packages/desktop-client/bin/remove-untranslated-languages
 
 export NODE_OPTIONS="--max-old-space-size=4096"
 
+yarn workspace @actual-app/crdt build
 yarn workspace plugins-service build
 yarn workspace @actual-app/core build:browser
 yarn workspace @actual-app/web build:browser

--- a/bin/package-electron
+++ b/bin/package-electron
@@ -51,6 +51,7 @@ fi
 
 export NODE_OPTIONS="--max-old-space-size=4096"
 
+yarn workspace @actual-app/crdt build
 yarn workspace plugins-service build
 yarn workspace @actual-app/core build:node
 yarn workspace @actual-app/web build --mode=desktop # electron specific build

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -9,7 +9,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "development": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
   },
   "publishConfig": {
     "exports": {

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -77,7 +77,7 @@
     "health-check": "yarn build && node build/src/scripts/health-check.js"
   },
   "dependencies": {
-    "@actual-app/crdt": "2.1.0",
+    "@actual-app/crdt": "workspace:*",
     "@actual-app/web": "workspace:*",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.8.0",

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -63,7 +63,7 @@
   "scripts": {
     "start": "yarn build && node build/app",
     "start-monitor": "nodemon --exec 'yarn build && node build/app' --ignore './build/**/*' --ext 'ts,js' build/app",
-    "build": "tsgo && yarn add-import-extensions && yarn copy-static-assets",
+    "build": "tsgo -b && yarn add-import-extensions && yarn copy-static-assets",
     "typecheck": "tsgo -b && tsc-strict",
     "add-import-extensions": "node bin/add-import-extensions.mjs",
     "copy-static-assets": "rm -rf build/src/sql && cp -r src/sql build/src/sql",

--- a/upcoming-release-notes/7541.md
+++ b/upcoming-release-notes/7541.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Server: consume latest version of crdt package

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,17 +153,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@actual-app/crdt@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@actual-app/crdt@npm:2.1.0"
-  dependencies:
-    google-protobuf: "npm:^3.12.0-rc.1"
-    murmurhash: "npm:^2.0.1"
-    uuid: "npm:^9.0.0"
-  checksum: 10/1007e78eb9bdfdca8ce5c6fc72543d6a9fb34cd13ea2eefd2176abcb181100418b51774fd6217f0b62418567a51f7724b4c72f7ebc9231f0ee13b6c1bdc729ba
-  languageName: node
-  linkType: hard
-
 "@actual-app/crdt@workspace:*, @actual-app/crdt@workspace:packages/crdt":
   version: 0.0.0-use.local
   resolution: "@actual-app/crdt@workspace:packages/crdt"
@@ -184,7 +173,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@actual-app/sync-server@workspace:packages/sync-server"
   dependencies:
-    "@actual-app/crdt": "npm:2.1.0"
+    "@actual-app/crdt": "workspace:*"
     "@actual-app/web": "workspace:*"
     "@types/bcrypt": "npm:^6.0.0"
     "@types/better-sqlite3": "npm:^7.6.13"
@@ -17033,7 +17022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-protobuf@npm:^3.12.0-rc.1, google-protobuf@npm:^3.15.5, google-protobuf@npm:^3.21.4":
+"google-protobuf@npm:^3.15.5, google-protobuf@npm:^3.21.4":
   version: 3.21.4
   resolution: "google-protobuf@npm:3.21.4"
   checksum: 10/0d87fe8ef221d105cbaa808f4024bd577638524d8e461469e3733f2e4933391ad4da86b7fcbd11e8781bee04eacf2e8ba19aaacd5f9deb336a220485841d980f
@@ -28061,15 +28050,6 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 10/9a5f7aa1d6f56dd1e8d5f2478f855f25c645e64e26e347a98e98d95781d5ed20062d6cca2eecb58ba7c84bc3910be95c0451ef4161906abaab44f9cb68ffbdd1
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10/9d0b6adb72b736e36f2b1b53da0d559125ba3e39d913b6072f6f033e0c87835b414f0836b45bcfaf2bdf698f92297fea1c3cc19b0b258bc182c9c43cc0fab9f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Using workspace crdt package

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A


## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

N/A


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.93 MB | 0%
loot-core | 1 | 4.85 MB → 4.85 MB (+4.04 kB) | +0.08%
api | 1 | 3.88 MB → 3.89 MB (+4.47 kB) | +0.11%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.93 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.13 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 709.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 484.53 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.49 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 7.62 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+4.04 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/crdt/dist/index.js` | 🆕 +27.85 kB | 0 B → 27.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/repair.ts` | 📈 +82 B (+14.04%) | 584 B → 666 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/encoder.ts` | 📈 +108 B (+3.78%) | 2.79 kB → 2.9 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/make-test-message.ts` | 📈 +12 B (+2.58%) | 466 B → 478 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +302 B (+2.09%) | 14.12 kB → 14.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/migrate.ts` | 📈 +12 B (+1.44%) | 834 B → 846 B
`home/runner/work/actual/actual/packages/loot-core/src/server/prefs.ts` | 📈 +12 B (+0.96%) | 1.23 kB → 1.24 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +150 B (+0.75%) | 19.52 kB → 19.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/undo.ts` | 📈 +24 B (+0.49%) | 4.83 kB → 4.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +48 B (+0.43%) | 10.98 kB → 11.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +59 B (+0.23%) | 24.7 kB → 24.76 kB
`node_modules/asn1.js/lib/asn1/decoders/pem.js` | 📈 +2 B (+0.15%) | 1.27 kB → 1.27 kB
`node_modules/safe-buffer/index.js` | 📈 +2 B (+0.13%) | 1.48 kB → 1.49 kB
`node_modules/core-util-is/lib/util.js` | 📈 +2 B (+0.10%) | 1.87 kB → 1.87 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +17 B (+0.07%) | 22.62 kB → 22.64 kB
`node_modules/asn1.js/lib/asn1/base/buffer.js` | 📈 +2 B (+0.06%) | 3.12 kB → 3.12 kB
`node_modules/ripemd160/index.js` | 📈 +2 B (+0.04%) | 5.52 kB → 5.53 kB
`node_modules/readable-stream/lib/internal/streams/buffer_list.js` | 📈 +2 B (+0.03%) | 6.59 kB → 6.6 kB
`node_modules/asn1.js/lib/asn1/encoders/der.js` | 📈 +2 B (+0.03%) | 7.01 kB → 7.02 kB
`node_modules/browserify-zlib/lib/index.js` | 📈 +4 B (+0.03%) | 14.24 kB → 14.24 kB
`node_modules/vite-plugin-node-polyfills/shims/buffer/dist/index.cjs` | 📈 +2 B (+0.00%) | 55.63 kB → 55.64 kB
`node_modules/bn.js/lib/bn.js` | 📈 +2 B (+0.00%) | 76.41 kB → 76.41 kB
`home/runner/work/actual/actual/packages/crdt/src/crdt/index.ts` |   +0 B (0%) | 0 B → 0 B
`home/runner/work/actual/actual/packages/crdt/src/proto/sync_pb.js` | 🔥 -17.19 kB (-100%) | 17.19 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/crdt/timestamp.ts` | 🔥 -5.14 kB (-100%) | 5.14 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/crdt/merkle.ts` | 🔥 -2.02 kB (-100%) | 2.02 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/index.ts` | 🔥 -320 B (-100%) | 320 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DTt2NNUm.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CfHq3vDC.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.89 MB (+4.47 kB) | +0.11%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/crdt/dist/index.js` | 🆕 +43.63 kB | 0 B → 43.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/repair.ts` | 📈 +82 B (+14.07%) | 583 B → 665 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/encoder.ts` | 📈 +108 B (+3.90%) | 2.7 kB → 2.81 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/make-test-message.ts` | 📈 +12 B (+2.59%) | 464 B → 476 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +302 B (+2.16%) | 13.68 kB → 13.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/migrate.ts` | 📈 +12 B (+1.48%) | 813 B → 825 B
`home/runner/work/actual/actual/packages/loot-core/src/server/prefs.ts` | 📈 +12 B (+1.00%) | 1.17 kB → 1.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +150 B (+0.73%) | 19.96 kB → 20.11 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/undo.ts` | 📈 +24 B (+0.50%) | 4.68 kB → 4.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +48 B (+0.44%) | 10.63 kB → 10.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +59 B (+0.24%) | 24.07 kB → 24.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +17 B (+0.08%) | 22.03 kB → 22.05 kB
`home/runner/work/actual/actual/packages/crdt/src/crdt/index.ts` |   +0 B (0%) | 0 B → 0 B
`home/runner/work/actual/actual/packages/crdt/src/proto/sync_pb.js` | 🔥 -32.37 kB (-100%) | 32.37 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/crdt/timestamp.ts` | 🔥 -5.29 kB (-100%) | 5.29 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/crdt/merkle.ts` | 🔥 -2 kB (-100%) | 2 kB → 0 B
`home/runner/work/actual/actual/packages/crdt/src/index.ts` | 🔥 -310 B (-100%) | 310 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.89 MB (+4.47 kB) | +0.11%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->