### PR TITLE
[codex] Exclude income categories from tracking spending budgets

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
@@ -1,0 +1,65 @@
+import * as connection from '@actual-app/core/platform/client/connection';
+import { describe, expect, it, vi } from 'vitest';
+
+import { aqlQuery } from '#queries/aqlQuery';
+
+import { createSpendingSpreadsheet } from './spending-spreadsheet';
+
+vi.mock('#queries/aqlQuery', () => ({
+  aqlQuery: vi.fn(),
+}));
+
+describe('createSpendingSpreadsheet', () => {
+  it('excludes income categories from the budgeted line in tracking budgets', async () => {
+    vi.spyOn(connection, 'send').mockImplementation(async name => {
+      if (name === 'make-filters-from-conditions') {
+        return { filters: [] };
+      }
+
+      if (name === 'get-categories') {
+        return {
+          grouped: [],
+          list: [
+            { id: 'food', is_income: false, name: 'Food' },
+            { id: 'income', is_income: true, name: 'Income' },
+          ],
+        };
+      }
+
+      throw new Error(`Unknown command: ${name}`);
+    });
+
+    vi.mocked(aqlQuery).mockImplementation(async query => {
+      const table = query.serialize().table;
+
+      if (table === 'transactions') {
+        return { data: [], dependencies: [] };
+      }
+
+      if (table === 'reflect_budgets') {
+        return {
+          data: [
+            { category: 'food', amount: 100 },
+            { category: 'income', amount: 100 },
+          ],
+          dependencies: [],
+        };
+      }
+
+      throw new Error(`Unexpected query table: ${table}`);
+    });
+
+    const setData = vi.fn();
+    const spreadsheet = createSpendingSpreadsheet({
+      compare: '2026-04',
+      compareTo: '2026-03',
+      budgetType: 'tracking',
+    });
+
+    await spreadsheet({} as never, setData);
+
+    const data = setData.mock.calls[0][0];
+
+    expect(data.intervalData[27].budget).toBeCloseTo(-100);
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -2,6 +2,7 @@ import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { q } from '@actual-app/core/shared/query';
 import type {
+  CategoryEntity,
   RuleConditionEntity,
   SpendingEntity,
   SpendingMonthEntity,
@@ -43,21 +44,26 @@ export function createSpendingSpreadsheet({
     spreadsheet: ReturnType<typeof useSpreadsheet>,
     setData: (data: SpendingEntity) => void,
   ) => {
-    const { filters } = await send('make-filters-from-conditions', {
-      conditions: conditions.filter(cond => !cond.customName),
-    });
-
-    const { filters: budgetFilters } = await send(
-      'make-filters-from-conditions',
-      {
-        conditions: conditions.filter(
-          cond => !cond.customName && cond.field === 'category',
-        ),
-        applySpecialCases: false,
-      },
-    );
+    const [{ filters }, { filters: budgetFilters }, { list: categories }] =
+      await Promise.all([
+        send('make-filters-from-conditions', {
+          conditions: conditions.filter(cond => !cond.customName),
+        }),
+        send('make-filters-from-conditions', {
+          conditions: conditions.filter(
+            cond => !cond.customName && cond.field === 'category',
+          ),
+          applySpecialCases: false,
+        }),
+        send('get-categories'),
+      ]);
 
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
+    const expenseCategoryIds = new Set(
+      categories
+        .filter((category: CategoryEntity) => !category.is_income)
+        .map((category: CategoryEntity) => category.id),
+    );
 
     const [assets, debts] = await Promise.all([
       aqlQuery(
@@ -133,9 +139,13 @@ export function createSpendingSpreadsheet({
       ).then(({ data }) => data),
     ]);
 
-    const dailyBudget =
-      budgets &&
-      budgets.reduce((a, v) => a + v.amount, 0) / compareInterval.length;
+    const totalBudgetAmount =
+      budgets?.reduce(
+        (sum, budget) =>
+          expenseCategoryIds.has(budget.category) ? sum + budget.amount : sum,
+        0,
+      ) ?? 0;
+    const dailyBudget = totalBudgetAmount / compareInterval.length;
 
     const intervals = monthUtils.dayRangeInclusive(startDate, endDate);
     if (endDateTo < startDate || startDateTo > endDate) {

--- a/upcoming-release-notes/7549.md
+++ b/upcoming-release-notes/7549.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [pranayseela]
+---
+
+Fix Spending Analysis budget totals for tracking budgets with income categories.


### PR DESCRIPTION
### Summary

- exclude income categories when summing tracking-budget values for the Spending Analysis report in Budgeted mode
- add a regression test covering mixed expense and income budgets
- add `upcoming-release-notes/7549.md`

## Description

Issue #7419 happens because the Budgeted line sums all reflected budget rows, including income categories, while the transaction side of the report already excludes income. This change fetches categories, filters the budget total down to non-income categories only, and adds a regression test so tracking budgets with income entries do not inflate the spending total.

## Related issue(s)

Fixes #7419

## Testing

- `/Users/pranaymbp/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node .yarn/releases/yarn-4.13.0.cjs workspace @actual-app/web vitest run src/components/reports/spreadsheets/spending-spreadsheet.test.ts`

## Checklist

- [x] Release notes added (see `upcoming-release-notes/7549.md`)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 12.94 MB → 12.94 MB (+246 B) | +0.00%
loot-core | 1 | 4.85 MB | 0%
api | 1 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 12.94 MB → 12.94 MB (+246 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📈 +246 B (+4.32%) | 5.56 kB → 5.8 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.18 MB → 1.18 MB (+246 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.85 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.13 kB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 185.13 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.34 MB | 0%
static/js/ca.js | 191.72 kB | 0%
static/js/chart-theme.js | 709.55 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.12 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.5 kB | 0%
static/js/es.js | 181.54 kB | 0%
static/js/extends.js | 487.8 kB | 0%
static/js/fr.js | 176.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.68 kB | 0%
static/js/narrow.js | 363.68 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.49 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 30.79 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 7.62 kB | 0%
static/js/wide.js | 292 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 110.19 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DvDd_fWg.js | 4.85 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->