### PR TITLE
[WIP] Docs: add step-by-step onboarding guide

### DIFF
--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -36,6 +36,7 @@ const sidebars = {
         'getting-started/roadmap-for-new-users',
         'getting-started/envelope-budgeting',
         'getting-started/tracking-budget',
+        'getting-started/onboarding-guide',
         {
           type: 'category',
           label: 'Installation and Configuration',

--- a/packages/docs/docs/getting-started/onboarding-guide.md
+++ b/packages/docs/docs/getting-started/onboarding-guide.md
@@ -17,7 +17,7 @@ Actual can be used in a few different ways. Choose the option that best matches 
 - **I want to try Actual without installing anything**: Use the [demo](https://demo.actualbudget.org) if you want to explore the interface before setting anything up.
 - **I want to use Actual on one computer**: Use the [desktop app](/docs/install/desktop-app) if you only need Actual on one device.
 - **I want to use Actual on multiple devices or share a budget**: Use [PikaPods](/docs/install/pikapods) or a [self-hosted server](/docs/install/docker) if you want syncing across devices.
-- **I want to contribute to Actual**: Use the [build from source](/docs/install/build-from-source) or development setup documentation if you want to edit the code or documentation.
+- **I want to contribute to Actual**: Use the [build from source](/docs/install/build-from-source) or [development setup documentation](/docs/contributing/development-setup) if you want to edit the code or documentation.
 
 If you are unsure, start with the demo or desktop app. You can move to a server-based setup later if you decide you want syncing across devices.
 

--- a/packages/docs/docs/getting-started/onboarding-guide.md
+++ b/packages/docs/docs/getting-started/onboarding-guide.md
@@ -57,7 +57,7 @@ Click the add account button. This will give you several options:
 
    Link a Brazilian bank account to automatically download transactions. Pluggy.ai provides reliable, up-to-date information from hundreds of banks.
 
-## Step Four: Create local account *(if you chose the local account option above)*
+## Step Four: Create local account _(if you chose the local account option above)_
 
 One of the great things about Actual is that you do not need to connect your bank account if you do not want to. When you press this option, a screen will pop up that lets you manually enter the amount in the account.
 

--- a/packages/docs/docs/getting-started/onboarding-guide.md
+++ b/packages/docs/docs/getting-started/onboarding-guide.md
@@ -1,0 +1,80 @@
+---
+title: Step-by-step onboarding guide
+---
+
+# Step-by-step onboarding guide
+
+## Who is this guide for?
+
+This guide is for new users who want a practical first path through Actual. It is not a replacement for the installation guides or the Starting Fresh guide. Instead, it helps you choose the setup option that best fits your needs and provides a simple order to follow after Actual starts.
+
+By the end of this guide, you should know which setup path to choose, how to start your first budget file, and which features to explore first.
+
+## Choose how you want to use Actual
+
+Actual can be used in a few different ways. Choose the option that best matches your goal:
+
+- **I want to try Actual without installing anything**: Use the demo if you want to explore the interface before setting anything up.
+- **I want to use Actual on one computer**: Use the [desktop app](/docs/install/desktop-app) if you only need Actual on one device.
+- **I want to use Actual on multiple devices or share a budget**: Use [PikaPods](/docs/install/pikapods) or a [self-hosted server](/docs/install/docker) if you want syncing across devices.
+- **I want to contribute to Actual**: Use the [build from source](/docs/install/build-from-source) or development setup documentation if you want to edit the code or documentation.
+
+If you are unsure, start with the demo or desktop app. You can move to a server-based setup later if you decide you want syncing across devices.
+
+### Step One: Set a server password
+
+Set a password for Actual. This password will be used every time you launch the application. So make sure it is both secure and memorable.
+
+### Step Two: Log in
+
+Log in with the same password you just created. This should take you to your Actual home dashboard.
+
+### Step Three: Add an account
+
+Click the add account button. This will give you several options:
+
+1. **Create local account**
+
+    Create a local account if you want to add transactions manually. You can also import QIF/OFX/QFX files into a local account.
+
+2. **Set up GoCardless for bank sync**
+
+    Link a European bank account to automatically download transactions. GoCardless provides reliable, up-to-date information from hundreds of banks.
+
+3. **Set up SimpleFIN for bank sync**
+
+    Link a North American bank account to automatically download transactions. SimpleFIN provides reliable, up-to-date information from hundreds of banks.
+
+4. **Set up Pluggy.ai for bank sync**
+
+    Link a Brazilian bank account to automatically download transactions. Pluggy.ai provides reliable, up-to-date information from hundreds of banks.
+
+### Step Four: Create local account
+
+One of the great things about Actual is that you do not need to connect your bank account if you do not want to. When you press this option, a screen will pop up that lets you manually enter the amount in the account.
+
+When creating a local account:
+
+- Enter the account name you would like to add.
+- Enter the current balance of the account.
+- Check **Off budget** option only if you want this account to be tracked without affecting your budget.
+
+### Step Five: Review available funds
+
+After adding an account, you should see a budget tab in the left sidebar. Clicking that will let you see your available funds and funds that can be assigned to budget categories.
+
+### Step Six: Assign money for each category
+
+From here, you can start adding your budget for each category. Keep in mind, it does not need to be perfect at first! As time goes on, you will start to see trends and ways to more optimally shift the budget.
+
+
+## What to read next
+
+After completing these steps, continue with the [Starting Fresh](/docs/getting-started/starting-fresh) guide for a deeper walkthrough of building your first budget.
+
+If you already know which setup option you want, use the installation guide that matches your path:
+
+- [Desktop app](/docs/install/desktop-app)
+- [PikaPods](/docs/install/pikapods)
+- [Docker](/docs/install/docker)
+- [Build from source](/docs/install/build-from-source)

--- a/packages/docs/docs/getting-started/onboarding-guide.md
+++ b/packages/docs/docs/getting-started/onboarding-guide.md
@@ -14,22 +14,30 @@ By the end of this guide, you should know which setup path to choose, how to sta
 
 Actual can be used in a few different ways. Choose the option that best matches your goal:
 
-- **I want to try Actual without installing anything**: Use the demo if you want to explore the interface before setting anything up.
+- **I want to try Actual without installing anything**: Use the [demo](https://demo.actualbudget.org) if you want to explore the interface before setting anything up.
 - **I want to use Actual on one computer**: Use the [desktop app](/docs/install/desktop-app) if you only need Actual on one device.
 - **I want to use Actual on multiple devices or share a budget**: Use [PikaPods](/docs/install/pikapods) or a [self-hosted server](/docs/install/docker) if you want syncing across devices.
 - **I want to contribute to Actual**: Use the [build from source](/docs/install/build-from-source) or development setup documentation if you want to edit the code or documentation.
 
 If you are unsure, start with the demo or desktop app. You can move to a server-based setup later if you decide you want syncing across devices.
 
-### Step One: Set a server password
+:::tip
+Steps one and two do not apply to demo or desktop users.
+:::
+
+## Step One: Set a server password
 
 Set a password for Actual. This password will be used every time you launch the application. So make sure it is both secure and memorable.
 
-### Step Two: Log in
+:::tip
+Use a password manager to generate and store a secure password for you.
+:::
+
+## Step Two: Log in
 
 Log in with the same password you just created. This should take you to your Actual home dashboard.
 
-### Step Three: Add an account
+## Step Three: Add an account
 
 Click the add account button. This will give you several options:
 
@@ -49,7 +57,7 @@ Click the add account button. This will give you several options:
 
    Link a Brazilian bank account to automatically download transactions. Pluggy.ai provides reliable, up-to-date information from hundreds of banks.
 
-### Step Four: Create local account
+## Step Four: Create local account *(if you chose the local account option above)*
 
 One of the great things about Actual is that you do not need to connect your bank account if you do not want to. When you press this option, a screen will pop up that lets you manually enter the amount in the account.
 
@@ -59,11 +67,11 @@ When creating a local account:
 - Enter the current balance of the account.
 - Check **Off budget** option only if you want this account to be tracked without affecting your budget.
 
-### Step Five: Review available funds
+## Step Five: Review available funds
 
 After adding an account, you should see a budget tab in the left sidebar. Clicking that will let you see your available funds and funds that can be assigned to budget categories.
 
-### Step Six: Assign money for each category
+## Step Six: Assign money for each category
 
 From here, you can start adding your budget for each category. Keep in mind, it does not need to be perfect at first! As time goes on, you will start to see trends and ways to more optimally shift the budget.
 

--- a/packages/docs/docs/getting-started/onboarding-guide.md
+++ b/packages/docs/docs/getting-started/onboarding-guide.md
@@ -35,19 +35,19 @@ Click the add account button. This will give you several options:
 
 1. **Create local account**
 
-    Create a local account if you want to add transactions manually. You can also import QIF/OFX/QFX files into a local account.
+   Create a local account if you want to add transactions manually. You can also import QIF/OFX/QFX files into a local account.
 
 2. **Set up GoCardless for bank sync**
 
-    Link a European bank account to automatically download transactions. GoCardless provides reliable, up-to-date information from hundreds of banks.
+   Link a European bank account to automatically download transactions. GoCardless provides reliable, up-to-date information from hundreds of banks.
 
 3. **Set up SimpleFIN for bank sync**
 
-    Link a North American bank account to automatically download transactions. SimpleFIN provides reliable, up-to-date information from hundreds of banks.
+   Link a North American bank account to automatically download transactions. SimpleFIN provides reliable, up-to-date information from hundreds of banks.
 
 4. **Set up Pluggy.ai for bank sync**
 
-    Link a Brazilian bank account to automatically download transactions. Pluggy.ai provides reliable, up-to-date information from hundreds of banks.
+   Link a Brazilian bank account to automatically download transactions. Pluggy.ai provides reliable, up-to-date information from hundreds of banks.
 
 ### Step Four: Create local account
 
@@ -66,7 +66,6 @@ After adding an account, you should see a budget tab in the left sidebar. Clicki
 ### Step Six: Assign money for each category
 
 From here, you can start adding your budget for each category. Keep in mind, it does not need to be perfect at first! As time goes on, you will start to see trends and ways to more optimally shift the budget.
-
 
 ## What to read next
 


### PR DESCRIPTION
## Description

This PR adds an initial step-by-step onboarding guide for new Actual users.

The guide helps new users choose a setup path, set a server password, log in, add an account, create a local account, review available funds, and understand where to go next. It is intended as a first version of the larger onboarding guide discussed in the issue.

I also added the new guide to the docs sidebar so it appears under Getting Started.

## Related issue(s)

Partially addresses #6190

## Testing

- Ran the docs site locally.
- Verified the new onboarding guide page renders correctly.
- Verified the guide appears in the left sidebar under Getting Started.
- Walked through the local Actual setup flow to compare the guide steps with the interface.
- No actual test have been written. 

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed