### PR TITLE
fix lint in generate release note workflow

### DIFF
--- a/.github/actions/release-notes/generate/action.yml
+++ b/.github/actions/release-notes/generate/action.yml
@@ -9,7 +9,7 @@ runs:
         node-version: 22
     - name: Install dependencies
       shell: bash
-      run: yarn workspaces focus @actual-app/ci-actions
+      run: yarn workspaces focus actual @actual-app/ci-actions
     - name: Generate release notes
       shell: bash
       env:

--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -229,10 +229,8 @@ await group('Remove used release notes', async () => {
   );
 });
 
-await group('Lint generated files', async () => {
-  const targets = `${blogPath} ${releasesPath}`;
-  await exec(`yarn exec oxfmt ${targets}`, { stdio: 'inherit' });
-  await exec(`yarn exec oxlint --fix --type-aware --quiet ${targets}`, {
+await group('Format generated files', async () => {
+  await exec(`yarn exec oxfmt ${blogPath} ${releasesPath}`, {
     stdio: 'inherit',
   });
 });


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Actual deps aren't brought in, oxlint does not run on markdown.

https://github.com/actualbudget/actual/actions/runs/25019288856/job/73275323304?pr=7621

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above) No need IMO, there are enough in already for this
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
