### PR TITLE
Enable stricter electron build options

### DIFF
--- a/bin/package-electron
+++ b/bin/package-electron
@@ -9,6 +9,14 @@ cd "$ROOT/.."
 POSITIONAL=()
 SKIP_EXE_BUILD=false
 SKIP_TRANSLATIONS=false
+EXTRA_ELECTRON_BUILDER_ARGS=()
+
+if [ "$(uname)" == "Darwin" ] && [ -z "${CSC_LINK:-}" ]; then
+  EXTRA_ELECTRON_BUILDER_ARGS+=(
+    "-c.electronFuses.resetAdHocDarwinSignature=true"
+  )
+fi
+
 while [[ $# -gt 0 ]]; do
   key="$1"
 
@@ -76,11 +84,13 @@ yarn workspace desktop-electron update-client
         echo "Skipping exe build"
     else
       if [ "$RELEASE" == "production" ]; then
-          yarn build
+          yarn build:dist
+          yarn exec electron-builder "${EXTRA_ELECTRON_BUILDER_ARGS[@]}"
 
           echo "Created release"
       else
-          yarn build
+          yarn build:dist
+          yarn exec electron-builder "${EXTRA_ELECTRON_BUILDER_ARGS[@]}"
       fi
     fi
 )

--- a/bin/package-electron
+++ b/bin/package-electron
@@ -9,14 +9,6 @@ cd "$ROOT/.."
 POSITIONAL=()
 SKIP_EXE_BUILD=false
 SKIP_TRANSLATIONS=false
-EXTRA_ELECTRON_BUILDER_ARGS=()
-
-if [ "$(uname)" == "Darwin" ] && [ -z "${CSC_LINK:-}" ]; then
-  EXTRA_ELECTRON_BUILDER_ARGS+=(
-    "-c.electronFuses.resetAdHocDarwinSignature=true"
-  )
-fi
-
 while [[ $# -gt 0 ]]; do
   key="$1"
 
@@ -84,13 +76,11 @@ yarn workspace desktop-electron update-client
         echo "Skipping exe build"
     else
       if [ "$RELEASE" == "production" ]; then
-          yarn build:dist
-          yarn exec electron-builder "${EXTRA_ELECTRON_BUILDER_ARGS[@]}"
+          yarn build
 
           echo "Created release"
       else
-          yarn build:dist
-          yarn exec electron-builder "${EXTRA_ELECTRON_BUILDER_ARGS[@]}"
+          yarn build
       fi
     fi
 )

--- a/packages/desktop-electron/afterSignHook.ts
+++ b/packages/desktop-electron/afterSignHook.ts
@@ -1,0 +1,27 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { AfterPackContext } from 'electron-builder';
+
+const execFileAsync = promisify(execFile);
+
+const afterSignHook = async (context: AfterPackContext) => {
+  if (context.electronPlatformName !== 'darwin' || process.env.CSC_LINK) {
+    return;
+  }
+
+  const appName = `${context.packager.appInfo.productFilename}.app`;
+  const appPath = `${context.appOutDir}/${appName}`;
+
+  await execFileAsync('codesign', [
+    '--sign',
+    '-',
+    '--force',
+    '--preserve-metadata=entitlements,requirements,flags,runtime',
+    '--deep',
+    appPath,
+  ]);
+};
+
+// oxlint-disable-next-line import/no-default-export
+export default afterSignHook;

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -47,6 +47,11 @@
       "!build/loot-core/lib-dist/electron/{browser,bundle.mobile*}"
     ],
     "beforePack": "./build/desktop-electron/beforePackHook.js",
+    "electronFuses": {
+      "runAsNode": false,
+      "enableNodeOptionsEnvironmentVariable": false,
+      "enableNodeCliInspectArguments": false
+    },
     "mac": {
       "category": "public.app-category.finance",
       "icon": "icons/icon.icns",

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -47,6 +47,7 @@
       "!build/loot-core/lib-dist/electron/{browser,bundle.mobile*}"
     ],
     "beforePack": "./build/desktop-electron/beforePackHook.js",
+    "afterSign": "./build/desktop-electron/afterSignHook.js",
     "electronFuses": {
       "runAsNode": false,
       "enableNodeOptionsEnvironmentVariable": false,

--- a/upcoming-release-notes/7609.md
+++ b/upcoming-release-notes/7609.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [jfdoming]
+---
+
+Enable stricter electron build options


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Slightly reduces app capabilities to reduce ability to perform privilege escalation.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Manually tested Electron build from this PR on MacOS—I see the budget page load.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.87 MB → 13.87 MB (+979 B) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.87 MB → 13.87 MB (+979 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/zh-Hans.json` | 📈 +394 B (+0.32%) | 119.35 kB → 119.73 kB
`locale/es.json` | 📈 +585 B (+0.32%) | 181.29 kB → 181.86 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/es.js | 181.29 kB → 181.86 kB (+585 B) | +0.32%
static/js/zh-Hans.js | 119.35 kB → 119.73 kB (+394 B) | +0.32%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.86 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.49 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.76 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.27 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.JKo6NKKa.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->