### PR TITLE
[AI] fix: match no transactions when "has tags" input lacks `#` (closes #7797)

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -540,6 +540,38 @@ describe('Transaction rules', () => {
     expect(transactions.map(t => t.id)).toEqual(['1']);
   });
 
+  test('hasTags matches nothing when input contains no `#` tag pattern', async () => {
+    await loadRules();
+    const account = await db.insertAccount({ name: 'bank' });
+    const payeeId = await db.insertPayee({ name: 'payee' });
+
+    await db.insertTransaction({
+      id: '1',
+      date: '2020-10-01',
+      account,
+      payee: payeeId,
+      notes: 'Follow up #foo issue',
+      amount: 123,
+    });
+
+    await db.insertTransaction({
+      id: '2',
+      date: '2020-10-01',
+      account,
+      payee: payeeId,
+      notes: 'unrelated note',
+      amount: 123,
+    });
+
+    // Input is missing the leading `#` — previously this returned every
+    // transaction; now it should match nothing.
+    const transactions = await getMatchingTransactions([
+      { field: 'notes', op: 'hasTags', value: 'foo' },
+    ]);
+
+    expect(transactions).toEqual([]);
+  });
+
   test('and sub expression builds $and condition', async () => {
     const conds = [{ field: 'category', op: 'is', value: null }];
     const { filters } = conditionsToAQL(conds);

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -623,6 +623,12 @@ export function conditionsToAQL(
           }
         }
 
+        if (tagValues.length === 0) {
+          // No `#tag` patterns in the input — match nothing rather than
+          // returning an empty `$and` (which would match every row).
+          return { id: null };
+        }
+
         return {
           $and: tagValues.map(v => {
             const escapedTag = v

--- a/upcoming-release-notes/7808.md
+++ b/upcoming-release-notes/7808.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MaksZhukov]
+---
+
+Fix the "Notes > has tags" transaction filter returning every transaction when the input is missing a `#` — it now matches nothing instead.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 34 → 33 | 13.99 MB → 13.9 MB (-83.08 kB) | -0.58%
loot-core | 1 | 5.28 MB → 5.28 MB (+54 B) | +0.00%
api | 2 | 3.9 MB → 3.9 MB (+53 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
34 → 33 | 13.99 MB → 13.9 MB (-83.08 kB) | -0.58%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +5 kB (+2.70%) | 185.11 kB → 190.1 kB
`locale/uk.json` | 📉 -120 B (-0.06%) | 207.75 kB → 207.63 kB
`locale/nb-NO.json` | 📉 -86 B (-0.06%) | 148.31 kB → 148.23 kB
`locale/pt-BR.json` | 📉 -137 B (-0.07%) | 189.58 kB → 189.45 kB
`locale/es.json` | 📉 -139 B (-0.08%) | 179 kB → 178.87 kB
`locale/de.json` | 📉 -137 B (-0.08%) | 170.55 kB → 170.42 kB
`locale/ca.json` | 📉 -151 B (-0.08%) | 187.91 kB → 187.76 kB
`locale/it.json` | 📉 -133 B (-0.08%) | 165.3 kB → 165.17 kB
`locale/fr.json` | 📉 -144 B (-0.08%) | 178.9 kB → 178.76 kB
`locale/nl.json` | 📉 -88 B (-0.08%) | 106.47 kB → 106.39 kB
`locale/th.json` | 📉 -146 B (-0.08%) | 174.76 kB → 174.62 kB
`locale/zh-Hans.json` | 📉 -118 B (-0.10%) | 117.91 kB → 117.79 kB
`locale/da.json` | 📉 -102 B (-0.10%) | 101.38 kB → 101.28 kB
`src/languages.ts` | 📉 -99 B (-6.17%) | 1.57 kB → 1.47 kB
`locale/pl.json` | 🔥 -86.52 kB (-100%) | 86.52 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 86.52 kB → 0 B (-86.52 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 185.11 kB → 190.1 kB (+5 kB) | +2.70%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ca.js | 187.91 kB → 187.76 kB (-151 B) | -0.08%
static/js/th.js | 174.76 kB → 174.62 kB (-146 B) | -0.08%
static/js/fr.js | 178.9 kB → 178.76 kB (-144 B) | -0.08%
static/js/es.js | 179 kB → 178.87 kB (-139 B) | -0.08%
static/js/de.js | 170.55 kB → 170.42 kB (-137 B) | -0.08%
static/js/pt-BR.js | 189.58 kB → 189.45 kB (-137 B) | -0.07%
static/js/it.js | 165.3 kB → 165.17 kB (-133 B) | -0.08%
static/js/uk.js | 207.75 kB → 207.63 kB (-120 B) | -0.06%
static/js/zh-Hans.js | 117.91 kB → 117.79 kB (-118 B) | -0.10%
static/js/da.js | 101.38 kB → 101.28 kB (-102 B) | -0.10%
static/js/extends.js | 519.39 kB → 519.29 kB (-99 B) | -0.02%
static/js/nl.js | 106.47 kB → 106.39 kB (-88 B) | -0.08%
static/js/nb-NO.js | 148.31 kB → 148.23 kB (-86 B) | -0.06%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.96 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.4 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.22 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+54 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +54 B (+0.25%) | 21.03 kB → 21.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BBEVWUkZ.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B9JGPKKy.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.9 MB → 3.9 MB (+53 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +53 B (+0.25%) | 20.52 kB → 20.57 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.9 MB → 3.9 MB (+53 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 43.41 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 43.41 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->