### PR TITLE
[WIP] [AI] Fix upcoming transactions sort when date overridden by rule

### DIFF
--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -100,6 +100,13 @@ export function usePreviewTransactions({
             ),
           }));
 
+          // Re-sort after rules run, since a "set date" action can change
+          // the date that was used for the original sort in
+          // computeSchedulePreviewTransactions.
+          withDefaults.sort(
+            (a, b) => b.date.localeCompare(a.date) || a.amount - b.amount,
+          );
+
           const ungroupedTransactions = ungroupTransactions(withDefaults);
           setPreviewTransactions(ungroupedTransactions);
 


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 35 → 34 | 14.07 MB → 13.95 MB (-124.16 kB) | -0.86%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
35 → 34 | 14.07 MB → 13.95 MB (-124.16 kB) | -0.86%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/usePreviewTransactions.ts` | 📈 +125 B (+5.47%) | 2.23 kB → 2.35 kB
`locale/en.json` | 📈 +8.75 kB (+4.94%) | 177.06 kB → 185.81 kB
`locale/pl.json` | 📉 -130 B (-0.14%) | 88.14 kB → 88.01 kB
`locale/nl.json` | 📉 -232 B (-0.21%) | 108.46 kB → 108.23 kB
`locale/th.json` | 📉 -443 B (-0.24%) | 178.63 kB → 178.2 kB
`locale/zh-Hans.json` | 📉 -695 B (-0.57%) | 119.88 kB → 119.2 kB
`locale/es.json` | 📉 -1.04 kB (-0.57%) | 182.3 kB → 181.26 kB
`locale/de.json` | 📉 -1.05 kB (-0.60%) | 173.88 kB → 172.83 kB
`locale/uk.json` | 📉 -1.28 kB (-0.60%) | 212.03 kB → 210.75 kB
`locale/nb-NO.json` | 📉 -937 B (-0.60%) | 151.39 kB → 150.48 kB
`locale/pt-BR.json` | 📉 -1.18 kB (-0.61%) | 193.24 kB → 192.06 kB
`locale/it.json` | 📉 -1.05 kB (-0.63%) | 168.33 kB → 167.28 kB
`locale/ca.json` | 📉 -1.23 kB (-0.64%) | 191.46 kB → 190.22 kB
`locale/fr.json` | 📉 -1.23 kB (-0.67%) | 182.5 kB → 181.27 kB
`locale/da.json` | 📉 -917 B (-0.86%) | 104.22 kB → 103.32 kB
`src/languages.ts` | 📉 -99 B (-5.81%) | 1.66 kB → 1.57 kB
`locale/ru.json` | 🔥 -121.6 kB (-100%) | 121.6 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ru.js | 121.6 kB → 0 B (-121.6 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 177.06 kB → 185.81 kB (+8.75 kB) | +4.94%
static/js/PayeeRuleCountLabel.js | 52.52 kB → 52.65 kB (+125 B) | +0.23%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/uk.js | 212.03 kB → 210.75 kB (-1.28 kB) | -0.60%
static/js/ca.js | 191.46 kB → 190.22 kB (-1.23 kB) | -0.64%
static/js/fr.js | 182.5 kB → 181.27 kB (-1.23 kB) | -0.67%
static/js/pt-BR.js | 193.24 kB → 192.06 kB (-1.18 kB) | -0.61%
static/js/it.js | 168.33 kB → 167.28 kB (-1.05 kB) | -0.63%
static/js/de.js | 173.88 kB → 172.83 kB (-1.05 kB) | -0.60%
static/js/es.js | 182.3 kB → 181.26 kB (-1.04 kB) | -0.57%
static/js/nb-NO.js | 151.39 kB → 150.48 kB (-937 B) | -0.60%
static/js/da.js | 104.22 kB → 103.32 kB (-917 B) | -0.86%
static/js/zh-Hans.js | 119.88 kB → 119.2 kB (-695 B) | -0.57%
static/js/th.js | 178.63 kB → 178.2 kB (-443 B) | -0.24%
static/js/nl.js | 108.46 kB → 108.23 kB (-232 B) | -0.21%
static/js/pl.js | 88.14 kB → 88.01 kB (-130 B) | -0.14%
static/js/extends.js | 518.76 kB → 518.66 kB (-99 B) | -0.02%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DQyIBq5w.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->