### PR TITLE
[WIP] Fix: Add escape character logic to new schedule name

### DIFF
--- a/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
@@ -6,7 +6,7 @@ import { Button } from '@actual-app/components/button';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import { send, sendCatch } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
-import { q } from '@actual-app/core/shared/query';
+import { q, prependEscapeChars } from '@actual-app/core/shared/query';
 import type {
   RecurConfig,
   ScheduleEntity,
@@ -100,7 +100,7 @@ export function ScheduleEditModal({ id, transaction }: ScheduleEditModalProps) {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: state.fields.name }).select('id'),
+        q('schedules').filter({ name: prependEscapeChars(state.fields.name) }).select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
@@ -6,7 +6,7 @@ import { Button } from '@actual-app/components/button';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import { send, sendCatch } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
-import { q, prependEscapeChars } from '@actual-app/core/shared/query';
+import { prependEscapeChars, q } from '@actual-app/core/shared/query';
 import type {
   RecurConfig,
   ScheduleEntity,
@@ -100,7 +100,9 @@ export function ScheduleEditModal({ id, transaction }: ScheduleEditModalProps) {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: prependEscapeChars(state.fields.name) }).select('id'),
+        q('schedules')
+          .filter({ name: prependEscapeChars(state.fields.name) })
+          .select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -456,9 +456,9 @@ function compileLiteral(value) {
   } else if (value instanceof Date) {
     return typed(nativeDateToInt(value), 'date', { literal: true });
   } else if (typeof value === 'string') {
-    // Allow user to escape $, and quote the string to make it a
+    // Allow user to escape $ and :, and quote the string to make it a
     // string literal in the output
-    value = value.replace(/\\\$/g, '$');
+    value = value.replace(/\\([$:])/g, '$1');
     return typed(value, 'string', { literal: true });
   } else if (typeof value === 'boolean') {
     return typed(value ? 1 : 0, 'boolean', { literal: true });

--- a/packages/loot-core/src/shared/query.ts
+++ b/packages/loot-core/src/shared/query.ts
@@ -174,3 +174,7 @@ export function getPrimaryOrderBy(
 export function q(table: QueryState['table']) {
   return new Query({ table });
 }
+
+export function prependEscapeChars(value: string): string {
+  return value.startsWith('$') || value.startsWith(':') ? '\\' + value : value;
+}

--- a/upcoming-release-notes/7733.md
+++ b/upcoming-release-notes/7733.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [10jake10]
+---
+
+Add escape character logic to new schedule names


### PR DESCRIPTION
## Description

This PR fixes the issue of new schedule names starting with '$' and ':' causing an unhandled error. This is solved by parsing these special characters with escape characters and later unescaping the string in the AQL compiler.

## Related issue(s)

Fixes #7358

## Testing

Creating a new schedule with name "$foo" and ":foo" no longer cause an error. See #7358 for a full description of the original issue.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (+138 B) | +0.00%
loot-core | 1 | 5.27 MB → 5.27 MB (+5 B) | +0.00%
api | 2 | 3.89 MB → 3.89 MB (+5 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (+138 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/query.ts` | 📈 +118 B (+4.05%) | 2.85 kB → 2.96 kB
`src/components/schedules/ScheduleEditModal.tsx` | 📈 +20 B (+0.37%) | 5.33 kB → 5.35 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (+118 B) | +0.00%
static/js/index.js | 1.93 MB → 1.93 MB (+20 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.11 kB | 0%
static/js/ca.js | 188.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.57 kB | 0%
static/js/de.js | 170.73 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.36 kB | 0%
static/js/es.js | 179.16 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/fr.js | 179.07 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.19 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.48 kB | 0%
static/js/nl.js | 106.65 kB | 0%
static/js/pl.js | 86.67 kB | 0%
static/js/pt-BR.js | 190.09 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 175.02 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.95 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 118.05 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+5 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +5 B (+0.02%) | 24.77 kB → 24.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CXUhJg7H.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DCbeRm_D.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.89 MB (+5 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +5 B (+0.02%) | 24.12 kB → 24.13 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.89 MB (+5 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->