### PR TITLE
[AI] Document Dev Container option in development-setup docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
 {
-  "name": "Actual development",
+  "name": "Actual Devcontainer",
   "dockerComposeFile": ["../docker-compose.yml", "docker-compose.yml"],
   // Alternatively:
   // "image": "mcr.microsoft.com/devcontainers/typescript-node:0-16",

--- a/.github/actions/docs-spelling/expect.txt
+++ b/.github/actions/docs-spelling/expect.txt
@@ -42,6 +42,7 @@ Cloudflare
 CMCIFRPAXXX
 COBADEFF
 CODEOWNERS
+Codespaces
 COEP
 commerzbank
 Copiar
@@ -61,7 +62,6 @@ Dockerfiles
 Dominguez
 DUSSDEDDXXX
 DUSSELDORF
-ecf
 EDATE
 ENTERCARD
 Entra

--- a/packages/docs/docs/contributing/development-setup.md
+++ b/packages/docs/docs/contributing/development-setup.md
@@ -6,6 +6,10 @@ This guide will help you set up your development environment for contributing to
 
 ## Prerequisites
 
+:::tip
+If you prefer not to install Node and Yarn locally, you can use the [Dev Container](#dev-container) or run [Docker Compose](#docker-compose) directly.
+:::
+
 Before you begin, ensure you have the following installed:
 
 - **Node.js**: Version 22 or greater. You can download it from the [Node.js website](https://nodejs.org/en/download) (we recommend the LTS version).
@@ -38,6 +42,34 @@ Before you begin, ensure you have the following installed:
    ```bash
    yarn typecheck
    ```
+
+## Dev Container
+
+The repo includes a [`.devcontainer/`](https://github.com/actualbudget/actual/tree/master/.devcontainer) configuration that follows the [Dev Containers spec](https://containers.dev/). Any tool that supports the spec can use it — for example VS Code or Cursor (with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)), JetBrains IDEs (via Gateway), GitHub Codespaces, or the [`@devcontainers/cli`](https://github.com/devcontainers/cli).
+
+In an editor that supports the spec, open the cloned repo and accept the **Reopen in Container** prompt (or run the equivalent command from your editor's command palette). The container will build, `yarn install` will run automatically via `postCreateCommand`, and you'll be dropped into a shell with the toolchain ready.
+
+To start the dev server, open a terminal inside the container and run:
+
+```bash
+yarn start
+```
+
+The dev server will be available at `http://localhost:3001/`. Most editors automatically forward the port from the container to your host.
+
+## Docker Compose
+
+For other editors, run from the repo root:
+
+```bash
+docker compose up --build
+```
+
+This starts a container that runs `yarn start:browser` on port 3001. Open `http://localhost:3001/` in your browser.
+
+:::note
+The container mounts your repo at `/app`. If you've already run `yarn install` on your host, the native modules (`better-sqlite3`, `bcrypt`, `electron`, `sharp`) will be compiled for your host OS and won't work inside the Linux container. Either delete `node_modules/` first and let the container reinstall, or run the dev container path above (which rebuilds them automatically).
+:::
 
 ## Essential Development Commands
 

--- a/upcoming-release-notes/7729.md
+++ b/upcoming-release-notes/7729.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [nikhilweee]
+---
+
+Document the Dev Container and Docker Compose options as alternatives to local Node and Yarn setup in the contributor development-setup guide.


### PR DESCRIPTION
## Description

Documents two Docker-based alternatives to the local Node + Yarn setup in the contributor development-setup guide.

Background: the repo has shipped a `.devcontainer/` config (and a root `Dockerfile` + `docker-compose.yml`) since June 2023 ([#1032](https://github.com/actualbudget/actual/pull/1032)), but the canonical [development-setup.md](https://github.com/actualbudget/actual/blob/master/packages/docs/docs/contributing/development-setup.md) only ever covered the local Node + Yarn install path. The Dev Container option was only mentioned briefly in `packages/desktop-client/README.md` inside the VRT instructions — easy to miss.

Changes:

- Added a `:::tip` admonition in the Prerequisites section pointing forward to the new options.
- Added a `## Dev Container` section that's tool-agnostic (mentions VS Code, Cursor, JetBrains Gateway, GitHub Codespaces, and the official [`@devcontainers/cli`](https://github.com/devcontainers/cli) — since [`devcontainer.json`](https://containers.dev/) is an open spec, not a VS Code-only thing).
- Added a `## Docker Compose` section for the plain `docker compose up --build` path, including a `:::note` about the native-modules gotcha (host `node_modules/` compiled for macOS won't load in the Linux container).
- Renamed the dev container from `Actual development` → `Actual Devcontainer` in `.devcontainer/devcontainer.json` for clarity (visible in VS Code's status bar and command palette).

## Related issue(s)

Relates to [#1032](https://github.com/actualbudget/actual/pull/1032) (original Dev Container support, June 2023).

## Testing

Both paths verified locally end-to-end:

- **Dev Container** via VS Code → `Reopen in Container` → `yarn install` ran via `postCreateCommand` (~44s, including native module rebuilds for Linux), then `yarn start` inside the container → `http://localhost:3001/` loaded successfully.
- **Docker Compose** via `docker compose up --build` from the repo root → container started, Vite ready in ~750ms, `curl http://localhost:3001` returned HTTP 200.
- Pre-push CI checks passed locally: `yarn lint` (0 errors), `yarn typecheck` (success on all 6 workspaces), `yarn test` (success on all workspaces).

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
