### PR TITLE
[WIP] Add Positive Dark theme to catalog

### DIFF
--- a/packages/desktop-client/src/data/customThemeCatalog.json
+++ b/packages/desktop-client/src/data/customThemeCatalog.json
@@ -223,27 +223,13 @@
   {
     "name": "YNA Theme Light",
     "repo": "Juulz/YNA-Theme-Light",
-    "colors": [
-      "#1c1f58",
-      "#fff",
-      "#192ee6",
-      "#f5f6ff",
-      "#93d53e",
-      "#191898"
-    ],
+    "colors": ["#1c1f58", "#fff", "#192ee6", "#f5f6ff", "#93d53e", "#191898"],
     "mode": "light"
   },
   {
     "name": "YNA Theme Dark",
     "repo": "Juulz/YNA-Theme-Dark",
-    "colors": [
-      "#121330",
-      "#fff",
-      "#0c0d22",
-      "#0f1443",
-      "#93d53e",
-      "#191898"
-    ],
+    "colors": ["#121330", "#fff", "#0c0d22", "#0f1443", "#93d53e", "#191898"],
     "mode": "dark"
   },
   {

--- a/packages/desktop-client/src/data/customThemeCatalog.json
+++ b/packages/desktop-client/src/data/customThemeCatalog.json
@@ -130,7 +130,7 @@
     "mode": "light"
   },
   {
-    "name": "Catppuccin Frappé",
+    "name": "Catppuccin Frapp\u00e9",
     "repo": "noahjalex/catppuccin-frappe-actual",
     "colors": [
       "#303446",
@@ -223,13 +223,27 @@
   {
     "name": "YNA Theme Light",
     "repo": "Juulz/YNA-Theme-Light",
-    "colors": ["#1c1f58", "#fff", "#192ee6", "#f5f6ff", "#93d53e", "#191898"],
+    "colors": [
+      "#1c1f58",
+      "#fff",
+      "#192ee6",
+      "#f5f6ff",
+      "#93d53e",
+      "#191898"
+    ],
     "mode": "light"
   },
   {
     "name": "YNA Theme Dark",
     "repo": "Juulz/YNA-Theme-Dark",
-    "colors": ["#121330", "#fff", "#0c0d22", "#0f1443", "#93d53e", "#191898"],
+    "colors": [
+      "#121330",
+      "#fff",
+      "#0c0d22",
+      "#0f1443",
+      "#93d53e",
+      "#191898"
+    ],
     "mode": "dark"
   },
   {
@@ -281,6 +295,19 @@
       "#fb4934",
       "#b8bb26",
       "#83a598"
+    ],
+    "mode": "dark"
+  },
+  {
+    "name": "Positive Dark",
+    "repo": "Hodl-Solo/positive-dark",
+    "colors": [
+      "#121212",
+      "#d4d4d4",
+      "#00b3c4",
+      "#00ff7f",
+      "#1e1e1e",
+      "#962d2d"
     ],
     "mode": "dark"
   }


### PR DESCRIPTION
## Theme: Positive Dark

A dark theme for Actual Budget with green positive balances.

**Repo:** https://github.com/Hodl-Solo/positive-dark

**Colors:**
- #121212 — Deep charcoal (page background)
- #d4d4d4 — Light gray (text)
- #00b3c4 — Cyan blue (links/accents)
- #00ff7f — Neon green (positive balances — the key tweak)
- #1e1e1e — Dark charcoal (cards/modals)
- #962d2d — Muted deep red (errors)

**Preview:** https://raw.githubusercontent.com/Hodl-Solo/positive-dark/main/palette.png

Based on "You Need A Dark Mode" with the budget positive numbers changed to green to match the theme's neon green accent.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB | 0%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 189.54 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->