### PR TITLE
[AI] Replace Support contact link with auto-closing tech-support issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,6 @@ contact_links:
   - name: Bank-sync issues
     url: https://discord.gg/pRYNYr4W5A
     about: Is bank-sync not working? Returning too much or too few information? Reach out to the community on Discord.
-  - name: Support
-    url: https://discord.gg/pRYNYr4W5A
-    about: Need help with something? Having troubles setting up? Or perhaps issues using the API? Reach out to the community on Discord.
   - name: Translations
     url: https://hosted.weblate.org/projects/actualbudget/actual/
     about: Found a string that needs a better translation? Add your suggestion or upvote an existing one in Weblate.

--- a/.github/ISSUE_TEMPLATE/tech-support.yml
+++ b/.github/ISSUE_TEMPLATE/tech-support.yml
@@ -1,0 +1,17 @@
+name: Tech Support
+description: Need help with something? Having troubles setting up? Or perhaps issues using the API?
+title: '[Support]: '
+labels: ['tech-support']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **Tech support tickets opened here are automatically closed.** GitHub Issues is reserved for bug reports and feature requests. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe your problem
+      description: Please describe, in as much detail as you can, what you need help with.
+      placeholder: I'm trying to [...] but [...]
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/tech-support.yml
+++ b/.github/ISSUE_TEMPLATE/tech-support.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > ⚠️ **Tech support tickets opened here are automatically closed.** GitHub Issues is reserved for bug reports and feature requests. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
+        > ⚠️ **Tech support tickets opened here are automatically closed.** GitHub Issues are reserved for bug reports and feature requests. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
   - type: textarea
     id: problem
     attributes:

--- a/.github/workflows/issues-close-tech-support.yml
+++ b/.github/workflows/issues-close-tech-support.yml
@@ -16,7 +16,7 @@ jobs:
           GitHub Issues is reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
 
           <!-- tech-support-auto-close-comment -->"
-          
+
           gh issue close "$ISSUE_URL"
         env:
           ISSUE_URL: https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}

--- a/.github/workflows/issues-close-tech-support.yml
+++ b/.github/workflows/issues-close-tech-support.yml
@@ -1,0 +1,25 @@
+name: Close tech support issues with automated message
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  tech-support:
+    if: ${{ github.event.label.name == 'tech-support' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            :wave: Thanks for reaching out!
+
+            GitHub Issues is reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
+
+            <!-- tech-support-auto-close-comment -->
+      - name: Close Issue
+        run: gh issue close "https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues-close-tech-support.yml
+++ b/.github/workflows/issues-close-tech-support.yml
@@ -9,17 +9,15 @@ jobs:
     if: ${{ github.event.label.name == 'tech-support' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Create comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            :wave: Thanks for reaching out!
+      - name: Create comment and close issue
+        run: |
+          gh issue comment "$ISSUE_URL" --body ":wave: Thanks for reaching out!
 
-            GitHub Issues is reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
+          GitHub Issues is reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
 
-            <!-- tech-support-auto-close-comment -->
-      - name: Close Issue
-        run: gh issue close "https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}"
+          <!-- tech-support-auto-close-comment -->"
+          
+          gh issue close "$ISSUE_URL"
         env:
+          ISSUE_URL: https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issues-close-tech-support.yml
+++ b/.github/workflows/issues-close-tech-support.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           gh issue comment "$ISSUE_URL" --body ":wave: Thanks for reaching out!
 
-          GitHub Issues is reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
+          GitHub Issues are reserved for bug reports and feature requests, so tech support tickets are automatically closed. The fastest way to get help is to ask the community on [Discord](https://discord.gg/pRYNYr4W5A) — that's where most of the community lives and can help you in real time.
 
           <!-- tech-support-auto-close-comment -->"
 

--- a/upcoming-release-notes/7670.md
+++ b/upcoming-release-notes/7670.md
@@ -1,6 +1,6 @@
 ---
-category: Enhancements
+category: Maintenance
 authors: [MatissJanis]
 ---
 
-Replace support contact link with auto-closing tech support issue template for streamlined user assistance.
+Replace support contact link with auto-closing tech support issue template.

--- a/upcoming-release-notes/7670.md
+++ b/upcoming-release-notes/7670.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Replace support contact link with auto-closing tech support issue template for streamlined user assistance.


### PR DESCRIPTION
Maybe this will help with the increase in tech support tickets we keep getting. 

Auto close them and direct folks again to the Discord. 