### PR TITLE
[WIP] fix: update PR template link to actualbudget.org docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://github.com/actualbudget/docs#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
+<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#submitting-a-pull-request. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->
 
 ## Description
 


### PR DESCRIPTION
## Summary

Fixes #7645

The PR template referenced the old archived GitHub docs (`actualbudget/docs\#writing-good-release-notes`) which no longer exists. Updated to point to the current documentation at `actualbudget.org/docs/contributing/#submitting-a-pull-request`.

## Changes

- Updated URL in `.github/PULL_REQUEST_TEMPLATE.md` from archived GitHub docs to actualbudget.org

## Testing

- Verified the new URL resolves correctly