### PR TITLE
[AI] Fix /update-vrt merge step when only one shard has changes

### DIFF
--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -264,8 +264,11 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          shopt -s nullglob
-          patches=(/tmp/shard-patches/*/vrt-shard.patch)
+          # actions/download-artifact puts a lone matched artifact directly in
+          # `path` but gives each of several its own `path/<name>/` subdir, so
+          # recurse instead of globbing `*/vrt-shard.patch` (which would miss
+          # the common single-shard case).
+          mapfile -t patches < <(find /tmp/shard-patches -type f -name 'vrt-shard.patch' | sort)
 
           if [ ${#patches[@]} -eq 0 ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/upcoming-release-notes/7802.md
+++ b/upcoming-release-notes/7802.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Fix `/update-vrt` screenshot merge operation when exactly one patch is generated


### PR DESCRIPTION
<!--
Thank you for submitting a PR! Please fill in the below sections, then we'll get your changes reviewed as soon as we can. See [our docs](https://actualbudget.org/docs/contributing/) for more information on how to contribute to Actual.

If your PR is not ready for review yet, please open it as a draft. We'll still take a quick look, but we'll wait for you to mark it as ready before doing a full review.
-->

## Description

<!-- Describe the changes that you made, including any context that would help the reviewers understand why you made the choices you did. -->

Patch for `/update-vrt` not working if exactly one patched screenshot zip is generated.

## Related issue(s)

<!-- Please link to the issue(s) that this PR addresses. If it doesn't address an existing issue, please give as much detail as you can about why you're making this change. -->

n/a

## Testing

<!-- Describe the testing you've done to validate that your changes work as expected. -->

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)