### PR TITLE
Fix Sankey income bug, when payee is not set

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -682,7 +682,7 @@ function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
 
   categoryData.forEach(entry => {
     if (entry.accountId && entry.accountName && entry.categoryId) {
-      if (entry.isIncome && entry.payeeId) {
+      if (entry.isIncome) {
         // Payee > Income category > Account
         addNode(
           graph,
@@ -691,9 +691,16 @@ function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
           entry.category,
         );
         addNode(graph, entry.accountId, GraphLayers.Account, entry.accountName);
-        addNode(graph, entry.payeeId, GraphLayers.IncomePayee, entry.payeeName);
         addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
-        addValueToLink(graph, entry.payeeId, entry.categoryId, entry.value);
+        if (entry.payeeId) {
+          addNode(
+            graph,
+            entry.payeeId,
+            GraphLayers.IncomePayee,
+            entry.payeeName,
+          );
+          addValueToLink(graph, entry.payeeId, entry.categoryId, entry.value);
+        }
       } else {
         // Account > Category group > Category
         addNode(graph, entry.accountId, GraphLayers.Account, entry.accountName);

--- a/upcoming-release-notes/7632.md
+++ b/upcoming-release-notes/7632.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [emiltb]
+---
+
+Fix Sankey income being shown as spent money, when payee was not set


### PR DESCRIPTION
## Description

A user reported a strange graph, with income shown as spent money ([here](https://github.com/actualbudget/actual/issues/1919#issuecomment-4322245233)). It turns out that if the transactions payee is not set, no payee node would be created and the entire transaction was treated as spent money instead of income. 

## Related issue(s)

Relates to #1919.

## Testing

Used the test budget supplied by the user to verify that the error is present before the fix and that the graph looks correct after.

<img width="1581" height="806" alt="2026-04-26T21:13:02,506299496+02:00" src="https://github.com/user-attachments/assets/2bfa0e3f-19ff-48d0-8115-8ed67f7a1957" />

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.88 MB → 13.88 MB (+424 B) | +0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.88 MB → 13.88 MB (+424 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/es.json` | 📈 +399 B (+0.21%) | 181.86 kB → 182.25 kB
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📈 +14 B (+0.06%) | 24.29 kB → 24.31 kB
`locale/zh-Hans.json` | 📈 +11 B (+0.01%) | 119.73 kB → 119.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/es.js | 181.86 kB → 182.25 kB (+399 B) | +0.21%
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (+14 B) | +0.00%
static/js/zh-Hans.js | 119.73 kB → 119.74 kB (+11 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.tCyo0gRC.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->