### PR TITLE
Fix shared worker resumption after tab suspend

### DIFF
--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -27,6 +27,13 @@ let worker = null;
 // The regular Worker running the backend, created only on the leader tab
 let localBackendWorker = null;
 
+function terminateLocalBackendWorker() {
+  if (localBackendWorker) {
+    localBackendWorker.terminate();
+    localBackendWorker = null;
+  }
+}
+
 /**
  * WorkerBridge wraps a SharedWorker port and presents a Worker-like interface
  * (onmessage, postMessage, addEventListener, start) to the connection layer.
@@ -43,9 +50,22 @@ class WorkerBridge {
     this._onmessage = null;
     this._listeners = [];
     this._started = false;
+    this._isInitialized = false;
+    this._currentBudgetId = null;
+    this._wasHidden = document.visibilityState === 'hidden';
+
+    this._onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        this._wasHidden = true;
+      } else if (this._wasHidden) {
+        this._wasHidden = false;
+        this._resumeAssociation();
+      }
+    };
 
     // Listen for all messages from the SharedWorker port
     sharedPort.addEventListener('message', e => this._onSharedMessage(e));
+    document.addEventListener('visibilitychange', this._onVisibilityChange);
   }
 
   set onmessage(handler) {
@@ -109,10 +129,7 @@ class WorkerBridge {
     // show-budgets normally.
     if (msg && msg.type === '__close-and-transfer') {
       console.log('[WorkerBridge] Leadership transferred — terminating Worker');
-      if (localBackendWorker) {
-        localBackendWorker.terminate();
-        localBackendWorker = null;
-      }
+      this._applyRole('UNASSIGNED', null);
       // Only dispatch a synthetic reply if there's an actual close-budget
       // request to complete. When requestId is null the eviction was
       // triggered externally (e.g. another tab deleted this budget).
@@ -126,6 +143,7 @@ class WorkerBridge {
 
     // Role change notification
     if (msg && msg.type === '__role-change') {
+      this._applyRole(msg.role, msg.budgetId ?? null);
       console.log(
         `[WorkerBridge] Role: ${msg.role}${msg.budgetId ? ` (budget: ${msg.budgetId})` : ''}`,
       );
@@ -146,13 +164,47 @@ class WorkerBridge {
     }
 
     // Everything else goes to the connection layer
+    if (msg && msg.type === 'push' && msg.name === 'show-budgets') {
+      this._applyRole('UNASSIGNED', null);
+    }
     this._dispatch(event);
   }
 
-  _createLocalWorker(initMsg, budgetToRestore, pendingMsg) {
-    if (localBackendWorker) {
-      localBackendWorker.terminate();
+  markInitialized() {
+    this._isInitialized = true;
+  }
+
+  _normalizeBudgetId(budgetId) {
+    if (
+      typeof budgetId === 'string' &&
+      budgetId.length > 0 &&
+      !budgetId.startsWith('__')
+    ) {
+      return budgetId;
     }
+    return null;
+  }
+
+  _applyRole(role, budgetId) {
+    this._currentBudgetId = this._normalizeBudgetId(budgetId);
+
+    if (role !== 'LEADER') {
+      terminateLocalBackendWorker();
+    }
+  }
+
+  _resumeAssociation() {
+    if (!this._isInitialized) {
+      return;
+    }
+    this._sharedPort.postMessage({
+      type: '__resume-tab',
+      budgetId: this._currentBudgetId,
+    });
+  }
+
+  _createLocalWorker(initMsg, budgetToRestore, pendingMsg) {
+    terminateLocalBackendWorker();
     localBackendWorker = new Worker(backendWorkerUrl);
     initSQLBackend(localBackendWorker);
 
@@ -238,10 +290,12 @@ function createBackendWorker() {
           'SharedArrayBufferOverride',
         ),
       });
+      worker.markInitialized();
 
-      window.addEventListener('beforeunload', () => {
+      const notifyTabClosing = () => {
         sharedPort.postMessage({ type: 'tab-closing' });
-      });
+      };
+      window.addEventListener('beforeunload', notifyTabClosing);
 
       return;
     } catch (e) {

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -895,6 +895,98 @@ describe('SharedWorker coordinator', () => {
       expect(group.requestNames.get('restore-1')).toBe('load-budget');
       expect(group.requestBudgetIds.get('restore-1')).toBe('budget-1');
     });
+
+    it('waits to broadcast connect until a promoted leader finishes restoring', () => {
+      const leader = setupBudgetGroup(coordinator, 'budget-1');
+
+      const follower = connectTab(coordinator);
+      sendInit(follower);
+      sendMsg(follower, {
+        id: 'lb-f',
+        name: 'load-budget',
+        args: { id: 'budget-1' },
+      });
+      follower.postMessage.mockClear();
+
+      sendMsg(leader, { id: 'cb-leader', name: 'close-budget' });
+      sendMsg(follower, {
+        type: '__track-restore',
+        requestId: '__restore-budget',
+        budgetId: 'budget-1',
+      });
+
+      const reloaded = connectTab(coordinator);
+      sendInit(reloaded);
+      reloaded.postMessage.mockClear();
+
+      sendMsg(follower, {
+        type: '__from-worker',
+        msg: { type: 'connect' },
+      });
+
+      expect(
+        coordinator.getState().budgetGroups.get('budget-1').backendConnected,
+      ).toBe(false);
+      expect(reloaded.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
+
+      sendMsg(follower, {
+        type: '__from-worker',
+        msg: { type: 'reply', id: '__restore-budget', result: {} },
+      });
+
+      expect(
+        coordinator.getState().budgetGroups.get('budget-1').backendConnected,
+      ).toBe(true);
+      expect(reloaded.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
+    });
+
+    it('still broadcasts connect if restore finishes before the worker connect event', () => {
+      const leader = setupBudgetGroup(coordinator, 'budget-1');
+
+      const follower = connectTab(coordinator);
+      sendInit(follower);
+      sendMsg(follower, {
+        id: 'lb-f',
+        name: 'load-budget',
+        args: { id: 'budget-1' },
+      });
+
+      sendMsg(leader, { id: 'cb-leader', name: 'close-budget' });
+      sendMsg(follower, {
+        type: '__track-restore',
+        requestId: '__restore-budget',
+        budgetId: 'budget-1',
+      });
+
+      const reloaded = connectTab(coordinator);
+      sendInit(reloaded);
+      reloaded.postMessage.mockClear();
+
+      sendMsg(follower, {
+        type: '__from-worker',
+        msg: { type: 'reply', id: '__restore-budget', result: {} },
+      });
+
+      expect(reloaded.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
+
+      sendMsg(follower, {
+        type: '__from-worker',
+        msg: { type: 'connect' },
+      });
+
+      expect(
+        coordinator.getState().budgetGroups.get('budget-1').backendConnected,
+      ).toBe(true);
+      expect(reloaded.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
+    });
   });
 
   // ── Multiple budgets ────────────────────────────────────────────────

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -380,7 +380,7 @@ describe('SharedWorker coordinator', () => {
 
   describe('tab disconnection', () => {
     it('leader disconnect promotes follower', () => {
-      setupBudgetGroup(coordinator, 'budget-1');
+      const leader = setupBudgetGroup(coordinator, 'budget-1');
 
       const follower = connectTab(coordinator);
       sendInit(follower);
@@ -390,10 +390,6 @@ describe('SharedWorker coordinator', () => {
         args: { id: 'budget-1' },
       });
       follower.postMessage.mockClear();
-
-      // Find current leader to disconnect it
-      const group = coordinator.getState().budgetGroups.get('budget-1');
-      const leader = group.leaderPort as MockPort;
 
       // Leader closes tab
       sendMsg(leader, { type: 'tab-closing' });
@@ -478,6 +474,116 @@ describe('SharedWorker coordinator', () => {
       vi.advanceTimersByTime(10_000);
 
       expect(coordinator.getState().connectedPorts.includes(leader)).toBe(true);
+    });
+  });
+
+  describe('__resume-tab', () => {
+    it('keeps the lobby leader attached during startup resume signals', () => {
+      const leader = connectTab(coordinator);
+      sendInit(leader);
+      leader.postMessage.mockClear();
+
+      sendMsg(leader, { type: '__resume-tab', budgetId: null });
+
+      expect(coordinator.getState().portToBudget.get(leader)).toBe('__lobby');
+      expect(coordinator.getState().unassignedPorts.has(leader)).toBe(false);
+      expect(
+        coordinator.getState().budgetGroups.get('__lobby').leaderPort,
+      ).toBe(leader);
+      expect(leader.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'UNASSIGNED',
+        }),
+      );
+    });
+
+    it('does not route orphaned ports through another live budget before they resume', () => {
+      const orphanedLeader = setupBudgetGroup(coordinator, 'budget-1');
+      const liveLeader = setupBudgetGroup(coordinator, 'budget-2');
+      orphanedLeader.postMessage.mockClear();
+      liveLeader.postMessage.mockClear();
+
+      vi.advanceTimersByTime(10_000);
+      sendMsg(liveLeader, { type: '__heartbeat-pong' });
+      vi.advanceTimersByTime(10_000);
+
+      sendMsg(orphanedLeader, { id: 'req-orphan', name: 'get-budgets' });
+
+      expect(liveLeader.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__to-worker',
+          msg: expect.objectContaining({ name: 'get-budgets' }),
+        }),
+      );
+    });
+
+    it('re-elects an orphaned solo tab as leader and restores its budget', () => {
+      const leader = setupBudgetGroup(coordinator, 'budget-1');
+      leader.postMessage.mockClear();
+
+      vi.advanceTimersByTime(10_000);
+      vi.advanceTimersByTime(10_000);
+
+      sendMsg(leader, { type: '__resume-tab', budgetId: 'budget-1' });
+
+      expect(coordinator.getState().connectedPorts.includes(leader)).toBe(true);
+      expect(coordinator.getState().portToBudget.get(leader)).toBe('budget-1');
+      expect(
+        coordinator.getState().budgetGroups.get('budget-1').leaderPort,
+      ).toBe(leader);
+      expect(leader.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'LEADER',
+          budgetId: 'budget-1',
+        }),
+      );
+      expect(leader.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__become-leader',
+          budgetToRestore: 'budget-1',
+        }),
+      );
+    });
+
+    it('reattaches an orphaned tab to an existing budget group as follower', () => {
+      const leader = setupBudgetGroup(coordinator, 'budget-1');
+
+      const follower = connectTab(coordinator);
+      sendInit(follower);
+      sendMsg(follower, {
+        id: 'lb-f',
+        name: 'load-budget',
+        args: { id: 'budget-1' },
+      });
+      follower.postMessage.mockClear();
+
+      vi.advanceTimersByTime(10_000);
+      sendMsg(leader, { type: '__heartbeat-pong' });
+      vi.advanceTimersByTime(10_000);
+
+      sendMsg(follower, { type: '__resume-tab', budgetId: 'budget-1' });
+
+      expect(coordinator.getState().connectedPorts.includes(follower)).toBe(
+        true,
+      );
+      expect(
+        coordinator
+          .getState()
+          .budgetGroups.get('budget-1')
+          .followers.has(follower),
+      ).toBe(true);
+      expect(follower.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'FOLLOWER',
+          budgetId: 'budget-1',
+        }),
+      );
+      expect(follower.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
     });
   });
 

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -534,7 +534,7 @@ export function createCoordinator({
         if (msg.type === '__resume-tab') {
           resumePort(
             port,
-            typeof msg.budgetId === 'string' ? (msg.budgetId as string) : null,
+            typeof msg.budgetId === 'string' ? msg.budgetId : null,
           );
           return;
         }

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -19,6 +19,8 @@ type BudgetGroup = {
   leaderPort: CoordinatorPort;
   followers: Set<CoordinatorPort>;
   backendConnected: boolean;
+  pendingConnect: boolean;
+  restoreBudgetId: string | null;
   requestToPort: Map<string, CoordinatorPort>;
   requestNames: Map<string, string>;
   requestBudgetIds: Map<string, string>;
@@ -89,10 +91,20 @@ export function createCoordinator({
       leaderPort,
       followers: new Set(),
       backendConnected: false,
+      pendingConnect: false,
+      restoreBudgetId: null,
       requestToPort: new Map(),
       requestNames: new Map(),
       requestBudgetIds: new Map(),
     };
+  }
+
+  function broadcastConnect(budgetId: string) {
+    const connectMsg = { type: 'connect' };
+    broadcastToAllInGroup(budgetId, connectMsg);
+    for (const port of unassignedPorts) {
+      port.postMessage(connectMsg);
+    }
   }
 
   function logState(action: string) {
@@ -298,9 +310,14 @@ export function createCoordinator({
     } else {
       group.leaderPort = port;
       group.backendConnected = false;
+      group.pendingConnect = false;
+      group.restoreBudgetId = budgetToRestore || null;
       group.requestToPort.clear();
       group.requestNames.clear();
       group.requestBudgetIds.clear();
+    }
+    if (!group.restoreBudgetId && budgetToRestore) {
+      group.restoreBudgetId = budgetToRestore;
     }
     const prevBudget = portToBudget.get(port);
     if (prevBudget && prevBudget !== budgetId) {
@@ -425,6 +442,15 @@ export function createCoordinator({
       console.log(
         `[SharedWorker] Budget loaded: "${newBudgetId}" (leader + ${oldGroup.followers.size} follower(s))`,
       );
+    }
+
+    if (oldGroup.restoreBudgetId === newBudgetId) {
+      oldGroup.restoreBudgetId = null;
+      if (oldGroup.pendingConnect) {
+        oldGroup.backendConnected = true;
+        oldGroup.pendingConnect = false;
+        broadcastConnect(newBudgetId);
+      }
     }
 
     logState(`Budget "${newBudgetId}" ready`);
@@ -580,10 +606,11 @@ export function createCoordinator({
               group.requestNames.delete(workerMsg.id as string);
             }
           } else if (workerMsg.type === 'connect') {
-            group.backendConnected = true;
-            broadcastToAllInGroup(portBudget!, workerMsg);
-            for (const p of unassignedPorts) {
-              p.postMessage(workerMsg);
+            if (group.restoreBudgetId) {
+              group.pendingConnect = true;
+            } else {
+              group.backendConnected = true;
+              broadcastConnect(portBudget!);
             }
           } else if (workerMsg.type === 'app-init-failure') {
             lastAppInitFailure = workerMsg;
@@ -598,6 +625,7 @@ export function createCoordinator({
 
         if (msg.type === '__track-restore') {
           if (group) {
+            group.restoreBudgetId = msg.budgetId as string;
             group.requestToPort.set(msg.requestId as string, port);
             group.requestNames.set(msg.requestId as string, 'load-budget');
             group.requestBudgetIds.set(

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -105,6 +105,110 @@ export function createCoordinator({
     );
   }
 
+  function isTrackedPort(port: CoordinatorPort) {
+    return connectedPorts.includes(port);
+  }
+
+  function ensureTrackedPort(port: CoordinatorPort) {
+    if (!isTrackedPort(port)) {
+      connectedPorts.push(port);
+    }
+  }
+
+  function hasConnectedBackend() {
+    for (const [, group] of budgetGroups) {
+      if (group.backendConnected) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function isGroupMember(group: BudgetGroup, port: CoordinatorPort) {
+    return group.leaderPort === port || group.followers.has(port);
+  }
+
+  function movePortToUnassigned(port: CoordinatorPort) {
+    const prevBudget = portToBudget.get(port);
+    if (prevBudget) {
+      removePortFromGroup(port, prevBudget);
+    }
+
+    portToBudget.delete(port);
+    unassignedPorts.add(port);
+  }
+
+  function restoreUnassignedPort(port: CoordinatorPort) {
+    movePortToUnassigned(port);
+    port.postMessage({ type: '__role-change', role: 'UNASSIGNED' });
+
+    if (hasConnectedBackend()) {
+      port.postMessage({ type: 'connect' });
+    }
+  }
+
+  function resumePort(port: CoordinatorPort, budgetId?: string | null) {
+    const normalizedBudgetId = budgetId || null;
+    const wasTracked = isTrackedPort(port);
+    const currentBudget = portToBudget.get(port);
+    const currentGroup = currentBudget ? budgetGroups.get(currentBudget) : null;
+    const alreadyAttached =
+      !!normalizedBudgetId &&
+      currentBudget === normalizedBudgetId &&
+      !!currentGroup &&
+      isGroupMember(currentGroup, port);
+    const alreadyUnassigned =
+      !normalizedBudgetId &&
+      !currentBudget &&
+      wasTracked &&
+      unassignedPorts.has(port);
+    const alreadyOnTemporaryGroup =
+      !normalizedBudgetId &&
+      !!currentBudget &&
+      !!currentGroup &&
+      currentBudget.startsWith('__') &&
+      isGroupMember(currentGroup, port);
+
+    ensureTrackedPort(port);
+    pendingPongs.delete(port);
+
+    if (alreadyAttached) {
+      logState(`Tab resumed on budget "${normalizedBudgetId}"`);
+      return;
+    }
+
+    if (alreadyUnassigned) {
+      logState('Tab resume confirmed while unassigned');
+      return;
+    }
+
+    if (alreadyOnTemporaryGroup) {
+      logState(`Tab resumed on coordinator group "${currentBudget}"`);
+      return;
+    }
+
+    if (!normalizedBudgetId) {
+      if (budgetGroups.size === 0) {
+        electLeader('__lobby', port);
+        logState('Tab resumed into lobby');
+      } else {
+        restoreUnassignedPort(port);
+        logState('Tab resumed as unassigned');
+      }
+      return;
+    }
+
+    const existingGroup = budgetGroups.get(normalizedBudgetId);
+    if (existingGroup) {
+      addFollower(normalizedBudgetId, port);
+      logState(`Tab resumed on budget "${normalizedBudgetId}" as follower`);
+      return;
+    }
+
+    electLeader(normalizedBudgetId, port, normalizedBudgetId);
+    logState(`Tab resumed on budget "${normalizedBudgetId}" as leader`);
+  }
+
   function broadcastToGroup(
     budgetId: string,
     msg: unknown,
@@ -401,6 +505,14 @@ export function createCoordinator({
           return;
         }
 
+        if (msg.type === '__resume-tab') {
+          resumePort(
+            port,
+            typeof msg.budgetId === 'string' ? (msg.budgetId as string) : null,
+          );
+          return;
+        }
+
         if (msg.type === '__heartbeat-pong') {
           pendingPongs.delete(port);
           return;
@@ -413,14 +525,7 @@ export function createCoordinator({
           if (lastAppInitFailure) {
             port.postMessage(lastAppInitFailure);
           } else {
-            let anyConnected = false;
-            for (const [, g] of budgetGroups) {
-              if (g.backendConnected) {
-                anyConnected = true;
-                break;
-              }
-            }
-            if (anyConnected) {
+            if (hasConnectedBackend()) {
               port.postMessage({ type: '__role-change', role: 'UNASSIGNED' });
               port.postMessage({ type: 'connect' });
             } else if (budgetGroups.size > 0) {
@@ -689,7 +794,7 @@ export function createCoordinator({
         // ── Default: track and forward to leader ───────────────────
 
         let targetGroup = group;
-        if (!targetGroup) {
+        if (!targetGroup && unassignedPorts.has(port) && isTrackedPort(port)) {
           for (const [, g] of budgetGroups) {
             if (g.backendConnected) {
               targetGroup = g;

--- a/upcoming-release-notes/7656.md
+++ b/upcoming-release-notes/7656.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [jfdoming]
+---
+
+Fix shared worker resumption after tab suspend


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

_Note: I used AI pretty aggressively for this PR since I wasn't familiar with this part of the codebase. I understand the architecture a bit better now as well as the solution, but very open to input on the PR since the code is not mine._

This PR fixes two bugs with multi-tab coordination that could leave tabs loading forever in certain cases.

First, in Safari, tabs are naturally suspended after a certain amount of time. When a tab is suspended, it is no longer able to keep up with heartbeats to the coordinator, which means it will be removed from the coordinator's internal state. When such a tab resumes, it uses the same `MessagePort` it was already assigned, but with no other tabs open, the coordinator wouldn't know which budget the port refers to, leaving the tab waiting forever. (This was the bug found by Claude in the other thread.) Fixed by adding explicit logic for resuming the shared worker connection, and attempting to reattach to the same budget group only if it still exists on the same port.

Second, when the leader tab is disconnected, the coordinator will fail the budget over to a new tab. In the specific scenario of a tab reload (encountered a lot during my testing), the failover process and the reloaded-tab reconnection logic occur in close succession, meaning that the reloaded tab would likely be told the backend is ready before the newly-promoted leader actually had a chance to load the budget. This meant that the reloaded tab would likely hang forever due to the connection error. Fixed by delaying the worker connect message until the new leader has actually finished loading.

## Related issue(s)

Fixes https://github.com/actualbudget/actual/issues/7598

## Testing

Would love some help testing this further! But I tested this in two ways:
(a) I found a process locally with Safari that reproduced the initial issue semi-reliably: I enabled the Safari Debug menu, then toggled "Always Suspend WebProcesses Aggressively" under "Miscellaneous Flags". (Not 100% sure this was necessary.) Then opened a bunch of tabs, unfocused the Actual window, and waited ~5 minutes. Without this PR, that reproduced the linked issue semi-reliably; with this PR, I was no longer able to reproduce.
(b) I opened two tabs next to each other, and tried various combinations of reloading the tabs and making changes. This is how I discovered the second bug, and with this PR I was no longer able to reproduce that bug.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 35 | 14.01 MB → 14.01 MB (+1.18 kB) | +0.01%
loot-core | 1 | 5.26 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
35 | 14.01 MB → 14.01 MB (+1.18 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/browser-preload.js` | 📈 +1.18 kB (+13.79%) | 8.53 kB → 9.7 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.87 MB → 1.87 MB (+1.18 kB) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 191.46 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 104.22 kB | 0%
static/js/de.js | 173.88 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 176.89 kB | 0%
static/js/es.js | 182.3 kB | 0%
static/js/extends.js | 518.76 kB | 0%
static/js/fr.js | 182.5 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 168.33 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 151.39 kB | 0%
static/js/nl.js | 108.46 kB | 0%
static/js/pl.js | 88.14 kB | 0%
static/js/pt-BR.js | 193.24 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/ru.js | 121.6 kB | 0%
static/js/th.js | 178.63 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 212.03 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.88 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.26 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B5tkfYkU.js | 5.26 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->