### PR TITLE
[AI] Support category_group filter in Budgeted custom report

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -43,8 +43,14 @@ async function mapWithConcurrency<TItem, TResult>(
   return results;
 }
 
+type CategoryOrGroupCondition = Extract<
+  RuleConditionEntity,
+  { field: 'category' | 'category_group' }
+>;
+
 function filterCategoriesByConditions(
   categories: CategoryEntity[],
+  categoryGroups: CategoryGroupEntity[],
   conditions: RuleConditionEntity[] | undefined,
   conditionsOp: BudgetDataConditionsOp | undefined,
 ) {
@@ -52,18 +58,17 @@ function filterCategoriesByConditions(
     return categories;
   }
 
-  const categoryConditions = conditions.filter(
-    (cond): cond is Extract<RuleConditionEntity, { field: 'category' }> =>
-      !cond.customName && cond.field === 'category',
+  const relevantConditions = conditions.filter(
+    (cond): cond is CategoryOrGroupCondition =>
+      !cond.customName &&
+      (cond.field === 'category' || cond.field === 'category_group'),
   );
 
-  if (categoryConditions.length === 0) {
+  if (relevantConditions.length === 0) {
     return categories;
   }
 
-  const isSupportedCondition = (
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
-  ) => {
+  const isSupportedCondition = (condition: CategoryOrGroupCondition) => {
     if (condition.op === 'is' || condition.op === 'isNot') {
       return typeof condition.value === 'string';
     }
@@ -75,33 +80,82 @@ function filterCategoriesByConditions(
       );
     }
 
+    if (
+      condition.op === 'contains' ||
+      condition.op === 'doesNotContain' ||
+      condition.op === 'matches'
+    ) {
+      return typeof condition.value === 'string';
+    }
+
     return false;
   };
 
-  // If we can't safely interpret any category condition, do not attempt to
-  // filter categories (better to be broad than silently exclude data).
-  if (!categoryConditions.every(isSupportedCondition)) {
+  // If we can't safely interpret any condition, do not attempt to filter
+  // categories (better to be broad than silently exclude data).
+  if (!relevantConditions.every(isSupportedCondition)) {
     return categories;
   }
 
+  // UUID → name map so text-based operators can match against group names.
+  const groupNameById = new Map(
+    categoryGroups.map(g => [g.id, g.name] as const),
+  );
+
   const evaluateCondition = (
     category: CategoryEntity,
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
+    condition: CategoryOrGroupCondition,
   ): boolean => {
+    const key =
+      condition.field === 'category_group'
+        ? (category.group ?? '')
+        : category.id;
+    const textValue =
+      condition.field === 'category_group'
+        ? (groupNameById.get(key) ?? key)
+        : category.name;
+
     if (condition.op === 'is') {
-      return category.id === condition.value;
+      return key === condition.value;
     }
 
     if (condition.op === 'isNot') {
-      return category.id !== condition.value;
+      return key !== condition.value;
     }
 
     if (condition.op === 'oneOf') {
-      return condition.value.includes(category.id);
+      return condition.value.includes(key);
     }
 
     if (condition.op === 'notOneOf') {
-      return !condition.value.includes(category.id);
+      return !condition.value.includes(key);
+    }
+
+    if (
+      condition.op === 'contains' ||
+      condition.op === 'doesNotContain' ||
+      condition.op === 'matches'
+    ) {
+      if (typeof condition.value !== 'string') {
+        return false;
+      }
+
+      if (condition.op === 'contains') {
+        return textValue.toLowerCase().includes(condition.value.toLowerCase());
+      }
+
+      if (condition.op === 'doesNotContain') {
+        return !textValue.toLowerCase().includes(condition.value.toLowerCase());
+      }
+
+      if (condition.value.length > 256) {
+        return false;
+      }
+      try {
+        return new RegExp(condition.value, 'i').test(textValue);
+      } catch {
+        return false;
+      }
     }
 
     return true;
@@ -111,8 +165,8 @@ function filterCategoriesByConditions(
 
   return categories.filter(cat =>
     op === 'or'
-      ? categoryConditions.some(cond => evaluateCondition(cat, cond))
-      : categoryConditions.every(cond => evaluateCondition(cat, cond)),
+      ? relevantConditions.some(cond => evaluateCondition(cat, cond))
+      : relevantConditions.every(cond => evaluateCondition(cat, cond)),
   );
 }
 
@@ -141,6 +195,7 @@ export async function fetchBudgetData({
 
   const filteredCategories = filterCategoriesByConditions(
     categories,
+    categoryGroups,
     conditions,
     conditionsOp,
   );

--- a/upcoming-release-notes/7570.md
+++ b/upcoming-release-notes/7570.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tylerlinquata]
+---
+
+Fix Category Group filtering in custom report widget when using the Budgeted type.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
Fixes issue #7550 by adding support for category groups in the custom report category filter.

## Related issue(s)

Fixes #7550.

## Testing

Testing instructions
1. Reports → + Add new widget → Custom Report
2. Sidebar: Type = Budgeted
3. Top bar: Filter → Category Group → pick one (e.g. Food)
4. Expected: chart shows only categories whose group is Food. Before fix: filter ignored.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.86 MB → 13.86 MB (+999 B) | +0.01%
loot-core | 1 | 5.26 MB | 0%
api | 1 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.86 MB → 13.86 MB (+999 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/budgetDataQuery.ts` | 📈 +999 B (+28.64%) | 3.41 kB → 4.38 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.2 MB → 1.2 MB (+999 B) | +0.08%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 186.46 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/extends.js | 518.36 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.25 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.wT3tRINf.js | 5.26 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->