### PR TITLE
Modal Blur remove static will-change: transform

### DIFF
--- a/packages/desktop-client/src/components/common/Modal.tsx
+++ b/packages/desktop-client/src/components/common/Modal.tsx
@@ -81,7 +81,6 @@ export const Modal = ({
         inset: 0,
         zIndex: MODAL_Z_INDEX,
         fontSize: 14,
-        willChange: 'transform',
         // on mobile, we disable the blurred background for performance reasons
         ...(isNarrowWidth
           ? {

--- a/upcoming-release-notes/7760.md
+++ b/upcoming-release-notes/7760.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [totallynotjon]
+---
+
+[WIP] Remove static css "will-change: transform" from Modal

--- a/upcoming-release-notes/7760.md
+++ b/upcoming-release-notes/7760.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [totallynotjon]
 ---
 
-[WIP] Remove static css "will-change: transform" from Modal
+Fix sporadic text blur in modals by removing unnecessary `will-change: transform` on the modal overlay.


### PR DESCRIPTION
## Description

Removes static use of CSS will-change: transform on Modal which sporadically blurs text unnecessarily.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/will-change

The modal would blur text sporadically in the Automation UI in Chrome.

## Testing
I could replicate inconsistently by having multiple categories with automation ui. When switching back and forth between them this would occasionally happen. Whenever this bug happened, going into the dev tools and removing the css "will-change: transform" from the modal made the text clear again. I saw this mostly in chrome and had a much harder time replicating in Firefox.

After removing the inline I retested and couldn't notice the issue anymore.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (-28 B) | -0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (-28 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/common/Modal.tsx` | 📉 -28 B (-0.23%) | 12.08 kB → 12.05 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (-28 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->