### PR TITLE
persist cleanup templates in the DB

### DIFF
--- a/packages/loot-core/migrations/1778510362740_add_cleanup_groups_and_def.sql
+++ b/packages/loot-core/migrations/1778510362740_add_cleanup_groups_and_def.sql
@@ -1,0 +1,10 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE categories ADD COLUMN cleanup_def TEXT DEFAULT NULL;
+
+CREATE TABLE cleanup_groups
+  (id TEXT PRIMARY KEY,
+   name TEXT NOT NULL,
+   tombstone INTEGER DEFAULT 0);
+
+COMMIT;

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -85,6 +85,7 @@ export const schema = {
     hidden: f('boolean'),
     group: f('id', { ref: 'category_groups' }),
     goal_def: f('string'),
+    cleanup_def: f('string'),
     template_settings: f('json', { default: { source: 'notes' } }),
     sort_order: f('float'),
     tombstone: f('boolean'),
@@ -95,6 +96,11 @@ export const schema = {
     is_income: f('boolean'),
     hidden: f('boolean'),
     sort_order: f('float'),
+    tombstone: f('boolean'),
+  },
+  cleanup_groups: {
+    id: f('id'),
+    name: f('string'),
     tombstone: f('boolean'),
   },
   schedules: {

--- a/packages/loot-core/src/server/budget/cleanup-template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template-notes.test.ts
@@ -1,0 +1,172 @@
+import { vi } from 'vitest';
+
+import * as db from '#server/db';
+
+import { storeNoteCleanups } from './cleanup-template-notes';
+
+vi.mock('#server/db');
+
+type CategoryRow = {
+  id: string;
+  note: string | null;
+};
+
+type GroupRow = {
+  id: string;
+  name: string;
+  tombstone: 0 | 1;
+};
+
+function setupDb(initial: { categories: CategoryRow[]; groups?: GroupRow[] }) {
+  const groups = new Map<string, GroupRow>(
+    (initial.groups ?? []).map(g => [g.id, { ...g }]),
+  );
+  const categoryDefs = new Map<string, string | null>();
+
+  vi.mocked(db.all).mockImplementation(async (sql: string) => {
+    if (sql.includes('FROM categories c')) {
+      return initial.categories as never;
+    }
+    return [] as never;
+  });
+
+  vi.mocked(db.first).mockImplementation(async (sql: string, params) => {
+    if (sql.includes('FROM cleanup_groups')) {
+      const key = (params as string[])[0];
+      const match = Array.from(groups.values()).find(
+        g => g.name.toLowerCase() === key,
+      );
+      return (match ?? null) as never;
+    }
+    return null as never;
+  });
+
+  vi.mocked(db.insertWithSchema).mockImplementation(async (table, row) => {
+    if (table === 'cleanup_groups') {
+      const r = row as GroupRow;
+      groups.set(r.id, { ...r, tombstone: 0 });
+    }
+    return row.id as never;
+  });
+
+  vi.mocked(db.update).mockImplementation(async (table, params) => {
+    if (table === 'cleanup_groups') {
+      const r = params as Partial<GroupRow> & { id: string };
+      const existing = groups.get(r.id);
+      if (existing) groups.set(r.id, { ...existing, ...r } as GroupRow);
+    }
+    return undefined as never;
+  });
+
+  vi.mocked(db.updateWithSchema).mockImplementation(async (table, fields) => {
+    if (table === 'categories') {
+      const r = fields as { id: string; cleanup_def: string | null };
+      categoryDefs.set(r.id, r.cleanup_def);
+    }
+    return undefined as never;
+  });
+
+  vi.mocked(db.run).mockImplementation(async (sql: string) => {
+    // tombstoneOrphanCleanupGroups: scan written cleanup_defs for referenced ids
+    if (sql.includes('UPDATE cleanup_groups')) {
+      const referenced = new Set<string>();
+      for (const def of categoryDefs.values()) {
+        if (!def) continue;
+        const arr = JSON.parse(def) as Array<{ groupId?: string | null }>;
+        for (const row of arr) {
+          if (row.groupId) referenced.add(row.groupId);
+        }
+      }
+      for (const [id, g] of groups) {
+        if (g.tombstone === 0 && !referenced.has(id)) {
+          groups.set(id, { ...g, tombstone: 1 });
+        }
+      }
+    }
+    return undefined as never;
+  });
+
+  return { groups, categoryDefs };
+}
+
+describe('storeNoteCleanups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('persists global source/sink lines as cleanup_def with null groupId', async () => {
+    const state = setupDb({
+      categories: [
+        { id: 'cat-1', note: '#cleanup source' },
+        { id: 'cat-2', note: '#cleanup sink 2' },
+      ],
+    });
+
+    await storeNoteCleanups();
+
+    expect(JSON.parse(state.categoryDefs.get('cat-1')!)).toEqual([
+      { role: 'source', groupId: null },
+    ]);
+    expect(JSON.parse(state.categoryDefs.get('cat-2')!)).toEqual([
+      { role: 'sink', groupId: null, weight: 2 },
+    ]);
+  });
+
+  it('resolves shared group names to a single group id, case-insensitively', async () => {
+    const state = setupDb({
+      categories: [
+        { id: 'cat-1', note: '#cleanup Vacations source' },
+        { id: 'cat-2', note: '#cleanup vacations sink' },
+        { id: 'cat-3', note: '#cleanup VACATIONS' },
+      ],
+    });
+
+    await storeNoteCleanups();
+
+    const def1 = JSON.parse(state.categoryDefs.get('cat-1')!);
+    const def2 = JSON.parse(state.categoryDefs.get('cat-2')!);
+    const def3 = JSON.parse(state.categoryDefs.get('cat-3')!);
+    expect(def1[0].groupId).toBe(def2[0].groupId);
+    expect(def2[0].groupId).toBe(def3[0].groupId);
+
+    // One group exists.
+    const liveGroups = Array.from(state.groups.values()).filter(
+      g => g.tombstone === 0,
+    );
+    expect(liveGroups).toHaveLength(1);
+    // Name preserves the casing of whichever line was seen first.
+    expect(liveGroups[0].name).toBe('Vacations');
+  });
+
+  it('clears cleanup_def for categories whose notes no longer carry cleanup', async () => {
+    const state = setupDb({
+      categories: [{ id: 'cat-1', note: 'totally unrelated note text' }],
+    });
+
+    await storeNoteCleanups();
+
+    expect(state.categoryDefs.get('cat-1')).toBeNull();
+  });
+
+  it('tombstones groups that no longer have any live members', async () => {
+    const state = setupDb({
+      categories: [{ id: 'cat-1', note: 'no cleanup here' }],
+      groups: [{ id: 'g-orphan', name: 'OldGroup', tombstone: 0 }],
+    });
+
+    await storeNoteCleanups();
+
+    expect(state.groups.get('g-orphan')!.tombstone).toBe(1);
+  });
+
+  it('resurrects a tombstoned group when a fresh note references its name', async () => {
+    const state = setupDb({
+      categories: [{ id: 'cat-1', note: '#cleanup Reborn source' }],
+      groups: [{ id: 'g-existing', name: 'Reborn', tombstone: 1 }],
+    });
+
+    await storeNoteCleanups();
+
+    expect(state.groups.get('g-existing')!.tombstone).toBe(0);
+    const def = JSON.parse(state.categoryDefs.get('cat-1')!);
+    expect(def[0].groupId).toBe('g-existing');
+  });
+});

