### PR TITLE
[WIP] [AI] Enhancement: Spending Report Compare to Categories Budgeted Amount

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
@@ -51,6 +51,7 @@ type CustomTooltipProps = {
   selection: string | 'budget' | 'average';
   compare: string;
   format: (value: unknown, type?: FormatType) => string;
+  budgetLabel: string;
 };
 
 const CustomTooltip = ({
@@ -60,6 +61,7 @@ const CustomTooltip = ({
   selection,
   compare,
   format,
+  budgetLabel,
 }: CustomTooltipProps) => {
   const { t } = useTranslation();
 
@@ -113,7 +115,7 @@ const CustomTooltip = ({
                   selection === 'average'
                     ? t('Average:')
                     : selection === 'budget'
-                      ? t('Budgeted:')
+                      ? budgetLabel
                       : t('To:')
                 }
                 right={
@@ -153,6 +155,7 @@ type SpendingGraphProps = {
   mode: 'single-month' | 'budget' | 'average';
   compare: string;
   compareTo: string;
+  budgetLabel?: string;
 };
 
 export function SpendingGraph({
@@ -162,6 +165,7 @@ export function SpendingGraph({
   mode,
   compare,
   compareTo,
+  budgetLabel,
 }: SpendingGraphProps) {
   const privacyMode = usePrivacyMode();
   const animationProps = useRechartsAnimation({ isAnimationActive: false });
@@ -277,6 +281,7 @@ export function SpendingGraph({
                     selection={selection}
                     compare={compare}
                     format={format}
+                    budgetLabel={budgetLabel ?? 'Budgeted:'}
                   />
                 }
                 formatter={numberFormatterTooltip}

--- a/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/SpendingGraph.tsx
@@ -51,7 +51,7 @@ type CustomTooltipProps = {
   selection: string | 'budget' | 'average';
   compare: string;
   format: (value: unknown, type?: FormatType) => string;
-  budgetLabel: string;
+  budgetLabel?: string;
 };
 
 const CustomTooltip = ({
@@ -115,7 +115,7 @@ const CustomTooltip = ({
                   selection === 'average'
                     ? t('Average:')
                     : selection === 'budget'
-                      ? budgetLabel
+                      ? (budgetLabel ?? t('Budgeted:'))
                       : t('To:')
                 }
                 right={
@@ -281,7 +281,7 @@ export function SpendingGraph({
                     selection={selection}
                     compare={compare}
                     format={format}
-                    budgetLabel={budgetLabel ?? 'Budgeted:'}
+                    budgetLabel={budgetLabel}
                   />
                 }
                 formatter={numberFormatterTooltip}

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -102,17 +102,15 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const [isLive, setIsLive] = useState(widget?.meta?.isLive ?? true);
   const [budgetCategoryScope, setBudgetCategoryScope] = useState<
     'all' | 'filtered'
-  >(widget?.meta?.budgetCategoryScope ?? 'filtered');
+  >(widget?.meta?.budgetCategoryScope ?? 'all');
 
   const hasCategoryConditions = conditions.some(
     c => c.field === 'category' || c.field === 'category_group',
   );
 
-  useEffect(() => {
-    if (!hasCategoryConditions) {
-      setBudgetCategoryScope('all');
-    }
-  }, [hasCategoryConditions]);
+  const effectiveBudgetCategoryScope: 'all' | 'filtered' = hasCategoryConditions
+    ? budgetCategoryScope
+    : 'all';
 
   const [reportMode, setReportMode] = useState(initialReportMode);
 
@@ -163,7 +161,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
         compare,
         compareTo,
         budgetType,
-        budgetCategoryScope,
+        budgetCategoryScope: effectiveBudgetCategoryScope,
       }),
     [
       conditions,
@@ -171,7 +169,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
       compare,
       compareTo,
       budgetType,
-      budgetCategoryScope,
+      effectiveBudgetCategoryScope,
     ],
   );
 
@@ -198,7 +196,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
             compareTo,
             isLive,
             mode: reportMode,
-            budgetCategoryScope,
+            budgetCategoryScope: effectiveBudgetCategoryScope,
           },
         },
       },
@@ -547,7 +545,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       reportMode === 'single-month'
                         ? monthUtils.format(compareTo, 'MMM yyyy', locale)
                         : reportMode === 'budget'
-                          ? budgetCategoryScope === 'filtered'
+                          ? effectiveBudgetCategoryScope === 'filtered'
                             ? t('Categories Budgeted')
                             : t('Total Budgeted')
                           : t('Average')
@@ -639,12 +637,12 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       left={
                         <Block>
                           {compare === monthUtils.currentMonth() ? (
-                            budgetCategoryScope === 'filtered' ? (
+                            effectiveBudgetCategoryScope === 'filtered' ? (
                               <Trans>Categories Budgeted MTD</Trans>
                             ) : (
                               <Trans>Total Budgeted MTD</Trans>
                             )
-                          ) : budgetCategoryScope === 'filtered' ? (
+                          ) : effectiveBudgetCategoryScope === 'filtered' ? (
                             <Trans>Categories Budgeted</Trans>
                           ) : (
                             <Trans>Total Budgeted</Trans>
@@ -710,7 +708,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                   compare={compare}
                   compareTo={compareTo}
                   budgetLabel={
-                    budgetCategoryScope === 'filtered'
+                    effectiveBudgetCategoryScope === 'filtered'
                       ? t('Categories Budgeted:')
                       : t('Total Budgeted:')
                   }

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -100,6 +100,19 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const [compare, setCompare] = useState(initialCompare);
   const [compareTo, setCompareTo] = useState(initialCompareTo);
   const [isLive, setIsLive] = useState(widget?.meta?.isLive ?? true);
+  const [budgetCategoryScope, setBudgetCategoryScope] = useState<
+    'all' | 'filtered'
+  >(widget?.meta?.budgetCategoryScope ?? 'filtered');
+
+  const hasCategoryConditions = conditions.some(
+    c => c.field === 'category' || c.field === 'category_group',
+  );
+
+  useEffect(() => {
+    if (!hasCategoryConditions) {
+      setBudgetCategoryScope('all');
+    }
+  }, [hasCategoryConditions]);
 
   const [reportMode, setReportMode] = useState(initialReportMode);
 
@@ -150,8 +163,16 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
         compare,
         compareTo,
         budgetType,
+        budgetCategoryScope,
       }),
-    [conditions, conditionsOp, compare, compareTo, budgetType],
+    [
+      conditions,
+      conditionsOp,
+      compare,
+      compareTo,
+      budgetType,
+      budgetCategoryScope,
+    ],
   );
 
   const data = useReport('default', getGraphData);
@@ -177,6 +198,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
             compareTo,
             isLive,
             mode: reportMode,
+            budgetCategoryScope,
           },
         },
       },
@@ -375,6 +397,34 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               </ModeButton>
             </SpaceBetween>
 
+            {reportMode === 'budget' && hasCategoryConditions && (
+              <>
+                <View
+                  style={{
+                    width: 1,
+                    height: 28,
+                    backgroundColor: theme.pillBorderDark,
+                    marginRight: 10,
+                    marginLeft: 10,
+                  }}
+                />
+                <Button
+                  variant={
+                    budgetCategoryScope === 'filtered' ? 'primary' : 'normal'
+                  }
+                  onPress={() =>
+                    setBudgetCategoryScope(s =>
+                      s === 'all' ? 'filtered' : 'all',
+                    )
+                  }
+                >
+                  {budgetCategoryScope === 'filtered'
+                    ? t('Categories Budgeted')
+                    : t('Total Budgeted')}
+                </Button>
+              </>
+            )}
+
             <View
               style={{
                 width: 1,
@@ -497,7 +547,9 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       reportMode === 'single-month'
                         ? monthUtils.format(compareTo, 'MMM yyyy', locale)
                         : reportMode === 'budget'
-                          ? t('Budgeted')
+                          ? budgetCategoryScope === 'filtered'
+                            ? t('Categories Budgeted')
+                            : t('Total Budgeted')
                           : t('Average')
                     }
                     style={{ padding: 0, paddingBottom: 10 }}
@@ -587,9 +639,15 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                       left={
                         <Block>
                           {compare === monthUtils.currentMonth() ? (
-                            <Trans>Budgeted MTD</Trans>
+                            budgetCategoryScope === 'filtered' ? (
+                              <Trans>Categories Budgeted MTD</Trans>
+                            ) : (
+                              <Trans>Total Budgeted MTD</Trans>
+                            )
+                          ) : budgetCategoryScope === 'filtered' ? (
+                            <Trans>Categories Budgeted</Trans>
                           ) : (
-                            <Trans>Budgeted</Trans>
+                            <Trans>Total Budgeted</Trans>
                           )}
                         </Block>
                       }
@@ -651,6 +709,11 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                   mode={reportMode}
                   compare={compare}
                   compareTo={compareTo}
+                  budgetLabel={
+                    budgetCategoryScope === 'filtered'
+                      ? t('Categories Budgeted:')
+                      : t('Total Budgeted:')
+                  }
                 />
               ) : (
                 <LoadingIndicator message={t('Loading report...')} />

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -5,6 +5,7 @@ import { send } from 'loot-core/platform/client/connection';
 import * as monthUtils from 'loot-core/shared/months';
 import { q } from 'loot-core/shared/query';
 import type {
+  CategoryEntity,
   RuleConditionEntity,
   SpendingEntity,
   SpendingMonthEntity,
@@ -21,6 +22,7 @@ type createSpendingSpreadsheetProps = {
   compare?: string;
   compareTo?: string;
   budgetType?: 'envelope' | 'tracking';
+  budgetCategoryScope?: 'all' | 'filtered';
 };
 
 export function createSpendingSpreadsheet({
@@ -29,6 +31,7 @@ export function createSpendingSpreadsheet({
   compare,
   compareTo,
   budgetType = 'envelope',
+  budgetCategoryScope = 'filtered',
 }: createSpendingSpreadsheetProps) {
   const startDate = monthUtils.subMonths(compare, 3) + '-01';
   const endDate = monthUtils.getMonthEnd(compare + '-01');
@@ -48,17 +51,51 @@ export function createSpendingSpreadsheet({
       conditions: conditions.filter(cond => !cond.customName),
     });
 
-    const { filters: budgetFilters } = await send(
-      'make-filters-from-conditions',
-      {
-        conditions: conditions.filter(
-          cond => !cond.customName && cond.field === 'category',
-        ),
-        applySpecialCases: false,
-      },
-    );
-
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
+
+    // Resolve which category IDs to filter the budget query by.
+    // We do this in JS rather than via make-filters-from-conditions because
+    // zero_budgets/reflect_budgets only have a raw `category` column — there
+    // is no join for category.group, so AQL-based group filters silently
+    // return all rows.
+    let budgetCategoryIds: string[] | null = null;
+    if (budgetCategoryScope === 'filtered') {
+      const categoryConditions = conditions.filter(
+        cond =>
+          !cond.customName &&
+          (cond.field === 'category' || cond.field === 'category_group'),
+      );
+      if (categoryConditions.length > 0) {
+        const { list: allCategories } = await send('get-categories');
+        const matched = new Set<string>();
+        for (const cond of categoryConditions) {
+          for (const cat of allCategories as CategoryEntity[]) {
+            const v = cond.value;
+            let hits = false;
+            if (cond.field === 'category') {
+              if (cond.op === 'is') {hits = cat.id === v;}
+              else if (cond.op === 'isNot') {hits = cat.id !== v;}
+              else if (cond.op === 'oneOf')
+                {hits = Array.isArray(v) && v.includes(cat.id);}
+              else if (cond.op === 'notOneOf')
+                {hits = Array.isArray(v) && !v.includes(cat.id);}
+            } else {
+              // category_group
+              if (cond.op === 'is') {hits = cat.group === v;}
+              else if (cond.op === 'isNot') {hits = cat.group !== v;}
+              else if (cond.op === 'oneOf')
+                {hits = Array.isArray(v) && v.includes(cat.group);}
+              else if (cond.op === 'notOneOf')
+                {hits = Array.isArray(v) && !v.includes(cat.group);}
+            }
+            if (hits) matched.add(cat.id);
+          }
+        }
+        if (matched.size > 0) {
+          budgetCategoryIds = [...matched];
+        }
+      }
+    }
 
     const [assets, debts] = await Promise.all([
       aqlQuery(
@@ -117,15 +154,18 @@ export function createSpendingSpreadsheet({
     const budgetMonth = parseInt(compare.replace('-', ''));
     const budgetTable =
       budgetType === 'tracking' ? 'reflect_budgets' : 'zero_budgets';
+    const budgetBaseQuery = q(budgetTable).filter({
+      $and: [{ month: { $eq: budgetMonth } }],
+    });
+    const budgetFilteredQuery =
+      budgetCategoryIds !== null
+        ? budgetBaseQuery.filter({
+            $or: budgetCategoryIds.map(id => ({ category: { $eq: id } })),
+          })
+        : budgetBaseQuery;
     const [budgets] = await Promise.all([
       aqlQuery(
-        q(budgetTable)
-          .filter({
-            $and: [{ month: { $eq: budgetMonth } }],
-          })
-          .filter({
-            [conditionsOpKey]: budgetFilters,
-          })
+        budgetFilteredQuery
           .groupBy([{ $id: '$category' }])
           .select([
             { category: { $id: '$category' } },

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -67,8 +67,9 @@ export function createSpendingSpreadsheet({
       );
       if (categoryConditions.length > 0) {
         const { list: allCategories } = await send('get-categories');
-        const matched = new Set<string>();
+        const perConditionSets: Array<Set<string>> = [];
         for (const cond of categoryConditions) {
+          const condSet = new Set<string>();
           for (const cat of allCategories as CategoryEntity[]) {
             const v = cond.value;
             let hits = false;
@@ -94,12 +95,25 @@ export function createSpendingSpreadsheet({
                 hits = Array.isArray(v) && !v.includes(cat.group);
               }
             }
-            if (hits) matched.add(cat.id);
+            if (hits) condSet.add(cat.id);
+          }
+          perConditionSets.push(condSet);
+        }
+        let matched: Set<string>;
+        if (conditionsOpKey === '$and' && perConditionSets.length > 0) {
+          matched = new Set(perConditionSets[0]);
+          for (let i = 1; i < perConditionSets.length; i++) {
+            for (const id of matched) {
+              if (!perConditionSets[i].has(id)) matched.delete(id);
+            }
+          }
+        } else {
+          matched = new Set<string>();
+          for (const s of perConditionSets) {
+            for (const id of s) matched.add(id);
           }
         }
-        if (matched.size > 0) {
-          budgetCategoryIds = [...matched];
-        }
+        budgetCategoryIds = [...matched];
       }
     }
 
@@ -163,22 +177,25 @@ export function createSpendingSpreadsheet({
     const budgetBaseQuery = q(budgetTable).filter({
       $and: [{ month: { $eq: budgetMonth } }],
     });
-    const budgetFilteredQuery =
-      budgetCategoryIds !== null
-        ? budgetBaseQuery.filter({
-            $or: budgetCategoryIds.map(id => ({ category: { $eq: id } })),
-          })
-        : budgetBaseQuery;
-    const [budgets] = await Promise.all([
-      aqlQuery(
+    let budgets: Array<{ category: string; amount: number }>;
+    if (budgetCategoryIds !== null && budgetCategoryIds.length === 0) {
+      budgets = [];
+    } else {
+      const budgetFilteredQuery =
+        budgetCategoryIds !== null
+          ? budgetBaseQuery.filter({
+              category: { $oneof: budgetCategoryIds },
+            })
+          : budgetBaseQuery;
+      budgets = await aqlQuery(
         budgetFilteredQuery
           .groupBy([{ $id: '$category' }])
           .select([
             { category: { $id: '$category' } },
             { amount: { $sum: '$amount' } },
           ]),
-      ).then(({ data }) => data),
-    ]);
+      ).then(({ data }) => data);
+    }
 
     const dailyBudget =
       budgets &&

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -73,20 +73,26 @@ export function createSpendingSpreadsheet({
             const v = cond.value;
             let hits = false;
             if (cond.field === 'category') {
-              if (cond.op === 'is') {hits = cat.id === v;}
-              else if (cond.op === 'isNot') {hits = cat.id !== v;}
-              else if (cond.op === 'oneOf')
-                {hits = Array.isArray(v) && v.includes(cat.id);}
-              else if (cond.op === 'notOneOf')
-                {hits = Array.isArray(v) && !v.includes(cat.id);}
+              if (cond.op === 'is') {
+                hits = cat.id === v;
+              } else if (cond.op === 'isNot') {
+                hits = cat.id !== v;
+              } else if (cond.op === 'oneOf') {
+                hits = Array.isArray(v) && v.includes(cat.id);
+              } else if (cond.op === 'notOneOf') {
+                hits = Array.isArray(v) && !v.includes(cat.id);
+              }
             } else {
               // category_group
-              if (cond.op === 'is') {hits = cat.group === v;}
-              else if (cond.op === 'isNot') {hits = cat.group !== v;}
-              else if (cond.op === 'oneOf')
-                {hits = Array.isArray(v) && v.includes(cat.group);}
-              else if (cond.op === 'notOneOf')
-                {hits = Array.isArray(v) && !v.includes(cat.group);}
+              if (cond.op === 'is') {
+                hits = cat.group === v;
+              } else if (cond.op === 'isNot') {
+                hits = cat.group !== v;
+              } else if (cond.op === 'oneOf') {
+                hits = Array.isArray(v) && v.includes(cat.group);
+              } else if (cond.op === 'notOneOf') {
+                hits = Array.isArray(v) && !v.includes(cat.group);
+              }
             }
             if (hits) matched.add(cat.id);
           }

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -67,6 +67,7 @@ export type SpendingWidget = AbstractWidget<
     compareTo?: string;
     isLive?: boolean;
     mode?: 'single-month' | 'budget' | 'average';
+    budgetCategoryScope?: 'all' | 'filtered';
   } | null
 >;
 export type BudgetAnalysisWidget = AbstractWidget<

--- a/upcoming-release-notes/7612.md
+++ b/upcoming-release-notes/7612.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [sys044]
+---
+
+Monthly Spending report: add category budget scope toggle to compare spending against budgeted amounts for filtered categories only


### PR DESCRIPTION
## Description

When using Budget comparison mode with category or category group filters, the budgeted line always reflected the full monthly budget. This made it hard to track spending against just the categories I cared about, like discretionary ones such as eating out or entertainment.

This adds a "Total Budgeted / Categories Budgeted" toggle that limits the compared budgeted amount to only the filtered categories. The toggle is only visible when category or category group filters are active.

Total Budgeted (with category filter)
<img width="1097" height="584" alt="image" src="https://github.com/user-attachments/assets/67ebf75f-020b-48e1-a361-ab40fc3bbc67" />

Categories Budgeted (with category filter)
<img width="1092" height="588" alt="image" src="https://github.com/user-attachments/assets/47316170-abd9-4622-a806-181d0b062bda" />

Default (no category filter)
<img width="1094" height="583" alt="image" src="https://github.com/user-attachments/assets/8b010e7f-1ec0-40bc-9c7d-414962898465" />



## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.88 MB → 13.89 MB (+4 kB) | +0.03%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.88 MB → 13.89 MB (+4 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📈 +1.63 kB (+29.22%) | 5.56 kB → 7.19 kB
`src/components/reports/reports/Spending.tsx` | 📈 +2.26 kB (+9.92%) | 22.8 kB → 25.06 kB
`src/components/reports/graphs/SpendingGraph.tsx` | 📈 +109 B (+1.21%) | 8.78 kB → 8.89 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +2 B (+0.01%) | 27.58 kB → 27.59 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (+4 kB) | +0.32%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/es.js | 181.86 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.73 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.JKo6NKKa.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->