### PR TITLE
[AI] Keep mobile transaction amount field at a consistent height when empty

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -160,7 +160,7 @@ const AmountInput = memo(function AmountInput({
         }}
         data-testid="amount-input-text"
       >
-        {editing ? text || ' ' : amountToCurrency(value)}
+        {editing ? text || amountToCurrency(0) : amountToCurrency(value)}
       </Text>
     </View>
   );

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -160,7 +160,7 @@ const AmountInput = memo(function AmountInput({
         }}
         data-testid="amount-input-text"
       >
-        {editing ? text : amountToCurrency(value)}
+        {editing ? text || ' ' : amountToCurrency(value)}
       </Text>
     </View>
   );

--- a/upcoming-release-notes/7638.md
+++ b/upcoming-release-notes/7638.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [MatissJanis]
 ---
 
-Ensure mobile transaction amount field maintains consistent height with non-breaking space placeholder when empty.
+Ensure mobile transaction amount field maintains consistent height when empty.

--- a/upcoming-release-notes/7638.md
+++ b/upcoming-release-notes/7638.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Ensure mobile transaction amount field maintains consistent height with non-breaking space placeholder when empty.


### PR DESCRIPTION
When you hit "backspace" in the transaction creation page on mobile - it clears the amount field entirely. Thus is gets a small height and we get a layout shift. Fixing that.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 35 | 14 MB → 14 MB (+23 B) | +0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
35 | 14 MB → 14 MB (+23 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/transactions/FocusableAmountInput.tsx` | 📈 +23 B (+0.18%) | 12.45 kB → 12.47 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionEdit.js | 186.56 kB → 186.58 kB (+23 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/es.js | 182.25 kB | 0%
static/js/extends.js | 518.76 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/ru.js | 121.6 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.88 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.tCyo0gRC.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->