### PR TITLE
fix cherrypicked commits not being respected and lint race in release note generation workflow

### DIFF
--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -230,7 +230,9 @@ await group('Remove used release notes', async () => {
 });
 
 await group('Lint generated files', async () => {
-  await exec(`yarn lint:fix ${blogPath} ${releasesPath}`, {
+  const targets = `${blogPath} ${releasesPath}`;
+  await exec(`yarn exec oxfmt ${targets}`, { stdio: 'inherit' });
+  await exec(`yarn exec oxlint --fix --type-aware --quiet ${targets}`, {
     stdio: 'inherit',
   });
 });

--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -98,14 +98,17 @@ await group('Prepare branch', async () => {
   const tmpDir = process.env.RUNNER_TEMP || '/tmp';
   for (const sha of genCommits) {
     const patchPath = join(tmpDir, `revert-${sha}.patch`);
-    await exec(
-      `git diff ${sha}~1..${sha} -- upcoming-release-notes > ${patchPath}`,
-    );
-    const { size } = await fs.stat(patchPath);
-    if (size > 0) {
-      await exec(`git apply -R ${patchPath}`, { stdio: 'inherit' });
+    try {
+      await exec(
+        `git diff --diff-filter=D ${sha}~1..${sha} -- upcoming-release-notes > ${patchPath}`,
+      );
+      const { size } = await fs.stat(patchPath);
+      if (size > 0) {
+        await exec(`git apply -R ${patchPath}`, { stdio: 'inherit' });
+      }
+    } finally {
+      await fs.unlink(patchPath).catch(() => undefined);
     }
-    await fs.unlink(patchPath).catch(() => undefined);
   }
 });
 

--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -81,18 +81,32 @@ await group('Prepare branch', async () => {
     });
   }
 
-  // the previous generation commit deletes source files from
-  // upcoming-release-notes, refetch them so we can regenerate from all of them
+  // recover deleted release note files from previous generation commits
   const baseRef = process.env.GITHUB_BASE_REF || 'master';
   await exec(`git fetch origin ${baseRef}`, { stdio: 'inherit' });
   const { stdout: mergeBase } = await exec(
     `git merge-base HEAD origin/${baseRef}`,
   );
   const base = mergeBase.trim();
-  console.log(`Restoring upcoming-release-notes from merge-base ${base}`);
-  await exec(`git checkout ${base} -- upcoming-release-notes`, {
-    stdio: 'inherit',
-  });
+  const { stdout: genLog } = await exec(
+    `git log --grep='${commitMessage}' --format=%H ${base}..HEAD`,
+  );
+  const genCommits = genLog.split('\n').filter(Boolean);
+  console.log(
+    `Reversing upcoming-release-notes deletions from ${genCommits.length} prior generation commit(s)`,
+  );
+  const tmpDir = process.env.RUNNER_TEMP || '/tmp';
+  for (const sha of genCommits) {
+    const patchPath = join(tmpDir, `revert-${sha}.patch`);
+    await exec(
+      `git diff ${sha}~1..${sha} -- upcoming-release-notes > ${patchPath}`,
+    );
+    const { size } = await fs.stat(patchPath);
+    if (size > 0) {
+      await exec(`git apply -R ${patchPath}`, { stdio: 'inherit' });
+    }
+    await fs.unlink(patchPath).catch(() => undefined);
+  }
 });
 
 const { notesByCategory, files } = await parseReleaseNotes(
@@ -109,12 +123,13 @@ if (files.length === 0) {
 
 const highlights = '- TODO: Add release highlights';
 
-await group('Generate blog post', async () => {
-  const blogPath = join(
-    'packages/docs/blog',
-    `${releaseDate}-release-${slug}.md`,
-  );
+const blogPath = join(
+  'packages/docs/blog',
+  `${releaseDate}-release-${slug}.md`,
+);
+const releasesPath = 'packages/docs/docs/releases.md';
 
+await group('Generate blog post', async () => {
   const template = `---
 title: Release ${version}
 description: New release of Actual.
@@ -132,6 +147,7 @@ ${highlights}
 **Docker Tag: ${version}**
 
 ${AUTOGEN_MARKER}
+
 ${categorizedNotes}
 `;
 
@@ -161,7 +177,6 @@ ${categorizedNotes}
 });
 
 await group('Update releases.md', async () => {
-  const releasesPath = 'packages/docs/docs/releases.md';
   const existing = await fs.readFile(releasesPath, 'utf-8');
 
   const sectionRe = new RegExp(
@@ -193,6 +208,7 @@ ${highlights}
 **Docker Tag: ${version}**
 
 ${AUTOGEN_MARKER}
+
 ${categorizedNotes}`;
     updated = existing.replace(
       '# Release Notes\n',
@@ -208,6 +224,12 @@ await group('Remove used release notes', async () => {
   await Promise.all(
     files.map(f => fs.unlink(join('upcoming-release-notes', f))),
   );
+});
+
+await group('Lint generated files', async () => {
+  await exec(`yarn lint:fix ${blogPath} ${releasesPath}`, {
+    stdio: 'inherit',
+  });
 });
 
 await group('Commit and push', async () => {

--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -104,7 +104,7 @@ await group('Prepare branch', async () => {
       );
       const { size } = await fs.stat(patchPath);
       if (size > 0) {
-        await exec(`git apply -R ${patchPath}`, { stdio: 'inherit' });
+        await exec(`git apply -R --3way ${patchPath}`, { stdio: 'inherit' });
       }
     } finally {
       await fs.unlink(patchPath).catch(() => undefined);

--- a/upcoming-release-notes/7640.md
+++ b/upcoming-release-notes/7640.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Make release note generation script respect cherry picked commits


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

If the release notes do not pass lint, the bots end up in an infinite loop. I've tweaked the templates so they should match but running lint doesn't hurt.

Also, my previous approach reset to the head of the branch to grab the deleted release notes back which obviously, in hindsight, ignores all cherry picked commits. Fixed by "undeleting" all of the release notes that were deleted in previous commits.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
