### PR TITLE
[AI] Fix publish-npm-packages workflow setup-node input

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -106,7 +106,6 @@ jobs:
           node-version: 24
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
-          cache: false
 
       - name: Publish Core
         run: |

--- a/upcoming-release-notes/7755.md
+++ b/upcoming-release-notes/7755.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfixes
+category: Maintenance
 authors: [MatissJanis]
 ---
 

--- a/upcoming-release-notes/7755.md
+++ b/upcoming-release-notes/7755.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Fix npm dependency caching in publish-npm-packages workflow by removing cache disabling setting.


### PR DESCRIPTION
## Summary
- The `cache` input on `actions/setup-node` expects a package-manager string (`'npm'` / `'yarn'` / `'pnpm'`), not a boolean. Passing `cache: false` made the v26.5.1 release `Publish npm packages` job fail with `Caching for 'false' is not supported` ([failed run](https://github.com/actualbudget/actual/actions/runs/25568669467/job/75058914839)).
- Caching is disabled by default when the input is omitted, so this PR drops the line entirely in `.github/workflows/publish-npm-packages.yml`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)