### PR TITLE
[WIP] [AI] [POC] Cumulative milestone allocation for #template by and schedule

### DIFF
--- a/packages/loot-core/src/server/budget/category-template-context.test.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.test.ts
@@ -860,7 +860,8 @@ describe('CategoryTemplateContext', () => {
 
     it('should calculate monthly amount needed for multiple targets', () => {
       const result = CategoryTemplateContext.runBy(instance);
-      expect(result).toBe(66667);
+      // Cumulative envelope: max of 1000/3 mo and 3000/6 mo to minor units
+      expect(result).toBe(50000);
     });
 
     it('should handle repeating targets', () => {
@@ -890,7 +891,7 @@ describe('CategoryTemplateContext', () => {
       );
 
       const result = CategoryTemplateContext.runBy(instance);
-      expect(result).toBe(83333);
+      expect(result).toBe(50000);
     });
 
     it('should handle existing balance', () => {
@@ -918,7 +919,7 @@ describe('CategoryTemplateContext', () => {
       );
 
       const result = CategoryTemplateContext.runBy(instance);
-      expect(result).toBe(66500); // (1000 + 2000 - 5) / 3
+      expect(result).toBe(49917);
     });
   });
 

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -819,10 +819,6 @@ export class CategoryTemplateContext {
     }
 
     const balance = templateContext.fromLastMonth + accumulatedToBudget;
-    return allocateCumulativeMilestones(
-      merged,
-      templateContext.month,
-      balance,
-    );
+    return allocateCumulativeMilestones(merged, templateContext.month, balance);
   }
 }

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -15,13 +15,18 @@ import type {
   PeriodicTemplate,
   RefillTemplate,
   RemainderTemplate,
+  ScheduleTemplate,
   SimpleTemplate,
   SpendTemplate,
   Template,
 } from '#types/models/templates';
 
 import { getSheetBoolean, getSheetValue, isTrackingBudget } from './actions';
