### PR TITLE
Fix release notes link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
+<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
 
 ## Description
 

--- a/upcoming-release-notes/7655.md
+++ b/upcoming-release-notes/7655.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [arjunrawal1]
+---
+
+Fix the release notes link in the pull request template.


### PR DESCRIPTION
## Summary

Fixes the release notes link in the GitHub pull request template so it points to the current Actual Budget contributing docs instead of the archived docs repository.

Closes #7645.

## Testing

Docs/template-only change; verified the replacement URL matches the existing contributing docs link used elsewhere in the repo.