### PR TITLE
sankey card should follow report settings

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -58,10 +58,38 @@ export function SankeyCard({
 
   const HEADER_HEIGHT = 82;
   const PX_PER_NODE = 50;
-  const topN = Math.max(
+  const heightBasedTopN = Math.max(
     2,
     Math.floor((cardHeight - HEADER_HEIGHT) / PX_PER_NODE),
   );
+  const topN = meta?.topNcategories ?? heightBasedTopN;
+
+  const isGraphLayer = (value: unknown): value is GraphLayers =>
+    typeof value === 'string' &&
+    (Object.values(GraphLayers) as string[]).includes(value);
+
+  const defaultLayerFrom =
+    mode === 'budgeted' ? GraphLayers.IncomeCategory : GraphLayers.IncomePayee;
+  const defaultLayerTo = GraphLayers.CategoryGroup;
+
+  const metaLayerFrom = isGraphLayer(meta?.layerFrom)
+    ? meta.layerFrom
+    : undefined;
+  const metaLayerTo = isGraphLayer(meta?.layerTo) ? meta.layerTo : undefined;
+
+  const layerFrom =
+    metaLayerFrom &&
+    !(mode === 'budgeted' && metaLayerFrom === GraphLayers.IncomePayee) &&
+    !(mode === 'spent' && metaLayerFrom === GraphLayers.Budget)
+      ? metaLayerFrom
+      : defaultLayerFrom;
+
+  const layerTo =
+    metaLayerTo &&
+    !(mode === 'budgeted' && metaLayerTo === GraphLayers.IncomePayee) &&
+    !(mode === 'spent' && metaLayerTo === GraphLayers.Budget)
+      ? metaLayerTo
+      : defaultLayerTo;
 
   const params = useMemo(
     () =>
@@ -74,8 +102,8 @@ export function SankeyCard({
         mode,
         topN,
         meta?.categorySort,
-        GraphLayers.IncomePayee,
-        GraphLayers.CategoryGroup,
+        layerFrom,
+        layerTo,
       ),
     [
       start,
@@ -86,6 +114,8 @@ export function SankeyCard({
       mode,
       topN,
       meta?.categorySort,
+      layerFrom,
+      layerTo,
     ],
   );
   const data = useReport('sankey', params);

--- a/upcoming-release-notes/7619.md
+++ b/upcoming-release-notes/7619.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Sankey card should follow report settings


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

cc @emiltb I found this once I'd updated my budget, looks like the sankey card wasn't respecting the options set in the main report. I'd like to get this in for this release to make the report more useful.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Related: https://github.com/actualbudget/actual/issues/1919

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Before: Sankey card using default options
After: Sankey card follows the options set in the report settings

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.88 MB → 13.88 MB (+1.01 kB) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.91 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.88 MB → 13.88 MB (+1.01 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/SankeyCard.tsx` | 📈 +962 B (+12.76%) | 7.37 kB → 8.3 kB
`locale/en.json` | 📈 +132 B (+0.07%) | 176.76 kB → 176.89 kB
`src/components/reports/SaveReport.tsx` | 📈 +2 B (+0.02%) | 12.91 kB → 12.91 kB
`locale/pt-BR.json` | 📉 -29 B (-0.01%) | 193.27 kB → 193.24 kB
`locale/ca.json` | 📉 -36 B (-0.02%) | 191.49 kB → 191.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (+964 B) | +0.08%
static/js/en.js | 176.76 kB → 176.89 kB (+132 B) | +0.07%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ca.js | 191.49 kB → 191.46 kB (-36 B) | -0.02%
static/js/pt-BR.js | 193.27 kB → 193.24 kB (-29 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/es.js | 181.86 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.73 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.JKo6NKKa.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.91 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.91 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->