-import { runSchedule } from './schedule-template';
+import {
+  allocateCumulativeMilestones,
+  milestonesFromByTemplates,
+} from './milestone-allocation';
+import { loadScheduleMilestones } from './schedule-template';
 import { getActiveSchedules } from './statements';
 
 export class CategoryTemplateContext {
@@ -148,9 +153,7 @@ export class CategoryTemplateContext {
     );
     let available = budgetAvail || 0;
     let toBudget = 0;
-    let byFlag = false;
-    let remainder = 0;
-    let scheduleFlag = false;
+    let milestoneFlag = false;
     // switch on template type and calculate the amount for the line
     for (const template of t) {
       let newBudget = 0;
@@ -183,35 +186,15 @@ export class CategoryTemplateContext {
           );
           break;
         }
-        case 'by': {
-          // all by's get run at once
-          if (!byFlag) {
-            newBudget = CategoryTemplateContext.runBy(this);
-          } else {
-            newBudget = 0;
-          }
-          byFlag = true;
-          break;
-        }
+        case 'by':
         case 'schedule': {
-          if (!scheduleFlag) {
-            const budgeted = this.fromLastMonth + toBudget;
-            const ret = await runSchedule(
+          if (!milestoneFlag) {
+            newBudget = await CategoryTemplateContext.runMilestoneTemplates(
+              this,
               t,
-              this.month,
-              budgeted,
-              remainder,
-              this.fromLastMonth,
               toBudget,
-              [],
-              this.category,
-              this.currency,
             );
-            // Schedules assume that its to budget value is the whole thing so this
-            // needs to remove the previous funds so they aren't double counted
-            newBudget = ret.to_budget - toBudget;
-            remainder = ret.remainder;
-            scheduleFlag = true;
+            milestoneFlag = true;
           }
           break;
         }
@@ -788,75 +771,58 @@ export class CategoryTemplateContext {
     const byTemplates: ByTemplate[] = templateContext.templates.filter(
       t => t.type === 'by',
     );
-    const savedInfo = [];
-    let totalNeeded = 0;
-    let workingShortNumMonths;
-    //find shortest time period
-    for (let i = 0; i < byTemplates.length; i++) {
-      const template = byTemplates[i];
-      let targetMonth = `${template.month}`;
-      const period = template.annual
-        ? (template.repeat || 1) * 12
-        : template.repeat != null
-          ? template.repeat
-          : null;
-      let numMonths = monthUtils.differenceInCalendarMonths(
-        targetMonth,
+    return allocateCumulativeMilestones(
+      milestonesFromByTemplates(
+        byTemplates,
         templateContext.month,
-      );
-      while (numMonths < 0 && period) {
-        targetMonth = monthUtils.addMonths(targetMonth, period);
-        numMonths = monthUtils.differenceInCalendarMonths(
-          targetMonth,
-          templateContext.month,
-        );
-      }
-      savedInfo.push({ numMonths, period });
-      if (
-        workingShortNumMonths === undefined ||
-        numMonths < workingShortNumMonths
-      ) {
-        workingShortNumMonths = numMonths;
-      }
+        templateContext.currency,
+      ),
+      templateContext.month,
+      templateContext.fromLastMonth,
+    );
+  }
+
+  private static async runMilestoneTemplates(
+    templateContext: CategoryTemplateContext,
+    templatesAtPriority: Template[],
+    accumulatedToBudget: number,
+  ): Promise<number> {
+    const byTemplates = templatesAtPriority.filter(
+      t => t.type === 'by',
+    ) as ByTemplate[];
+    const scheduleTemplates = templatesAtPriority.filter(
+      t => t.type === 'schedule',
+    ) as ScheduleTemplate[];
+
+    if (byTemplates.length === 0 && scheduleTemplates.length === 0) {
+      return 0;
     }
 
-    // calculate needed funds per template
-    const shortNumMonths = workingShortNumMonths || 0;
-    for (let i = 0; i < byTemplates.length; i++) {
-      const template = byTemplates[i];
-      const numMonths = savedInfo[i].numMonths;
-      const period = savedInfo[i].period;
-      let amount;
-      // back interpolate what is needed in the short window
-      if (numMonths > shortNumMonths && period) {
-        amount = Math.round(
-          (amountToInteger(
-            template.amount,
-            templateContext.currency.decimalPlaces,
-          ) /
-            period) *
-            (period - numMonths + shortNumMonths),
-        );
-        // fallback to this.  This matches what the prior math accomplished, just more round about
-      } else if (numMonths > shortNumMonths) {
-        amount = Math.round(
-          (amountToInteger(
-            template.amount,
-            templateContext.currency.decimalPlaces,
-          ) /
-            (numMonths + 1)) *
-            (shortNumMonths + 1),
-        );
-      } else {
-        amount = amountToInteger(
-          template.amount,
-          templateContext.currency.decimalPlaces,
-        );
+    const fromBy = milestonesFromByTemplates(
+      byTemplates,
+      templateContext.month,
+      templateContext.currency,
+    );
+    const { milestones: fromSchedules, errors } = await loadScheduleMilestones(
+      scheduleTemplates,
+      templateContext.month,
+      templateContext.category,
+      templateContext.currency,
+    );
+
+    const merged = [...fromBy, ...fromSchedules];
+    if (merged.length === 0) {
+      if (errors.length > 0) {
+        throw new Error(errors.join('\n\n'));
       }
-      totalNeeded += amount;
+      return 0;
     }
-    return Math.round(
-      (totalNeeded - templateContext.fromLastMonth) / (shortNumMonths + 1),
+
+    const balance = templateContext.fromLastMonth + accumulatedToBudget;
+    return allocateCumulativeMilestones(
+      merged,
+      templateContext.month,
+      balance,
     );
   }
 }

--- a/packages/loot-core/src/server/budget/milestone-allocation.ts
+++ b/packages/loot-core/src/server/budget/milestone-allocation.ts
@@ -1,0 +1,105 @@
+import type { Currency } from '#shared/currencies';
+import * as monthUtils from '#shared/months';
+import { amountToInteger } from '#shared/util';
+import type { ByTemplate } from '#types/models/templates';
+
+/** One savings obligation: by the end of `month` (YYYY-MM), add `increment` to the running total needed. */
+export type BudgetMilestone = {
+  month: string;
+  increment: number;
+};
+
+function isMilestoneActive(deadlineMonth: string, currentMonth: string): boolean {
+  return monthUtils.differenceInCalendarMonths(deadlineMonth, currentMonth) >= 0;
+}
+
+/**
+ * Resolves `#template X by Y` lines into milestone increments (integer minor units).
+ * Drops targets that are still in the past after repeat roll-forward (caller validation may already reject those).
+ */
+export function milestonesFromByTemplates(
+  byTemplates: ByTemplate[],
+  currentMonth: string,
+  currency: Currency,
+): BudgetMilestone[] {
+  const out: BudgetMilestone[] = [];
+
+  for (const template of byTemplates) {
+    let targetMonth = `${template.month}`;
+    const period = template.annual
+      ? (template.repeat || 1) * 12
+      : template.repeat != null
+        ? template.repeat
+        : null;
+    let numMonths = monthUtils.differenceInCalendarMonths(
+      targetMonth,
+      currentMonth,
+    );
+    while (numMonths < 0 && period) {
+      targetMonth = monthUtils.addMonths(targetMonth, period);
+      numMonths = monthUtils.differenceInCalendarMonths(
+        targetMonth,
+        currentMonth,
+      );
+    }
+    if (numMonths < 0 || !isMilestoneActive(targetMonth, currentMonth)) {
+      continue;
+    }
+
+    const increment = amountToInteger(template.amount, currency.decimalPlaces);
+    out.push({ month: targetMonth, increment });
+  }
+
+  return out;
+}
+
+/**
+ * Cumulative milestone envelope: sort deadlines, cumulate increments, and take the maximum
+ * shortfall rate (minimax constant monthly contribution).
+ *
+ * `balance` is the category balance available toward these goals (carryover + amount already
+ * budgeted this month before this allocation).
+ *
+ * Uses the same month span convention as the previous `runBy` / `runSpend` helpers:
+ * monthly need = shortfall / (differenceInCalendarMonths(deadline, current) + 1).
+ */
+export function allocateCumulativeMilestones(
+  milestones: BudgetMilestone[],
+  currentMonth: string,
+  balance: number,
+): number {
+  if (milestones.length === 0) {
+    return 0;
+  }
+
+  const byMonth = new Map<string, number>();
+  for (const m of milestones) {
+    if (!isMilestoneActive(m.month, currentMonth)) {
+      continue;
+    }
+    byMonth.set(m.month, (byMonth.get(m.month) ?? 0) + m.increment);
+  }
+
+  const sortedMonths = [...byMonth.keys()].sort();
+  if (sortedMonths.length === 0) {
+    return 0;
+  }
+
+  let cumulative = 0;
+  let maxMonthly = 0;
+
+  for (const month of sortedMonths) {
+    cumulative += byMonth.get(month)!;
+    const numMonths = monthUtils.differenceInCalendarMonths(month, currentMonth);
+    if (numMonths < 0) {
+      continue;
+    }
+    const shortfall = Math.max(0, cumulative - balance);
+    const monthly = shortfall / (numMonths + 1);
+    if (monthly > maxMonthly) {
+      maxMonthly = monthly;
+    }
+  }
+
+  return Math.round(maxMonthly);
+}

--- a/packages/loot-core/src/server/budget/milestone-allocation.ts
+++ b/packages/loot-core/src/server/budget/milestone-allocation.ts
@@ -9,8 +9,13 @@ export type BudgetMilestone = {
   increment: number;
 };
 
-function isMilestoneActive(deadlineMonth: string, currentMonth: string): boolean {
-  return monthUtils.differenceInCalendarMonths(deadlineMonth, currentMonth) >= 0;
+function isMilestoneActive(
+  deadlineMonth: string,
+  currentMonth: string,
+): boolean {
+  return (
+    monthUtils.differenceInCalendarMonths(deadlineMonth, currentMonth) >= 0
+  );
 }
 
 /**
@@ -90,7 +95,10 @@ export function allocateCumulativeMilestones(
 
   for (const month of sortedMonths) {
     cumulative += byMonth.get(month)!;
-    const numMonths = monthUtils.differenceInCalendarMonths(month, currentMonth);
+    const numMonths = monthUtils.differenceInCalendarMonths(
+      month,
+      currentMonth,
+    );
     if (numMonths < 0) {
       continue;
     }

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -177,8 +177,8 @@ describe('runSchedule', () => {
       currency,
     );
 
-    // Then
-    expect(result.to_budget).toBe(1000);
+    // Then — fully funded for the next yearly occurrence; minimax monthly add is 0
+    expect(result.to_budget).toBe(0);
     expect(result.errors).toHaveLength(0);
     expect(result.remainder).toBe(0);
   });

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -15,10 +15,8 @@ import { amountToInteger } from '#shared/util';
 import type { CategoryEntity, TransactionEntity } from '#types/models';
 import type { ScheduleTemplate, Template } from '#types/models/templates';
 
-import {
-  allocateCumulativeMilestones,
-  type BudgetMilestone,
-} from './milestone-allocation';
+import { allocateCumulativeMilestones } from './milestone-allocation';
+import type { BudgetMilestone } from './milestone-allocation';
 
 type ScheduleTemplateTarget = {
   name: string;

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -15,7 +15,10 @@ import { amountToInteger } from '#shared/util';
 import type { CategoryEntity, TransactionEntity } from '#types/models';
 import type { ScheduleTemplate, Template } from '#types/models/templates';
 
-import { getSheetValue, isTrackingBudget } from './actions';
+import {
+  allocateCumulativeMilestones,
+  type BudgetMilestone,
+} from './milestone-allocation';
 
 type ScheduleTemplateTarget = {
   name: string;
@@ -208,98 +211,37 @@ async function createScheduleList(
   return { t: t.filter(c => c.completed === 0), errors };
 }
 
-function getPayMonthOfTotal(t: ScheduleTemplateTarget[]) {
-  //return the contribution amounts of full or every month type schedules
-  let total = 0;
-  const schedules = t.filter(c => c.num_months === 0);
-  for (const schedule of schedules) {
-    total += schedule.target;
-  }
-  return total;
-}
-
-async function getSinkingContributionTotal(
-  t: ScheduleTemplateTarget[],
-  remainder: number,
-  last_month_balance: number,
-) {
-  //return the contribution amount if there is a balance carried in the category
-  let total = 0;
-  for (const [index, schedule] of t.entries()) {
-    remainder =
-      index === 0
-        ? schedule.target - last_month_balance
-        : schedule.target - remainder;
-    let tg = 0;
-    if (remainder >= 0) {
-      tg = remainder;
-      remainder = 0;
-    } else {
-      tg = 0;
-      remainder = Math.abs(remainder);
+function scheduleTargetsToMilestones(
+  targets: ScheduleTemplateTarget[],
+  current_month: string,
+): BudgetMilestone[] {
+  const milestones: BudgetMilestone[] = [];
+  for (const s of targets) {
+    const month = s.next_date_string.slice(0, 7);
+    if (monthUtils.differenceInCalendarMonths(month, current_month) < 0) {
+      continue;
     }
-    total += tg / (schedule.num_months + 1);
+    milestones.push({ month, increment: s.target });
   }
-  return total;
+  return milestones;
 }
 
-function getSinkingBaseContributionTotal(t: ScheduleTemplateTarget[]) {
-  //return only the base contribution of each schedule
-  let total = 0;
-  for (const schedule of t) {
-    let monthlyAmount = 0;
-    let prevDate;
-    let intervalMonths;
-    switch (schedule.target_frequency) {
-      case 'yearly':
-        monthlyAmount = schedule.target / schedule.target_interval / 12;
-        break;
-      case 'monthly':
-        monthlyAmount = schedule.target / schedule.target_interval;
-        break;
-      case 'weekly':
-        prevDate = monthUtils.subWeeks(
-          schedule.next_date_string,
-          schedule.target_interval,
-        );
-        intervalMonths = monthUtils.differenceInCalendarMonths(
-          schedule.next_date_string,
-          prevDate,
-        );
-        // shouldn't be possible, but better check
-        if (intervalMonths === 0) intervalMonths = 1;
-        monthlyAmount = schedule.target / intervalMonths;
-        break;
-      case 'daily':
-        prevDate = monthUtils.subDays(
-          schedule.next_date_string,
-          schedule.target_interval,
-        );
-        intervalMonths = monthUtils.differenceInCalendarMonths(
-          schedule.next_date_string,
-          prevDate,
-        );
-        // shouldn't be possible, but better check
-        if (intervalMonths === 0) intervalMonths = 1;
-        monthlyAmount = schedule.target / intervalMonths;
-        break;
-      default:
-        // default to same math as monthly for now for non-reoccuring
-        monthlyAmount = schedule.target / schedule.target_interval;
-        break;
-    }
-    total += monthlyAmount;
-  }
-  return total;
-}
-
-function getSinkingTotal(t: ScheduleTemplateTarget[]) {
-  //sum the total of all upcoming schedules
-  let total = 0;
-  for (const schedule of t) {
-    total += schedule.target;
-  }
-  return total;
+export async function loadScheduleMilestones(
+  scheduleTemplates: ScheduleTemplate[],
+  current_month: string,
+  category: CategoryEntity,
+  currency: Currency,
+): Promise<{ milestones: BudgetMilestone[]; errors: string[] }> {
+  const { t, errors } = await createScheduleList(
+    scheduleTemplates,
+    current_month,
+    category,
+    currency,
+  );
+  return {
+    milestones: scheduleTargetsToMilestones(t, current_month),
+    errors,
+  };
 }
 
 export async function runSchedule(
@@ -313,67 +255,21 @@ export async function runSchedule(
   category: CategoryEntity,
   currency: Currency,
 ) {
+  void remainder;
+  void last_month_balance;
   const scheduleTemplates = template_lines.filter(t => t.type === 'schedule');
 
-  const t = await createScheduleList(
+  const { milestones, errors: loadErrors } = await loadScheduleMilestones(
     scheduleTemplates,
     current_month,
     category,
     currency,
   );
-  errors = errors.concat(t.errors);
-
-  const isPayMonthOf = c =>
-    c.full ||
-    ((c.target_frequency === 'monthly' || !c.target_frequency) &&
-      c.target_interval === 1 &&
-      c.num_months === 0) ||
-    (c.target_frequency === 'weekly' && c.target_interval <= 4) ||
-    (c.target_frequency === 'daily' && c.target_interval <= 31) ||
-    isTrackingBudget();
-
-  const isSubMonthly = c =>
-    c.target_frequency === 'weekly' || c.target_frequency === 'daily';
-
-  const t_payMonthOf = t.t.filter(isPayMonthOf);
-  const t_sinking = t.t
-    .filter(c => !isPayMonthOf(c))
-    .sort((a, b) => a.next_date_string.localeCompare(b.next_date_string));
-  const numSubMonthly = t.t.filter(isSubMonthly).length;
-  const totalPayMonthOf = getPayMonthOfTotal(t_payMonthOf);
-  const totalSinking = getSinkingTotal(t_sinking);
-  const totalSinkingBaseContribution =
-    getSinkingBaseContributionTotal(t_sinking);
-  const lastMonthGoal = await getSheetValue(
-    monthUtils.sheetForMonth(monthUtils.subMonths(current_month, 1)),
-    `goal-${category.id}`,
+  const mergedErrors = errors.concat(loadErrors);
+  const monthly = allocateCumulativeMilestones(
+    milestones,
+    current_month,
+    balance,
   );
-
-  // check and see if we should budget the full amount becaue the previous schedules
-  // haven't been paid yet, or if we can use the leftover balance for this month
-  // First option: check if the previous month doesn't have its monthly schedules paid yet
-  // Second option: check if the previous month needed less than this month and hasn't paid yet
-  if (
-    balance >= totalSinking + totalPayMonthOf ||
-    (lastMonthGoal < totalSinking + totalPayMonthOf &&
-      lastMonthGoal !== 0 &&
-      balance >= lastMonthGoal &&
-      numSubMonthly > 0)
-  ) {
-    to_budget += Math.round(totalPayMonthOf + totalSinkingBaseContribution);
-  } else {
-    const totalSinkingContribution = await getSinkingContributionTotal(
-      t_sinking,
-      remainder,
-      last_month_balance,
-    );
-    if (t_sinking.length === 0) {
-      to_budget +=
-        Math.round(totalPayMonthOf + totalSinkingContribution) -
-        last_month_balance;
-    } else {
-      to_budget += Math.round(totalPayMonthOf + totalSinkingContribution);
-    }
-  }
-  return { to_budget, errors, remainder };
+  return { to_budget: to_budget + monthly, errors: mergedErrors, remainder: 0 };
 }

--- a/upcoming-release-notes/7562.md
+++ b/upcoming-release-notes/7562.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [StephenBrown2]
+---
+
+Use cumulative milestone allocation for by and schedule templates


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

This PR replaces the previous `#template … by …` math (shortest-window interpolation and summed scaled targets) and the separate sinking-fund / pay-month path for `#template schedule …` with a **single cumulative milestone allocator**.

Behavior:

- Collect each `#template X by Y` and each active schedule line as a **deadline month** plus an **increment** (integer minor units, same as today).
- Sort by month, **sum increments that share the same deadline month**, then take a **running cumulative** requirement at each deadline.
- For each deadline *j*, let **B** be category carryover plus any amount already budgeted earlier at the **same priority** before this block; let **C<sub>j</sub>** be the cumulative target due by that deadline, and **n<sub>j</sub>** = `differenceInCalendarMonths(deadlineMonth, currentMonth)`. Compute **rate<sub>j</sub>** = max(0, C<sub>j</sub> - B) / (n<sub>j</sub> + 1), then budget **max over j of rate<sub>j</sub>** (rounded).

This is memoryless with respect to template-specific history: only current month, balances, and stated targets matter, and one-off deposits or withdrawals flow through **B**.

<details><summary>Implementation notes:</summary>

- New module: `packages/loot-core/src/server/budget/milestone-allocation.ts` (`milestonesFromByTemplates`, `allocateCumulativeMilestones`).
- `category-template-context.ts`: at a given priority, `by` and `schedule` run **once** via `runMilestoneTemplates`; balance input is `fromLastMonth + accumulatedToBudget` for that priority pass.
- `schedule-template.ts`: `loadScheduleMilestones` reuses existing `createScheduleList` (rules, adjustments, repeating monthly aggregation); `runSchedule` delegates to the same allocator as `by`. Uses `isTrackingBudget` after upstream rename from `isReflectBudget`.
- Unit tests updated for new numeric expectations (including a fully funded yearly schedule where the monthly add is 0).

</details>

## Related issue(s)

See this Discord thread for a fairly detailed explanation of the logic and demonstration using graphs.

https://discord.com/channels/937901803608096828/1493290910937645137

## Testing

Automated tests updated to match expected budget amounts, manually tested locally.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

NOTE: This will probably need documentation if actually adopted, I think it may surprise people coming from the previous additive method, as well as those expecting a simpler calculation.

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.86 MB | 0%
loot-core | 1 | 5.26 MB → 5.26 MB (-1.51 kB) | -0.03%
api | 1 | 3.89 MB → 3.89 MB (-1.47 kB) | -0.04%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 186.46 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/extends.js | 518.36 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.25 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB → 5.26 MB (-1.51 kB) | -0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/milestone-allocation.ts` | 🆕 +2.4 kB | 0 B → 2.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📉 -856 B (-4.89%) | 17.08 kB → 16.25 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📉 -3.07 kB (-40.32%) | 7.62 kB → 4.55 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DIg1cc1g.js | 0 B → 5.26 MB (+5.26 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Flemh25r.js | 5.26 MB → 0 B (-5.26 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.89 MB → 3.89 MB (-1.47 kB) | -0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/milestone-allocation.ts` | 🆕 +2.36 kB | 0 B → 2.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📉 -837 B (-5.04%) | 16.23 kB → 15.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📉 -3.01 kB (-40.27%) | 7.47 kB → 4.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.89 MB (-1.47 kB) | -0.04%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->