### PR TITLE
docs: fix wrong example number

### DIFF
--- a/packages/docs/docs/budgeting/joint-accounts.md
+++ b/packages/docs/docs/budgeting/joint-accounts.md
@@ -72,7 +72,7 @@ Both will then contribute their share of the joint expenses. This is called _pla
 
 But how do you find your just share? The most just way to do this is by percentage of normal income per partner.
 If Bob makes $ 4,000 a month and Alice makes $ 6,000, the total income is $ 10,000. Out of
-this, Bob will contribute 40% to the joint expenses. To compute the percentage for Bob: 400 (Bob's income) \* 100 / 10000
+this, Bob will contribute 40% to the joint expenses. To compute the percentage for Bob: 4000 (Bob's income) \* 100 / 10000
 (total income). Alice's percentage is 60%, found by subtracting Bob's percentage from 100.
 
 ### Tracking personal spending in the budget


### PR DESCRIPTION
---
category: Bugfixes
authors: [tquin]
---

fix typo in joint account docs example
