### PR TITLE
[AI] Add Bridge Bank to Community Projects (Bank Export and Importers)

### DIFF
--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -13,6 +13,7 @@ for it to be added, your project must have a proper README file.
 The following are implementations of bank syncing using the Actual API. For instructions on using them, see the respective repositories.
 
 - **Akahu and Up bank sync to Actual Budget** - https://github.com/tim-smart/actualbudget-sync
+- **Bridge Bank: sync 2,500+ European banks into Actual via Enable Banking (open source, paid licence)** - https://github.com/DAdjadj/bridge-bank
 - **ICS Cards Holland CVS exporter** - https://github.com/IeuanK/ICS-Exporter/
 - **Lunch Flow: Import transactions from GoCardless, MX, Finicity, Finverse, and more** - https://github.com/lunchflow/actual-flow
 - **MoneyMan an israel banks importer** - https://github.com/daniel-hauser/moneyman


### PR DESCRIPTION
Adds Bridge Bank to the Community Projects → Bank Export and Importers list.

Bridge Bank is a self-hosted Docker tool that syncs transactions from 2,500+ European banks (Revolut, N26, Wise, Millennium BCP, etc.) into Actual Budget via Enable Banking open banking. Source on GitHub (MIT + Commons Clause); requires a paid licence to run.

- Repo: https://github.com/DAdjadj/bridge-bank
- Site: https://bridgebank.app

Happy to tweak description wording or licence phrasing if maintainers prefer something different.