--- a/packages/loot-core/src/server/budget/cleanup-template-notes.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template-notes.ts
@@ -59,9 +59,8 @@ function parseCleanupNote(note: string): ParsedCleanupRow[] {
   for (const line of note.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed.toLowerCase().startsWith(CLEANUP_PREFIX)) continue;
-    const expression = trimmed.slice(CLEANUP_PREFIX.length);
     try {
-      const raw = parse(expression) as {
+      const raw = parse(trimmed) as {
         type: 'source' | 'sink' | null;
         group: string | null;
         weight?: number;

--- a/packages/loot-core/src/server/budget/cleanup-template-notes.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template-notes.ts
@@ -95,11 +95,15 @@ function toCleanupTemplate(
         groupId: resolveGroup(row.group, nameToId),
         weight: row.weight,
       };
-    case 'overspend':
-      return {
-        role: 'overspend',
-        groupId: nameToId.get(row.group.toLowerCase())!,
-      };
+    case 'overspend': {
+      const groupId = nameToId.get(row.group.toLowerCase());
+      if (groupId == null) {
+        throw new Error(
+          `Unresolved cleanup group for overspend row: ${row.group}`,
+        );
+      }
+      return { role: 'overspend', groupId };
+    }
     default:
       throw new Error(`Unknown cleanup row type: ${String(row)}`);
   }

--- a/packages/loot-core/src/server/budget/cleanup-template-notes.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template-notes.ts
@@ -1,0 +1,179 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import * as db from '#server/db';
+import type { CleanupTemplate } from '#types/models/cleanup-templates';
+
+import { parse } from './cleanup-template.pegjs';
+
+export const CLEANUP_PREFIX = '#cleanup ';
+
+// The grammar emits `type: null` for the bare `<group>` line; we re-key
+// that to `'overspend'` so the discriminator is a non-null literal.
+type ParsedCleanupRow =
+  | { type: 'source'; group: string | null }
+  | { type: 'sink'; group: string | null; weight: number }
+  | { type: 'overspend'; group: string };
+
+type CategoryWithCleanupNote = {
+  id: string;
+  note: string | null;
+};
+
+export async function storeNoteCleanups(categoryIds?: string[]): Promise<void> {
+  const candidates = await getCategoriesWithCleanupNotes(categoryIds);
+
+  const parsedByCategory = new Map<string, ParsedCleanupRow[]>();
+  const allGroupNames = new Set<string>();
+  for (const { id, note } of candidates) {
+    if (!note) continue;
+    const rows = parseCleanupNote(note);
+    if (rows.length === 0) continue;
+    parsedByCategory.set(id, rows);
+    for (const r of rows) {
+      if (r.group != null) allGroupNames.add(r.group);
+    }
+  }
+
+  const nameToId = await resolveCleanupGroups(allGroupNames);
+
+  for (const { id } of candidates) {
+    const parsed = parsedByCategory.get(id);
+    if (!parsed) {
+      await db.updateWithSchema('categories', { id, cleanup_def: null });
+      continue;
+    }
+    const cleanupDef: CleanupTemplate[] = parsed.map(row =>
+      toCleanupTemplate(row, nameToId),
+    );
+    await db.updateWithSchema('categories', {
+      id,
+      cleanup_def: JSON.stringify(cleanupDef),
+    });
+  }
+
+  await tombstoneOrphanCleanupGroups();
+}
+
+function parseCleanupNote(note: string): ParsedCleanupRow[] {
+  const rows: ParsedCleanupRow[] = [];
+  for (const line of note.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.toLowerCase().startsWith(CLEANUP_PREFIX)) continue;
+    const expression = trimmed.slice(CLEANUP_PREFIX.length);
+    try {
+      const raw = parse(expression) as {
+        type: 'source' | 'sink' | null;
+        group: string | null;
+        weight?: number;
+      };
+      const row: ParsedCleanupRow =
+        raw.type === 'source'
+          ? { type: 'source', group: raw.group }
+          : raw.type === 'sink'
+            ? { type: 'sink', group: raw.group, weight: raw.weight ?? 1 }
+            : { type: 'overspend', group: raw.group ?? '' };
+      // The grammar should guarantee a non-null group for `overspend`, but
+      // guard so a malformed parse can't write a blank-group row.
+      if (row.type === 'overspend' && row.group === '') continue;
+      rows.push(row);
+    } catch {
+      // Match the legacy engine: silently skip unparseable lines.
+    }
+  }
+  return rows;
+}
+
+function toCleanupTemplate(
+  row: ParsedCleanupRow,
+  nameToId: Map<string, string>,
+): CleanupTemplate {
+  switch (row.type) {
+    case 'source':
+      return { role: 'source', groupId: resolveGroup(row.group, nameToId) };
+    case 'sink':
+      return {
+        role: 'sink',
+        groupId: resolveGroup(row.group, nameToId),
+        weight: row.weight,
+      };
+    case 'overspend':
+      return {
+        role: 'overspend',
+        groupId: nameToId.get(row.group.toLowerCase())!,
+      };
+    default:
+      throw new Error(`Unknown cleanup row type: ${String(row)}`);
+  }
+}
+
+function resolveGroup(
+  name: string | null,
+  nameToId: Map<string, string>,
+): string | null {
+  return name != null ? (nameToId.get(name.toLowerCase()) ?? null) : null;
+}
+
+async function resolveCleanupGroups(
+  names: ReadonlySet<string>,
+): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  for (const name of names) {
+    const key = name.toLowerCase();
+    const existing = await db.first<{ id: string; tombstone: 0 | 1 }>(
+      `SELECT id, tombstone FROM cleanup_groups WHERE lower(name) = ? LIMIT 1`,
+      [key],
+    );
+    if (existing) {
+      // Resurrect a tombstoned row so the id stays stable across edits.
+      if (existing.tombstone === 1) {
+        await db.update('cleanup_groups', { id: existing.id, tombstone: 0 });
+      }
+      map.set(key, existing.id);
+      continue;
+    }
+    const id = uuidv4();
+    await db.insertWithSchema('cleanup_groups', { id, name, tombstone: 0 });
+    map.set(key, id);
+  }
+  return map;
+}
+
+async function tombstoneOrphanCleanupGroups(): Promise<void> {
+  await db.run(
+    `
+      UPDATE cleanup_groups
+      SET tombstone = 1
+      WHERE tombstone = 0
+        AND id NOT IN (
+          SELECT json_extract(je.value, '$.groupId') AS group_id
+          FROM categories c, json_each(c.cleanup_def) je
+          WHERE c.tombstone = 0
+            AND c.cleanup_def IS NOT NULL
+            AND json_extract(je.value, '$.groupId') IS NOT NULL
+        )
+    `,
+  );
+}
+
+// Scoped to non-ui-managed categories so a migrated category is not
+// overwritten by stale note text.
+async function getCategoriesWithCleanupNotes(
+  categoryIds?: string[],
+): Promise<CategoryWithCleanupNote[]> {
+  const baseQuery = `
+    SELECT c.id AS id, n.note AS note
+    FROM categories c
+    LEFT JOIN notes n ON n.id = c.id
+    WHERE c.tombstone = 0
+      AND COALESCE(JSON_EXTRACT(c.template_settings, '$.source'), 'notes') <> 'ui'
+  `;
+  if (!categoryIds) {
+    return db.all<CategoryWithCleanupNote>(baseQuery);
+  }
+  if (categoryIds.length === 0) return [];
+  const placeholders = categoryIds.map(() => '?').join(',');
+  return db.all<CategoryWithCleanupNote>(
+    `${baseQuery} AND c.id IN (${placeholders})`,
+    categoryIds,
+  );
+}

--- a/packages/loot-core/src/server/budget/cleanup-template.pegjs
+++ b/packages/loot-core/src/server/budget/cleanup-template.pegjs
@@ -1,6 +1,9 @@
 // https://peggyjs.org
 
 expr
+  = '#cleanup' _ inner: inner { return inner }
+
+inner
   = source
   	{ return { group: null, type: 'source' }}
     /
@@ -8,9 +11,9 @@ expr
     	{ return { type: 'sink', weight: +weight || 1, group: null } }
   /
   group: sourcegroup _? source
-    	{return {group: group || null, type: 'source'}} 
+    	{return {group: group || null, type: 'source'}}
     /
-   	group: sinkgroup? _? sink _? weight: weight? 
+   	group: sinkgroup? _? sink _? weight: weight?
     	{ return { type: 'sink', weight: +weight || 1, group: group || null } }
     /
     group: sourcegroup

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -28,6 +28,7 @@ async function applyGroupCleanups(
   sourceGroups: GroupSourceRow[],
   sinkGroups: GroupSinkRow[],
   overspendGroups: GroupOverspendRow[],
+  groupNamesById: Map<string, string>,
 ) {
   const sheetName = monthUtils.sheetForMonth(month);
   const warnings = [];
@@ -134,8 +135,9 @@ async function applyGroupCleanups(
         });
       }
     } else {
+      const groupName = groupNamesById.get(groupId) ?? groupId;
       warnings.push(
-        `Cleanup group "${groupId}" has no matching sink categories.`,
+        `Cleanup group "${groupName}" has no matching sink categories.`,
       );
     }
     sourceGroups = sourceGroups.filter(c => c.groupId !== groupId);
