### PR TITLE
Fix split transaction popover wrapping

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1384,7 +1384,8 @@ const Transaction = memo(function Transaction({
             isOpen
             isNonModal
             style={{
-              maxWidth: 500,
+              width: 'max-content',
+              maxWidth: 'none',
               minWidth: 375,
               padding: 5,
             }}
@@ -1978,7 +1979,6 @@ function TransactionError({
           <View
             style={{
               flexDirection: 'row',
-              flexWrap: 'wrap',
               alignItems: 'center',
               padding: '0 5px',
               gap: 5,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1387,7 +1387,6 @@ const Transaction = memo(function Transaction({
               maxWidth: 500,
               minWidth: 375,
               padding: 5,
-              maxHeight: '38px !important',
             }}
             shouldFlip={false}
             placement="bottom end"
@@ -1979,8 +1978,10 @@ function TransactionError({
           <View
             style={{
               flexDirection: 'row',
+              flexWrap: 'wrap',
               alignItems: 'center',
               padding: '0 5px',
+              gap: 5,
               ...style,
             }}
             data-testid="transaction-error"
@@ -1996,7 +1997,6 @@ function TransactionError({
             <View style={{ flex: 1 }} />
             <Button
               variant="normal"
-              style={{ marginLeft: 15 }}
               onPress={onDistributeRemainder}
               data-testid="distribute-split-button"
             >
@@ -2004,7 +2004,7 @@ function TransactionError({
             </Button>
             <Button
               variant="primary"
-              style={{ marginLeft: 10, padding: '4px 10px' }}
+              style={{ padding: '4px 10px' }}
               onPress={onAddSplit}
               data-testid="add-split-button"
             >

--- a/upcoming-release-notes/7814.md
+++ b/upcoming-release-notes/7814.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [impetus82]
+---
+
+Fix split transaction popover layout so translated buttons remain visible.


### PR DESCRIPTION
## Summary
- removes the fixed 38px max height from the split transaction error popover
- allows the error row to wrap when translated button labels need more space
- replaces fixed left margins between controls with a small `gap`

## Notes
This targets the issue where the split transaction popover can show scrollbars or hide buttons with longer translated labels, especially in German/high-DPI layouts.

## Verification
- `git diff --check`
- Not run: full app build/test. This workspace uses a sparse checkout because cloning the full repository repeatedly hit network resets.

Fixes #7738

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.91 MB → 13.91 MB (-189 B) | -0.00%
loot-core | 1 | 5.31 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.91 MB → 13.91 MB (-189 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📉 -189 B (-0.21%) | 88.46 kB → 88.28 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.96 MB → 4.96 MB (-189 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.97 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.76 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.42 kB | 0%
static/js/en-GB.js | 8.2 kB | 0%
static/js/en.js | 190.1 kB | 0%
static/js/es.js | 178.87 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.76 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.17 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.23 kB | 0%
static/js/nl.js | 106.39 kB | 0%
static/js/pt-BR.js | 189.45 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.63 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.79 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cozwd3bP.js | 5.31 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->