### PR TITLE
[AI] Recover from BackendInitFailure and show a meaningful error

### DIFF
--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -76,9 +76,11 @@ self.addEventListener('message', async event => {
           return;
         }
 
+        // A single failed importScripts bricks the SharedWorker until
+        // it's evicted, so retry in production too.
         await importScriptsWithRetry(
           `${msg.publicUrl}/kcab/kcab.worker.${hash}.js`,
-          { maxRetries: isDev ? 5 : 0 },
+          { maxRetries: isDev ? 5 : 3 },
         );
 
         backend.initApp(isDev, self).catch(err => {

--- a/packages/desktop-client/src/browser-server.js
+++ b/packages/desktop-client/src/browser-server.js
@@ -25,14 +25,15 @@ const importScriptsWithRetry = async (script, { maxRetries = 5 } = {}) => {
     }
 
     // Attempt to retry after a small delay
-    await new Promise(resolve =>
-      setTimeout(async () => {
-        await importScriptsWithRetry(script, {
+    await new Promise((resolve, reject) => {
+      setTimeout(() => {
+        importScriptsWithRetry(script, {
           maxRetries: maxRetries - 1,
-        });
-        resolve();
-      }, 5000),
-    );
+        })
+          .then(resolve)
+          .catch(reject);
+      }, 5000);
+    });
   }
 };
 

--- a/packages/desktop-client/src/components/FatalError.test.tsx
+++ b/packages/desktop-client/src/components/FatalError.test.tsx
@@ -30,11 +30,21 @@ describe('FatalError', () => {
     expect(screen.getByText(/IndexedDB/)).toBeInTheDocument();
   });
 
-  it('renders the generic simple message for an app-init-failure without a specific cause', () => {
+  it('renders a backend-worker message for a BackendInitFailure', () => {
     const error = {
       type: 'app-init-failure',
       BackendInitFailure: true,
     };
+
+    render(<FatalError error={error} />, { wrapper: TestProviders });
+
+    expect(
+      screen.getByText(/couldn't load a critical backend worker/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the generic simple message for an app-init-failure without a specific cause', () => {
+    const error = { type: 'app-init-failure' };
 
     render(<FatalError error={error} />, { wrapper: TestProviders });
 

--- a/packages/desktop-client/src/components/FatalError.tsx
+++ b/packages/desktop-client/src/components/FatalError.tsx
@@ -69,10 +69,17 @@ function RenderSimple({ error }: RenderSimpleProps) {
         </Trans>
       </Text>
     );
+  } else if ('BackendInitFailure' in error && error.BackendInitFailure) {
+    msg = (
+      <Text>
+        <Trans>
+          Actual couldn't load a critical backend worker. Reload the page to try
+          again; if the problem persists, do a hard refresh to clear any stale
+          cached assets.
+        </Trans>
+      </Text>
+    );
   } else {
-    // This indicates the backend failed to initialize. Show the
-    // user something at least so they aren't looking at a blank
-    // screen
     msg = (
       <Text>
         <Trans>

--- a/packages/desktop-client/src/components/FatalError.tsx
+++ b/packages/desktop-client/src/components/FatalError.tsx
@@ -99,19 +99,6 @@ function RenderSimple({ error }: RenderSimpleProps) {
       }}
     >
       <Text>{msg}</Text>
-      <Text>
-        <Trans>
-          Please get{' '}
-          <Link
-            variant="external"
-            linkColor="muted"
-            to="https://actualbudget.org/contact"
-          >
-            in touch
-          </Link>{' '}
-          for support
-        </Trans>
-      </Text>
     </SpaceBetween>
   );
 }

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -172,6 +172,47 @@ describe('SharedWorker coordinator', () => {
         expect.objectContaining({ type: 'app-init-failure', error: 'boom' }),
       );
     });
+
+    it('clears the cached init failure when the client acknowledges it', () => {
+      const leader = connectTab(coordinator);
+      sendInit(leader);
+      simulateWorkerConnect(leader);
+
+      sendMsg(leader, {
+        type: '__from-worker',
+        msg: { type: 'app-init-failure', error: 'boom' },
+      });
+      expect(coordinator.getState().lastAppInitFailure).toEqual(
+        expect.objectContaining({ type: 'app-init-failure' }),
+      );
+
+      sendMsg(leader, { name: '__app-init-failure-acknowledged' });
+      expect(coordinator.getState().lastAppInitFailure).toBeNull();
+
+      const port2 = connectTab(coordinator);
+      sendInit(port2);
+      expect(port2.postMessage).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'app-init-failure' }),
+      );
+    });
+
+    it('clears the cached init failure when a backend later connects successfully', () => {
+      const failedLeader = connectTab(coordinator);
+      sendInit(failedLeader);
+      sendMsg(failedLeader, {
+        type: '__from-worker',
+        msg: { type: 'app-init-failure', error: 'boom' },
+      });
+      expect(coordinator.getState().lastAppInitFailure).not.toBeNull();
+
+      sendMsg(failedLeader, { type: 'tab-closing' });
+
+      const newLeader = connectTab(coordinator);
+      sendInit(newLeader);
+      simulateWorkerConnect(newLeader);
+
+      expect(coordinator.getState().lastAppInitFailure).toBeNull();
+    });
   });
 
   // ── Load budget ─────────────────────────────────────────────────────

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -100,6 +100,7 @@ export function createCoordinator({
   }
 
   function broadcastConnect(budgetId: string) {
+    lastAppInitFailure = null;
     const connectMsg = { type: 'connect' };
     broadcastToAllInGroup(budgetId, connectMsg);
     for (const port of unassignedPorts) {
@@ -544,10 +545,22 @@ export function createCoordinator({
           return;
         }
 
+        // Drop the cache once the client has surfaced the failure, so a
+        // subsequent init can re-attempt. Falls through to the leader so
+        // the Worker still stops its retry interval.
+        if (msg.name === '__app-init-failure-acknowledged') {
+          lastAppInitFailure = null;
+        }
+
         // ── Initialization ─────────────────────────────────────────
 
         if (msg.type === 'init') {
           cachedInitMsg = msg;
+          // The leader that produced the failure is gone, so the cache
+          // can't recover — drop it and let this tab attempt a fresh init.
+          if (lastAppInitFailure && budgetGroups.size === 0) {
+            lastAppInitFailure = null;
+          }
           if (lastAppInitFailure) {
             port.postMessage(lastAppInitFailure);
           } else {

--- a/upcoming-release-notes/7761.md
+++ b/upcoming-release-notes/7761.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Surface the backend init failures with a custom error screen and message.


### PR DESCRIPTION
Related #7759

Surfacing the backend init failures with a user-friendly message and screen instead of the fatal error.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (-86 B) | -0.00%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (-86 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/FatalError.tsx` | 📉 -86 B (-0.77%) | 10.87 kB → 10.78 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.93 MB (-86 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->