### PR TITLE
[AI] Revert crypto.randomUUID back to uuid library

### DIFF
--- a/.github/actions/docs-spelling/excludes.txt
+++ b/.github/actions/docs-spelling/excludes.txt
@@ -1,13 +1,16 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-excludes
+(?:^|/)(?i).nojekyll
 (?:^|/)(?i)COPYRIGHT
+(?:^|/)(?i)docusaurus.config.js
 (?:^|/)(?i)LICEN[CS]E
+(?:^|/)(?i)README.md
 (?:^|/)3rdparty/
 (?:^|/)go\.sum$
 (?:^|/)package(?:-lock|)\.json$
 (?:^|/)pyproject.toml
 (?:^|/)requirements(?:-dev|-doc|-test|)\.txt$
 (?:^|/)vendor/
-ignore$
+(?:^|/)yarn\.lock$
 \.a$
 \.ai$
 \.avi$
@@ -53,6 +56,7 @@ ignore$
 \.svgz?$
 \.tar$
 \.tiff?$
+\.tsx$
 \.ttf$
 \.wav$
 \.webm$
@@ -62,15 +66,12 @@ ignore$
 \.zip$
 ^\.github/actions/spelling/
 ^\.github/ISSUE_TEMPLATE/
-^\Q.github/workflows/spelling.yml\E$
 ^\.yarn/
+^\Q.github/\E$
+^\Q.github/workflows/spelling.yml\E$
 ^\Qnode_modules/\E$
 ^\Qsrc/\E$
 ^\Qstatic/\E$
-^\Q.github/\E$
-(?:^|/)yarn\.lock$
-(?:^|/)(?i)docusaurus.config.js
-(?:^|/)(?i)README.md
-(?:^|/)(?i).nojekyll
 ^\static/
-\.tsx$
+^packages/docs/docs/releases\.md$
+ignore$

--- a/.github/actions/docs-spelling/expect.txt
+++ b/.github/actions/docs-spelling/expect.txt
@@ -38,7 +38,9 @@ Cetelem
 cimode
 Citi
 Citibank
+claude
 Cloudflare
+CLP
 CMCIFRPAXXX
 COBADEFF
 CODEOWNERS
@@ -53,6 +55,7 @@ crt
 CZK
 Danske
 datadir
+datamodel
 DATEDIF
 Depositos
 deselection
@@ -61,7 +64,6 @@ Dockerfiles
 Dominguez
 DUSSDEDDXXX
 DUSSELDORF
-ecf
 EDATE
 ENTERCARD
 Entra
@@ -83,6 +85,7 @@ Globecard
 GLS
 gocardless
 Grafana
+Gruvbox
 HABAL
 Hampel
 HELADEF
@@ -90,6 +93,7 @@ HLOOKUP
 HUF
 IFERROR
 IFNA
+Ilavenil
 INDUSTRIEL
 INGBPLPW
 Ingo
@@ -128,6 +132,7 @@ murmurhash
 NETWORKDAYS
 nginx
 nodenext
+nord
 OIDC
 Okabe
 overbudgeted
@@ -147,6 +152,7 @@ QNTOFRP
 QONTO
 Raiffeisen
 REGEXREPLACE
+relinking
 revolut
 RIED
 RSchedule
@@ -178,6 +184,7 @@ TIMEFRAME
 touchscreen
 triaging
 tsgo
+tsgolint
 TWD
 UAH
 ubuntu
@@ -193,4 +200,6 @@ websecure
 WEEKNUM
 Widiba
 WOR
+worktree
 youngcw
