### PR TITLE
[AI] Add nightly CI scan for custom theme catalog

### DIFF
--- a/.github/workflows/nightly-theme-catalog-scan.yml
+++ b/.github/workflows/nightly-theme-catalog-scan.yml
@@ -1,0 +1,29 @@
+name: Nightly theme catalog scan
+
+on:
+  schedule:
+    # 05:15 UTC daily — runs after the i18n extract job (04:00) and well
+    # before the nightly Electron/npm publishes (00:00 UTC the next day).
+    - cron: '15 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-theme-catalog:
+    name: Validate custom theme catalog
+    runs-on: ubuntu-latest
+    if: github.repository == 'actualbudget/actual'
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Validate themes
+        run: yarn workspace @actual-app/web validate:theme-catalog

--- a/packages/desktop-client/bin/validate-theme-catalog.mts
+++ b/packages/desktop-client/bin/validate-theme-catalog.mts
@@ -1,36 +1,16 @@
-/**
- * Nightly validation for the custom theme catalog.
- *
- * Reads packages/desktop-client/src/data/customThemeCatalog.json, fetches the
- * `actual.css` for each entry from its GitHub repo, and runs the same
- * validation the app uses at install time. Exits 1 if any theme fails.
- *
- * Security posture: third-party CSS is treated as opaque text throughout.
- * It is never executed, never injected into a DOM, size-capped, time-capped,
- * and only fetched over HTTPS from a pinned host (raw.githubusercontent.com)
- * constructed from a schema-checked `owner/repo` string.
- */
-
-import { readFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  type CatalogTheme,
   embedThemeFonts,
   validateThemeCss,
 } from '../src/style/customThemes.ts';
 
-const MAX_CSS_BYTES = 512 * 1024; // 512 KB — hard cap on actual.css size.
-const FETCH_TIMEOUT_MS = 15_000; // Per-request timeout.
-const INTER_REQUEST_DELAY_MS = 250; // Gentle rate-limit to raw.githubusercontent.com.
+const MAX_CSS_BYTES = 512 * 1024;
+const FETCH_TIMEOUT_MS = 15_000;
 const REPO_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-
