### PR TITLE
fix needs info stale workflow

### DIFF
--- a/.github/workflows/needs-info-cleanup.yml
+++ b/.github/workflows/needs-info-cleanup.yml
@@ -14,12 +14,14 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'needs info',
-            });
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Remove needs-info label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: yarn workspace @actual-app/ci-actions tsx bin/remove-needs-info-on-reply.ts

--- a/.github/workflows/needs-info-cleanup.yml
+++ b/.github/workflows/needs-info-cleanup.yml
@@ -7,6 +7,7 @@ jobs:
   remove-label:
     if: >
       github.event.issue.state == 'open' &&
+      !github.event.issue.pull_request &&
       github.event.issue.user.login == github.event.comment.user.login &&
       contains(github.event.issue.labels.*.name, 'needs info')
     runs-on: ubuntu-latest

--- a/.github/workflows/needs-info-cleanup.yml
+++ b/.github/workflows/needs-info-cleanup.yml
@@ -2,6 +2,7 @@ name: Remove needs-info on OP reply
 on:
   issue_comment:
     types: [created]
+permissions: {}
 
 jobs:
   remove-label:
@@ -12,6 +13,7 @@ jobs:
       contains(github.event.issue.labels.*.name, 'needs info')
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/needs-info-cleanup.yml
+++ b/.github/workflows/needs-info-cleanup.yml
@@ -1,0 +1,24 @@
+name: Remove needs-info on OP reply
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  remove-label:
+    if: >
+      github.event.issue.state == 'open' &&
+      github.event.issue.user.login == github.event.comment.user.login &&
+      contains(github.event.issue.labels.*.name, 'needs info')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: 'needs info',
+            });

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,10 +33,9 @@ jobs:
 
   stale-needs-info:
     permissions:
+      contents: read
       issues: write
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -38,58 +38,14 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const cutoff = 7 * 24 * 60 * 60 * 1000; // 7 days
-            const now = Date.now();
-
-            const issues = await github.paginate(github.rest.issues.listForRepo, {
-              owner, repo, state: 'open', labels: 'needs info', per_page: 100,
-            });
-
-            const closeIssue = async number => {
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: number,
-                body: 'This issue has been automatically closed because there have been no comments for 7 days after the "needs info" label was added. If you still need help, please feel free to reopen the issue with the requested information.',
-              });
-              await github.rest.issues.update({
-                owner, repo, issue_number: number, state: 'closed',
-              });
-            };
-
-            for (const issue of issues) {
-              if (issue.pull_request) continue;
-
-              if (now - new Date(issue.updated_at).getTime() >= cutoff) {
-                await closeIssue(issue.number);
-                continue;
-              }
-
-              const events = await github.paginate(
-                github.rest.issues.listEventsForTimeline,
-                { owner, repo, issue_number: issue.number, per_page: 100 },
-              );
-
-              const labelings = events.filter(
-                e => e.event === 'labeled' && e.label?.name === 'needs info',
-              );
-              if (labelings.length === 0) continue;
-              const labelAddedAt = new Date(
-                labelings[labelings.length - 1].created_at,
-              ).getTime();
-
-              const comments = await github.paginate(
-                github.rest.issues.listComments,
-                { owner, repo, issue_number: issue.number, per_page: 100 },
-              );
-              const lastCommentAt = comments.length
-                ? new Date(comments[comments.length - 1].created_at).getTime()
-                : 0;
-
-              const effective = Math.max(labelAddedAt, lastCommentAt);
-              if (now - effective < cutoff) continue;
-
-              await closeIssue(issue.number);
-            }
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+      - name: Close stale needs-info issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: yarn workspace @actual-app/ci-actions tsx bin/close-stale-needs-info.ts

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -35,15 +35,61 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          stale-issue-label: 'needs info'
-          days-before-stale: -1
-          days-before-close: 7
-          close-issue-message: 'This issue has been automatically closed because there have been no comments for 7 days after the "needs info" label was added. If you still need help, please feel free to reopen the issue with the requested information.'
-          remove-stale-when-updated: false
-          stale-pr-message: '' # Disable PR processing
-          close-pr-message: '' # Disable PR processing
-          days-before-pr-stale: -1 # Disable PR processing
-          days-before-pr-close: -1 # Disable PR processing
+          script: |
+            const { owner, repo } = context.repo;
+            const cutoff = 7 * 24 * 60 * 60 * 1000; // 7 days
+            const now = Date.now();
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: 'needs info', per_page: 100,
+            });
+
+            const closeIssue = async number => {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: number,
+                body: 'This issue has been automatically closed because there have been no comments for 7 days after the "needs info" label was added. If you still need help, please feel free to reopen the issue with the requested information.',
+              });
+              await github.rest.issues.update({
+                owner, repo, issue_number: number, state: 'closed',
+              });
+            };
+
+            for (const issue of issues) {
+              if (issue.pull_request) continue;
+
+              if (now - new Date(issue.updated_at).getTime() >= cutoff) {
+                await closeIssue(issue.number);
+                continue;
+              }
+
+              const events = await github.paginate(
+                github.rest.issues.listEventsForTimeline,
+                { owner, repo, issue_number: issue.number, per_page: 100 },
+              );
+
+              const labelings = events.filter(
+                e => e.event === 'labeled' && e.label?.name === 'needs info',
+              );
+              if (labelings.length === 0) continue;
+              const labelAddedAt = new Date(
+                labelings[labelings.length - 1].created_at,
+              ).getTime();
+
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: issue.number, per_page: 100 },
+              );
+              const lastCommentAt = comments.length
+                ? new Date(comments[comments.length - 1].created_at).getTime()
+                : 0;
+
+              const effective = Math.max(labelAddedAt, lastCommentAt);
+              if (now - effective < cutoff) continue;
+
+              await closeIssue(issue.number);
+            }

