### PR TITLE
[AI] Stop mirroring transfer dates on linked transfer updates

### DIFF
--- a/packages/loot-core/src/server/__snapshots__/main.test.ts.snap
+++ b/packages/loot-core/src/server/__snapshots__/main.test.ts.snap
@@ -76,7 +76,7 @@ exports[`Accounts > Transfers are properly updated 2`] = `
       "id": "test-transfer",
       "imported_description": null,
       "isChild": 0,
-@@ -24,15 +24,15 @@
+@@ -24,11 +24,11 @@
       "tombstone": 0,
       "transferred_id": "id2",
       "type": null,
@@ -87,13 +87,8 @@ exports[`Accounts > Transfers are properly updated 2`] = `
       "amount": -5000,
       "category": null,
       "cleared": 0,
--     "date": 20170101,
-+     "date": 20170103,
-      "description": "transfer-one",
-      "error": null,
-      "financial_id": null,
-      "id": "id2",
-      "imported_description": null,"
+      "date": 20170101,
+      "description": "transfer-one","
 `;
 
 exports[`Accounts > Transfers are properly updated 3`] = `

--- a/packages/loot-core/src/server/transactions/__snapshots__/transfer.test.ts.snap
+++ b/packages/loot-core/src/server/transactions/__snapshots__/transfer.test.ts.snap
@@ -355,7 +355,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
 "- First value
 + Second value
 
-@@ -2,73 +2,73 @@
+@@ -2,52 +2,52 @@
     Object {
       "account": "one",
       "amount": 5000,
@@ -387,48 +387,13 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
 +     "transfer_id": "id8",
     },
     Object {
--     "account": "one",
--     "amount": 5000,
-+     "account": "two",
-+     "amount": -5000,
+      "account": "one",
+      "amount": 5000,
       "category": null,
--     "cleared": 1,
--     "date": 20170101,
-+     "cleared": 0,
-+     "date": 20170105,
-      "error": null,
--     "id": "id7",
-+     "id": "id8",
-      "imported_id": null,
-      "imported_payee": null,
-      "is_child": 0,
-      "is_parent": 0,
--     "notes": null,
-+     "notes": "This is a note",
-      "parent_id": null,
--     "payee": "id3",
-+     "payee": "id2",
-      "payee_name": "",
-      "raw_synced_data": null,
-      "reconciled": 0,
-      "schedule": null,
-      "sort_order": 123456789,
-      "starting_balance_flag": 0,
-      "tombstone": 0,
--     "transfer_id": "id8",
-+     "transfer_id": "id7",
-    },
-    Object {
--     "account": "two",
--     "amount": -5000,
-+     "account": "one",
-+     "amount": 5000,
-      "category": null,
--     "cleared": 0,
-+     "cleared": 1,
+      "cleared": 1,
       "date": 20170101,
       "error": null,
--     "id": "id8",
+-     "id": "id7",
 +     "id": "id6",
       "imported_id": null,
       "imported_payee": null,
@@ -436,7 +401,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
       "is_parent": 0,
       "notes": null,
       "parent_id": null,
--     "payee": "id2",
+-     "payee": "id3",
 -     "payee_name": "",
 +     "payee": "id5",
 +     "payee_name": "Non-transfer",
@@ -446,17 +411,33 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
       "sort_order": 123456789,
       "starting_balance_flag": 0,
       "tombstone": 0,
--     "transfer_id": "id7",
+-     "transfer_id": "id8",
 +     "transfer_id": null,
     },
