### PR TITLE
[AI] External sync accounts API, persisted bank sync state

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import type { RuleEntity } from '@actual-app/core/types/models';
 import { vi } from 'vitest';
 
+import * as db from '../loot-core/src/server/db';
+
 import * as api from './index';
 
 declare global {
@@ -336,6 +338,98 @@ describe('API CRUD operations', () => {
         }),
       ]),
     );
+  });
+
+  test('Accounts: external sync metadata uses getAccounts and updateAccount', async () => {
+    const accountId = await api.createAccount({ name: 'external-account' }, 0);
+
+    await api.updateAccount(accountId, {
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bank_id: 'test-provider:institution-1',
+      bank_name: 'External Credit Union',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      last_sync: '1715000000000',
+    });
+
+    let account = (await api.getAccounts()).find(
+      existingAccount => existingAccount.id === accountId,
+    );
+    expect(account).toMatchObject({
+      id: accountId,
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bank_id: 'test-provider:institution-1',
+      bank_name: 'External Credit Union',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      last_sync: '1715000000000',
+    });
+
+    await api.updateAccount(accountId, { account_sync_source: null });
+
+    account = (await api.getAccounts()).find(
+      existingAccount => existingAccount.id === accountId,
+    );
+    expect(account).toMatchObject({
+      id: accountId,
+      account_sync_source: null,
+      account_id: null,
+      bank_id: null,
+      bank_name: null,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+    });
+  });
+
+  test('Preferences: getSyncedPreferences returns saved sync preferences', async () => {
+    const accountId = await api.createAccount({ name: 'external-account' }, 0);
+
+    await api.updateAccount(accountId, {
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bank_id: 'test-provider:institution-1',
+      bank_name: 'External Credit Union',
+    });
+
+    await db.update('preferences', {
+      id: `sync-import-pending-${accountId}`,
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: `sync-import-notes-${accountId}`,
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: `sync-reimport-deleted-${accountId}`,
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: `sync-import-transactions-${accountId}`,
+      value: 'false',
+    });
+    await db.update('preferences', {
+      id: `sync-update-dates-${accountId}`,
+      value: 'true',
+    });
+
+    const preferences = await api.getSyncedPreferences();
+
+    expect(preferences).toMatchObject({
+      [`sync-import-pending-${accountId}`]: 'false',
+      [`sync-import-notes-${accountId}`]: 'false',
+      [`sync-reimport-deleted-${accountId}`]: 'false',
+      [`sync-import-transactions-${accountId}`]: 'false',
+      [`sync-update-dates-${accountId}`]: 'true',
+    });
   });
 
   // apis: createPayee, getPayees, updatePayee, deletePayee

--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -355,6 +355,9 @@ describe('API CRUD operations', () => {
       balance_limit: 2000,
       last_sync: '1715000000000',
     });
+    await api.updateAccount(accountId, {
+      bank_sync_status: 'sync-requested',
+    });
 
     let account = (await api.getAccounts()).find(
       existingAccount => existingAccount.id === accountId,
@@ -371,9 +374,10 @@ describe('API CRUD operations', () => {
       balance_available: 900,
       balance_limit: 2000,
       last_sync: '1715000000000',
+      bank_sync_status: 'sync-requested',
     });
 
-    await api.updateAccount(accountId, { account_sync_source: null });
+    await api.unlinkAccount(accountId);
 
     account = (await api.getAccounts()).find(
       existingAccount => existingAccount.id === accountId,
@@ -387,6 +391,7 @@ describe('API CRUD operations', () => {
       balance_current: null,
       balance_available: null,
       balance_limit: null,
+      bank_sync_status: null,
     });
   });
 

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -185,6 +185,10 @@ export function updateAccount(
   return send('api/account-update', { id, fields });
 }
 
