### PR TITLE
docs: add Enable Actual to community repos

### DIFF
--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -13,6 +13,7 @@ for it to be added, your project must have a proper README file.
 The following are implementations of bank syncing using the Actual API. For instructions on using them, see the respective repositories.
 
 - **Akahu and Up bank sync to Actual Budget** - https://github.com/tim-smart/actualbudget-sync
+- **Enable Actual: Import transactions from European banks using Enable Banking** - https://github.com/2manyvcos/enable-actual
 - **ICS Cards Holland CVS exporter** - https://github.com/IeuanK/ICS-Exporter/
 - **Lunch Flow: Import transactions from GoCardless, MX, Finicity, Finverse, and more** - https://github.com/lunchflow/actual-flow
 - **MoneyMan an israel banks importer** - https://github.com/daniel-hauser/moneyman


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Added Enable Actual to the Community Repos page.

This is an external tool to import transactions from Enable Banking to Actual Budget.

Link(s): https://github.com/2manyvcos/enable-actual
Summary: [Enable Banking](https://enablebanking.com/) provides free (for personal use) access to bank transactions via official PSD2 APIs. Enable Actual connects this data to [Actual Budget](https://actualbudget.com/) and keeps your transactions in sync automatically.

<!--- actual-bot-sections --->
