### PR TITLE
Import Transactions - Persist and set reimport deleted transactions config to true

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -1,11 +1,11 @@
 // @ts-strict-ignore
-import React, { useCallback, useEffect, useEffectEvent, useState } from 'react';
 import type {
   ComponentProps,
   Dispatch,
   ReactNode,
   SetStateAction,
 } from 'react';
+import { useCallback, useEffect, useEffectEvent, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button, ButtonWithLoading } from '@actual-app/components/button';
@@ -39,6 +39,7 @@ import { FieldMappings } from './FieldMappings';
 import { InOutOption } from './InOutOption';
 import { MultiplierOption } from './MultiplierOption';
 import { Transaction } from './Transaction';
+import type { DateFormat, FieldMapping, ImportTransaction } from './utils';
 import {
   applyFieldMappings,
   dateFormats,
@@ -48,7 +49,6 @@ import {
   parseDate,
   stripCsvImportTransaction,
 } from './utils';
-import type { DateFormat, FieldMapping, ImportTransaction } from './utils';
 
 function CheckboxToggle({
   id,
@@ -203,7 +203,6 @@ export function ImportTransactionsModal({
   const [flipAmount, setFlipAmount] = useState(false);
   const [multiplierEnabled, setMultiplierEnabled] = useState(false);
   const [reconcile, setReconcile] = useState(true);
-  const [reimportDeleted, setReimportDeleted] = useState(false);
   const [importNotes, setImportNotes] = useState(true);
 
   // This cannot be set after parsing the file, because changing it
@@ -241,6 +240,9 @@ export function ImportTransactionsModal({
   );
   const [camtSwapPayeeAndMemo, setCamtSwapPayeeAndMemo] = useState(
     String(prefs[`camt-swap-payee-memo-${accountId}`]) === 'true',
+  );
+  const [reimportDeleted, setReimportDeleted] = useState(
+    String(prefs[`import-reimport-deleted-${accountId}`] || 'true') === 'true',
   );
 
   const [parseDateFormat, setParseDateFormat] = useState<DateFormat | null>(
@@ -705,6 +707,10 @@ export function ImportTransactionsModal({
         [`camt-swap-payee-memo-${accountId}`]: String(camtSwapPayeeAndMemo),
       });
     }
+
+    savePrefs({
+      [`import-reimport-deleted-${accountId}`]: String(reimportDeleted),
+    });
 
     importTransactions.mutate(
       {

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -34,6 +34,7 @@ export type SyncedPrefs = Partial<
     | `hide-reconciled-${string}`
     // TODO: pull from src/components/modals/ImportTransactions.js
     | `parse-date-${string}-${'csv' | 'qif'}`
+    | `import-reimport-deleted-${string}`
     | `csv-mappings-${string}`
     | `csv-delimiter-${string}`
     | `csv-skip-start-lines-${string}`

--- a/upcoming-release-notes/7610.md
+++ b/upcoming-release-notes/7610.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [alecbakholdin]
+---
+
+Reimport Deleted is now on by default and is persisted between imports

--- a/upcoming-release-notes/7610.md
+++ b/upcoming-release-notes/7610.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [alecbakholdin]
 ---
 
-Reimport Deleted is now on by default and is persisted between imports
+Reimport Deleted is now on by default and persisted between imports


### PR DESCRIPTION
## Description

Changing the default value to true to restore functionality from 26.3.0. Also makes the property a synced pref to make it persist between imports.

## Related issue(s)

resolves #7580

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.87 MB → 13.87 MB (+153 B) | +0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.87 MB → 13.87 MB (+153 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx` | 📈 +153 B (+0.47%) | 32.03 kB → 32.18 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.86 MB → 1.86 MB (+153 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.49 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.76 kB | 0%
static/js/es.js | 181.86 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.27 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.73 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.JKo6NKKa.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->