### PR TITLE
Fix Category Group filtering in Custom Report budgeted type

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -114,7 +114,7 @@ function useSelectedCategories(
 
 const BUDGETED_SUPPORTED_CONDITION_FIELDS = new Set<
   RuleConditionEntity['field']
->(['category']);
+>(['category', 'category_group']);
 
 export function CustomReport() {
   const params = useParams();

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -45,6 +45,7 @@ async function mapWithConcurrency<TItem, TResult>(
 
 function filterCategoriesByConditions(
   categories: CategoryEntity[],
+  categoryGroups: CategoryGroupEntity[],
   conditions: RuleConditionEntity[] | undefined,
   conditionsOp: BudgetDataConditionsOp | undefined,
 ) {
@@ -52,17 +53,27 @@ function filterCategoriesByConditions(
     return categories;
   }
 
-  const categoryConditions = conditions.filter(
-    (cond): cond is Extract<RuleConditionEntity, { field: 'category' }> =>
-      !cond.customName && cond.field === 'category',
+  const relevantConditions = conditions.filter(
+    cond =>
+      !cond.customName &&
+      (cond.field === 'category' || cond.field === 'category_group'),
   );
 
-  if (categoryConditions.length === 0) {
+  if (relevantConditions.length === 0) {
     return categories;
   }
 
+  // Build a UUID → name map for category groups so text-based operators
+  // (contains, doesNotContain, matches) can match against the group name.
+  const groupNameById = new Map<string, string>(
+    categoryGroups.map(g => [g.id, g.name] as const),
+  );
+
   const isSupportedCondition = (
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
+    condition: Extract<
+      RuleConditionEntity,
+      { field: 'category' | 'category_group' }
+    >,
   ) => {
     if (condition.op === 'is' || condition.op === 'isNot') {
       return typeof condition.value === 'string';
@@ -75,33 +86,83 @@ function filterCategoriesByConditions(
       );
     }
 
+    if (
+      condition.op === 'contains' ||
+      condition.op === 'doesNotContain' ||
+      condition.op === 'matches'
+    ) {
+      return typeof condition.value === 'string';
+    }
+
     return false;
   };
 
-  // If we can't safely interpret any category condition, do not attempt to
+  // If we can't safely interpret any relevant condition, do not attempt to
   // filter categories (better to be broad than silently exclude data).
-  if (!categoryConditions.every(isSupportedCondition)) {
+  if (!relevantConditions.every(isSupportedCondition)) {
     return categories;
   }
 
   const evaluateCondition = (
     category: CategoryEntity,
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
+    condition: Extract<
+      RuleConditionEntity,
+      { field: 'category' | 'category_group' }
+    >,
   ): boolean => {
+    const key =
+      condition.field === 'category_group' ? category.group : category.id;
+    const textValue =
+      condition.field === 'category_group'
+        ? (groupNameById.get(key) ?? key)
+        : category.name;
+    const matchesRegex =
+      condition.op === 'matches' &&
+      typeof condition.value === 'string' &&
+      condition.value.length <= 256
+        ? (() => {
+            try {
+              return new RegExp(condition.value, 'i');
+            } catch {
+              return null;
+            }
+          })()
+        : null;
+
     if (condition.op === 'is') {
-      return category.id === condition.value;
+      return condition.value === key;
     }
 
     if (condition.op === 'isNot') {
-      return category.id !== condition.value;
+      return condition.value !== key;
     }
 
     if (condition.op === 'oneOf') {
-      return condition.value.includes(category.id);
+      return Array.isArray(condition.value) && condition.value.includes(key);
     }
 
     if (condition.op === 'notOneOf') {
-      return !condition.value.includes(category.id);
+      return (
+        Array.isArray(condition.value) && !condition.value.includes(key)
+      );
+    }
+
+    if (condition.op === 'contains') {
+      return (
+        typeof condition.value === 'string' &&
+        textValue.toLowerCase().includes(condition.value.toLowerCase())
+      );
+    }
+
+    if (condition.op === 'doesNotContain') {
+      return (
+        typeof condition.value === 'string' &&
+        !textValue.toLowerCase().includes(condition.value.toLowerCase())
+      );
+    }
+
+    if (condition.op === 'matches') {
+      return matchesRegex?.test(textValue) ?? false;
     }
 
     return true;
@@ -111,8 +172,8 @@ function filterCategoriesByConditions(
 
   return categories.filter(cat =>
     op === 'or'
-      ? categoryConditions.some(cond => evaluateCondition(cat, cond))
-      : categoryConditions.every(cond => evaluateCondition(cat, cond)),
+      ? relevantConditions.some(cond => evaluateCondition(cat, cond))
+      : relevantConditions.every(cond => evaluateCondition(cat, cond)),
   );
 }
 
@@ -141,6 +202,7 @@ export async function fetchBudgetData({
 
   const filteredCategories = filterCategoriesByConditions(
     categories,
+    categoryGroups,
     conditions,
     conditionsOp,
   );

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -111,10 +111,10 @@ function filterCategoriesByConditions(
     >,
   ): boolean => {
     const key =
-      condition.field === 'category_group' ? category.group : category.id;
+      condition.field === 'category_group' ? category.group ?? '' : category.id;
     const textValue =
       condition.field === 'category_group'
-        ? (groupNameById.get(key) ?? key)
+        ? (groupNameById.get(key ?? '') ?? key ?? '')
         : category.name;
     const matchesRegex =
       condition.op === 'matches' &&

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -111,7 +111,9 @@ function filterCategoriesByConditions(
     >,
   ): boolean => {
     const key =
-      condition.field === 'category_group' ? category.group ?? '' : category.id;
+      condition.field === 'category_group'
+        ? (category.group ?? '')
+        : category.id;
     const textValue =
       condition.field === 'category_group'
         ? (groupNameById.get(key ?? '') ?? key ?? '')
@@ -142,9 +144,7 @@ function filterCategoriesByConditions(
     }
 
     if (condition.op === 'notOneOf') {
-      return (
-        Array.isArray(condition.value) && !condition.value.includes(key)
-      );
+      return Array.isArray(condition.value) && !condition.value.includes(key);
     }
 
     if (condition.op === 'contains') {

--- a/upcoming-release-notes/7550.md
+++ b/upcoming-release-notes/7550.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [vedparkasharya]
+---
+
+Add Category Group filtering support to Custom Report budgeted type.


### PR DESCRIPTION
## Summary
Adds Category Group filtering support to the Custom Report when using the Budgeted type, mirroring the fix previously applied to the Budget Analysis Report in #7116.

## Problem
When creating a Custom Report with Type set to Budgeted, users could not filter by Category Group. The filter either had no effect or was silently stripped out because:
1. `CustomReport.tsx` only allowed `category` conditions in `BUDGETED_SUPPORTED_CONDITION_FIELDS`, causing `category_group` filters to be removed when switching to Budgeted.
2. `budgetDataQuery.ts` only looked at `cond.field === 'category'` when evaluating conditions, completely ignoring `category_group` filters.

## Solution
1. **CustomReport.tsx**: Add `'category_group'` to `BUDGETED_SUPPORTED_CONDITION_FIELDS` so Category Group conditions are preserved when Budgeted type is selected.
2. **budgetDataQuery.ts**: Update `filterCategoriesByConditions` to:
   - Accept both `category` and `category_group` conditions
   - Build a group name map for text-based operators
   - Evaluate `category_group` conditions against `cat.group` (group ID) and group name
   - Support all operators (`is`, `isNot`, `oneOf`, `notOneOf`, `contains`, `doesNotContain`, `matches`)

## Changes
- `packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts`
- `packages/desktop-client/src/components/reports/reports/CustomReport.tsx`
- `upcoming-release-notes/7550.md`

## Testing
- Verified that `category_group` conditions are no longer stripped when `balanceTypeOp === 'totalBudgeted'`.
- Mentally validated the condition evaluation logic against all supported operators for both `category` and `category_group` fields.
- Confirmed the fix pattern matches the previously merged Budget Analysis Report fix (#7116).

Fixes #7550