-  ]"
+    Object {
+      "account": "two",
+      "amount": -5000,
+      "category": null,
+@@ -57,11 +57,11 @@
+      "id": "id8",
+      "imported_id": null,
+      "imported_payee": null,
+      "is_child": 0,
+      "is_parent": 0,
+-     "notes": null,
++     "notes": "This is a note",
+      "parent_id": null,
+      "payee": "id2",
+      "payee_name": "",
+      "raw_synced_data": null,
+      "reconciled": 0,"
 `;
 
 exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
 "- First value
 + Second value
 
-@@ -11,22 +11,22 @@
+@@ -11,11 +11,11 @@
       "imported_payee": null,
       "is_child": 0,
       "is_parent": 0,
@@ -469,9 +450,10 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
       "reconciled": 0,
       "schedule": null,
       "sort_order": 123456789,
+@@ -46,11 +46,11 @@
       "starting_balance_flag": 0,
       "tombstone": 0,
-      "transfer_id": "id8",
+      "transfer_id": null,
     },
     Object {
 -     "account": "two",
@@ -479,7 +461,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
       "amount": -5000,
       "category": null,
       "cleared": 0,
-      "date": 20170105,
+      "date": 20170101,
       "error": null,"
 `;
 
@@ -487,7 +469,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
 "- First value
 + Second value
 
-@@ -11,43 +11,19 @@
+@@ -11,19 +11,19 @@
       "imported_payee": null,
       "is_child": 0,
       "is_parent": 0,
@@ -504,13 +486,25 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
       "starting_balance_flag": 0,
       "tombstone": 0,
 -     "transfer_id": "id8",
++     "transfer_id": null,
+    },
+    Object {
+      "account": "one",
+      "amount": 5000,
+      "category": null,
+@@ -44,31 +44,7 @@
+      "schedule": null,
+      "sort_order": 123456789,
+      "starting_balance_flag": 0,
+      "tombstone": 0,
+      "transfer_id": null,
 -   },
 -   Object {
 -     "account": "three",
 -     "amount": -5000,
 -     "category": null,
 -     "cleared": 0,
--     "date": 20170105,
+-     "date": 20170101,
 -     "error": null,
 -     "id": "id8",
 -     "imported_id": null,
@@ -528,12 +522,8 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
 -     "starting_balance_flag": 0,
 -     "tombstone": 0,
 -     "transfer_id": "id7",
-+     "transfer_id": null,
     },
-    Object {
-      "account": "one",
-      "amount": 5000,
-      "category": null,"
+  ]"
 `;
 
 exports[`Transfer > transfers are properly inserted/updated/deleted 6`] = `

--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -126,7 +126,6 @@ export async function updateTransfer(transaction, transferredAccount) {
     // Make sure to update the payee on the other side in case the
     // user moved this transaction into another account
     payee: payee.id,
-    date: transaction.date,
     notes: transaction.notes,
     amount: -transaction.amount,
     schedule: transaction.schedule,

--- a/upcoming-release-notes/7722.md
+++ b/upcoming-release-notes/7722.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [StephenBrown2]
+---
+
+No longer require transfers to have the same date


### PR DESCRIPTION
## Description

Transfer pairs created via the transfer payee flow are kept in sync for amount, notes, payee, account moves, and schedule, but dates no longer need to match on both sides. This change removes only the behavior that overwrote the opposite leg's date when one side of a linked transfer was updated (`updateTransfer` in `packages/loot-core/src/server/transactions/transfer.ts`). Other validation and transfer logic are unchanged.

## Related issue(s)

Fixes #661

## Testing

- `yarn workspace @actual-app/core test`
- Manually: create or link two transactions as a transfer with **different** dates; confirm both remain linked and amounts / opposite account behavior still correct; confirm editing one side does not overwrite the other side’s date.

### Screenshots

1. Created two transactions with different dates, then merged them:
<img width="1186" height="61" alt="Screenshot_2026-05-05_11-40-21" src="https://github.com/user-attachments/assets/bad3cb68-bb1c-4b05-a0e9-9d81b3b25ad3" />

2a. Created a single transfer transaction:
<img width="1186" height="67" alt="Screenshot_2026-05-05_11-41-38" src="https://github.com/user-attachments/assets/84129238-609b-4eda-90df-ba31e9e6be66" />

2b. Then updated the date on one of them:
<img width="1186" height="133" alt="Screenshot_2026-05-05_11-42-27" src="https://github.com/user-attachments/assets/de1d7add-5a2f-4d96-be4d-27156b500e55" />



## Checklist

- [x] Release notes added (see [Writing good release notes](https://actualbudget.org/docs/contributing/#writing-good-release-notes); consider `yarn generate:release-notes` before pushing)
- [x] No obvious regressions in affected areas (transfers, budget load tests, AQL executor tests)
- [x] Self-review has been performed — each change is understood and justified

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB | 0%
loot-core | 1 | 5.27 MB → 5.27 MB (-27 B) | -0.00%
api | 2 | 3.9 MB → 3.9 MB (-26 B) | -0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.7 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.63 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (-27 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transfer.ts` | 📉 -27 B (-0.71%) | 3.71 kB → 3.68 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CBFVZ2-G.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DbAkUAmB.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (-26 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transfer.ts` | 📉 -26 B (-0.70%) | 3.61 kB → 3.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (-26 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.7 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.7 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->