### PR TITLE
[AI] Update preview-builds doc with current URL pattern and additional previews

### DIFF
--- a/packages/docs/docs/contributing/preview-builds.md
+++ b/packages/docs/docs/contributing/preview-builds.md
@@ -1,12 +1,16 @@
 # Preview Builds
 
-It is possible using our deployment pipeline to run preview builds of Actual directly on Netlify.
+Each pull request automatically deploys preview builds to Netlify, so you can try out changes without cloning the branch.
 
-To do this, find the pull request (PR) that you would like to preview in GitHub, you can find the pull requests in scope of the preview builds [here](https://github.com/actualbudget/actual/pulls).
+To find a PR, browse the [open pull requests](https://github.com/actualbudget/actual/pulls). Once you have the PR number, replace `{pr-number}` in the URLs below.
 
-Once you have the number of the PR navigate to the following URL: https://deploy-preview-pr_number--actualbudget.netlify.app/ replacing pr_number with the number of the PR you would like to preview, for example https://deploy-preview-414--actualbudget.netlify.app/
+Three previews are deployed per PR:
 
-This will load directly on Netlify where you will be able to preview the changes in that pull request without the need to clone the specific branch.
+- **Main app:** `https://deploy-preview-{pr-number}.demo.actualbudget.org/`
+- **Storybook:** `https://deploy-preview-{pr-number}--actualbudget-storybook.netlify.app/`
+- **Website (docs and marketing):** `https://deploy-preview-{pr-number}.www.actualbudget.org/`
+
+The exact URLs are also posted as a comment on each PR by the Netlify bot.
 
 :::info
 There is no sync server on preview builds so when asked "Where's the server" select "Don't use a server." Alternatively, you can use your own self-hosted server. You should exercise caution when using a server with preview builds because they are much more likely to have bugs that could damage your budget. Consider running a separate local server for preview builds.

--- a/packages/docs/docs/contributing/preview-builds.md
+++ b/packages/docs/docs/contributing/preview-builds.md
@@ -6,9 +6,9 @@ To find a PR, browse the [open pull requests](https://github.com/actualbudget/ac
 
 Three previews are deployed per PR:
 
-- **Main app:** `https://deploy-preview-{pr-number}.demo.actualbudget.org/`
+- **Demo:** `https://deploy-preview-{pr-number}.demo.actualbudget.org/`
 - **Storybook:** `https://deploy-preview-{pr-number}--actualbudget-storybook.netlify.app/`
-- **Website (docs and marketing):** `https://deploy-preview-{pr-number}.www.actualbudget.org/`
+- **Website:** `https://deploy-preview-{pr-number}.www.actualbudget.org/`
 
 The exact URLs are also posted as a comment on each PR by the Netlify bot.
 

--- a/upcoming-release-notes/7728.md
+++ b/upcoming-release-notes/7728.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [nikhilweee]
+---
+
+Update the preview-builds contributing doc to reflect the current `deploy-preview-{pr-number}.demo.actualbudget.org` URL pattern and mention the Storybook and website previews.


### PR DESCRIPTION
## Description

Updates packages/docs/docs/contributing/preview-builds.md to reflect the current Netlify preview deployments.

Changes:

* Switch the documented main-app URL to the canonical https://deploy-preview-{pr-number}.demo.actualbudget.org/ form (instead of the older --actualbudget.netlify.app pattern).
* Drop the dead pr-414 example link, since preview deployments age out and return 404.
* Add the Storybook and Website preview URLs — each PR actually gets three previews, but only the main app was documented.

## Related issue(s)

None.

## Testing

* Verified all three URL patterns return HTTP 200 against an active PR.
* Ran yarn lint, yarn typecheck, and yarn test locally; all green (typecheck has a pre-existing proper-lockfile warning in @actual-app/cli unrelated to this change).
* Rendered the docs site locally with yarn workspace docs start to confirm the page reads cleanly.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

