### PR TITLE
Cannot read properties of null (reading 'toLowerCase')

### DIFF
--- a/packages/loot-core/src/server/post.ts
+++ b/packages/loot-core/src/server/post.ts
@@ -11,7 +11,7 @@ function throwIfNot200(res: Response, text: string) {
       throw new PostError(res.status === 500 ? 'internal' : text);
     }
 
-    const contentType = res.headers.get('Content-Type');
+    const contentType = res.headers.get('Content-Type') ?? '';
     if (contentType.toLowerCase().indexOf('application/json') !== -1) {
       const json = JSON.parse(text);
       throw new PostError(json.reason);

--- a/upcoming-release-notes/7704.md
+++ b/upcoming-release-notes/7704.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [alecbakholdin]
 ---
 
-Fixed cannot read properties of null (reading 'toLowerCase')
+Fixed cannot read properties of null in throwIfNot200 (reading 'toLowerCase')

--- a/upcoming-release-notes/7704.md
+++ b/upcoming-release-notes/7704.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [alecbakholdin]
+---
+
+Fixed cannot read properties of null (reading 'toLowerCase')


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<img width="602" height="84" alt="image" src="https://github.com/user-attachments/assets/3b0ee32d-8b5b-4abc-9254-4040fade4257" />
<img width="770" height="202" alt="image" src="https://github.com/user-attachments/assets/bdc8f327-25b6-403a-8586-af4fb07b6483" />


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.95 MB | 0%
loot-core | 1 | 5.27 MB → 5.27 MB (+8 B) | +0.00%
api | 2 | 3.89 MB → 3.89 MB (+8 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.95 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 52.52 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/ca.js | 190.22 kB | 0%
static/js/chart-theme.js | 796.5 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 103.32 kB | 0%
static/js/de.js | 172.83 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.81 kB | 0%
static/js/es.js | 181.26 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 181.27 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 167.28 kB | 0%
static/js/narrow.js | 364.31 kB | 0%
static/js/nb-NO.js | 150.48 kB | 0%
static/js/nl.js | 108.23 kB | 0%
static/js/pl.js | 88.01 kB | 0%
static/js/pt-BR.js | 192.06 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 178.2 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 210.75 kB | 0%
static/js/useFormatList.js | 8.63 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 119.2 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+8 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +8 B (+0.20%) | 3.94 kB → 3.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DPChB-0o.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DiBErB6z.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.89 MB (+8 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +8 B (+0.21%) | 3.79 kB → 3.8 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.89 MB (+8 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->