### PR TITLE
[WIP] [AI] Fix Category Group filtering in Custom Report with Budgeted type

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -45,6 +45,7 @@ async function mapWithConcurrency<TItem, TResult>(
 
 function filterCategoriesByConditions(
   categories: CategoryEntity[],
+  categoryGroups: CategoryGroupEntity[],
   conditions: RuleConditionEntity[] | undefined,
   conditionsOp: BudgetDataConditionsOp | undefined,
 ) {
@@ -52,18 +53,23 @@ function filterCategoriesByConditions(
     return categories;
   }
 
-  const categoryConditions = conditions.filter(
-    (cond): cond is Extract<RuleConditionEntity, { field: 'category' }> =>
-      !cond.customName && cond.field === 'category',
+  const relevantConditions = conditions.filter(
+    cond =>
+      !cond.customName &&
+      (cond.field === 'category' || cond.field === 'category_group'),
   );
 
-  if (categoryConditions.length === 0) {
+  if (relevantConditions.length === 0) {
     return categories;
   }
 
-  const isSupportedCondition = (
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
-  ) => {
+  // Build a UUID → name map for category groups so text-based operators
+  // (contains, doesNotContain, matches) can match against the group name.
+  const groupNameById = new Map<string, string>(
+    categoryGroups.map(g => [g.id, g.name] as const),
+  );
+
+  const isSupportedCondition = (condition: RuleConditionEntity) => {
     if (condition.op === 'is' || condition.op === 'isNot') {
       return typeof condition.value === 'string';
     }
@@ -75,33 +81,78 @@ function filterCategoriesByConditions(
       );
     }
 
+    if (
+      condition.op === 'contains' ||
+      condition.op === 'doesNotContain' ||
+      condition.op === 'matches'
+    ) {
+      return typeof condition.value === 'string';
+    }
+
     return false;
   };
 
-  // If we can't safely interpret any category condition, do not attempt to
+  // If we can't safely interpret any condition, do not attempt to
   // filter categories (better to be broad than silently exclude data).
-  if (!categoryConditions.every(isSupportedCondition)) {
+  if (!relevantConditions.every(isSupportedCondition)) {
     return categories;
   }
 
   const evaluateCondition = (
     category: CategoryEntity,
-    condition: Extract<RuleConditionEntity, { field: 'category' }>,
+    condition: RuleConditionEntity,
   ): boolean => {
+    const key =
+      condition.field === 'category_group' ? category.group : category.id;
+    // For text-based operators, compare against the human-readable name
+    const textValue =
+      condition.field === 'category_group'
+        ? (groupNameById.get(key ?? '') ?? key ?? '')
+        : category.name;
+
     if (condition.op === 'is') {
-      return category.id === condition.value;
+      return condition.value === key;
     }
 
     if (condition.op === 'isNot') {
-      return category.id !== condition.value;
+      return condition.value !== key;
     }
 
     if (condition.op === 'oneOf') {
-      return condition.value.includes(category.id);
+      return Array.isArray(condition.value) && condition.value.includes(key);
     }
 
     if (condition.op === 'notOneOf') {
-      return !condition.value.includes(category.id);
+      return Array.isArray(condition.value) && !condition.value.includes(key);
+    }
+
+    if (condition.op === 'contains') {
+      return (
+        typeof condition.value === 'string' &&
+        (textValue ?? '')
+          .toLowerCase()
+          .includes(condition.value.toLowerCase())
+      );
+    }
+
+    if (condition.op === 'doesNotContain') {
+      return (
+        typeof condition.value === 'string' &&
+        !(textValue ?? '')
+          .toLowerCase()
+          .includes(condition.value.toLowerCase())
+      );
+    }
+
+    if (condition.op === 'matches') {
+      if (typeof condition.value !== 'string' || condition.value.length > 256) {
+        return false;
+      }
+      try {
+        return new RegExp(condition.value, 'i').test(textValue ?? '');
+      } catch {
+        return false;
+      }
     }
 
     return true;
@@ -111,8 +162,8 @@ function filterCategoriesByConditions(
 
   return categories.filter(cat =>
     op === 'or'
-      ? categoryConditions.some(cond => evaluateCondition(cat, cond))
-      : categoryConditions.every(cond => evaluateCondition(cat, cond)),
+      ? relevantConditions.some(cond => evaluateCondition(cat, cond))
+      : relevantConditions.every(cond => evaluateCondition(cat, cond)),
   );
 }
 
@@ -141,6 +192,7 @@ export async function fetchBudgetData({
 
   const filteredCategories = filterCategoriesByConditions(
     categories,
+    categoryGroups,
     conditions,
     conditionsOp,
   );

--- a/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budgetDataQuery.ts
@@ -129,18 +129,14 @@ function filterCategoriesByConditions(
     if (condition.op === 'contains') {
       return (
         typeof condition.value === 'string' &&
-        (textValue ?? '')
-          .toLowerCase()
-          .includes(condition.value.toLowerCase())
+        (textValue ?? '').toLowerCase().includes(condition.value.toLowerCase())
       );
     }
 
     if (condition.op === 'doesNotContain') {
       return (
         typeof condition.value === 'string' &&
-        !(textValue ?? '')
-          .toLowerCase()
-          .includes(condition.value.toLowerCase())
+        !(textValue ?? '').toLowerCase().includes(condition.value.toLowerCase())
       );
     }
 

--- a/upcoming-release-notes/7550.md
+++ b/upcoming-release-notes/7550.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [okxint]
+---
+
+Fix Category Group filtering in Custom Report with Budgeted type


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.96 MB → 13.93 MB (-26.27 kB) | -0.18%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.96 MB → 13.93 MB (-26.27 kB) | -0.18%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/budgetDataQuery.ts` | 📈 +1.06 kB (+31.08%) | 3.41 kB → 4.46 kB
`locale/en.json` | 📉 -457 B (-0.24%) | 185.81 kB → 185.36 kB
`locale/pt-BR.json` | 📉 -1.98 kB (-1.03%) | 192.06 kB → 190.09 kB
`locale/ca.json` | 📉 -2.14 kB (-1.13%) | 190.22 kB → 188.08 kB
`locale/es.json` | 📉 -2.1 kB (-1.16%) | 181.26 kB → 179.16 kB
`locale/fr.json` | 📉 -2.2 kB (-1.21%) | 181.27 kB → 179.07 kB
`locale/de.json` | 📉 -2.1 kB (-1.22%) | 172.83 kB → 170.73 kB
`locale/it.json` | 📉 -2.09 kB (-1.25%) | 167.28 kB → 165.19 kB
`locale/uk.json` | 📉 -2.8 kB (-1.33%) | 210.75 kB → 207.95 kB
`locale/nb-NO.json` | 📉 -2 kB (-1.33%) | 150.48 kB → 148.48 kB
`locale/zh-Hans.json` | 📉 -1.62 kB (-1.36%) | 119.2 kB → 117.58 kB
`locale/nl.json` | 📉 -1.58 kB (-1.46%) | 108.23 kB → 106.65 kB
`locale/pl.json` | 📉 -1.34 kB (-1.52%) | 88.01 kB → 86.67 kB
`locale/da.json` | 📉 -1.75 kB (-1.70%) | 103.32 kB → 101.57 kB
`locale/th.json` | 📉 -3.17 kB (-1.78%) | 178.2 kB → 175.02 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (+1.06 kB) | +0.08%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 178.2 kB → 175.02 kB (-3.17 kB) | -1.78%
static/js/uk.js | 210.75 kB → 207.95 kB (-2.8 kB) | -1.33%
static/js/fr.js | 181.27 kB → 179.07 kB (-2.2 kB) | -1.21%
static/js/ca.js | 190.22 kB → 188.08 kB (-2.14 kB) | -1.13%
static/js/es.js | 181.26 kB → 179.16 kB (-2.1 kB) | -1.16%
static/js/de.js | 172.83 kB → 170.73 kB (-2.1 kB) | -1.22%
static/js/it.js | 167.28 kB → 165.19 kB (-2.09 kB) | -1.25%
static/js/nb-NO.js | 150.48 kB → 148.48 kB (-2 kB) | -1.33%
static/js/pt-BR.js | 192.06 kB → 190.09 kB (-1.98 kB) | -1.03%
static/js/da.js | 103.32 kB → 101.57 kB (-1.75 kB) | -1.70%
static/js/zh-Hans.js | 119.2 kB → 117.58 kB (-1.62 kB) | -1.36%
static/js/nl.js | 108.23 kB → 106.65 kB (-1.58 kB) | -1.46%
static/js/pl.js | 88.01 kB → 86.67 kB (-1.34 kB) | -1.52%
static/js/en.js | 185.81 kB → 185.36 kB (-457 B) | -0.24%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 53.96 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.02 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DiBErB6z.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->