+zizmor

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -338,6 +338,11 @@
             "message": "Don't directly reference imports from other platforms"
           },
           {
+            "group": ["uuid"],
+            "importNames": ["*"],
+            "message": "Use `import { v4 as uuidv4 } from 'uuid'` instead"
+          },
+          {
             "group": ["**/style", "**/colors"],
             "importNames": ["colors"],
             "message": "Please use themes instead of colors"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "playwright": "yarn workspace @actual-app/web run playwright",
     "vrt": "yarn workspace @actual-app/web run vrt",
     "vrt:docker": "./bin/run-vrt",
-    "rebuild-electron": "./node_modules/.bin/electron-rebuild -f -o better-sqlite3,bcrypt",
+    "rebuild-electron": "./node_modules/.bin/electron-rebuild -f -m ./packages/desktop-electron -o better-sqlite3,bcrypt",
     "rebuild-node": "yarn workspace @actual-app/core rebuild",
     "lint": "oxfmt --check . && oxlint --type-aware --quiet",
     "lint:fix": "oxfmt . && oxlint --fix --type-aware --quiet",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -49,7 +49,8 @@
     "@actual-app/core": "workspace:*",
     "@actual-app/crdt": "workspace:*",
     "better-sqlite3": "^12.8.0",
-    "compare-versions": "^6.1.1"
+    "compare-versions": "^6.1.1",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@typescript/native-preview": "beta",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,7 +50,7 @@
     "@actual-app/crdt": "workspace:*",
     "better-sqlite3": "^12.8.0",
     "compare-versions": "^6.1.1",
-    "uuid": "^13.0.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@typescript/native-preview": "beta",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,7 +50,7 @@
     "@actual-app/crdt": "workspace:*",
     "better-sqlite3": "^12.8.0",
     "compare-versions": "^6.1.1",
-    "uuid": "^11.1.0"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@typescript/native-preview": "beta",

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -36,7 +36,8 @@
   },
   "dependencies": {
     "google-protobuf": "^3.21.4",
-    "murmurhash": "^2.0.1"
+    "murmurhash": "^2.0.1",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/google-protobuf": "3.15.12",

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "google-protobuf": "^3.21.4",
     "murmurhash": "^2.0.1",
-    "uuid": "^13.0.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/google-protobuf": "3.15.12",

--- a/packages/crdt/package.json
+++ b/packages/crdt/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "google-protobuf": "^3.21.4",
     "murmurhash": "^2.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@types/google-protobuf": "3.15.12",

--- a/packages/crdt/src/crdt/timestamp.ts
+++ b/packages/crdt/src/crdt/timestamp.ts
@@ -1,4 +1,5 @@
 import murmurhash from 'murmurhash';
+import { v4 as uuidv4 } from 'uuid';
 
 import type { TrieNode } from './merkle';
 
@@ -76,7 +77,7 @@ export function deserializeClock(clock: string): Clock {
 }
 
 export function makeClientId() {
-  return crypto.randomUUID().replace(/-/g, '').slice(-16);
+  return uuidv4().replace(/-/g, '').slice(-16);
 }
 
 const config = {

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -199,6 +199,7 @@
     "sass": "^1.99.0",
     "typescript-strict-plugin": "^2.4.4",
     "usehooks-ts": "^3.1.1",
+    "uuid": "^13.0.0",
     "vite": "^8.0.5",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.2"

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -199,7 +199,7 @@
     "sass": "^1.99.0",
     "typescript-strict-plugin": "^2.4.4",
     "usehooks-ts": "^3.1.1",
-    "uuid": "^13.0.0",
+    "uuid": "^11.1.0",
     "vite": "^8.0.5",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.2"

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -199,7 +199,7 @@
     "sass": "^1.99.0",
     "typescript-strict-plugin": "^2.4.4",
     "usehooks-ts": "^3.1.1",
-    "uuid": "^11.1.0",
+    "uuid": "^13.0.0",
     "vite": "^8.0.5",
     "vite-plugin-pwa": "^1.2.0",
     "vitest": "^4.1.2"

--- a/packages/desktop-client/src/accounts/mutations.ts
+++ b/packages/desktop-client/src/accounts/mutations.ts
@@ -12,6 +12,7 @@ import type {
 } from '@actual-app/core/types/models';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
 import { sync } from '#app/appSlice';
 import { useAccounts } from '#hooks/useAccounts';
@@ -43,7 +44,7 @@ const dispatchErrorNotification = (
   dispatch(
     addNotification({
       notification: {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message,
         pre: error ? error.message : undefined,

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -9,6 +9,7 @@ import type {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
 import type { TFunction } from 'i18next';
+import { v4 as uuidv4 } from 'uuid';
 
 import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
@@ -31,7 +32,7 @@ function dispatchErrorNotification(
   dispatch(
     addNotification({
       notification: {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message,
         pre: error ? error.message : undefined,

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -36,6 +36,7 @@ import type {
 import { t } from 'i18next';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   useReopenAccountMutation,
@@ -1118,7 +1119,7 @@ class AccountInternal extends PureComponent<
 
     const [firstTransaction] = transactions;
     const parentTransaction = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       is_parent: true,
       cleared: transactions.every(t => !!t.cleared),
       date: firstTransaction.date,

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -44,6 +44,7 @@ import type {
   RuleEntity,
 } from '@actual-app/core/types/models';
 import { css } from '@emotion/css';
+import { v4 as uuid } from 'uuid';
 
 import { FinancialText } from '#components/FinancialText';
 import { StatusBadge } from '#components/schedules/StatusBadge';
@@ -782,7 +783,7 @@ function StageButton({
 }
 
 function newInput(item) {
-  return { ...item, inputKey: crypto.randomUUID() };
+  return { ...item, inputKey: uuid() };
 }
 
 function ConditionsList({
@@ -820,7 +821,7 @@ function ConditionsList({
       field,
       op: 'is',
       value: null,
-      inputKey: crypto.randomUUID(),
+      inputKey: uuid(),
     });
     onChangeConditions(copy);
   }
@@ -1006,9 +1007,7 @@ export function RuleEditor({
 }: RuleEditorProps) {
   const { t } = useTranslation();
   const [conditions, setConditions] = useState(
-    defaultRule.conditions
-      .map(parse)
-      .map(c => ({ ...c, inputKey: crypto.randomUUID() })),
+    defaultRule.conditions.map(parse).map(c => ({ ...c, inputKey: uuid() })),
   );
   const [actionSplits, setActionSplits] = useState(() => {
     const parsedActions = defaultRule.actions.map(parse);
@@ -1016,17 +1015,17 @@ export function RuleEditor({
       (acc, action) => {
         const splitIndex = action.options?.splitIndex ?? 0;
         acc[splitIndex] = acc[splitIndex] ?? {
-          id: crypto.randomUUID(),
+          id: uuid(),
           actions: [],
         };
         acc[splitIndex].actions.push({
           ...action,
-          inputKey: crypto.randomUUID(),
+          inputKey: uuid(),
         });
         return acc;
       },
       // The pre-split group is always there
-      [{ id: crypto.randomUUID(), actions: [] }],
+      [{ id: uuid(), actions: [] }],
     );
   });
   const [stage, setStage] = useState(defaultRule.stage);
@@ -1086,12 +1085,12 @@ export function RuleEditor({
   function addActionToSplitAfterIndex(splitIndex, actionIndex) {
     let newAction;
     if (splitIndex && !actionSplits[splitIndex]?.actions?.length) {
-      actionSplits[splitIndex] = { id: crypto.randomUUID(), actions: [] };
+      actionSplits[splitIndex] = { id: uuid(), actions: [] };
       newAction = {
         op: 'set-split-amount',
         options: { method: 'remainder', splitIndex },
         value: null,
-        inputKey: crypto.randomUUID(),
+        inputKey: uuid(),
       };
     } else {
       const fieldsArray =
@@ -1107,7 +1106,7 @@ export function RuleEditor({
         op: 'set',
         value: '',
         options: { splitIndex },
-        inputKey: crypto.randomUUID(),
+        inputKey: uuid(),
       };
     }
 

--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -44,7 +44,7 @@ import type {
   RuleEntity,
 } from '@actual-app/core/types/models';
 import { css } from '@emotion/css';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 import { FinancialText } from '#components/FinancialText';
 import { StatusBadge } from '#components/schedules/StatusBadge';
@@ -783,7 +783,7 @@ function StageButton({
 }
 
 function newInput(item) {
-  return { ...item, inputKey: uuid() };
+  return { ...item, inputKey: uuidv4() };
 }
 
 function ConditionsList({
@@ -821,7 +821,7 @@ function ConditionsList({
       field,
       op: 'is',
       value: null,
-      inputKey: uuid(),
+      inputKey: uuidv4(),
     });
     onChangeConditions(copy);
   }
@@ -1007,7 +1007,7 @@ export function RuleEditor({
 }: RuleEditorProps) {
   const { t } = useTranslation();
   const [conditions, setConditions] = useState(
-    defaultRule.conditions.map(parse).map(c => ({ ...c, inputKey: uuid() })),
+    defaultRule.conditions.map(parse).map(c => ({ ...c, inputKey: uuidv4() })),
   );
   const [actionSplits, setActionSplits] = useState(() => {
     const parsedActions = defaultRule.actions.map(parse);
@@ -1015,17 +1015,17 @@ export function RuleEditor({
       (acc, action) => {
         const splitIndex = action.options?.splitIndex ?? 0;
         acc[splitIndex] = acc[splitIndex] ?? {
-          id: uuid(),
+          id: uuidv4(),
           actions: [],
         };
         acc[splitIndex].actions.push({
           ...action,
-          inputKey: uuid(),
+          inputKey: uuidv4(),
         });
         return acc;
       },
       // The pre-split group is always there
-      [{ id: uuid(), actions: [] }],
+      [{ id: uuidv4(), actions: [] }],
     );
   });
   const [stage, setStage] = useState(defaultRule.stage);
@@ -1085,12 +1085,12 @@ export function RuleEditor({
   function addActionToSplitAfterIndex(splitIndex, actionIndex) {
     let newAction;
     if (splitIndex && !actionSplits[splitIndex]?.actions?.length) {
-      actionSplits[splitIndex] = { id: uuid(), actions: [] };
+      actionSplits[splitIndex] = { id: uuidv4(), actions: [] };
       newAction = {
         op: 'set-split-amount',
         options: { method: 'remainder', splitIndex },
         value: null,
-        inputKey: uuid(),
+        inputKey: uuidv4(),
       };
     } else {
       const fieldsArray =
@@ -1106,7 +1106,7 @@ export function RuleEditor({
         op: 'set',
         value: '',
         options: { splitIndex },
-        inputKey: uuid(),
+        inputKey: uuidv4(),
       };
     }
 

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -23,6 +23,7 @@ import type {
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { format as formatDate, parse as parseDate } from 'date-fns';
+import { v4 as uuidv4 } from 'uuid';
 
 import { AuthProvider } from '#auth/AuthProvider';
 import { SchedulesProvider } from '#hooks/useCachedSchedules';
@@ -1086,7 +1087,7 @@ describe('Transactions', () => {
     // Change the id to simulate a new transaction being added, and
     // work with that one. This makes sure that the transaction table
     // properly references new data.
-    transactions[0] = { ...transactions[0], id: crypto.randomUUID() };
+    transactions[0] = { ...transactions[0], id: uuidv4() };
     updateProps({ transactions });
 
     function expectErrorToNotExist(transactions: TransactionEntity[]) {

--- a/packages/desktop-client/src/notifications/notificationsSlice.ts
+++ b/packages/desktop-client/src/notifications/notificationsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { t } from 'i18next';
+import { v4 as uuidv4 } from 'uuid';
 
 import { resetApp } from '#app/appSlice';
 
@@ -58,7 +59,7 @@ const notificationsSlice = createSlice({
     addNotification(state, action: PayloadAction<AddNotificationPayload>) {
       const notification = {
         ...action.payload.notification,
-        id: action.payload.notification.id || crypto.randomUUID(),
+        id: action.payload.notification.id || uuidv4(),
       };
 
       if (state.notifications.find(n => n.id === notification.id)) {
@@ -68,7 +69,7 @@ const notificationsSlice = createSlice({
     },
     addGenericErrorNotification(state) {
       const notification: NotificationWithId = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message: t(
           'Something internally went wrong. You may want to restart the app if anything looks wrong. ' +

--- a/packages/desktop-client/src/payees/mutations.ts
+++ b/packages/desktop-client/src/payees/mutations.ts
@@ -4,6 +4,7 @@ import { send } from '@actual-app/core/platform/client/connection';
 import type { PayeeEntity } from '@actual-app/core/types/models';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
@@ -26,7 +27,7 @@ function dispatchErrorNotification(
   dispatch(
     addNotification({
       notification: {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message,
         pre: error ? error.message : undefined,

--- a/packages/desktop-client/src/reports/mutations.ts
+++ b/packages/desktop-client/src/reports/mutations.ts
@@ -13,6 +13,7 @@ import type {
 } from '@actual-app/core/types/util';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
@@ -54,7 +55,7 @@ function dispatchErrorNotification(
   dispatch(
     addNotification({
       notification: {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message,
         pre: error ? error.message : undefined,

--- a/packages/desktop-client/src/tags/mutations.ts
+++ b/packages/desktop-client/src/tags/mutations.ts
@@ -4,6 +4,7 @@ import { send } from '@actual-app/core/platform/client/connection';
 import type { TagEntity } from '@actual-app/core/types/models';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import { v4 as uuidv4 } from 'uuid';
 
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
@@ -25,7 +26,7 @@ function dispatchErrorNotification(
   dispatch(
     addNotification({
       notification: {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         type: 'error',
         message,
         pre: error ? error.message : undefined,

--- a/packages/desktop-client/src/util/ruleUtils.ts
+++ b/packages/desktop-client/src/util/ruleUtils.ts
@@ -1,5 +1,5 @@
 import type { RuleEntity } from '@actual-app/core/types/models';
-import { v4 as uuid } from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 
 export type ActionSplit = {
   id: string;
@@ -13,7 +13,7 @@ export function groupActionsBySplitIndex(
     const splitIndex =
       'options' in action ? (action.options?.splitIndex ?? 0) : 0;
     acc[splitIndex] = acc[splitIndex] ?? {
-      id: uuid(),
+      id: uuidv4(),
       actions: [],
     };
     acc[splitIndex].actions.push(action);

--- a/packages/desktop-client/src/util/ruleUtils.ts
+++ b/packages/desktop-client/src/util/ruleUtils.ts
@@ -1,4 +1,5 @@
 import type { RuleEntity } from '@actual-app/core/types/models';
+import { v4 as uuid } from 'uuid';
 
 export type ActionSplit = {
   id: string;
@@ -12,7 +13,7 @@ export function groupActionsBySplitIndex(
     const splitIndex =
       'options' in action ? (action.options?.splitIndex ?? 0) : 0;
     acc[splitIndex] = acc[splitIndex] ?? {
-      id: crypto.randomUUID(),
+      id: uuid(),
       actions: [],
     };
     acc[splitIndex].actions.push(action);

--- a/packages/desktop-electron/e2e/fixtures.ts
+++ b/packages/desktop-electron/e2e/fixtures.ts
@@ -1,3 +1,4 @@
+import { createWriteStream } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -30,10 +31,27 @@ export const test = base.extend<ElectronFixtures>({
       },
     });
 
+    // TEMP debug: capture electron stdout+stderr to file inside test-results
+    const logPath = path.join(
+      testInfo.outputDir ?? testInfo.outputPath('.'),
+      'electron.log',
+    );
+    await mkdir(path.dirname(logPath), { recursive: true });
+    const logStream = createWriteStream(logPath, { flags: 'a' });
+    app.process().stdout?.on('data', d => {
+      logStream.write(`[stdout] ${d}`);
+      process.stderr.write(`[electron stdout] ${d}`);
+    });
+    app.process().stderr?.on('data', d => {
+      logStream.write(`[stderr] ${d}`);
+      process.stderr.write(`[electron stderr] ${d}`);
+    });
+
     await use(app);
 
     // Cleanup after tests
     await app.close();
+    logStream.end();
     await rm(testDataDir, { recursive: true, force: true });
   },
 

--- a/packages/desktop-electron/e2e/fixtures.ts
+++ b/packages/desktop-electron/e2e/fixtures.ts
@@ -1,4 +1,3 @@
-import { createWriteStream } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -31,27 +30,10 @@ export const test = base.extend<ElectronFixtures>({
       },
     });
 
-    // TEMP debug: capture electron stdout+stderr to file inside test-results
-    const logPath = path.join(
-      testInfo.outputDir ?? testInfo.outputPath('.'),
-      'electron.log',
-    );
-    await mkdir(path.dirname(logPath), { recursive: true });
-    const logStream = createWriteStream(logPath, { flags: 'a' });
-    app.process().stdout?.on('data', d => {
-      logStream.write(`[stdout] ${d}`);
-      process.stderr.write(`[electron stdout] ${d}`);
-    });
-    app.process().stderr?.on('data', d => {
-      logStream.write(`[stderr] ${d}`);
-      process.stderr.write(`[electron stderr] ${d}`);
-    });
-
     await use(app);
 
     // Cleanup after tests
     await app.close();
-    logStream.end();
     await rm(testDataDir, { recursive: true, force: true });
   },
 

--- a/packages/docs/docs/contributing/code-style.md
+++ b/packages/docs/docs/contributing/code-style.md
@@ -84,6 +84,7 @@ Use custom hooks from `src/hooks` instead of importing directly from react-route
 
 ### Never Use
 
+- **`uuid` without destructuring**: Use `import { v4 as uuidv4 } from 'uuid'`
 - **Direct color imports**: Use theme instead of importing colors directly
 - **`@actual-app/web/*` imports in `loot-core`**: Don't import from web package in core
 

--- a/packages/loot-core/migrations/1722804019000_create_dashboard_table.js
+++ b/packages/loot-core/migrations/1722804019000_create_dashboard_table.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { DEFAULT_DASHBOARD_STATE } from '#shared/dashboard';
 
 export default async function runMigration(db) {
@@ -25,7 +27,7 @@ export default async function runMigration(db) {
         db.runQuery(
           `INSERT INTO dashboard (id, type, width, height, x, y, meta) VALUES (?, ?, ?, ?, ?, ?, ?)`,
           [
-            crypto.randomUUID(),
+            uuidv4(),
             widget.type,
             widget.width,
             widget.height,
@@ -43,9 +45,9 @@ export default async function runMigration(db) {
     db.execQuery(`
       INSERT INTO dashboard (id, type, width, height, x, y)
       VALUES
-        ('${crypto.randomUUID()}', 'net-worth-card', 8, 2, 0, 0),
-        ('${crypto.randomUUID()}', 'cash-flow-card', 4, 2, 8, 0),
-        ('${crypto.randomUUID()}', 'spending-card', 4, 2, 0, 2);
+        ('${uuidv4()}', 'net-worth-card', 8, 2, 0, 0),
+        ('${uuidv4()}', 'cash-flow-card', 4, 2, 8, 0),
+        ('${uuidv4()}', 'spending-card', 4, 2, 0, 2);
     `);
 
     // Add custom reports to the dashboard
@@ -53,7 +55,7 @@ export default async function runMigration(db) {
       db.runQuery(
         `INSERT INTO dashboard (id, type, width, height, x, y, meta) VALUES (?, ?, ?, ?, ?, ?, ?)`,
         [
-          crypto.randomUUID(),
+          uuidv4(),
           'custom-report',
           4,
           2,

--- a/packages/loot-core/migrations/1765518577215_multiple_dashboards.js
+++ b/packages/loot-core/migrations/1765518577215_multiple_dashboards.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 export default async function runMigration(db) {
   db.transaction(() => {
     // 1. Create dashboards table
@@ -14,7 +16,7 @@ export default async function runMigration(db) {
     `);
 
     // 3. Create a default dashboard
-    const defaultDashboardId = crypto.randomUUID();
+    const defaultDashboardId = uuidv4();
     db.runQuery(`INSERT INTO dashboard_pages (id, name) VALUES (?, ?)`, [
       defaultDashboardId,
       'Main',

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -191,6 +191,7 @@
     "promise-retry": "^2.0.1",
     "typescript-strict-plugin": "^2.4.4",
     "ua-parser-js": "^2.0.9",
+    "uuid": "^13.0.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -191,7 +191,7 @@
     "promise-retry": "^2.0.1",
     "typescript-strict-plugin": "^2.4.4",
     "ua-parser-js": "^2.0.9",
-    "uuid": "^11.1.0",
+    "uuid": "^13.0.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -191,7 +191,7 @@
     "promise-retry": "^2.0.1",
     "typescript-strict-plugin": "^2.4.4",
     "ua-parser-js": "^2.0.9",
-    "uuid": "^13.0.0",
+    "uuid": "^11.1.0",
     "xml2js": "^0.6.2"
   },
   "devDependencies": {

--- a/packages/loot-core/src/mocks/budget.ts
+++ b/packages/loot-core/src/mocks/budget.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import { addTransactions } from '#server/accounts/sync';
 import { aqlQuery } from '#server/aql';
@@ -127,7 +128,7 @@ async function fillPrimaryChecking(
     );
 
     const transaction: TransactionEntity = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       amount,
       payee: payee.id,
       account: account.id,
@@ -144,21 +145,21 @@ async function fillPrimaryChecking(
           : pickRandom(expenseCategories).id;
       transaction.subtransactions = [
         {
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           date: currentDate,
           account: account.id,
           amount: a,
           category: pick(),
         },
         {
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           date: currentDate,
           account: account.id,
           amount: a,
           category: pick(),
         },
         {
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           date: currentDate,
           account: account.id,
           amount: transaction.amount - a * 2,
@@ -428,7 +429,7 @@ async function fillOther(handlers, account, payees, groups) {
 
   const transactions: TransactionEntity[] = [
     {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       amount: integer(3250, 3700) * 100 * 100,
       payee: payees.find(p => p.name === 'Starting Balance').id,
       account: account.id,
@@ -443,7 +444,7 @@ async function fillOther(handlers, account, payees, groups) {
     const amount = integer(4, 9) * 100 * 100;
 
     transactions.push({
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       amount,
       payee: payee.id,
       account: account.id,

--- a/packages/loot-core/src/mocks/index.ts
+++ b/packages/loot-core/src/mocks/index.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import * as monthUtils from '#shared/months';
 import type {
   AccountEntity,
@@ -14,7 +16,7 @@ export function generateAccount(
   offbudget?: boolean,
 ): AccountEntity {
   const offlineAccount: AccountEntity = {
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     name,
     offbudget: offbudget ? 1 : 0,
     sort_order: 0,
@@ -80,7 +82,7 @@ export function generateCategory(
   isIncome: boolean = false,
 ): CategoryEntity {
   return {
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     name,
     group,
     is_income: isIncome,
@@ -94,7 +96,7 @@ export function generateCategoryGroup(
   isIncome: boolean = false,
 ): CategoryGroupEntity {
   return {
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     name,
     is_income: isIncome,
     sort_order: groupSortOrder++,
@@ -131,7 +133,7 @@ function _generateTransaction(
   data: Partial<TransactionEntity> & Pick<TransactionEntity, 'account'>,
 ): TransactionEntity {
   return {
-    id: data.id || crypto.randomUUID(),
+    id: data.id || uuidv4(),
     amount: data.amount || Math.floor(random() * 10000 - 7000),
     payee: data.payee || 'payed-to',
     notes: 'Notes',
@@ -160,14 +162,14 @@ export function generateTransaction(
 
     result.push(
       {
-        id: parent.id + '/' + crypto.randomUUID(),
+        id: parent.id + '/' + uuidv4(),
         amount: trans.amount - splitAmount,
         account: parent.account,
         date: parent.date,
         is_child: true,
       },
       {
-        id: parent.id + '/' + crypto.randomUUID(),
+        id: parent.id + '/' + uuidv4(),
         amount: splitAmount,
         account: parent.account,
         date: parent.date,

--- a/packages/loot-core/src/mocks/setup.ts
+++ b/packages/loot-core/src/mocks/setup.ts
@@ -57,9 +57,12 @@ let _id = 1;
 global.resetRandomId = () => {
   _id = 1;
 };
-Object.defineProperty(crypto, 'randomUUID', {
-  value: () => 'id' + _id++,
-});
+
+vi.mock('uuid', () => ({
+  v4: () => {
+    return 'id' + _id++;
+  },
+}));
 vi.mock('#server/migrate/migrations', async () => {
   const realMigrations = await vi.importActual<typeof MigrationsType>(
     '#server/migrate/migrations',

--- a/packages/loot-core/src/platform/client/connection/index.electron.ts
+++ b/packages/loot-core/src/platform/client/connection/index.electron.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import * as undo from '#platform/client/undo';
 
@@ -84,7 +85,7 @@ export const send: T.Send = function (
 ): ReturnType<T.Send> {
   const [name, args, { catchErrors = false } = {}] = params;
   return new Promise((resolve, reject) => {
-    const id = crypto.randomUUID();
+    const id = uuidv4();
     replyHandlers.set(id, { resolve, reject });
 
     if (socketClient) {

--- a/packages/loot-core/src/platform/client/connection/index.ts
+++ b/packages/loot-core/src/platform/client/connection/index.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import { t } from 'i18next';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as undo from '#platform/client/undo';
 import { captureBreadcrumb, captureException } from '#platform/exceptions';
@@ -160,7 +161,7 @@ export const send: T.Send = function (
 ): ReturnType<T.Send> {
   const [name, args, { catchErrors = false } = {}] = params;
   return new Promise((resolve, reject) => {
-    const id = crypto.randomUUID();
+    const id = uuidv4();
 
     replyHandlers.set(id, { resolve, reject });
     const message = {

--- a/packages/loot-core/src/platform/client/undo/index.ts
+++ b/packages/loot-core/src/platform/client/undo/index.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import type { UndoState as ServerUndoState } from '#server/undo';
 
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,7 +36,7 @@ export const setUndoState = <K extends keyof Omit<UndoState, 'id'>>(
   value: UndoState[K],
 ) => {
   currentUndoState[name] = value;
-  currentUndoState.id = crypto.randomUUID();
+  currentUndoState.id = uuidv4();
 };
 
 export const getUndoState = <K extends keyof UndoState>(name: K) => {
@@ -46,7 +48,7 @@ export const getTaggedState = (id: string) => {
 };
 
 export const snapshot = () => {
-  const tagged = { ...currentUndoState, id: crypto.randomUUID() };
+  const tagged = { ...currentUndoState, id: uuidv4() };
   UNDO_STATE_MRU.unshift(tagged);
   UNDO_STATE_MRU = UNDO_STATE_MRU.slice(0, HISTORY_SIZE);
   return tagged.id;

--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import SQL from 'better-sqlite3';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getDataDir, readFile, removeFile } from '#platform/server/fs';
 import { logger } from '#platform/server/log';
@@ -122,7 +123,7 @@ export function closeDatabase(db: SQL.Database) {
 export async function exportDatabase(db: SQL.Database) {
   // electron does not support better-sqlite serialize since v21
   // save to file and read in the raw data.
-  const name = `${getDataDir()}/backup-for-export-${crypto.randomUUID()}.db`;
+  const name = `${getDataDir()}/backup-for-export-${uuidv4()}.db`;
 
   await db.backup(name);
 

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1,4 +1,5 @@
 import { t } from 'i18next';
+import { v4 as uuidv4 } from 'uuid';
 
 import { captureException } from '#platform/exceptions';
 import * as asyncStorage from '#platform/server/asyncStorage';
@@ -178,7 +179,7 @@ async function linkGoCardlessAccount({
       account_sync_source: 'goCardless',
     });
   } else {
-    id = crypto.randomUUID();
+    id = uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: account.account_id,
@@ -253,7 +254,7 @@ async function linkSimpleFinAccount({
       account_sync_source: 'simpleFin',
     });
   } else {
-    id = crypto.randomUUID();
+    id = uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: externalAccount.account_id,
@@ -327,7 +328,7 @@ async function linkPluggyAiAccount({
       account_sync_source: 'pluggyai',
     });
   } else {
-    id = crypto.randomUUID();
+    id = uuidv4();
     await db.insertWithUUID('accounts', {
       id,
       account_id: externalAccount.account_id,
@@ -501,7 +502,7 @@ async function closeAccount({
         }
 
         await mainApp.handlers['transaction-add']({
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           payee: transferPayee.id,
           amount: -balance,
           account: id,

--- a/packages/loot-core/src/server/accounts/link.ts
+++ b/packages/loot-core/src/server/accounts/link.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import * as db from '#server/db';
 
@@ -13,7 +14,7 @@ export async function findOrCreateBank(institution, requisitionId) {
   }
 
   const bankData = {
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     bank_id: requisitionId,
     name: institution.name,
   };

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import * as dateFns from 'date-fns';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as asyncStorage from '#platform/server/asyncStorage';
 import { logger } from '#platform/server/log';
@@ -322,7 +323,7 @@ async function resolvePayee(trans, payeeName, payeesToCreate) {
       return payee.id;
     } else {
       // Otherwise we're going to create a new one
-      const newPayee = { id: crypto.randomUUID(), name: payeeName };
+      const newPayee = { id: uuidv4(), name: payeeName };
       payeesToCreate.set(payeeName.toLowerCase(), newPayee);
       return newPayee.id;
     }
@@ -616,7 +617,7 @@ export async function reconcileTransactions(
       const { forceAddTransaction: _forceAddTransaction, ...newTrans } = trans;
       const finalTransaction = {
         ...newTrans,
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         category: trans.category || null,
         cleared: trans.cleared ?? defaultCleared,
       };
@@ -880,7 +881,7 @@ export async function addTransactions(
     const trans = await runRules(originalTrans, accountsMap);
 
     const finalTransaction = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       ...trans,
       account: acctId,
       cleared: trans.cleared != null ? trans.cleared : true,

--- a/packages/loot-core/src/server/aql/exec.test.ts
+++ b/packages/loot-core/src/server/aql/exec.test.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import * as db from '#server/db';
 import { q } from '#shared/query';
@@ -38,14 +39,14 @@ async function insertTransactions(repeatTimes = 1) {
     });
 
     const parent = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       account: 'acct',
       date: '2020-01-04',
       amount: -100,
       is_parent: true,
     };
     const parent2 = {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       account: 'acct',
       date: '2020-01-01',
       amount: -89,
@@ -113,7 +114,7 @@ describe('compileAndRunQuery', () => {
   });
 
   it('provides named parameters and converts types', async () => {
-    const transId = crypto.randomUUID();
+    const transId = uuidv4();
     await db.insertTransaction({
       id: transId,
       account: 'acct',
@@ -242,7 +243,7 @@ describe('compileAndRunQuery', () => {
   });
 
   it('parameters have the correct order', async () => {
-    const transId = crypto.randomUUID();
+    const transId = uuidv4();
     await db.insertTransaction({
       id: transId,
       account: 'acct',

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import AdmZip from 'adm-zip';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as asyncStorage from '#platform/server/asyncStorage';
 import { fetch } from '#platform/server/fetch';
@@ -286,7 +287,7 @@ export async function upload() {
   }
 
   if (!cloudFileId) {
-    cloudFileId = crypto.randomUUID();
+    cloudFileId = uuidv4();
   }
 
   let res;

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -1,4 +1,5 @@
 import isMatch from 'lodash/isMatch';
+import { v4 as uuidv4 } from 'uuid';
 
 import { captureException } from '#platform/exceptions';
 import * as fs from '#platform/server/fs';
@@ -101,7 +102,7 @@ const exportModel = {
 };
 
 async function createDashboardPage({ name }: { name: string }) {
-  const id = crypto.randomUUID();
+  const id = uuidv4();
   await db.insertWithSchema('dashboard_pages', { id, name });
 
   return id;

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@actual-app/crdt';
 import type { Database, Statement } from '@jlongster/sql.js';
 import { LRUCache } from 'lru-cache';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as fs from '#platform/server/fs';
 import * as sqlite from '#platform/server/sqlite';
@@ -223,7 +224,7 @@ export async function update(table, params) {
 
 export async function insertWithUUID(table, row) {
   if (!row.id) {
-    row = { ...row, id: crypto.randomUUID() };
+    row = { ...row, id: uuidv4() };
   }
 
   await insert(table, row);
@@ -292,7 +293,7 @@ export function insertWithSchema(table, row) {
   // Even though `insertWithUUID` does this, we need to do it here so
   // the schema validation passes
   if (!row.id) {
-    row = { ...row, id: crypto.randomUUID() };
+    row = { ...row, id: uuidv4() };
   }
 
   return insertWithUUID(

--- a/packages/loot-core/src/server/encryption/app.ts
+++ b/packages/loot-core/src/server/encryption/app.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import * as asyncStorage from '#platform/server/asyncStorage';
 import { logger } from '#platform/server/log';
 import { createApp } from '#server/app';
@@ -28,7 +30,7 @@ async function keyMake({ password }: { password: string }) {
   }
 
   const salt = encryption.randomBytes(32).toString('base64');
-  const id = crypto.randomUUID();
+  const id = uuidv4();
   const key = await encryption.createKey({ id, password, salt });
 
   // Load the key

--- a/packages/loot-core/src/server/encryption/index.ts
+++ b/packages/loot-core/src/server/encryption/index.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import * as internals from '#server/encryption/encryption-internals';
 
@@ -11,7 +12,7 @@ class Key {
   value;
 
   constructor({ id }) {
-    this.id = id || crypto.randomUUID();
+    this.id = id || uuidv4();
   }
 
   async createFromPassword({ password, salt }) {

--- a/packages/loot-core/src/server/filters/app.ts
+++ b/packages/loot-core/src/server/filters/app.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import { createApp } from '#server/app';
 import * as db from '#server/db';
@@ -109,7 +110,7 @@ function filterOptionsMatch(options1, options2) {
 }
 
 async function createFilter(filter): Promise<TransactionFilterEntity['id']> {
-  const filterId = crypto.randomUUID();
+  const filterId = uuidv4();
   const item = {
     id: filterId,
     conditions: filter.state.conditions,

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import AdmZip from 'adm-zip';
+import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '#platform/server/log';
 import { send } from '#server/main-app';
@@ -164,11 +165,11 @@ async function importTransactions(
   // Go ahead and generate ids for all of the transactions so we can
   // reliably resolve transfers
   for (const transaction of data.transactions) {
-    entityIdMap.set(transaction.entityId, crypto.randomUUID());
+    entityIdMap.set(transaction.entityId, uuidv4());
 
     if (transaction.subTransactions) {
       for (const subTransaction of transaction.subTransactions) {
-        entityIdMap.set(subTransaction.entityId, crypto.randomUUID());
+        entityIdMap.set(subTransaction.entityId, uuidv4());
       }
     }
   }

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '#platform/server/log';
 import { send } from '#server/main-app';
@@ -599,7 +600,7 @@ async function importTransactions(
   // reliably resolve transfers
   // Also identify orphan transfer transactions and subtransactions.
   for (const transaction of data.subtransactions) {
-    entityIdMap.set(transaction.id, crypto.randomUUID());
+    entityIdMap.set(transaction.id, uuidv4());
 
     if (transaction.transfer_account_id) {
       orphanSubtransfer.push(transaction);
@@ -608,7 +609,7 @@ async function importTransactions(
   }
 
   for (const transaction of data.transactions) {
-    entityIdMap.set(transaction.id, crypto.randomUUID());
+    entityIdMap.set(transaction.id, uuidv4());
 
     if (
       transaction.transfer_account_id &&

--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import { deserializeClock, getClock } from '@actual-app/crdt';
+import { v4 as uuidv4 } from 'uuid';
 
 import { expectSnapshotWithDiffer } from '#mocks/util';
 import * as connection from '#platform/server/connection';
@@ -180,7 +181,7 @@ describe('Budget', () => {
     // budgets for the earlier months
     db.runQuery("INSERT INTO accounts (id, name) VALUES ('one', 'boa')");
     await runHandler(handlers['transaction-add'], {
-      id: crypto.randomUUID(),
+      id: uuidv4(),
       date: '2016-05-06',
       amount: 50,
       account: 'one',

--- a/packages/loot-core/src/server/reports/app.ts
+++ b/packages/loot-core/src/server/reports/app.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { createApp } from '#server/app';
 import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
@@ -128,7 +130,7 @@ async function reportNameExists(
 }
 
 async function createReport(report: CustomReportEntity) {
-  const reportId = crypto.randomUUID();
+  const reportId = uuidv4();
   const item: CustomReportEntity = {
     ...report,
     id: reportId,

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import * as d from 'date-fns';
+import { v4 as uuidv4 } from 'uuid';
 
 import { captureBreadcrumb } from '#platform/exceptions';
 import * as connection from '#platform/server/connection';
@@ -254,7 +255,7 @@ export async function createSchedule({
   schedule = null,
   conditions = [],
 } = {}): Promise<ScheduleEntity['id']> {
-  const scheduleId = schedule?.id || crypto.randomUUID();
+  const scheduleId = schedule?.id || uuidv4();
 
   const { date: dateCond } = extractScheduleConds(conditions);
   if (dateCond == null) {

--- a/packages/loot-core/src/server/schedules/find-schedules.ts
+++ b/packages/loot-core/src/server/schedules/find-schedules.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import * as d from 'date-fns';
+import { v4 as uuidv4 } from 'uuid';
 
 import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
@@ -359,7 +360,7 @@ export async function findSchedules() {
 
       // Convert to schedule and return it
       return {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         account: winner.account,
         payee: winner.payee,
         date: winner.date,

--- a/packages/loot-core/src/server/util/budget-name.ts
+++ b/packages/loot-core/src/server/util/budget-name.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import * as fs from '#platform/server/fs';
 import { handlers } from '#server/main';
 
@@ -37,10 +39,7 @@ export async function validateBudgetName(
 }
 
 export async function idFromBudgetName(name: string): Promise<string> {
-  let id =
-    name.replace(/( |[^A-Za-z0-9])/g, '-') +
-    '-' +
-    crypto.randomUUID().slice(0, 7);
+  let id = name.replace(/( |[^A-Za-z0-9])/g, '-') + '-' + uuidv4().slice(0, 7);
 
   // Make sure the id is unique. There's a chance one could already
   // exist (although very unlikely now that we append unique

--- a/packages/loot-core/src/shared/transactions.test.ts
+++ b/packages/loot-core/src/shared/transactions.test.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { v4 as uuidv4 } from 'uuid';
 
 import type { TransactionEntity } from '#types/models';
 
@@ -13,7 +14,7 @@ import {
 
 function makeTransaction(data: Partial<TransactionEntity>): TransactionEntity {
   return {
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     amount: 2422,
     date: '2020-01-05',
     account: 'acc-id-1',

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { logger } from '#platform/server/log';
 import type { TransactionEntity } from '#types/models';
 
@@ -39,7 +41,7 @@ export function makeChild<T extends GenericTransactionEntity>(
     ...data,
     category: 'category' in data ? data.category : parent.category,
     payee: 'payee' in data ? data.payee : parent.payee,
-    id: 'id' in data ? data.id : prefix + crypto.randomUUID(),
+    id: 'id' in data ? data.id : prefix + uuidv4(),
     account: parent.account,
     date: parent.date,
     cleared: parent.cleared != null ? parent.cleared : null,
@@ -357,7 +359,7 @@ export function realizeTempTransactions(
 ): TransactionEntity[] {
   const parent = {
     ...transactions.find(t => !t.is_child),
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     sort_order: Date.now(),
   } as TransactionEntity;
   const children = transactions.filter(t => t.is_child);
@@ -367,7 +369,7 @@ export function realizeTempTransactions(
       child =>
         ({
           ...child,
-          id: crypto.randomUUID(),
+          id: uuidv4(),
           parent_id: parent.id,
         }) satisfies TransactionEntity,
     ),

--- a/packages/sync-server/migrations/1719409568000-multiuser.js
+++ b/packages/sync-server/migrations/1719409568000-multiuser.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { getAccountDb } from '../src/account-db';
 
 export const up = async function () {
@@ -36,7 +38,7 @@ export const up = async function () {
         `,
     );
 
-    const userId = crypto.randomUUID();
+    const userId = uuidv4();
     accountDb.mutate(
       'INSERT INTO users (id, user_name, display_name, enabled, owner, role) VALUES (?, ?, ?, 1, 1, ?)',
       [userId, '', '', 'ADMIN'],

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -99,6 +99,7 @@
     "migrate": "^2.1.0",
     "openid-client": "^5.7.1",
     "pluggy-sdk": "^0.83.0",
+    "uuid": "^13.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -99,7 +99,7 @@
     "migrate": "^2.1.0",
     "openid-client": "^5.7.1",
     "pluggy-sdk": "^0.83.0",
-    "uuid": "^11.1.0",
+    "uuid": "^13.0.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -99,7 +99,7 @@
     "migrate": "^2.1.0",
     "openid-client": "^5.7.1",
     "pluggy-sdk": "^0.83.0",
-    "uuid": "^13.0.0",
+    "uuid": "^11.1.0",
     "winston": "^3.19.0"
   },
   "devDependencies": {

--- a/packages/sync-server/src/accounts/openid.ts
+++ b/packages/sync-server/src/accounts/openid.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import { custom, generators, Issuer } from 'openid-client';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   clearExpiredSessions,
@@ -262,7 +263,7 @@ export async function loginWithOpenIdFinalize(body) {
           (countUsersWithUserName === 0 ||
             config.get('userCreationMode') === 'login')
         ) {
-          userId = crypto.randomUUID();
+          userId = uuidv4();
           accountDb.mutate(
             'INSERT INTO users (id, user_name, display_name, enabled, owner, role) VALUES (?, ?, ?, 1, ?, ?)',
             [
@@ -311,7 +312,7 @@ export async function loginWithOpenIdFinalize(body) {
       }
     }
 
-    const token = crypto.randomUUID();
+    const token = uuidv4();
 
     let expiration;
     if (config.get('token_expiration') === 'openid-provider') {

--- a/packages/sync-server/src/accounts/password.js
+++ b/packages/sync-server/src/accounts/password.js
@@ -1,4 +1,5 @@
 import * as bcrypt from 'bcrypt';
+import { v4 as uuidv4 } from 'uuid';
 
 import { clearExpiredSessions, getAccountDb } from '#account-db';
 import { config } from '#load-config';
@@ -57,14 +58,14 @@ export function loginWithPassword(password) {
     ['password'],
   );
 
-  const token = sessionRow ? sessionRow.token : crypto.randomUUID();
+  const token = sessionRow ? sessionRow.token : uuidv4();
 
   const { totalOfUsers } = accountDb.first(
     'SELECT count(*) as totalOfUsers FROM users',
   );
   let userId = null;
   if (totalOfUsers === 0) {
-    userId = crypto.randomUUID();
+    userId = uuidv4();
     accountDb.mutate(
       'INSERT INTO users (id, user_name, display_name, enabled, owner, role) VALUES (?, ?, ?, 1, 1, ?)',
       [userId, '', '', 'ADMIN'],

--- a/packages/sync-server/src/app-account.test.js
+++ b/packages/sync-server/src/app-account.test.js
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getAccountDb, getLoginMethod, getServerPrefs } from './account-db';
 import { bootstrapPassword } from './accounts/password';
@@ -27,7 +28,7 @@ const createSession = (userId, sessionToken, authMethod = null) => {
   );
 };
 
-const generateSessionToken = () => `token-${crypto.randomUUID()}`;
+const generateSessionToken = () => `token-${uuidv4()}`;
 
 const clearServerPrefs = () => {
   getAccountDb().mutate('DELETE FROM server_prefs');
@@ -97,8 +98,8 @@ describe('/change-password', () => {
     basicPasswordToken;
 
   beforeEach(() => {
-    adminUserId = crypto.randomUUID();
-    basicUserId = crypto.randomUUID();
+    adminUserId = uuidv4();
+    basicUserId = uuidv4();
     adminPasswordToken = generateSessionToken();
     adminOpenidToken = generateSessionToken();
     basicPasswordToken = generateSessionToken();
@@ -260,8 +261,8 @@ describe('/server-prefs', () => {
     let adminUserId, basicUserId, adminSessionToken, basicSessionToken;
 
     beforeEach(() => {
-      adminUserId = crypto.randomUUID();
-      basicUserId = crypto.randomUUID();
+      adminUserId = uuidv4();
+      basicUserId = uuidv4();
       adminSessionToken = generateSessionToken();
       basicSessionToken = generateSessionToken();
 

--- a/packages/sync-server/src/app-admin.js
+++ b/packages/sync-server/src/app-admin.js
@@ -1,4 +1,5 @@
 import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
 
 import { isAdmin } from './account-db';
 import * as UserService from './services/user-service';
@@ -77,7 +78,7 @@ app.post('/users', validateSessionMiddleware, async (req, res) => {
     return;
   }
 
-  const userId = crypto.randomUUID();
+  const userId = uuidv4();
   UserService.insertUser(
     userId,
     userName,

--- a/packages/sync-server/src/app-admin.test.js
+++ b/packages/sync-server/src/app-admin.test.js
@@ -1,4 +1,5 @@
 import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getAccountDb } from './account-db';
 import { handlers as app } from './app-admin';
@@ -26,13 +27,13 @@ const createSession = (userId, sessionToken) => {
   );
 };
 
-const generateSessionToken = () => `token-${crypto.randomUUID()}`;
+const generateSessionToken = () => `token-${uuidv4()}`;
 
 describe('/admin', () => {
   describe('/owner-created', () => {
     it('should return 200 and true if an owner user is created', async () => {
       const sessionToken = generateSessionToken();
-      const adminId = crypto.randomUUID();
+      const adminId = uuidv4();
       createUser(adminId, 'admin', ADMIN_ROLE, 1);
       createSession(adminId, sessionToken);
 
@@ -50,8 +51,8 @@ describe('/admin', () => {
       let sessionUserId, testUserId, sessionToken;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
-        testUserId = crypto.randomUUID();
+        sessionUserId = uuidv4();
+        testUserId = uuidv4();
         sessionToken = generateSessionToken();
 
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);
@@ -80,7 +81,7 @@ describe('/admin', () => {
       let duplicateUserId;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
+        sessionUserId = uuidv4();
         sessionToken = generateSessionToken();
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);
         createSession(sessionUserId, sessionToken);
@@ -151,8 +152,8 @@ describe('/admin', () => {
       let sessionUserId, testUserId, sessionToken;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
-        testUserId = crypto.randomUUID();
+        sessionUserId = uuidv4();
+        testUserId = uuidv4();
         sessionToken = generateSessionToken();
 
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);
@@ -208,8 +209,8 @@ describe('/admin', () => {
       let sessionUserId, testUserId, sessionToken;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
-        testUserId = crypto.randomUUID();
+        sessionUserId = uuidv4();
+        testUserId = uuidv4();
         sessionToken = generateSessionToken();
 
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);
@@ -259,9 +260,9 @@ describe('/admin', () => {
       let sessionUserId, testUserId, fileId, sessionToken;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
-        testUserId = crypto.randomUUID();
-        fileId = crypto.randomUUID();
+        sessionUserId = uuidv4();
+        testUserId = uuidv4();
+        fileId = uuidv4();
         sessionToken = generateSessionToken();
 
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);
@@ -320,9 +321,9 @@ describe('/admin', () => {
       let sessionUserId, testUserId, fileId, sessionToken;
 
       beforeEach(() => {
-        sessionUserId = crypto.randomUUID();
-        testUserId = crypto.randomUUID();
-        fileId = crypto.randomUUID();
+        sessionUserId = uuidv4();
+        testUserId = uuidv4();
+        fileId = uuidv4();
         sessionToken = generateSessionToken();
 
         createUser(sessionUserId, 'sessionUser', ADMIN_ROLE);

--- a/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
+++ b/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import {
   BankFactory,
   isSpecialContinuousAccessBank,
@@ -287,7 +289,7 @@ export const goCardlessService = {
     const body = {
       redirectUrl: host + '/gocardless/link',
       institutionId,
-      referenceId: crypto.randomUUID(),
+      referenceId: uuidv4(),
       accessValidForDays: institution.max_access_valid_for_days,
       maxHistoricalDays: isSpecialContinuousAccessBank(institutionId)
         ? 90

--- a/packages/sync-server/src/app-sync.ts
+++ b/packages/sync-server/src/app-sync.ts
@@ -6,6 +6,7 @@ import { resolve } from 'node:path';
 import { SyncProtoBuf } from '@actual-app/crdt';
 import type { Request, Response } from 'express';
 import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getAccountDb, isAdmin } from './account-db';
 import { FileNotFound } from './app-sync/errors';
@@ -61,7 +62,7 @@ function boolToInt(deleted: boolean) {
 }
 
 function generateGroupId(): GroupId {
-  const id = crypto.randomUUID();
+  const id = uuidv4();
   if (!isValidGroupId(id)) {
     throw new TypeError('UUID format no longer matches expected format');
   }

--- a/upcoming-release-notes/7734.md
+++ b/upcoming-release-notes/7734.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Revert UUID generation to use `uuid` library instead of `crypto.randomUUID()`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,7 @@ __metadata:
     compare-versions: "npm:^6.1.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript-strict-plugin: "npm:^2.4.4"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-peggy-loader: "npm:^2.0.1"
     vitest: "npm:^4.1.2"
@@ -146,6 +147,7 @@ __metadata:
     typescript-strict-plugin: "npm:^2.4.4"
     ua-parser-js: "npm:^2.0.9"
     util: "npm:^0.12.5"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-node-polyfills: "npm:^0.26.0"
     vite-plugin-peggy-loader: "npm:^2.0.1"
@@ -166,6 +168,7 @@ __metadata:
     protoc-gen-js: "npm:3.21.4-4"
     rollup-plugin-visualizer: "npm:^7.0.1"
     ts-protoc-gen: "npm:0.15.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vitest: "npm:^4.1.2"
   languageName: unknown
@@ -203,6 +206,7 @@ __metadata:
     pluggy-sdk: "npm:^0.83.0"
     supertest: "npm:^7.2.2"
     typescript-strict-plugin: "npm:^2.4.4"
+    uuid: "npm:^13.0.0"
     vitest: "npm:^4.1.2"
     winston: "npm:^3.19.0"
   bin:
@@ -292,6 +296,7 @@ __metadata:
     sass: "npm:^1.99.0"
     typescript-strict-plugin: "npm:^2.4.4"
     usehooks-ts: "npm:^3.1.1"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-pwa: "npm:^1.2.0"
     vitest: "npm:^4.1.2"
@@ -28344,6 +28349,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^13.0.0":
+  version: 13.0.2
+  resolution: "uuid@npm:13.0.2"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10/567dddca18a8520796dd3cd1e4513f4c7c522f25602c15381615395d60c7892f330366680fc21373f19fb83c991f3da8413f57dbd85bf976069cf0818aa6c61c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
     compare-versions: "npm:^6.1.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript-strict-plugin: "npm:^2.4.4"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.1.0"
     vite: "npm:^8.0.5"
     vite-plugin-peggy-loader: "npm:^2.0.1"
     vitest: "npm:^4.1.2"
@@ -147,7 +147,7 @@ __metadata:
     typescript-strict-plugin: "npm:^2.4.4"
     ua-parser-js: "npm:^2.0.9"
     util: "npm:^0.12.5"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.1.0"
     vite: "npm:^8.0.5"
     vite-plugin-node-polyfills: "npm:^0.26.0"
     vite-plugin-peggy-loader: "npm:^2.0.1"
@@ -168,7 +168,7 @@ __metadata:
     protoc-gen-js: "npm:3.21.4-4"
     rollup-plugin-visualizer: "npm:^7.0.1"
     ts-protoc-gen: "npm:0.15.0"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.1.0"
     vite: "npm:^8.0.5"
     vitest: "npm:^4.1.2"
   languageName: unknown
@@ -206,7 +206,7 @@ __metadata:
     pluggy-sdk: "npm:^0.83.0"
     supertest: "npm:^7.2.2"
     typescript-strict-plugin: "npm:^2.4.4"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.1.0"
     vitest: "npm:^4.1.2"
     winston: "npm:^3.19.0"
   bin:
@@ -296,7 +296,7 @@ __metadata:
     sass: "npm:^1.99.0"
     typescript-strict-plugin: "npm:^2.4.4"
     usehooks-ts: "npm:^3.1.1"
-    uuid: "npm:^13.0.0"
+    uuid: "npm:^11.1.0"
     vite: "npm:^8.0.5"
     vite-plugin-pwa: "npm:^1.2.0"
     vitest: "npm:^4.1.2"
@@ -28349,15 +28349,6 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^13.0.0":
-  version: 13.0.2
-  resolution: "uuid@npm:13.0.2"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10/567dddca18a8520796dd3cd1e4513f4c7c522f25602c15381615395d60c7892f330366680fc21373f19fb83c991f3da8413f57dbd85bf976069cf0818aa6c61c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ __metadata:
     compare-versions: "npm:^6.1.1"
     rollup-plugin-visualizer: "npm:^7.0.1"
     typescript-strict-plugin: "npm:^2.4.4"
-    uuid: "npm:^11.1.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-peggy-loader: "npm:^2.0.1"
     vitest: "npm:^4.1.2"
@@ -147,7 +147,7 @@ __metadata:
     typescript-strict-plugin: "npm:^2.4.4"
     ua-parser-js: "npm:^2.0.9"
     util: "npm:^0.12.5"
-    uuid: "npm:^11.1.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-node-polyfills: "npm:^0.26.0"
     vite-plugin-peggy-loader: "npm:^2.0.1"
@@ -168,7 +168,7 @@ __metadata:
     protoc-gen-js: "npm:3.21.4-4"
     rollup-plugin-visualizer: "npm:^7.0.1"
     ts-protoc-gen: "npm:0.15.0"
-    uuid: "npm:^11.1.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vitest: "npm:^4.1.2"
   languageName: unknown
@@ -206,7 +206,7 @@ __metadata:
     pluggy-sdk: "npm:^0.83.0"
     supertest: "npm:^7.2.2"
     typescript-strict-plugin: "npm:^2.4.4"
-    uuid: "npm:^11.1.0"
+    uuid: "npm:^13.0.0"
     vitest: "npm:^4.1.2"
     winston: "npm:^3.19.0"
   bin:
@@ -296,7 +296,7 @@ __metadata:
     sass: "npm:^1.99.0"
     typescript-strict-plugin: "npm:^2.4.4"
     usehooks-ts: "npm:^3.1.1"
-    uuid: "npm:^11.1.0"
+    uuid: "npm:^13.0.0"
     vite: "npm:^8.0.5"
     vite-plugin-pwa: "npm:^1.2.0"
     vitest: "npm:^4.1.2"
@@ -28349,6 +28349,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10/d2da43b49b154d154574891ced66d0c83fc70caaad87e043400cf644423b067542d6f3eb641b7c819224a7cd3b4c2f21906acbedd6ec9c6a05887aa9115a9cf5
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^13.0.0":
+  version: 13.0.2
+  resolution: "uuid@npm:13.0.2"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10/567dddca18a8520796dd3cd1e4513f4c7c522f25602c15381615395d60c7892f330366680fc21373f19fb83c991f3da8413f57dbd85bf976069cf0818aa6c61c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Partial revert of #7529

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (-1.17 kB) | -0.01%
loot-core | 1 | 5.27 MB → 5.27 MB (+3.3 kB) | +0.06%
api | 2 | 3.89 MB → 3.9 MB (+3.22 kB) | +0.08%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB → 43.7 kB (+1.87 kB) | +4.47%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (-1.17 kB) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/uuid/dist/v4.js` | 🆕 +758 B | 0 B → 758 B
`node_modules/uuid/dist/stringify.js` | 🆕 +727 B | 0 B → 727 B
`node_modules/uuid/dist/rng.js` | 🆕 +437 B | 0 B → 437 B
`node_modules/uuid/dist/native.js` | 🆕 +202 B | 0 B → 202 B
`package.json` | 📈 +20 B (+0.22%) | 8.96 kB → 8.98 kB
`src/components/accounts/Account.tsx` | 📉 -15 B (-0.03%) | 44.12 kB → 44.1 kB
`locale/es.json` | 📉 -162 B (-0.09%) | 179.16 kB → 179 kB
`locale/ca.json` | 📉 -172 B (-0.09%) | 188.08 kB → 187.91 kB
`locale/fr.json` | 📉 -176 B (-0.10%) | 179.07 kB → 178.9 kB
`locale/uk.json` | 📉 -212 B (-0.10%) | 207.95 kB → 207.75 kB
`locale/de.json` | 📉 -183 B (-0.10%) | 170.73 kB → 170.55 kB
`locale/it.json` | 📉 -187 B (-0.11%) | 165.19 kB → 165.01 kB
`locale/nb-NO.json` | 📉 -170 B (-0.11%) | 148.48 kB → 148.31 kB
`src/accounts/mutations.ts` | 📉 -15 B (-0.12%) | 12.61 kB → 12.6 kB
`src/budget/mutations.ts` | 📉 -15 B (-0.12%) | 12.52 kB → 12.5 kB
`locale/zh-Hans.json` | 📉 -147 B (-0.12%) | 118.05 kB → 117.91 kB
`locale/en.json` | 📉 -261 B (-0.14%) | 185.36 kB → 185.11 kB
`locale/th.json` | 📉 -270 B (-0.15%) | 175.02 kB → 174.76 kB
`locale/nl.json` | 📉 -178 B (-0.16%) | 106.65 kB → 106.47 kB
`locale/da.json` | 📉 -186 B (-0.18%) | 101.57 kB → 101.38 kB
`locale/pl.json` | 📉 -161 B (-0.18%) | 86.67 kB → 86.52 kB
`src/reports/mutations.ts` | 📉 -15 B (-0.19%) | 7.6 kB → 7.59 kB
`locale/pt-BR.json` | 📉 -515 B (-0.26%) | 190.09 kB → 189.58 kB
`src/components/rules/RuleEditor.tsx` | 📉 -135 B (-0.28%) | 47.02 kB → 46.89 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/connection/index.ts` | 📉 -15 B (-0.44%) | 3.35 kB → 3.33 kB
`src/tags/mutations.ts` | 📉 -15 B (-0.53%) | 2.76 kB → 2.74 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -45 B (-0.54%) | 8.21 kB → 8.17 kB
`src/payees/mutations.ts` | 📉 -15 B (-0.70%) | 2.1 kB → 2.08 kB
`src/notifications/notificationsSlice.ts` | 📉 -30 B (-1.98%) | 1.48 kB → 1.45 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/undo/index.ts` | 📉 -30 B (-3.81%) | 787 B → 757 B
`src/util/ruleUtils.ts` | 📉 -15 B (-4.10%) | 366 B → 351 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 518.66 kB → 520.63 kB (+1.97 kB) | +0.38%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pt-BR.js | 190.09 kB → 189.58 kB (-515 B) | -0.26%
static/js/th.js | 175.02 kB → 174.76 kB (-270 B) | -0.15%
static/js/en.js | 185.36 kB → 185.11 kB (-261 B) | -0.14%
static/js/uk.js | 207.95 kB → 207.75 kB (-212 B) | -0.10%
static/js/Value.js | 4.94 MB → 4.94 MB (-195 B) | -0.00%
static/js/it.js | 165.19 kB → 165.01 kB (-187 B) | -0.11%
static/js/da.js | 101.57 kB → 101.38 kB (-186 B) | -0.18%
static/js/de.js | 170.73 kB → 170.55 kB (-183 B) | -0.10%
static/js/nl.js | 106.65 kB → 106.47 kB (-178 B) | -0.16%
static/js/fr.js | 179.07 kB → 178.9 kB (-176 B) | -0.10%
static/js/ca.js | 188.08 kB → 187.91 kB (-172 B) | -0.09%
static/js/nb-NO.js | 148.48 kB → 148.31 kB (-170 B) | -0.11%
static/js/es.js | 179.16 kB → 179 kB (-162 B) | -0.09%
static/js/pl.js | 86.67 kB → 86.52 kB (-161 B) | -0.18%
static/js/zh-Hans.js | 118.05 kB → 117.91 kB (-147 B) | -0.12%
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (-15 B) | -0.00%
static/js/bankSyncUtils.js | 54.11 kB → 54.1 kB (-15 B) | -0.03%
static/js/index.js | 1.93 MB → 1.93 MB (-10 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+3.3 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/uuid/dist/v4.js` | 🆕 +776 B | 0 B → 776 B
`node_modules/uuid/dist/stringify.js` | 🆕 +732 B | 0 B → 732 B
`node_modules/uuid/dist/rng.js` | 🆕 +446 B | 0 B → 446 B
`node_modules/uuid/dist/native.js` | 🆕 +204 B | 0 B → 204 B
`home/runner/work/actual/actual/packages/crdt/dist/index.js` | 📈 +1.72 kB (+3.84%) | 44.82 kB → 46.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -30 B (-0.12%) | 24.74 kB → 24.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -15 B (-0.12%) | 11.98 kB → 11.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📉 -30 B (-0.14%) | 20.56 kB → 20.53 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -15 B (-0.17%) | 8.51 kB → 8.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📉 -15 B (-0.20%) | 7.46 kB → 7.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -45 B (-0.20%) | 22.29 kB → 22.25 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/find-schedules.ts` | 📉 -15 B (-0.20%) | 7.19 kB → 7.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -15 B (-0.24%) | 6.06 kB → 6.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -60 B (-0.27%) | 22.02 kB → 21.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📉 -30 B (-0.31%) | 9.43 kB → 9.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/filters/app.ts` | 📉 -15 B (-0.39%) | 3.8 kB → 3.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📉 -15 B (-0.40%) | 3.66 kB → 3.64 kB
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📉 -90 B (-0.43%) | 20.44 kB → 20.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/app.ts` | 📉 -15 B (-0.78%) | 1.88 kB → 1.86 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/index.ts` | 📉 -15 B (-0.96%) | 1.53 kB → 1.52 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/budget-name.ts` | 📉 -15 B (-1.25%) | 1.17 kB → 1.15 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📉 -15 B (-2.38%) | 629 B → 614 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📉 -15 B (-3.55%) | 422 B → 407 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1722804019000_create_dashboard_table.js` | 📉 -75 B (-4.73%) | 1.55 kB → 1.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DbAkUAmB.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DCbeRm_D.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.9 MB (+3.22 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/uuid/dist/v4.js` | 🆕 +758 B | 0 B → 758 B
`node_modules/uuid/dist/stringify.js` | 🆕 +727 B | 0 B → 727 B
`node_modules/uuid/dist/rng.js` | 🆕 +437 B | 0 B → 437 B
`node_modules/uuid/dist/native.js` | 🆕 +202 B | 0 B → 202 B
`home/runner/work/actual/actual/packages/crdt/dist/index.js` | 📈 +1.69 kB (+3.87%) | 43.63 kB → 45.32 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -30 B (-0.12%) | 24.14 kB → 24.11 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -15 B (-0.12%) | 11.72 kB → 11.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📉 -30 B (-0.15%) | 20.11 kB → 20.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -15 B (-0.18%) | 8.25 kB → 8.24 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📉 -15 B (-0.20%) | 7.3 kB → 7.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -45 B (-0.20%) | 21.78 kB → 21.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/find-schedules.ts` | 📉 -15 B (-0.21%) | 6.99 kB → 6.97 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📉 -15 B (-0.25%) | 5.86 kB → 5.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -60 B (-0.27%) | 21.46 kB → 21.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📉 -30 B (-0.32%) | 9.22 kB → 9.19 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/filters/app.ts` | 📉 -15 B (-0.39%) | 3.71 kB → 3.7 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📉 -15 B (-0.41%) | 3.57 kB → 3.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📉 -90 B (-0.44%) | 19.8 kB → 19.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/index.electron.ts` | 📉 -15 B (-0.73%) | 2.02 kB → 2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/app.ts` | 📉 -15 B (-0.81%) | 1.8 kB → 1.78 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/index.ts` | 📉 -15 B (-1.05%) | 1.4 kB → 1.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/budget-name.ts` | 📉 -15 B (-1.29%) | 1.14 kB → 1.12 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📉 -15 B (-2.42%) | 620 B → 605 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📉 -15 B (-3.65%) | 411 B → 396 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1722804019000_create_dashboard_table.js` | 📉 -75 B (-4.83%) | 1.52 kB → 1.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.9 MB (+3.22 kB) | +0.08%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB → 43.7 kB (+1.87 kB) | +4.47%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/uuid/dist-node/v4.js` | 🆕 +763 B | 0 B → 763 B
`node_modules/uuid/dist-node/stringify.js` | 🆕 +732 B | 0 B → 732 B
`node_modules/uuid/dist-node/rng.js` | 🆕 +305 B | 0 B → 305 B
`node_modules/uuid/dist-node/native.js` | 🆕 +128 B | 0 B → 128 B
`src/crdt/timestamp.ts` | 📉 -15 B (-0.28%) | 5.2 kB → 5.18 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB → 43.7 kB (+1.87 kB) | +4.47%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->