### PR TITLE
[WIP] Post scheduled future transactions with correct date

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1489,16 +1489,13 @@ class AccountInternal extends PureComponent<
     name: 'skip' | 'post-transaction' | 'post-transaction-today' | 'complete',
     ids: TransactionEntity['id'][],
   ) => {
-    const scheduleIds = ids.map(id => id.split('/')[1]);
+    const idParts = ids.map(id => id.split('/'));
+    const scheduleIds = idParts.map(parts => parts[1]);
 
     switch (name) {
       case 'post-transaction':
-        for (const id of ids) {
-          const parts = id.split('/');
-          await send('schedule/post-transaction', {
-            id: parts[1],
-            date: parts[2],
-          });
+        for (const [, scheduleId, date] of idParts) {
+          await send('schedule/post-transaction', { id: scheduleId, date });
         }
         void this.refetchTransactions();
         break;

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1493,8 +1493,12 @@ class AccountInternal extends PureComponent<
 
     switch (name) {
       case 'post-transaction':
-        for (const id of scheduleIds) {
-          await send('schedule/post-transaction', { id });
+        for (const id of ids) {
+          const parts = id.split('/');
+          await send('schedule/post-transaction', {
+            id: parts[1],
+            date: parts[2],
+          });
         }
         void this.refetchTransactions();
         break;

--- a/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountTransactions.tsx
@@ -158,6 +158,7 @@ function TransactionListWithPreviews({
                   await send('schedule/post-transaction', {
                     id: parts[1],
                     today,
+                    date: today ? undefined : parts[2],
                   });
                   dispatch(
                     collapseModals({

--- a/packages/desktop-client/src/components/mobile/accounts/AllAccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AllAccountTransactions.tsx
@@ -76,6 +76,7 @@ function TransactionListWithPreviews() {
                   await send('schedule/post-transaction', {
                     id: parts[1],
                     today,
+                    date: today ? undefined : parts[2],
                   });
                   dispatch(
                     collapseModals({

--- a/packages/desktop-client/src/components/mobile/accounts/OffBudgetAccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/OffBudgetAccountTransactions.tsx
@@ -90,6 +90,7 @@ function TransactionListWithPreviews() {
                   await send('schedule/post-transaction', {
                     id: parts[1],
                     today,
+                    date: today ? undefined : parts[2],
                   });
                   dispatch(
                     collapseModals({

--- a/packages/desktop-client/src/components/mobile/accounts/OnBudgetAccountTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/OnBudgetAccountTransactions.tsx
@@ -90,6 +90,7 @@ function TransactionListWithPreviews() {
                   await send('schedule/post-transaction', {
                     id: parts[1],
                     today,
+                    date: today ? undefined : parts[2],
                   });
                   dispatch(
                     collapseModals({

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -535,14 +535,13 @@ describe('schedule app', () => {
         ],
       });
 
-      // Confirm initial next_date is Nov 28 (first occurrence on or after today Nov 29 is Dec 12,
-      // but createSchedule calls getNextDate with new Date() = Nov 29, so it should be Dec 12).
-      // Actually createSchedule uses getNextDate without a MockDate start – let's just check it's set.
+      // In test mode, monthUtils.currentDay() is hardcoded to '2017-01-01' (MockDate has no
+      // effect on it). So getNextDate picks the first occurrence of the bi-weekly schedule
+      // on or after 2017-01-01, which is the schedule start date: Nov 14 2020.
       let res = await aqlQuery(
         q('schedules').filter({ id: scheduleId }).select(['next_date']),
       );
-      // next_date is Dec 12 because createSchedule is called on Nov 29
-      expect(res.data[0].next_date).toBe('2020-12-12');
+      expect(res.data[0].next_date).toBe('2020-11-14');
 
       // Simulate: user manually posts the Dec 26 preview occurrence
       // (as if Dec 12 was already paid and Dec 26 is the next upcoming preview)

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -2,6 +2,7 @@
 import MockDate from 'mockdate';
 
 import { aqlQuery } from '#server/aql';
+import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 import { loadRules, updateRule } from '#server/transactions/transaction-rules';
 import { q } from '#shared/query';
@@ -11,6 +12,7 @@ import {
   areConditionValuesEqual,
   createSchedule,
   deleteSchedule,
+  postTransactionForSchedule,
   setNextDate,
   skipNextDate,
   updateConditions,
@@ -497,6 +499,63 @@ describe('schedule app', () => {
       row = res.data[0];
 
       expect(row.next_date).toBe('2020-12-11');
+    });
+
+    it('postTransactionForSchedule posts with the provided date and advances next_date', async () => {
+      /* Bi-weekly schedule starting Nov 14 2020:
+       * occurrences: Nov 14, Nov 28, Dec 12, Dec 26, ...
+       * Scenario: Nov 28 transaction already exists (schedule is 'paid'),
+       * UI shows Dec 12 as the next upcoming preview and user posts it.
+       * Expected: transaction posts on Dec 12 and next_date advances to Dec 26.
+       */
+      MockDate.set(new Date(2020, 10, 29)); // Nov 29 – after Nov 28 was manually posted
+
+      const accountId = await db.insertAccount({
+        id: 'test-account',
+        name: 'Test Account',
+      });
+
+      const scheduleId = await createSchedule({
+        conditions: [
+          {
+            op: 'is',
+            field: 'account',
+            value: accountId,
+          },
+          {
+            op: 'isapprox',
+            field: 'date',
+            value: {
+              start: '2020-11-14',
+              frequency: 'weekly',
+              interval: 2,
+              patterns: [],
+            },
+          },
+        ],
+      });
+
+      // Confirm initial next_date is Nov 28 (first occurrence on or after today Nov 29 is Dec 12,
+      // but createSchedule calls getNextDate with new Date() = Nov 29, so it should be Dec 12).
+      // Actually createSchedule uses getNextDate without a MockDate start – let's just check it's set.
+      let res = await aqlQuery(
+        q('schedules').filter({ id: scheduleId }).select(['next_date']),
+      );
+      // next_date is Dec 12 because createSchedule is called on Nov 29
+      expect(res.data[0].next_date).toBe('2020-12-12');
+
+      // Simulate: user manually posts the Dec 26 preview occurrence
+      // (as if Dec 12 was already paid and Dec 26 is the next upcoming preview)
+      await postTransactionForSchedule({
+        id: scheduleId,
+        date: '2020-12-26',
+      });
+
+      res = await aqlQuery(
+        q('schedules').filter({ id: scheduleId }).select(['next_date']),
+      );
+      // next_date should now be Jan 9 2021 (two weeks after Dec 26)
+      expect(res.data[0].next_date).toBe('2021-01-09');
     });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -535,6 +535,15 @@ describe('schedule app', () => {
         ],
       });
 
+      // Seed schedules_json_paths so the AQL view can resolve _account.
+      // In production this is done by the trackJSONPaths service; in tests
+      // that service is not started so we insert the paths manually.
+      // Conditions are ordered [account (idx 0), date (idx 1)].
+      db.runQuery(
+        'INSERT OR REPLACE INTO schedules_json_paths (schedule_id, payee, account, amount, date) VALUES (?, ?, ?, ?, ?)',
+        [scheduleId, null, '$[0]', null, '$[1]'],
+      );
+
       // In test mode, monthUtils.currentDay() is hardcoded to '2017-01-01' (MockDate has no
       // effect on it). So getNextDate picks the first occurrence of the bi-weekly schedule
       // on or after 2017-01-01, which is the schedule start date: Nov 14 2020.

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -510,10 +510,10 @@ export async function postTransactionForSchedule({
   if (transaction.account) {
     await addTransactions(transaction.account, [transaction]);
 
-    // If a specific future date was provided that differs from the stored
-    // next_date, advance the schedule past the posted date so it won't
+    // If a specific future date was provided that is strictly later than the
+    // stored next_date, advance the schedule past the posted date so it won't
     // appear as an unpaid occurrence on the next service run.
-    if (!today && date && date !== schedule.next_date) {
+    if (!today && date && schedule.next_date && date > schedule.next_date) {
       await setNextDate({
         id,
         start: () => d.addDays(parseDate(date), 1),

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -509,16 +509,16 @@ export async function postTransactionForSchedule({
 
   if (transaction.account) {
     await addTransactions(transaction.account, [transaction]);
-  }
 
-  // If a specific future date was provided that differs from the stored
-  // next_date, advance the schedule past the posted date so it won't
-  // appear as an unpaid occurrence on the next service run.
-  if (!today && date && date !== schedule.next_date) {
-    await setNextDate({
-      id,
-      start: () => d.addDays(parseDate(date), 1),
-    });
+    // If a specific future date was provided that differs from the stored
+    // next_date, advance the schedule past the posted date so it won't
+    // appear as an unpaid occurrence on the next service run.
+    if (!today && date && date !== schedule.next_date) {
+      await setNextDate({
+        id,
+        start: () => d.addDays(parseDate(date), 1),
+      });
+    }
   }
 }
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -492,7 +492,7 @@ export async function postTransactionForSchedule({
 }) {
   const { data } = await aqlQuery(q('schedules').filter({ id }).select('*'));
   const schedule = data[0];
-  if (schedule == null || schedule._account == null) {
+  if (!schedule) {
     return;
   }
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -481,12 +481,14 @@ function onApplySync(oldValues, newValues) {
 // This is the service that move schedules forward automatically and
 // posts transactions
 
-async function postTransactionForSchedule({
+export async function postTransactionForSchedule({
   id,
   today,
+  date,
 }: {
   id: string;
   today?: boolean;
+  date?: string;
 }) {
   const { data } = await aqlQuery(q('schedules').filter({ id }).select('*'));
   const schedule = data[0];
@@ -494,17 +496,29 @@ async function postTransactionForSchedule({
     return;
   }
 
+  const transactionDate = today ? currentDay() : (date ?? schedule.next_date);
+
   const transaction = {
     payee: schedule._payee,
     account: schedule._account,
     amount: getScheduledAmount(schedule._amount),
-    date: today ? currentDay() : schedule.next_date,
+    date: transactionDate,
     schedule: schedule.id,
     cleared: false,
   };
 
   if (transaction.account) {
     await addTransactions(transaction.account, [transaction]);
+  }
+
+  // If a specific future date was provided that differs from the stored
+  // next_date, advance the schedule past the posted date so it won't
+  // appear as an unpaid occurrence on the next service run.
+  if (!today && date && date !== schedule.next_date) {
+    await setNextDate({
+      id,
+      start: () => d.addDays(parseDate(date), 1),
+    });
   }
 }
 

--- a/upcoming-release-notes/7544.md
+++ b/upcoming-release-notes/7544.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [validorange]
+---
+
+Post scheduled future transactions with correct date


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

This fixes a bug: When a schedule already has a future-dated transaction posted, posting another transaction further in the future posts with the wrong date.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

- Create a schedule "Paycheck" with a weekly schedule
- "Change upcoming length" to 1 month or greater (so that multiple future transactions show)
- Go to the account view, select the next scheduled transaction and post it. This one posts correctly.
- Select the next scheduled transaction and post it. This one posts with the same date as the first one, creating a duplicate (despite showing the correct scheduled date).
 
## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.93 MB → 12.93 MB (+363 B) | +0.00%
loot-core | 1 | 4.85 MB → 4.85 MB (+186 B) | +0.00%
api | 1 | 3.88 MB → 3.88 MB (+179 B) | +0.00%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.93 MB → 12.93 MB (+363 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/accounts/AllAccountTransactions.tsx` | 📈 +67 B (+1.41%) | 4.65 kB → 4.71 kB
`src/components/mobile/accounts/OnBudgetAccountTransactions.tsx` | 📈 +67 B (+1.24%) | 5.26 kB → 5.33 kB
`src/components/mobile/accounts/OffBudgetAccountTransactions.tsx` | 📈 +67 B (+1.24%) | 5.27 kB → 5.34 kB
`src/components/mobile/accounts/AccountTransactions.tsx` | 📈 +67 B (+0.76%) | 8.6 kB → 8.67 kB
`src/components/accounts/Account.tsx` | 📈 +95 B (+0.21%) | 44.12 kB → 44.21 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/narrow.js | 363.68 kB → 363.94 kB (+268 B) | +0.07%
static/js/index.js | 1.85 MB → 1.85 MB (+95 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.13 kB | 0%
static/js/ReportRouter.js | 1.18 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 709.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 484.53 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.49 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 7.62 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB → 4.85 MB (+186 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +186 B (+1.52%) | 11.93 kB → 12.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DVgRSCIb.js | 0 B → 4.85 MB (+4.85 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CfHq3vDC.js | 4.85 MB → 0 B (-4.85 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.88 MB → 3.88 MB (+179 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +179 B (+1.50%) | 11.69 kB → 11.86 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+179 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->