@@ -155,7 +157,6 @@ async function processCleanup(month: string): Promise<Notification> {
     weight: number;
   };
   const sinkCategory: SinkCategoryRow[] = [];
-  const sourceWithRollover = [];
   const db_month = parseInt(month.replace('-', ''));
 
   const categories = await db.all<db.DbViewCategory>(
@@ -185,12 +186,18 @@ async function processCleanup(month: string): Promise<Notification> {
     }
   }
 
+  const groupRows = await db.all<{ id: string; name: string }>(
+    'SELECT id, name FROM cleanup_groups WHERE tombstone = 0',
+  );
+  const groupNamesById = new Map(groupRows.map(g => [g.id, g.name]));
+
   //run category groups
   const newWarnings = await applyGroupCleanups(
     month,
     groupSource,
     groupSink,
     groupOverspend,
+    groupNamesById,
   );
   warnings.splice(1, 0, ...newWarnings);
 
@@ -219,13 +226,6 @@ async function processCleanup(month: string): Promise<Notification> {
         num_sources += 1;
       } else {
         warnings.push(category.name + ' does not have available funds.');
-      }
-      const carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
-        `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
-        [db_month, category.id],
-      );
-      if (carryover !== null && carryover.carryover === 1) {
-        sourceWithRollover.push({ cat: category, def });
       }
     }
 

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -1,9 +1,10 @@
 import * as db from '#server/db';
 // @ts-strict-ignore
 import * as monthUtils from '#shared/months';
+import type { CleanupTemplate } from '#types/models/cleanup-templates';
 
 import { getSheetValue, setBudget, setGoal } from './actions';
-import { parse } from './cleanup-template.pegjs';
+import { storeNoteCleanups } from './cleanup-template-notes';
 
 type Notification = {
   type?: 'message' | 'error' | 'warning' | undefined;
@@ -13,15 +14,20 @@ type Notification = {
   sticky?: boolean | undefined;
 };
 
-export function cleanupTemplate({ month }: { month: string }) {
+export async function cleanupTemplate({ month }: { month: string }) {
+  await storeNoteCleanups();
   return processCleanup(month);
 }
 
+type GroupSourceRow = { category: string; groupId: string };
+type GroupSinkRow = { category: string; groupId: string; weight: number };
+type GroupOverspendRow = { category: string; groupId: string };
+
 async function applyGroupCleanups(
   month: string,
-  sourceGroups,
-  sinkGroups,
-  generalGroups,
+  sourceGroups: GroupSourceRow[],
+  sinkGroups: GroupSinkRow[],
+  overspendGroups: GroupOverspendRow[],
 ) {
   const sheetName = monthUtils.sheetForMonth(month);
   const warnings = [];
@@ -29,16 +35,16 @@ async function applyGroupCleanups(
   let groupLength = sourceGroups.length;
   while (groupLength > 0) {
     //function for each unique group
-    const groupName = sourceGroups[0].group;
-    const tempSourceGroups = sourceGroups.filter(c => c.group === groupName);
-    const sinkGroup = sinkGroups.filter(c => c.group === groupName);
-    const generalGroup = generalGroups.filter(c => c.group === groupName);
+    const groupId = sourceGroups[0].groupId;
+    const tempSourceGroups = sourceGroups.filter(c => c.groupId === groupId);
+    const sinkGroup = sinkGroups.filter(c => c.groupId === groupId);
+    const overspendGroup = overspendGroups.filter(c => c.groupId === groupId);
     let total_weight = 0;
     // We track how mouch amount was produced by all group sinks and only
     // distribute this instead of the "to-budget" amount.
     let available_amount = 0;
 
-    if (sinkGroup.length > 0 || generalGroup.length > 0) {
+    if (sinkGroup.length > 0 || overspendGroup.length > 0) {
       //only return group source funds to To Budget if there are corresponding sinking groups or underfunded included groups
       for (let ii = 0; ii < tempSourceGroups.length; ii++) {
         const balance = await getSheetValue(
@@ -63,17 +69,21 @@ async function applyGroupCleanups(
       }
 
       //fill underfunded categories within the group first
-      for (let ii = 0; ii < generalGroup.length && available_amount > 0; ii++) {
+      for (
+        let ii = 0;
+        ii < overspendGroup.length && available_amount > 0;
+        ii++
+      ) {
         const balance = await getSheetValue(
           sheetName,
-          `leftover-${generalGroup[ii].category}`,
+          `leftover-${overspendGroup[ii].category}`,
         );
         const budgeted = await getSheetValue(
           sheetName,
-          `budget-${generalGroup[ii].category}`,
+          `budget-${overspendGroup[ii].category}`,
         );
         const to_budget = budgeted + Math.abs(balance);
-        const categoryId = generalGroup[ii].category;
+        const categoryId = overspendGroup[ii].category;
         let carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
           `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
           [db_month, categoryId],
