### PR TITLE
[AI] Fix transaction row drag breaking inline text edits

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1215,10 +1215,18 @@ const Transaction = memo(function Transaction({
     ? siblingCount <= 1
     : prevRowDate !== transaction.date && nextRowDate !== transaction.date;
   const previewRef = useRef<DragPreviewRenderer>(null);
+  // Row-level drag must not compete with inline editors (notes, amounts,
+  // payee, etc.): otherwise clicks/drags inside inputs start a reorder drag
+  // instead of moving the caret or selecting text (see GH #7567).
+  const allowRowDrag =
+    canDrag &&
+    !isPreview &&
+    !isOnlyTransactionOnDate &&
+    (!editing || focusedField === 'select' || focusedField === 'cleared');
   const { dragRef, dragProps } = useDrag<TransactionEntity>({
     item: originalTransaction,
     type: 'transaction',
-    canDrag: canDrag && !isPreview && !isOnlyTransactionOnDate,
+    canDrag: allowRowDrag,
     onDragChange,
     preview: previewRef,
   });

--- a/upcoming-release-notes/7572.md
+++ b/upcoming-release-notes/7572.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [StephenBrown2]
+---
+
+Fix transaction row drag interfering with inline text edits.


### PR DESCRIPTION
## Description

Transaction reordering attaches React Aria drag behavior to the entire transaction row. While editing inline cells (especially Notes when another transaction shares the same date), that row-level drag competed with normal mouse interactions: clicks did not move the caret, and drag-to-select text instead picked up the row for reordering.

This change disables row reorder drag whenever the row is in table edit mode and the focused column is anything other than **select** or **cleared**, so inputs and autocomplete fields receive pointer events as usual.

## Related issue(s)

Fixes #7567

## Testing

- Ran `yarn workspace @actual-app/web run typecheck`.
- Ran `yarn workspace @actual-app/web run vitest run src/components/transactions/TransactionsTable.test.tsx` (21 passed, 1 skipped).

Manual test performed: In an account, create two transactions on the same day (or use the Test Budget); open Notes on one; click within the text and drag to select. The caret and selection should behave like a normal text field. Reordering should still work when the row is not in that edit state (e.g. with **select** or **cleared** focused, or after leaving the inline editor).

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.86 MB → 13.86 MB (+73 B) | +0.00%
loot-core | 1 | 5.26 MB | 0%
api | 1 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.86 MB → 13.86 MB (+73 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📈 +73 B (+0.08%) | 88.39 kB → 88.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (+73 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 186.46 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/extends.js | 518.36 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.25 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.wT3tRINf.js | 5.26 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->