--- a/packages/ci-actions/bin/close-stale-needs-info.ts
+++ b/packages/ci-actions/bin/close-stale-needs-info.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import process from 'node:process';
+
+import { Octokit } from '@octokit/rest';
+
+const LABEL = 'needs info';
+const cutoff = 7 * 24 * 60 * 60 * 1000;
+const now = Date.now();
+
+const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '').split('/');
+if (!owner || !repo) {
+  throw new Error('GITHUB_REPOSITORY must be set to "owner/repo"');
+}
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
+const closeIssue = async (number: number) => {
+  await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: number,
+    body: 'This issue has been automatically closed because there have been no comments for 7 days after the "needs info" label was added. If you still need help, please feel free to reopen the issue with the requested information.',
+  });
+  await octokit.issues.update({
+    owner,
+    repo,
+    issue_number: number,
+    state: 'closed',
+  });
+};
+
+const issues = await octokit.paginate(octokit.issues.listForRepo, {
+  owner,
+  repo,
+  state: 'open',
+  labels: LABEL,
+  per_page: 100,
+});
+
+for (const issue of issues) {
+  if (issue.pull_request) continue;
+
+  if (now - new Date(issue.updated_at).getTime() >= cutoff) {
+    await closeIssue(issue.number);
+    continue;
+  }
+
+  const events = await octokit.paginate(octokit.issues.listEventsForTimeline, {
+    owner,
+    repo,
+    issue_number: issue.number,
+    per_page: 100,
+  });
+
+  const labelings = events.filter(
+    e => e.event === 'labeled' && 'label' in e && e.label?.name === LABEL,
+  );
+  if (labelings.length === 0) continue;
+  const labelAddedAt = new Date(
+    (labelings[labelings.length - 1] as { created_at: string }).created_at,
+  ).getTime();
+
+  const comments = await octokit.paginate(octokit.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issue.number,
+    per_page: 100,
+  });
+  const lastCommentAt = comments.length
+    ? new Date(comments[comments.length - 1].created_at).getTime()
+    : 0;
+
+  const effective = Math.max(labelAddedAt, lastCommentAt);
+  if (now - effective < cutoff) continue;
+
+  await closeIssue(issue.number);
+}

