### PR TITLE
automation UI: seperate percentage sources in error logic

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/useBudgetAutomationCategories.ts
+++ b/packages/desktop-client/src/components/budget/goals/useBudgetAutomationCategories.ts
@@ -7,7 +7,7 @@ export function useBudgetAutomationCategories() {
   const { t } = useTranslation();
   const { data: { grouped } = { grouped: [] } } = useCategories();
   const categories = useMemo(() => {
-    const incomeGroup = grouped.filter(group => group.name === 'Income')[0];
+    const incomeGroups = grouped.filter(group => group.is_income);
     return [
       {
         id: '',
@@ -21,7 +21,10 @@ export function useBudgetAutomationCategories() {
           },
         ],
       },
-      { ...incomeGroup, name: t('Income categories') },
+      ...incomeGroups.map(group => ({
+        ...group,
+        name: t('Income categories'),
+      })),
     ];
   }, [grouped, t]);
 

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
@@ -1,0 +1,61 @@
+import type { Template } from '@actual-app/core/types/models/templates';
+import { describe, expect, it } from 'vitest';
+
+import { validatePercentageAllocation } from './validateAutomation';
+
+function percent(
+  category: string,
+  percent: number,
+  previous = false,
+): Template {
+  return {
+    type: 'percentage',
+    percent,
+    previous,
+    category,
+    directive: 'template',
+    priority: 1,
+  };
+}
+
+describe('validatePercentageAllocation', () => {
+  it('returns null when no percentage templates are present', () => {
+    expect(validatePercentageAllocation([])).toBeNull();
+  });
+
+  it('flags a single source over 100%', () => {
+    expect(
+      validatePercentageAllocation([
+        percent('Salary', 60),
+        percent('Salary', 50),
+      ]),
+    ).toEqual({ kind: 'percent-over-100', total: 110 });
+  });
+
+  it('does not sum across distinct income sources', () => {
+    expect(
+      validatePercentageAllocation([
+        percent('Income-HSA', 100, true),
+        percent('Interest-HSA', 100),
+      ]),
+    ).toBeNull();
+  });
+
+  it('treats this-month and last-month income as different sources', () => {
+    expect(
+      validatePercentageAllocation([
+        percent('Salary', 100, false),
+        percent('Salary', 100, true),
+      ]),
+    ).toBeNull();
+  });
+
+  it('matches sources case-insensitively', () => {
+    expect(
+      validatePercentageAllocation([
+        percent('Salary', 60),
+        percent('salary', 50),
+      ]),
+    ).toEqual({ kind: 'percent-over-100', total: 110 });
+  });
+});

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
@@ -50,6 +50,14 @@ describe('validatePercentageAllocation', () => {
     ).toBeNull();
   });
 
