### PR TITLE
automation UI: dry run should show full demand

### DIFF
--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -2,8 +2,10 @@ import { useEffect, useState } from 'react';
 import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
+import { SvgInformationCircle } from '@actual-app/components/icons/v2';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import type {
@@ -255,18 +257,46 @@ export function BudgetAutomationsBody({
           </Text>
         </View>
         <View style={{ textAlign: 'right', flexShrink: 0, minWidth: 220 }}>
-          <Text
+          <View
             style={{
-              fontSize: 11,
-              textTransform: 'uppercase',
-              color: theme.pageTextSubdued,
-              letterSpacing: '0.04em',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              gap: 4,
             }}
           >
-            <Trans>
-              Projected for {{ month: formatMonthLabel(month, locale) }}
-            </Trans>
-          </Text>
+            <Text
+              style={{
+                fontSize: 11,
+                textTransform: 'uppercase',
+                color: theme.pageTextSubdued,
+                letterSpacing: '0.04em',
+              }}
+            >
+              <Trans>
+                Projected for {{ month: formatMonthLabel(month, locale) }}
+              </Trans>
+            </Text>
+            <Tooltip
+              content={
+                <View style={{ maxWidth: 260 }}>
+                  <Trans>
+                    The projection shows the most that these automations could
+                    budget on their own. The actual amount may be smaller when
+                    To Budget is empty or when higher-priority categories run
+                    first.
+                  </Trans>
+                </View>
+              }
+              placement="bottom end"
+            >
+              <SvgInformationCircle
+                width={12}
+                height={12}
+                style={{ color: theme.pageTextSubdued, cursor: 'help' }}
+              />
+            </Tooltip>
+          </View>
           <Text
             style={{
               fontSize: 22,

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/ConflictBanner.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/ConflictBanner.tsx
@@ -1,8 +1,6 @@
-import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
 import { Text } from '@actual-app/components/text';
-import { theme } from '@actual-app/components/theme';
-import { View } from '@actual-app/components/view';
 
+import { Error } from '#components/alerts';
 import {
   GlobalConflictDetail,
   GlobalConflictTitle,
@@ -15,25 +13,20 @@ type ConflictBannerProps = {
 
 export function ConflictBanner({ conflict }: ConflictBannerProps) {
   return (
-    <View
+    <Error
       style={{
-        padding: '8px 22px',
-        backgroundColor: theme.errorBackground,
-        borderBottom: `1px solid ${theme.errorBorder}`,
-        color: theme.errorText,
+        padding: '8px 12px',
+        margin: '12px 24px 0',
         fontSize: 12,
-        flexDirection: 'row',
-        gap: 8,
-        alignItems: 'center',
+        flexShrink: 0,
       }}
     >
-      <SvgAlertTriangle width={14} height={14} style={{ color: 'inherit' }} />
-      <Text style={{ color: 'inherit' }}>
+      <Text>
         <strong>
           <GlobalConflictTitle conflict={conflict} />.
         </strong>{' '}
         <GlobalConflictDetail conflict={conflict} />
       </Text>
-    </View>
+    </Error>
   );
 }

--- a/packages/loot-core/src/server/budget/category-template-context.ts
+++ b/packages/loot-core/src/server/budget/category-template-context.ts
@@ -49,6 +49,7 @@ export class CategoryTemplateContext {
     category: CategoryEntity,
     month: string,
     budgeted: number,
+    skipAvailableClamp: boolean = false,
   ) {
     // get all the needed setup values
     const lastMonthSheet = monthUtils.sheetForMonth(
@@ -96,6 +97,7 @@ export class CategoryTemplateContext {
       hideDecimal.data.length > 0
         ? hideDecimal.data[0].value === 'true'
         : false,
+      skipAvailableClamp,
     );
   }
 
@@ -286,7 +288,12 @@ export class CategoryTemplateContext {
     }
 
     // don't overbudget when using a priority unless income category
-    if (priority > 0 && available < 0 && !this.category.is_income) {
+    if (
+      priority > 0 &&
+      available < 0 &&
+      !this.category.is_income &&
+      !this.skipAvailableClamp
+    ) {
       this.fullAmount = (this.fullAmount || 0) + toBudget;
       const adjusted = Math.max(0, toBudget + available);
       if (toBudget > 0) scale *= adjusted / toBudget;
@@ -383,6 +390,7 @@ export class CategoryTemplateContext {
   private goals: GoalTemplate[] = [];
   private priorities: Set<number> = new Set();
   readonly hideDecimal: boolean = false;
+  readonly skipAvailableClamp: boolean = false;
   private remainderWeight: number = 0;
   private toBudgetAmount: number = 0; // amount that will be budgeted by the templates
   private perTemplateContribution = new Map<Template, number>();
@@ -406,6 +414,7 @@ export class CategoryTemplateContext {
     budgeted: number,
     currencyCode: string,
     hideDecimal: boolean = false,
+    skipAvailableClamp: boolean = false,
   ) {
     this.category = category;
     this.month = month;
@@ -413,6 +422,7 @@ export class CategoryTemplateContext {
     this.previouslyBudgeted = budgeted;
     this.currency = getCurrency(currencyCode);
     this.hideDecimal = hideDecimal;
+    this.skipAvailableClamp = skipAvailableClamp;
     // sort the template lines into regular template, goals, and remainder templates
     if (templates) {
       templates.forEach(t => {

--- a/packages/loot-core/src/server/budget/goal-template.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.test.ts
@@ -74,6 +74,9 @@ function setupAqlForCategoryLookup(cat: CategoryEntity) {
         dependencies: [],
       };
     }
+    if (queryStr.includes('categories')) {
+      return { data: [cat], dependencies: [] };
+    }
     return { data: [], dependencies: [] };
   });
 }
@@ -216,98 +219,39 @@ describe('dryRunCategoryTemplate', () => {
     expect(result).toEqual({ budgeted: 0, perTemplate: [0] });
   });
 
-  it('competes with sibling remainder templates under wide scope', async () => {
-    // Remainder triggers wide scope: the engine must see the sibling so
-    // weights divide the leftover proportionally instead of giving it all
-    // to the target.
-    const sibling: CategoryEntity = {
-      id: 'cat-sibling',
-      name: 'Other',
-      group: 'g1',
-      is_income: false,
-    };
-    setupSheetMock({ 'to-budget': 20000 });
-    setupAqlForWideScope(
-      [
-        {
-          category: sibling,
-          templates: [
-            {
-              type: 'remainder',
-              weight: 1,
-              directive: 'template',
-              priority: null,
-            },
-          ],
-        },
-      ],
-      [category, sibling],
-    );
+  it('ignores sibling contention', async () => {
+    // The reproducer for issue #7692: a per-category dry run shouldn't have
+    // its demand clamped by other categories competing at the same priority,
+    // because applySingleCategoryTemplate (the per-category apply button)
+    // doesn't include them either.
+    setupSheetMock({ 'to-budget': 500000 });
+    setupAqlForCategoryLookup(category);
 
     const templates: Template[] = [
       {
-        type: 'remainder',
-        weight: 3,
+        type: 'periodic',
+        amount: 1800,
+        period: { period: 'month', amount: 1 },
+        starting: '2026-05-01',
         directive: 'template',
-        priority: null,
+        priority: 150,
       },
-    ];
-    const result = await dryRunCategoryTemplate({
-      month: '2024-01',
-      categoryId: category.id,
-      templates,
-    });
-    expect(result.budgeted).toBe(15000);
-    expect(result.perTemplate).toEqual([15000]);
-  });
-
-  it('reads availBudget consumed by siblings for percentage of available funds', async () => {
-    // Sibling at priority 1 spends $50 of $200 first, leaving $150. The
-    // target's 50%-of-available-funds at priority 2 should then resolve to
-    // $75, not the $100 a narrow-scope run would produce.
-    const sibling: CategoryEntity = {
-      id: 'cat-sibling',
-      name: 'Other',
-      group: 'g1',
-      is_income: false,
-    };
-    setupSheetMock({ 'to-budget': 20000 });
-    setupAqlForWideScope(
-      [
-        {
-          category: sibling,
-          templates: [
-            {
-              type: 'periodic',
-              amount: 50,
-              period: { period: 'month', amount: 1 },
-              starting: '2024-01-01',
-              directive: 'template',
-              priority: 1,
-            },
-          ],
-        },
-      ],
-      [sibling, category],
-    );
-
-    const templates: Template[] = [
       {
-        type: 'percentage',
-        percent: 50,
-        previous: false,
-        category: 'available funds',
+        type: 'periodic',
+        amount: 3200,
+        period: { period: 'month', amount: 3 },
+        starting: '2026-06-01',
         directive: 'template',
-        priority: 2,
+        priority: 150,
       },
     ];
     const result = await dryRunCategoryTemplate({
-      month: '2024-01',
+      month: '2026-06',
       categoryId: category.id,
       templates,
     });
-    expect(result.budgeted).toBe(7500);
-    expect(result.perTemplate).toEqual([7500]);
+    expect(result.budgeted).toBe(500000);
+    expect(result.perTemplate).toEqual([180000, 320000]);
   });
 });
 

--- a/packages/loot-core/src/server/budget/goal-template.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.test.ts
@@ -219,12 +219,12 @@ describe('dryRunCategoryTemplate', () => {
     expect(result).toEqual({ budgeted: 0, perTemplate: [0] });
   });
 
-  it('ignores sibling contention', async () => {
-    // The reproducer for issue #7692: a per-category dry run shouldn't have
-    // its demand clamped by other categories competing at the same priority,
-    // because applySingleCategoryTemplate (the per-category apply button)
-    // doesn't include them either.
-    setupSheetMock({ 'to-budget': 500000 });
+  it('shows full demand even when To Budget cannot cover it', async () => {
+    // With priority>0 and a constrained To Budget, the engine clamps the
+    // actual budgeted amount to fit. The dry run should still report the
+    // templates' full demand so the user sees what the rules want, not
+    // what would survive clamping.
+    setupSheetMock({ 'to-budget': 5000 });
     setupAqlForCategoryLookup(category);
 
     const templates: Template[] = [

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -359,19 +359,20 @@ export async function dryRunCategoryTemplate({
   categoryId: CategoryEntity['id'];
   templates: Template[];
 }): Promise<DryRunCategoryResult> {
-  // Always run the full set of saved category templates and override the
-  // target's saved templates with the in-flight ones. Sibling categories
-  // consume from To Budget at each priority; running them too keeps the
-  // projection in sync with what an actual apply would produce — including
-  // the constrained-budget case where prior categories at the same priority
-  // exhaust the pool and clamp this category's amount.
-  const allCategoryTemplates = await getTemplates();
-  allCategoryTemplates[categoryId] = templates;
+  // Mirror applySingleCategoryTemplate: only this category competes for
+  // To Budget, so the projection isn't clamped to 0 in months without
+  // available funds.
+  const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
+    q('categories').filter({ id: categoryId }).select('*'),
+  );
+  if (categoryData.length === 0) {
+    return { budgeted: 0, perTemplate: templates.map(() => 0) };
+  }
   const { contexts } = await computeTemplates(
     month,
     true,
-    allCategoryTemplates,
-    [],
+    { [categoryId]: templates },
+    categoryData,
   );
   const ctx = contexts.find(c => c.category.id === categoryId);
   if (!ctx) return { budgeted: 0, perTemplate: templates.map(() => 0) };

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -214,6 +214,7 @@ async function computeTemplates(
   force: boolean,
   categoryTemplates: Record<CategoryEntity['id'], Template[]>,
   categories: CategoryEntity[] = [],
+  skipAvailableClamp: boolean = false,
 ): Promise<ComputedTemplates> {
   // setup categories
   const isTracking = isTrackingBudget();
@@ -247,6 +248,7 @@ async function computeTemplates(
           category,
           month,
           budgeted,
+          skipAvailableClamp,
         );
         // don't use the funds that are not from templates
         if (!templateContext.isGoalOnly()) {
@@ -359,9 +361,9 @@ export async function dryRunCategoryTemplate({
   categoryId: CategoryEntity['id'];
   templates: Template[];
 }): Promise<DryRunCategoryResult> {
-  // Mirror applySingleCategoryTemplate: only this category competes for
-  // To Budget, so the projection isn't clamped to 0 in months without
-  // available funds.
+  // The projection answers "how much do these templates demand" — it
+  // skips the priority clamp so future months (where To Budget is empty)
+  // still show the templates' intended amount instead of 0.
   const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
     q('categories').filter({ id: categoryId }).select('*'),
   );
@@ -373,6 +375,7 @@ export async function dryRunCategoryTemplate({
     true,
     { [categoryId]: templates },
     categoryData,
+    true,
   );
   const ctx = contexts.find(c => c.category.id === categoryId);
   if (!ctx) return { budgeted: 0, perTemplate: templates.map(() => 0) };

--- a/upcoming-release-notes/7790.md
+++ b/upcoming-release-notes/7790.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: change dry run logic to only run on a single category


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Addresses:
https://github.com/actualbudget/actual/issues/7692#issuecomment-4419719566

Also fixes some inconsistent error/warning styling I saw

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.93 MB → 13.94 MB (+1.02 kB) | +0.01%
loot-core | 1 | 5.27 MB → 5.27 MB (+385 B) | +0.01%
api | 2 | 3.9 MB → 3.9 MB (+359 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.93 MB → 13.94 MB (+1.02 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/component-library/src/icons/v2/InformationCircle.tsx` | 🆕 +652 B | 0 B → 652 B
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +921 B (+9.46%) | 9.51 kB → 10.41 kB
`src/components/modals/BudgetAutomationsModal/ConflictBanner.tsx` | 📉 -531 B (-32.22%) | 1.61 kB → 1.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.94 MB → 4.94 MB (+652 B) | +0.01%
static/js/index.js | 1.93 MB → 1.93 MB (+390 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 145.76 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/alerts.js | 800.08 kB | 0%
static/js/bankSyncUtils.js | 54.1 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.14 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/narrow.js | 364.41 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.27 MB (+385 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +177 B (+2.53%) | 6.83 kB → 7.01 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +208 B (+0.98%) | 20.74 kB → 20.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.3TTsQ_Cs.js | 0 B → 5.27 MB (+5.27 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CfcE9hoo.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+359 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +178 B (+2.61%) | 6.67 kB → 6.84 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +181 B (+0.89%) | 19.78 kB → 19.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+359 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->