@@ -87,11 +97,10 @@ async function applyGroupCleanups(
           // We have enough to fully cover the overspent.
           balance < 0 &&
           Math.abs(balance) <= available_amount &&
-          !generalGroup[ii].category.is_income &&
           carryover.carryover === 0
         ) {
           await setBudget({
-            category: generalGroup[ii].category,
+            category: categoryId,
             month,
             amount: to_budget,
           });
@@ -99,12 +108,11 @@ async function applyGroupCleanups(
         } else if (
           // We can only cover this category partially.
           balance < 0 &&
-          !generalGroup[ii].category.is_income &&
           carryover.carryover === 0 &&
           Math.abs(balance) > available_amount
         ) {
           await setBudget({
-            category: generalGroup[ii].category,
+            category: categoryId,
             month,
             amount: budgeted + available_amount,
           });
@@ -126,9 +134,11 @@ async function applyGroupCleanups(
         });
       }
     } else {
-      warnings.push(groupName + ' has no matching sink categories.');
+      warnings.push(
+        `Cleanup group "${groupId}" has no matching sink categories.`,
+      );
     }
-    sourceGroups = sourceGroups.filter(c => c.group !== groupName);
+    sourceGroups = sourceGroups.filter(c => c.groupId !== groupId);
     groupLength = sourceGroups.length;
   }
   return warnings;
