### PR TITLE
[AI] Replace any-typed Modal in undo state with structural type

### DIFF
--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -8,6 +8,7 @@ import { setAppState } from './app/appSlice';
 import { categoryQueries } from './budget';
 import { closeBudgetUI } from './budgetfiles/budgetfilesSlice';
 import { closeModal, pushModal, replaceModal } from './modals/modalsSlice';
+import type { Modal } from './modals/modalsSlice';
 import {
   addGenericErrorNotification,
   addNotification,
@@ -90,13 +91,16 @@ export function handleGlobalEvents(store: AppStore, queryClient: QueryClient) {
 
         // If a modal has been tagged, open it instead of navigating
         if (tagged.openModal) {
+          // The undo store keeps modals as an opaque structural shape; re-narrow
+          // to the real Modal union now that we're back in desktop-client.
+          const openModal = tagged.openModal as Modal;
           const { modalStack } = store.getState().modals;
 
           if (
             modalStack.length === 0 ||
-            modalStack[modalStack.length - 1].name !== tagged.openModal.name
+            modalStack[modalStack.length - 1].name !== openModal.name
           ) {
-            store.dispatch(replaceModal({ modal: tagged.openModal }));
+            store.dispatch(replaceModal({ modal: openModal }));
           }
         } else {
           store.dispatch(closeModal());

--- a/packages/desktop-client/src/global-events.ts
+++ b/packages/desktop-client/src/global-events.ts
@@ -93,6 +93,9 @@ export function handleGlobalEvents(store: AppStore, queryClient: QueryClient) {
         if (tagged.openModal) {
           // The undo store keeps modals as an opaque structural shape; re-narrow
           // to the real Modal union now that we're back in desktop-client.
+          // TODO: drop this cast once the Modal type lives somewhere both
+          // loot-core and desktop-client can import (e.g. consolidated under
+          // @actual-app/core types).
           const openModal = tagged.openModal as Modal;
           const { modalStack } = store.getState().modals;
 

--- a/packages/loot-core/src/platform/client/undo/index.ts
+++ b/packages/loot-core/src/platform/client/undo/index.ts
@@ -2,8 +2,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type { UndoState as ServerUndoState } from '#server/undo';
 
-// oxlint-disable-next-line @typescript-eslint/no-explicit-any
-type Modal = any; // TODO: fix me
+// Minimal structural shape of desktop-client's Modal union. loot-core can't
+// import the full type from @actual-app/web; the undo system only stores the
+// modal and reads `name`. `options` is kept loose so the real Modal assigns.
+type Modal = { name: string; options?: unknown };
 
 type UndoState = {
   url: string | null;

--- a/upcoming-release-notes/7813.md
+++ b/upcoming-release-notes/7813.md
@@ -1,6 +1,6 @@
 ---
-category: Enhancements
+category: Maintenance
 authors: [MatissJanis]
 ---
 
-Replace any-typed Modal in undo state with a defined structural type for improved safety.
+Replace any-typed Modal in undo state with a defined structural type.

--- a/upcoming-release-notes/7813.md
+++ b/upcoming-release-notes/7813.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Replace any-typed Modal in undo state with a defined structural type for improved safety.


### PR DESCRIPTION
Slightly improving typing of the "Modal" type. 

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.91 MB → 13.91 MB (+1.24 kB) | +0.01%
loot-core | 1 | 5.31 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.91 MB → 13.91 MB (+1.24 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en-GB.json` | 📈 +1.81 kB (+22.12%) | 8.2 kB → 10.01 kB
`src/global-events.ts` | 📈 +26 B (+0.74%) | 3.42 kB → 3.45 kB
`locale/es.json` | 📉 -41 B (-0.02%) | 178.87 kB → 178.83 kB
`locale/ca.json` | 📉 -45 B (-0.02%) | 187.76 kB → 187.72 kB
`locale/de.json` | 📉 -42 B (-0.02%) | 170.42 kB → 170.38 kB
`locale/fr.json` | 📉 -47 B (-0.03%) | 178.76 kB → 178.71 kB
`locale/nb-NO.json` | 📉 -41 B (-0.03%) | 148.23 kB → 148.19 kB
`locale/it.json` | 📉 -46 B (-0.03%) | 165.17 kB → 165.13 kB
`locale/pt-BR.json` | 📉 -58 B (-0.03%) | 189.45 kB → 189.39 kB
`locale/zh-Hans.json` | 📉 -37 B (-0.03%) | 117.79 kB → 117.75 kB
`locale/uk.json` | 📉 -68 B (-0.03%) | 207.63 kB → 207.56 kB
`locale/nl.json` | 📉 -46 B (-0.04%) | 106.39 kB → 106.34 kB
`locale/en.json` | 📉 -138 B (-0.07%) | 190.1 kB → 189.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en-GB.js | 8.2 kB → 10.01 kB (+1.81 kB) | +22.12%
static/js/index.js | 1.97 MB → 1.97 MB (+26 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 190.1 kB → 189.97 kB (-138 B) | -0.07%
static/js/uk.js | 207.63 kB → 207.56 kB (-68 B) | -0.03%
static/js/pt-BR.js | 189.45 kB → 189.39 kB (-58 B) | -0.03%
static/js/fr.js | 178.76 kB → 178.71 kB (-47 B) | -0.03%
static/js/it.js | 165.17 kB → 165.13 kB (-46 B) | -0.03%
static/js/nl.js | 106.39 kB → 106.34 kB (-46 B) | -0.04%
static/js/ca.js | 187.76 kB → 187.72 kB (-45 B) | -0.02%
static/js/de.js | 170.42 kB → 170.38 kB (-42 B) | -0.02%
static/js/es.js | 178.87 kB → 178.83 kB (-41 B) | -0.02%
static/js/nb-NO.js | 148.23 kB → 148.19 kB (-41 B) | -0.03%
static/js/zh-Hans.js | 117.79 kB → 117.75 kB (-37 B) | -0.03%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cozwd3bP.js | 5.31 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->