### PR TITLE
Add Discord notification for nightly theme catalog scan failures

### DIFF
--- a/.github/workflows/nightly-theme-catalog-scan.yml
+++ b/.github/workflows/nightly-theme-catalog-scan.yml
@@ -27,9 +27,6 @@ jobs:
           download-translations: 'false'
       - name: Validate themes
         run: yarn workspace @actual-app/web validate:theme-catalog
-      # Requires the DISCORD_WEBHOOK_URL repo secret (Settings → Secrets and
-      # variables → Actions). Fires for both theme validation failures and any
-      # earlier step failure (checkout/setup).
       - name: Notify Discord on failure
         if: failure()
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0

--- a/.github/workflows/nightly-theme-catalog-scan.yml
+++ b/.github/workflows/nightly-theme-catalog-scan.yml
@@ -27,3 +27,16 @@ jobs:
           download-translations: 'false'
       - name: Validate themes
         run: yarn workspace @actual-app/web validate:theme-catalog
+      # Requires the DISCORD_WEBHOOK_URL repo secret (Settings → Secrets and
+      # variables → Actions). Fires for both theme validation failures and any
+      # earlier step failure (checkout/setup).
+      - name: Notify Discord on failure
+        if: failure()
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: Failure
+          title: Nightly theme catalog scan failed
+          description: The nightly scan failed. One or more themes may be broken, or the scan itself did not complete.
+          username: Actual Nightly
+          nofail: true

--- a/.github/workflows/nightly-theme-catalog-scan.yml
+++ b/.github/workflows/nightly-theme-catalog-scan.yml
@@ -27,8 +27,16 @@ jobs:
           download-translations: 'false'
       - name: Validate themes
         run: yarn workspace @actual-app/web validate:theme-catalog
-      - name: Notify Discord on failure
-        if: failure()
+
+  notify-failure:
+    name: Notify Discord on failure
+    needs: validate-theme-catalog
+    if: failure() && github.repository == 'actualbudget/actual'
+    runs-on: ubuntu-latest
+    environment: nightly-alerts
+    timeout-minutes: 5
+    steps:
+      - name: Notify Discord
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/upcoming-release-notes/7595.md
+++ b/upcoming-release-notes/7595.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Notify Discord when the nightly custom theme catalog scan fails.


### PR DESCRIPTION
## Description

Notify us on discord if the nightly custom themes run failed.

(we could and should expand the same logic to other CI runs too such as publishing packages, etc.)

## Related issue(s)

<!-- Please add any related issue numbers here if applicable -->

n/a

## Testing

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_01TRtdxMJ7vpLogLEHmw2Six