@@ -140,123 +150,95 @@ async function processCleanup(month: string): Promise<Notification> {
   let total_weight = 0;
   const errors = [];
   const warnings = [];
-  const sinkCategory = [];
+  type SinkCategoryRow = {
+    cat: db.DbViewCategory;
+    weight: number;
+  };
+  const sinkCategory: SinkCategoryRow[] = [];
   const sourceWithRollover = [];
   const db_month = parseInt(month.replace('-', ''));
 
-  const category_templates = await getCategoryTemplates();
   const categories = await db.all<db.DbViewCategory>(
     'SELECT * FROM v_categories WHERE tombstone = 0',
   );
   const sheetName = monthUtils.sheetForMonth(month);
-  const groupSource = [];
-  const groupSink = [];
-  const groupGeneral = [];
+  const groupSource: GroupSourceRow[] = [];
+  const groupSink: GroupSinkRow[] = [];
+  const groupOverspend: GroupOverspendRow[] = [];
 
-  //filter out category groups
-  for (let c = 0; c < categories.length; c++) {
-    const category = categories[c];
-    const template = category_templates[category.id];
+  for (const category of categories) {
+    const def = parseCleanupDef(category.cleanup_def);
+    if (!def) continue;
 
-    //filter out source and sink groups for processing
-    if (template) {
-      if (
-        template.filter(t => t.type === 'source' && t.group !== null).length > 0
-      ) {
-        groupSource.push({
-          category: category.id,
-          group: template.filter(
-            t => t.type === 'source' && t.group !== null,
-          )[0].group,
-        });
-      }
-      if (
-        template.filter(t => t.type === 'sink' && t.group !== null).length > 0
-      ) {
-        //only supports 1 sink reference per category.  Need more?
+    for (const row of def) {
+      if (row.role === 'source' && row.groupId !== null) {
+        groupSource.push({ category: category.id, groupId: row.groupId });
+      } else if (row.role === 'sink' && row.groupId !== null) {
         groupSink.push({
           category: category.id,
-          group: template.filter(t => t.type === 'sink' && t.group !== null)[0]
-            .group,
-          weight: template.filter(t => t.type === 'sink' && t.group !== null)[0]
-            .weight,
+          groupId: row.groupId,
+          weight: row.weight,
         });
-      }
-      if (
-        template.filter(t => t.type === null && t.group !== null).length > 0
-      ) {
-        groupGeneral.push({ category: category.id, group: template[0].group });
+      } else if (row.role === 'overspend') {
+        groupOverspend.push({ category: category.id, groupId: row.groupId });
       }
     }
   }
+
   //run category groups
   const newWarnings = await applyGroupCleanups(
     month,
     groupSource,
     groupSink,
-    groupGeneral,
+    groupOverspend,
   );
   warnings.splice(1, 0, ...newWarnings);
 
-  for (let c = 0; c < categories.length; c++) {
-    const category = categories[c];
-    const template = category_templates[category.id];
-    if (template) {
-      if (
-        template.filter(t => t.type === 'source' && t.group === null).length > 0
-      ) {
-        const balance = await getSheetValue(
-          sheetName,
-          `leftover-${category.id}`,
-        );
-        const budgeted = await getSheetValue(
-          sheetName,
-          `budget-${category.id}`,
-        );
-        if (balance >= 0) {
-          // const spent = await getSheetValue(
-          //   sheetName,
-          //   `sum-amount-${category.id}`,
-          // );
-          await setBudget({
-            category: category.id,
-            month,
-            amount: budgeted - balance,
-          });
-          await setGoal({
-            category: category.id,
-            month,
-            goal: budgeted - balance,
-            long_goal: 0,
-          });
-          num_sources += 1;
-        } else {
-          warnings.push(category.name + ' does not have available funds.');
-        }
-        const carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
-          `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
-          [db_month, category.id],
-        );
-        if (carryover !== null) {
-          //keep track of source categories with rollover enabled
-          if (carryover.carryover === 1) {
-            sourceWithRollover.push({ cat: category, temp: template });
-          }
-        }
+  for (const category of categories) {
+    const def = parseCleanupDef(category.cleanup_def);
+    if (!def) continue;
+
+    const globalSource = def.find(
+      r => r.role === 'source' && r.groupId === null,
+    );
+    if (globalSource) {
+      const balance = await getSheetValue(sheetName, `leftover-${category.id}`);
+      const budgeted = await getSheetValue(sheetName, `budget-${category.id}`);
+      if (balance >= 0) {
+        await setBudget({
+          category: category.id,
+          month,
+          amount: budgeted - balance,
+        });
+        await setGoal({
+          category: category.id,
+          month,
+          goal: budgeted - balance,
+          long_goal: 0,
+        });
+        num_sources += 1;
+      } else {
+        warnings.push(category.name + ' does not have available funds.');
       }
-      if (
-        template.filter(t => t.type === 'sink' && t.group === null).length > 0
-      ) {
-        sinkCategory.push({ cat: category, temp: template });
-        num_sinks += 1;
-        total_weight += template.filter(w => w.type === 'sink')[0].weight;
+      const carryover = await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
+        `SELECT carryover FROM zero_budgets WHERE month = ? and category = ?`,
+        [db_month, category.id],
+      );
+      if (carryover !== null && carryover.carryover === 1) {
+        sourceWithRollover.push({ cat: category, def });
       }
+    }
+
+    const globalSink = def.find(r => r.role === 'sink' && r.groupId === null);
+    if (globalSink && globalSink.role === 'sink') {
+      sinkCategory.push({ cat: category, weight: globalSink.weight });
+      num_sinks += 1;
+      total_weight += globalSink.weight;
     }
   }
 
   //funds all underfunded categories first unless the overspending rollover is checked
-  for (let c = 0; c < categories.length; c++) {
-    const category = categories[c];
+  for (const category of categories) {
     const budgetAvailable = await getSheetValue(sheetName, `to-budget`);
     const balance = await getSheetValue(sheetName, `leftover-${category.id}`);
     const budgeted = await getSheetValue(sheetName, `budget-${category.id}`);
@@ -303,13 +285,8 @@ async function processCleanup(month: string): Promise<Notification> {
 
   //fill sinking categories
   for (let c = 0; c < sinkCategory.length; c++) {
-    const budgeted = await getSheetValue(
-      sheetName,
-      `budget-${sinkCategory[c].cat.id}`,
-    );
-    const categoryId = sinkCategory[c].cat.id;
-    const weight = sinkCategory[c].temp.filter(w => w.type === 'sink')[0]
-      .weight;
+    const { cat, weight } = sinkCategory[c];
+    const budgeted = await getSheetValue(sheetName, `budget-${cat.id}`);
     let to_budget =
       budgeted + Math.round((weight / total_weight) * budgetAvailable);
     if (c === sinkCategory.length - 1) {
@@ -322,7 +299,7 @@ async function processCleanup(month: string): Promise<Notification> {
       }
     }
     await setBudget({
-      category: categoryId,
+      category: cat.id,
       month,
       amount: to_budget,
     });
@@ -378,31 +355,14 @@ async function processCleanup(month: string): Promise<Notification> {
   }
 }
 
-const TEMPLATE_PREFIX = '#cleanup ';
-async function getCategoryTemplates() {
-  const templates = {};
-
-  const notes = await db.all<db.DbNote>(
-    `SELECT * FROM notes WHERE lower(note) like '%${TEMPLATE_PREFIX}%'`,
-  );
-
-  for (let n = 0; n < notes.length; n++) {
-    const lines = notes[n].note.split('\n');
-    const template_lines = [];
-    for (let l = 0; l < lines.length; l++) {
-      const line = lines[l].trim();
-      if (!line.toLowerCase().startsWith(TEMPLATE_PREFIX)) continue;
-      const expression = line.slice(TEMPLATE_PREFIX.length);
-      try {
-        const parsed = parse(expression);
-        template_lines.push(parsed);
-      } catch (e) {
-        template_lines.push({ type: 'error', line, error: e });
-      }
-    }
-    if (template_lines.length) {
-      templates[notes[n].id] = template_lines;
-    }
+function parseCleanupDef(
+  raw: string | null | undefined,
+): CleanupTemplate[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as CleanupTemplate[];
+    return Array.isArray(parsed) && parsed.length > 0 ? parsed : null;
+  } catch {
+    return null;
   }
-  return templates;
 }

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -9,6 +9,7 @@ import type { Template } from '#types/models/templates';
 
 import { getSheetValue, isTrackingBudget, setBudget, setGoal } from './actions';
 import { CategoryTemplateContext } from './category-template-context';
+import { storeNoteCleanups } from './cleanup-template-notes';
 import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
 
 export function distributeRemainder(
@@ -50,6 +51,12 @@ export async function storeTemplates({
   }[];
   source: 'notes' | 'ui';
 }): Promise<void> {
+  // Once source flips to 'ui' the notes stop being read; migrate any
+  // `#cleanup` lines into `cleanup_def` first so the cleanup engine still
+  // sees them.
+  if (source === 'ui') {
+    await storeNoteCleanups(categoriesWithTemplates.map(c => c.id));
+  }
   await batchMessages(async () => {
     for (const { id, templates } of categoriesWithTemplates) {
       const goalDefs = templates.length > 0 ? JSON.stringify(templates) : null;

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -51,12 +51,7 @@ export async function storeTemplates({
   }[];
   source: 'notes' | 'ui';
 }): Promise<void> {
-  // Once source flips to 'ui' the notes stop being read; migrate any
-  // `#cleanup` lines into `cleanup_def` first so the cleanup engine still
-  // sees them.
-  if (source === 'ui') {
-    await storeNoteCleanups(categoriesWithTemplates.map(c => c.id));
-  }
+  await storeNoteCleanups(categoriesWithTemplates.map(c => c.id));
   await batchMessages(async () => {
     for (const { id, templates } of categoriesWithTemplates) {
       const goalDefs = templates.length > 0 ? JSON.stringify(templates) : null;

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -34,6 +34,7 @@ function mockDbUpdate() {
 describe('storeNoteTemplates', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(db.all).mockResolvedValue([]);
   });
 
   const testCases = [

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -41,6 +41,7 @@ export type DbCategory = {
   sort_order: number;
   hidden: 1 | 0;
   goal_def?: JsonString | null;
+  cleanup_def?: JsonString | null;
   template_settings?: { source: 'notes' | 'ui' };
   tombstone: 1 | 0;
 };
@@ -51,6 +52,12 @@ export type DbCategoryGroup = {
   is_income: 1 | 0;
   sort_order: number;
   hidden: 1 | 0;
+  tombstone: 1 | 0;
+};
+
+export type DbCleanupGroup = {
+  id: string;
+  name: string;
   tombstone: 1 | 0;
 };
 
@@ -293,6 +300,7 @@ export type DbViewCategory = {
   group: DbCategoryGroup['id'];
   sort_order: DbCategory['sort_order'];
   tombstone: DbCategory['tombstone'];
+  cleanup_def?: DbCategory['cleanup_def'];
 };
 
 export type DbViewCategoryWithGroupHidden = {

--- a/packages/loot-core/src/types/models/category.ts
+++ b/packages/loot-core/src/types/models/category.ts
@@ -6,6 +6,7 @@ export type CategoryEntity = {
   is_income?: boolean;
   group: CategoryGroupEntity['id'];
   goal_def?: string;
+  cleanup_def?: string;
   template_settings?: { source: 'notes' | 'ui' };
   sort_order?: number;
   tombstone?: boolean;

--- a/packages/loot-core/src/types/models/cleanup-templates.ts
+++ b/packages/loot-core/src/types/models/cleanup-templates.ts
@@ -1,0 +1,5 @@
+// Persisted shape stored on `categories.cleanup_def` (JSON array).
+export type CleanupTemplate =
+  | { role: 'source'; groupId: string | null }
+  | { role: 'sink'; groupId: string | null; weight: number }
+  | { role: 'overspend'; groupId: string };

--- a/packages/loot-core/src/types/models/cleanup-templates.ts
+++ b/packages/loot-core/src/types/models/cleanup-templates.ts
@@ -1,4 +1,3 @@
-// Persisted shape stored on `categories.cleanup_def` (JSON array).
 export type CleanupTemplate =
   | { role: 'source'; groupId: string | null }
   | { role: 'sink'; groupId: string | null; weight: number }

--- a/upcoming-release-notes/7794.md
+++ b/upcoming-release-notes/7794.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [matt-fidd]
 ---
 
-Persist end of month cleanup templates in the database
+Persist end-of-month cleanup templates in the database

--- a/upcoming-release-notes/7794.md
+++ b/upcoming-release-notes/7794.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Persist end of month cleanup templates in the database


### PR DESCRIPTION
# CONTANS A DB MIGRATION

-------

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

cleanup directives are not currently persisted anywhere but the notes field, every time they run the notes are re-parsed and then run. this works for notes, but means that we can't generate a UI off them easily, and just generally makes it hard. this is the first step in supporting `#cleanup` in the UI.

AI disclaimer: I used claude to help me with the structure here

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Added tests for cleanup behaviour, they pass on master as well as here. Also ran with a budget file with multiple cleanup directives, both group scoped and general.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 | 13.96 MB | 0%
loot-core | 1 | 5.27 MB → 5.28 MB (+3.54 kB) | +0.07%
api | 2 | 3.9 MB → 3.9 MB (+3.42 kB) | +0.09%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 | 13.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.96 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.94 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.91 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.38 kB | 0%
static/js/de.js | 170.55 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 185.11 kB | 0%
static/js/es.js | 179 kB | 0%
static/js/extends.js | 520.98 kB | 0%
static/js/fr.js | 178.9 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.3 kB | 0%
static/js/narrow.js | 364.22 kB | 0%
static/js/nb-NO.js | 148.31 kB | 0%
static/js/nl.js | 106.47 kB | 0%
static/js/pl.js | 86.52 kB | 0%
static/js/pt-BR.js | 189.58 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.76 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.75 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.91 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.27 MB → 5.28 MB (+3.54 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template-notes.ts` | 🆕 +3.9 kB | 0 B → 3.9 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.pegjs` | 📈 +751 B (+4.68%) | 15.67 kB → 16.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +119 B (+1.20%) | 9.65 kB → 9.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +69 B (+0.96%) | 7.01 kB → 7.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📉 -1.28 kB (-13.63%) | 9.38 kB → 8.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B4ZmTvir.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.1rt-Ujz2.js | 5.27 MB → 0 B (-5.27 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+3.42 kB) | +0.09%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template-notes.ts` | 🆕 +3.79 kB | 0 B → 3.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.pegjs` | 📈 +717 B (+4.64%) | 15.1 kB → 15.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +113 B (+1.18%) | 9.36 kB → 9.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +68 B (+0.97%) | 6.84 kB → 6.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📉 -1.25 kB (-13.70%) | 9.14 kB → 7.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+3.42 kB) | +0.09%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->