### PR TITLE
[WIP] docs: reorganize FAQ and file management sidebar items

### DIFF
--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -27,6 +27,7 @@ const sidebars = {
     'index',
     'vision',
     'releases',
+    'faq',
     {
       type: 'category',
       label: 'Getting Started',
@@ -190,13 +191,20 @@ const sidebars = {
         },
         {
           type: 'category',
-          label: 'Backup & Restore',
+          label: 'Files, Sync & Settings',
           collapsed: true,
-          items: ['backup-restore/backup', 'backup-restore/restore'],
+          items: [
+            'settings/index',
+            'getting-started/sync',
+            'getting-started/manage-files',
+            {
+              type: 'category',
+              label: 'Backup & Restore',
+              collapsed: true,
+              items: ['backup-restore/backup', 'backup-restore/restore'],
+            },
+          ],
         },
-        'settings/index',
-        'getting-started/sync',
-        'getting-started/manage-files',
 
         {
           type: 'category',
@@ -246,7 +254,6 @@ const sidebars = {
       collapsible: false,
       className: 'no-indent',
       items: [
-        'faq',
         'actual-server-repo-move',
         {
           type: 'category',


### PR DESCRIPTION
## Summary

Reorganizes a small part of the docs sidebar to make common help and file-management pages easier to find.

Changes made:
- Moves FAQ to the top-level sidebar after Release Notes
- Groups Settings, Sync, Manage Files, Backup, and Restore under a new “Files, Sync & Settings” category
- Removes FAQ from the Help & Support section to avoid duplicate placement

## Related issue

Part of #7474

## Notes

This is a documentation-only sidebar organization change. It keeps the PR small while improving the structure of the docs sidebar.