### PR TITLE
[AI] Fix #2155: duplicated transactions are marked as uncleared

### DIFF
--- a/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
+++ b/packages/desktop-client/src/components/modals/ConfirmTransactionEditModal.tsx
@@ -73,21 +73,6 @@ export function ConfirmTransactionEditModal({
                   out of balance.
                 </Trans>
               </Block>
-            ) : confirmReason === 'batchDuplicateWithReconciledTransfer' ? (
-              <Block>
-                <Trans>
-                  This transfer has a linked transaction in another account that
-                  is reconciled. Duplicating it may bring that account's
-                  reconciliation out of balance.
-                </Trans>
-              </Block>
-            ) : confirmReason === 'batchDuplicateWithReconciled' ? (
-              <Block>
-                <Trans>
-                  Duplicating reconciled transactions may bring your
-                  reconciliation out of balance.
-                </Trans>
-              </Block>
             ) : confirmReason === 'editReconciled' ? (
               <Block>
                 <Trans>

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -297,7 +297,11 @@ export function useTransactionBatchActions() {
         added: transactions.reduce(
           (newTransactions: TransactionEntity[], trans: TransactionEntity) => {
             return newTransactions.concat(
-              realizeTempTransactions(ungroupTransaction(trans)),
+              realizeTempTransactions(ungroupTransaction(trans)).map(t => ({
+                ...t,
+                cleared: false,
+                reconciled: false,
+              })),
             );
           },
           [],
@@ -309,11 +313,7 @@ export function useTransactionBatchActions() {
       onSuccess?.(ids);
     };
 
-    await checkForReconciledTransactions(
-      ids,
-      'batchDuplicateWithReconciled',
-      onConfirmDuplicate,
-    );
+    await onConfirmDuplicate(ids);
   };
 
   const onBatchDelete = async ({ ids, onSuccess }: BatchDeleteProps) => {
@@ -445,7 +445,6 @@ export function useTransactionBatchActions() {
   > = {
     batchDeleteWithReconciled: 'batchDeleteWithReconciledTransfer',
     batchEditWithReconciled: 'batchEditWithReconciledTransfer',
-    batchDuplicateWithReconciled: 'batchDuplicateWithReconciledTransfer',
   };
 
   const checkForReconciledTransactions = async (

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -32,8 +32,6 @@ export type ConfirmTransactionEditReason =
   | 'batchDeleteWithReconciledTransfer'
   | 'batchEditWithReconciled'
   | 'batchEditWithReconciledTransfer'
-  | 'batchDuplicateWithReconciled'
-  | 'batchDuplicateWithReconciledTransfer'
   | 'editReconciled'
   | 'unlockReconciled'
   | 'deleteReconciled';

--- a/upcoming-release-notes/7723.md
+++ b/upcoming-release-notes/7723.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [youngcw]
+---
+
+Duplicated transactions are marked as uncleared and unlocked


### PR DESCRIPTION
<!-- Please do not delete this template -->

<!-- ## Description -->
<!-- Describe your changes here -->
Duplicated transactions are treated as new transactions, like you just manually added it.  So they are uncleared and un reconciled.  I also removed the warnings about reconciled duplicates because they are no longer reconciled after.
<!-- ## Related issue(s) -->
<!-- Link any related issues here -->
Fixes #2155

<!-- ## Testing -->
<!-- Describe how you tested your changes -->

<!-- ## Checklist -->
<!-- - [ ] I have read the contributing guidelines -->

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (-672 B) | -0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.89 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (-672 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useTransactionBatchActions.ts` | 📉 -59 B (-0.66%) | 8.72 kB → 8.66 kB
`src/components/modals/ConfirmTransactionEditModal.tsx` | 📉 -613 B (-11.48%) | 5.21 kB → 4.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.93 MB (-613 B) | -0.03%
static/js/Value.js | 4.94 MB → 4.94 MB (-59 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 53.96 kB | 0%
static/js/ca.js | 188.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.57 kB | 0%
static/js/de.js | 170.73 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.36 kB | 0%
static/js/es.js | 179.16 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 179.07 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.19 kB | 0%
static/js/narrow.js | 364.02 kB | 0%
static/js/nb-NO.js | 148.48 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 86.67 kB | 0%
static/js/pt-BR.js | 190.09 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 175.02 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.95 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.58 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DiBErB6z.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->