### PR TITLE
clean up GoCardless bank factory loading process

### DIFF
--- a/packages/sync-server/src/app-gocardless/bank-factory.js
+++ b/packages/sync-server/src/app-gocardless/bank-factory.js
@@ -2,19 +2,9 @@ import IntegrationBank from './banks/integration-bank';
 
 // Filename convention: <name>_<bic>.{ts,js} (skips bank.interface,
 // integration-bank, and any other helper without an underscore).
-const bankLoaders = import.meta.glob('./banks/*_*.{ts,js}');
+const bankModules = import.meta.glob('./banks/*_*.{ts,js}', { eager: true });
 
-async function loadBanks() {
-  const imports = await Promise.all(
-    Object.values(bankLoaders).map(loader =>
-      loader().then(handler => handler.default),
-    ),
-  );
-
-  return imports;
-}
-
-export const banks = await loadBanks();
+export const banks = Object.values(bankModules).map(m => m.default);
 
 export function BankFactory(institutionId) {
   return (

--- a/upcoming-release-notes/7809.md
+++ b/upcoming-release-notes/7809.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Clean up GoCardless bank factory loading process


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Hit this on my server after #7702. Bundling sync-server into a single chunk (which I had to do to work around a cyclic import deadlock on illumos) crashes with Cannot access X before initialization. Something about the top level await was letting them be evaluated before they were loaded (wording up for debate...) and was failing with "cannot access before initialisation".

Technically this adds to the startup time, but it's absolutely minuscule and cleans up a bit of a smell here anyway.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
