### PR TITLE
Enable trusted publishing for nightly `npm` packages

### DIFF
--- a/.github/workflows/publish-nightly-npm-packages.yml
+++ b/.github/workflows/publish-nightly-npm-packages.yml
@@ -81,7 +81,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write  # Required for OIDC
+      id-token: write # Required for OIDC
     steps:
       - name: Download the artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish-nightly-npm-packages.yml
+++ b/.github/workflows/publish-nightly-npm-packages.yml
@@ -81,6 +81,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for OIDC
     steps:
       - name: Download the artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -96,29 +97,19 @@ jobs:
       - name: Publish Core
         run: |
           npm publish loot-core/@actual-app/core.tgz --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Web
         run: |
           npm publish desktop-client/@actual-app/web.tgz --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Sync-Server
         run: |
           npm publish sync-server/@actual-app/sync-server.tgz --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish API
         run: |
           npm publish api/@actual-app/api.tgz --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish CLI
         run: |
           npm publish cli/@actual-app/cli.tgz --access public --tag nightly
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/upcoming-release-notes/7556.md
+++ b/upcoming-release-notes/7556.md
@@ -1,6 +1,6 @@
 ---
-category: Enhancements
+category: Maintenance
 authors: [jfdoming]
 ---
 
-Enable OIDC-based authentication for nightly npm package publishing, enhancing security and simplicity.
+Enable [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) for nightly `npm` packages

--- a/upcoming-release-notes/7556.md
+++ b/upcoming-release-notes/7556.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [jfdoming]
+---
+
+Enable OIDC-based authentication for nightly npm package publishing, enhancing security and simplicity.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Ref: https://docs.npmjs.com/trusted-publishers

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Will merge and test with the nightly workflow first before we migrate regular publishing

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
