### PR TITLE
[AI] automated publishing workflow for crdt package

### DIFF
--- a/.github/workflows/crdt-version-check.yml
+++ b/.github/workflows/crdt-version-check.yml
@@ -15,33 +15,19 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Fetch base branch
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-
       - name: Verify version bump
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
 
-          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- packages/crdt/)
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No changes in packages/crdt/ - skipping version bump check."
-            exit 0
-          fi
-
-          echo "Detected changes in packages/crdt/:"
-          echo "$CHANGED_FILES"
-
           if ! git cat-file -e "origin/${BASE_REF}:packages/crdt/package.json" 2>/dev/null; then
             echo "packages/crdt/package.json does not exist on the base branch; skipping."
             exit 0
           fi
 
-          BASE_VERSION=$(git show "origin/${BASE_REF}:packages/crdt/package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf-8')).version")
-          HEAD_VERSION=$(node -p "require('./packages/crdt/package.json').version")
-
+          BASE_VERSION=$(git show "origin/${BASE_REF}:packages/crdt/package.json" | jq -r .version)
+          HEAD_VERSION=$(jq -r .version packages/crdt/package.json)
           echo "Base version: $BASE_VERSION"
           echo "Head version: $HEAD_VERSION"
 
@@ -50,15 +36,8 @@ jobs:
             exit 1
           fi
 
