### PR TITLE
[WIP] chore: remove i18next usage from loot-core

### DIFF
--- a/packages/desktop-client/src/app/appSlice.ts
+++ b/packages/desktop-client/src/app/appSlice.ts
@@ -1,3 +1,5 @@
+import { t } from 'i18next';
+
 import { send } from '@actual-app/core/platform/client/connection';
 import { getUploadError } from '@actual-app/core/shared/errors';
 import type { AtLeastOne } from '@actual-app/core/types/util';
@@ -50,7 +52,8 @@ export const resetSync = createAppAsyncThunk(
     const { error } = await send('sync-reset');
 
     if (error) {
-      alert(getUploadError(error));
+      const uploadErr = getUploadError(error);
+      alert(typeof uploadErr === 'string' ? t(uploadErr) : t(uploadErr.key, uploadErr.params));
 
       if (
         (error.reason === 'encrypt-failure' &&

--- a/packages/desktop-client/src/app/appSlice.ts
+++ b/packages/desktop-client/src/app/appSlice.ts
@@ -1,10 +1,9 @@
-import { t } from 'i18next';
-
 import { send } from '@actual-app/core/platform/client/connection';
 import { getUploadError } from '@actual-app/core/shared/errors';
 import type { AtLeastOne } from '@actual-app/core/types/util';
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
+import { t } from 'i18next';
 
 import { pushModal } from '#modals/modalsSlice';
 import { loadPrefs } from '#prefs/prefsSlice';
@@ -53,7 +52,11 @@ export const resetSync = createAppAsyncThunk(
 
     if (error) {
       const uploadErr = getUploadError(error);
-      alert(typeof uploadErr === 'string' ? t(uploadErr) : t(uploadErr.key, uploadErr.params));
+      alert(
+        typeof uploadErr === 'string'
+          ? t(uploadErr)
+          : t(uploadErr.key, uploadErr.params),
+      );
 
       if (
         (error.reason === 'encrypt-failure' &&

--- a/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
+++ b/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
@@ -62,7 +62,10 @@ export const loadBudget = createAppAsyncThunk(
 
     if (error) {
       const syncErr = getSyncError(error, id);
-      const message = typeof syncErr === 'string' ? t(syncErr) : t(syncErr.key, syncErr.params);
+      const message =
+        typeof syncErr === 'string'
+          ? t(syncErr)
+          : t(syncErr.key, syncErr.params);
       if (error === 'out-of-sync-migrations') {
         dispatch(pushModal({ modal: { name: 'out-of-sync-migrations' } }));
       } else if (error === 'out-of-sync-data') {
@@ -362,7 +365,9 @@ export const downloadBudget = createAppAsyncThunk(
       } else {
         dispatch(setAppState({ loadingText: null }));
         const dlErr = getDownloadError(error);
-        alert(typeof dlErr === 'string' ? t(dlErr) : t(dlErr.key, dlErr.params));
+        alert(
+          typeof dlErr === 'string' ? t(dlErr) : t(dlErr.key, dlErr.params),
+        );
       }
       return null;
     } else {

--- a/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
+++ b/packages/desktop-client/src/budgetfiles/budgetfilesSlice.ts
@@ -61,7 +61,8 @@ export const loadBudget = createAppAsyncThunk(
     const { error } = await send('load-budget', { id, ...options });
 
     if (error) {
-      const message = getSyncError(error, id);
+      const syncErr = getSyncError(error, id);
+      const message = typeof syncErr === 'string' ? t(syncErr) : t(syncErr.key, syncErr.params);
       if (error === 'out-of-sync-migrations') {
         dispatch(pushModal({ modal: { name: 'out-of-sync-migrations' } }));
       } else if (error === 'out-of-sync-data') {
@@ -360,7 +361,8 @@ export const downloadBudget = createAppAsyncThunk(
         ).unwrap();
       } else {
         dispatch(setAppState({ loadingText: null }));
-        alert(getDownloadError(error));
+        const dlErr = getDownloadError(error);
+        alert(typeof dlErr === 'string' ? t(dlErr) : t(dlErr.key, dlErr.params));
       }
       return null;
     } else {

--- a/packages/desktop-client/src/components/admin/UserAccess/UserAccessRow.tsx
+++ b/packages/desktop-client/src/components/admin/UserAccess/UserAccessRow.tsx
@@ -69,6 +69,7 @@ export const UserAccessRow = memo(
 
     const handleError = (error: string) => {
       if (error === 'token-expired') {
+        const e = getUserAccessErrors(error);
         dispatch(
           addNotification({
             notification: {
@@ -76,7 +77,7 @@ export const UserAccessRow = memo(
               id: 'login-expired',
               title: t('Login expired'),
               sticky: true,
-              message: getUserAccessErrors(error),
+              message: typeof e === 'string' ? t(e) : t(e.key, e.params),
               button: {
                 title: t('Go to login'),
                 action: () => {
@@ -87,13 +88,14 @@ export const UserAccessRow = memo(
           }),
         );
       } else {
+        const e = getUserAccessErrors(error);
         dispatch(
           addNotification({
             notification: {
               type: 'error',
               title: t('Something happened while editing access'),
               sticky: true,
-              message: getUserAccessErrors(error),
+              message: typeof e === 'string' ? t(e) : t(e.key, e.params),
             },
           }),
         );

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -200,9 +200,9 @@ export function Status({
     >
       {isSplit
         ? t('{{status}} (Split)', {
-            status: titleFirst(getStatusLabel(status)),
+            status: titleFirst(t(getStatusLabel(status))),
           })
-        : titleFirst(getStatusLabel(status))}
+        : titleFirst(t(getStatusLabel(status)))}
     </Text>
   );
 }

--- a/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/CreateEncryptionKeyModal.tsx
@@ -55,7 +55,9 @@ export function CreateEncryptionKeyModal({
       const res = await send('key-make', { password });
       if (res.error) {
         setLoading(null);
-        setError(getCreateKeyError(res.error));
+        const e = getCreateKeyError(res.error);
+        setError(typeof e === 'string' ? t(e) : t(e.key, e.params));
+
         return;
       }
 

--- a/packages/desktop-client/src/components/modals/EditAccess.tsx
+++ b/packages/desktop-client/src/components/modals/EditAccess.tsx
@@ -65,6 +65,7 @@ export function EditUserAccess({
       originalOnSave?.(userAccess);
       close();
     } else {
+      const e = getUserAccessErrors(error);
       if (error === 'token-expired') {
         dispatch(
           addNotification({
@@ -73,7 +74,7 @@ export function EditUserAccess({
               id: 'login-expired',
               title: t('Login expired'),
               sticky: true,
-              message: getUserAccessErrors(error),
+              message: typeof e === 'string' ? t(e) : t(e.key, e.params),
               button: {
                 title: t('Go to login'),
                 action: () => {
@@ -84,7 +85,7 @@ export function EditUserAccess({
           }),
         );
       } else {
-        setSetError(getUserAccessErrors(error));
+        setSetError(typeof e === 'string' ? t(e) : t(e.key, e.params));
       }
     }
   }

--- a/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
+++ b/packages/desktop-client/src/components/modals/FixEncryptionKeyModal.tsx
@@ -51,7 +51,7 @@ export function FixEncryptionKeyModal({
         cloudFileId,
       });
       if (error) {
-        setError(getTestKeyError(error));
+        setError(t(getTestKeyError(error)));
         setLoading(false);
         return;
       }

--- a/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/GoCardlessInitialiseModal.tsx
@@ -58,7 +58,7 @@ export const GoCardlessInitialiseModal = ({
     if (error) {
       setIsLoading(false);
       setIsValid(false);
-      setError(getSecretsError(error, reason));
+      setError(t(getSecretsError(error, reason)));
       return;
     } else {
       ({ error, reason } =
@@ -69,7 +69,7 @@ export const GoCardlessInitialiseModal = ({
       if (error) {
         setIsLoading(false);
         setIsValid(false);
-        setError(getSecretsError(error, reason));
+        setError(t(getSecretsError(error, reason)));
         return;
       }
     }

--- a/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
@@ -52,7 +52,8 @@ export function OpenIDEnableModal({
           );
         }
       } else {
-        setError(getOpenIdErrors(error));
+        const openIdErr = getOpenIdErrors(error);
+        setError(typeof openIdErr === 'string' ? t(openIdErr) : t(openIdErr.key, openIdErr.params));
       }
     } catch (e) {
       console.error('Failed to enable OpenID:', e);

--- a/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
+++ b/packages/desktop-client/src/components/modals/OpenIDEnableModal.tsx
@@ -53,7 +53,11 @@ export function OpenIDEnableModal({
         }
       } else {
         const openIdErr = getOpenIdErrors(error);
-        setError(typeof openIdErr === 'string' ? t(openIdErr) : t(openIdErr.key, openIdErr.params));
+        setError(
+          typeof openIdErr === 'string'
+            ? t(openIdErr)
+            : t(openIdErr.key, openIdErr.params),
+        );
       }
     } catch (e) {
       console.error('Failed to enable OpenID:', e);

--- a/packages/desktop-client/src/components/modals/PluggyAiInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/PluggyAiInitialiseModal.tsx
@@ -63,7 +63,7 @@ export const PluggyAiInitialiseModal = ({
     if (error) {
       setIsLoading(false);
       setIsValid(false);
-      setError(getSecretsError(error, reason));
+      setError(t(getSecretsError(error, reason)));
       return;
     } else {
       ({ error, reason } =
@@ -74,7 +74,7 @@ export const PluggyAiInitialiseModal = ({
       if (error) {
         setIsLoading(false);
         setIsValid(false);
-        setError(getSecretsError(error, reason));
+        setError(t(getSecretsError(error, reason)));
         return;
       } else {
         ({ error, reason } =
@@ -86,7 +86,7 @@ export const PluggyAiInitialiseModal = ({
         if (error) {
           setIsLoading(false);
           setIsValid(false);
-          setError(getSecretsError(error, reason));
+          setError(t(getSecretsError(error, reason)));
           return;
         }
       }

--- a/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
@@ -50,7 +50,7 @@ export const SimpleFinInitialiseModal = ({
 
     if (error) {
       setIsValid(false);
-      setError(getSecretsError(error, reason));
+      setError(t(getSecretsError(error, reason)));
     } else {
       onSuccess();
     }

--- a/packages/desktop-client/src/components/modals/TransferOwnership.tsx
+++ b/packages/desktop-client/src/components/modals/TransferOwnership.tsx
@@ -90,7 +90,8 @@ export function TransferOwnership({
       if (!error) {
         originalOnSave?.();
       } else {
-        setError(getUserAccessErrors(error));
+        const accessErr = getUserAccessErrors(error);
+        setError(typeof accessErr === 'string' ? t(accessErr) : t(accessErr.key, accessErr.params));
       }
     } else {
       setError(t('Cloud file ID is missing.'));

--- a/packages/desktop-client/src/components/modals/TransferOwnership.tsx
+++ b/packages/desktop-client/src/components/modals/TransferOwnership.tsx
@@ -91,7 +91,11 @@ export function TransferOwnership({
         originalOnSave?.();
       } else {
         const accessErr = getUserAccessErrors(error);
-        setError(typeof accessErr === 'string' ? t(accessErr) : t(accessErr.key, accessErr.params));
+        setError(
+          typeof accessErr === 'string'
+            ? t(accessErr)
+            : t(accessErr.key, accessErr.params),
+        );
       }
     } else {
       setError(t('Cloud file ID is missing.'));

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -13,6 +13,8 @@ import {
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
+import { t } from 'i18next';
+
 import { getStatusLabel } from '@actual-app/core/shared/schedules';
 import type { ScheduleStatusType } from '@actual-app/core/shared/schedules';
 import { titleFirst } from '@actual-app/core/shared/util';
@@ -113,7 +115,7 @@ export function StatusBadge({ status }: { status: ScheduleStatusType }) {
         }}
       />
       <Text style={{ lineHeight: '1em' }}>
-        {titleFirst(getStatusLabel(status))}
+        {titleFirst(t(getStatusLabel(status)))}
       </Text>
     </View>
   );

--- a/packages/desktop-client/src/components/schedules/StatusBadge.tsx
+++ b/packages/desktop-client/src/components/schedules/StatusBadge.tsx
@@ -13,11 +13,10 @@ import {
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
-import { t } from 'i18next';
-
 import { getStatusLabel } from '@actual-app/core/shared/schedules';
 import type { ScheduleStatusType } from '@actual-app/core/shared/schedules';
 import { titleFirst } from '@actual-app/core/shared/util';
+import { t } from 'i18next';
 
 // Consists of Schedule Statuses + Transaction statuses
 export type StatusTypes =

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1634,7 +1634,7 @@ const Transaction = memo(function Transaction({
                   whiteSpace: 'nowrap',
                 }}
               >
-                {titleFirst(getStatusLabel(previewStatus ?? ''))}
+                {titleFirst(t(getStatusLabel(previewStatus ?? '')))}
               </View>
             )}
             <CellButton

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,5 +1,6 @@
 import { listen } from '@actual-app/core/platform/client/connection';
 import * as undo from '@actual-app/core/platform/client/undo';
+import { t } from 'i18next';
 // @ts-strict-ignore
 import type { QueryClient } from '@tanstack/react-query';
 
@@ -132,6 +133,14 @@ export function handleGlobalEvents(store: AppStore, queryClient: QueryClient) {
     );
   });
 
+  const unlistenIndexedDBQuota = listen('indexeddb-quota-error', () => {
+    alert(
+      t(
+        'We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.',
+      ),
+    );
+  });
+
   const unlistenStartLoad = listen('start-load', () => {
     void store.dispatch(closeBudgetUI());
     store.dispatch(setAppState({ loadingText: '' }));
@@ -169,6 +178,7 @@ export function handleGlobalEvents(store: AppStore, queryClient: QueryClient) {
     unlistenSync();
     unlistenUndo();
     unlistenFallbackWriteError();
+    unlistenIndexedDBQuota();
     unlistenStartLoad();
     unlistenFinishLoad();
     unlistenStartImport();

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -1,8 +1,8 @@
 import { listen } from '@actual-app/core/platform/client/connection';
 import * as undo from '@actual-app/core/platform/client/undo';
-import { t } from 'i18next';
 // @ts-strict-ignore
 import type { QueryClient } from '@tanstack/react-query';
+import { t } from 'i18next';
 
 import { accountQueries } from './accounts';
 import { setAppState } from './app/appSlice';

--- a/packages/loot-core/src/platform/client/connection/index.ts
+++ b/packages/loot-core/src/platform/client/connection/index.ts
@@ -1,6 +1,4 @@
 // @ts-strict-ignore
-import { t } from 'i18next';
-
 import * as undo from '#platform/client/undo';
 import { captureBreadcrumb, captureException } from '#platform/exceptions';
 
@@ -126,11 +124,7 @@ function connectWorker(worker, onOpen, onError) {
       );
 
       if (msg.message && msg.message.includes('indexeddb-quota-error')) {
-        alert(
-          t(
-            'We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.',
-          ),
-        );
+        alert('We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.');
       }
     } else if (msg.type === 'capture-breadcrumb') {
       captureBreadcrumb(msg.data);

--- a/packages/loot-core/src/platform/client/connection/index.ts
+++ b/packages/loot-core/src/platform/client/connection/index.ts
@@ -124,7 +124,9 @@ function connectWorker(worker, onOpen, onError) {
       );
 
       if (msg.message && msg.message.includes('indexeddb-quota-error')) {
-        alert('We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.');
+        alert(
+          'We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.',
+        );
       }
     } else if (msg.type === 'capture-breadcrumb') {
       captureBreadcrumb(msg.data);

--- a/packages/loot-core/src/platform/client/connection/index.ts
+++ b/packages/loot-core/src/platform/client/connection/index.ts
@@ -124,9 +124,13 @@ function connectWorker(worker, onOpen, onError) {
       );
 
       if (msg.message && msg.message.includes('indexeddb-quota-error')) {
-        alert(
-          'We hit a limit on the local storage available. Edits may not be saved. Please get in touch https://actualbudget.org/contact/ so we can help debug this.',
-        );
+        // Emit a stable event so the desktop client can display a translated message.
+        const listens = listeners.get('indexeddb-quota-error');
+        if (listens) {
+          for (const cb of listens) {
+            cb({});
+          }
+        }
       }
     } else if (msg.type === 'capture-breadcrumb') {
       captureBreadcrumb(msg.data);

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1,5 +1,3 @@
-import { t } from 'i18next';
-
 import { captureException } from '#platform/exceptions';
 import * as asyncStorage from '#platform/server/asyncStorage';
 import * as connection from '#platform/server/connection';
@@ -227,7 +225,7 @@ async function linkSimpleFinAccount({
   let id;
 
   const institution = {
-    name: externalAccount.institution ?? t('Unknown'),
+    name: externalAccount.institution ?? 'Unknown',
   };
 
   const bank = await link.findOrCreateBank(
@@ -301,7 +299,7 @@ async function linkPluggyAiAccount({
   let id;
 
   const institution = {
-    name: externalAccount.institution ?? t('Unknown'),
+    name: externalAccount.institution ?? 'Unknown',
   };
 
   const bank = await link.findOrCreateBank(

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -1,9 +1,9 @@
-import { t } from 'i18next';
-
 type ErrorWithMeta = {
   reason: string;
   meta?: unknown;
 };
+
+export type ErrorResult = string | { key: string; params: Record<string, unknown> };
 
 export function getUploadError({ reason, meta }: ErrorWithMeta) {
   switch (reason) {
@@ -24,10 +24,10 @@ export function getUploadError({ reason, meta }: ErrorWithMeta) {
     case 'network':
       return 'Uploading the file failed. Check your network connection.';
     default:
-      return t(
-        'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
-        { reason },
-      );
+      return {
+        key: 'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
+        params: { reason },
+      };
   }
 }
 
@@ -66,10 +66,10 @@ export function getDownloadError({
         meta && typeof meta === 'object' && 'fileId' in meta && meta.fileId
           ? `, fileId: ${String(meta.fileId)}`
           : '';
-      return t(
-        'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
-        { reason, info },
-      );
+      return {
+        key: 'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
+        params: { reason, info },
+      };
   }
 }
 
@@ -94,14 +94,17 @@ export function getSyncError(error: string, id: string) {
   if (error === 'out-of-sync-migrations' || error === 'out-of-sync-data') {
     return 'This budget cannot be loaded with this version of the app.';
   } else if (error === 'budget-not-found') {
-    return t(
-      'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
-      { id },
-    );
+    return {
+      key: 'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
+      params: { id },
+    };
   } else if (error === 'clock-drift') {
     return 'Failed to sync because your device time differs too much from the server. Please check your device time settings and ensure they are correct.';
   } else {
-    return t('We had an unknown problem opening "{{id}}".', { id });
+    return {
+      key: 'We had an unknown problem opening "{{id}}".',
+      params: { id },
+    };
   }
 }
 
@@ -135,10 +138,10 @@ export function getUserAccessErrors(reason: string) {
     case 'user-already-have-access':
       return 'User already has access.';
     default:
-      return t(
-        'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
-        { reason },
-      );
+      return {
+        key: 'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
+        params: { reason },
+      };
   }
 }
 
@@ -162,9 +165,9 @@ export function getOpenIdErrors(reason: string) {
     case 'unable-to-change-file-config-enabled':
       return 'Unable to enable OpenID. Please update the config.json file in this case.';
     default:
-      return t(
-        'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
-        { reason },
-      );
+      return {
+        key: 'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
+        params: { reason },
+      };
   }
 }

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -11,7 +11,7 @@ export function getUploadError({ reason, meta }: ErrorWithMeta) {
       return 'You are not logged in.';
     case 'encrypt-failure':
       if ((meta as { isMissingKey: boolean }).isMissingKey) {
-        return 'Encrypting your file failed because you are missing your encryption key. Create your key in the next step.'
+        return 'Encrypting your file failed because you are missing your encryption key. Create your key in the next step.';
       }
       return 'Encrypting the file failed. You have the correct key so this is an internal bug. To fix this, generate a new key in the next step.';
     case 'file-has-reset':
@@ -28,7 +28,8 @@ export function getUploadError({ reason, meta }: ErrorWithMeta) {
         'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
         { reason },
       );
-}}
+  }
+}
 
 export function getDownloadError({
   reason,
@@ -56,20 +57,20 @@ export function getDownloadError({
       );
 
     case 'out-of-sync-migrations':
-      return 'This budget cannot be loaded with this version of the app. Make sure the app is up-to-date.'
+      return 'This budget cannot be loaded with this version of the app. Make sure the app is up-to-date.';
     case 'clock-drift':
-      return 'Failed to download the budget because your device time differs too much from the server. Please check your device time settings and ensure they are correct.'
+      return 'Failed to download the budget because your device time differs too much from the server. Please check your device time settings and ensure they are correct.';
 
     default:
       const info =
         meta && typeof meta === 'object' && 'fileId' in meta && meta.fileId
           ? `, fileId: ${String(meta.fileId)}`
           : '';
-        return t(
-          'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
-          { reason, info },
+      return t(
+        'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
+        { reason, info },
       );
-    }
+  }
 }
 
 export function getCreateKeyError(error: ErrorWithMeta) {
@@ -93,10 +94,10 @@ export function getSyncError(error: string, id: string) {
   if (error === 'out-of-sync-migrations' || error === 'out-of-sync-data') {
     return 'This budget cannot be loaded with this version of the app.';
   } else if (error === 'budget-not-found') {
-      return t(
-        'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
+    return t(
+      'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
       { id },
-      );
+    );
   } else if (error === 'clock-drift') {
     return 'Failed to sync because your device time differs too much from the server. Please check your device time settings and ensure they are correct.';
   } else {

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -8,36 +8,27 @@ type ErrorWithMeta = {
 export function getUploadError({ reason, meta }: ErrorWithMeta) {
   switch (reason) {
     case 'unauthorized':
-      return t('You are not logged in.');
+      return 'You are not logged in.';
     case 'encrypt-failure':
       if ((meta as { isMissingKey: boolean }).isMissingKey) {
-        return t(
-          'Encrypting your file failed because you are missing your encryption key. Create your key in the next step.',
-        );
+        return 'Encrypting your file failed because you are missing your encryption key. Create your key in the next step.'
       }
-      return t(
-        'Encrypting the file failed. You have the correct key so this is an internal bug. To fix this, generate a new key in the next step.',
-      );
+      return 'Encrypting the file failed. You have the correct key so this is an internal bug. To fix this, generate a new key in the next step.';
     case 'file-has-reset':
       // Something really weird happened - during reset a sanity
       // check on the server failed. The user just needs to
       // restart the whole process.
-      return t(
-        'Something went wrong while resetting your file. Please try again.',
-      );
+      return 'Something went wrong while resetting your file. Please try again.';
     case 'file-has-new-key':
-      return t(
-        'Unable to encrypt your data because you are missing the key. Create the latest key in the next step.',
-      );
+      return 'Unable to encrypt your data because you are missing the key. Create the latest key in the next step.';
     case 'network':
-      return t('Uploading the file failed. Check your network connection.');
+      return 'Uploading the file failed. Check your network connection.';
     default:
       return t(
         'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
         { reason },
       );
-  }
-}
+}}
 
 export function getDownloadError({
   reason,
@@ -51,13 +42,11 @@ export function getDownloadError({
   switch (reason) {
     case 'network':
     case 'download-failure':
-      return t('Downloading the file failed. Check your network connection.');
+      return 'Downloading the file failed. Check your network connection.';
     case 'not-zip-file':
     case 'invalid-zip-file':
     case 'invalid-meta-file':
-      return t(
-        'Downloaded file is invalid, sorry! Visit https://actualbudget.org/contact/ for support.',
-      );
+      return 'Downloaded file is invalid, sorry! Visit https://actualbudget.org/contact/ for support.';
     case 'decrypt-failure':
       return (
         'Unable to decrypt file ' +
@@ -67,25 +56,20 @@ export function getDownloadError({
       );
 
     case 'out-of-sync-migrations':
-      return t(
-        'This budget cannot be loaded with this version of the app. Make sure the app is up-to-date.',
-      );
-
+      return 'This budget cannot be loaded with this version of the app. Make sure the app is up-to-date.'
     case 'clock-drift':
-      return t(
-        'Failed to download the budget because your device time differs too much from the server. Please check your device time settings and ensure they are correct.',
-      );
+      return 'Failed to download the budget because your device time differs too much from the server. Please check your device time settings and ensure they are correct.'
 
     default:
       const info =
         meta && typeof meta === 'object' && 'fileId' in meta && meta.fileId
           ? `, fileId: ${String(meta.fileId)}`
           : '';
-      return t(
-        'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
-        { reason, info },
+        return t(
+          'Something went wrong trying to download that file, sorry! Visit https://actualbudget.org/contact/ for support. reason: {{reason}}{{info}}',
+          { reason, info },
       );
-  }
+    }
 }
 
 export function getCreateKeyError(error: ErrorWithMeta) {
@@ -95,41 +79,33 @@ export function getCreateKeyError(error: ErrorWithMeta) {
 export function getTestKeyError({ reason }: ErrorWithMeta) {
   switch (reason) {
     case 'network':
-      return t(
-        'Unable to connect to the server. We need to access the server to get some information about your keys.',
-      );
+      return 'Unable to connect to the server. We need to access the server to get some information about your keys.';
     case 'old-key-style':
-      return t(
-        'This file is encrypted with an old unsupported key style. Recreate the key on a device where the file is available, or use an older version of Actual to download it.',
-      );
+      return 'This file is encrypted with an old unsupported key style. Recreate the key on a device where the file is available, or use an older version of Actual to download it.';
     case 'decrypt-failure':
-      return t('Unable to decrypt file with this password. Please try again.');
+      return 'Unable to decrypt file with this password. Please try again.';
     default:
-      return t(
-        'Something went wrong trying to create a key, sorry! Visit https://actualbudget.org/contact/ for support.',
-      );
+      return 'Something went wrong trying to create a key, sorry! Visit https://actualbudget.org/contact/ for support.';
   }
 }
 
 export function getSyncError(error: string, id: string) {
   if (error === 'out-of-sync-migrations' || error === 'out-of-sync-data') {
-    return t('This budget cannot be loaded with this version of the app.');
+    return 'This budget cannot be loaded with this version of the app.';
   } else if (error === 'budget-not-found') {
-    return t(
-      'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
+      return t(
+        'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',
       { id },
-    );
+      );
   } else if (error === 'clock-drift') {
-    return t(
-      'Failed to sync because your device time differs too much from the server. Please check your device time settings and ensure they are correct.',
-    );
+    return 'Failed to sync because your device time differs too much from the server. Please check your device time settings and ensure they are correct.';
   } else {
     return t('We had an unknown problem opening "{{id}}".', { id });
   }
 }
 
 export function getBankSyncError(error: { message?: string }) {
-  return error.message || t('We had an unknown problem syncing the account.');
+  return error.message || 'We had an unknown problem syncing the account.';
 }
 
 export class LazyLoadFailedError extends Error {
@@ -146,17 +122,17 @@ export class LazyLoadFailedError extends Error {
 export function getUserAccessErrors(reason: string) {
   switch (reason) {
     case 'unauthorized':
-      return t('You are not logged in.');
+      return 'You are not logged in.';
     case 'token-expired':
-      return t('Login expired, please log in again.');
+      return 'Login expired, please log in again.';
     case 'user-cant-be-empty':
-      return t('Please select a user.');
+      return 'Please select a user.';
     case 'invalid-file-id':
-      return t('This file is invalid.');
+      return 'This file is invalid.';
     case 'file-denied':
-      return t('You don`t have permissions over this file.');
+      return 'You don`t have permissions over this file.';
     case 'user-already-have-access':
-      return t('User already has access.');
+      return 'User already has access.';
     default:
       return t(
         'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',
@@ -168,9 +144,9 @@ export function getUserAccessErrors(reason: string) {
 export function getSecretsError(error: string, reason: string) {
   switch (reason) {
     case 'unauthorized':
-      return t('You are not logged in.');
+      return 'You are not logged in.';
     case 'not-admin':
-      return t('You have to be admin to set secrets');
+      return 'You have to be admin to set secrets';
     default:
       return error;
   }
@@ -179,13 +155,11 @@ export function getSecretsError(error: string, reason: string) {
 export function getOpenIdErrors(reason: string) {
   switch (reason) {
     case 'unauthorized':
-      return t('You are not logged in.');
+      return 'You are not logged in.';
     case 'configuration-error':
-      return t('This configuration is not valid. Please check it again.');
+      return 'This configuration is not valid. Please check it again.';
     case 'unable-to-change-file-config-enabled':
-      return t(
-        'Unable to enable OpenID. Please update the config.json file in this case.',
-      );
+      return 'Unable to enable OpenID. Please update the config.json file in this case.';
     default:
       return t(
         'An internal error occurred, sorry! Visit https://actualbudget.org/contact/ for support. (ref: {{reason}})',

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -3,7 +3,9 @@ type ErrorWithMeta = {
   meta?: unknown;
 };
 
-export type ErrorResult = string | { key: string; params: Record<string, unknown> };
+export type ErrorResult =
+  | string
+  | { key: string; params: Record<string, unknown> };
 
 export function getUploadError({ reason, meta }: ErrorWithMeta) {
   switch (reason) {

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -1,5 +1,4 @@
 // @ts-strict-ignore
-import { t } from 'i18next';
 
 import type { FieldValueTypes, RuleConditionOp } from '#types/models';
 
@@ -120,10 +119,10 @@ export function getValidOps(field: keyof FieldValueTypes): RuleConditionOp[] {
 
 export function getAllocationMethods(hasFormulaMode = false) {
   return {
-    'fixed-amount': t('a fixed amount'),
-    'fixed-percent': t('a fixed percent of the remainder'),
-    ...(hasFormulaMode && { formula: t('based on a formula') }),
-    remainder: t('an equal portion of the remainder'),
+    'fixed-amount': 'a fixed amount',
+    'fixed-percent': 'a fixed percent of the remainder',
+    ...(hasFormulaMode && { formula: 'based on a formula' }),
+    remainder: 'an equal portion of the remainder',
   };
 }
 
@@ -132,40 +131,40 @@ export function mapField(field, opts?) {
 
   switch (field) {
     case 'imported_payee':
-      return t('imported payee');
+      return 'imported payee';
     case 'payee_name':
-      return t('payee (name)');
+      return 'payee (name)';
     case 'amount':
       if (opts.inflow) {
-        return t('amount (inflow)');
+        return 'amount (inflow)';
       } else if (opts.outflow) {
-        return t('amount (outflow)');
+        return 'amount (outflow)';
       }
-      return t('amount');
+      return 'amount';
     case 'amount-inflow':
-      return t('amount (inflow)');
+      return 'amount (inflow)';
     case 'amount-outflow':
-      return t('amount (outflow)');
+      return 'amount (outflow)';
     case 'account':
-      return t('account');
+      return 'account';
     case 'date':
-      return t('date');
+      return 'date';
     case 'category':
-      return t('category');
+      return 'category';
     case 'category_group':
-      return t('category group');
+      return 'category group';
     case 'notes':
-      return t('notes');
+      return 'notes';
     case 'payee':
-      return t('payee');
+      return 'payee';
     case 'saved':
-      return t('saved');
+      return 'saved';
     case 'cleared':
-      return t('cleared');
+      return 'cleared';
     case 'reconciled':
-      return t('reconciled');
+      return 'reconciled';
     case 'transfer':
-      return t('transfer');
+      return 'transfer';
     default:
       return field;
   }
@@ -174,67 +173,67 @@ export function mapField(field, opts?) {
 export function friendlyOp(op, type?) {
   switch (op) {
     case 'oneOf':
-      return t('one of');
+      return 'one of';
     case 'notOneOf':
-      return t('not one of');
+      return 'not one of';
     case 'is':
-      return t('is');
+      return 'is';
     case 'isNot':
-      return t('is not');
+      return 'is not';
     case 'isapprox':
-      return t('is approx');
+      return 'is approx';
     case 'isbetween':
-      return t('is between');
+      return 'is between';
     case 'contains':
-      return t('contains');
+      return 'contains';
     case 'hasTags':
-      return t('has tags');
+      return 'has tags';
     case 'matches':
-      return t('matches');
+      return 'matches';
     case 'doesNotContain':
-      return t('does not contain');
+      return 'does not contain';
     case 'gt':
       if (type === 'date') {
-        return t('is after');
+        return 'is after';
       }
-      return t('is greater than');
+      return 'is greater than';
     case 'gte':
       if (type === 'date') {
-        return t('is after or equals');
+        return 'is after or equals';
       }
-      return t('is greater than or equals');
+      return 'is greater than or equals';
     case 'lt':
       if (type === 'date') {
-        return t('is before');
+        return 'is before';
       }
-      return t('is less than');
+      return 'is less than';
     case 'lte':
       if (type === 'date') {
-        return t('is before or equals');
+        return 'is before or equals';
       }
-      return t('is less than or equals');
+      return 'is less than or equals';
     case 'true':
-      return t('is true');
+      return 'is true';
     case 'false':
-      return t('is false');
+      return 'is false';
     case 'set':
-      return t('set');
+      return 'set';
     case 'set-split-amount':
-      return t('allocate');
+      return 'allocate';
     case 'link-schedule':
-      return t('link schedule');
+      return 'link schedule';
     case 'prepend-notes':
-      return t('prepend to notes');
+      return 'prepend to notes';
     case 'append-notes':
-      return t('append to notes');
+      return 'append to notes';
     case 'and':
-      return t('and');
+      return 'and';
     case 'or':
-      return t('or');
+      return 'or';
     case 'onBudget':
-      return t('is on budget');
+      return 'is on budget';
     case 'offBudget':
-      return t('is off budget');
+      return 'is off budget';
     case 'delete-transaction':
       return 'delete transaction';
     default:
@@ -245,9 +244,9 @@ export function friendlyOp(op, type?) {
 export function translateRuleStage(stage: string): string {
   switch (stage) {
     case 'pre':
-      return t('Pre');
+      return 'Pre';
     case 'post':
-      return t('Post');
+      return 'Post';
     default:
       return '';
   }

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -39,19 +39,19 @@ export function getStatus(
 export function getStatusLabel(status: string) {
   switch (status) {
     case 'completed':
-      return t('completed');
+      return 'completed';
     case 'paid':
-      return t('paid');
+      return 'paid';
     case 'due':
-      return t('due');
+      return 'due';
     case 'upcoming':
-      return t('upcoming');
+      return 'upcoming';
     case 'missed':
-      return t('missed');
+      return 'missed';
     case 'scheduled':
-      return t('scheduled');
+      return 'scheduled';
     default:
-      return t('unknown');
+      return 'unknown';
   }
 }
 
@@ -86,13 +86,13 @@ function makeNumberSuffix(num: number, locale: Locale) {
 
 function prettyDayName(day) {
   const days = {
-    SU: t('Sunday'),
-    MO: t('Monday'),
-    TU: t('Tuesday'),
-    WE: t('Wednesday'),
-    TH: t('Thursday'),
-    FR: t('Friday'),
-    SA: t('Saturday'),
+    SU: 'Sunday',
+    MO: 'Monday',
+    TU: 'Tuesday',
+    WE: 'Wednesday',
+    TH: 'Thursday',
+    FR: 'Friday',
+    SA: 'Saturday',
   };
   return days[day];
 }
@@ -108,7 +108,7 @@ export function getRecurringDescription(
   switch (config.endMode) {
     case 'after_n_occurrences':
       if (config.endOccurrences === 1) {
-        endModeSuffix = t('once');
+        endModeSuffix = 'once';
       } else {
         endModeSuffix = t('{{endOccurrences}} times', {
           endOccurrences: config.endOccurrences,
@@ -126,8 +126,8 @@ export function getRecurringDescription(
 
   const weekendSolveModeString = config.weekendSolveMode
     ? config.weekendSolveMode === 'after'
-      ? t('(after weekend)')
-      : t('(before weekend)')
+      ? '(after weekend)'
+      : '(before weekend)'
     : '';
 
   const weekendSolveSuffix = config.skipWeekend ? weekendSolveModeString : '';

--- a/packages/loot-core/src/types/server-events.ts
+++ b/packages/loot-core/src/types/server-events.ts
@@ -66,6 +66,7 @@ type ShowBudgetsEvent = undefined;
 type StartImportEvent = { budgetName: string };
 type StartLoadEvent = undefined;
 type ApiFetchRedirectedEvent = undefined;
+type IndexedDBQuotaErrorEvent = undefined;
 
 export type ServerEvents = {
   'backups-updated': BackupUpdatedEvent;
@@ -83,4 +84,5 @@ export type ServerEvents = {
   'sync-event': SyncEvent;
   'undo-event': UndoState;
   'api-fetch-redirected': ApiFetchRedirectedEvent;
+  'indexeddb-quota-error': IndexedDBQuotaErrorEvent;
 };

--- a/upcoming-release-notes/7646.md
+++ b/upcoming-release-notes/7646.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [SupaSeeka]
 ---
 
-Remove the usage of i18next, and its `t()` function used to translate text, from loot-core.
+Reduce the usage of i18next, and its `t()` function used to translate text, from loot-core.

--- a/upcoming-release-notes/7646.md
+++ b/upcoming-release-notes/7646.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [SupaSeeka]
+---
+
+Remove the usage of i18next, and its `t()` function used to translate text, from loot-core.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

This PR reduces the usage of `t()` from `i18next` in the `loot-core` section.

There is a level of regressiona this stage until I recieve clarification on how translation should be handled with variables.
## Related issue(s)

Fixes issue #7633 

## Testing

Still WIP on this reguard, need to wait for maintainer feedback/answers to some questions.

## Checklist

- [x] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 35 | 14 MB → 14 MB (-346 B) | -0.00%
loot-core | 1 | 5.26 MB → 5.26 MB (-111 B) | -0.00%
api | 2 | 3.89 MB → 3.89 MB (-111 B) | -0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
35 | 14 MB → 14 MB (-346 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/es.json` | 📈 +54 B (+0.03%) | 182.25 kB → 182.3 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/connection/index.ts` | 📉 -5 B (-0.15%) | 3.35 kB → 3.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📉 -135 B (-2.66%) | 4.96 kB → 4.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📉 -260 B (-3.54%) | 7.17 kB → 6.91 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/es.js | 182.25 kB → 182.3 kB (+54 B) | +0.03%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (-260 B) | -0.01%
static/js/extends.js | 518.76 kB → 518.62 kB (-140 B) | -0.03%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 186.58 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/ru.js | 121.6 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.88 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB → 5.26 MB (-111 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/chevrotain/lib_esm/src/scan/tokens_public.js` | 📈 +2 B (+0.09%) | 2.25 kB → 2.25 kB
`node_modules/chevrotain/lib_esm/src/scan/lexer.js` | 📈 +18 B (+0.07%) | 24.83 kB → 24.84 kB
`node_modules/chevrotain/lib_esm/src/utils/utils.js` | 📈 +2 B (+0.02%) | 8.71 kB → 8.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -6 B (-0.03%) | 22.02 kB → 22.01 kB
`node_modules/i18next/dist/esm/i18next.js` | 📉 -94 B (-0.12%) | 74.94 kB → 74.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📉 -33 B (-1.26%) | 2.55 kB → 2.52 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CYe02DYH.js | 0 B → 5.26 MB (+5.26 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B5tkfYkU.js | 5.26 MB → 0 B (-5.26 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.89 MB (-111 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/chevrotain/lib_esm/src/scan/tokens_public.js` | 📈 +2 B (+0.09%) | 2.18 kB → 2.19 kB
`node_modules/chevrotain/lib_esm/src/scan/lexer.js` | 📈 +18 B (+0.07%) | 24.22 kB → 24.24 kB
`node_modules/chevrotain/lib_esm/src/utils/utils.js` | 📈 +2 B (+0.02%) | 8.4 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -6 B (-0.03%) | 21.46 kB → 21.45 kB
`node_modules/i18next/dist/esm/i18next.js` | 📉 -94 B (-0.13%) | 73.02 kB → 72.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📉 -33 B (-1.28%) | 2.52 kB → 2.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.89 MB (-111 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->