### PR TITLE
automation UI: add options section to sidebar

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
+++ b/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
@@ -65,7 +65,9 @@ export function getDisplayTemplateMeta(
     case 'limit':
       return {
         label: t('Balance cap'),
-        description: t('Never let the category balance exceed a cap.'),
+        description: t(
+          'Stop budgeting to this category once the balance reaches a cap.',
+        ),
         icon: SvgEquals,
       };
     case 'refill':

--- a/packages/desktop-client/src/components/budget/goals/editor/LimitAutomationShort.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LimitAutomationShort.tsx
@@ -1,0 +1,31 @@
+import { Trans } from 'react-i18next';
+
+import { amountToInteger } from '@actual-app/core/shared/util';
+import type { LimitTemplate } from '@actual-app/core/types/models/templates';
+
+import { useFormat } from '#hooks/useFormat';
+
+type LimitAutomationShortProps = {
+  template: LimitTemplate;
+};
+
+export const LimitAutomationShort = ({
+  template,
+}: LimitAutomationShortProps) => {
+  const format = useFormat();
+  const amount = format(
+    amountToInteger(template.amount, format.currency.decimalPlaces),
+    'financial',
+  );
+
+  switch (template.period) {
+    case 'daily':
+      return <Trans>{{ amount }} / day</Trans>;
+    case 'weekly':
+      return <Trans>{{ amount }} / week</Trans>;
+    case 'monthly':
+      return <Trans>{{ amount }} / month</Trans>;
+    default:
+      return null;
+  }
+};

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -20,6 +20,7 @@ import {
   AutomationErrorTitle,
 } from '#components/budget/goals/automationMessages';
 import type { DisplayTemplateType } from '#components/budget/goals/constants';
+import { getDisplayTemplateMeta } from '#components/budget/goals/displayTemplateMeta';
 import {
   getInitialState,
   templateReducer,
@@ -222,6 +223,18 @@ export function AutomationEditorPane({
               border: `1px solid ${theme.tableBorder}`,
             }}
           >
+            {NON_CONTRIBUTION_TYPES.has(state.displayType) && (
+              <Text
+                style={{
+                  fontSize: 12,
+                  color: theme.pageTextSubdued,
+                  display: 'block',
+                  marginBottom: 4,
+                }}
+              >
+                {getDisplayTemplateMeta(state.displayType).description}
+              </Text>
+            )}
             <ActiveEditor
               state={state}
               dispatch={dispatch}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -26,7 +26,7 @@ import {
 } from '#components/budget/goals/reducer';
 import type { AutomationErrorKind } from '#components/budget/goals/validateAutomation';
 
-import { TypePicker } from './TypePicker';
+import { NON_CONTRIBUTION_TYPES, TypePicker } from './TypePicker';
 
 const CONFIG_PANEL_CLASS = css({
   '& > *:first-child': {
@@ -179,22 +179,26 @@ export function AutomationEditorPane({
         </View>
       )}
 
-      <Text
-        style={{
-          fontSize: 11,
-          textTransform: 'uppercase',
-          color: theme.pageTextSubdued,
-          fontWeight: 600,
-          letterSpacing: '0.05em',
-        }}
-      >
-        <Trans>Automation type</Trans>
-      </Text>
-      <TypePicker
-        active={state.displayType}
-        disabledTypes={disabledTypes}
-        onPick={type => dispatch({ type: 'set-type', payload: type })}
-      />
+      {!NON_CONTRIBUTION_TYPES.has(state.displayType) && (
+        <>
+          <Text
+            style={{
+              fontSize: 11,
+              textTransform: 'uppercase',
+              color: theme.pageTextSubdued,
+              fontWeight: 600,
+              letterSpacing: '0.05em',
+            }}
+          >
+            <Trans>Automation type</Trans>
+          </Text>
+          <TypePicker
+            active={state.displayType}
+            disabledTypes={disabledTypes}
+            onPick={type => dispatch({ type: 'set-type', payload: type })}
+          />
+        </>
+      )}
 
       {state.displayType !== 'refill' && (
         <>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
@@ -8,9 +8,12 @@ import { View } from '@actual-app/components/view';
 import type { AutomationEntry } from '#components/budget/goals/automationExamples';
 import { AutomationErrorShort } from '#components/budget/goals/automationMessages';
 import { getDisplayTemplateMeta } from '#components/budget/goals/displayTemplateMeta';
+import { LimitAutomationShort } from '#components/budget/goals/editor/LimitAutomationShort';
 import { TemplateSentence } from '#components/budget/goals/TemplateSentence';
 import type { AutomationErrorKind } from '#components/budget/goals/validateAutomation';
 import { useFormat } from '#hooks/useFormat';
+
+import { NON_CONTRIBUTION_TYPES } from './TypePicker';
 
 type AutomationListRowProps = {
   index: number;
@@ -38,6 +41,8 @@ export function AutomationListRow({
 
   const subtitle = error ? (
     <AutomationErrorShort error={error} />
+  ) : entry.template.type === 'limit' ? (
+    <LimitAutomationShort template={entry.template} />
   ) : (
     <TemplateSentence
       template={entry.template}
@@ -135,45 +140,47 @@ export function AutomationListRow({
           {subtitle}
         </Text>
       </View>
-      <View
-        style={{
-          flexShrink: 0,
-          alignItems: 'flex-end',
-          gap: 2,
-        }}
-      >
-        <Text
+      {!NON_CONTRIBUTION_TYPES.has(entry.displayType) && (
+        <View
           style={{
-            fontSize: 12,
-            fontWeight: 600,
-            fontVariantNumeric: 'tabular-nums',
-            color:
-              contribution == null ||
-              Number.isNaN(contribution) ||
-              contribution === 0
-                ? theme.pageTextSubdued
-                : theme.pageText,
+            flexShrink: 0,
+            alignItems: 'flex-end',
+            gap: 2,
           }}
         >
-          {contribution == null || Number.isNaN(contribution)
-            ? '—'
-            : contribution > 0
-              ? '+' + format(contribution, 'financial')
-              : format(contribution, 'financial')}
-        </Text>
-        {priority != null && (
           <Text
             style={{
-              fontSize: 10,
-              color: theme.pageTextSubdued,
+              fontSize: 12,
+              fontWeight: 600,
               fontVariantNumeric: 'tabular-nums',
-              letterSpacing: '0.04em',
+              color:
+                contribution == null ||
+                Number.isNaN(contribution) ||
+                contribution === 0
+                  ? theme.pageTextSubdued
+                  : theme.pageText,
             }}
           >
-            {t('Priority: {{priority}}', { priority })}
+            {contribution == null || Number.isNaN(contribution)
+              ? '—'
+              : contribution > 0
+                ? '+' + format(contribution, 'financial')
+                : format(contribution, 'financial')}
           </Text>
-        )}
-      </View>
+          {priority != null && (
+            <Text
+              style={{
+                fontSize: 10,
+                color: theme.pageTextSubdued,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '0.04em',
+              }}
+            >
+              {t('Priority: {{priority}}', { priority })}
+            </Text>
+          )}
+        </View>
+      )}
     </View>
   );
 }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -52,6 +53,82 @@ const ALWAYS_SCROLL_CLASS = css({
     backgroundColor: theme.tableBorder,
   },
 });
+
+function SidebarSectionHeader({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <View
+      style={{
+        flexShrink: 0,
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '6px 8px',
+        fontSize: 11,
+        textTransform: 'uppercase',
+        color: theme.pageTextSubdued,
+        fontWeight: 600,
+        letterSpacing: '0.05em',
+        ...style,
+      }}
+    >
+      <Text>{children}</Text>
+    </View>
+  );
+}
+
+function SidebarAddButton({
+  onPress,
+  children,
+}: {
+  onPress: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Button
+      variant="bare"
+      onPress={onPress}
+      style={{
+        flexShrink: 0,
+        width: '100%',
+        marginTop: 8,
+        padding: 10,
+        border: `1px dashed ${theme.tableBorder}`,
+        borderRadius: 6,
+        color: theme.pageTextPositive,
+        fontWeight: 600,
+        fontSize: 12,
+        justifyContent: 'center',
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+
+function SidebarPlaceholderRow({ children }: { children: ReactNode }) {
+  return (
+    <View
+      style={{
+        flexShrink: 0,
+        padding: '8px 10px',
+        marginTop: 4,
+        borderRadius: 6,
+        border: `1px dashed ${theme.tableBorder}`,
+        color: theme.pageTextSubdued,
+        fontSize: 12,
+        opacity: 0.6,
+      }}
+    >
+      <Text>{children}</Text>
+    </View>
+  );
+}
 
 type BudgetAutomationsBodyProps = {
   categoryId: string;
@@ -111,8 +188,11 @@ export function BudgetAutomationsBody({
       },
       'limit',
     );
-    setEntries(prev => [entry, ...prev]);
-    setActiveIdx(0);
+    setEntries(prev => {
+      const next = [...prev, entry];
+      setActiveIdx(next.length - 1);
+      return next;
+    });
   };
 
   const onDelete = (index: number) => {
@@ -225,6 +305,14 @@ export function BudgetAutomationsBody({
 
   const hasLimitAutomation = entries.some(e => e.displayType === 'limit');
 
+  const indexedEntries = entries.map((entry, idx) => ({ entry, idx }));
+  const contributionEntries = indexedEntries.filter(
+    ({ entry }) => entry.displayType !== 'limit',
+  );
+  const constraintEntries = indexedEntries.filter(
+    ({ entry }) => entry.displayType === 'limit',
+  );
+
   const safeActiveIdx = Math.min(activeIdx, Math.max(0, entries.length - 1));
 
   return (
@@ -307,53 +395,51 @@ export function BudgetAutomationsBody({
             overflowY: 'scroll',
           }}
         >
-          <View
-            style={{
-              flexShrink: 0,
-              flexDirection: 'row',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              padding: '6px 8px',
-              fontSize: 11,
-              textTransform: 'uppercase',
-              color: theme.pageTextSubdued,
-              fontWeight: 600,
-              letterSpacing: '0.05em',
-            }}
-          >
-            <Text>
-              <Trans>Automations</Trans>
-            </Text>
-          </View>
-          {entries.map((entry, i) => (
+          <SidebarSectionHeader>
+            <Trans>Automations</Trans>
+          </SidebarSectionHeader>
+          {contributionEntries.map(({ entry, idx }) => (
             <AutomationListRow
               key={entry.id}
-              index={i}
+              index={idx}
               entry={entry}
-              isActive={i === safeActiveIdx}
-              error={automationErrors[i]}
-              contribution={contributions[i]}
+              isActive={idx === safeActiveIdx}
+              error={automationErrors[idx]}
+              contribution={contributions[idx]}
               categoryNameMap={categoryNameMap}
               onSelect={setActiveIdx}
             />
           ))}
-          <Button
-            variant="bare"
-            onPress={() => onAddAutomation()}
-            style={{
-              width: '100%',
-              marginTop: 8,
-              padding: 10,
-              border: `1px dashed ${theme.tableBorder}`,
-              borderRadius: 6,
-              color: theme.pageTextPositive,
-              fontWeight: 600,
-              fontSize: 12,
-              justifyContent: 'center',
-            }}
-          >
+          <SidebarAddButton onPress={() => onAddAutomation()}>
             + <Trans>Add an automation</Trans>
-          </Button>
+          </SidebarAddButton>
+
+          <SidebarSectionHeader style={{ marginTop: 16 }}>
+            <Trans>Options</Trans>
+          </SidebarSectionHeader>
+          {constraintEntries.map(({ entry, idx }) => (
+            <AutomationListRow
+              key={entry.id}
+              index={idx}
+              entry={entry}
+              isActive={idx === safeActiveIdx}
+              error={automationErrors[idx]}
+              contribution={contributions[idx]}
+              categoryNameMap={categoryNameMap}
+              onSelect={setActiveIdx}
+            />
+          ))}
+          {!hasLimitAutomation && (
+            <SidebarAddButton onPress={onAddLimitAutomation}>
+              + <Trans>Add balance cap</Trans>
+            </SidebarAddButton>
+          )}
+          <SidebarPlaceholderRow>
+            <Trans>Long-term goal (coming soon)</Trans>
+          </SidebarPlaceholderRow>
+          <SidebarPlaceholderRow>
+            <Trans>End of month cleanup (coming soon)</Trans>
+          </SidebarPlaceholderRow>
         </View>
 
         <View style={{ flex: 1, minWidth: 0 }}>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
@@ -8,6 +8,12 @@ import { displayTemplateTypes } from '#components/budget/goals/constants';
 import type { DisplayTemplateType } from '#components/budget/goals/constants';
 import { getDisplayTemplateMeta } from '#components/budget/goals/displayTemplateMeta';
 
+// Types managed in the Options sidebar section, not as contribution-type
+// swaps.
+const NON_CONTRIBUTION_TYPES: ReadonlySet<DisplayTemplateType> = new Set([
+  'limit',
+]);
+
 type TypePickerProps = {
   active: DisplayTemplateType;
   disabledTypes: ReadonlySet<DisplayTemplateType>;
@@ -16,9 +22,9 @@ type TypePickerProps = {
 
 export function TypePicker({ active, disabledTypes, onPick }: TypePickerProps) {
   const { t } = useTranslation();
-  const entries = displayTemplateTypes.map(
-    id => [id, getDisplayTemplateMeta(id)] as const,
-  );
+  const entries = displayTemplateTypes
+    .filter(id => !NON_CONTRIBUTION_TYPES.has(id))
+    .map(id => [id, getDisplayTemplateMeta(id)] as const);
   const disabledHint = t('Only one of this type allowed per category');
 
   return (

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
@@ -10,9 +10,9 @@ import { getDisplayTemplateMeta } from '#components/budget/goals/displayTemplate
 
 // Types managed in the Options sidebar section, not as contribution-type
 // swaps.
-const NON_CONTRIBUTION_TYPES: ReadonlySet<DisplayTemplateType> = new Set([
-  'limit',
-]);
+export const NON_CONTRIBUTION_TYPES: ReadonlySet<DisplayTemplateType> = new Set(
+  ['limit'],
+);
 
 type TypePickerProps = {
   active: DisplayTemplateType;

--- a/upcoming-release-notes/7791.md
+++ b/upcoming-release-notes/7791.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: Add options section for one-off settings


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

This is prep for adding cleanup and goal functionality. I've opted for splitting "things that add to the balance" from "things that influence how that happens".

<img width="962" height="763" alt="image" src="https://github.com/user-attachments/assets/8109e4f3-257d-42c6-a3bf-a0ea15e5c159" />

AI disclaimer: claude did some of the legwork here

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.96 MB → 13.97 MB (+5.02 kB) | +0.04%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.96 MB → 13.97 MB (+5.02 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/editor/LimitAutomationShort.tsx` | 🆕 +1.19 kB | 0 B → 1.19 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +3.08 kB (+29.61%) | 10.41 kB → 13.49 kB
`src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx` | 📈 +889 B (+8.89%) | 9.76 kB → 10.63 kB
`src/components/modals/BudgetAutomationsModal/TypePicker.tsx` | 📈 +141 B (+4.41%) | 3.12 kB → 3.26 kB
`src/components/budget/goals/displayTemplateMeta.ts` | 📈 +19 B (+1.28%) | 1.44 kB → 1.46 kB
`src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx` | 📉 -284 B (-4.12%) | 6.73 kB → 6.45 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.96 MB → 1.96 MB (+5.02 kB) | +0.25%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.98 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/narrow.js | 364.22 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.1jYQKhxA.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->