### PR TITLE
Added logic to prevent autocomplete from flickering on alt tab

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -251,7 +251,7 @@ function SingleAutocomplete<T extends AutocompleteItem>({
   );
   const [highlightedIndex, setHighlightedIndex] = useState(null);
   const [isOpen, setIsOpen] = useState(embedded);
-  const [allowOpening, setAllowOpening] = useState(false);
+  const [allowOpening, setAllowOpening] = useState(true);
   useEffect(() => {
     // without this logic, leaving the window and returning will always reopen the
     // dropdown, which makes a poor user experience, especially when clicking into the window.

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type {
   ComponentProps,
   HTMLProps,
@@ -251,10 +251,31 @@ function SingleAutocomplete<T extends AutocompleteItem>({
   );
   const [highlightedIndex, setHighlightedIndex] = useState(null);
   const [isOpen, setIsOpen] = useState(embedded);
-  const open = () => setIsOpen(true);
+  const [allowOpening, setAllowOpening] = useState(false);
+  useEffect(() => {
+    // without this logic, leaving the window and returning will always reopen the
+    // dropdown, which makes a poor user experience, especially when clicking into the window.
+    // You will find that the dropdown is "invisible" but reappears instantly, resulting in clicking
+    // on the "ghost" dropdown's first option
+    const setAllowOpenChange = () => setTimeout(() => setAllowOpening(true))
+    window.addEventListener('focus', setAllowOpenChange);
+    const setDontAllowOpenChange = () => setAllowOpening(false)
+    window.addEventListener('blur', setDontAllowOpenChange);
+    return () => {
+      window.removeEventListener('focus', setAllowOpenChange)
+      window.removeEventListener('blur', setDontAllowOpenChange)
+    }
+  }, [])
+  const open = () => {
+    if (allowOpening) {
+      setIsOpen(true);
+    }
+  }
   const close = () => {
-    setIsOpen(false);
-    onClose?.();
+    if (document.hasFocus()) {
+      setIsOpen(false);
+      onClose?.();
+    }
   };
 
   const triggerRef = useRef(null);
@@ -264,8 +285,8 @@ function SingleAutocomplete<T extends AutocompleteItem>({
   const narrowInputStyle =
     embedded && isNarrowWidth
       ? {
-          ...styles.mobileMenuItem,
-        }
+        ...styles.mobileMenuItem,
+      }
       : {};
 
   inputProps = {
@@ -780,10 +801,10 @@ function MultiAutocomplete<T extends AutocompleteItem>({
             className={
               typeof inputClassName === 'function'
                 ? renderProps =>
-                    cx(
-                      defaultMultiAutocompleteInputClassName,
-                      inputClassName(renderProps),
-                    )
+                  cx(
+                    defaultMultiAutocompleteInputClassName,
+                    inputClassName(renderProps),
+                  )
                 : cx(defaultMultiAutocompleteInputClassName, inputClassName)
             }
           />

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -1,11 +1,5 @@
 // @ts-strict-ignore
-import React, {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type {
   ComponentProps,
   HTMLProps,

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -1,5 +1,11 @@
 // @ts-strict-ignore
-import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type {
   ComponentProps,
   HTMLProps,
@@ -257,20 +263,20 @@ function SingleAutocomplete<T extends AutocompleteItem>({
     // dropdown, which makes a poor user experience, especially when clicking into the window.
     // You will find that the dropdown is "invisible" but reappears instantly, resulting in clicking
     // on the "ghost" dropdown's first option
-    const setAllowOpenChange = () => setTimeout(() => setAllowOpening(true))
+    const setAllowOpenChange = () => setTimeout(() => setAllowOpening(true));
     window.addEventListener('focus', setAllowOpenChange);
-    const setDontAllowOpenChange = () => setAllowOpening(false)
+    const setDontAllowOpenChange = () => setAllowOpening(false);
     window.addEventListener('blur', setDontAllowOpenChange);
     return () => {
-      window.removeEventListener('focus', setAllowOpenChange)
-      window.removeEventListener('blur', setDontAllowOpenChange)
-    }
-  }, [])
+      window.removeEventListener('focus', setAllowOpenChange);
+      window.removeEventListener('blur', setDontAllowOpenChange);
+    };
+  }, []);
   const open = () => {
     if (allowOpening) {
       setIsOpen(true);
     }
-  }
+  };
   const close = () => {
     if (document.hasFocus()) {
       setIsOpen(false);
@@ -285,8 +291,8 @@ function SingleAutocomplete<T extends AutocompleteItem>({
   const narrowInputStyle =
     embedded && isNarrowWidth
       ? {
-        ...styles.mobileMenuItem,
-      }
+          ...styles.mobileMenuItem,
+        }
       : {};
 
   inputProps = {
@@ -801,10 +807,10 @@ function MultiAutocomplete<T extends AutocompleteItem>({
             className={
               typeof inputClassName === 'function'
                 ? renderProps =>
-                  cx(
-                    defaultMultiAutocompleteInputClassName,
-                    inputClassName(renderProps),
-                  )
+                    cx(
+                      defaultMultiAutocompleteInputClassName,
+                      inputClassName(renderProps),
+                    )
                 : cx(defaultMultiAutocompleteInputClassName, inputClassName)
             }
           />

--- a/upcoming-release-notes/7637.md
+++ b/upcoming-release-notes/7637.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [alecbakholdin]
+---
+
+Added logic to prevent autocomplete from flickering on alt tab

--- a/upcoming-release-notes/7637.md
+++ b/upcoming-release-notes/7637.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [alecbakholdin]
 ---
 
-Added logic to improve dropdown behavior when switching windows
+Added logic to improve dropdown behavior when switching window focus

--- a/upcoming-release-notes/7637.md
+++ b/upcoming-release-notes/7637.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [alecbakholdin]
 ---
 
-Added logic to prevent autocomplete from flickering on alt tab
+Added logic to improve dropdown behavior when switching windows


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

When alt tabbing, I think it's more intuitive for the category/payee autocompletes to stay open/stay closed. Current behavior results in a situation where there is no open dropdown but when you click back into the window a dropdown appears out of nowhere. For specifically the category field, this can cause the user to create a split transaction out of nowhere.

By adding a window listener, we can detect when the window gains/loses focus to determine if the window being switched to is the cause of the dropdown opening/closing, then we can use that information to determine whether to do open/close behavior.

## Related issue(s)

Fixes #7634

## Testing

Tested standard operations with keyboard and mouse clicking/moving around. 

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 35 | 14 MB → 14 MB (+827 B) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
35 | 14 MB → 14 MB (+827 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/autocomplete/Autocomplete.tsx` | 📈 +827 B (+3.50%) | 23.08 kB → 23.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (+827 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.56 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/es.js | 182.25 kB | 0%
static/js/extends.js | 518.76 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/ru.js | 121.6 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.88 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.tCyo0gRC.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->