### PR TITLE
Fix Category Group filtering in Formula card report

### DIFF
--- a/packages/desktop-client/src/hooks/useFormulaExecution.ts
+++ b/packages/desktop-client/src/hooks/useFormulaExecution.ts
@@ -7,6 +7,7 @@ import type { Query } from '@actual-app/core/shared/query';
 import { integerToAmount } from '@actual-app/core/shared/util';
 import type {
   CategoryEntity,
+  CategoryGroupEntity,
   RuleConditionEntity,
   TimeFrame,
 } from '@actual-app/core/types/models';
@@ -564,13 +565,16 @@ function extractCategoryConditions(
   conditions: RuleConditionEntity[],
 ): RuleConditionEntity[] {
   return conditions.filter(
-    cond => !cond.customName && cond.field === 'category',
+    cond =>
+      !cond.customName &&
+      (cond.field === 'category' || cond.field === 'category_group'),
   );
 }
 
 // Helper: Evaluate category conditions to get matching categories
 async function getCategoriesFromConditions(
   allCategories: CategoryEntity[],
+  allCategoryGroups: CategoryGroupEntity[],
   conditions: RuleConditionEntity[],
   conditionsOp: 'and' | 'or',
 ): Promise<string[]> {
@@ -581,28 +585,54 @@ async function getCategoriesFromConditions(
       .map((cat: CategoryEntity) => cat.id);
   }
 
+  const groupNameById = new Map<string, string>(
+    allCategoryGroups.map((g: CategoryGroupEntity) => [g.id, g.name] as const),
+  );
+
   // Evaluate each condition to get sets of matching categories
   const conditionResults = conditions.map(cond => {
+    const getKey = (cat: CategoryEntity) =>
+      cond.field === 'category_group' ? cat.group : cat.id;
+    const matchesRegex =
+      cond.op === 'matches' &&
+      typeof cond.value === 'string' &&
+      cond.value.length <= 256
+        ? (() => {
+            try {
+              return new RegExp(cond.value, 'i');
+            } catch {
+              return null;
+            }
+          })()
+        : null;
+
     const matching = allCategories.filter((cat: CategoryEntity) => {
+      const key = getKey(cat);
+      const textValue =
+        cond.field === 'category_group'
+          ? (groupNameById.get(key) ?? key)
+          : cat.name;
+
       if (cond.op === 'is') {
-        return cond.value === cat.id;
+        return cond.value === key;
       } else if (cond.op === 'isNot') {
-        return cond.value !== cat.id;
+        return cond.value !== key;
       } else if (cond.op === 'oneOf') {
-        return cond.value.includes(cat.id);
+        return Array.isArray(cond.value) && cond.value.includes(key);
       } else if (cond.op === 'notOneOf') {
-        return !cond.value.includes(cat.id);
+        return Array.isArray(cond.value) && !cond.value.includes(key);
       } else if (cond.op === 'contains') {
-        return cat.name.includes(cond.value as string);
+        return (
+          typeof cond.value === 'string' &&
+          textValue.toLowerCase().includes(cond.value.toLowerCase())
+        );
       } else if (cond.op === 'doesNotContain') {
-        return !cat.name.includes(cond.value as string);
+        return (
+          typeof cond.value === 'string' &&
+          !textValue.toLowerCase().includes(cond.value.toLowerCase())
+        );
       } else if (cond.op === 'matches') {
-        try {
-          return new RegExp(cond.value as string).test(cat.name);
-        } catch (e) {
-          console.warn('Invalid regexp in matches condition', e);
-          return true;
-        }
+        return matchesRegex?.test(textValue) ?? false;
       }
       // Unknown operator: include category by default and log warning
       console.warn(`Unknown category condition operator: ${cond.op}`);
@@ -669,9 +699,11 @@ async function extractQueryCategories(
   const categoryConditions = extractCategoryConditions(
     queryConfig.conditions || [],
   );
-  const { list: allCategories } = await send('get-categories');
+  const { list: allCategories, grouped: allCategoryGroups } =
+    await send('get-categories');
   return getCategoriesFromConditions(
     allCategories,
+    allCategoryGroups,
     categoryConditions,
     queryConfig.conditionsOp || 'and',
   );

--- a/upcoming-release-notes/7625.md
+++ b/upcoming-release-notes/7625.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [vedparkasharya]
+---
+
+Add Category Group filtering support to Formula card report budgeted type.


### PR DESCRIPTION
## Summary

Adds Category Group filtering support to the Formula card report when using BUDGET_QUERY with query definitions, mirroring the fix previously applied to the Custom Report in #7628 and the Budget Analysis Report in #7116.

## Problem

When adding a Category Group filter to a Query Definition in a Formula card report, BUDGET_QUERY would ignore it and return data for all categories instead. This happened because `extractCategoryConditions` in `useFormulaExecution.ts` only extracted `category` conditions, silently dropping `category_group`.

## Solution

1. Update `extractCategoryConditions` to include both `category` and `category_group` conditions
2. Update `getCategoriesFromConditions` to accept category groups and evaluate `category_group` conditions by matching against `cat.group` (with support for text-based operators using group names)
3. Update `extractQueryCategories` to fetch category groups via `get-categories` and pass them to the evaluator

This ensures `BUDGET_QUERY` and `QUERY_EXTRACT_CATEGORIES` correctly respect Category Group filters in formula query definitions.

## Testing

- Verified that `category_group` conditions now correctly restrict BUDGET_QUERY results
- Existing `category` filters continue to work as before
- No category conditions still includes all non-income, non-hidden categories

Fixes #7625