-          IS_HIGHER=$(node -e "
-            const parse = v => v.split('-')[0].split('.').map(Number);
-            const [a1, a2, a3] = parse('$BASE_VERSION');
-            const [b1, b2, b3] = parse('$HEAD_VERSION');
-            const cmp = b1 - a1 || b2 - a2 || b3 - a3;
-            process.stdout.write(cmp > 0 ? 'yes' : 'no');
-          ")
-
-          if [ "$IS_HIGHER" != "yes" ]; then
+          HIGHEST=$(printf '%s\n%s\n' "$BASE_VERSION" "$HEAD_VERSION" | sort -V | tail -n1)
+          if [ "$HIGHEST" != "$HEAD_VERSION" ]; then
             echo "::error file=packages/crdt/package.json::The @actual-app/crdt version ($HEAD_VERSION) must be greater than the base version ($BASE_VERSION)."
             exit 1
           fi

--- a/.github/workflows/crdt-version-check.yml
+++ b/.github/workflows/crdt-version-check.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'packages/crdt/**'
 
+permissions:
+  contents: read
+
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/crdt-version-check.yml
+++ b/.github/workflows/crdt-version-check.yml
@@ -1,0 +1,66 @@
+name: CRDT version bump check
+
+on:
+  pull_request:
+    paths:
+      - 'packages/crdt/**'
+
+jobs:
+  check-version-bump:
+    runs-on: ubuntu-latest
+    name: Ensure @actual-app/crdt version is bumped
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Verify version bump
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          CHANGED_FILES=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- packages/crdt/)
+
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "No changes in packages/crdt/ - skipping version bump check."
+            exit 0
+          fi
+
+          echo "Detected changes in packages/crdt/:"
+          echo "$CHANGED_FILES"
+
+          if ! git cat-file -e "origin/${BASE_REF}:packages/crdt/package.json" 2>/dev/null; then
+            echo "packages/crdt/package.json does not exist on the base branch; skipping."
+            exit 0
+          fi
+
+          BASE_VERSION=$(git show "origin/${BASE_REF}:packages/crdt/package.json" | node -p "JSON.parse(require('fs').readFileSync(0, 'utf-8')).version")
+          HEAD_VERSION=$(node -p "require('./packages/crdt/package.json').version")
+
+          echo "Base version: $BASE_VERSION"
+          echo "Head version: $HEAD_VERSION"
+
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::error file=packages/crdt/package.json::Files in packages/crdt/ were modified but the @actual-app/crdt version was not bumped. Please update the \"version\" field in packages/crdt/package.json."
+            exit 1
+          fi
+
+          IS_HIGHER=$(node -e "
+            const parse = v => v.split('-')[0].split('.').map(Number);
+            const [a1, a2, a3] = parse('$BASE_VERSION');
+            const [b1, b2, b3] = parse('$HEAD_VERSION');
+            const cmp = b1 - a1 || b2 - a2 || b3 - a3;
+            process.stdout.write(cmp > 0 ? 'yes' : 'no');
+          ")
+
+          if [ "$IS_HIGHER" != "yes" ]; then
+            echo "::error file=packages/crdt/package.json::The @actual-app/crdt version ($HEAD_VERSION) must be greater than the base version ($BASE_VERSION)."
+            exit 1
+          fi
+
+          echo "Version bumped from $BASE_VERSION to $HEAD_VERSION."

--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -20,7 +20,6 @@ jobs:
     name: Check if publish is needed
     outputs:
       should-publish: ${{ steps.check.outputs.should-publish }}
-      version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,7 +32,6 @@ jobs:
 
           LOCAL_VERSION=$(node -p "require('./packages/crdt/package.json').version")
           echo "Local version: $LOCAL_VERSION"
-          echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
 
           PUBLISHED_VERSION=$(npm view @actual-app/crdt version 2>/dev/null || echo "")
           echo "Published version: ${PUBLISHED_VERSION:-<none>}"
@@ -52,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Publish @actual-app/crdt to npm
     permissions:
-      contents: write
+      contents: read
       id-token: write # Required for npm OIDC provenance
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -79,19 +77,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish packages/crdt/@actual-app/crdt.tgz --access public --provenance
-
-      - name: Create git tag
-        env:
-          VERSION: ${{ needs.check-version.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          TAG="crdt-v${VERSION}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists on origin - skipping."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "@actual-app/crdt ${VERSION}"
-          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"

--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -1,0 +1,97 @@
+name: Publish @actual-app/crdt
+
+# Automatically publishes @actual-app/crdt when its package.json version
+# changes on master (typically via a merged PR that bumped the version).
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'packages/crdt/package.json'
+  workflow_dispatch:
+
+concurrency:
+  group: publish-crdt
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    name: Check if publish is needed
+    outputs:
+      should-publish: ${{ steps.check.outputs.should-publish }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Compare local version against npm registry
+        id: check
+        run: |
+          set -euo pipefail
+
+          LOCAL_VERSION=$(node -p "require('./packages/crdt/package.json').version")
+          echo "Local version: $LOCAL_VERSION"
+          echo "version=$LOCAL_VERSION" >> "$GITHUB_OUTPUT"
+
+          PUBLISHED_VERSION=$(npm view @actual-app/crdt version 2>/dev/null || echo "")
+          echo "Published version: ${PUBLISHED_VERSION:-<none>}"
+
+          if [ "$LOCAL_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Versions match - nothing to publish."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version changed - publish required."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: check-version
+    if: needs.check-version.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    name: Publish @actual-app/crdt to npm
+    permissions:
+      contents: write
+      id-token: write # Required for npm OIDC provenance
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: ./.github/actions/setup
+        with:
+          download-translations: 'false'
+
+      - name: Build @actual-app/crdt
+        run: yarn workspace @actual-app/crdt build
+
+      - name: Pack @actual-app/crdt
+        run: yarn workspace @actual-app/crdt pack --filename @actual-app/crdt.tgz
+
+      - name: Setup node and npm registry
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+          check-latest: true
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        run: npm publish packages/crdt/@actual-app/crdt.tgz --access public --provenance
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ needs.check-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="crdt-v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin - skipping."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "@actual-app/crdt ${VERSION}"
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${TAG}"

--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          LOCAL_VERSION=$(node -p "require('./packages/crdt/package.json').version")
+          LOCAL_VERSION=$(jq -r .version packages/crdt/package.json)
           echo "Local version: $LOCAL_VERSION"
 
           PUBLISHED_VERSION=$(npm view @actual-app/crdt version 2>/dev/null || echo "")

--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -10,6 +10,9 @@ on:
       - 'packages/crdt/package.json'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: publish-crdt
   cancel-in-progress: false

--- a/upcoming-release-notes/7805.md
+++ b/upcoming-release-notes/7805.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Require an `@actual-app/crdt` version bump when files in `packages/crdt` change, and automatically publish the new version to npm once merged.


### PR DESCRIPTION
## Description

Two changes:

1. auto publish the crdt package when its version is bumped;
2. force a version bump if any change is done in the crdt package;

## Related issue(s)

<!-- Add any related issue numbers here if applicable -->

n/a

## Testing

n/a

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - workflows follow GitHub Actions best practices with pinned action versions and appropriate permissions

https://claude.ai/code/session_019MaGzvERmFYSvLdEfD1JF8