### PR TITLE
ci: disable fail-fast for Electron build workflows

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/.github/workflows/publish-nightly-electron.yml
+++ b/.github/workflows/publish-nightly-electron.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu-22.04

--- a/upcoming-release-notes/7547.md
+++ b/upcoming-release-notes/7547.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Disable fail-fast in Electron build workflows to allow all matrix jobs to complete independently.


### PR DESCRIPTION
## Description

This PR disables the `fail-fast` strategy in three Electron build workflows to ensure all matrix jobs complete even if one fails. 

## Related issue(s)

N/A

## Testing

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed
