### PR TITLE
[AI] Mobile: live value tracking

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -190,9 +190,11 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
   buttonProps,
   onFocus,
   onBlur,
+  onChangeValue,
   ...props
 }: FocusableAmountInputProps) {
   const [isNegative, setIsNegative] = useState(true);
+  const [liveValue, setLiveValue] = useState(Math.abs(value));
 
   const maybeApplyNegative = (amount: number, negative: boolean) => {
     const absValue = Math.abs(amount);
@@ -202,6 +204,15 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
   const onUpdateAmount = (amount: number, negative: boolean) => {
     props.onUpdateAmount?.(maybeApplyNegative(amount, negative));
   };
+
+  const handleChangeValue = (text: string) => {
+    setLiveValue(currencyToAmount(text) || 0);
+    onChangeValue?.(text);
+  };
+
+  useEffect(() => {
+    setLiveValue(Math.abs(value));
+  }, [value]);
 
   useEffect(() => {
     if (sign) {
@@ -227,10 +238,11 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
         value={value}
         onFocus={onFocus}
         onBlur={onBlur}
+        onChangeValue={handleChangeValue}
         onUpdateAmount={amount => onUpdateAmount(amount, isNegative)}
         focused={focused && !disabled}
         style={{
-          ...makeAmountFullStyle(value, {
+          ...makeAmountFullStyle(liveValue, {
             zeroColor: isNegative ? theme.numberNegative : theme.numberNeutral,
             positiveColor: theme.numberPositive,
             negativeColor: theme.numberNegative,

--- a/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/FocusableAmountInput.tsx
@@ -242,7 +242,7 @@ export const FocusableAmountInput = memo(function FocusableAmountInput({
         onUpdateAmount={amount => onUpdateAmount(amount, isNegative)}
         focused={focused && !disabled}
         style={{
-          ...makeAmountFullStyle(liveValue, {
+          ...makeAmountFullStyle(maybeApplyNegative(liveValue, isNegative), {
             zeroColor: isNegative ? theme.numberNegative : theme.numberNeutral,
             positiveColor: theme.numberPositive,
             negativeColor: theme.numberNegative,

--- a/upcoming-release-notes/7774.md
+++ b/upcoming-release-notes/7774.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [MatissJanis]
+---
+
+Add live value tracking for user input in mobile transactions, enhancing editing experience.

--- a/upcoming-release-notes/7774.md
+++ b/upcoming-release-notes/7774.md
@@ -1,6 +1,6 @@
 ---
-category: Features
+category: Bugfix
 authors: [MatissJanis]
 ---
 
-Add live value tracking for user input in mobile transactions, enhancing editing experience.
+Mobile: add live value tracking for user input in mobile transactions.


### PR DESCRIPTION
## Description

Mobile: when setting the "budgeted" value from zero to something else - the number color remains gray until you save.

This PR fixes that - the number color changes when numbers are typed in, not when they are saved.

## Related issue(s)

<!-- Link to any related issues if applicable -->

N/A

## Testing

Check on mobile: delete a "budgeted" amount; save and then re-open the budgeted amount and type in numbers; it will change the color as you type.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_013D5NsSnAqdxeLBgUYSZpex

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.93 MB (+882 B) | +0.01%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.93 MB (+882 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/transactions/FocusableAmountInput.tsx` | 📈 +882 B (+6.91%) | 12.47 kB → 13.33 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionEdit.js | 189.54 kB → 190.4 kB (+882 B) | +0.45%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.01 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.hJfPtoKI.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->