+  it('ignores templates with a missing source', () => {
+    const orphan = {
+      ...percent('Salary', 100),
+      category: null as unknown as string,
+    };
+    expect(validatePercentageAllocation([orphan])).toBeNull();
+  });
+
   it('matches sources case-insensitively', () => {
     expect(
       validatePercentageAllocation([

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
@@ -99,7 +99,7 @@ export function validatePercentageAllocation(
 ): GlobalConflictKind | null {
   const percentBySource = new Map<string, number>();
   for (const t of templates) {
-    if (t.type !== 'percentage') continue;
+    if (t.type !== 'percentage' || !t.category) continue;
     const key = `${t.previous}|${t.category.toLocaleLowerCase()}`;
     percentBySource.set(key, (percentBySource.get(key) ?? 0) + t.percent);
   }

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
@@ -93,3 +93,18 @@ export function validateAutomation(
       return null;
   }
 }
+
+export function validatePercentageAllocation(
+  templates: readonly Template[],
+): GlobalConflictKind | null {
+  const percentBySource = new Map<string, number>();
+  for (const t of templates) {
+    if (t.type !== 'percentage') continue;
+    const key = `${t.previous}|${t.category.toLocaleLowerCase()}`;
+    percentBySource.set(key, (percentBySource.get(key) ?? 0) + t.percent);
+  }
+  const maxPercent = Math.max(0, ...percentBySource.values());
+  return maxPercent > 100
+    ? { kind: 'percent-over-100', total: maxPercent }
+    : null;
+}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -212,12 +212,15 @@ export function BudgetAutomationsBody({
     dryRun?.perTemplate?.[i] != null ? dryRun.perTemplate[i] : null,
   );
   const hasErrors = automationErrors.some(error => error !== null);
-  const percentSum = templates.reduce<number>((sum, t) => {
-    if (t.type === 'percentage') return sum + t.percent;
-    return sum;
-  }, 0);
+  const percentBySource = new Map<string, number>();
+  for (const t of templates) {
+    if (t.type !== 'percentage') continue;
+    const key = `${t.previous}|${t.category.toLocaleLowerCase()}`;
+    percentBySource.set(key, (percentBySource.get(key) ?? 0) + t.percent);
+  }
+  const maxPercent = Math.max(0, ...percentBySource.values());
   const conflict: GlobalConflictKind | null =
-    percentSum > 100 ? { kind: 'percent-over-100', total: percentSum } : null;
+    maxPercent > 100 ? { kind: 'percent-over-100', total: maxPercent } : null;
 
   const categoryNameMap: Record<string, string> = {};
   for (const group of categories) {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -19,8 +19,10 @@ import {
 } from '#components/budget/goals/automationExamples';
 import type { AutomationEntry } from '#components/budget/goals/automationExamples';
 import { formatMonthLabel } from '#components/budget/goals/formatMonthLabel';
-import { validateAutomation } from '#components/budget/goals/validateAutomation';
-import type { GlobalConflictKind } from '#components/budget/goals/validateAutomation';
+import {
+  validateAutomation,
+  validatePercentageAllocation,
+} from '#components/budget/goals/validateAutomation';
 import { Link } from '#components/common/Link';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -212,15 +214,7 @@ export function BudgetAutomationsBody({
     dryRun?.perTemplate?.[i] != null ? dryRun.perTemplate[i] : null,
   );
   const hasErrors = automationErrors.some(error => error !== null);
-  const percentBySource = new Map<string, number>();
-  for (const t of templates) {
-    if (t.type !== 'percentage') continue;
-    const key = `${t.previous}|${t.category.toLocaleLowerCase()}`;
-    percentBySource.set(key, (percentBySource.get(key) ?? 0) + t.percent);
-  }
-  const maxPercent = Math.max(0, ...percentBySource.values());
-  const conflict: GlobalConflictKind | null =
-    maxPercent > 100 ? { kind: 'percent-over-100', total: maxPercent } : null;
+  const conflict = validatePercentageAllocation(templates);
 
   const categoryNameMap: Record<string, string> = {};
   for (const group of categories) {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -65,9 +65,20 @@ export function BudgetAutomationsModal({
     hasSpendTemplate ||
     hasCleanupDirective;
 
+  const incomeNameToId = new Map<string, string>();
+  for (const group of categories) {
+    for (const cat of group.categories ?? []) {
+      if (cat.name) incomeNameToId.set(cat.name.toLowerCase(), cat.id);
+    }
+  }
+  const resolved = parsedTemplates?.map(t => {
+    if (t.type !== 'percentage' || !t.category) return t;
+    const id = incomeNameToId.get(t.category.toLowerCase());
+    return id ? { ...t, category: id } : t;
+  });
   const initialEntries =
-    parsedTemplates && !hasUnsupportedDirective
-      ? migrateTemplatesToAutomations(parsedTemplates)
+    resolved && !hasUnsupportedDirective
+      ? migrateTemplatesToAutomations(resolved)
       : null;
 
   return (

--- a/upcoming-release-notes/7694.md
+++ b/upcoming-release-notes/7694.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix percentage calculation in automation UI error message


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

AI disclaimer, I did the fixes, claude helped to write the tests.

Fixes income category resolution (were showing blank) and scopes the percentage error message per source.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4367351791

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Use test budget for before and after comparison.

[2026-05-04-Test Budget.zip](https://github.com/user-attachments/files/27326107/2026-05-04-Test.Budget.zip)

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.95 MB → 13.95 MB (+799 B) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.95 MB → 13.95 MB (+799 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/validateAutomation.ts` | 📈 +482 B (+29.23%) | 1.61 kB → 2.08 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📈 +466 B (+9.29%) | 4.9 kB → 5.35 kB
`src/components/budget/goals/useBudgetAutomationCategories.ts` | 📈 +18 B (+2.67%) | 674 B → 692 B
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📉 -167 B (-1.69%) | 9.67 kB → 9.51 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.93 MB (+799 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 190.22 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 103.32 kB | 0%
static/js/de.js | 172.83 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.81 kB | 0%
static/js/es.js | 181.26 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 181.27 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 167.28 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 150.48 kB | 0%
static/js/nl.js | 108.23 kB | 0%
static/js/pl.js | 88.01 kB | 0%
static/js/pt-BR.js | 192.06 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.2 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 210.75 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.2 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DiBErB6z.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->