### PR TITLE
show all blog posts on docs site

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -50,6 +50,8 @@ module.exports = {
         },
         blog: {
           ...defaultOptions,
+          blogSidebarTitle: 'All posts',
+          blogSidebarCount: 'ALL',
           feedOptions: {
             type: 'rss',
             title: 'Actual Budget Blog',


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

https://docusaurus.io/docs/blog#blog-sidebar

as it says on the tin. blog posts are pretty hard to find once they drop out of recent, especially with one every month for the release.

Before:
<img width="703" height="545" alt="image" src="https://github.com/user-attachments/assets/1a0f3378-7f93-4789-bd7e-32302bcf640d" />

After:
<img width="753" height="859" alt="image" src="https://github.com/user-attachments/assets/61d831d9-a1a8-45d8-a3ad-edfc9d30b4c6" />


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