+export function unlinkAccount(id: APIAccountEntity['id']) {
+  return send('api/account-unlink', { id });
+}
+
 export function closeAccount(
   id: APIAccountEntity['id'],
   transferAccountId?: APIAccountEntity['id'],

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -17,6 +17,7 @@ import type {
   RuleEntity,
   TransactionEntity,
 } from '@actual-app/core/types/models';
+import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
 export { q } from './app/query';
 
@@ -164,6 +165,10 @@ export function deleteTransaction(id: TransactionEntity['id']) {
 
 export function getAccounts() {
   return send('api/accounts-get');
+}
+
+export function getSyncedPreferences(): Promise<SyncedPrefs> {
+  return send('preferences/get');
 }
 
 export function createAccount(

--- a/packages/desktop-client/src/accounts/accountsSlice.ts
+++ b/packages/desktop-client/src/accounts/accountsSlice.ts
@@ -71,7 +71,7 @@ const accountsSlice = createSlice({
       action: PayloadAction<MarkUpdatedAccountsPayload>,
     ) {
       state.updatedAccounts = action.payload.ids
-        ? [...state.updatedAccounts, ...action.payload.ids]
+        ? Array.from(new Set([...state.updatedAccounts, ...action.payload.ids]))
         : state.updatedAccounts;
     },
     markAccountRead(state, action: PayloadAction<MarkAccountReadPayload>) {

--- a/packages/desktop-client/src/accounts/mutations.ts
+++ b/packages/desktop-client/src/accounts/mutations.ts
@@ -653,7 +653,13 @@ function handleSyncResponse(
   resMatchedTransactions: Array<TransactionEntity['id']>,
   resUpdatedAccounts: Array<AccountEntity['id']>,
 ) {
-  const { errors, newTransactions, matchedTransactions, updatedAccounts } = res;
+  const {
+    errors,
+    newTransactions,
+    matchedTransactions,
+    updatedAccounts,
+    hasUpdates,
+  } = res;
 
   // Mark the account as failed or succeeded (depending on sync output)
   const [error] = errors;
@@ -703,7 +709,7 @@ function handleSyncResponse(
 
   invalidateQueries(queryClient);
 
-  return newTransactions.length > 0 || matchedTransactions.length > 0;
+  return hasUpdates;
 }
 
 type SyncAndDownloadPayload = {
@@ -729,20 +735,19 @@ export function useSyncAndDownloadMutation() {
         return { error: syncState.error };
       }
 
-      const hasDownloaded = await syncAccounts.mutateAsync({ id });
+      const hasUpdates = await syncAccounts.mutateAsync({ id });
 
-      if (hasDownloaded) {
-        // Sync again afterwards if new transactions were created
+      if (hasUpdates) {
+        // Sync again afterwards if bank sync changed the local budget.
         const syncState = await dispatch(sync()).unwrap();
         if (syncState.error) {
           return { error: syncState.error };
         }
 
-        // `hasDownloaded` is already true, we know there has been
-        // updates
+        // `hasUpdates` is already true, we know there has been changes.
         return true;
       }
-      return { hasUpdated: hasDownloaded };
+      return { hasUpdated: hasUpdates };
     },
     onSuccess: () => invalidateQueries(queryClient),
     onError: error => {

--- a/packages/desktop-client/src/accounts/syncStatus.test.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.test.ts
@@ -13,13 +13,15 @@ describe('syncStatus', () => {
   it('treats pending and sync-requested as pending', () => {
     expect(isAccountPendingSync(makeAccount('pending'))).toBe(true);
     expect(isAccountPendingSync(makeAccount('sync-requested'))).toBe(true);
+    expect(isAccountPendingSync(makeAccount('failed'))).toBe(false);
     expect(isAccountPendingSync(makeAccount('ok'))).toBe(false);
     expect(isAccountPendingSync(makeAccount('attention-required'))).toBe(false);
     expect(isAccountPendingSync(makeAccount('reauth-required'))).toBe(false);
     expect(isAccountPendingSync(makeAccount(null))).toBe(false);
   });
 
-  it('treats attention-required and reauth-required as failed', () => {
+  it('treats failed, attention-required and reauth-required as failed', () => {
+    expect(isAccountFailedSync(makeAccount('failed'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('attention-required'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('reauth-required'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('pending'))).toBe(false);

--- a/packages/desktop-client/src/accounts/syncStatus.test.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AccountEntity } from '@actual-app/core/types/models';
+
+import { isAccountFailedSync, isAccountPendingSync } from './syncStatus';
+
+function makeAccount(
+  bank_sync_status: AccountEntity['bank_sync_status'],
+): Pick<AccountEntity, 'bank_sync_status'> {
+  return { bank_sync_status };
+}
+
+describe('syncStatus', () => {
+  it('treats pending and sync-requested as pending', () => {
+    expect(isAccountPendingSync(makeAccount('pending'))).toBe(true);
+    expect(isAccountPendingSync(makeAccount('sync-requested'))).toBe(true);
+    expect(isAccountPendingSync(makeAccount('ok'))).toBe(false);
+    expect(isAccountPendingSync(makeAccount('attention-required'))).toBe(
+      false,
+    );
+    expect(isAccountPendingSync(makeAccount('reauth-required'))).toBe(false);
+    expect(isAccountPendingSync(makeAccount(null))).toBe(false);
+  });
+
+  it('treats attention-required and reauth-required as failed', () => {
+    expect(isAccountFailedSync(makeAccount('attention-required'))).toBe(true);
+    expect(isAccountFailedSync(makeAccount('reauth-required'))).toBe(true);
+    expect(isAccountFailedSync(makeAccount('pending'))).toBe(false);
+    expect(isAccountFailedSync(makeAccount('sync-requested'))).toBe(false);
+    expect(isAccountFailedSync(makeAccount('ok'))).toBe(false);
+    expect(isAccountFailedSync(makeAccount(null))).toBe(false);
+  });
+});

--- a/packages/desktop-client/src/accounts/syncStatus.test.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest';
-
 import type { AccountEntity } from '@actual-app/core/types/models';
+import { describe, expect, it } from 'vitest';
 
 import { isAccountFailedSync, isAccountPendingSync } from './syncStatus';
 
@@ -15,9 +14,7 @@ describe('syncStatus', () => {
     expect(isAccountPendingSync(makeAccount('pending'))).toBe(true);
     expect(isAccountPendingSync(makeAccount('sync-requested'))).toBe(true);
     expect(isAccountPendingSync(makeAccount('ok'))).toBe(false);
-    expect(isAccountPendingSync(makeAccount('attention-required'))).toBe(
-      false,
-    );
+    expect(isAccountPendingSync(makeAccount('attention-required'))).toBe(false);
     expect(isAccountPendingSync(makeAccount('reauth-required'))).toBe(false);
     expect(isAccountPendingSync(makeAccount(null))).toBe(false);
   });

--- a/packages/desktop-client/src/accounts/syncStatus.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.ts
@@ -1,0 +1,17 @@
+import type { AccountEntity, BankSyncStatus } from '@actual-app/core/types/models';
+
+function isBankSyncStatusPending(status: BankSyncStatus | null | undefined) {
+  return status === 'pending' || status === 'sync-requested';
+}
+
+function isBankSyncStatusFailed(status: BankSyncStatus | null | undefined) {
+  return status === 'attention-required' || status === 'reauth-required';
+}
+
+export function isAccountPendingSync(account: Pick<AccountEntity, 'bank_sync_status'>) {
+  return isBankSyncStatusPending(account.bank_sync_status);
+}
+
+export function isAccountFailedSync(account: Pick<AccountEntity, 'bank_sync_status'>) {
+  return isBankSyncStatusFailed(account.bank_sync_status);
+}

--- a/packages/desktop-client/src/accounts/syncStatus.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.ts
@@ -8,7 +8,11 @@ function isBankSyncStatusPending(status: BankSyncStatus | null | undefined) {
 }
 
 function isBankSyncStatusFailed(status: BankSyncStatus | null | undefined) {
-  return status === 'attention-required' || status === 'reauth-required';
+  return (
+    status === 'failed' ||
+    status === 'attention-required' ||
+    status === 'reauth-required'
+  );
 }
 
 export function isAccountPendingSync(

--- a/packages/desktop-client/src/accounts/syncStatus.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.ts
@@ -1,4 +1,7 @@
-import type { AccountEntity, BankSyncStatus } from '@actual-app/core/types/models';
+import type {
+  AccountEntity,
+  BankSyncStatus,
+} from '@actual-app/core/types/models';
 
 function isBankSyncStatusPending(status: BankSyncStatus | null | undefined) {
   return status === 'pending' || status === 'sync-requested';
@@ -8,10 +11,14 @@ function isBankSyncStatusFailed(status: BankSyncStatus | null | undefined) {
   return status === 'attention-required' || status === 'reauth-required';
 }
 
-export function isAccountPendingSync(account: Pick<AccountEntity, 'bank_sync_status'>) {
+export function isAccountPendingSync(
+  account: Pick<AccountEntity, 'bank_sync_status'>,
+) {
   return isBankSyncStatusPending(account.bank_sync_status);
 }
 
-export function isAccountFailedSync(account: Pick<AccountEntity, 'bank_sync_status'>) {
+export function isAccountFailedSync(
+  account: Pick<AccountEntity, 'bank_sync_status'>,
+) {
   return isBankSyncStatusFailed(account.bank_sync_status);
 }

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -15,8 +15,8 @@ import {
 } from '@actual-app/core/platform/client/connection';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { setAppState, sync } from '#app/appSlice';
 import { isAccountPendingSync } from '#accounts/syncStatus';
+import { setAppState, sync } from '#app/appSlice';
 import { closeBudget, loadBudget } from '#budgetfiles/budgetfilesSlice';
 import { handleGlobalEvents } from '#global-events';
 import { useAccounts } from '#hooks/useAccounts';

--- a/packages/desktop-client/src/components/App.tsx
+++ b/packages/desktop-client/src/components/App.tsx
@@ -16,12 +16,16 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 
 import { setAppState, sync } from '#app/appSlice';
+import { isAccountPendingSync } from '#accounts/syncStatus';
 import { closeBudget, loadBudget } from '#budgetfiles/budgetfilesSlice';
 import { handleGlobalEvents } from '#global-events';
+import { useAccounts } from '#hooks/useAccounts';
 import { useIsTestEnv } from '#hooks/useIsTestEnv';
 import { useMetadataPref } from '#hooks/useMetadataPref';
 import { useOnVisible } from '#hooks/useOnVisible';
+import { usePendingSyncPolling } from '#hooks/usePendingSyncPolling';
 import { SpreadsheetProvider } from '#hooks/useSpreadsheet';
+import { useSyncServerStatus } from '#hooks/useSyncServerStatus';
 import { setI18NextLanguage } from '#i18n';
 import { addNotification } from '#notifications/notificationsSlice';
 import { installPolyfills } from '#polyfills';
@@ -45,6 +49,26 @@ import { ManagementApp } from './manager/ManagementApp';
 import { Modals } from './Modals';
 import { SidebarProvider } from './sidebar/SidebarProvider';
 import { UpdateNotification } from './UpdateNotification';
+
+function PendingSyncPolling() {
+  const dispatch = useDispatch();
+  const syncServerStatus = useSyncServerStatus();
+  const { data: accounts = [] } = useAccounts();
+  const accountsSyncing = useSelector(state => state.account.accountsSyncing);
+  const hasPendingAccounts = accounts.some(isAccountPendingSync);
+
+  usePendingSyncPolling({
+    enabled:
+      syncServerStatus === 'online' &&
+      hasPendingAccounts &&
+      accountsSyncing.length === 0,
+    onPoll: async () => {
+      await dispatch(sync());
+    },
+  });
+
+  return null;
+}
 
 function AppInner() {
   const [budgetId] = useMetadataPref('id');
@@ -152,7 +176,14 @@ function AppInner() {
     }
   }, [dispatch, t, userData?.tokenExpired]);
 
-  return budgetId ? <FinancesApp /> : <ManagementApp />;
+  return budgetId ? (
+    <>
+      <PendingSyncPolling />
+      <FinancesApp />
+    </>
+  ) : (
+    <ManagementApp />
+  );
 }
 
 function ErrorFallback({ error }: FallbackProps) {

--- a/packages/desktop-client/src/components/BankSyncStatus.test.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.test.tsx
@@ -49,7 +49,7 @@ describe('BankSyncStatus', () => {
     const { rerender } = render(<BankSyncStatus />, { wrapper: TestProviders });
 
     expect(
-      screen.getByText(/Syncing... 1 account remaining/i),
+      screen.getByText(/Syncing\.\.\. 1 accounts? remaining/i),
     ).toBeInTheDocument();
 
     useAccounts.mockReturnValue({
@@ -62,7 +62,7 @@ describe('BankSyncStatus', () => {
     rerender(<BankSyncStatus />);
 
     expect(
-      screen.queryByText(/Syncing... 1 account remaining/i),
+      screen.queryByText(/Syncing\.\.\. 1 accounts? remaining/i),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop-client/src/components/BankSyncStatus.test.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AccountEntity } from '@actual-app/core/types/models';
+
+import { TestProviders } from '#mocks';
+
+import { BankSyncStatus } from './BankSyncStatus';
+
+const useAccounts = vi.fn();
+
+vi.mock('#hooks/useAccounts', () => ({
+  useAccounts: () => useAccounts(),
+}));
+
+function makeAccount(
+  overrides: Partial<AccountEntity> = {},
+): AccountEntity {
+  return {
+    id: 'acct-1',
+    name: 'Checking',
+    offbudget: 0,
+    closed: 0,
+    sort_order: 0,
+    last_reconciled: null,
+    tombstone: 0,
+    account_id: null,
+    bank: null,
+    bankName: null,
+    bankId: null,
+    mask: null,
+    official_name: null,
+    balance_current: null,
+    balance_available: null,
+    balance_limit: null,
+    account_sync_source: null,
+    last_sync: null,
+    bank_sync_status: null,
+    ...overrides,
+  };
+}
+
+describe('BankSyncStatus', () => {
+  it('shows and clears the banner based on persisted bank_sync_status transitions', () => {
+    useAccounts.mockReturnValue({
+      data: [
+        makeAccount({ id: 'pending-1', bank_sync_status: 'sync-requested' }),
+        makeAccount({ id: 'ok-1', bank_sync_status: 'ok' }),
+      ],
+    });
+
+    const { rerender } = render(<BankSyncStatus />, { wrapper: TestProviders });
+
+    expect(
+      screen.getByText(/Syncing... 1 account remaining/i),
+    ).toBeInTheDocument();
+
+    useAccounts.mockReturnValue({
+      data: [
+        makeAccount({ bank_sync_status: 'ok' }),
+        makeAccount({ id: 'failed-1', bank_sync_status: 'reauth-required' }),
+      ],
+    });
+
+    rerender(<BankSyncStatus />);
+
+    expect(
+      screen.queryByText(/Syncing... 1 account remaining/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/desktop-client/src/components/BankSyncStatus.test.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.test.tsx
@@ -49,7 +49,7 @@ describe('BankSyncStatus', () => {
     const { rerender } = render(<BankSyncStatus />, { wrapper: TestProviders });
 
     expect(
-      screen.getByText(/Syncing\.\.\. 1 accounts? remaining/i),
+      screen.getByText(/Syncing\.\.\. 1 account remaining/i),
     ).toBeInTheDocument();
 
     useAccounts.mockReturnValue({
@@ -62,7 +62,7 @@ describe('BankSyncStatus', () => {
     rerender(<BankSyncStatus />);
 
     expect(
-      screen.queryByText(/Syncing\.\.\. 1 accounts? remaining/i),
+      screen.queryByText(/Syncing\.\.\. 1 account remaining/i),
     ).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop-client/src/components/BankSyncStatus.test.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.test.tsx
@@ -1,7 +1,6 @@
+import type { AccountEntity } from '@actual-app/core/types/models';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-
-import type { AccountEntity } from '@actual-app/core/types/models';
 
 import { TestProviders } from '#mocks';
 
@@ -13,9 +12,7 @@ vi.mock('#hooks/useAccounts', () => ({
   useAccounts: () => useAccounts(),
 }));
 
-function makeAccount(
-  overrides: Partial<AccountEntity> = {},
-): AccountEntity {
+function makeAccount(overrides: Partial<AccountEntity> = {}): AccountEntity {
   return {
     id: 'acct-1',
     name: 'Checking',

--- a/packages/desktop-client/src/components/BankSyncStatus.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.tsx
@@ -76,9 +76,11 @@ export function BankSyncStatus() {
                   iconStyle={{ color: theme.pillTextSelected }}
                 />
                 <Text style={{ marginLeft: 5 }}>
-                  <Trans count={accountsSyncingCount}>
-                    Syncing... {{ count }} accounts remaining
-                  </Trans>
+                  {accountsSyncingCount === 1 ? (
+                    <Trans>Syncing... {{ count }} account remaining</Trans>
+                  ) : (
+                    <Trans>Syncing... {{ count }} accounts remaining</Trans>
+                  )}
                 </Text>
               </View>
             </animated.div>

--- a/packages/desktop-client/src/components/BankSyncStatus.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.tsx
@@ -8,9 +8,8 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { useAccounts } from '#hooks/useAccounts';
-
 import { isAccountPendingSync } from '#accounts/syncStatus';
+import { useAccounts } from '#hooks/useAccounts';
 
 import { AnimatedRefresh } from './AnimatedRefresh';
 

--- a/packages/desktop-client/src/components/BankSyncStatus.tsx
+++ b/packages/desktop-client/src/components/BankSyncStatus.tsx
@@ -2,19 +2,24 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 import { animated, useTransition } from 'react-spring';
 
+import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
-import { useSelector } from '#redux';
+import { useAccounts } from '#hooks/useAccounts';
+
+import { isAccountPendingSync } from '#accounts/syncStatus';
 
 import { AnimatedRefresh } from './AnimatedRefresh';
 
 export function BankSyncStatus() {
-  const accountsSyncing = useSelector(state => state.account.accountsSyncing);
-  const accountsSyncingCount = accountsSyncing.length;
+  const { isNarrowWidth } = useResponsive();
+  const { data: accounts = [] } = useAccounts();
+  const accountsSyncingCount = accounts.filter(isAccountPendingSync).length;
   const count = accountsSyncingCount;
+  const contentInset = 52;
 
   const transitions = useTransition(
     accountsSyncingCount > 0 ? 'syncing' : null,
@@ -28,13 +33,27 @@ export function BankSyncStatus() {
   return (
     <View
       style={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        right: 0,
-        marginTop: 5,
-        alignItems: 'center',
-        zIndex: 501,
+        ...(isNarrowWidth
+          ? {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              marginTop: 5,
+              alignItems: 'center',
+            }
+          : {
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              marginTop: 5,
+              paddingLeft: contentInset,
+              paddingRight: contentInset,
+              alignItems: 'flex-start',
+            }),
+        zIndex: 1101,
+        pointerEvents: 'none',
       }}
     >
       {transitions(
@@ -49,6 +68,7 @@ export function BankSyncStatus() {
                   padding: '5px 13px',
                   flexDirection: 'row',
                   alignItems: 'center',
+                  pointerEvents: 'auto',
                   ...styles.shadow,
                 }}
               >

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -54,7 +54,6 @@ import { useAccounts } from '#hooks/useAccounts';
 import { SchedulesProvider } from '#hooks/useCachedSchedules';
 import { useCategories } from '#hooks/useCategories';
 import { useDateFormat } from '#hooks/useDateFormat';
-import { useFailedAccounts } from '#hooks/useFailedAccounts';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { usePayees } from '#hooks/usePayees';
 import { getSchedulesQuery } from '#hooks/useSchedules';
@@ -240,7 +239,6 @@ type AccountInternalProps = {
   onBatchDelete: ReturnType<typeof useTransactionBatchActions>['onBatchDelete'];
   categoryId?: string;
   location: ReturnType<typeof useLocation>;
-  failedAccounts: ReturnType<typeof useFailedAccounts>;
   dateFormat: ReturnType<typeof useDateFormat>;
   payees: PayeeEntity[];
   categoryGroups: CategoryGroupEntity[];
@@ -1713,7 +1711,6 @@ class AccountInternal extends PureComponent<
       dateFormat,
       hideFraction,
       accountsSyncing,
-      failedAccounts,
       showExtraBalances,
       accountId,
       categoryId,
@@ -1790,7 +1787,6 @@ class AccountInternal extends PureComponent<
                 savedFilters={this.props.savedFilters}
                 accountName={accountName}
                 accountsSyncing={accountsSyncing}
-                failedAccounts={failedAccounts}
                 accounts={accounts}
                 transactions={transactions}
                 showBalances={showBalances ?? false}
@@ -1985,7 +1981,6 @@ export function Account() {
   );
   const { data: accounts = [] } = useAccounts();
   const { data: payees = [] } = usePayees();
-  const failedAccounts = useFailedAccounts();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [hideFraction] = useSyncedPref('hideFraction');
   const [expandSplits] = useLocalPref('expand-splits');
@@ -2043,7 +2038,6 @@ export function Account() {
             newTransactions={newTransactions}
             matchedTransactions={matchedTransactions}
             accounts={accounts}
-            failedAccounts={failedAccounts}
             dateFormat={dateFormat}
             hideFraction={String(hideFraction) === 'true'}
             expandSplits={expandSplits}

--- a/packages/desktop-client/src/components/accounts/Header.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.test.tsx
@@ -1,8 +1,7 @@
-import { render } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-
 import { theme } from '@actual-app/components/theme';
 import type { AccountEntity } from '@actual-app/core/types/models';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
 import { AccountSyncSidebar } from './Header';
 

--- a/packages/desktop-client/src/components/accounts/Header.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { theme } from '@actual-app/components/theme';
+import type { AccountEntity } from '@actual-app/core/types/models';
+
+import { AccountSyncSidebar } from './Header';
+
+function makeAccount(
+  bank_sync_status: AccountEntity['bank_sync_status'],
+): AccountEntity {
+  return {
+    id: 'acct-1',
+    name: 'Checking',
+    offbudget: 0,
+    closed: 0,
+    sort_order: 0,
+    last_reconciled: null,
+    tombstone: 0,
+    account_id: 'ext-1',
+    bank: 'bank-1',
+    bankName: 'Test Bank',
+    bankId: 'bank-id-1',
+    mask: null,
+    official_name: null,
+    balance_current: null,
+    balance_available: null,
+    balance_limit: null,
+    account_sync_source: 'external',
+    last_sync: null,
+    bank_sync_status,
+  };
+}
+
+describe('AccountSyncSidebar', () => {
+  it('renders pending styles for pending and sync-requested accounts', () => {
+    const { rerender, container } = render(
+      <AccountSyncSidebar account={makeAccount('pending')} />,
+    );
+
+    expect(container.firstChild).toHaveStyle({
+      backgroundColor: theme.sidebarItemBackgroundPending,
+    });
+
+    rerender(<AccountSyncSidebar account={makeAccount('sync-requested')} />);
+
+    expect(container.firstChild).toHaveStyle({
+      backgroundColor: theme.sidebarItemBackgroundPending,
+    });
+  });
+
+  it('renders failed styles for failed accounts and positive styles for ok accounts', () => {
+    const { rerender, container } = render(
+      <AccountSyncSidebar account={makeAccount('attention-required')} />,
+    );
+
+    expect(container.firstChild).toHaveStyle({
+      backgroundColor: theme.sidebarItemBackgroundFailed,
+    });
+
+    rerender(<AccountSyncSidebar account={makeAccount('ok')} />);
+
+    expect(container.firstChild).toHaveStyle({
+      backgroundColor: theme.sidebarItemBackgroundPositive,
+    });
+  });
+});

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -206,10 +206,28 @@ export function AccountHeader({
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const locale = useLocale();
 
-  let canSync = !!(account?.account_id && isUsingServer);
+  let canSync = !!(
+    account?.account_id &&
+    account.account_sync_source !== 'external' &&
+    isUsingServer
+  );
+  let canUnlink = !!(account?.account_id && isUsingServer);
+  let canLink = !!(
+    account &&
+    !account.closed &&
+    !account.account_id &&
+    !account.account_sync_source &&
+    syncServerStatus === 'online'
+  );
   if (!account) {
     // All accounts - check for any syncable account
-    canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
+    canSync =
+      !!accounts.find(
+        account =>
+          !!account.account_id && account.account_sync_source !== 'external',
+      ) && isUsingServer;
+    canUnlink = false;
+    canLink = false;
   }
 
   // Only show the ability to make linked transfers on multi-account views.
@@ -509,7 +527,8 @@ export function AccountHeader({
                   <Dialog>
                     <AccountMenu
                       account={account}
-                      canSync={canSync}
+                      canUnlink={canUnlink}
+                      canLink={canLink}
                       showNetWorthChart={showNetWorthChart}
                       canShowBalances={
                         canCalculateBalance ? canCalculateBalance() : false
@@ -735,7 +754,8 @@ function AccountNameField({
 
 type AccountMenuProps = {
   account: AccountEntity;
-  canSync: boolean;
+  canUnlink: boolean;
+  canLink: boolean;
   showNetWorthChart: boolean;
   showBalances: boolean;
   canShowBalances: boolean;
@@ -759,7 +779,8 @@ type AccountMenuProps = {
 
 function AccountMenu({
   account,
-  canSync,
+  canUnlink,
+  canLink,
   showNetWorthChart,
   showBalances,
   canShowBalances,
@@ -769,7 +790,6 @@ function AccountMenu({
   onMenuSelect,
 }: AccountMenuProps) {
   const { t } = useTranslation();
-  const syncServerStatus = useSyncServerStatus();
 
   return (
     <Menu
@@ -816,14 +836,14 @@ function AccountMenu({
         },
         { name: 'export', text: t('Export') },
         ...(account && !account.closed
-          ? canSync
+          ? canUnlink
             ? [
                 {
                   name: 'unlink',
                   text: t('Unlink account'),
                 } as const,
               ]
-            : syncServerStatus === 'online'
+            : canLink
               ? [
                   {
                     name: 'link',

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -36,6 +36,10 @@ import type {
 import { format as formatDate } from 'date-fns';
 
 import { AnimatedRefresh } from '#components/AnimatedRefresh';
+import {
+  isAccountFailedSync,
+  isAccountPendingSync,
+} from '#accounts/syncStatus';
 import { Search } from '#components/common/Search';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { FiltersStack } from '#components/filters/FiltersStack';
@@ -64,7 +68,6 @@ type AccountHeaderProps = {
   filterId?: SavedFilter;
   savedFilters: TransactionFilterEntity[];
   accountsSyncing: string[];
-  failedAccounts: AccountSyncSidebarProps['failedAccounts'];
   accounts: AccountEntity[];
   transactions: TransactionEntity[];
   showBalances: boolean;
@@ -140,7 +143,6 @@ export function AccountHeader({
   filterId,
   savedFilters,
   accountsSyncing,
-  failedAccounts,
   accounts,
   transactions,
   showBalances,
@@ -207,19 +209,9 @@ export function AccountHeader({
   const locale = useLocale();
 
   let canSync = !!(account?.account_id && isUsingServer);
-  let canUnlink = !!(account?.account_id && isUsingServer);
-  let canLink = !!(
-    account &&
-    !account.closed &&
-    !account.account_id &&
-    !account.account_sync_source &&
-    syncServerStatus === 'online'
-  );
   if (!account) {
     // All accounts - check for any syncable account
     canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
-    canUnlink = false;
-    canLink = false;
   }
 
   // Only show the ability to make linked transfers on multi-account views.
@@ -312,11 +304,7 @@ export function AccountHeader({
               }}
             >
               {!!account?.bank && (
-                <AccountSyncSidebar
-                  account={account}
-                  failedAccounts={failedAccounts}
-                  accountsSyncing={accountsSyncing}
-                />
+                <AccountSyncSidebar account={account} />
               )}
               <AccountNameField
                 account={account}
@@ -519,8 +507,7 @@ export function AccountHeader({
                   <Dialog>
                     <AccountMenu
                       account={account}
-                      canUnlink={canUnlink}
-                      canLink={canLink}
+                      canSync={canSync}
                       showNetWorthChart={showNetWorthChart}
                       canShowBalances={
                         canCalculateBalance ? canCalculateBalance() : false
@@ -603,27 +590,15 @@ export function AccountHeader({
 
 type AccountSyncSidebarProps = {
   account: AccountEntity;
-  failedAccounts: Map<
-    string,
-    {
-      type: string;
-      code: string;
-    }
-  >;
-  accountsSyncing: string[];
 };
 
-function AccountSyncSidebar({
-  account,
-  failedAccounts,
-  accountsSyncing,
-}: AccountSyncSidebarProps) {
+export function AccountSyncSidebar({ account }: AccountSyncSidebarProps) {
   return (
     <View
       style={{
-        backgroundColor: accountsSyncing.includes(account.id)
+        backgroundColor: isAccountPendingSync(account)
           ? theme.sidebarItemBackgroundPending
-          : failedAccounts.has(account.id)
+          : isAccountFailedSync(account)
             ? theme.sidebarItemBackgroundFailed
             : theme.sidebarItemBackgroundPositive,
         marginRight: '4px',
@@ -746,8 +721,7 @@ function AccountNameField({
 
 type AccountMenuProps = {
   account: AccountEntity;
-  canUnlink: boolean;
-  canLink: boolean;
+  canSync: boolean;
   showNetWorthChart: boolean;
   showBalances: boolean;
   canShowBalances: boolean;
@@ -771,8 +745,7 @@ type AccountMenuProps = {
 
 function AccountMenu({
   account,
-  canUnlink,
-  canLink,
+  canSync,
   showNetWorthChart,
   showBalances,
   canShowBalances,
@@ -782,6 +755,7 @@ function AccountMenu({
   onMenuSelect,
 }: AccountMenuProps) {
   const { t } = useTranslation();
+  const syncServerStatus = useSyncServerStatus();
 
   return (
     <Menu
@@ -828,14 +802,14 @@ function AccountMenu({
         },
         { name: 'export', text: t('Export') },
         ...(account && !account.closed
-          ? canUnlink
+          ? canSync
             ? [
                 {
                   name: 'unlink',
                   text: t('Unlink account'),
                 } as const,
               ]
-            : canLink
+            : syncServerStatus === 'online'
               ? [
                   {
                     name: 'link',

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -35,11 +35,11 @@ import type {
 } from '@actual-app/core/types/models';
 import { format as formatDate } from 'date-fns';
 
-import { AnimatedRefresh } from '#components/AnimatedRefresh';
 import {
   isAccountFailedSync,
   isAccountPendingSync,
 } from '#accounts/syncStatus';
+import { AnimatedRefresh } from '#components/AnimatedRefresh';
 import { Search } from '#components/common/Search';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { FiltersStack } from '#components/filters/FiltersStack';
@@ -303,9 +303,7 @@ export function AccountHeader({
                 gap: 3,
               }}
             >
-              {!!account?.bank && (
-                <AccountSyncSidebar account={account} />
-              )}
+              {!!account?.bank && <AccountSyncSidebar account={account} />}
               <AccountNameField
                 account={account}
                 accountName={accountName}

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -206,11 +206,7 @@ export function AccountHeader({
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const locale = useLocale();
 
-  let canSync = !!(
-    account?.account_id &&
-    account.account_sync_source !== 'external' &&
-    isUsingServer
-  );
+  let canSync = !!(account?.account_id && isUsingServer);
   let canUnlink = !!(account?.account_id && isUsingServer);
   let canLink = !!(
     account &&
@@ -221,11 +217,7 @@ export function AccountHeader({
   );
   if (!account) {
     // All accounts - check for any syncable account
-    canSync =
-      !!accounts.find(
-        account =>
-          !!account.account_id && account.account_sync_source !== 'external',
-      ) && isUsingServer;
+    canSync = !!accounts.find(account => !!account.account_id) && isUsingServer;
     canUnlink = false;
     canLink = false;
   }

--- a/packages/desktop-client/src/components/banksync/AccountRow.tsx
+++ b/packages/desktop-client/src/components/banksync/AccountRow.tsx
@@ -23,15 +23,20 @@ type AccountRowProps = {
 export const AccountRow = memo(
   ({ account, hovered, onHover, onAction, locale }: AccountRowProps) => {
     const backgroundFocus = hovered;
+    const hasLastSync = Boolean(account.last_sync);
 
-    const lastSyncString = tsToRelativeTime(account.last_sync, locale, {
-      capitalize: true,
-    });
-    const lastSyncDateTime = formatDate(
-      new Date(parseInt(account.last_sync ?? '0', 10)),
-      'MMM d, yyyy, HH:mm:ss',
-      { locale },
-    );
+    const lastSyncString = hasLastSync
+      ? tsToRelativeTime(account.last_sync, locale, {
+          capitalize: true,
+        })
+      : '-';
+    const lastSyncDateTime = hasLastSync
+      ? formatDate(
+          new Date(parseInt(account.last_sync ?? '0', 10)),
+          'MMM d, yyyy, HH:mm:ss',
+          { locale },
+        )
+      : null;
 
     const potentiallyTruncatedAccountName =
       account.name.length > 30
@@ -69,13 +74,11 @@ export const AccountRow = memo(
           {account.bankName}
         </Cell>
 
-        {account.account_sync_source ? (
+        {account.account_sync_source && hasLastSync ? (
           <Tooltip
             placement="bottom start"
             content={lastSyncDateTime}
-            style={{
-              ...styles.tooltip,
-            }}
+            style={{ ...styles.tooltip }}
           >
             <Cell
               name="lastSync"
@@ -94,6 +97,15 @@ export const AccountRow = memo(
               {lastSyncString}
             </Cell>
           </Tooltip>
+        ) : account.account_sync_source ? (
+          <Cell
+            name="lastSync"
+            width={200}
+            plain
+            style={{ color: theme.tableText, padding: '11px' }}
+          >
+            {lastSyncString}
+          </Cell>
         ) : (
           ''
         )}

--- a/packages/desktop-client/src/components/banksync/AccountRow.tsx
+++ b/packages/desktop-client/src/components/banksync/AccountRow.tsx
@@ -32,7 +32,7 @@ export const AccountRow = memo(
       : '-';
     const lastSyncDateTime = hasLastSync
       ? formatDate(
-          new Date(parseInt(account.last_sync ?? '0', 10)),
+          new Date(parseInt(account.last_sync!, 10)),
           'MMM d, yyyy, HH:mm:ss',
           { locale },
         )

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
@@ -1,4 +1,5 @@
 import { generateAccount } from '@actual-app/core/mocks';
+import type { AccountEntity } from '@actual-app/core/types/models';
 import { describe, expect, it } from 'vitest';
 
 import { getSyncSourceReadable, groupBankSyncAccounts } from './bankSyncUtils';
@@ -6,34 +7,41 @@ import { getSyncSourceReadable, groupBankSyncAccounts } from './bankSyncUtils';
 describe('bankSyncUtils', () => {
   it('groups open accounts by provider and leaves unlinked last', () => {
     const goCardlessAccount = generateAccount('GoCardless', true, false);
+    const externalAccount = {
+      ...generateAccount('External', true, false),
+      account_sync_source: 'external',
+    } satisfies AccountEntity;
     const pluggyAccount = {
       ...generateAccount('Pluggy', true, false),
-      account_sync_source: 'pluggyai' as const,
-    };
+      account_sync_source: 'pluggyai',
+    } satisfies AccountEntity;
     const simpleFinAccount = {
       ...generateAccount('SimpleFIN', true, false),
-      account_sync_source: 'simpleFin' as const,
-    };
+      account_sync_source: 'simpleFin',
+    } satisfies AccountEntity;
     const unlinkedAccount = generateAccount('Manual', false, false);
     const closedAccount = {
       ...generateAccount('Closed', true, false),
-      closed: 1 as const,
-    };
+      closed: 1,
+    } satisfies AccountEntity;
 
     const groupedAccounts = groupBankSyncAccounts([
       unlinkedAccount,
       simpleFinAccount,
       closedAccount,
+      externalAccount,
       pluggyAccount,
       goCardlessAccount,
     ]);
 
     expect(Object.keys(groupedAccounts)).toEqual([
+      'external',
       'goCardless',
       'pluggyai',
       'simpleFin',
       'unlinked',
     ]);
+    expect(groupedAccounts.external).toEqual([externalAccount]);
     expect(groupedAccounts.goCardless).toEqual([goCardlessAccount]);
     expect(groupedAccounts.pluggyai).toEqual([pluggyAccount]);
     expect(groupedAccounts.simpleFin).toEqual([simpleFinAccount]);
@@ -48,6 +56,7 @@ describe('bankSyncUtils', () => {
     expect(readable.goCardless).toBe('GoCardless');
     expect(readable.simpleFin).toBe('SimpleFIN');
     expect(readable.pluggyai).toBe('Pluggy.ai');
+    expect(readable.external).toBe('translated:External');
     expect(readable.unlinked).toBe('translated:Unlinked');
   });
 });

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
@@ -1,9 +1,10 @@
 import type {
   AccountEntity,
+  AccountSyncSource,
   BankSyncProviders,
 } from '@actual-app/core/types/models';
 
-export type SyncProviders = BankSyncProviders | 'unlinked';
+export type SyncProviders = AccountSyncSource | 'unlinked';
 export type GroupedBankSyncAccounts = Partial<
   Record<SyncProviders, AccountEntity[]>
 >;
@@ -16,6 +17,7 @@ export const BUILT_IN_BANK_SYNC_PROVIDERS = [
 
 const SYNC_PROVIDER_KEYS = [
   ...BUILT_IN_BANK_SYNC_PROVIDERS,
+  'external',
   'unlinked',
 ] as const satisfies readonly SyncProviders[];
 
@@ -32,6 +34,7 @@ export function getSyncSourceReadable(
     goCardless: 'GoCardless',
     simpleFin: 'SimpleFIN',
     pluggyai: 'Pluggy.ai',
+    external: translate('External'),
     unlinked: translate('Unlinked'),
   };
 }

--- a/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
@@ -12,18 +12,21 @@ import { send } from '@actual-app/core/platform/client/connection';
 import type { AccountEntity } from '@actual-app/core/types/models';
 
 import { useReopenAccountMutation, useUpdateAccountMutation } from '#accounts';
+import {
+  isAccountFailedSync,
+  isAccountPendingSync,
+} from '#accounts/syncStatus';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { AddTransactionButton } from '#components/mobile/transactions/AddTransactionButton';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useAccount } from '#hooks/useAccount';
-import { useFailedAccounts } from '#hooks/useFailedAccounts';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import {
   collapseModals,
   openAccountCloseModal,
   pushModal,
 } from '#modals/modalsSlice';
-import { useDispatch, useSelector } from '#redux';
+import { useDispatch } from '#redux';
 
 import { AccountTransactions } from './AccountTransactions';
 import { AllAccountTransactions } from './AllAccountTransactions';
@@ -92,17 +95,9 @@ export function AccountPage() {
 }
 
 function AccountHeader({ account }: { readonly account: AccountEntity }) {
-  const failedAccounts = useFailedAccounts();
   const { t } = useTranslation();
-  const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
-  const pending = useMemo(
-    () => syncingAccountIds.includes(account.id),
-    [syncingAccountIds, account.id],
-  );
-  const failed = useMemo(
-    () => failedAccounts.has(account.id),
-    [failedAccounts, account.id],
-  );
+  const pending = useMemo(() => isAccountPendingSync(account), [account]);
+  const failed = useMemo(() => isAccountFailedSync(account), [account]);
 
   const dispatch = useDispatch();
   const { mutate: updateAccount } = useUpdateAccountMutation();

--- a/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo } from 'react';
+import React, { Fragment, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -96,8 +96,8 @@ export function AccountPage() {
 
 function AccountHeader({ account }: { readonly account: AccountEntity }) {
   const { t } = useTranslation();
-  const pending = useMemo(() => isAccountPendingSync(account), [account]);
-  const failed = useMemo(() => isAccountFailedSync(account), [account]);
+  const pending = isAccountPendingSync(account);
+  const failed = isAccountFailedSync(account);
 
   const dispatch = useDispatch();
   const { mutate: updateAccount } = useUpdateAccountMutation();

--- a/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
@@ -24,13 +24,16 @@ import type { AccountEntity } from '@actual-app/core/types/models';
 import { css } from '@emotion/css';
 
 import { useMoveAccountMutation, useSyncAndDownloadMutation } from '#accounts';
+import {
+  isAccountFailedSync,
+  isAccountPendingSync,
+} from '#accounts/syncStatus';
 import { makeAmountFullStyle } from '#components/budget/util';
 import { MOBILE_NAV_HEIGHT } from '#components/mobile/MobileNavTabs';
 import { PullToRefresh } from '#components/mobile/PullToRefresh';
 import { MobilePageHeader, Page } from '#components/Page';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
 import { useAccounts } from '#hooks/useAccounts';
-import { useFailedAccounts } from '#hooks/useFailedAccounts';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
 import { useSyncedPref } from '#hooks/useSyncedPref';
@@ -397,10 +400,6 @@ const AccountList = forwardRef<HTMLDivElement, AccountListProps>(
     }: AccountListProps,
     ref,
   ) => {
-    const failedAccounts = useFailedAccounts();
-    const syncingAccountIds = useSelector(
-      state => state.account.accountsSyncing,
-    );
     const updatedAccounts = useSelector(state => state.account.updatedAccounts);
 
     const moveAccount = useMoveAccountMutation();
@@ -484,8 +483,8 @@ const AccountList = forwardRef<HTMLDivElement, AccountListProps>(
             value={account}
             isUpdated={updatedAccounts && updatedAccounts.includes(account.id)}
             isConnected={!!account.bank}
-            isPending={syncingAccountIds.includes(account.id)}
-            isFailed={failedAccounts && failedAccounts.has(account.id)}
+            isPending={isAccountPendingSync(account)}
+            isFailed={isAccountFailedSync(account)}
             getBalanceQuery={getBalanceBinding}
             onSelect={onOpenAccount}
           />

--- a/packages/desktop-client/src/components/sidebar/Accounts.tsx
+++ b/packages/desktop-client/src/components/sidebar/Accounts.tsx
@@ -6,14 +6,16 @@ import { View } from '@actual-app/components/view';
 import type { AccountEntity } from '@actual-app/core/types/models';
 
 import { useMoveAccountMutation } from '#accounts';
+import {
+  isAccountFailedSync,
+  isAccountPendingSync,
+} from '#accounts/syncStatus';
 import { useAccounts } from '#hooks/useAccounts';
 import { useClosedAccounts } from '#hooks/useClosedAccounts';
-import { useFailedAccounts } from '#hooks/useFailedAccounts';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useOffBudgetAccounts } from '#hooks/useOffBudgetAccounts';
 import { useOnBudgetAccounts } from '#hooks/useOnBudgetAccounts';
 import { useUpdatedAccounts } from '#hooks/useUpdatedAccounts';
-import { useSelector } from '#redux';
 import * as bindings from '#spreadsheet/bindings';
 
 import { Account } from './Account';
@@ -25,12 +27,10 @@ export function Accounts() {
   const { t } = useTranslation();
   const [isDragging, setIsDragging] = useState(false);
   const { data: accounts = [] } = useAccounts();
-  const failedAccounts = useFailedAccounts();
   const updatedAccounts = useUpdatedAccounts();
   const { data: offbudgetAccounts = [] } = useOffBudgetAccounts();
   const { data: onBudgetAccounts = [] } = useOnBudgetAccounts();
   const { data: closedAccounts = [] } = useClosedAccounts();
-  const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
 
   const getAccountPath = (account: AccountEntity) => `/accounts/${account.id}`;
 
@@ -121,8 +121,8 @@ export function Accounts() {
             name={account.name}
             account={account}
             connected={!!account.bank}
-            pending={syncingAccountIds.includes(account.id)}
-            failed={failedAccounts.has(account.id)}
+            pending={isAccountPendingSync(account)}
+            failed={isAccountFailedSync(account)}
             updated={updatedAccounts.includes(account.id)}
             to={getAccountPath(account)}
             query={bindings.accountBalance(account.id)}
@@ -153,8 +153,8 @@ export function Accounts() {
             name={account.name}
             account={account}
             connected={!!account.bank}
-            pending={syncingAccountIds.includes(account.id)}
-            failed={failedAccounts.has(account.id)}
+            pending={isAccountPendingSync(account)}
+            failed={isAccountFailedSync(account)}
             updated={updatedAccounts.includes(account.id)}
             to={getAccountPath(account)}
             query={bindings.accountBalance(account.id)}

--- a/packages/desktop-client/src/hooks/usePendingSyncPolling.test.ts
+++ b/packages/desktop-client/src/hooks/usePendingSyncPolling.test.ts
@@ -1,0 +1,88 @@
+// @ts-strict-ignore
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { usePendingSyncPolling } from './usePendingSyncPolling';
+
+function setVisibilityState(value: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('usePendingSyncPolling', () => {
+  const originalVisibilityState = document.visibilityState;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setVisibilityState('visible');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    setVisibilityState(originalVisibilityState);
+    vi.clearAllMocks();
+  });
+
+  it('polls immediately and on an interval when enabled', async () => {
+    const onPoll = vi.fn().mockResolvedValue(undefined);
+
+    renderHook(() =>
+      usePendingSyncPolling({ enabled: true, intervalMs: 1000, onPoll }),
+    );
+
+    expect(onPoll).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onPoll).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not poll when disabled', async () => {
+    const onPoll = vi.fn();
+
+    renderHook(() =>
+      usePendingSyncPolling({ enabled: false, intervalMs: 1000, onPoll }),
+    );
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onPoll).not.toHaveBeenCalled();
+  });
+
+  it('does not poll while the document is hidden', async () => {
+    const onPoll = vi.fn();
+    setVisibilityState('hidden');
+
+    renderHook(() =>
+      usePendingSyncPolling({ enabled: true, intervalMs: 1000, onPoll }),
+    );
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onPoll).not.toHaveBeenCalled();
+  });
+
+  it('does not overlap polls while a previous one is still running', async () => {
+    let resolvePoll: () => void;
+    const onPoll = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolvePoll = resolve;
+        }),
+    );
+
+    renderHook(() =>
+      usePendingSyncPolling({ enabled: true, intervalMs: 1000, onPoll }),
+    );
+
+    expect(onPoll).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(onPoll).toHaveBeenCalledTimes(1);
+
+    resolvePoll();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onPoll).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/desktop-client/src/hooks/usePendingSyncPolling.ts
+++ b/packages/desktop-client/src/hooks/usePendingSyncPolling.ts
@@ -40,5 +40,5 @@ export function usePendingSyncPolling({
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [enabled, intervalMs, poll]);
+  }, [enabled, intervalMs]);
 }

--- a/packages/desktop-client/src/hooks/usePendingSyncPolling.ts
+++ b/packages/desktop-client/src/hooks/usePendingSyncPolling.ts
@@ -1,0 +1,44 @@
+import { useEffect, useEffectEvent, useRef } from 'react';
+
+type UsePendingSyncPollingOptions = {
+  enabled: boolean;
+  intervalMs?: number;
+  onPoll: () => void | Promise<void>;
+};
+
+export function usePendingSyncPolling({
+  enabled,
+  intervalMs = 2000,
+  onPoll,
+}: UsePendingSyncPollingOptions) {
+  const inProgress = useRef(false);
+
+  const poll = useEffectEvent(async () => {
+    if (document.visibilityState !== 'visible' || inProgress.current) {
+      return;
+    }
+
+    inProgress.current = true;
+    try {
+      await onPoll();
+    } finally {
+      inProgress.current = false;
+    }
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    void poll();
+
+    const intervalId = window.setInterval(() => {
+      void poll();
+    }, intervalMs);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [enabled, intervalMs, poll]);
+}

--- a/packages/desktop-client/src/sync-events.test.ts
+++ b/packages/desktop-client/src/sync-events.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { markUpdatedAccounts } from './accounts/accountsSlice';
+import { listenForSyncEvent } from './sync-events';
+
+const listeners = new Map<string, Array<(event: unknown) => void>>();
+
+vi.mock('@actual-app/core/platform/client/connection', () => ({
+  listen: vi.fn((name: string, listener: (event: unknown) => void) => {
+    const current = listeners.get(name) ?? [];
+    current.push(listener);
+    listeners.set(name, current);
+    return () => {
+      listeners.set(
+        name,
+        (listeners.get(name) ?? []).filter(l => l !== listener),
+      );
+    };
+  }),
+  send: vi.fn(),
+}));
+
+function emitSyncEvent(event: unknown) {
+  for (const listener of listeners.get('sync-event') ?? []) {
+    listener(event);
+  }
+}
+
+describe('listenForSyncEvent', () => {
+  beforeEach(() => {
+    listeners.clear();
+  });
+
+  it('marks accounts updated for newly applied remote transactions', () => {
+    const dispatch = vi.fn();
+    const store = {
+      dispatch,
+      getState: () => ({
+        prefs: {
+          local: {
+            id: 'budget-1',
+          },
+        },
+      }),
+    };
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    listenForSyncEvent(store as never, queryClient as never);
+
+    emitSyncEvent({
+      type: 'applied',
+      tables: ['transactions'],
+      prevData: new Map([
+        [
+          'transactions',
+          new Map([['t1', { id: 't1', acct: 'acct-1' }]]),
+        ],
+      ]),
+      data: new Map([
+        [
+          'transactions',
+          new Map([
+            ['t1', { id: 't1', acct: 'acct-1' }],
+            ['t2', { id: 't2', acct: 'acct-2' }],
+          ]),
+        ],
+      ]),
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      markUpdatedAccounts({ ids: ['acct-2'] }),
+    );
+  });
+
+  it('does not mark accounts updated for existing or tombstoned transactions', () => {
+    const dispatch = vi.fn();
+    const store = {
+      dispatch,
+      getState: () => ({
+        prefs: {
+          local: {
+            id: 'budget-1',
+          },
+        },
+      }),
+    };
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    listenForSyncEvent(store as never, queryClient as never);
+
+    emitSyncEvent({
+      type: 'applied',
+      tables: ['transactions'],
+      prevData: new Map([
+        [
+          'transactions',
+          new Map([['t1', { id: 't1', acct: 'acct-1' }]]),
+        ],
+      ]),
+      data: new Map([
+        [
+          'transactions',
+          new Map([
+            ['t1', { id: 't1', acct: 'acct-1' }],
+            ['t2', { id: 't2', acct: 'acct-2', tombstone: 1 }],
+          ]),
+        ],
+      ]),
+    });
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      markUpdatedAccounts({ ids: ['acct-2'] }),
+    );
+  });
+});

--- a/packages/desktop-client/src/sync-events.test.ts
+++ b/packages/desktop-client/src/sync-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { markUpdatedAccounts } from './accounts/accountsSlice';
 import { listenForSyncEvent } from './sync-events';
@@ -53,10 +53,7 @@ describe('listenForSyncEvent', () => {
       type: 'applied',
       tables: ['transactions'],
       prevData: new Map([
-        [
-          'transactions',
-          new Map([['t1', { id: 't1', acct: 'acct-1' }]]),
-        ],
+        ['transactions', new Map([['t1', { id: 't1', acct: 'acct-1' }]])],
       ]),
       data: new Map([
         [
@@ -96,10 +93,7 @@ describe('listenForSyncEvent', () => {
       type: 'applied',
       tables: ['transactions'],
       prevData: new Map([
-        [
-          'transactions',
-          new Map([['t1', { id: 't1', acct: 'acct-1' }]]),
-        ],
+        ['transactions', new Map([['t1', { id: 't1', acct: 'acct-1' }]])],
       ]),
       data: new Map([
         [

--- a/packages/desktop-client/src/sync-events.test.ts
+++ b/packages/desktop-client/src/sync-events.test.ts
@@ -31,7 +31,7 @@ describe('listenForSyncEvent', () => {
     listeners.clear();
   });
 
-  it('marks accounts updated for newly applied remote transactions', () => {
+  it('marks accounts updated from explicit applied sync metadata', () => {
     const dispatch = vi.fn();
     const store = {
       dispatch,
@@ -51,19 +51,10 @@ describe('listenForSyncEvent', () => {
 
     emitSyncEvent({
       type: 'applied',
-      tables: ['transactions'],
-      prevData: new Map([
-        ['transactions', new Map([['t1', { id: 't1', acct: 'acct-1' }]])],
-      ]),
-      data: new Map([
-        [
-          'transactions',
-          new Map([
-            ['t1', { id: 't1', acct: 'acct-1' }],
-            ['t2', { id: 't2', acct: 'acct-2' }],
-          ]),
-        ],
-      ]),
+      tables: ['accounts', 'transactions'],
+      meta: {
+        updatedAccountIds: ['acct-2'],
+      },
     });
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -71,47 +62,7 @@ describe('listenForSyncEvent', () => {
     );
   });
 
-  it('does not mark accounts updated for existing or tombstoned transactions', () => {
-    const dispatch = vi.fn();
-    const store = {
-      dispatch,
-      getState: () => ({
-        prefs: {
-          local: {
-            id: 'budget-1',
-          },
-        },
-      }),
-    };
-    const queryClient = {
-      invalidateQueries: vi.fn(),
-    };
-
-    listenForSyncEvent(store as never, queryClient as never);
-
-    emitSyncEvent({
-      type: 'applied',
-      tables: ['transactions'],
-      prevData: new Map([
-        ['transactions', new Map([['t1', { id: 't1', acct: 'acct-1' }]])],
-      ]),
-      data: new Map([
-        [
-          'transactions',
-          new Map([
-            ['t1', { id: 't1', acct: 'acct-1' }],
-            ['t2', { id: 't2', acct: 'acct-2', tombstone: 1 }],
-          ]),
-        ],
-      ]),
-    });
-
-    expect(dispatch).not.toHaveBeenCalledWith(
-      markUpdatedAccounts({ ids: ['acct-2'] }),
-    );
-  });
-
-  it('does not mark accounts updated when applied events omit previous rows', () => {
+  it('does not infer updated accounts from generic applied transaction rows', () => {
     const dispatch = vi.fn();
     const store = {
       dispatch,
@@ -144,7 +95,38 @@ describe('listenForSyncEvent', () => {
     });
 
     expect(dispatch).not.toHaveBeenCalledWith(
-      markUpdatedAccounts({ ids: ['acct-1', 'acct-2'] }),
+      markUpdatedAccounts({ ids: ['acct-2'] }),
+    );
+  });
+
+  it('ignores invalid updated account metadata', () => {
+    const dispatch = vi.fn();
+    const store = {
+      dispatch,
+      getState: () => ({
+        prefs: {
+          local: {
+            id: 'budget-1',
+          },
+        },
+      }),
+    };
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    listenForSyncEvent(store as never, queryClient as never);
+
+    emitSyncEvent({
+      type: 'applied',
+      tables: ['accounts', 'transactions'],
+      meta: {
+        updatedAccountIds: ['acct-1', null, 123],
+      },
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      markUpdatedAccounts({ ids: ['acct-1'] }),
     );
   });
 });

--- a/packages/desktop-client/src/sync-events.test.ts
+++ b/packages/desktop-client/src/sync-events.test.ts
@@ -110,4 +110,41 @@ describe('listenForSyncEvent', () => {
       markUpdatedAccounts({ ids: ['acct-2'] }),
     );
   });
+
+  it('does not mark accounts updated when applied events omit previous rows', () => {
+    const dispatch = vi.fn();
+    const store = {
+      dispatch,
+      getState: () => ({
+        prefs: {
+          local: {
+            id: 'budget-1',
+          },
+        },
+      }),
+    };
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    };
+
+    listenForSyncEvent(store as never, queryClient as never);
+
+    emitSyncEvent({
+      type: 'applied',
+      tables: ['transactions'],
+      data: new Map([
+        [
+          'transactions',
+          new Map([
+            ['t1', { id: 't1', acct: 'acct-1' }],
+            ['t2', { id: 't2', acct: 'acct-2' }],
+          ]),
+        ],
+      ]),
+    });
+
+    expect(dispatch).not.toHaveBeenCalledWith(
+      markUpdatedAccounts({ ids: ['acct-1', 'acct-2'] }),
+    );
+  });
 });

--- a/packages/desktop-client/src/sync-events.ts
+++ b/packages/desktop-client/src/sync-events.ts
@@ -18,63 +18,19 @@ import { loadPrefs } from './prefs/prefsSlice';
 import type { AppStore } from './redux/store';
 import { signOut } from './users/usersSlice';
 
-type RawTransaction = {
-  id: string;
-  acct?: string | null;
-  tombstone?: boolean | number | null;
-};
-
-function isRawTransaction(value: unknown): value is RawTransaction {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'id' in value &&
-    typeof value.id === 'string'
-  );
-}
-
-function getTransactionsById(value: unknown) {
-  if (!(value instanceof Map)) {
-    return new Map<string, RawTransaction>();
-  }
-
-  return new Map(
-    Array.from(value.entries()).filter(
-      (entry): entry is [string, RawTransaction] => isRawTransaction(entry[1]),
-    ),
-  );
-}
-
 function getAppliedUpdatedAccountIds(event: {
   type: 'applied';
   tables: string[];
-  data?: Map<string, unknown>;
-  prevData?: Map<string, unknown>;
+  meta?: {
+    updatedAccountIds?: unknown;
+  };
 }) {
-  if (!event.tables.includes('transactions')) {
+  if (!Array.isArray(event.meta?.updatedAccountIds)) {
     return [];
   }
 
-  const transactions = event.data?.get('transactions');
-  const previousTransactions = event.prevData?.get('transactions');
-  if (transactions == null || previousTransactions == null) {
-    return [];
-  }
-
-  const nextTransactionsById = getTransactionsById(transactions);
-  const previousTransactionsById = getTransactionsById(previousTransactions);
-
-  return Array.from(
-    new Set(
-      Array.from(nextTransactionsById.values())
-        .filter(
-          transaction =>
-            !previousTransactionsById.has(transaction.id) &&
-            !transaction.tombstone &&
-            !!transaction.acct,
-        )
-        .map(transaction => transaction.acct as string),
-    ),
+  return event.meta.updatedAccountIds.filter(
+    (accountId): accountId is string => typeof accountId === 'string',
   );
 }
 

--- a/packages/desktop-client/src/sync-events.ts
+++ b/packages/desktop-client/src/sync-events.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 
 import { accountQueries } from './accounts';
+import { markUpdatedAccounts } from './accounts/accountsSlice';
 import { resetSync, sync } from './app/appSlice';
 import { categoryQueries } from './budget';
 import {
@@ -16,6 +17,62 @@ import { payeeQueries } from './payees';
 import { loadPrefs } from './prefs/prefsSlice';
 import type { AppStore } from './redux/store';
 import { signOut } from './users/usersSlice';
+
+type RawTransaction = {
+  id: string;
+  acct?: string | null;
+  tombstone?: boolean | number | null;
+};
+
+function isRawTransaction(value: unknown): value is RawTransaction {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof value.id === 'string'
+  );
+}
+
+function getTransactionsById(value: unknown) {
+  if (!(value instanceof Map)) {
+    return new Map<string, RawTransaction>();
+  }
+
+  return new Map(
+    Array.from(value.entries()).filter(
+      (entry): entry is [string, RawTransaction] => isRawTransaction(entry[1]),
+    ),
+  );
+}
+
+function getAppliedUpdatedAccountIds(event: {
+  type: 'applied';
+  tables: string[];
+  data?: Map<string, unknown>;
+  prevData?: Map<string, unknown>;
+}) {
+  if (!event.tables.includes('transactions')) {
+    return [];
+  }
+
+  const transactions = event.data?.get('transactions');
+  const previousTransactions = event.prevData?.get('transactions');
+  const nextTransactionsById = getTransactionsById(transactions);
+  const previousTransactionsById = getTransactionsById(previousTransactions);
+
+  return Array.from(
+    new Set(
+      Array.from(nextTransactionsById.values())
+        .filter(
+          transaction =>
+            !previousTransactionsById.has(transaction.id) &&
+            !transaction.tombstone &&
+            !!transaction.acct,
+        )
+        .map(transaction => transaction.acct as string),
+    ),
+  );
+}
 
 export function listenForSyncEvent(store: AppStore, queryClient: QueryClient) {
   // TODO: Should this run on mobile too?
@@ -89,6 +146,13 @@ export function listenForSyncEvent(store: AppStore, queryClient: QueryClient) {
         void queryClient.invalidateQueries({
           queryKey: accountQueries.lists(),
         });
+      }
+
+      if (event.type === 'applied') {
+        const updatedAccountIds = getAppliedUpdatedAccountIds(event);
+        if (updatedAccountIds.length > 0) {
+          store.dispatch(markUpdatedAccounts({ ids: updatedAccountIds }));
+        }
       }
     } else if (event.type === 'error') {
       let notif: Notification | null = null;

--- a/packages/desktop-client/src/sync-events.ts
+++ b/packages/desktop-client/src/sync-events.ts
@@ -57,6 +57,10 @@ function getAppliedUpdatedAccountIds(event: {
 
   const transactions = event.data?.get('transactions');
   const previousTransactions = event.prevData?.get('transactions');
+  if (transactions == null || previousTransactions == null) {
+    return [];
+  }
+
   const nextTransactionsById = getTransactionsById(transactions);
   const previousTransactionsById = getTransactionsById(previousTransactions);
 

--- a/packages/loot-core/migrations/1769500000000_add_bank_sync_status.sql
+++ b/packages/loot-core/migrations/1769500000000_add_bank_sync_status.sql
@@ -1,0 +1,5 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE accounts ADD COLUMN bank_sync_status text;
+
+COMMIT;

--- a/packages/loot-core/src/mocks/index.ts
+++ b/packages/loot-core/src/mocks/index.ts
@@ -40,6 +40,7 @@ export function generateAccount(
       balance_limit: 0,
       account_sync_source: 'goCardless',
       last_sync: new Date().getTime().toString(),
+      bank_sync_status: 'ok',
     };
   }
 
@@ -59,6 +60,7 @@ function emptySyncFields(): Pick<
   | 'balance_limit'
   | 'account_sync_source'
   | 'last_sync'
+  | 'bank_sync_status'
 > {
   return {
     account_id: null,
@@ -72,6 +74,7 @@ function emptySyncFields(): Pick<
     balance_limit: null,
     account_sync_source: null,
     last_sync: null,
+    bank_sync_status: null,
   };
 }
 

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -1,4 +1,6 @@
 // @ts-strict-ignore
+import * as asyncStorage from '#platform/server/asyncStorage';
+import { accountModel } from '#server/api-models';
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 
@@ -12,6 +14,7 @@ vi.mock('./sync', async () => ({
 }));
 
 const simpleFinBatchSyncHandler = app.handlers['simplefin-batch-sync'];
+const accountsBankSyncHandler = app.handlers['accounts-bank-sync'];
 
 function insertBank(bank: { id: string; bank_id: string; name: string }) {
   db.runQuery(
@@ -41,6 +44,10 @@ async function setupSimpleFinAccounts(
 
 beforeEach(async () => {
   vi.resetAllMocks();
+  vi.mocked(asyncStorage.multiGet).mockResolvedValue({
+    'user-id': 'user-1',
+    'user-key': 'key-1',
+  });
   await global.emptyDatabase()();
   await loadMappings();
 });
@@ -132,6 +139,82 @@ describe('simpleFinBatchSync', () => {
       // Account 2 should have no errors
       const acct2Result = result.find(r => r.accountId === 'acct2');
       expect(acct2Result!.res.errors).toHaveLength(0);
+    });
+  });
+});
+
+describe('accountsBankSync', () => {
+  it('persists ok status after a successful sync', async () => {
+    insertBank({ id: 'bank1', bank_id: 'gc-bank', name: 'GoCardless' });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      bank: 'bank1',
+      account_id: 'ext-1',
+      account_sync_source: 'goCardless',
+    });
+
+    vi.mocked(bankSync.syncAccount).mockResolvedValue({
+      added: [],
+      updated: [],
+      updatedPreview: [],
+    });
+
+    await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    const account = await db.select('accounts', 'acct1');
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct1',
+      bank_sync_status: 'ok',
+    });
+  });
+
+  it('persists reauth-required status after a reauth error', async () => {
+    insertBank({ id: 'bank1', bank_id: 'gc-bank', name: 'GoCardless' });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      bank: 'bank1',
+      account_id: 'ext-1',
+      account_sync_source: 'goCardless',
+    });
+
+    vi.mocked(bankSync.syncAccount).mockRejectedValue({
+      type: 'BankSyncError',
+      reason: 'login required',
+      category: 'ITEM_ERROR',
+      code: 'ITEM_LOGIN_REQUIRED',
+      message: 'login required',
+    });
+
+    await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    const account = await db.select('accounts', 'acct1');
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct1',
+      bank_sync_status: 'reauth-required',
+    });
+  });
+
+  it('skips externally linked accounts', async () => {
+    insertBank({ id: 'bank1', bank_id: 'external:bank-1', name: 'External' });
+    await db.insertAccount({
+      id: 'acct-external',
+      name: 'External Checking',
+      bank: 'bank1',
+      account_id: 'external-account-1',
+      account_sync_source: 'external',
+      bank_sync_status: null,
+    });
+
+    const result = await accountsBankSyncHandler({ ids: ['acct-external'] });
+
+    expect(bankSync.syncAccount).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      errors: [],
+      newTransactions: [],
+      matchedTransactions: [],
+      updatedAccounts: [],
     });
   });
 });

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -201,6 +201,29 @@ describe('accountsBankSync', () => {
     });
   });
 
+  it('persists failed status after an operational sync error', async () => {
+    insertBank({ id: 'bank1', bank_id: 'gc-bank', name: 'GoCardless' });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      bank: 'bank1',
+      account_id: 'ext-1',
+      account_sync_source: 'goCardless',
+    });
+
+    vi.mocked(bankSync.syncAccount).mockRejectedValue(
+      new Error('connection timeout'),
+    );
+
+    await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    const account = await db.select('accounts', 'acct1');
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct1',
+      bank_sync_status: 'failed',
+    });
+  });
+
   it('requests sync for externally linked accounts', async () => {
     insertBank({ id: 'bank1', bank_id: 'external:bank-1', name: 'External' });
     await db.insertAccount({

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -160,7 +160,12 @@ describe('accountsBankSync', () => {
       updatedPreview: [],
     });
 
-    await accountsBankSyncHandler({ ids: ['acct1'] });
+    const result = await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    expect(result).toMatchObject({
+      errors: [],
+      hasUpdates: true,
+    });
 
     const account = await db.select('accounts', 'acct1');
     expect(accountModel.toExternal(account!)).toMatchObject({
@@ -215,6 +220,7 @@ describe('accountsBankSync', () => {
       newTransactions: [],
       matchedTransactions: [],
       updatedAccounts: [],
+      hasUpdates: true,
     });
 
     const account = await db.select('accounts', 'acct-external');

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -196,7 +196,7 @@ describe('accountsBankSync', () => {
     });
   });
 
-  it('skips externally linked accounts', async () => {
+  it('requests sync for externally linked accounts', async () => {
     insertBank({ id: 'bank1', bank_id: 'external:bank-1', name: 'External' });
     await db.insertAccount({
       id: 'acct-external',
@@ -215,6 +215,12 @@ describe('accountsBankSync', () => {
       newTransactions: [],
       matchedTransactions: [],
       updatedAccounts: [],
+    });
+
+    const account = await db.select('accounts', 'acct-external');
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct-external',
+      bank_sync_status: 'sync-requested',
     });
   });
 });

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -107,6 +107,28 @@ describe('external account sync metadata', () => {
     });
   });
 
+  it('does not overload account-update with unlink behavior', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'test-provider:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      account_sync_source: 'external',
+    });
+
+    await expect(
+      updateAccount({
+        id: 'acct1',
+        account_sync_source: null,
+      }),
+    ).rejects.toThrow('Use account-unlink to unlink an account.');
+  });
+
   it('unlinks an existing provider before linking external metadata', async () => {
     await db.insertWithUUID('banks', {
       id: 'bank1',
@@ -239,6 +261,29 @@ describe('external account sync metadata', () => {
       bank_id: 'gc-bank',
       bank_name: 'GoCardless Bank',
       bank_sync_status: null,
+    });
+  });
+
+  it('allows updating bank_sync_status through the existing account update handler', async () => {
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'external-account-1',
+      account_sync_source: 'external',
+    });
+
+    await updateAccount({
+      id: 'acct1',
+      bank_sync_status: 'sync-requested',
+    });
+
+    const account = (await getAccounts()).find(
+      existingAccount => existingAccount.id === 'acct1',
+    );
+
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct1',
+      bank_sync_status: 'sync-requested',
     });
   });
 

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -1,0 +1,260 @@
+import { accountModel } from '#server/api-models';
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+
+import { app } from './app';
+
+declare global {
+  var emptyDatabase: (deleteFile?: boolean) => () => Promise<void>;
+}
+
+const emptyDatabase = globalThis.emptyDatabase;
+const updateAccount = app.handlers['account-update'];
+const getAccounts = app.handlers['accounts-get'];
+const unlinkAccount = app.handlers['account-unlink'];
+
+beforeEach(async () => {
+  await emptyDatabase()();
+  await loadMappings();
+});
+
+describe('external account sync metadata', () => {
+  it('writes external sync metadata and creates a bank row', async () => {
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+    });
+
+    await updateAccount({
+      id: 'acct1',
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bankName: 'External Credit Union',
+      bankId: 'test-provider:institution-1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      last_sync: '1715000000000',
+    });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    const bank = await db.first<db.DbBank>('SELECT * FROM banks WHERE id = ?', [
+      account!.bank!,
+    ]);
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: 'provider-acct-1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+      bank_sync_status: null,
+    });
+    expect(bank).toMatchObject({
+      name: 'External Credit Union',
+      bank_id: 'test-provider:institution-1',
+    });
+  });
+
+  it('reuses native unlink semantics for external accounts', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'test-provider:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+    });
+
+    await unlinkAccount({ id: 'acct1' });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: null,
+      bank: null,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+      account_sync_source: null,
+      bank_sync_status: null,
+      mask: '1234',
+      official_name: 'Checking Account',
+      last_sync: '1715000000000',
+    });
+  });
+
+  it('unlinks an existing provider before linking external metadata', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'gc-bank',
+      name: 'GoCardless Bank',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'gc-acct-1',
+      bank: 'bank1',
+      balance_current: 500,
+      balance_available: 400,
+      balance_limit: 1000,
+      account_sync_source: 'goCardless',
+    });
+
+    await updateAccount({
+      id: 'acct1',
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bankName: 'External Credit Union',
+      bankId: 'test-provider:institution-1',
+    });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    const bank = await db.first<db.DbBank>('SELECT * FROM banks WHERE id = ?', [
+      account!.bank!,
+    ]);
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: 'provider-acct-1',
+      bank: bank!.id,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+      account_sync_source: 'external',
+    });
+    expect(bank).toMatchObject({
+      name: 'External Credit Union',
+      bank_id: 'test-provider:institution-1',
+    });
+  });
+
+  it('returns external sync metadata through the existing accounts shape', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'test-provider:institution-1',
+      name: 'External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+      last_sync: '1715000000000',
+    });
+    await db.insertAccount({
+      id: 'acct2',
+      name: 'Cash',
+    });
+
+    const accounts = await getAccounts();
+    const linkedAccount = accounts.find(account => account.id === 'acct1');
+    const unlinkedAccount = accounts.find(account => account.id === 'acct2');
+
+    expect(accountModel.toExternal(linkedAccount!)).toMatchObject({
+      id: 'acct1',
+      account_sync_source: 'external',
+      account_id: 'provider-acct-1',
+      bank_id: 'test-provider:institution-1',
+      bank_name: 'External Credit Union',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      last_sync: '1715000000000',
+      bank_sync_status: null,
+    });
+
+    expect(accountModel.toExternal(unlinkedAccount!)).toMatchObject({
+      id: 'acct2',
+      account_sync_source: null,
+      account_id: null,
+      bank_id: null,
+      bank_name: null,
+      mask: null,
+      official_name: null,
+      balance_current: null,
+      balance_available: null,
+      balance_limit: null,
+      last_sync: null,
+      bank_sync_status: null,
+    });
+  });
+
+  it('returns bank_id for non-external linked accounts too', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'gc-bank',
+      name: 'GoCardless Bank',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'gc-acct-1',
+      bank: 'bank1',
+      account_sync_source: 'goCardless',
+    });
+
+    const account = (await getAccounts()).find(
+      existingAccount => existingAccount.id === 'acct1',
+    );
+
+    expect(accountModel.toExternal(account!)).toMatchObject({
+      id: 'acct1',
+      account_sync_source: 'goCardless',
+      account_id: 'gc-acct-1',
+      bank_id: 'gc-bank',
+      bank_name: 'GoCardless Bank',
+      bank_sync_status: null,
+    });
+  });
+
+  it('requires a stable bankId for external links', async () => {
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+    });
+
+    await expect(
+      updateAccount({
+        id: 'acct1',
+        account_sync_source: 'external',
+        account_id: 'provider-acct-1',
+        bankName: 'External Credit Union',
+      }),
+    ).rejects.toThrow('bankId is required');
+  });
+});

--- a/packages/loot-core/src/server/accounts/app-external-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-external-sync.test.ts
@@ -177,6 +177,48 @@ describe('external account sync metadata', () => {
     });
   });
 
+  it('preserves existing optional metadata when relinking externally without those fields', async () => {
+    await db.insertWithUUID('banks', {
+      id: 'bank1',
+      bank_id: 'external:old-bank',
+      name: 'Old External Credit Union',
+    });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      account_id: 'provider-acct-1',
+      bank: 'bank1',
+      mask: '1234',
+      official_name: 'Checking Account',
+      balance_current: 1000,
+      balance_available: 900,
+      balance_limit: 2000,
+      account_sync_source: 'external',
+    });
+
+    await updateAccount({
+      id: 'acct1',
+      account_sync_source: 'external',
+      account_id: 'provider-acct-2',
+      bankName: 'New External Credit Union',
+      bankId: 'external:new-bank',
+    });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+
+    expect(account).toMatchObject({
+      id: 'acct1',
+      account_id: 'provider-acct-2',
+      mask: '1234',
+      official_name: 'Checking Account',
+      account_sync_source: 'external',
+      bank_sync_status: null,
+    });
+  });
+
   it('returns external sync metadata through the existing accounts shape', async () => {
     await db.insertWithUUID('banks', {
       id: 'bank1',
@@ -292,6 +334,24 @@ describe('external account sync metadata', () => {
       id: 'acct1',
       name: 'Checking',
     });
+
+    await expect(
+      updateAccount({
+        id: 'acct1',
+        account_sync_source: 'external',
+        bankName: 'External Credit Union',
+        bankId: 'test-provider:institution-1',
+      }),
+    ).rejects.toThrow('account_id is required');
+
+    await expect(
+      updateAccount({
+        id: 'acct1',
+        account_sync_source: 'external',
+        account_id: 'provider-acct-1',
+        bankId: 'test-provider:institution-1',
+      }),
+    ).rejects.toThrow('bankName is required');
 
     await expect(
       updateAccount({

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -907,6 +907,7 @@ type SyncResponse = {
   newTransactions: Array<TransactionEntity['id']>;
   matchedTransactions: Array<TransactionEntity['id']>;
   updatedAccounts: Array<AccountEntity['id']>;
+  hasUpdates: boolean;
 };
 
 async function handleSyncResponse(
@@ -939,6 +940,7 @@ async function handleSyncResponse(
     newTransactions,
     matchedTransactions,
     updatedAccounts,
+    hasUpdates: true,
   };
 }
 
@@ -1146,7 +1148,17 @@ async function accountsBankSync({
     });
   }
 
-  return { errors, newTransactions, matchedTransactions, updatedAccounts };
+  return {
+    errors,
+    newTransactions,
+    matchedTransactions,
+    updatedAccounts,
+    hasUpdates:
+      hasAccountUpdates ||
+      newTransactions.length > 0 ||
+      matchedTransactions.length > 0 ||
+      updatedAccounts.length > 0,
+  };
 }
 
 async function simpleFinBatchSync({
@@ -1176,6 +1188,7 @@ async function simpleFinBatchSync({
       newTransactions: Array<TransactionEntity['id']>;
       matchedTransactions: Array<TransactionEntity['id']>;
       updatedAccounts: Array<AccountEntity['id']>;
+      hasUpdates: boolean;
     };
   }> = [];
 
@@ -1221,6 +1234,7 @@ async function simpleFinBatchSync({
       const newTransactions: Array<TransactionEntity['id']> = [];
       const matchedTransactions: Array<TransactionEntity['id']> = [];
       const updatedAccounts: Array<AccountEntity['id']> = [];
+      const hasUpdates = true;
 
       if (syncResponse.res?.error_code) {
         await db.update('accounts', {
@@ -1269,7 +1283,13 @@ async function simpleFinBatchSync({
 
       retVal.push({
         accountId: syncResponse.accountId,
-        res: { errors, newTransactions, matchedTransactions, updatedAccounts },
+        res: {
+          errors,
+          newTransactions,
+          matchedTransactions,
+          updatedAccounts,
+          hasUpdates,
+        },
       });
     }
   } catch (err) {
@@ -1286,6 +1306,7 @@ async function simpleFinBatchSync({
           newTransactions: [],
           matchedTransactions: [],
           updatedAccounts: [],
+          hasUpdates: true,
         },
       });
     }
@@ -1464,7 +1485,7 @@ app.method('simplefin-accounts', simpleFinAccounts);
 app.method('pluggyai-accounts', pluggyAiAccounts);
 app.method('gocardless-get-banks', getGoCardlessBanks);
 app.method('gocardless-create-web-token', createGoCardlessWebToken);
-app.method('accounts-bank-sync', accountsBankSync);
-app.method('simplefin-batch-sync', simpleFinBatchSync);
+app.method('accounts-bank-sync', mutator(accountsBankSync));
+app.method('simplefin-batch-sync', mutator(simpleFinBatchSync));
 app.method('transactions-import', mutator(undoable(importTransactions)));
 app.method('account-unlink', mutator(unlinkAccount));

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -107,18 +107,32 @@ async function updateAccount(
 
     const bank = await link.findOrCreateBank({ name: bankName }, bankId);
 
-    await db.update('accounts', {
+    const externalUpdate: Partial<AccountEntity> & {
+      id: AccountEntity['id'];
+    } = {
       id,
       account_id: providerAccountId,
       bank: bank.id,
-      mask: params.mask ?? null,
-      official_name: params.official_name ?? null,
-      balance_current: params.balance_current ?? null,
-      balance_available: params.balance_available ?? null,
-      balance_limit: params.balance_limit ?? null,
       account_sync_source: 'external',
       bank_sync_status: null,
-    });
+    };
+    if (hasField('mask')) {
+      externalUpdate.mask = params.mask ?? null;
+    }
+    if (hasField('official_name')) {
+      externalUpdate.official_name = params.official_name ?? null;
+    }
+    if (hasField('balance_current')) {
+      externalUpdate.balance_current = params.balance_current ?? null;
+    }
+    if (hasField('balance_available')) {
+      externalUpdate.balance_available = params.balance_available ?? null;
+    }
+    if (hasField('balance_limit')) {
+      externalUpdate.balance_limit = params.balance_limit ?? null;
+    }
+
+    await db.update('accounts', externalUpdate);
   } else if (hasField('account_sync_source') && account_sync_source == null) {
     throw new Error('Use account-unlink to unlink an account.');
   }
@@ -1033,7 +1047,7 @@ function getBankSyncStatusFromError(
     }
   }
 
-  return 'attention-required';
+  return 'failed';
 }
 
 export type SyncResponseWithErrors = SyncResponse & {
@@ -1237,26 +1251,18 @@ async function simpleFinBatchSync({
       const hasUpdates = true;
 
       if (syncResponse.res?.error_code) {
+        const bankSyncError = {
+          type: 'BankSyncError',
+          reason: 'Failed syncing account "' + account.name + '."',
+          category: syncResponse.res.error_type,
+          code: syncResponse.res.error_code,
+        } as BankSyncError;
+
         await db.update('accounts', {
           id: account.id,
-          bank_sync_status: getBankSyncStatusFromError({
-            type: 'BankSyncError',
-            reason: 'Failed syncing account "' + account.name + '."',
-            category: syncResponse.res.error_type,
-            code: syncResponse.res.error_code,
-          } as BankSyncError),
+          bank_sync_status: getBankSyncStatusFromError(bankSyncError),
         });
-        errors.push(
-          handleSyncError(
-            {
-              type: 'BankSyncError',
-              reason: 'Failed syncing account "' + account.name + '."',
-              category: syncResponse.res.error_type,
-              code: syncResponse.res.error_code,
-            } as BankSyncError,
-            account,
-          ),
-        );
+        errors.push(handleSyncError(bankSyncError, account));
       } else if (syncResponse.res) {
         const syncResponseData = await handleSyncResponse(
           syncResponse.res,
@@ -1267,18 +1273,14 @@ async function simpleFinBatchSync({
         matchedTransactions.push(...syncResponseData.matchedTransactions);
         updatedAccounts.push(...syncResponseData.updatedAccounts);
       } else {
+        const emptyResponseError = new Error(
+          'Failed syncing account "' + account.name + '": empty response',
+        );
         await db.update('accounts', {
           id: account.id,
-          bank_sync_status: 'attention-required',
+          bank_sync_status: getBankSyncStatusFromError(emptyResponseError),
         });
-        errors.push(
-          handleSyncError(
-            new Error(
-              'Failed syncing account "' + account.name + '": empty response',
-            ),
-            account,
-          ),
-        );
+        errors.push(handleSyncError(emptyResponseError, account));
       }
 
       retVal.push({

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -26,6 +26,7 @@ import { amountToInteger } from '#shared/util';
 import type { ImportTransactionsOpts } from '#types/api-handlers';
 import type {
   AccountEntity,
+  BankSyncStatus,
   CategoryEntity,
   GoCardlessToken,
   ImportTransactionEntity,
@@ -76,17 +77,88 @@ export type AccountHandlers = {
   'account-unlink': typeof unlinkAccount;
 };
 
-async function updateAccount({
-  id,
-  name,
-  last_reconciled,
-}: Pick<AccountEntity, 'id' | 'name'> &
-  Partial<Pick<AccountEntity, 'last_reconciled'>>) {
-  await db.update('accounts', {
+async function updateAccount(
+  params: { id: AccountEntity['id'] } & Partial<AccountEntity>,
+) {
+  const { id, bankName, bankId, account_sync_source } = params;
+  const hasField = <K extends keyof typeof params>(field: K) =>
+    Object.prototype.hasOwnProperty.call(params, field);
+
+  if (hasField('account_sync_source') && account_sync_source === 'external') {
+    const providerAccountId = params.account_id;
+
+    if (!providerAccountId) {
+      throw new Error(
+        'account_id is required when linking an external sync account.',
+      );
+    }
+    if (!bankName) {
+      throw new Error(
+        'bankName is required when linking an external sync account.',
+      );
+    }
+    if (!bankId) {
+      throw new Error(
+        'bankId is required when linking an external sync account.',
+      );
+    }
+
+    await unlinkAccount({ id });
+
+    const bank = await link.findOrCreateBank({ name: bankName }, bankId);
+
+    await db.update('accounts', {
+      id,
+      account_id: providerAccountId,
+      bank: bank.id,
+      mask: params.mask ?? null,
+      official_name: params.official_name ?? null,
+      balance_current: params.balance_current ?? null,
+      balance_available: params.balance_available ?? null,
+      balance_limit: params.balance_limit ?? null,
+      account_sync_source: 'external',
+      bank_sync_status: null,
+    });
+  } else if (hasField('account_sync_source') && account_sync_source == null) {
+    const accRow = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      [id],
+    );
+
+    if (!accRow) {
+      throw new Error(`Account with ID ${id} not found.`);
+    }
+
+    if (accRow.account_sync_source !== 'external') {
+      throw new Error(`Account with ID ${id} is not externally linked.`);
+    }
+
+    await unlinkAccount({ id });
+  }
+
+  const accountUpdate: Partial<AccountEntity> & { id: AccountEntity['id'] } = {
     id,
-    name,
-    ...(last_reconciled && { last_reconciled }),
-  });
+  };
+  if (hasField('name')) {
+    accountUpdate.name = params.name;
+  }
+  if (hasField('last_reconciled')) {
+    accountUpdate.last_reconciled = params.last_reconciled ?? null;
+  }
+  if (hasField('last_sync')) {
+    accountUpdate.last_sync = params.last_sync ?? null;
+  }
+  if (hasField('offbudget')) {
+    accountUpdate.offbudget = params.offbudget;
+  }
+  if (hasField('closed')) {
+    accountUpdate.closed = params.closed;
+  }
+
+  if (Object.keys(accountUpdate).length > 1) {
+    await db.update('accounts', accountUpdate);
+  }
+
   return {};
 }
 
@@ -113,6 +185,7 @@ async function getAccounts(): Promise<AccountEntity[]> {
         balance_limit: dbAccount.balance_limit ?? null,
         account_sync_source: dbAccount.account_sync_source ?? null,
         last_sync: dbAccount.last_sync ?? null,
+        bank_sync_status: dbAccount.bank_sync_status ?? null,
       }) satisfies AccountEntity,
   );
 }
@@ -866,7 +939,11 @@ async function handleSyncResponse(
   }
 
   const ts = new Date().getTime().toString();
-  await db.update('accounts', { id: acctId, last_sync: ts });
+  await db.update('accounts', {
+    id: acctId,
+    last_sync: ts,
+    bank_sync_status: 'ok',
+  });
 
   return {
     newTransactions,
@@ -946,6 +1023,27 @@ function handleSyncError(
   };
 }
 
+function getBankSyncStatusFromError(
+  err: Error | PostError | BankSyncError,
+): BankSyncStatus {
+  if (isBankSyncError(err)) {
+    if (
+      (err.category === 'ITEM_ERROR' && err.code === 'ITEM_LOGIN_REQUIRED') ||
+      (err.category === 'INVALID_INPUT' &&
+        err.code === 'INVALID_ACCESS_TOKEN') ||
+      err.category === 'INVALID_ACCESS_TOKEN'
+    ) {
+      return 'reauth-required';
+    }
+
+    if (err.category === 'ACCOUNT_NEEDS_ATTENTION') {
+      return 'attention-required';
+    }
+  }
+
+  return 'attention-required';
+}
+
 export type SyncResponseWithErrors = SyncResponse & {
   errors: SyncError[];
 };
@@ -975,10 +1073,25 @@ async function accountsBankSync({
   const newTransactions: Array<TransactionEntity['id']> = [];
   const matchedTransactions: Array<TransactionEntity['id']> = [];
   const updatedAccounts: Array<AccountEntity['id']> = [];
+  let hasAccountUpdates = false;
 
   for (const acct of accounts) {
+    if (acct.account_sync_source === 'external') {
+      continue;
+    }
+
     if (acct.bankId && acct.account_id) {
       try {
+        await db.update('accounts', {
+          id: acct.id,
+          bank_sync_status: 'pending',
+        });
+        connection.send('sync-event', {
+          type: 'success',
+          tables: ['accounts'],
+        });
+        hasAccountUpdates = true;
+
         logger.group('Bank Sync operation for account:', acct.name);
         const syncResponse = await bankSync.syncAccount(
           userId as string,
@@ -996,23 +1109,39 @@ async function accountsBankSync({
         newTransactions.push(...syncResponseData.newTransactions);
         matchedTransactions.push(...syncResponseData.matchedTransactions);
         updatedAccounts.push(...syncResponseData.updatedAccounts);
+        connection.send('sync-event', {
+          type: 'success',
+          tables: ['accounts'],
+        });
       } catch (err) {
         const error = err as Error;
+        await db.update('accounts', {
+          id: acct.id,
+          bank_sync_status: getBankSyncStatusFromError(error),
+        });
         errors.push(handleSyncError(error, acct));
         captureException({
           ...error,
           message: 'Failed syncing account "' + acct.name + '."',
         } as Error);
+        connection.send('sync-event', {
+          type: 'success',
+          tables: ['accounts'],
+        });
+        hasAccountUpdates = true;
       } finally {
         logger.groupEnd();
       }
     }
   }
 
-  if (updatedAccounts.length > 0) {
+  if (updatedAccounts.length > 0 || hasAccountUpdates) {
     connection.send('sync-event', {
       type: 'success',
-      tables: ['transactions'],
+      tables:
+        updatedAccounts.length > 0
+          ? ['transactions', 'accounts']
+          : ['accounts'],
     });
   }
 
@@ -1051,6 +1180,19 @@ async function simpleFinBatchSync({
 
   logger.group('Bank Sync operation for all SimpleFin accounts');
   try {
+    for (const account of accounts) {
+      await db.update('accounts', {
+        id: account.id,
+        bank_sync_status: 'pending',
+      });
+    }
+    if (accounts.length > 0) {
+      connection.send('sync-event', {
+        type: 'success',
+        tables: ['accounts'],
+      });
+    }
+
     const syncResponses: Array<{
       accountId: AccountEntity['id'];
       res: {
@@ -1080,6 +1222,15 @@ async function simpleFinBatchSync({
       const updatedAccounts: Array<AccountEntity['id']> = [];
 
       if (syncResponse.res?.error_code) {
+        await db.update('accounts', {
+          id: account.id,
+          bank_sync_status: getBankSyncStatusFromError({
+            type: 'BankSyncError',
+            reason: 'Failed syncing account "' + account.name + '."',
+            category: syncResponse.res.error_type,
+            code: syncResponse.res.error_code,
+          } as BankSyncError),
+        });
         errors.push(
           handleSyncError(
             {
@@ -1101,6 +1252,10 @@ async function simpleFinBatchSync({
         matchedTransactions.push(...syncResponseData.matchedTransactions);
         updatedAccounts.push(...syncResponseData.updatedAccounts);
       } else {
+        await db.update('accounts', {
+          id: account.id,
+          bank_sync_status: 'attention-required',
+        });
         errors.push(
           handleSyncError(
             new Error(
@@ -1119,6 +1274,10 @@ async function simpleFinBatchSync({
   } catch (err) {
     for (const account of accounts) {
       const error = err as Error;
+      await db.update('accounts', {
+        id: account.id,
+        bank_sync_status: getBankSyncStatusFromError(error),
+      });
       retVal.push({
         accountId: account.id,
         res: {
@@ -1134,7 +1293,12 @@ async function simpleFinBatchSync({
   if (retVal.some(a => a.res.updatedAccounts.length > 0)) {
     connection.send('sync-event', {
       type: 'success',
-      tables: ['transactions'],
+      tables: ['transactions', 'accounts'],
+    });
+  } else if (accounts.length > 0) {
+    connection.send('sync-event', {
+      type: 'success',
+      tables: ['accounts'],
     });
   }
 
@@ -1221,6 +1385,7 @@ async function unlinkAccount({ id }: { id: AccountEntity['id'] }) {
     balance_available: null,
     balance_limit: null,
     account_sync_source: null,
+    bank_sync_status: null,
   });
 
   if (isGoCardless === false) {

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -120,20 +120,7 @@ async function updateAccount(
       bank_sync_status: null,
     });
   } else if (hasField('account_sync_source') && account_sync_source == null) {
-    const accRow = await db.first<db.DbAccount>(
-      'SELECT * FROM accounts WHERE id = ?',
-      [id],
-    );
-
-    if (!accRow) {
-      throw new Error(`Account with ID ${id} not found.`);
-    }
-
-    if (accRow.account_sync_source !== 'external') {
-      throw new Error(`Account with ID ${id} is not externally linked.`);
-    }
-
-    await unlinkAccount({ id });
+    throw new Error('Use account-unlink to unlink an account.');
   }
 
   const accountUpdate: Partial<AccountEntity> & { id: AccountEntity['id'] } = {
@@ -153,6 +140,9 @@ async function updateAccount(
   }
   if (hasField('closed')) {
     accountUpdate.closed = params.closed;
+  }
+  if (hasField('bank_sync_status')) {
+    accountUpdate.bank_sync_status = params.bank_sync_status ?? null;
   }
 
   if (Object.keys(accountUpdate).length > 1) {
@@ -1077,6 +1067,17 @@ async function accountsBankSync({
 
   for (const acct of accounts) {
     if (acct.account_sync_source === 'external') {
+      if (acct.bankId && acct.account_id) {
+        await db.update('accounts', {
+          id: acct.id,
+          bank_sync_status: 'sync-requested',
+        });
+        connection.send('sync-event', {
+          type: 'success',
+          tables: ['accounts'],
+        });
+        hasAccountUpdates = true;
+      }
       continue;
     }
 

--- a/packages/loot-core/src/server/api-models.ts
+++ b/packages/loot-core/src/server/api-models.ts
@@ -1,6 +1,7 @@
 import type { Budget } from '#types/budget';
 import type {
   AccountEntity,
+  AccountSyncSource,
   CategoryEntity,
   CategoryGroupEntity,
   PayeeEntity,
@@ -14,7 +15,17 @@ import * as models from './models';
 export type APIAccountEntity = Pick<AccountEntity, 'id' | 'name'> & {
   offbudget?: boolean;
   closed?: boolean;
+  account_id?: string | null;
+  bank_id?: string | null;
+  bank_name?: string | null;
+  mask?: string | null;
+  official_name?: string | null;
   balance_current?: number | null;
+  balance_available?: number | null;
+  balance_limit?: number | null;
+  account_sync_source?: AccountSyncSource | null;
+  last_sync?: string | null;
+  bank_sync_status?: AccountEntity['bank_sync_status'] | null;
 };
 
 export const accountModel = {
@@ -26,12 +37,23 @@ export const accountModel = {
       name: account.name,
       offbudget: account.offbudget ? true : false,
       closed: account.closed ? true : false,
+      account_id: account.account_id ?? null,
+      bank_id: account.bankId ?? null,
+      bank_name: account.bankName ?? null,
+      mask: account.mask ?? null,
+      official_name: account.official_name ?? null,
       balance_current: account.balance_current ?? null,
+      balance_available: account.balance_available ?? null,
+      balance_limit: account.balance_limit ?? null,
+      account_sync_source: account.account_sync_source ?? null,
+      last_sync: account.last_sync ?? null,
+      bank_sync_status: account.bank_sync_status ?? null,
     };
   },
 
-  fromExternal(account: APIAccountEntity) {
-    const result = { ...account } as unknown as AccountEntity;
+  fromExternal(account: Partial<APIAccountEntity>) {
+    const { bank_id: _bankId, bank_name: _bankName, ...apiAccount } = account;
+    const result = { ...apiAccount } as unknown as AccountEntity;
     if ('offbudget' in account) {
       result.offbudget = account.offbudget ? 1 : 0;
     }

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -593,8 +593,13 @@ handlers['api/account-create'] = withMutation(async function ({
 
 handlers['api/account-update'] = withMutation(async function ({ id, fields }) {
   checkFileOpen();
-  // @ts-expect-error - fix me
-  return db.updateAccount({ id, ...accountModel.fromExternal(fields) });
+  const { bank_id, bank_name, ...accountFieldsInput } = fields;
+  await handlers['account-update']({
+    id,
+    ...accountModel.fromExternal(accountFieldsInput),
+    bankName: bank_name,
+    bankId: bank_id ?? null,
+  });
 });
 
 handlers['api/account-close'] = withMutation(async function ({

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -602,6 +602,11 @@ handlers['api/account-update'] = withMutation(async function ({ id, fields }) {
   });
 });
 
+handlers['api/account-unlink'] = withMutation(async function ({ id }) {
+  checkFileOpen();
+  await handlers['account-unlink']({ id });
+});
+
 handlers['api/account-close'] = withMutation(async function ({
   id,
   transferAccountId,

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -77,6 +77,7 @@ export const schema = {
     account_sync_source: f('string'),
     last_reconciled: f('string'),
     last_sync: f('string'),
+    bank_sync_status: f('string'),
   },
   categories: {
     id: f('id'),

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -717,10 +717,10 @@ export function getAccounts() {
   return all<
     DbAccount & {
       bankName: DbBank['name'];
-      bankId: DbBank['id'];
+      bankId: DbBank['bank_id'];
     }
   >(
-    `SELECT a.*, b.name as bankName, b.id as bankId FROM accounts a
+    `SELECT a.*, b.name as bankName, b.bank_id as bankId FROM accounts a
        LEFT JOIN banks b ON a.bank = b.id
        WHERE a.tombstone = 0
        ORDER BY sort_order, name`,

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -32,6 +32,7 @@ export type DbAccount = {
   bank_sync_status?:
     | 'ok'
     | 'pending'
+    | 'sync-requested'
     | 'reauth-required'
     | 'attention-required'
     | null;

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -21,9 +21,20 @@ export type DbAccount = {
   type?: string | null;
   subtype?: string | null;
   bank?: string | null;
-  account_sync_source?: 'simpleFin' | 'goCardless' | null;
+  account_sync_source?:
+    | 'simpleFin'
+    | 'goCardless'
+    | 'pluggyai'
+    | 'external'
+    | null;
   last_reconciled?: string | null;
   last_sync?: string | null;
+  bank_sync_status?:
+    | 'ok'
+    | 'pending'
+    | 'reauth-required'
+    | 'attention-required'
+    | null;
 };
 
 export type DbBank = {

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -33,6 +33,7 @@ export type DbAccount = {
     | 'ok'
     | 'pending'
     | 'sync-requested'
+    | 'failed'
     | 'reauth-required'
     | 'attention-required'
     | null;

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -186,6 +186,65 @@ type DataMap = Map<string, unknown>;
 type SyncListener = (oldData: DataMap, newData: DataMap) => unknown;
 let _syncListeners: SyncListener[] = [];
 
+function getRowsById<T extends { id: string }>(value: unknown) {
+  if (!(value instanceof Map)) {
+    return new Map<string, T>();
+  }
+
+  return new Map(
+    Array.from(value.entries()).filter(
+      (entry): entry is [string, T] =>
+        typeof entry[1] === 'object' &&
+        entry[1] !== null &&
+        'id' in entry[1] &&
+        typeof entry[1].id === 'string',
+    ),
+  );
+}
+
+export function getUpdatedAccountIdsForAppliedMessages(
+  messages: Message[],
+  oldData: DataMap,
+) {
+  const previousTransactionsById = getRowsById<{ id: string }>(
+    oldData.get('transactions'),
+  );
+  const accountsSyncing = new Set<string>();
+  const updatedAccountIds = new Set<string>();
+  const isSyncWindowStatus = (value: unknown) =>
+    value === 'pending' || value === 'sync-requested';
+
+  for (const message of messages) {
+    if (message.old) {
+      continue;
+    }
+
+    if (
+      message.dataset === 'accounts' &&
+      message.column === 'bank_sync_status'
+    ) {
+      if (isSyncWindowStatus(message.value)) {
+        accountsSyncing.add(message.row);
+      } else {
+        accountsSyncing.delete(message.row);
+      }
+      continue;
+    }
+
+    if (
+      message.dataset === 'transactions' &&
+      message.column === 'acct' &&
+      typeof message.value === 'string' &&
+      !previousTransactionsById.has(message.row) &&
+      accountsSyncing.has(message.value)
+    ) {
+      updatedAccountIds.add(message.value);
+    }
+  }
+
+  return Array.from(updatedAccountIds);
+}
+
 export function addSyncListener(func: SyncListener) {
   _syncListeners.push(func);
 
@@ -434,11 +493,21 @@ export const applyMessages = sequential(async (messages: Message[]) => {
   _syncListeners.forEach(func => func(oldData, newData));
 
   const tables = getTablesFromMessages(messages.filter(msg => !msg.old));
+  const updatedAccountIds = getUpdatedAccountIdsForAppliedMessages(
+    messages,
+    oldData,
+  );
   app.events.emit('sync', {
     type: 'applied',
     tables,
     data: newData,
     prevData: oldData,
+    meta:
+      updatedAccountIds.length > 0
+        ? {
+            updatedAccountIds,
+          }
+        : undefined,
   });
 
   return messages;

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -9,7 +9,13 @@ import * as mockSyncServer from '#server/tests/mockSyncServer';
 import * as encoder from './encoder';
 import { isError } from './utils';
 
-import { applyMessages, fullSync, sendMessages, setSyncingMode } from './index';
+import {
+  applyMessages,
+  fullSync,
+  getUpdatedAccountIdsForAppliedMessages,
+  sendMessages,
+  setSyncingMode,
+} from './index';
 
 beforeEach(() => {
   mockSyncServer.reset();
@@ -20,6 +26,121 @@ beforeEach(() => {
 afterEach(() => {
   global.resetTime();
   setSyncingMode('disabled');
+});
+
+describe('getUpdatedAccountIdsForAppliedMessages', () => {
+  it('marks newly added transactions while bank sync is pending', () => {
+    expect(
+      getUpdatedAccountIdsForAppliedMessages(
+        [
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'pending',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:01.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'transactions',
+            row: 'tx-1',
+            column: 'acct',
+            value: 'acct-1',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:02.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'ok',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:03.000Z-0000-0000testinguuid1',
+            ),
+          },
+        ],
+        new Map([
+          ['transactions', new Map([['tx-existing', { id: 'tx-existing' }]])],
+        ]),
+      ),
+    ).toEqual(['acct-1']);
+  });
+
+  it('marks newly added transactions while external sync is requested', () => {
+    expect(
+      getUpdatedAccountIdsForAppliedMessages(
+        [
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'sync-requested',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:01.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'transactions',
+            row: 'tx-1',
+            column: 'acct',
+            value: 'acct-1',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:02.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'ok',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:03.000Z-0000-0000testinguuid1',
+            ),
+          },
+        ],
+        new Map(),
+      ),
+    ).toEqual(['acct-1']);
+  });
+
+  it('does not mark transactions added after pending has cleared', () => {
+    expect(
+      getUpdatedAccountIdsForAppliedMessages(
+        [
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'pending',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:01.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'accounts',
+            row: 'acct-1',
+            column: 'bank_sync_status',
+            value: 'ok',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:02.000Z-0000-0000testinguuid1',
+            ),
+          },
+          {
+            dataset: 'transactions',
+            row: 'tx-1',
+            column: 'acct',
+            value: 'acct-1',
+            timestamp: Timestamp.parse(
+              '1970-01-01T00:00:03.000Z-0000-0000testinguuid1',
+            ),
+          },
+        ],
+        new Map(),
+      ),
+    ).toEqual([]);
+  });
 });
 
 describe('Sync', () => {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -147,6 +147,8 @@ export type ApiHandlers = {
     fields: Partial<APIAccountEntity>;
   }) => Promise<void>;
 
+  'api/account-unlink': (arg: { id: APIAccountEntity['id'] }) => Promise<void>;
+
   'api/account-close': (arg: {
     id: APIAccountEntity['id'];
     transferAccountId?: APIAccountEntity['id'];

--- a/packages/loot-core/src/types/models/account.ts
+++ b/packages/loot-core/src/types/models/account.ts
@@ -31,5 +31,6 @@ export type AccountSyncSource =
 export type BankSyncStatus =
   | 'ok'
   | 'pending'
+  | 'sync-requested'
   | 'reauth-required'
   | 'attention-required';

--- a/packages/loot-core/src/types/models/account.ts
+++ b/packages/loot-core/src/types/models/account.ts
@@ -32,5 +32,6 @@ export type BankSyncStatus =
   | 'ok'
   | 'pending'
   | 'sync-requested'
+  | 'failed'
   | 'reauth-required'
   | 'attention-required';

--- a/packages/loot-core/src/types/models/account.ts
+++ b/packages/loot-core/src/types/models/account.ts
@@ -19,6 +19,17 @@ export type AccountEntity = {
   balance_limit: number | null;
   account_sync_source: AccountSyncSource | null;
   last_sync: string | null;
+  bank_sync_status: BankSyncStatus | null;
 };
 
-export type AccountSyncSource = 'simpleFin' | 'goCardless' | 'pluggyai';
+export type AccountSyncSource =
+  | 'simpleFin'
+  | 'goCardless'
+  | 'pluggyai'
+  | 'external';
+
+export type BankSyncStatus =
+  | 'ok'
+  | 'pending'
+  | 'reauth-required'
+  | 'attention-required';

--- a/upcoming-release-notes/7782.md
+++ b/upcoming-release-notes/7782.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [jcam,openai]
+---
+
+Extend accounts API for external sync, persist bank sync status

--- a/upcoming-release-notes/7782.md
+++ b/upcoming-release-notes/7782.md
@@ -1,6 +1,6 @@
 ---
 category: Features
-authors: [jcam,openai]
+authors: [jcam, openai]
 ---
 
 Extend accounts API for external sync, persist bank sync status


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

- Extends the accounts APIs to include all the bank sync fields
- Shifts the bank sync status to be a persisted item in the DB and wires up everything so that pending/failed is propagated through all connected desktop/mobile clients (as well as API clients like my sync system, or future plugins if they end up getting tied in as separate docker containers)
- You can request a bank sync through the actual UI and an external/plugin sync system can be triggered by it
- Even updates the bolding/color change to show that there are new transactions after a sync completes :)

** Utilized codex for most of the work, with significant review/cleanup by me/re-prompting


## Related issue(s)

#7735

## Testing

lots of new test cases, dozens of rounds of rebuilding and tying in and watching sync messages

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.94 MB (+2.21 kB) | +0.02%
loot-core | 1 | 5.27 MB → 5.28 MB (+6.58 kB) | +0.12%
api | 2 | 3.9 MB → 3.9 MB (+6.58 kB) | +0.16%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.94 MB (+2.21 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/usePendingSyncPolling.ts` | 🆕 +667 B | 0 B → 667 B
`src/accounts/syncStatus.ts` | 🆕 +498 B | 0 B → 498 B
`src/components/BankSyncStatus.tsx` | 📈 +668 B (+29.38%) | 2.22 kB → 2.87 kB
`src/components/App.tsx` | 📈 +1.11 kB (+13.40%) | 8.28 kB → 9.39 kB
`src/components/banksync/AccountRow.tsx` | 📈 +477 B (+10.50%) | 4.44 kB → 4.9 kB
`src/sync-events.ts` | 📈 +411 B (+5.05%) | 7.95 kB → 8.35 kB
`src/components/banksync/bankSyncUtils.ts` | 📈 +52 B (+3.54%) | 1.44 kB → 1.49 kB
`src/accounts/accountsSlice.ts` | 📈 +21 B (+1.64%) | 1.25 kB → 1.27 kB
`src/components/UpdateNotification.tsx` | 📈 +4 B (+0.07%) | 5.26 kB → 5.27 kB
`src/components/payees/ManagePayees.tsx` | 📈 +2 B (+0.01%) | 15.15 kB → 15.15 kB
`src/components/mobile/budget/BudgetTable.tsx` | 📉 -2 B (-0.01%) | 23.41 kB → 23.41 kB
`src/components/accounts/Account.tsx` | 📉 -156 B (-0.35%) | 44.1 kB → 43.95 kB
`src/accounts/mutations.ts` | 📉 -47 B (-0.36%) | 12.6 kB → 12.55 kB
`src/components/accounts/Header.tsx` | 📉 -216 B (-0.75%) | 28.01 kB → 27.8 kB
`src/components/mobile/accounts/AccountsPage.tsx` | 📉 -306 B (-1.49%) | 20.11 kB → 19.82 kB
`src/components/mobile/accounts/AccountPage.tsx` | 📉 -300 B (-3.23%) | 9.07 kB → 8.78 kB
`src/components/sidebar/Accounts.tsx` | 📉 -647 B (-7.20%) | 8.77 kB → 8.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.93 MB → 1.94 MB (+2.55 kB) | +0.13%
static/js/bankSyncUtils.js | 54.1 kB → 54.37 kB (+285 B) | +0.51%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/narrow.js | 364.41 kB → 363.82 kB (-608 B) | -0.16%
static/js/extends.js | 520.14 kB → 520.11 kB (-26 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.28 MB (+6.58 kB) | +0.12%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +4.41 kB (+20.08%) | 21.96 kB → 26.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +553 B (+14.65%) | 3.69 kB → 4.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.31 kB (+9.09%) | 14.42 kB → 15.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +284 B (+1.21%) | 22.92 kB → 23.2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +34 B (+0.34%) | 9.65 kB → 9.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +5 B (+0.02%) | 20.53 kB → 20.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.naj8F5e5.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CfcE9hoo.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+6.58 kB) | +0.16%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +4.31 kB (+20.15%) | 21.4 kB → 25.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +542 B (+15.03%) | 3.52 kB → 4.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.29 kB (+9.23%) | 13.98 kB → 15.27 kB
`methods.ts` | 📈 +144 B (+2.48%) | 5.67 kB → 5.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +277 B (+1.21%) | 22.31 kB → 22.58 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +33 B (+0.34%) | 9.36 kB → 9.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +5 B (+0.02%) | 20.08 kB → 20.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+6.58 kB) | +0.16%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->