-type CatalogEntry = {
-  name: string;
-  repo: string;
-  mode: 'light' | 'dark';
-  colors?: string[];
-};
 
 type ThemeResult = {
   name: string;
@@ -48,7 +28,7 @@ const catalogPath = resolve(
   'customThemeCatalog.json',
 );
 
-function readCatalog(): CatalogEntry[] {
+function readCatalog(): CatalogTheme[] {
   const raw = readFileSync(catalogPath, 'utf8');
   const parsed: unknown = JSON.parse(raw);
 
@@ -59,7 +39,7 @@ function readCatalog(): CatalogEntry[] {
   return parsed.map((entry, i) => validateCatalogEntry(entry, i));
 }
 
-function validateCatalogEntry(value: unknown, index: number): CatalogEntry {
+function validateCatalogEntry(value: unknown, index: number): CatalogTheme {
   if (!value || typeof value !== 'object') {
     throw new Error(`Catalog entry #${index} is not an object.`);
   }
@@ -68,6 +48,7 @@ function validateCatalogEntry(value: unknown, index: number): CatalogEntry {
   if (typeof e.name !== 'string' || !e.name.trim()) {
     throw new Error(`Catalog entry #${index} is missing a valid "name".`);
   }
+  // Schema-check the repo before it gets interpolated into a fetch URL.
   if (typeof e.repo !== 'string' || !REPO_PATTERN.test(e.repo)) {
     throw new Error(
       `Catalog entry "${String(e.name)}" has an invalid "repo" (expected "owner/repo"): ${JSON.stringify(e.repo)}`,
@@ -96,12 +77,7 @@ function validateCatalogEntry(value: unknown, index: number): CatalogEntry {
   };
 }
 
-async function fetchWithLimits(url: string): Promise<string> {
-  // Pin the URL shape defensively — even though callers construct it, re-check here.
-  if (!url.startsWith('https://raw.githubusercontent.com/')) {
-    throw new Error(`Refusing to fetch from non-pinned URL: ${url}`);
-  }
-
+async function fetchCss(url: string): Promise<string> {
   const response = await fetch(url, {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'error',
@@ -148,21 +124,14 @@ async function fetchWithLimits(url: string): Promise<string> {
   return text;
 }
 
-async function validateOne(entry: CatalogEntry): Promise<ThemeResult> {
+async function validateOne(entry: CatalogTheme): Promise<ThemeResult> {
   try {
     const url = `https://raw.githubusercontent.com/${entry.repo}/refs/heads/main/actual.css`;
-    const css = await fetchWithLimits(url);
-    // Match the install-time flow in ThemeInstaller: embed referenced fonts
-    // into data: URIs first, then validate the result. Validating before
-    // embedding rejects any theme that references fonts via relative url()
-    // paths, because the validator only accepts data: URIs in @font-face.
-    // Cap the font-embedding phase with the same per-fetch timeout as the
-    // CSS fetch so a slow font host can't stall the job's 10-min budget.
-    const embedded = await embedThemeFonts(
-      css,
-      entry.repo,
-      AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    );
+    const css = await fetchCss(url);
+    // Embed fonts before validation: the validator only accepts data: URIs in
+    // @font-face, and embedThemeFonts is what turns relative url() refs into
+    // data: URIs. Matches ThemeInstaller's install flow.
+    const embedded = await embedThemeFonts(css, entry.repo);
     validateThemeCss(embedded);
     return { name: entry.name, repo: entry.repo, status: 'ok' };
   } catch (err) {
@@ -176,12 +145,10 @@ async function validateOne(entry: CatalogEntry): Promise<ThemeResult> {
 }
 
 function escapeForMarkdown(s: string): string {
-  // Escape backticks and HTML-ish characters so a crafted error message
-  // cannot break out of the step summary or inject markup.
   return s.replace(/[`<>|]/g, c => `\\${c}`).replace(/\r?\n/g, ' ');
 }
 
-async function writeStepSummary(results: ThemeResult[]): Promise<void> {
+function writeStepSummary(results: ThemeResult[]): void {
   const summaryPath = process.env.GITHUB_STEP_SUMMARY;
   if (!summaryPath) return;
 
@@ -206,7 +173,6 @@ async function writeStepSummary(results: ThemeResult[]): Promise<void> {
   }
   lines.push('');
 
-  const { appendFileSync } = await import('node:fs');
   appendFileSync(summaryPath, lines.join('\n') + '\n');
 }
 
@@ -225,7 +191,6 @@ async function main(): Promise<void> {
       );
     }
     results.push(result);
-    await new Promise(r => setTimeout(r, INTER_REQUEST_DELAY_MS));
   }
 
   const failed = results.filter(r => r.status === 'error');
@@ -234,7 +199,7 @@ async function main(): Promise<void> {
     `Summary: ${results.length - failed.length}/${results.length} passing, ${failed.length} failing.`,
   );
 
-  await writeStepSummary(results);
+  writeStepSummary(results);
 
   process.exit(failed.length === 0 ? 0 : 1);
 }

--- a/packages/desktop-client/bin/validate-theme-catalog.mts
+++ b/packages/desktop-client/bin/validate-theme-catalog.mts
@@ -2,8 +2,8 @@ import { appendFileSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import type { CatalogTheme } from '../src/style/customThemes.ts';
 import {
-  type CatalogTheme,
   embedThemeFonts,
   validateThemeCss,
 } from '../src/style/customThemes.ts';

--- a/packages/desktop-client/bin/validate-theme-catalog.mts
+++ b/packages/desktop-client/bin/validate-theme-catalog.mts
@@ -1,0 +1,245 @@
+/**
+ * Nightly validation for the custom theme catalog.
+ *
+ * Reads packages/desktop-client/src/data/customThemeCatalog.json, fetches the
+ * `actual.css` for each entry from its GitHub repo, and runs the same
+ * validation the app uses at install time. Exits 1 if any theme fails.
+ *
+ * Security posture: third-party CSS is treated as opaque text throughout.
+ * It is never executed, never injected into a DOM, size-capped, time-capped,
+ * and only fetched over HTTPS from a pinned host (raw.githubusercontent.com)
+ * constructed from a schema-checked `owner/repo` string.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  embedThemeFonts,
+  validateThemeCss,
+} from '../src/style/customThemes.ts';
+
+const MAX_CSS_BYTES = 512 * 1024; // 512 KB — hard cap on actual.css size.
+const FETCH_TIMEOUT_MS = 15_000; // Per-request timeout.
+const INTER_REQUEST_DELAY_MS = 250; // Gentle rate-limit to raw.githubusercontent.com.
+const REPO_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+type CatalogEntry = {
+  name: string;
+  repo: string;
+  mode: 'light' | 'dark';
+  colors?: string[];
+};
+
+type ThemeResult = {
+  name: string;
+  repo: string;
+  status: 'ok' | 'error';
+  error?: string;
+};
+
+const here = dirname(fileURLToPath(import.meta.url));
+const catalogPath = resolve(
+  here,
+  '..',
+  'src',
+  'data',
+  'customThemeCatalog.json',
+);
+
+function readCatalog(): CatalogEntry[] {
+  const raw = readFileSync(catalogPath, 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+
+  if (!Array.isArray(parsed)) {
+    throw new Error('Catalog JSON must be an array.');
+  }
+
+  return parsed.map((entry, i) => validateCatalogEntry(entry, i));
+}
+
+function validateCatalogEntry(value: unknown, index: number): CatalogEntry {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`Catalog entry #${index} is not an object.`);
+  }
+  const e = value as Record<string, unknown>;
+
+  if (typeof e.name !== 'string' || !e.name.trim()) {
+    throw new Error(`Catalog entry #${index} is missing a valid "name".`);
+  }
+  if (typeof e.repo !== 'string' || !REPO_PATTERN.test(e.repo)) {
+    throw new Error(
+      `Catalog entry "${String(e.name)}" has an invalid "repo" (expected "owner/repo"): ${JSON.stringify(e.repo)}`,
+    );
+  }
+  if (e.mode !== 'light' && e.mode !== 'dark') {
+    throw new Error(
+      `Catalog entry "${String(e.name)}" has an invalid "mode" (expected "light" or "dark").`,
+    );
+  }
+  if (
+    e.colors !== undefined &&
+    (!Array.isArray(e.colors) ||
+      !e.colors.every((c: unknown) => typeof c === 'string'))
+  ) {
+    throw new Error(
+      `Catalog entry "${String(e.name)}" has an invalid "colors" (expected string[]).`,
+    );
+  }
+
+  return {
+    name: e.name,
+    repo: e.repo,
+    mode: e.mode,
+    colors: e.colors as string[] | undefined,
+  };
+}
+
+async function fetchWithLimits(url: string): Promise<string> {
+  // Pin the URL shape defensively — even though callers construct it, re-check here.
+  if (!url.startsWith('https://raw.githubusercontent.com/')) {
+    throw new Error(`Refusing to fetch from non-pinned URL: ${url}`);
+  }
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: 'error',
+    headers: { Accept: 'text/css, text/plain, */*' },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${url}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null) {
+    const size = Number.parseInt(contentLength, 10);
+    if (Number.isFinite(size) && size > MAX_CSS_BYTES) {
+      throw new Error(
+        `CSS at ${url} is ${size} bytes; max allowed is ${MAX_CSS_BYTES} bytes.`,
+      );
+    }
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error(`Response from ${url} has no body.`);
+  }
+
+  const decoder = new TextDecoder('utf-8');
+  let received = 0;
+  let text = '';
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    received += value.byteLength;
+    if (received > MAX_CSS_BYTES) {
+      await reader.cancel();
+      throw new Error(
+        `CSS at ${url} exceeds max allowed size of ${MAX_CSS_BYTES} bytes.`,
+      );
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  return text;
+}
+
+async function validateOne(entry: CatalogEntry): Promise<ThemeResult> {
+  try {
+    const url = `https://raw.githubusercontent.com/${entry.repo}/refs/heads/main/actual.css`;
+    const css = await fetchWithLimits(url);
+    // Match the install-time flow in ThemeInstaller: embed referenced fonts
+    // into data: URIs first, then validate the result. Validating before
+    // embedding rejects any theme that references fonts via relative url()
+    // paths, because the validator only accepts data: URIs in @font-face.
+    // Cap the font-embedding phase with the same per-fetch timeout as the
+    // CSS fetch so a slow font host can't stall the job's 10-min budget.
+    const embedded = await embedThemeFonts(
+      css,
+      entry.repo,
+      AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    );
+    validateThemeCss(embedded);
+    return { name: entry.name, repo: entry.repo, status: 'ok' };
+  } catch (err) {
+    return {
+      name: entry.name,
+      repo: entry.repo,
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function escapeForMarkdown(s: string): string {
+  // Escape backticks and HTML-ish characters so a crafted error message
+  // cannot break out of the step summary or inject markup.
+  return s.replace(/[`<>|]/g, c => `\\${c}`).replace(/\r?\n/g, ' ');
+}
+
+async function writeStepSummary(results: ThemeResult[]): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+
+  const okCount = results.filter(r => r.status === 'ok').length;
+  const failCount = results.length - okCount;
+
+  const lines: string[] = [];
+  lines.push('# Custom theme catalog scan');
+  lines.push('');
+  lines.push(`- Total themes: ${results.length}`);
+  lines.push(`- Passing: ${okCount}`);
+  lines.push(`- Failing: ${failCount}`);
+  lines.push('');
+  lines.push('| Status | Theme | Repo | Error |');
+  lines.push('| --- | --- | --- | --- |');
+  for (const r of results) {
+    const status = r.status === 'ok' ? 'pass' : 'FAIL';
+    const err = r.error ? escapeForMarkdown(r.error) : '';
+    lines.push(
+      `| ${status} | ${escapeForMarkdown(r.name)} | ${escapeForMarkdown(r.repo)} | ${err} |`,
+    );
+  }
+  lines.push('');
+
+  const { appendFileSync } = await import('node:fs');
+  appendFileSync(summaryPath, lines.join('\n') + '\n');
+}
+
+async function main(): Promise<void> {
+  const catalog = readCatalog();
+  console.log(`Validating ${catalog.length} theme(s) from the catalog…`);
+
+  const results: ThemeResult[] = [];
+  for (const entry of catalog) {
+    const result = await validateOne(entry);
+    if (result.status === 'ok') {
+      console.log(`  ok    ${entry.repo.padEnd(55)} ${entry.name}`);
+    } else {
+      console.log(
+        `  FAIL  ${entry.repo.padEnd(55)} ${entry.name}\n        → ${result.error}`,
+      );
+    }
+    results.push(result);
+    await new Promise(r => setTimeout(r, INTER_REQUEST_DELAY_MS));
+  }
+
+  const failed = results.filter(r => r.status === 'error');
+  console.log('');
+  console.log(
+    `Summary: ${results.length - failed.length}/${results.length} passing, ${failed.length} failing.`,
+  );
+
+  await writeStepSummary(results);
+
+  process.exit(failed.length === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -101,6 +101,7 @@
     "build:browser": "cross-env ./bin/build-browser",
     "generate:i18n": "i18next",
     "test": "vitest --run",
+    "validate:theme-catalog": "node --experimental-strip-types bin/validate-theme-catalog.mts",
     "e2e": "npx playwright test --browser=chromium",
     "vrt": "cross-env VRT=true npx playwright test --browser=chromium",
     "playwright": "playwright",

--- a/packages/desktop-client/src/style/customThemes.ts
+++ b/packages/desktop-client/src/style/customThemes.ts
@@ -216,6 +216,9 @@ export const MAX_FONT_FILE_SIZE = 2 * 1024 * 1024;
 /** Maximum total size of all embedded font data across all @font-face blocks. 10 MB. */
 export const MAX_TOTAL_FONT_SIZE = 10 * 1024 * 1024;
 
+/** Per-font-file fetch timeout so a hung font host can't stall theme install. */
+const FONT_FETCH_TIMEOUT_MS = 15_000;
+
 /**
  * Extract @font-face blocks from CSS. Returns the blocks and the remaining CSS.
  * Only matches top-level @font-face blocks (not nested inside other rules).
@@ -592,7 +595,11 @@ export async function embedThemeFonts(
   let totalBytes = 0;
   for (const ref of fontRefs) {
     const fontUrl = baseUrl + ref.cleanPath;
-    const response = await fetch(fontUrl, { signal });
+    const perFontTimeout = AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS);
+    const fetchSignal = signal
+      ? AbortSignal.any([signal, perFontTimeout])
+      : perFontTimeout;
+    const response = await fetch(fontUrl, { signal: fetchSignal });
     if (!response.ok) {
       throw new Error(
         `Failed to fetch font file "${ref.cleanPath}" from ${fontUrl}: ${response.status} ${response.statusText}`,

--- a/packages/desktop-client/src/style/customThemes.ts
+++ b/packages/desktop-client/src/style/customThemes.ts
@@ -514,6 +514,7 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
 export async function embedThemeFonts(
   css: string,
   repo: string,
+  signal?: AbortSignal,
 ): Promise<string> {
   const baseUrl = `https://raw.githubusercontent.com/${repo}/refs/heads/main/`;
 
@@ -591,7 +592,7 @@ export async function embedThemeFonts(
   let totalBytes = 0;
   for (const ref of fontRefs) {
     const fontUrl = baseUrl + ref.cleanPath;
-    const response = await fetch(fontUrl);
+    const response = await fetch(fontUrl, { signal });
     if (!response.ok) {
       throw new Error(
         `Failed to fetch font file "${ref.cleanPath}" from ${fontUrl}: ${response.status} ${response.statusText}`,

--- a/upcoming-release-notes/7566.md
+++ b/upcoming-release-notes/7566.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Custom Themes: nightly scan to catch broken themes


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Added nightly scan to detect broken custom themes. So we can remove them from the catalog if-need-be.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/6607

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Run the new cli locally 

```
Validating 21 theme(s) from the catalog…
(node:57833) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/matiss/actual/actual/.claude/worktrees/resilient-beaming-globe/packages/desktop-client/src/style/customThemes.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /Users/matiss/actual/actual/.claude/worktrees/resilient-beaming-globe/packages/desktop-client/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
  ok    actualbudget/demo-theme                                 Demo Theme
  ok    Juulz/shades-of-coffee                                  Shades of Coffee
  ok    Juulz/miami-beach                                       Miami Beach
  ok    Juulz/simple-dark                                       Simple Dark
  ok    MatissJanis/actualbudget-matrix-theme                   Matrix
  ok    MikesGlitch/actual-black-gold-theme                     Black Gold
  ok    Juulz/okabe-ito                                         Color-blind (Dark)
  ok    Juulz/1970-theme                                        Theme from 1970
  ok    Juulz/shades-of-gray                                    Shades of Gray (light)
  ok    noahjalex/catppuccin-latte-actual                       Catppuccin Latte
  ok    noahjalex/catppuccin-frappe-actual                      Catppuccin Frappé
  ok    noahjalex/catppuccin-macchiato-actual                   Catppuccin Macchiato
  ok    noahjalex/catppuccin-mocha-actual                       Catppuccin Mocha
  ok    distantvapor/you-need-a-dark-mode                       You Need A Dark Mode
  ok    samekh248/actual-butterfly-theme                        Butterfly
  ok    Juulz/high-contrast-light                               High-contrast (Light)
  ok    vcruzdesigns/Notion-Dark-Mode                           Notion Dark Mode
  ok    Juulz/YNA-Theme-Light                                   YNA Theme Light
  ok    Juulz/YNA-Theme-Dark                                    YNA Theme Dark
  ok    aadhithbala/actual-nord-theme                           Nord
  ok    aadhithbala/Ilavenil                                    Ilavenil
```

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.86 MB → 13.86 MB (+402 B) | +0.00%
loot-core | 1 | 5.26 MB | 0%
api | 1 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.86 MB → 13.86 MB (+402 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/style/customThemes.ts` | 📈 +309 B (+1.72%) | 17.55 kB → 17.85 kB
`package.json` | 📈 +93 B (+1.14%) | 7.99 kB → 8.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 518.36 kB → 518.66 kB (+309 B) | +0.06%
static/js/index.js | 1.87 MB → 1.87 MB (+93 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 186.46 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.25 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.wT3tRINf.js | 5.26 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->