### PR TITLE
Add APIs to allow external sync tools easier places to tie in

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -9,7 +9,10 @@ import type {
 } from '@actual-app/core/server/api-models';
 import { lib } from '@actual-app/core/server/main';
 import type { Query } from '@actual-app/core/shared/query';
-import type { ImportTransactionsOpts } from '@actual-app/core/types/api-handlers';
+import type {
+  ExternalSyncMetadataInput,
+  ImportTransactionsOpts,
+} from '@actual-app/core/types/api-handlers';
 import type { Handlers } from '@actual-app/core/types/handlers';
 import type {
   ImportTransactionEntity,
@@ -177,6 +180,17 @@ export function updateAccount(
   fields: Partial<APIAccountEntity>,
 ) {
   return send('api/account-update', { id, fields });
+}
+
+export function linkExternalSyncAccount(
+  id: APIAccountEntity['id'],
+  metadata: ExternalSyncMetadataInput,
+) {
+  return send('api/account-external-sync-link', { id, metadata });
+}
+
+export function unlinkExternalSyncAccount(id: APIAccountEntity['id']) {
+  return send('api/account-external-sync-unlink', { id });
 }
 
 export function closeAccount(

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -10,6 +10,7 @@ import type {
 import { lib } from '@actual-app/core/server/main';
 import type { Query } from '@actual-app/core/shared/query';
 import type {
+  ExternalSyncAccountInfo,
   ExternalSyncMetadataInput,
   ImportTransactionsOpts,
 } from '@actual-app/core/types/api-handlers';
@@ -187,6 +188,12 @@ export function linkExternalSyncAccount(
   metadata: ExternalSyncMetadataInput,
 ) {
   return send('api/account-external-sync-link', { id, metadata });
+}
+
+export function getExternalSyncAccount(
+  id: APIAccountEntity['id'],
+): Promise<ExternalSyncAccountInfo> {
+  return send('api/account-external-sync-get', { id });
 }
 
 export function unlinkExternalSyncAccount(id: APIAccountEntity['id']) {

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -211,6 +211,14 @@ export function AccountHeader({
     account.account_sync_source !== 'external' &&
     isUsingServer
   );
+  let canUnlink = !!(account?.account_id && isUsingServer);
+  let canLink = !!(
+    account &&
+    !account.closed &&
+    !account.account_id &&
+    !account.account_sync_source &&
+    syncServerStatus === 'online'
+  );
   if (!account) {
     // All accounts - check for any syncable account
     canSync =
@@ -218,6 +226,8 @@ export function AccountHeader({
         account =>
           !!account.account_id && account.account_sync_source !== 'external',
       ) && isUsingServer;
+    canUnlink = false;
+    canLink = false;
   }
 
   // Only show the ability to make linked transfers on multi-account views.
@@ -517,7 +527,8 @@ export function AccountHeader({
                   <Dialog>
                     <AccountMenu
                       account={account}
-                      canSync={canSync}
+                      canUnlink={canUnlink}
+                      canLink={canLink}
                       showNetWorthChart={showNetWorthChart}
                       canShowBalances={
                         canCalculateBalance ? canCalculateBalance() : false
@@ -743,7 +754,8 @@ function AccountNameField({
 
 type AccountMenuProps = {
   account: AccountEntity;
-  canSync: boolean;
+  canUnlink: boolean;
+  canLink: boolean;
   showNetWorthChart: boolean;
   showBalances: boolean;
   canShowBalances: boolean;
@@ -767,7 +779,8 @@ type AccountMenuProps = {
 
 function AccountMenu({
   account,
-  canSync,
+  canUnlink,
+  canLink,
   showNetWorthChart,
   showBalances,
   canShowBalances,
@@ -777,7 +790,6 @@ function AccountMenu({
   onMenuSelect,
 }: AccountMenuProps) {
   const { t } = useTranslation();
-  const syncServerStatus = useSyncServerStatus();
 
   return (
     <Menu
@@ -824,14 +836,14 @@ function AccountMenu({
         },
         { name: 'export', text: t('Export') },
         ...(account && !account.closed
-          ? canSync
+          ? canUnlink
             ? [
                 {
                   name: 'unlink',
                   text: t('Unlink account'),
                 } as const,
               ]
-            : syncServerStatus === 'online'
+            : canLink
               ? [
                   {
                     name: 'link',

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -206,10 +206,18 @@ export function AccountHeader({
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const locale = useLocale();
 
-  let canSync = !!(account?.account_id && isUsingServer);
+  let canSync = !!(
+    account?.account_id &&
+    account.account_sync_source !== 'external' &&
+    isUsingServer
+  );
   if (!account) {
     // All accounts - check for any syncable account
-    canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
+    canSync =
+      !!accounts.find(
+        account =>
+          !!account.account_id && account.account_sync_source !== 'external',
+      ) && isUsingServer;
   }
 
   // Only show the ability to make linked transfers on multi-account views.

--- a/packages/desktop-client/src/components/banksync/AccountRow.tsx
+++ b/packages/desktop-client/src/components/banksync/AccountRow.tsx
@@ -23,15 +23,20 @@ type AccountRowProps = {
 export const AccountRow = memo(
   ({ account, hovered, onHover, onAction, locale }: AccountRowProps) => {
     const backgroundFocus = hovered;
+    const hasLastSync = Boolean(account.last_sync);
 
-    const lastSyncString = tsToRelativeTime(account.last_sync, locale, {
-      capitalize: true,
-    });
-    const lastSyncDateTime = formatDate(
-      new Date(parseInt(account.last_sync ?? '0', 10)),
-      'MMM d, yyyy, HH:mm:ss',
-      { locale },
-    );
+    const lastSyncString = hasLastSync
+      ? tsToRelativeTime(account.last_sync, locale, {
+          capitalize: true,
+        })
+      : '-';
+    const lastSyncDateTime = hasLastSync
+      ? formatDate(
+          new Date(parseInt(account.last_sync ?? '0', 10)),
+          'MMM d, yyyy, HH:mm:ss',
+          { locale },
+        )
+      : null;
 
     const potentiallyTruncatedAccountName =
       account.name.length > 30
@@ -69,13 +74,11 @@ export const AccountRow = memo(
           {account.bankName}
         </Cell>
 
-        {account.account_sync_source ? (
+        {account.account_sync_source && hasLastSync ? (
           <Tooltip
             placement="bottom start"
             content={lastSyncDateTime}
-            style={{
-              ...styles.tooltip,
-            }}
+            style={{ ...styles.tooltip }}
           >
             <Cell
               name="lastSync"
@@ -94,6 +97,15 @@ export const AccountRow = memo(
               {lastSyncString}
             </Cell>
           </Tooltip>
+        ) : account.account_sync_source ? (
+          <Cell
+            name="lastSync"
+            width={200}
+            plain
+            style={{ color: theme.tableText, padding: '11px' }}
+          >
+            {lastSyncString}
+          </Cell>
         ) : (
           ''
         )}

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
@@ -1,4 +1,5 @@
 import { generateAccount } from '@actual-app/core/mocks';
+import type { AccountEntity } from '@actual-app/core/types/models';
 import { describe, expect, it } from 'vitest';
 
 import { getSyncSourceReadable, groupBankSyncAccounts } from './bankSyncUtils';
@@ -6,34 +7,41 @@ import { getSyncSourceReadable, groupBankSyncAccounts } from './bankSyncUtils';
 describe('bankSyncUtils', () => {
   it('groups open accounts by provider and leaves unlinked last', () => {
     const goCardlessAccount = generateAccount('GoCardless', true, false);
+    const externalAccount = {
+      ...generateAccount('External', true, false),
+      account_sync_source: 'external',
+    } satisfies AccountEntity;
     const pluggyAccount = {
       ...generateAccount('Pluggy', true, false),
-      account_sync_source: 'pluggyai' as const,
-    };
+      account_sync_source: 'pluggyai',
+    } satisfies AccountEntity;
     const simpleFinAccount = {
       ...generateAccount('SimpleFIN', true, false),
-      account_sync_source: 'simpleFin' as const,
-    };
+      account_sync_source: 'simpleFin',
+    } satisfies AccountEntity;
     const unlinkedAccount = generateAccount('Manual', false, false);
     const closedAccount = {
       ...generateAccount('Closed', true, false),
-      closed: 1 as const,
-    };
+      closed: 1,
+    } satisfies AccountEntity;
 
     const groupedAccounts = groupBankSyncAccounts([
       unlinkedAccount,
       simpleFinAccount,
       closedAccount,
+      externalAccount,
       pluggyAccount,
       goCardlessAccount,
     ]);
 
     expect(Object.keys(groupedAccounts)).toEqual([
+      'external',
       'goCardless',
       'pluggyai',
       'simpleFin',
       'unlinked',
     ]);
+    expect(groupedAccounts.external).toEqual([externalAccount]);
     expect(groupedAccounts.goCardless).toEqual([goCardlessAccount]);
     expect(groupedAccounts.pluggyai).toEqual([pluggyAccount]);
     expect(groupedAccounts.simpleFin).toEqual([simpleFinAccount]);

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
@@ -48,6 +48,7 @@ describe('bankSyncUtils', () => {
     expect(readable.goCardless).toBe('GoCardless');
     expect(readable.simpleFin).toBe('SimpleFIN');
     expect(readable.pluggyai).toBe('Pluggy.ai');
+    expect(readable.external).toBe('translated:External');
     expect(readable.unlinked).toBe('translated:Unlinked');
   });
 });

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
@@ -1,9 +1,10 @@
 import type {
   AccountEntity,
+  AccountSyncSource,
   BankSyncProviders,
 } from '@actual-app/core/types/models';
 
-export type SyncProviders = BankSyncProviders | 'unlinked';
+export type SyncProviders = AccountSyncSource | 'unlinked';
 export type GroupedBankSyncAccounts = Partial<
   Record<SyncProviders, AccountEntity[]>
 >;
@@ -16,6 +17,7 @@ export const BUILT_IN_BANK_SYNC_PROVIDERS = [
 
 const SYNC_PROVIDER_KEYS = [
   ...BUILT_IN_BANK_SYNC_PROVIDERS,
+  'external',
   'unlinked',
 ] as const satisfies readonly SyncProviders[];
 
@@ -32,6 +34,7 @@ export function getSyncSourceReadable(
     goCardless: 'GoCardless',
     simpleFin: 'SimpleFIN',
     pluggyai: 'Pluggy.ai',
+    external: translate('External'),
     unlinked: translate('Unlinked'),
   };
 }

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import * as asyncStorage from '#platform/server/asyncStorage';
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 
@@ -12,6 +13,7 @@ vi.mock('./sync', async () => ({
 }));
 
 const simpleFinBatchSyncHandler = app.handlers['simplefin-batch-sync'];
+const accountsBankSyncHandler = app.handlers['accounts-bank-sync'];
 
 function insertBank(bank: { id: string; bank_id: string; name: string }) {
   db.runQuery(
@@ -41,6 +43,10 @@ async function setupSimpleFinAccounts(
 
 beforeEach(async () => {
   vi.resetAllMocks();
+  vi.mocked(asyncStorage.multiGet).mockResolvedValue({
+    'user-id': 'user-1',
+    'user-key': 'key-1',
+  });
   await global.emptyDatabase()();
   await loadMappings();
 });
@@ -132,6 +138,29 @@ describe('simpleFinBatchSync', () => {
       // Account 2 should have no errors
       const acct2Result = result.find(r => r.accountId === 'acct2');
       expect(acct2Result!.res.errors).toHaveLength(0);
+    });
+  });
+});
+
+describe('accountsBankSync', () => {
+  it('skips externally linked accounts', async () => {
+    insertBank({ id: 'bank1', bank_id: 'external:bank-1', name: 'External' });
+    await db.insertAccount({
+      id: 'acct-external',
+      name: 'External Checking',
+      bank: 'bank1',
+      account_id: 'external-account-1',
+      account_sync_source: 'external',
+    });
+
+    const result = await accountsBankSyncHandler({ ids: ['acct-external'] });
+
+    expect(bankSync.syncAccount).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      errors: [],
+      newTransactions: [],
+      matchedTransactions: [],
+      updatedAccounts: [],
     });
   });
 });

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -1,15 +1,19 @@
-// @ts-strict-ignore
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 
 import { app } from './app';
 
+declare global {
+  var emptyDatabase: (deleteFile?: boolean) => () => Promise<void>;
+}
+
+const emptyDatabase = globalThis.emptyDatabase;
 const linkExternalSyncAccount = app.handlers['account-external-sync-link'];
 const getExternalSyncAccount = app.handlers['account-external-sync-get'];
 const unlinkExternalSyncAccount = app.handlers['account-external-sync-unlink'];
 
 beforeEach(async () => {
-  await global.emptyDatabase()();
+  await emptyDatabase()();
   await loadMappings();
 });
 
@@ -57,14 +61,14 @@ describe('external account sync metadata', () => {
     });
     expect(bank).toMatchObject({
       name: 'External Credit Union',
-      bank_id: 'external:institution-1',
+      bank_id: 'external:id:institution-1',
     });
   });
 
   it('reuses native unlink semantics for external accounts', async () => {
     await db.insertWithUUID('banks', {
       id: 'bank1',
-      bank_id: 'external:institution-1',
+      bank_id: 'external:id:institution-1',
       name: 'External Credit Union',
     });
     await db.insertAccount({
@@ -102,10 +106,60 @@ describe('external account sync metadata', () => {
     });
   });
 
+  it('unlinks an existing provider before linking external metadata', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'gc-bank',
+      name: 'GoCardless Bank',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'gc-acct-1',
+      bank: 'bank1',
+      balance_current: 500,
+      balance_available: 400,
+      balance_limit: 1000,
+      account_sync_source: 'goCardless',
+    });
+
+    await linkExternalSyncAccount({
+      id: 'acct1',
+      metadata: {
+        syncSource: 'external',
+        providerAccountId: 'provider-acct-1',
+        institutionName: 'External Credit Union',
+        institutionExternalId: 'institution-1',
+      },
+    });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    const bank = await db.first<db.DbBank>('SELECT * FROM banks WHERE id = ?', [
+      account!.bank!,
+    ]);
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: 'provider-acct-1',
+      bank: bank!.id,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+      account_sync_source: 'external',
+    });
+    expect(bank).toMatchObject({
+      name: 'External Credit Union',
+      bank_id: 'external:id:institution-1',
+    });
+  });
+
   it('returns external sync metadata for linked and unlinked accounts', async () => {
     await db.insertWithUUID('banks', {
       id: 'bank1',
-      bank_id: 'external:institution-1',
+      bank_id: 'external:id:institution-1',
       name: 'External Credit Union',
     });
     await db.insertAccount({
@@ -174,7 +228,7 @@ describe('external account sync metadata', () => {
   it('returns saved sync prefs alongside external sync metadata', async () => {
     await db.insertWithUUID('banks', {
       id: 'bank1',
-      bank_id: 'external:institution-1',
+      bank_id: 'external:id:institution-1',
       name: 'External Credit Union',
     });
     await db.insertAccount({
@@ -215,6 +269,51 @@ describe('external account sync metadata', () => {
           importTransactions: false,
           updateDates: true,
         },
+      }),
+    );
+  });
+
+  it('returns null institutionExternalId when the bank key falls back to the institution name', async () => {
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+    });
+
+    await linkExternalSyncAccount({
+      id: 'acct1',
+      metadata: {
+        syncSource: 'external',
+        providerAccountId: 'provider-acct-1',
+        institutionName: 'External Credit Union',
+      },
+    });
+
+    await expect(getExternalSyncAccount({ id: 'acct1' })).resolves.toEqual(
+      expect.objectContaining({
+        institutionName: 'External Credit Union',
+        institutionExternalId: null,
+      }),
+    );
+  });
+
+  it('decodes legacy external bank keys that stored only the suffix value', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'external:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      account_sync_source: 'external',
+    });
+
+    await expect(getExternalSyncAccount({ id: 'acct1' })).resolves.toEqual(
+      expect.objectContaining({
+        institutionName: 'External Credit Union',
+        institutionExternalId: 'institution-1',
       }),
     );
   });

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -5,6 +5,7 @@ import { loadMappings } from '#server/db/mappings';
 import { app } from './app';
 
 const linkExternalSyncAccount = app.handlers['account-external-sync-link'];
+const getExternalSyncAccount = app.handlers['account-external-sync-get'];
 const unlinkExternalSyncAccount = app.handlers['account-external-sync-unlink'];
 
 beforeEach(async () => {
@@ -99,5 +100,122 @@ describe('external account sync metadata', () => {
       official_name: 'Checking Account',
       last_sync: '1715000000000',
     });
+  });
+
+  it('returns external sync metadata for linked and unlinked accounts', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'external:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+    });
+    await db.insertAccount({
+      id: 'acct2',
+      name: 'Cash',
+    });
+
+    await expect(getExternalSyncAccount({ id: 'acct1' })).resolves.toEqual({
+      id: 'acct1',
+      linked: true,
+      syncSource: 'external',
+      providerAccountId: 'provider-acct-1',
+      institutionName: 'External Credit Union',
+      institutionExternalId: 'institution-1',
+      mask: '1234',
+      officialName: 'Checking Account',
+      balanceCurrent: 1000,
+      balanceAvailable: 900,
+      balanceLimit: 2000,
+      lastSync: '1715000000000',
+      prefs: {
+        importPending: true,
+        importNotes: true,
+        reimportDeleted: true,
+        importTransactions: true,
+        updateDates: false,
+      },
+    });
+
+    await expect(getExternalSyncAccount({ id: 'acct2' })).resolves.toEqual({
+      id: 'acct2',
+      linked: false,
+      syncSource: null,
+      providerAccountId: null,
+      institutionName: null,
+      institutionExternalId: null,
+      mask: null,
+      officialName: null,
+      balanceCurrent: null,
+      balanceAvailable: null,
+      balanceLimit: null,
+      lastSync: null,
+      prefs: {
+        importPending: true,
+        importNotes: true,
+        reimportDeleted: true,
+        importTransactions: true,
+        updateDates: false,
+      },
+    });
+  });
+
+  it('returns saved sync prefs alongside external sync metadata', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'external:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      account_sync_source: 'external',
+    });
+
+    await db.update('preferences', {
+      id: 'sync-import-pending-acct1',
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: 'sync-import-notes-acct1',
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: 'sync-reimport-deleted-acct1',
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: 'sync-import-transactions-acct1',
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: 'sync-update-dates-acct1',
+      value: 'true',
+    });
+
+    await expect(getExternalSyncAccount({ id: 'acct1' })).resolves.toEqual(
+      expect.objectContaining({
+        prefs: {
+          importPending: false,
+          importNotes: false,
+          reimportDeleted: false,
+          importTransactions: false,
+          updateDates: true,
+        },
+      }),
+    );
   });
 });

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -1,0 +1,103 @@
+// @ts-strict-ignore
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+
+import { app } from './app';
+
+const linkExternalSyncAccount = app.handlers['account-external-sync-link'];
+const unlinkExternalSyncAccount = app.handlers['account-external-sync-unlink'];
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+});
+
+describe('external account sync metadata', () => {
+  it('writes external sync metadata and creates a bank row', async () => {
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+    });
+
+    await linkExternalSyncAccount({
+      id: 'acct1',
+      metadata: {
+        syncSource: 'external',
+        providerAccountId: 'provider-acct-1',
+        institutionName: 'External Credit Union',
+        institutionExternalId: 'institution-1',
+        mask: '1234',
+        officialName: 'Checking Account',
+        balanceCurrent: 1000,
+        balanceAvailable: 900,
+        balanceLimit: 2000,
+        lastSync: '1715000000000',
+      },
+    });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    const bank = await db.first<db.DbBank>('SELECT * FROM banks WHERE id = ?', [
+      account!.bank!,
+    ]);
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: 'provider-acct-1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+    });
+    expect(bank).toMatchObject({
+      name: 'External Credit Union',
+      bank_id: 'external:institution-1',
+    });
+  });
+
+  it('reuses native unlink semantics for external accounts', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'external:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+    });
+
+    await unlinkExternalSyncAccount({ id: 'acct1' });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: null,
+      bank: null,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+      account_sync_source: null,
+      mask: '1234',
+      official_name: 'Checking Account',
+      last_sync: '1715000000000',
+    });
+  });
+});

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -22,7 +22,10 @@ import { isNonProductionEnvironment } from '#shared/environment';
 import { dayFromDate } from '#shared/months';
 import * as monthUtils from '#shared/months';
 import { amountToInteger } from '#shared/util';
-import type { ImportTransactionsOpts } from '#types/api-handlers';
+import type {
+  ExternalSyncMetadataInput,
+  ImportTransactionsOpts,
+} from '#types/api-handlers';
 import type {
   AccountEntity,
   CategoryEntity,
@@ -54,6 +57,8 @@ export type AccountHandlers = {
   'gocardless-accounts-link': typeof linkGoCardlessAccount;
   'simplefin-accounts-link': typeof linkSimpleFinAccount;
   'pluggyai-accounts-link': typeof linkPluggyAiAccount;
+  'account-external-sync-link': typeof linkExternalSyncAccount;
+  'account-external-sync-unlink': typeof unlinkExternalSyncAccount;
   'account-create': typeof createAccount;
   'account-close': typeof closeAccount;
   'account-reopen': typeof reopenAccount;
@@ -358,6 +363,47 @@ async function linkPluggyAiAccount({
   connection.send('sync-event', {
     type: 'success',
     tables: ['transactions'],
+  });
+
+  return 'ok';
+}
+
+async function linkExternalSyncAccount({
+  id,
+  metadata,
+}: {
+  id: AccountEntity['id'];
+  metadata: ExternalSyncMetadataInput;
+}) {
+  const accRow = await db.first<db.DbAccount>(
+    'SELECT * FROM accounts WHERE id = ?',
+    [id],
+  );
+
+  if (!accRow) {
+    throw new Error(`Account with ID ${id} not found.`);
+  }
+
+  if (metadata.syncSource !== 'external') {
+    throw new Error('Only the "external" sync source is supported.');
+  }
+
+  const bank = await link.findOrCreateExternalBank(
+    metadata.institutionName,
+    metadata.institutionExternalId,
+  );
+
+  await db.update('accounts', {
+    id,
+    account_id: metadata.providerAccountId,
+    bank: bank.id,
+    mask: metadata.mask ?? null,
+    official_name: metadata.officialName ?? null,
+    balance_current: metadata.balanceCurrent ?? null,
+    balance_available: metadata.balanceAvailable ?? null,
+    balance_limit: metadata.balanceLimit ?? null,
+    account_sync_source: 'external',
+    last_sync: metadata.lastSync ?? null,
   });
 
   return 'ok';
@@ -976,6 +1022,10 @@ async function accountsBankSync({
   const updatedAccounts: Array<AccountEntity['id']> = [];
 
   for (const acct of accounts) {
+    if (acct.account_sync_source === 'external') {
+      continue;
+    }
+
     if (acct.bankId && acct.account_id) {
       try {
         logger.group('Bank Sync operation for account:', acct.name);
@@ -1273,6 +1323,24 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
   return 'ok';
 }
 
+async function unlinkExternalSyncAccount({ id }: { id: AccountEntity['id'] }) {
+  const accRow = await db.first<db.DbAccount>(
+    'SELECT * FROM accounts WHERE id = ?',
+    [id],
+  );
+
+  if (!accRow) {
+    throw new Error(`Account with ID ${id} not found.`);
+  }
+
+  if (accRow.account_sync_source !== 'external') {
+    throw new Error(`Account with ID ${id} is not externally linked.`);
+  }
+
+  await unlinkAccount({ id });
+  return 'ok';
+}
+
 export const app = createApp<AccountHandlers>();
 
 app.method('account-update', mutator(undoable(updateAccount)));
@@ -1282,6 +1350,8 @@ app.method('account-properties', getAccountProperties);
 app.method('gocardless-accounts-link', linkGoCardlessAccount);
 app.method('simplefin-accounts-link', linkSimpleFinAccount);
 app.method('pluggyai-accounts-link', linkPluggyAiAccount);
+app.method('account-external-sync-link', linkExternalSyncAccount);
+app.method('account-external-sync-unlink', unlinkExternalSyncAccount);
 app.method('account-create', mutator(undoable(createAccount)));
 app.method('account-close', mutator(closeAccount));
 app.method('account-reopen', mutator(undoable(reopenAccount)));

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -23,6 +23,7 @@ import { dayFromDate } from '#shared/months';
 import * as monthUtils from '#shared/months';
 import { amountToInteger } from '#shared/util';
 import type {
+  ExternalSyncAccountInfo,
   ExternalSyncMetadataInput,
   ImportTransactionsOpts,
 } from '#types/api-handlers';
@@ -58,6 +59,7 @@ export type AccountHandlers = {
   'simplefin-accounts-link': typeof linkSimpleFinAccount;
   'pluggyai-accounts-link': typeof linkPluggyAiAccount;
   'account-external-sync-link': typeof linkExternalSyncAccount;
+  'account-external-sync-get': typeof getExternalSyncAccount;
   'account-external-sync-unlink': typeof unlinkExternalSyncAccount;
   'account-create': typeof createAccount;
   'account-close': typeof closeAccount;
@@ -407,6 +409,77 @@ async function linkExternalSyncAccount({
   });
 
   return 'ok';
+}
+
+async function getExternalSyncAccount({
+  id,
+}: {
+  id: AccountEntity['id'];
+}): Promise<ExternalSyncAccountInfo> {
+  const prefRows = await db.all<Pick<db.DbPreference, 'id' | 'value'>>(
+    `SELECT id, value FROM preferences WHERE id IN (?, ?, ?, ?, ?)`,
+    [
+      `sync-import-pending-${id}`,
+      `sync-import-notes-${id}`,
+      `sync-reimport-deleted-${id}`,
+      `sync-import-transactions-${id}`,
+      `sync-update-dates-${id}`,
+    ],
+  );
+  const accRow = await db.first<
+    db.DbAccount & {
+      bank_name: db.DbBank['name'] | null;
+      bank_id: db.DbBank['bank_id'] | null;
+    }
+  >(
+    `SELECT accounts.*, banks.name as bank_name, banks.bank_id
+     FROM accounts
+     LEFT JOIN banks ON banks.id = accounts.bank
+     WHERE accounts.id = ?`,
+    [id],
+  );
+
+  if (!accRow) {
+    throw APIError('external-account-not-found');
+  }
+
+  const prefsById = prefRows.reduce<Record<string, string | null | undefined>>(
+    (carry, row) => {
+      carry[row.id] = row.value;
+      return carry;
+    },
+    {},
+  );
+  const getBooleanPref = (prefId: string, defaultValue: boolean) =>
+    String(prefsById[prefId] ?? String(defaultValue)) === 'true';
+
+  const linked = accRow.account_sync_source === 'external';
+  const institutionExternalId =
+    linked && accRow.bank_id && accRow.bank_id.startsWith('external:')
+      ? accRow.bank_id.slice('external:'.length)
+      : null;
+
+  return {
+    id: accRow.id,
+    linked,
+    syncSource: linked ? 'external' : null,
+    providerAccountId: linked ? (accRow.account_id ?? null) : null,
+    institutionName: linked ? (accRow.bank_name ?? null) : null,
+    institutionExternalId,
+    mask: linked ? (accRow.mask ?? null) : null,
+    officialName: linked ? (accRow.official_name ?? null) : null,
+    balanceCurrent: linked ? (accRow.balance_current ?? null) : null,
+    balanceAvailable: linked ? (accRow.balance_available ?? null) : null,
+    balanceLimit: linked ? (accRow.balance_limit ?? null) : null,
+    lastSync: linked ? (accRow.last_sync ?? null) : null,
+    prefs: {
+      importPending: getBooleanPref(`sync-import-pending-${id}`, true),
+      importNotes: getBooleanPref(`sync-import-notes-${id}`, true),
+      reimportDeleted: getBooleanPref(`sync-reimport-deleted-${id}`, true),
+      importTransactions: getBooleanPref(`sync-import-transactions-${id}`, true),
+      updateDates: getBooleanPref(`sync-update-dates-${id}`, false),
+    },
+  };
 }
 
 async function createAccount({
@@ -1351,6 +1424,7 @@ app.method('gocardless-accounts-link', linkGoCardlessAccount);
 app.method('simplefin-accounts-link', linkSimpleFinAccount);
 app.method('pluggyai-accounts-link', linkPluggyAiAccount);
 app.method('account-external-sync-link', linkExternalSyncAccount);
+app.method('account-external-sync-get', getExternalSyncAccount);
 app.method('account-external-sync-unlink', unlinkExternalSyncAccount);
 app.method('account-create', mutator(undoable(createAccount)));
 app.method('account-close', mutator(closeAccount));

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -390,6 +390,8 @@ async function linkExternalSyncAccount({
     throw new Error('Only the "external" sync source is supported.');
   }
 
+  await unlinkAccount({ id });
+
   const bank = await link.findOrCreateExternalBank(
     metadata.institutionName,
     metadata.institutionExternalId,
@@ -416,16 +418,6 @@ async function getExternalSyncAccount({
 }: {
   id: AccountEntity['id'];
 }): Promise<ExternalSyncAccountInfo> {
-  const prefRows = await db.all<Pick<db.DbPreference, 'id' | 'value'>>(
-    `SELECT id, value FROM preferences WHERE id IN (?, ?, ?, ?, ?)`,
-    [
-      `sync-import-pending-${id}`,
-      `sync-import-notes-${id}`,
-      `sync-reimport-deleted-${id}`,
-      `sync-import-transactions-${id}`,
-      `sync-update-dates-${id}`,
-    ],
-  );
   const accRow = await db.first<
     db.DbAccount & {
       bank_name: db.DbBank['name'] | null;
@@ -443,6 +435,17 @@ async function getExternalSyncAccount({
     throw APIError('external-account-not-found');
   }
 
+  const prefRows = await db.all<Pick<db.DbPreference, 'id' | 'value'>>(
+    `SELECT id, value FROM preferences WHERE id IN (?, ?, ?, ?, ?)`,
+    [
+      `sync-import-pending-${id}`,
+      `sync-import-notes-${id}`,
+      `sync-reimport-deleted-${id}`,
+      `sync-import-transactions-${id}`,
+      `sync-update-dates-${id}`,
+    ],
+  );
+
   const prefsById = prefRows.reduce<Record<string, string | null | undefined>>(
     (carry, row) => {
       carry[row.id] = row.value;
@@ -454,10 +457,21 @@ async function getExternalSyncAccount({
     String(prefsById[prefId] ?? String(defaultValue)) === 'true';
 
   const linked = accRow.account_sync_source === 'external';
-  const institutionExternalId =
+  const bankKey =
     linked && accRow.bank_id && accRow.bank_id.startsWith('external:')
-      ? accRow.bank_id.slice('external:'.length)
+      ? accRow.bank_id
       : null;
+  let institutionExternalId: string | null = null;
+  if (bankKey?.startsWith('external:id:')) {
+    institutionExternalId = bankKey.slice('external:id:'.length);
+  } else if (bankKey?.startsWith('external:name:')) {
+    institutionExternalId = null;
+  } else if (bankKey != null) {
+    // Backward compatibility for earlier external:<value> rows.
+    const legacySuffix = bankKey.slice('external:'.length);
+    institutionExternalId =
+      legacySuffix !== accRow.bank_name ? legacySuffix : null;
+  }
 
   return {
     id: accRow.id,

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -476,7 +476,10 @@ async function getExternalSyncAccount({
       importPending: getBooleanPref(`sync-import-pending-${id}`, true),
       importNotes: getBooleanPref(`sync-import-notes-${id}`, true),
       reimportDeleted: getBooleanPref(`sync-reimport-deleted-${id}`, true),
-      importTransactions: getBooleanPref(`sync-import-transactions-${id}`, true),
+      importTransactions: getBooleanPref(
+        `sync-import-transactions-${id}`,
+        true,
+      ),
       updateDates: getBooleanPref(`sync-update-dates-${id}`, false),
     },
   };

--- a/packages/loot-core/src/server/accounts/link.ts
+++ b/packages/loot-core/src/server/accounts/link.ts
@@ -27,7 +27,11 @@ export function getExternalBankKey(
   institutionName: string,
   institutionExternalId?: string | null,
 ) {
-  return `external:${(institutionExternalId || institutionName).trim()}`;
+  const normalizedExternalId = institutionExternalId?.trim();
+
+  return normalizedExternalId
+    ? `external:id:${normalizedExternalId}`
+    : `external:name:${institutionName.trim()}`;
 }
 
 export async function findOrCreateExternalBank(

--- a/packages/loot-core/src/server/accounts/link.ts
+++ b/packages/loot-core/src/server/accounts/link.ts
@@ -22,3 +22,35 @@ export async function findOrCreateBank(institution, requisitionId) {
 
   return bankData;
 }
+
+export function getExternalBankKey(
+  institutionName: string,
+  institutionExternalId?: string | null,
+) {
+  return `external:${(institutionExternalId || institutionName).trim()}`;
+}
+
+export async function findOrCreateExternalBank(
+  institutionName: string,
+  institutionExternalId?: string | null,
+) {
+  const bankKey = getExternalBankKey(institutionName, institutionExternalId);
+  const bank = await db.first<Pick<db.DbBank, 'id' | 'bank_id'>>(
+    'SELECT id, bank_id FROM banks WHERE bank_id = ?',
+    [bankKey],
+  );
+
+  if (bank) {
+    return bank;
+  }
+
+  const bankData = {
+    id: crypto.randomUUID(),
+    bank_id: bankKey,
+    name: institutionName,
+  };
+
+  await db.insertWithUUID('banks', bankData);
+
+  return bankData;
+}

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -597,6 +597,21 @@ handlers['api/account-update'] = withMutation(async function ({ id, fields }) {
   return db.updateAccount({ id, ...accountModel.fromExternal(fields) });
 });
 
+handlers['api/account-external-sync-link'] = withMutation(async function ({
+  id,
+  metadata,
+}) {
+  checkFileOpen();
+  await handlers['account-external-sync-link']({ id, metadata });
+});
+
+handlers['api/account-external-sync-unlink'] = withMutation(async function ({
+  id,
+}) {
+  checkFileOpen();
+  await handlers['account-external-sync-unlink']({ id });
+});
+
 handlers['api/account-close'] = withMutation(async function ({
   id,
   transferAccountId,

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -605,6 +605,11 @@ handlers['api/account-external-sync-link'] = withMutation(async function ({
   await handlers['account-external-sync-link']({ id, metadata });
 });
 
+handlers['api/account-external-sync-get'] = async function ({ id }) {
+  checkFileOpen();
+  return handlers['account-external-sync-get']({ id });
+};
+
 handlers['api/account-external-sync-unlink'] = withMutation(async function ({
   id,
 }) {

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -21,7 +21,12 @@ export type DbAccount = {
   type?: string | null;
   subtype?: string | null;
   bank?: string | null;
-  account_sync_source?: 'simpleFin' | 'goCardless' | null;
+  account_sync_source?:
+    | 'simpleFin'
+    | 'goCardless'
+    | 'pluggyai'
+    | 'external'
+    | null;
   last_reconciled?: string | null;
   last_sync?: string | null;
 };

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -32,6 +32,19 @@ export type ImportTransactionsOpts = {
   reimportDeleted?: boolean;
 };
 
+export type ExternalSyncMetadataInput = {
+  syncSource: 'external';
+  providerAccountId: string;
+  institutionName: string;
+  institutionExternalId?: string | null;
+  mask?: string | null;
+  officialName?: string | null;
+  balanceCurrent?: number | null;
+  balanceAvailable?: number | null;
+  balanceLimit?: number | null;
+  lastSync?: string | null;
+};
+
 export type ApiHandlers = {
   'api/batch-budget-start': () => Promise<void>;
 
@@ -144,6 +157,15 @@ export type ApiHandlers = {
   'api/account-update': (arg: {
     id: APIAccountEntity['id'];
     fields: Partial<APIAccountEntity>;
+  }) => Promise<void>;
+
+  'api/account-external-sync-link': (arg: {
+    id: APIAccountEntity['id'];
+    metadata: ExternalSyncMetadataInput;
+  }) => Promise<void>;
+
+  'api/account-external-sync-unlink': (arg: {
+    id: APIAccountEntity['id'];
   }) => Promise<void>;
 
   'api/account-close': (arg: {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -45,6 +45,28 @@ export type ExternalSyncMetadataInput = {
   lastSync?: string | null;
 };
 
+export type ExternalSyncAccountInfo = {
+  id: APIAccountEntity['id'];
+  linked: boolean;
+  syncSource: 'external' | null;
+  providerAccountId: string | null;
+  institutionName: string | null;
+  institutionExternalId: string | null;
+  mask: string | null;
+  officialName: string | null;
+  balanceCurrent: number | null;
+  balanceAvailable: number | null;
+  balanceLimit: number | null;
+  lastSync: string | null;
+  prefs: {
+    importPending: boolean;
+    importNotes: boolean;
+    reimportDeleted: boolean;
+    importTransactions: boolean;
+    updateDates: boolean;
+  };
+};
+
 export type ApiHandlers = {
   'api/batch-budget-start': () => Promise<void>;
 
@@ -163,6 +185,10 @@ export type ApiHandlers = {
     id: APIAccountEntity['id'];
     metadata: ExternalSyncMetadataInput;
   }) => Promise<void>;
+
+  'api/account-external-sync-get': (arg: {
+    id: APIAccountEntity['id'];
+  }) => Promise<ExternalSyncAccountInfo>;
 
   'api/account-external-sync-unlink': (arg: {
     id: APIAccountEntity['id'];

--- a/packages/loot-core/src/types/models/account.ts
+++ b/packages/loot-core/src/types/models/account.ts
@@ -21,4 +21,8 @@ export type AccountEntity = {
   last_sync: string | null;
 };
 
-export type AccountSyncSource = 'simpleFin' | 'goCardless' | 'pluggyai';
+export type AccountSyncSource =
+  | 'simpleFin'
+  | 'goCardless'
+  | 'pluggyai'
+  | 'external';

--- a/upcoming-release-notes/7735.md
+++ b/upcoming-release-notes/7735.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jcam]
+---
+
+Add APIs to allow cleaner external/scheduled bank/etc sync tools


### PR DESCRIPTION
## Description

I've had a *lot* of trouble with SimpleFin failing for my accounts, so I want to leverage some alternative sync gateways (plaid, teller.io, stripe, etc). Rather than going through the very deep process of building a first class sync that won't necessarily get a lot of use, or keep waiting for the plugin architecture to arrive, I decided to build a docker app that will sit next to my Actual container and handle scheduled sync from any number of providers.

I did use **codex** to help put this together, as my typescript was rusty, to say the least, but I then did a lot of manual trimming and review. I'll admit that I didn't really review the test cases that codex wrote.

The side app I'm building is here: https://github.com/jcam/actual-sync-hub (also heavily vibecoded), but these APIs should be usable by anyone who wants an easy way to plug in an external account.
My app supports Plaid, Teller.io, and Simplefin (primarily as a migration step, but also to have a unified automated sync)
I'll be adding a few more providers as well, if anyone else wants to use it... looking at SaltEdge and Stripe next

It creates an `external` sync source, wires in the various parts that touch that field to not explode, and allows the external tool to read and update more detailed account data, keep the 'last sync' updated, etc.

I don't know the conventions here, so I won't @ lelemm and youngcw, but I know you both have put a lot into sync, so would appreciate feedback on this!

I tried to keep it very minimal, so that once the big plugin system arrives, it can be torn back out with minimal fuss.

## Related issue(s)

Relates to pretty much all of the Community Repos for external sync, #7697 comes to mind, but also especially that Plaid now has a free tier again: #898 

## Testing

I let codex build lots of test cases around it as I described what it should be doing. I also ran a full `yarn build:api` to generate an updated node module I could directly use in my app, as well as `yarn build:server` plus a docker build of the alpine variant of sync-server, so I would know that it worked end to end and wasn't relying on any local environment weirdness.

## Checklist

- [ X ] Release notes added (see link above)
- [ X ] No obvious regressions in affected areas
- [ X ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (-2.08 kB) | -0.01%
loot-core | 1 | 5.27 MB → 5.27 MB (+4.9 kB) | +0.09%
api | 2 | 3.89 MB → 3.9 MB (+5.12 kB) | +0.13%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (-2.08 kB) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/AccountRow.tsx` | 📈 +484 B (+10.65%) | 4.44 kB → 4.91 kB
`src/components/banksync/bankSyncUtils.ts` | 📈 +52 B (+3.54%) | 1.44 kB → 1.49 kB
`src/components/accounts/Header.tsx` | 📈 +318 B (+1.11%) | 28.01 kB → 28.33 kB
`locale/es.json` | 📉 -162 B (-0.09%) | 179.16 kB → 179 kB
`locale/ca.json` | 📉 -172 B (-0.09%) | 188.08 kB → 187.91 kB
`locale/fr.json` | 📉 -176 B (-0.10%) | 179.07 kB → 178.9 kB
`locale/uk.json` | 📉 -212 B (-0.10%) | 207.95 kB → 207.75 kB
`locale/de.json` | 📉 -183 B (-0.10%) | 170.73 kB → 170.55 kB
`locale/it.json` | 📉 -187 B (-0.11%) | 165.19 kB → 165.01 kB
`locale/nb-NO.json` | 📉 -170 B (-0.11%) | 148.48 kB → 148.31 kB
`locale/zh-Hans.json` | 📉 -147 B (-0.12%) | 118.05 kB → 117.91 kB
`locale/en.json` | 📉 -261 B (-0.14%) | 185.36 kB → 185.11 kB
`locale/th.json` | 📉 -270 B (-0.15%) | 175.02 kB → 174.76 kB
`locale/nl.json` | 📉 -178 B (-0.16%) | 106.65 kB → 106.47 kB
`locale/da.json` | 📉 -186 B (-0.18%) | 101.57 kB → 101.38 kB
`locale/pl.json` | 📉 -161 B (-0.18%) | 86.67 kB → 86.52 kB
`locale/pt-BR.json` | 📉 -515 B (-0.26%) | 190.09 kB → 189.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.93 MB (+802 B) | +0.04%
static/js/bankSyncUtils.js | 54.11 kB → 54.16 kB (+52 B) | +0.09%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pt-BR.js | 190.09 kB → 189.58 kB (-515 B) | -0.26%
static/js/th.js | 175.02 kB → 174.76 kB (-270 B) | -0.15%
static/js/en.js | 185.36 kB → 185.11 kB (-261 B) | -0.14%
static/js/uk.js | 207.95 kB → 207.75 kB (-212 B) | -0.10%
static/js/it.js | 165.19 kB → 165.01 kB (-187 B) | -0.11%
static/js/da.js | 101.57 kB → 101.38 kB (-186 B) | -0.18%
static/js/de.js | 170.73 kB → 170.55 kB (-183 B) | -0.10%
static/js/nl.js | 106.65 kB → 106.47 kB (-178 B) | -0.16%
static/js/fr.js | 179.07 kB → 178.9 kB (-176 B) | -0.10%
static/js/ca.js | 188.08 kB → 187.91 kB (-172 B) | -0.09%
static/js/nb-NO.js | 148.48 kB → 148.31 kB (-170 B) | -0.11%
static/js/es.js | 179.16 kB → 179 kB (-162 B) | -0.09%
static/js/pl.js | 86.67 kB → 86.52 kB (-161 B) | -0.18%
static/js/zh-Hans.js | 118.05 kB → 117.91 kB (-147 B) | -0.12%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.68 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/extends.js | 518.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+4.9 kB) | +0.09%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📈 +694 B (+164.45%) | 422 B → 1.09 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.71 kB (+16.86%) | 22.02 kB → 25.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +521 B (+2.25%) | 22.65 kB → 23.16 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.RuExqU0o.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DCbeRm_D.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.89 MB → 3.9 MB (+5.12 kB) | +0.13%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📈 +678 B (+164.96%) | 411 B → 1.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.65 kB (+17.01%) | 21.46 kB → 25.11 kB
`methods.ts` | 📈 +318 B (+5.62%) | 5.53 kB → 5.84 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +506 B (+2.24%) | 22.05 kB → 22.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.89 MB → 3.9 MB (+5.12 kB) | +0.13%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 41.83 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 41.83 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->