### PR TITLE
[WIP] [AI] feat: add persistent SharedArrayBuffer warning indicator

### DIFF
--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -254,9 +254,7 @@ type SharedArrayBufferWarningProps = {
   style?: CSSProperties;
 };
 
-function SharedArrayBufferWarning({
-  style,
-}: SharedArrayBufferWarningProps) {
+function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
   const { t } = useTranslation();
   const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
   const isOverrideEnabled = localStorage.getItem('SharedArrayBufferOverride');

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -265,8 +265,16 @@ function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
   }
 
   const warningMessage = t(
-    'Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Consider using HTTPS or a supported browser.',
+    'Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Click to learn more.',
   );
+
+  const handlePress = () => {
+    window.open(
+      'https://actualbudget.org/docs/troubleshooting/shared-array-buffer',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  };
 
   return (
     <Button
@@ -278,9 +286,7 @@ function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
         WebkitAppRegion: 'none',
         color: theme.errorTextDark,
       }}
-      onPress={() => {
-        // Optional: could open a help dialog or link to documentation
-      }}
+      onPress={handlePress}
     >
       <SvgAlertTriangle width={13} />
     </Button>

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -250,6 +250,45 @@ function ServerSyncButton({ style, isMobile = false }: ServerSyncButtonProps) {
   );
 }
 
+type SharedArrayBufferWarningProps = {
+  style?: CSSProperties;
+};
+
+function SharedArrayBufferWarning({
+  style,
+}: SharedArrayBufferWarningProps) {
+  const { t } = useTranslation();
+  const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
+  const isOverrideEnabled = localStorage.getItem('SharedArrayBufferOverride');
+
+  // Only show warning if SharedArrayBuffer is not supported but user has overridden the warning
+  if (hasSharedArrayBuffer || !isOverrideEnabled) {
+    return null;
+  }
+
+  const warningMessage = t(
+    'Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Consider using HTTPS or a supported browser.',
+  );
+
+  return (
+    <Button
+      variant="bare"
+      aria-label={warningMessage}
+      title={warningMessage}
+      style={{
+        ...style,
+        WebkitAppRegion: 'none',
+        color: theme.errorTextDark,
+      }}
+      onPress={() => {
+        // Optional: could open a help dialog or link to documentation
+      }}
+    >
+      <SvgAlertTriangle width={13} />
+    </Button>
+  );
+}
+
 function BudgetTitlebar() {
   const [maxMonths, setMaxMonthsPref] = useGlobalPref('maxMonths');
 
@@ -344,6 +383,7 @@ export function Titlebar({ style }: TitlebarProps) {
         {isDevelopmentEnvironment() && !isTestEnv && <ThemeSelector />}
         <PrivacyButton />
         {serverURL ? <ServerSyncButton /> : null}
+        <SharedArrayBufferWarning />
         <LoggedInUser />
         <HelpMenu />
       </SpaceBetween>


### PR DESCRIPTION
## Summary

Adds a persistent visual indicator in the titlebar when SharedArrayBuffer is not supported but the user has overridden the warning. This addresses the issue where users can circumvent the initial warning and then have no indication they are running in a degraded state.

## Changes

- Added `SharedArrayBufferWarning` component that displays a warning icon (alert triangle) in the titlebar
- Icon appears next to the sync button, using the same error color scheme
- Only shows when:
  - `SharedArrayBuffer` is not available in the environment
  - User has set the `SharedArrayBufferOverride` flag in localStorage
- Includes tooltip (via `title` attribute) explaining the issue and recommending HTTPS or a supported browser
- Uses `aria-label` for accessibility

## UI/UX

- **Location**: Titlebar, between ServerSyncButton and LoggedInUser
- **Icon**: Alert triangle (same as used in ServerSyncButton error state)
- **Color**: `theme.errorTextDark` to indicate danger
- **Tooltip**: "Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Consider using HTTPS or a supported browser."

## Testing

- Type checking passed: `yarn typecheck`
- Linting passed: `yarn lint:fix`
- Component only renders when conditions are met (SharedArrayBuffer unavailable + override enabled)
- Follows existing patterns from ServerSyncButton and PrivacyButton

## Notes

This is a minimal, non-intrusive implementation that provides persistent feedback without blocking the user. The exact UI/UX is open for discussion as mentioned in the issue.

Fixes #7747

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (+1.38 kB) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (+1.38 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/Titlebar.tsx` | 📈 +1.38 kB (+11.55%) | 11.93 kB → 13.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.93 MB (+1.38 kB) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->