--- a/packages/ci-actions/bin/remove-needs-info-on-reply.ts
+++ b/packages/ci-actions/bin/remove-needs-info-on-reply.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+import { Octokit } from '@octokit/rest';
+import type { IssueCommentEvent } from '@octokit/webhooks-types';
+
+const LABEL = 'needs info';
+
+const [owner, repo] = (process.env.GITHUB_REPOSITORY ?? '').split('/');
+if (!owner || !repo) {
+  throw new Error('GITHUB_REPOSITORY must be set to "owner/repo"');
+}
+
+const event: IssueCommentEvent = JSON.parse(
+  await readFile(process.env.GITHUB_EVENT_PATH ?? '', 'utf8'),
+);
+
+if (
+  event.action !== 'created' ||
+  event.issue.pull_request ||
+  event.issue.state !== 'open' ||
+  event.issue.user.login !== event.comment.user.login ||
+  !event.issue.labels?.some(l => l.name === LABEL)
+) {
+  process.exit(0);
+}
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+await octokit.issues.removeLabel({
+  owner,
+  repo,
+  issue_number: event.issue.number,
+  name: LABEL,
+});

--- a/packages/ci-actions/bin/remove-needs-info-on-reply.ts
+++ b/packages/ci-actions/bin/remove-needs-info-on-reply.ts
@@ -28,9 +28,19 @@ if (
 }
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
-await octokit.issues.removeLabel({
-  owner,
-  repo,
-  issue_number: event.issue.number,
-  name: LABEL,
-});
+try {
+  await octokit.issues.removeLabel({
+    owner,
+    repo,
+    issue_number: event.issue.number,
+    name: LABEL,
+  });
+} catch (err) {
+  // Another run may have removed the label in the meantime; anything else
+  // should still surface.
+  if (
+    !(err && typeof err === 'object' && 'status' in err && err.status === 404)
+  ) {
+    throw err;
+  }
+}

--- a/packages/ci-actions/package.json
+++ b/packages/ci-actions/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@octokit/rest": "^22.0.1",
+    "@octokit/webhooks-types": "^7.6.1",
     "@typescript/native-preview": "beta",
     "extensionless": "^2.0.6",
     "gray-matter": "^4.0.3",

--- a/upcoming-release-notes/7586.md
+++ b/upcoming-release-notes/7586.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix issues tagged with "needs info" being closed automatically after becoming stale

--- a/upcoming-release-notes/7586.md
+++ b/upcoming-release-notes/7586.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [matt-fidd]
 ---
 
-Fix issues tagged with "needs info" being closed automatically after becoming stale
+Fix issues tagged with "needs info" not being closed automatically after becoming stale.

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,6 +41,7 @@ __metadata:
   resolution: "@actual-app/ci-actions@workspace:packages/ci-actions"
   dependencies:
     "@octokit/rest": "npm:^22.0.1"
+    "@octokit/webhooks-types": "npm:^7.6.1"
     "@typescript/native-preview": "npm:beta"
     extensionless: "npm:^2.0.6"
     gray-matter: "npm:^4.0.3"
@@ -5465,6 +5466,13 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^27.0.0"
   checksum: 10/03d5cfc29556a9b53eae8beb1bf15c0b704dc722db2c51b53f093f3c3ee6c1d8e20b682be8117a3a17034b458be7746d1b22aaefb959ceb5152ad7589b39e2c9
+  languageName: node
+  linkType: hard
+
+"@octokit/webhooks-types@npm:^7.6.1":
+  version: 7.6.1
+  resolution: "@octokit/webhooks-types@npm:7.6.1"
+  checksum: 10/0b11bd7e8d13b5a9cf14214421298a423d0180a5e1aaaea876ee4db6f97b5cca536f48d89af63105db75419d777a2402733eb0e110002d4dd59581ef36037bdc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

I was looking over the issues and noticed we weren't closing "needs info" issues automatically, looks like the stale job isn't able to do what we'd like so I've rolled our own. I also added a new workflow that removes the label if the issue author comments after the label has been applied, should hopefully stop us forgetting to remove the label.

This is possibly a bit more than we need, so any thoughts welcome.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes needs info issues being kept open

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested by running the script locally, I've gone and fixed the ones it would have closed manually

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.86 MB | 0%
loot-core | 1 | 5.26 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 136.13 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.68 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.4 kB | 0%
static/js/de.js | 174.08 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.64 kB | 0%
static/js/es.js | 181.5 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.7 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.53 kB | 0%
static/js/narrow.js | 364.25 kB | 0%
static/js/nb-NO.js | 151.58 kB | 0%
static/js/nl.js | 108.66 kB | 0%
static/js/pl.js | 88.34 kB | 0%
static/js/pt-BR.js | 193.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.91 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.28 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.52 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.ODx7v0DZ.js | 5.26 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->