### PR TITLE
automation UI: add goal template functionality

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/ActiveEditor.tsx
+++ b/packages/desktop-client/src/components/budget/goals/ActiveEditor.tsx
@@ -9,6 +9,7 @@ import { BySaveAutomation } from './editor/BySaveAutomation';
 import { FixedAutomation } from './editor/FixedAutomation';
 import { HistoricalAutomation } from './editor/HistoricalAutomation';
 import { LimitAutomation } from './editor/LimitAutomation';
+import { LongTermGoalAutomation } from './editor/LongTermGoalAutomation';
 import { PercentageAutomation } from './editor/PercentageAutomation';
 import { RefillAutomation } from './editor/RefillAutomation';
 import { RemainderAutomation } from './editor/RemainderAutomation';
@@ -68,6 +69,10 @@ export function ActiveEditor({
     case 'remainder':
       return (
         <RemainderAutomation template={state.template} dispatch={dispatch} />
+      );
+    case 'goal':
+      return (
+        <LongTermGoalAutomation template={state.template} dispatch={dispatch} />
       );
     default:
       state satisfies never;

--- a/packages/desktop-client/src/components/budget/goals/BudgetAutomationEditor.tsx
+++ b/packages/desktop-client/src/components/budget/goals/BudgetAutomationEditor.tsx
@@ -23,6 +23,7 @@ import { BySaveAutomation } from './editor/BySaveAutomation';
 import { FixedAutomation } from './editor/FixedAutomation';
 import { HistoricalAutomation } from './editor/HistoricalAutomation';
 import { LimitAutomation } from './editor/LimitAutomation';
+import { LongTermGoalAutomation } from './editor/LongTermGoalAutomation';
 import { PercentageAutomation } from './editor/PercentageAutomation';
 import { RefillAutomation } from './editor/RefillAutomation';
 import { RemainderAutomation } from './editor/RemainderAutomation';
@@ -95,6 +96,13 @@ const displayTypeToDescription = {
       Higher weights take a larger share of the leftover funds.
     </Trans>
   ),
+  goal: (
+    <Trans>
+      Set a long-term savings target. This changes the coloring of the balance
+      on the budget page to be based on progress towards the target rather than
+      the current month funding progress.
+    </Trans>
+  ),
 };
 
 export function BudgetAutomationEditor({
@@ -159,6 +167,11 @@ export function BudgetAutomationEditor({
     case 'remainder':
       automationEditor = (
         <RemainderAutomation template={state.template} dispatch={dispatch} />
+      );
+      break;
+    case 'goal':
+      automationEditor = (
+        <LongTermGoalAutomation template={state.template} dispatch={dispatch} />
       );
       break;
     default:

--- a/packages/desktop-client/src/components/budget/goals/BudgetAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/BudgetAutomationReadOnly.tsx
@@ -18,6 +18,7 @@ import { BySaveAutomationReadOnly } from './editor/BySaveAutomationReadOnly';
 import { FixedAutomationReadOnly } from './editor/FixedAutomationReadOnly';
 import { HistoricalAutomationReadOnly } from './editor/HistoricalAutomationReadOnly';
 import { LimitAutomationReadOnly } from './editor/LimitAutomationReadOnly';
+import { LongTermGoalAutomationReadOnly } from './editor/LongTermGoalAutomationReadOnly';
 import { PercentageAutomationReadOnly } from './editor/PercentageAutomationReadOnly';
 import { RefillAutomationReadOnly } from './editor/RefillAutomationReadOnly';
 import { RemainderAutomationReadOnly } from './editor/RemainderAutomationReadOnly';
@@ -85,6 +86,11 @@ export function BudgetAutomationReadOnly({
     case 'remainder':
       automationReadOnly = (
         <RemainderAutomationReadOnly template={state.template} />
+      );
+      break;
+    case 'goal':
+      automationReadOnly = (
+        <LongTermGoalAutomationReadOnly template={state.template} />
       );
       break;
     default:

--- a/packages/desktop-client/src/components/budget/goals/TemplateSentence.tsx
+++ b/packages/desktop-client/src/components/budget/goals/TemplateSentence.tsx
@@ -7,6 +7,7 @@ import { BySaveAutomationReadOnly } from './editor/BySaveAutomationReadOnly';
 import { FixedAutomationReadOnly } from './editor/FixedAutomationReadOnly';
 import { HistoricalAutomationReadOnly } from './editor/HistoricalAutomationReadOnly';
 import { LimitAutomationReadOnly } from './editor/LimitAutomationReadOnly';
+import { LongTermGoalAutomationReadOnly } from './editor/LongTermGoalAutomationReadOnly';
 import { PercentageAutomationReadOnly } from './editor/PercentageAutomationReadOnly';
 import { RefillAutomationReadOnly } from './editor/RefillAutomationReadOnly';
 import { RemainderAutomationReadOnly } from './editor/RemainderAutomationReadOnly';
@@ -44,9 +45,10 @@ export function TemplateSentence({
       return <BySaveAutomationReadOnly template={template} />;
     case 'remainder':
       return <RemainderAutomationReadOnly template={template} />;
+    case 'goal':
+      return <LongTermGoalAutomationReadOnly template={template} />;
     case 'simple':
     case 'spend':
-    case 'goal':
     case 'error': {
       const type = template.type;
       return (

--- a/packages/desktop-client/src/components/budget/goals/constants.ts
+++ b/packages/desktop-client/src/components/budget/goals/constants.ts
@@ -2,6 +2,7 @@ import type {
   AverageTemplate,
   ByTemplate,
   CopyTemplate,
+  GoalTemplate,
   LimitTemplate,
   PercentageTemplate,
   PeriodicTemplate,
@@ -19,6 +20,7 @@ export const displayTemplateTypes = [
   'limit',
   'refill',
   'remainder',
+  'goal',
 ] as const;
 
 export type DisplayTemplateType = (typeof displayTemplateTypes)[number];
@@ -55,4 +57,8 @@ export type ReducerState =
   | {
       template: RemainderTemplate;
       displayType: 'remainder';
+    }
+  | {
+      template: GoalTemplate;
+      displayType: 'goal';
     };

--- a/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
+++ b/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
@@ -90,7 +90,9 @@ export function getDisplayTemplateMeta(
     case 'goal':
       return {
         label: t('Long-term goal'),
-        description: t('Track a savings target for this category.'),
+        description: t(
+          'Set a long-term savings target. This changes the coloring of the balance on the budget page to be based on progress towards the target rather than the current month funding progress.',
+        ),
         icon: SvgFlag,
       };
     default:

--- a/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
+++ b/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
@@ -3,6 +3,7 @@ import type { ComponentType, SVGProps } from 'react';
 import {
   SvgChartPie,
   SvgEquals,
+  SvgFlag,
   SvgMoneyBag,
   SvgPiggyBank,
   SvgShare,
@@ -85,6 +86,12 @@ export function getDisplayTemplateMeta(
           'Split any remaining To Budget across these categories.',
         ),
         icon: SvgShare,
+      };
+    case 'goal':
+      return {
+        label: t('Long-term goal'),
+        description: t('Track a savings target for this category.'),
+        icon: SvgFlag,
       };
     default:
       displayType satisfies never;

--- a/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomation.tsx
@@ -1,8 +1,6 @@
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { SpaceBetween } from '@actual-app/components/space-between';
-import { Text } from '@actual-app/components/text';
-import { theme } from '@actual-app/components/theme';
 import { amountToInteger, integerToAmount } from '@actual-app/core/shared/util';
 import type { GoalTemplate } from '@actual-app/core/types/models/templates';
 
@@ -46,13 +44,6 @@ export function LongTermGoalAutomation({
           }
         />
       </FormField>
-      <Text style={{ flex: 2, color: theme.pageTextSubdued, fontSize: 12 }}>
-        <Trans>
-          Set a long-term savings target. This changes the coloring of the
-          balance on the budget page to be based on progress towards the target
-          rather than the current month funding progress.
-        </Trans>
-      </Text>
     </SpaceBetween>
   );
 }

--- a/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomation.tsx
@@ -1,0 +1,58 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import { SpaceBetween } from '@actual-app/components/space-between';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { amountToInteger, integerToAmount } from '@actual-app/core/shared/util';
+import type { GoalTemplate } from '@actual-app/core/types/models/templates';
+
+import { updateTemplate } from '#components/budget/goals/actions';
+import type { Action } from '#components/budget/goals/actions';
+import { FormField, FormLabel } from '#components/forms';
+import { AmountInput } from '#components/util/AmountInput';
+import { useFormat } from '#hooks/useFormat';
+
+type LongTermGoalAutomationProps = {
+  template: GoalTemplate;
+  dispatch: (action: Action) => void;
+};
+
+export function LongTermGoalAutomation({
+  template,
+  dispatch,
+}: LongTermGoalAutomationProps) {
+  const { t } = useTranslation();
+  const format = useFormat();
+  const amount = amountToInteger(
+    template.amount,
+    format.currency.decimalPlaces,
+  );
+
+  return (
+    <SpaceBetween align="center" gap={10} style={{ marginTop: 10 }}>
+      <FormField style={{ flex: 1 }}>
+        <FormLabel title={t('Target amount')} htmlFor="goal-amount-field" />
+        <AmountInput
+          id="goal-amount-field"
+          value={amount}
+          sign="+"
+          onUpdate={(value: number) =>
+            dispatch(
+              updateTemplate({
+                type: 'goal',
+                amount: integerToAmount(value, format.currency.decimalPlaces),
+              }),
+            )
+          }
+        />
+      </FormField>
+      <Text style={{ flex: 2, color: theme.pageTextSubdued, fontSize: 12 }}>
+        <Trans>
+          Set a long-term savings target. This changes the coloring of the
+          balance on the budget page to be based on progress towards the target
+          rather than the current month funding progress.
+        </Trans>
+      </Text>
+    </SpaceBetween>
+  );
+}

--- a/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LongTermGoalAutomationReadOnly.tsx
@@ -1,0 +1,29 @@
+import { Trans } from 'react-i18next';
+
+import { amountToInteger } from '@actual-app/core/shared/util';
+import type { GoalTemplate } from '@actual-app/core/types/models/templates';
+import type { TransObjectLiteral } from '@actual-app/core/types/util';
+
+import { FinancialText } from '#components/FinancialText';
+import { useFormat } from '#hooks/useFormat';
+
+type LongTermGoalAutomationReadOnlyProps = {
+  template: GoalTemplate;
+};
+
+export function LongTermGoalAutomationReadOnly({
+  template,
+}: LongTermGoalAutomationReadOnlyProps) {
+  const format = useFormat();
+  const amount = format(
+    amountToInteger(template.amount, format.currency.decimalPlaces),
+    'financial',
+  );
+
+  return (
+    <Trans>
+      Long-term goal of{' '}
+      <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>
+    </Trans>
+  );
+}

--- a/packages/desktop-client/src/components/budget/goals/reducer.ts
+++ b/packages/desktop-client/src/components/budget/goals/reducer.ts
@@ -76,7 +76,10 @@ export const getInitialState = (template: Template | null): ReducerState => {
         displayType: 'historical',
       };
     case 'goal':
-      throw new Error('Goal is not yet supported');
+      return {
+        template,
+        displayType: 'goal',
+      };
     case 'error':
       throw new Error('An error occurred while parsing the template');
     default:
@@ -207,6 +210,18 @@ const changeType = (
           type: 'remainder',
           weight: 1,
           priority: null,
+        },
+      };
+    case 'goal':
+      if (prevState.template.type === 'goal') {
+        return prevState;
+      }
+      return {
+        displayType: visualType,
+        template: {
+          directive: 'goal',
+          type: 'goal',
+          amount: 1000,
         },
       };
     default:

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -197,6 +197,22 @@ export function BudgetAutomationsBody({
     });
   };
 
+  const onAddGoalAutomation = () => {
+    const entry = createAutomationEntry(
+      {
+        directive: 'goal',
+        type: 'goal',
+        amount: 1000,
+      },
+      'goal',
+    );
+    setEntries(prev => {
+      const next = [...prev, entry];
+      setActiveIdx(next.length - 1);
+      return next;
+    });
+  };
+
   const onDelete = (index: number) => {
     setEntries(prev => {
       const next = prev.filter((_, i) => i !== index);
@@ -306,14 +322,15 @@ export function BudgetAutomationsBody({
   }
 
   const hasLimitAutomation = entries.some(e => e.displayType === 'limit');
+  const hasGoalAutomation = entries.some(e => e.displayType === 'goal');
 
+  const isOption = (entry: AutomationEntry) =>
+    entry.displayType === 'limit' || entry.displayType === 'goal';
   const indexedEntries = entries.map((entry, idx) => ({ entry, idx }));
   const contributionEntries = indexedEntries.filter(
-    ({ entry }) => entry.displayType !== 'limit',
+    ({ entry }) => !isOption(entry),
   );
-  const constraintEntries = indexedEntries.filter(
-    ({ entry }) => entry.displayType === 'limit',
-  );
+  const optionEntries = indexedEntries.filter(({ entry }) => isOption(entry));
 
   const safeActiveIdx = Math.min(activeIdx, Math.max(0, entries.length - 1));
 
@@ -447,7 +464,7 @@ export function BudgetAutomationsBody({
           <SidebarSectionHeader style={{ marginTop: 16 }}>
             <Trans>Options</Trans>
           </SidebarSectionHeader>
-          {constraintEntries.map(({ entry, idx }) => (
+          {optionEntries.map(({ entry, idx }) => (
             <AutomationListRow
               key={entry.id}
               index={idx}
@@ -464,9 +481,11 @@ export function BudgetAutomationsBody({
               + <Trans>Add balance cap</Trans>
             </SidebarAddButton>
           )}
-          <SidebarPlaceholderRow>
-            <Trans>Long-term goal (coming soon)</Trans>
-          </SidebarPlaceholderRow>
+          {!hasGoalAutomation && (
+            <SidebarAddButton onPress={onAddGoalAutomation}>
+              + <Trans>Add long-term goal</Trans>
+            </SidebarAddButton>
+          )}
           <SidebarPlaceholderRow>
             <Trans>End of month cleanup (coming soon)</Trans>
           </SidebarPlaceholderRow>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
@@ -26,16 +26,17 @@ describe('migrateTemplatesToAutomations', () => {
     expect(migrateTemplatesToAutomations([simpleTemplate])).toEqual([]);
   });
 
-  it('throws when a goal directive reaches migration', () => {
+  it('migrates a goal directive to a long-term goal entry', () => {
     const goalTemplate = {
       type: 'goal',
       amount: 1000,
       directive: 'goal',
     } satisfies Template;
 
-    expect(() => migrateTemplatesToAutomations([goalTemplate])).toThrow(
-      /Unsupported template type/,
-    );
+    const [entry, ...rest] = migrateTemplatesToAutomations([goalTemplate]);
+    expect(rest).toHaveLength(0);
+    expect(entry.displayType).toBe('goal');
+    expect(entry.template).toEqual(goalTemplate);
   });
 
   it('expands a simple template with limit into limit and refill entries', () => {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -49,8 +49,6 @@ export function BudgetAutomationsModal({
 
   const needsMigration = currentCategory?.template_settings?.source !== 'ui';
 
-  const hasGoalTemplate =
-    parsedTemplates?.some(t => t.type === 'goal') ?? false;
   const hasErrorTemplate =
     parsedTemplates?.some(t => t.type === 'error') ?? false;
   const hasSpendTemplate =
@@ -60,10 +58,7 @@ export function BudgetAutomationsModal({
   // are no longer the source of truth.
   const hasCleanupDirective = needsMigration && hasCleanupLine(notes);
   const hasUnsupportedDirective =
-    hasGoalTemplate ||
-    hasErrorTemplate ||
-    hasSpendTemplate ||
-    hasCleanupDirective;
+    hasErrorTemplate || hasSpendTemplate || hasCleanupDirective;
 
   const incomeNameToId = new Map<string, string>();
   for (const group of categories) {
@@ -111,10 +106,8 @@ export function BudgetAutomationsModal({
             </View>
           ) : hasUnsupportedDirective ? (
             <UnsupportedDirectivesNotice
-              hasGoalTemplate={hasGoalTemplate}
               hasErrorTemplate={hasErrorTemplate}
               hasSpendTemplate={hasSpendTemplate}
-              hasCleanupDirective={hasCleanupDirective}
               onClose={() => state.close()}
             />
           ) : (

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
@@ -11,7 +11,7 @@ import { getDisplayTemplateMeta } from '#components/budget/goals/displayTemplate
 // Types managed in the Options sidebar section, not as contribution-type
 // swaps.
 export const NON_CONTRIBUTION_TYPES: ReadonlySet<DisplayTemplateType> = new Set(
-  ['limit'],
+  ['limit', 'goal'],
 );
 
 type TypePickerProps = {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
@@ -7,16 +7,12 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 export function UnsupportedDirectivesNotice({
-  hasGoalTemplate,
   hasErrorTemplate,
   hasSpendTemplate,
-  hasCleanupDirective,
   onClose,
 }: {
-  hasGoalTemplate: boolean;
   hasErrorTemplate: boolean;
   hasSpendTemplate: boolean;
-  hasCleanupDirective: boolean;
   onClose: () => void;
 }) {
   return (
@@ -63,19 +59,6 @@ export function UnsupportedDirectivesNotice({
             This category uses a <code>spend from</code> template, which the
             budget automations UI doesn&rsquo;t handle yet. Keep editing it as
             text in the category&rsquo;s notes.
-          </Trans>
-        ) : hasGoalTemplate && hasCleanupDirective ? (
-          <Trans>
-            This category&rsquo;s notes use <code>#goal</code> and{' '}
-            <code>#cleanup</code> directives, neither of which the budget
-            automations UI handles yet. Keep editing them as text in the
-            category&rsquo;s notes.
-          </Trans>
-        ) : hasGoalTemplate ? (
-          <Trans>
-            This category uses a <code>#goal</code> directive, which the budget
-            automations UI doesn&rsquo;t handle yet. Keep editing it as text in
-            the category&rsquo;s notes.
           </Trans>
         ) : (
           <Trans>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -26,6 +26,7 @@ function getDisplayTypeFromTemplate(template: Template): DisplayTemplateType {
     case 'remainder':
       return 'remainder';
     case 'goal':
+      return 'goal';
     case 'error':
     case 'spend':
       // filtered upstream by hasUnsupportedDirective; surface if it ever isn't

--- a/upcoming-release-notes/7792.md
+++ b/upcoming-release-notes/7792.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [matt-fidd]
 ---
 
-Automation UI: Add long term goal functionality
+Automation UI: Add long-term goal functionality

--- a/upcoming-release-notes/7792.md
+++ b/upcoming-release-notes/7792.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: Add long term goal functionality


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Depends on https://github.com/actualbudget/actual/pull/7791

Adds goal template functionality

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.97 MB → 13.97 MB (+3.34 kB) | +0.02%
loot-core | 1 | 5.27 MB | 0%
api | 2 | 3.9 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.97 MB → 13.97 MB (+3.34 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/editor/LongTermGoalAutomation.tsx` | 🆕 +1.95 kB | 0 B → 1.95 kB
`src/components/budget/goals/editor/LongTermGoalAutomationReadOnly.tsx` | 🆕 +887 B | 0 B → 887 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/Flag.tsx` | 🆕 +414 B | 0 B → 414 B
`src/components/budget/goals/displayTemplateMeta.ts` | 📈 +282 B (+18.83%) | 1.46 kB → 1.74 kB
`src/components/budget/goals/ActiveEditor.tsx` | 📈 +323 B (+10.71%) | 2.94 kB → 3.26 kB
`src/components/budget/goals/TemplateSentence.tsx` | 📈 +220 B (+8.33%) | 2.58 kB → 2.79 kB
`src/components/budget/goals/constants.ts` | 📈 +9 B (+4.74%) | 190 B → 199 B
`src/components/budget/goals/reducer.ts` | 📈 +209 B (+3.90%) | 5.23 kB → 5.44 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +485 B (+3.51%) | 13.49 kB → 13.96 kB
`src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts` | 📈 +15 B (+0.84%) | 1.74 kB → 1.76 kB
`src/components/modals/BudgetAutomationsModal/TypePicker.tsx` | 📈 +8 B (+0.24%) | 3.26 kB → 3.27 kB
`src/components/accounts/Account.tsx` | 📉 -2 B (-0.00%) | 44.1 kB → 44.1 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📉 -482 B (-8.80%) | 5.35 kB → 4.88 kB
`src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx` | 📉 -949 B (-22.33%) | 4.15 kB → 3.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.96 MB → 1.97 MB (+2.93 kB) | +0.15%
static/js/Value.js | 4.94 MB → 4.94 MB (+414 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 519.39 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/narrow.js | 364.22 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.1jYQKhxA.js | 5.27 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->