### PR TITLE
[AI] Add getNote and updateNote to public API

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -516,6 +516,29 @@ describe('API CRUD operations', () => {
     );
   });
 
+  // apis: getNote, updateNote
+  test('Notes: successfully get and update note', async () => {
+    const categories = await api.getCategories();
+    const categoryId = categories[0].id;
+
+    // No note exists initially
+    const initial = await api.getNote(categoryId);
+    expect(initial).toBeNull();
+
+    // Set a note
+    await api.updateNote(categoryId, 'Test note content');
+    const afterSet = await api.getNote(categoryId);
+    expect(afterSet).toEqual({ id: categoryId, note: 'Test note content' });
+
+    // Update the note
+    await api.updateNote(categoryId, 'Updated note content');
+    const afterUpdate = await api.getNote(categoryId);
+    expect(afterUpdate).toEqual({
+      id: categoryId,
+      note: 'Updated note content',
+    });
+  });
+
   // apis: getRules, getPayeeRules, createRule, updateRule, deleteRule
   test('Rules: successfully update rules', async () => {
     await api.createPayee({ name: 'test-payee' });

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -247,6 +247,14 @@ export function deleteCategory(
   return send('api/category-delete', { id, transferCategoryId });
 }
 
+export function getNote(id: string) {
+  return send('api/note-get', { id });
+}
+
+export function updateNote(id: string, note: string) {
+  return send('api/note-update', { id, note });
+}
+
 export function getCommonPayees() {
   return send('api/common-payees-get');
 }

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -13,6 +13,7 @@ import type { ImportTransactionsOpts } from '@actual-app/core/types/api-handlers
 import type { Handlers } from '@actual-app/core/types/handlers';
 import type {
   ImportTransactionEntity,
+  NoteEntity,
   RuleEntity,
   TransactionEntity,
 } from '@actual-app/core/types/models';
@@ -247,11 +248,11 @@ export function deleteCategory(
   return send('api/category-delete', { id, transferCategoryId });
 }
 
-export function getNote(id: string) {
+export function getNote(id: NoteEntity['id']) {
   return send('api/note-get', { id });
 }
 
-export function updateNote(id: string, note: string) {
+export function updateNote(id: NoteEntity['id'], note: NoteEntity['note']) {
   return send('api/note-update', { id, note });
 }
 

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -87,6 +87,11 @@ import APIList from './APIList';
 "deleteSchedule"
 ]} />
 
+<APIList title="Notes" sections={[
+"getNote",
+"updateNote"
+]} />
+
 <APIList title="Misc" sections={[
 "BudgetFile",
 "initConfig",
@@ -729,6 +734,22 @@ Update fields of a rule. `fields` can specify any field described in [`Schedule`
 #### `deleteSchedule`
 
 <Method name="deleteSchedule" args={[{ name: 'id', type: 'id' }]} returns="Promise<null>" />
+
+## Notes
+
+Notes can be attached to any entity (categories, budget months, etc.) by ID. They are also used to define budget templates and savings goals (e.g. `#template 250`, `#goal 1000`).
+
+#### `getNote`
+
+<Method name="getNote" args={[{ name: 'id', type: 'id' }]} returns="Promise<Note | null>" />
+
+Returns the note for the given entity ID, or `null` if no note has been set.
+
+#### `updateNote`
+
+<Method name="updateNote" args={[{ name: 'id', type: 'id' }, { name: 'note', type: 'string' }]} returns="Promise<void>" />
+
+Sets the note on the entity with the given ID. Pass an empty string to clear the note.
 
 ## Misc
 

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -707,6 +707,16 @@ handlers['api/category-delete'] = withMutation(async function ({
   });
 });
 
+handlers['api/note-get'] = async function ({ id }) {
+  checkFileOpen();
+  return handlers['notes-get']({ id });
+};
+
+handlers['api/note-update'] = withMutation(async function ({ id, note }) {
+  checkFileOpen();
+  return handlers['notes-save']({ id, note });
+});
+
 handlers['api/common-payees-get'] = async function () {
   checkFileOpen();
   const payees = await handlers['common-payees-get']();

--- a/packages/loot-core/src/server/notes/app.ts
+++ b/packages/loot-core/src/server/notes/app.ts
@@ -7,12 +7,18 @@ import type { NoteEntity } from '#types/models';
 export type NotesHandlers = {
   'notes-save': typeof updateNotes;
   'notes-save-undoable': typeof updateNotes;
+  'notes-get': (arg: { id: string }) => Promise<NoteEntity | null>;
 };
 
 export const app = createApp<NotesHandlers>();
 app.method('notes-save', updateNotes);
 app.method('notes-save-undoable', mutator(undoable(updateNotes)));
+app.method('notes-get', getNotes);
 
 async function updateNotes({ id, note }: NoteEntity) {
   await db.update('notes', { id, note });
+}
+
+async function getNotes({ id }: { id: string }): Promise<NoteEntity | null> {
+  return db.first<NoteEntity>('SELECT id, note FROM notes WHERE id = ?', [id]);
 }

--- a/packages/loot-core/src/server/notes/app.ts
+++ b/packages/loot-core/src/server/notes/app.ts
@@ -7,18 +7,20 @@ import type { NoteEntity } from '#types/models';
 export type NotesHandlers = {
   'notes-save': typeof updateNotes;
   'notes-save-undoable': typeof updateNotes;
-  'notes-get': (arg: { id: string }) => Promise<NoteEntity | null>;
+  'notes-get': (arg: Pick<NoteEntity, 'id'>) => Promise<NoteEntity | null>;
 };
 
 export const app = createApp<NotesHandlers>();
 app.method('notes-save', updateNotes);
 app.method('notes-save-undoable', mutator(undoable(updateNotes)));
-app.method('notes-get', getNotes);
+app.method('notes-get', getNote);
 
 async function updateNotes({ id, note }: NoteEntity) {
   await db.update('notes', { id, note });
 }
 
-async function getNotes({ id }: { id: string }): Promise<NoteEntity | null> {
+async function getNote({
+  id,
+}: Pick<NoteEntity, 'id'>): Promise<NoteEntity | null> {
   return db.first<NoteEntity>('SELECT id, note FROM notes WHERE id = ?', [id]);
 }

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -19,6 +19,7 @@ import type {
   ImportTransactionEntity,
   NearbyPayeeEntity,
   NewRuleEntity,
+  NoteEntity,
   PayeeEntity,
   PayeeLocationEntity,
   RuleEntity,
@@ -194,6 +195,10 @@ export type ApiHandlers = {
     id: APICategoryEntity['id'];
     transferCategoryId?: APICategoryEntity['id'];
   }) => Promise<void>;
+
+  'api/note-get': (arg: { id: string }) => Promise<NoteEntity | null>;
+
+  'api/note-update': (arg: { id: string; note: string }) => Promise<void>;
 
   'api/payees-get': () => Promise<APIPayeeEntity[]>;
 

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -196,9 +196,9 @@ export type ApiHandlers = {
     transferCategoryId?: APICategoryEntity['id'];
   }) => Promise<void>;
 
-  'api/note-get': (arg: { id: string }) => Promise<NoteEntity | null>;
+  'api/note-get': (arg: Pick<NoteEntity, 'id'>) => Promise<NoteEntity | null>;
 
-  'api/note-update': (arg: { id: string; note: string }) => Promise<void>;
+  'api/note-update': (arg: NoteEntity) => Promise<void>;
 
   'api/payees-get': () => Promise<APIPayeeEntity[]>;
 

--- a/upcoming-release-notes/7769.md
+++ b/upcoming-release-notes/7769.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [whlapinel]
+---
+
+Add `getNote` and `updateNote` to the public `@actual-app/api`, enabling programmatic read/write of category notes (templates, goals, etc.) without internal API access.


### PR DESCRIPTION
## Summary

This PR adds two new public methods to `@actual-app/api`:

- **`getNote(id: string)`** — retrieves the note attached to any entity (category, budget month, etc.) by ID. Returns `NoteEntity | null`.
- **`updateNote(id: string, note: string)`** — sets or clears the note on any entity. Wrapped in `withMutation()` for proper CRDT/undo support.

## Background

Budget templates and savings goals in Actual are stored as specially-formatted notes on categories (e.g. `#template 250`, `#goal 1000`). Until now, the only way to read or write these notes programmatically was through internal `lib.send('notes-save', ...)` calls that bypass the public API surface.

I'm using an MCP (Model Context Protocol) server to let AI assistants manage my Actual budget — categorizing transactions, setting budget amounts, and configuring category templates/goals. Without a public notes API, the MCP server had to rely on undocumented internals. This PR closes that gap.

## Implementation

The change follows the existing pattern for all public API methods:

1. **`loot-core/src/server/notes/app.ts`** — Added `notes-get` handler (reads a single note by ID) alongside the existing `notes-save`.
2. **`loot-core/src/types/api-handlers.ts`** — Added `api/note-get` and `api/note-update` handler type signatures.
3. **`loot-core/src/server/api.ts`** — Wired up the two handlers. `api/note-update` uses `withMutation()` for undo/CRDT support.
4. **`packages/api/methods.ts`** — Exported `getNote()` and `updateNote()` as public methods.
5. **`packages/api/methods.test.ts`** — Added an integration test covering get (null on fresh category), set, and update.

## Testing

```
yarn workspace @actual-app/api test
```

All 19 tests pass (the source map warning for `hyperformula` is a pre-existing issue unrelated to this change).

---

> AI generated — written with Claude Sonnet 4.6 via Claude Code

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB | 0%
loot-core | 1 | 5.27 MB → 5.27 MB (+421 B) | +0.01%
api | 2 | 3.9 MB → 3.9 MB (+555 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+421 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/notes/app.ts` | 📈 +143 B (+48.97%) | 292 B → 435 B
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +278 B (+1.20%) | 22.65 kB → 22.92 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B9bj08r7.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+555 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/notes/app.ts` | 📈 +139 B (+49.12%) | 283 B → 422 B
`methods.ts` | 📈 +149 B (+2.63%) | 5.53 kB → 5.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +267 B (+1.18%) | 22.05 kB → 22.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+555 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->