### PR TITLE
automation UI: add cleanup functionality

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -42,6 +42,7 @@
     "#components/budget": "./src/components/budget/index.tsx",
     "#components/budget/goals/actions": "./src/components/budget/goals/actions.ts",
     "#components/budget/goals/automationExamples": "./src/components/budget/goals/automationExamples.ts",
+    "#components/budget/goals/cleanupModel": "./src/components/budget/goals/cleanupModel.ts",
     "#components/budget/goals/constants": "./src/components/budget/goals/constants.ts",
     "#components/budget/goals/displayTemplateMeta": "./src/components/budget/goals/displayTemplateMeta.ts",
     "#components/budget/goals/formatMonthLabel": "./src/components/budget/goals/formatMonthLabel.ts",

--- a/packages/desktop-client/src/components/budget/SidebarCategoryButtons.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategoryButtons.tsx
@@ -43,7 +43,7 @@ export const SidebarCategoryButtons = ({
           showPlaceholder={
             !goalsShown &&
             isGoalTemplatesUIEnabled &&
-            !!category.goal_def?.length
+            (!!category.goal_def?.length || !!category.cleanup_def?.length)
           }
         />
       </View>

--- a/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
+++ b/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
@@ -38,7 +38,8 @@ export function CategoryAutomationButton({
   const goalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const goalTemplatesUIEnabled = useFeatureFlag('goalTemplatesUIEnabled');
   const [budgetType = 'envelope'] = useSyncedPref('budgetType');
-  const hasAutomations = !!category.goal_def?.length;
+  const hasAutomations =
+    !!category.goal_def?.length || !!category.cleanup_def?.length;
 
   if (!goalTemplatesEnabled || !goalTemplatesUIEnabled) {
     return null;

--- a/packages/desktop-client/src/components/budget/goals/cleanupModel.ts
+++ b/packages/desktop-client/src/components/budget/goals/cleanupModel.ts
@@ -11,7 +11,6 @@ export type GroupCleanup = {
   send: boolean;
   take: boolean;
   weight: number;
-  // engine's `overspend` role — group-only, caps the take at the overspend amount
   overspendOnly: boolean;
 };
 
@@ -25,46 +24,12 @@ export const emptyCleanupConfig = (): CleanupConfig => ({
   groups: [],
 });
 
-const isCleared = (config: CleanupConfig): boolean =>
-  !config.global.send &&
-  !config.global.take &&
-  config.groups.every(g => !g.send && !g.take);
-
-export function cleanupToConfig(cleanup: CleanupTemplate[]): CleanupConfig {
-  const config = emptyCleanupConfig();
-  const groupScopes = new Map<string, GroupCleanup>();
-
-  for (const row of cleanup) {
-    if (row.role === 'source') {
-      if (row.groupId === null) {
-        config.global.send = true;
-      } else {
-        const g = ensureGroup(groupScopes, row.groupId);
-        g.send = true;
-      }
-    } else if (row.role === 'sink') {
-      if (row.groupId === null) {
-        config.global.take = true;
-        config.global.weight = row.weight;
-      } else {
-        const g = ensureGroup(groupScopes, row.groupId);
-        g.take = true;
-        g.weight = row.weight;
-        // a sink wins over a stray prior overspend row for the same group
-        g.overspendOnly = false;
-      }
-    } else {
-      const g = ensureGroup(groupScopes, row.groupId);
-      // don't downgrade a real sink row already recorded for this group
-      if (!g.take) {
-        g.take = true;
-        g.overspendOnly = true;
-      }
-    }
-  }
-
-  config.groups = Array.from(groupScopes.values());
-  return config;
+export function isCleanupConfigured(config: CleanupConfig): boolean {
+  return (
+    config.global.send ||
+    config.global.take ||
+    config.groups.some(group => group.send || group.take)
+  );
 }
 
 function ensureGroup(
@@ -84,8 +49,45 @@ function ensureGroup(
   return fresh;
 }
 
-export function configToCleanup(config: CleanupConfig): CleanupTemplate[] {
-  if (isCleared(config)) return [];
+export function cleanupDefToEditor(cleanup: CleanupTemplate[]): CleanupConfig {
+  const config = emptyCleanupConfig();
+  const groupScopes = new Map<string, GroupCleanup>();
+
+  for (const row of cleanup) {
+    if (row.role === 'source') {
+      if (row.groupId === null) {
+        config.global.send = true;
+      } else {
+        const group = ensureGroup(groupScopes, row.groupId);
+        group.send = true;
+      }
+    } else if (row.role === 'sink') {
+      if (row.groupId === null) {
+        config.global.take = true;
+        config.global.weight = row.weight;
+      } else {
+        const group = ensureGroup(groupScopes, row.groupId);
+        group.take = true;
+        group.weight = row.weight;
+        // a sink wins over a stray prior overspend row for the same group
+        group.overspendOnly = false;
+      }
+    } else {
+      const group = ensureGroup(groupScopes, row.groupId);
+      // don't downgrade a real sink row already recorded for this group
+      if (!group.take) {
+        group.take = true;
+        group.overspendOnly = true;
+      }
+    }
+  }
+
+  config.groups = Array.from(groupScopes.values());
+  return config;
+}
+
+export function editorToCleanupDef(config: CleanupConfig): CleanupTemplate[] {
+  if (!isCleanupConfigured(config)) return [];
 
   const rows: CleanupTemplate[] = [];
 
@@ -94,13 +96,13 @@ export function configToCleanup(config: CleanupConfig): CleanupTemplate[] {
     rows.push({ role: 'sink', groupId: null, weight: config.global.weight });
   }
 
-  for (const g of config.groups) {
-    if (g.send) rows.push({ role: 'source', groupId: g.groupId });
-    if (g.take) {
+  for (const group of config.groups) {
+    if (group.send) rows.push({ role: 'source', groupId: group.groupId });
+    if (group.take) {
       rows.push(
-        g.overspendOnly
-          ? { role: 'overspend', groupId: g.groupId }
-          : { role: 'sink', groupId: g.groupId, weight: g.weight },
+        group.overspendOnly
+          ? { role: 'overspend', groupId: group.groupId }
+          : { role: 'sink', groupId: group.groupId, weight: group.weight },
       );
     }
   }
@@ -108,12 +110,6 @@ export function configToCleanup(config: CleanupConfig): CleanupTemplate[] {
   return rows;
 }
 
-export function isConfigActive(config: CleanupConfig): boolean {
-  return !isCleared(config);
-}
-
-// Drops rows whose group can't be resolved rather than emitting a UUID that
-// the grammar would later parse as a literal group name.
 export function cleanupToNotes(
   cleanup: CleanupTemplate[],
   groupName: (groupId: string) => string | null,

--- a/packages/desktop-client/src/components/budget/goals/cleanupModel.ts
+++ b/packages/desktop-client/src/components/budget/goals/cleanupModel.ts
@@ -1,0 +1,140 @@
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
+
+export type GlobalCleanup = {
+  send: boolean;
+  take: boolean;
+  weight: number;
+};
+
+export type GroupCleanup = {
+  groupId: string;
+  send: boolean;
+  take: boolean;
+  weight: number;
+  // engine's `overspend` role — group-only, caps the take at the overspend amount
+  overspendOnly: boolean;
+};
+
+export type CleanupConfig = {
+  global: GlobalCleanup;
+  groups: GroupCleanup[];
+};
+
+export const emptyCleanupConfig = (): CleanupConfig => ({
+  global: { send: false, take: false, weight: 1 },
+  groups: [],
+});
+
+const isCleared = (config: CleanupConfig): boolean =>
+  !config.global.send &&
+  !config.global.take &&
+  config.groups.every(g => !g.send && !g.take);
+
+export function cleanupToConfig(cleanup: CleanupTemplate[]): CleanupConfig {
+  const config = emptyCleanupConfig();
+  const groupScopes = new Map<string, GroupCleanup>();
+
+  for (const row of cleanup) {
+    if (row.role === 'source') {
+      if (row.groupId === null) {
+        config.global.send = true;
+      } else {
+        const g = ensureGroup(groupScopes, row.groupId);
+        g.send = true;
+      }
+    } else if (row.role === 'sink') {
+      if (row.groupId === null) {
+        config.global.take = true;
+        config.global.weight = row.weight;
+      } else {
+        const g = ensureGroup(groupScopes, row.groupId);
+        g.take = true;
+        g.weight = row.weight;
+        // a sink wins over a stray prior overspend row for the same group
+        g.overspendOnly = false;
+      }
+    } else {
+      const g = ensureGroup(groupScopes, row.groupId);
+      // don't downgrade a real sink row already recorded for this group
+      if (!g.take) {
+        g.take = true;
+        g.overspendOnly = true;
+      }
+    }
+  }
+
+  config.groups = Array.from(groupScopes.values());
+  return config;
+}
+
+function ensureGroup(
+  map: Map<string, GroupCleanup>,
+  groupId: string,
+): GroupCleanup {
+  const existing = map.get(groupId);
+  if (existing) return existing;
+  const fresh: GroupCleanup = {
+    groupId,
+    send: false,
+    take: false,
+    weight: 1,
+    overspendOnly: false,
+  };
+  map.set(groupId, fresh);
+  return fresh;
+}
+
+export function configToCleanup(config: CleanupConfig): CleanupTemplate[] {
+  if (isCleared(config)) return [];
+
+  const rows: CleanupTemplate[] = [];
+
+  if (config.global.send) rows.push({ role: 'source', groupId: null });
+  if (config.global.take) {
+    rows.push({ role: 'sink', groupId: null, weight: config.global.weight });
+  }
+
+  for (const g of config.groups) {
+    if (g.send) rows.push({ role: 'source', groupId: g.groupId });
+    if (g.take) {
+      rows.push(
+        g.overspendOnly
+          ? { role: 'overspend', groupId: g.groupId }
+          : { role: 'sink', groupId: g.groupId, weight: g.weight },
+      );
+    }
+  }
+
+  return rows;
+}
+
+export function isConfigActive(config: CleanupConfig): boolean {
+  return !isCleared(config);
+}
+
+// Drops rows whose group can't be resolved rather than emitting a UUID that
+// the grammar would later parse as a literal group name.
+export function cleanupToNotes(
+  cleanup: CleanupTemplate[],
+  groupName: (groupId: string) => string | null,
+): string {
+  return cleanup
+    .flatMap(row => {
+      if (row.role === 'overspend') {
+        const name = groupName(row.groupId);
+        return name ? [`#cleanup ${name}`] : [];
+      }
+      let scope = '';
+      if (row.groupId !== null) {
+        const name = groupName(row.groupId);
+        if (!name) return [];
+        scope = `${name} `;
+      }
+      if (row.role === 'source') {
+        return [`#cleanup ${scope}source`];
+      }
+      const weight = row.weight !== 1 ? ` ${row.weight}` : '';
+      return [`#cleanup ${scope}sink${weight}`];
+    })
+    .join('\n');
+}

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { SvgDelete } from '@actual-app/components/icons/v0';
+import { Input } from '@actual-app/components/input';
+import { SpaceBetween } from '@actual-app/components/space-between';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+import type {
+  CleanupConfig,
+  GroupCleanup,
+} from '#components/budget/goals/cleanupModel';
+import { FormLabel } from '#components/forms';
+import { LabeledCheckbox } from '#components/forms/LabeledCheckbox';
+import type { CleanupGroup } from '#hooks/useCleanupGroups';
+
+import { CleanupGroupPicker } from './CleanupGroupPicker';
+
+type CleanupAutomationProps = {
+  config: CleanupConfig;
+  groups: CleanupGroup[];
+  onChange: (next: CleanupConfig) => void;
+  onCreateGroup: (name: string) => Promise<string>;
+};
+
+export function CleanupAutomation({
+  config,
+  groups,
+  onChange,
+  onCreateGroup,
+}: CleanupAutomationProps) {
+  const { t } = useTranslation();
+  const [pickingGroup, setPickingGroup] = useState(false);
+
+  const updateGlobal = (patch: Partial<CleanupConfig['global']>) =>
+    onChange({ ...config, global: { ...config.global, ...patch } });
+
+  const updateGroup = (groupId: string, patch: Partial<GroupCleanup>) =>
+    onChange({
+      ...config,
+      groups: config.groups.map(g =>
+        g.groupId === groupId ? { ...g, ...patch } : g,
+      ),
+    });
+
+  const removeGroup = (groupId: string) =>
+    onChange({
+      ...config,
+      groups: config.groups.filter(g => g.groupId !== groupId),
+    });
+
+  const addGroup = (groupId: string) => {
+    if (config.groups.some(g => g.groupId === groupId)) return;
+    onChange({
+      ...config,
+      groups: [
+        ...config.groups,
+        {
+          groupId,
+          send: false,
+          take: false,
+          weight: 1,
+          overspendOnly: false,
+        },
+      ],
+    });
+  };
+
+  return (
+    <View style={{ gap: 14 }}>
+      <Text style={{ fontSize: 12, color: theme.pageTextSubdued }}>
+        <Trans>
+          End of month cleanup is a one-click rebalance you can run at the end
+          of a month. Categories you mark to <strong>send leftover</strong>{' '}
+          return their surplus to a pool; categories you mark to{' '}
+          <strong>take a share</strong> receive part of that pool back. By
+          default the pool is To Budget. You can also create named groups so the
+          surplus only moves between a chosen set of categories.
+        </Trans>
+      </Text>
+
+      <ScopeCard
+        title={t('Global')}
+        sendLabel={t('Send any leftover here to To Budget')}
+        takeLabel={t('Take a share of leftover To Budget')}
+        send={config.global.send}
+        take={config.global.take}
+        weight={config.global.weight}
+        overspendOnly={false}
+        showOverspendOnly={false}
+        onChangeSend={send => updateGlobal({ send })}
+        onChangeTake={take => updateGlobal({ take })}
+        onChangeWeight={weight => updateGlobal({ weight })}
+        onChangeOverspendOnly={() => undefined}
+      />
+
+      {config.groups.map(g => {
+        const groupName =
+          groups.find(gg => gg.id === g.groupId)?.name ?? t('Unknown group');
+        return (
+          <ScopeCard
+            key={g.groupId}
+            title={t('Group: {{groupName}}', { groupName })}
+            sendLabel={t("Send any leftover here to the group's pool")}
+            takeLabel={t("Take a share of the group's pool")}
+            send={g.send}
+            take={g.take}
+            weight={g.weight}
+            overspendOnly={g.overspendOnly}
+            showOverspendOnly
+            onChangeSend={send => updateGroup(g.groupId, { send })}
+            onChangeTake={take => updateGroup(g.groupId, { take })}
+            onChangeWeight={weight => updateGroup(g.groupId, { weight })}
+            onChangeOverspendOnly={overspendOnly =>
+              updateGroup(g.groupId, { overspendOnly })
+            }
+            onRemove={() => removeGroup(g.groupId)}
+          />
+        );
+      })}
+
+      {/* The engine accepts multiple group scopes per category but the result
+          depends on category sort order, so the editor caps it at one. */}
+      {config.groups.length === 0 &&
+        (pickingGroup ? (
+          <View style={{ gap: 6 }}>
+            <FormLabel
+              title={t('Pick or create a group')}
+              htmlFor="cleanup-add-group-field"
+            />
+            <CleanupGroupPicker
+              id="cleanup-add-group-field"
+              groups={groups}
+              autoFocus
+              onSelect={groupId => {
+                addGroup(groupId);
+                setPickingGroup(false);
+              }}
+              onCreate={onCreateGroup}
+            />
+          </View>
+        ) : (
+          <Button
+            variant="bare"
+            onPress={() => setPickingGroup(true)}
+            style={{ alignSelf: 'flex-start', color: theme.pageTextPositive }}
+          >
+            + <Trans>Add to a group</Trans>
+          </Button>
+        ))}
+    </View>
+  );
+}
+
+type ScopeCardProps = {
+  title: string;
+  sendLabel: string;
+  takeLabel: string;
+  send: boolean;
+  take: boolean;
+  weight: number;
+  overspendOnly: boolean;
+  showOverspendOnly: boolean;
+  onChangeSend: (send: boolean) => void;
+  onChangeTake: (take: boolean) => void;
+  onChangeWeight: (weight: number) => void;
+  onChangeOverspendOnly: (overspendOnly: boolean) => void;
+  onRemove?: () => void;
+};
+
+function ScopeCard({
+  title,
+  sendLabel,
+  takeLabel,
+  send,
+  take,
+  weight,
+  overspendOnly,
+  showOverspendOnly,
+  onChangeSend,
+  onChangeTake,
+  onChangeWeight,
+  onChangeOverspendOnly,
+  onRemove,
+}: ScopeCardProps) {
+  const { t } = useTranslation();
+  return (
+    <View
+      style={{
+        padding: 12,
+        backgroundColor: theme.tableBackground,
+        borderRadius: 6,
+        border: `1px solid ${theme.tableBorder}`,
+        gap: 8,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Text
+          style={{
+            fontSize: 11,
+            textTransform: 'uppercase',
+            color: theme.pageTextSubdued,
+            fontWeight: 600,
+            letterSpacing: '0.04em',
+          }}
+        >
+          {title}
+        </Text>
+        {onRemove && (
+          <Button
+            variant="bare"
+            onPress={onRemove}
+            aria-label={t('Remove group')}
+            style={{ color: theme.pageTextSubdued, padding: 2 }}
+          >
+            <SvgDelete width={10} height={10} style={{ color: 'inherit' }} />
+          </Button>
+        )}
+      </View>
+
+      <LabeledCheckbox
+        id={`cleanup-send-${title}`}
+        checked={send}
+        onChange={e => onChangeSend(e.target.checked)}
+      >
+        <span style={{ marginLeft: 6, fontSize: 12 }}>{sendLabel}</span>
+      </LabeledCheckbox>
+
+      <LabeledCheckbox
+        id={`cleanup-take-${title}`}
+        checked={take}
+        onChange={e => onChangeTake(e.target.checked)}
+      >
+        <span style={{ marginLeft: 6, fontSize: 12 }}>{takeLabel}</span>
+      </LabeledCheckbox>
+
+      {take && (
+        <View style={{ marginLeft: 22, gap: 6 }}>
+          {showOverspendOnly && (
+            <LabeledCheckbox
+              id={`cleanup-overspend-${title}`}
+              checked={overspendOnly}
+              onChange={e => onChangeOverspendOnly(e.target.checked)}
+            >
+              <span style={{ marginLeft: 6, fontSize: 12 }}>
+                <Trans>Only enough to cover any overspending</Trans>
+              </span>
+            </LabeledCheckbox>
+          )}
+          {!overspendOnly && (
+            <SpaceBetween align="center" gap={10}>
+              <FormLabel
+                title={t('Weight')}
+                htmlFor={`cleanup-weight-${title}`}
+              />
+              <Input
+                id={`cleanup-weight-${title}`}
+                type="number"
+                min={1}
+                step={1}
+                style={{ width: 80 }}
+                value={String(weight)}
+                onChangeValue={value => {
+                  const parsed = Math.max(1, Math.trunc(Number(value)) || 1);
+                  onChangeWeight(parsed);
+                }}
+              />
+            </SpaceBetween>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
@@ -13,6 +13,7 @@ import type {
   CleanupConfig,
   GroupCleanup,
 } from '#components/budget/goals/cleanupModel';
+import { Link } from '#components/common/Link';
 import { FormLabel } from '#components/forms';
 import { LabeledCheckbox } from '#components/forms/LabeledCheckbox';
 import type { CleanupGroup } from '#hooks/useCleanupGroups';
@@ -73,19 +74,25 @@ export function CleanupAutomation({
     <View style={{ gap: 14 }}>
       <Text style={{ fontSize: 12, color: theme.pageTextSubdued }}>
         <Trans>
-          End of month cleanup is a one-click rebalance you can run at the end
-          of a month. Categories you mark to <strong>send leftover</strong>{' '}
-          return their surplus to a pool; categories you mark to{' '}
-          <strong>take a share</strong> receive part or all of that pool back.
-          By default the pool is To Budget. You can also create named groups so
-          the surplus only moves between a chosen set of categories.
+          End of month cleanup is a one-click reallocation of funds. Categories
+          you choose to <strong>send leftover</strong> return their surplus to a
+          pool; categories you mark to <strong>receive leftover</strong> receive
+          part or all of that pool back. By default, the pool is To Budget. You
+          can also create named pools so the surplus only moves between
+          categories set to use that pool.{' '}
+          <Link
+            variant="external"
+            to="https://actualbudget.org/docs/experimental/monthly-cleanup#local-group-source-and-sinks"
+          >
+            Learn more
+          </Link>
         </Trans>
       </Text>
 
       <ScopeCard
         title={t('Global')}
-        sendLabel={t('Send any leftover here to To Budget')}
-        takeLabel={t('Take a share of leftover To Budget')}
+        sendLabel={t('Send leftover')}
+        takeLabel={t('Receive leftover')}
         send={config.global.send}
         take={config.global.take}
         weight={config.global.weight}
@@ -99,13 +106,13 @@ export function CleanupAutomation({
 
       {config.groups.map(group => {
         const groupName =
-          groups.find(g => g.id === group.groupId)?.name ?? t('Unknown group');
+          groups.find(g => g.id === group.groupId)?.name ?? t('Unknown pool');
         return (
           <ScopeCard
             key={group.groupId}
-            title={t('Group: {{groupName}}', { groupName })}
-            sendLabel={t("Send any leftover here to the group's pool")}
-            takeLabel={t("Take a share of the group's pool")}
+            title={t('Pool: {{groupName}}', { groupName })}
+            sendLabel={t('Send leftover to pool')}
+            takeLabel={t('Receive leftover from pool')}
             send={group.send}
             take={group.take}
             weight={group.weight}
@@ -122,13 +129,13 @@ export function CleanupAutomation({
         );
       })}
 
-      {/* The engine accepts multiple group scopes per category but the result
+      {/* The engine accepts multiple pool scopes per category but the result
           depends on category sort order, so the editor caps it at one. */}
       {config.groups.length === 0 &&
         (pickingGroup ? (
           <View style={{ gap: 6 }}>
             <FormLabel
-              title={t('Pick or create a group')}
+              title={t('Pick or create a pool')}
               htmlFor="cleanup-add-group-field"
             />
             <CleanupGroupPicker
@@ -148,7 +155,7 @@ export function CleanupAutomation({
             onPress={() => setPickingGroup(true)}
             style={{ alignSelf: 'flex-start', color: theme.pageTextPositive }}
           >
-            + <Trans>Add to a group</Trans>
+            + <Trans>Add to a pool</Trans>
           </Button>
         ))}
     </View>
@@ -219,7 +226,7 @@ function ScopeCard({
           <Button
             variant="bare"
             onPress={onRemove}
-            aria-label={t('Remove group')}
+            aria-label={t('Remove pool')}
             style={{ color: theme.pageTextSubdued, padding: 2 }}
           >
             <SvgDelete width={10} height={10} style={{ color: 'inherit' }} />

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomation.tsx
@@ -41,19 +41,19 @@ export function CleanupAutomation({
   const updateGroup = (groupId: string, patch: Partial<GroupCleanup>) =>
     onChange({
       ...config,
-      groups: config.groups.map(g =>
-        g.groupId === groupId ? { ...g, ...patch } : g,
+      groups: config.groups.map(group =>
+        group.groupId === groupId ? { ...group, ...patch } : group,
       ),
     });
 
   const removeGroup = (groupId: string) =>
     onChange({
       ...config,
-      groups: config.groups.filter(g => g.groupId !== groupId),
+      groups: config.groups.filter(group => group.groupId !== groupId),
     });
 
   const addGroup = (groupId: string) => {
-    if (config.groups.some(g => g.groupId === groupId)) return;
+    if (config.groups.some(group => group.groupId === groupId)) return;
     onChange({
       ...config,
       groups: [
@@ -76,9 +76,9 @@ export function CleanupAutomation({
           End of month cleanup is a one-click rebalance you can run at the end
           of a month. Categories you mark to <strong>send leftover</strong>{' '}
           return their surplus to a pool; categories you mark to{' '}
-          <strong>take a share</strong> receive part of that pool back. By
-          default the pool is To Budget. You can also create named groups so the
-          surplus only moves between a chosen set of categories.
+          <strong>take a share</strong> receive part or all of that pool back.
+          By default the pool is To Budget. You can also create named groups so
+          the surplus only moves between a chosen set of categories.
         </Trans>
       </Text>
 
@@ -97,27 +97,27 @@ export function CleanupAutomation({
         onChangeOverspendOnly={() => undefined}
       />
 
-      {config.groups.map(g => {
+      {config.groups.map(group => {
         const groupName =
-          groups.find(gg => gg.id === g.groupId)?.name ?? t('Unknown group');
+          groups.find(g => g.id === group.groupId)?.name ?? t('Unknown group');
         return (
           <ScopeCard
-            key={g.groupId}
+            key={group.groupId}
             title={t('Group: {{groupName}}', { groupName })}
             sendLabel={t("Send any leftover here to the group's pool")}
             takeLabel={t("Take a share of the group's pool")}
-            send={g.send}
-            take={g.take}
-            weight={g.weight}
-            overspendOnly={g.overspendOnly}
+            send={group.send}
+            take={group.take}
+            weight={group.weight}
+            overspendOnly={group.overspendOnly}
             showOverspendOnly
-            onChangeSend={send => updateGroup(g.groupId, { send })}
-            onChangeTake={take => updateGroup(g.groupId, { take })}
-            onChangeWeight={weight => updateGroup(g.groupId, { weight })}
+            onChangeSend={send => updateGroup(group.groupId, { send })}
+            onChangeTake={take => updateGroup(group.groupId, { take })}
+            onChangeWeight={weight => updateGroup(group.groupId, { weight })}
             onChangeOverspendOnly={overspendOnly =>
-              updateGroup(g.groupId, { overspendOnly })
+              updateGroup(group.groupId, { overspendOnly })
             }
-            onRemove={() => removeGroup(g.groupId)}
+            onRemove={() => removeGroup(group.groupId)}
           />
         );
       })}

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
@@ -15,10 +15,10 @@ export function CleanupAutomationReadOnly({
   const { t } = useTranslation();
   const isGlobal = config.global.send || config.global.take;
   const groupNames: string[] = [];
-  for (const g of config.groups) {
-    if (!g.send && !g.take) continue;
+  for (const group of config.groups) {
+    if (!group.send && !group.take) continue;
     const name =
-      groups.find(x => x.id === g.groupId)?.name ?? t('Unknown group');
+      groups.find(g => g.id === group.groupId)?.name ?? t('Unknown group');
     groupNames.push(name);
   }
 

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
@@ -1,0 +1,34 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
+import type { CleanupGroup } from '#hooks/useCleanupGroups';
+
+type CleanupAutomationReadOnlyProps = {
+  config: CleanupConfig;
+  groups: CleanupGroup[];
+};
+
+export function CleanupAutomationReadOnly({
+  config,
+  groups,
+}: CleanupAutomationReadOnlyProps) {
+  const { t } = useTranslation();
+  const isGlobal = config.global.send || config.global.take;
+  const groupNames: string[] = [];
+  for (const g of config.groups) {
+    if (!g.send && !g.take) continue;
+    const name =
+      groups.find(x => x.id === g.groupId)?.name ?? t('Unknown group');
+    groupNames.push(name);
+  }
+
+  const total = (isGlobal ? 1 : 0) + groupNames.length;
+  if (total === 0) return <Trans>No cleanup configured</Trans>;
+  if (total > 1) {
+    const count = total;
+    return <Trans count={count}>Active in {{ count }} scopes</Trans>;
+  }
+  if (isGlobal) return <Trans>Active globally</Trans>;
+  const scope = groupNames[0];
+  return <Trans>Active in {{ scope }}</Trans>;
+}

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx
@@ -18,7 +18,7 @@ export function CleanupAutomationReadOnly({
   for (const group of config.groups) {
     if (!group.send && !group.take) continue;
     const name =
-      groups.find(g => g.id === group.groupId)?.name ?? t('Unknown group');
+      groups.find(g => g.id === group.groupId)?.name ?? t('Unknown pool');
     groupNames.push(name);
   }
 

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupGroupPicker.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupGroupPicker.tsx
@@ -143,7 +143,7 @@ export function CleanupGroupPicker({
               >
                 {item.kind === 'group'
                   ? item.group.name
-                  : t('+ Create "{{name}}"', { name: trimmed })}
+                  : `+ ${t('Create "{{name}}"', { name: trimmed })}`}
               </View>
             );
           })}

--- a/packages/desktop-client/src/components/budget/goals/editor/CleanupGroupPicker.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/CleanupGroupPicker.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Input } from '@actual-app/components/input';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+import type { CleanupGroup } from '#hooks/useCleanupGroups';
+
+type CleanupGroupPickerProps = {
+  id?: string;
+  groups: CleanupGroup[];
+  onSelect: (groupId: string) => void;
+  onCreate: (name: string) => Promise<string>;
+  placeholder?: string;
+  autoFocus?: boolean;
+};
+
+export function CleanupGroupPicker({
+  id,
+  groups,
+  onSelect,
+  onCreate,
+  placeholder,
+  autoFocus,
+}: CleanupGroupPickerProps) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const trimmed = query.trim();
+  const matches = groups.filter(g =>
+    g.name.toLowerCase().includes(trimmed.toLowerCase()),
+  );
+  const exact = matches.find(
+    g => g.name.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const showCreate = trimmed.length > 0 && !exact;
+  type Item = { kind: 'group'; group: CleanupGroup } | { kind: 'create' };
+  const items: Item[] = [
+    ...matches.map(group => ({ kind: 'group' as const, group })),
+    ...(showCreate ? [{ kind: 'create' as const }] : []),
+  ];
+
+  useEffect(() => {
+    if (highlight >= items.length) setHighlight(Math.max(0, items.length - 1));
+  }, [items.length, highlight]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const pick = async (item: Item) => {
+    if (item.kind === 'group') {
+      onSelect(item.group.id);
+    } else {
+      const newId = await onCreate(trimmed);
+      onSelect(newId);
+    }
+    setQuery('');
+    setOpen(false);
+  };
+
+  return (
+    <View ref={containerRef} style={{ position: 'relative' }}>
+      <Input
+        id={id}
+        autoFocus={autoFocus}
+        value={query}
+        placeholder={placeholder ?? t('Type to search or create…')}
+        onChangeValue={value => {
+          setQuery(value);
+          setOpen(true);
+          setHighlight(0);
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={e => {
+          if (!open) return;
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setHighlight(h => Math.min(items.length - 1, h + 1));
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setHighlight(h => Math.max(0, h - 1));
+          } else if (e.key === 'Enter' && items[highlight]) {
+            e.preventDefault();
+            void pick(items[highlight]);
+          } else if (e.key === 'Escape') {
+            setOpen(false);
+          }
+        }}
+      />
+      {open && items.length > 0 && (
+        <View
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            marginTop: 2,
+            backgroundColor: theme.menuBackground,
+            border: `1px solid ${theme.menuBorder}`,
+            borderRadius: 6,
+            boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+            zIndex: 10,
+            maxHeight: 240,
+            overflowY: 'auto',
+          }}
+        >
+          {items.map((item, i) => {
+            const active = i === highlight;
+            const isCreate = item.kind === 'create';
+            return (
+              <View
+                key={item.kind === 'group' ? item.group.id : '__create__'}
+                onClick={() => void pick(item)}
+                onMouseEnter={() => setHighlight(i)}
+                style={{
+                  padding: '8px 10px',
+                  cursor: 'pointer',
+                  backgroundColor: active
+                    ? theme.menuAutoCompleteBackgroundHover
+                    : 'transparent',
+                  fontSize: 12,
+                  fontWeight: isCreate ? 500 : undefined,
+                  color: isCreate
+                    ? active
+                      ? theme.menuAutoCompleteTextHover
+                      : theme.noticeTextMenu
+                    : active
+                      ? theme.menuAutoCompleteTextHover
+                      : theme.menuItemText,
+                }}
+              >
+                {item.kind === 'group'
+                  ? item.group.name
+                  : t('+ Create "{{name}}"', { name: trimmed })}
+              </View>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
@@ -77,7 +77,6 @@ export function AutomationListRow({
         alignItems: 'center',
         gap: 10,
         padding: 10,
-        marginBottom: 4,
         borderRadius: 6,
         border: `1px solid ${borderColor}`,
         backgroundColor,

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -24,10 +24,10 @@ import {
 } from '#components/budget/goals/automationExamples';
 import type { AutomationEntry } from '#components/budget/goals/automationExamples';
 import {
-  cleanupToConfig,
-  configToCleanup,
+  cleanupDefToEditor,
+  editorToCleanupDef,
   emptyCleanupConfig,
-  isConfigActive,
+  isCleanupConfigured,
 } from '#components/budget/goals/cleanupModel';
 import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
 import { CleanupAutomation } from '#components/budget/goals/editor/CleanupAutomation';
@@ -139,6 +139,20 @@ type BudgetAutomationsBodyProps = {
 
 type ActiveSelection = { kind: 'entry'; idx: number } | { kind: 'cleanup' };
 
+function pickInitialSelection(
+  entries: AutomationEntry[],
+  cleanup: CleanupConfig,
+): ActiveSelection {
+  if (entries.length > 0) {
+    const idx = entries.findIndex(
+      e => !NON_CONTRIBUTION_TYPES.has(e.displayType),
+    );
+    return { kind: 'entry', idx: idx >= 0 ? idx : 0 };
+  }
+  if (isCleanupConfigured(cleanup)) return { kind: 'cleanup' };
+  return { kind: 'entry', idx: 0 };
+}
+
 export function BudgetAutomationsBody({
   categoryId,
   categoryName,
@@ -157,20 +171,11 @@ export function BudgetAutomationsBody({
     useCleanupGroups();
 
   const [entries, setEntries] = useState<AutomationEntry[]>(initialEntries);
-  const [cleanup, setCleanup] = useState<CleanupConfig>(() =>
-    cleanupToConfig(initialCleanup),
+  const initialCleanupConfig = cleanupDefToEditor(initialCleanup);
+  const [cleanup, setCleanup] = useState<CleanupConfig>(initialCleanupConfig);
+  const [active, setActive] = useState<ActiveSelection>(() =>
+    pickInitialSelection(initialEntries, initialCleanupConfig),
   );
-  const [active, setActive] = useState<ActiveSelection>(() => {
-    if (initialEntries.length > 0) {
-      const contributionIdx = initialEntries.findIndex(
-        e => !NON_CONTRIBUTION_TYPES.has(e.displayType),
-      );
-      return { kind: 'entry', idx: contributionIdx >= 0 ? contributionIdx : 0 };
-    }
-    return isConfigActive(cleanupToConfig(initialCleanup))
-      ? { kind: 'cleanup' }
-      : { kind: 'entry', idx: 0 };
-  });
   const [saving, setSaving] = useState(false);
   const [dryRun, setDryRun] = useState<{
     budgeted: number;
@@ -226,7 +231,7 @@ export function BudgetAutomationsBody({
   };
 
   const onAddCleanup = () => {
-    if (!isConfigActive(cleanup)) setCleanup(emptyCleanupConfig());
+    if (!isCleanupConfigured(cleanup)) setCleanup(emptyCleanupConfig());
     setActive({ kind: 'cleanup' });
   };
 
@@ -260,7 +265,7 @@ export function BudgetAutomationsBody({
           {
             id: categoryId,
             templates: templatesToSave,
-            cleanup: configToCleanup(cleanup),
+            cleanup: editorToCleanupDef(cleanup),
           },
         ],
         source: 'ui',
@@ -279,13 +284,15 @@ export function BudgetAutomationsBody({
           options: {
             categoryId,
             templates: entries.map(({ template }) => template),
-            cleanup: configToCleanup(cleanup),
+            cleanup: editorToCleanupDef(cleanup),
           },
         },
       }),
     );
   };
 
+  // the react compiler wasn't memoising this properly and causing infinite
+  // re-renders
   const templates = useMemo(() => entries.map(e => e.template), [entries]);
 
   const validPercentageSources = new Set<string>([
@@ -521,7 +528,7 @@ export function BudgetAutomationsBody({
               + <Trans>Add long-term goal</Trans>
             </SidebarAddButton>
           )}
-          {isConfigActive(cleanup) ? (
+          {isCleanupConfigured(cleanup) ? (
             <CleanupListRow
               config={cleanup}
               groups={cleanupGroups}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -237,7 +237,7 @@ export function BudgetAutomationsBody({
 
   const onDeleteCleanup = () => {
     setCleanup(emptyCleanupConfig());
-    if (entries.length > 0) setActive({ kind: 'entry', idx: 0 });
+    setActive({ kind: 'entry', idx: 0 });
   };
 
   const onDelete = (index: number) => {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { Trans } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
+import { SvgDelete } from '@actual-app/components/icons/v0';
 import { SvgInformationCircle } from '@actual-app/components/icons/v2';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
@@ -13,6 +14,7 @@ import type {
   CategoryGroupEntity,
   ScheduleEntity,
 } from '@actual-app/core/types/models';
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
 import { css } from '@emotion/css';
 import debounce from 'lodash/debounce';
 
@@ -21,12 +23,21 @@ import {
   getAutomationExamples,
 } from '#components/budget/goals/automationExamples';
 import type { AutomationEntry } from '#components/budget/goals/automationExamples';
+import {
+  cleanupToConfig,
+  configToCleanup,
+  emptyCleanupConfig,
+  isConfigActive,
+} from '#components/budget/goals/cleanupModel';
+import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
+import { CleanupAutomation } from '#components/budget/goals/editor/CleanupAutomation';
 import { formatMonthLabel } from '#components/budget/goals/formatMonthLabel';
 import {
   validateAutomation,
   validatePercentageAllocation,
 } from '#components/budget/goals/validateAutomation';
 import { Link } from '#components/common/Link';
+import { useCleanupGroups } from '#hooks/useCleanupGroups';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { pushModal } from '#modals/modalsSlice';
@@ -35,6 +46,7 @@ import { useDispatch } from '#redux';
 import { AutomationEditorPane } from './AutomationEditorPane';
 import { AutomationListRow } from './AutomationListRow';
 import { BudgetAutomationMigrationWarning } from './BudgetAutomationMigrationWarning';
+import { CleanupListRow } from './CleanupListRow';
 import { ConflictBanner } from './ConflictBanner';
 import { EmptyState } from './EmptyState';
 import { NON_CONTRIBUTION_TYPES } from './TypePicker';
@@ -99,7 +111,6 @@ function SidebarAddButton({
       style={{
         flexShrink: 0,
         width: '100%',
-        marginTop: 8,
         padding: 10,
         border: `1px dashed ${theme.tableBorder}`,
         borderRadius: 6,
@@ -114,41 +125,26 @@ function SidebarAddButton({
   );
 }
 
-function SidebarPlaceholderRow({ children }: { children: ReactNode }) {
-  return (
-    <View
-      style={{
-        flexShrink: 0,
-        padding: '8px 10px',
-        marginTop: 4,
-        borderRadius: 6,
-        border: `1px dashed ${theme.tableBorder}`,
-        color: theme.pageTextSubdued,
-        fontSize: 12,
-        opacity: 0.6,
-      }}
-    >
-      <Text>{children}</Text>
-    </View>
-  );
-}
-
 type BudgetAutomationsBodyProps = {
   categoryId: string;
   categoryName: string;
   needsMigration: boolean;
   initialEntries: AutomationEntry[];
+  initialCleanup: CleanupTemplate[];
   schedules: readonly ScheduleEntity[];
   categories: CategoryGroupEntity[];
   month: string;
   onClose: () => void;
 };
 
+type ActiveSelection = { kind: 'entry'; idx: number } | { kind: 'cleanup' };
+
 export function BudgetAutomationsBody({
   categoryId,
   categoryName,
   needsMigration,
   initialEntries,
+  initialCleanup,
   schedules,
   categories,
   month,
@@ -157,14 +153,24 @@ export function BudgetAutomationsBody({
   const dispatch = useDispatch();
   const format = useFormat();
   const locale = useLocale();
+  const { groups: cleanupGroups, createGroup: createCleanupGroup } =
+    useCleanupGroups();
 
   const [entries, setEntries] = useState<AutomationEntry[]>(initialEntries);
-  const initialContributionIdx = initialEntries.findIndex(
-    e => !NON_CONTRIBUTION_TYPES.has(e.displayType),
+  const [cleanup, setCleanup] = useState<CleanupConfig>(() =>
+    cleanupToConfig(initialCleanup),
   );
-  const [activeIdx, setActiveIdx] = useState(
-    initialContributionIdx >= 0 ? initialContributionIdx : 0,
-  );
+  const [active, setActive] = useState<ActiveSelection>(() => {
+    if (initialEntries.length > 0) {
+      const contributionIdx = initialEntries.findIndex(
+        e => !NON_CONTRIBUTION_TYPES.has(e.displayType),
+      );
+      return { kind: 'entry', idx: contributionIdx >= 0 ? contributionIdx : 0 };
+    }
+    return isConfigActive(cleanupToConfig(initialCleanup))
+      ? { kind: 'cleanup' }
+      : { kind: 'entry', idx: 0 };
+  });
   const [saving, setSaving] = useState(false);
   const [dryRun, setDryRun] = useState<{
     budgeted: number;
@@ -179,7 +185,7 @@ export function BudgetAutomationsBody({
     if (!entry) return;
     setEntries(prev => {
       const next = [...prev, entry];
-      setActiveIdx(next.length - 1);
+      setActive({ kind: 'entry', idx: next.length - 1 });
       return next;
     });
   };
@@ -198,7 +204,7 @@ export function BudgetAutomationsBody({
     );
     setEntries(prev => {
       const next = [...prev, entry];
-      setActiveIdx(next.length - 1);
+      setActive({ kind: 'entry', idx: next.length - 1 });
       return next;
     });
   };
@@ -214,18 +220,30 @@ export function BudgetAutomationsBody({
     );
     setEntries(prev => {
       const next = [...prev, entry];
-      setActiveIdx(next.length - 1);
+      setActive({ kind: 'entry', idx: next.length - 1 });
       return next;
     });
+  };
+
+  const onAddCleanup = () => {
+    if (!isConfigActive(cleanup)) setCleanup(emptyCleanupConfig());
+    setActive({ kind: 'cleanup' });
+  };
+
+  const onDeleteCleanup = () => {
+    setCleanup(emptyCleanupConfig());
+    if (entries.length > 0) setActive({ kind: 'entry', idx: 0 });
   };
 
   const onDelete = (index: number) => {
     setEntries(prev => {
       const next = prev.filter((_, i) => i !== index);
-      setActiveIdx(currentActive => {
-        if (next.length === 0) return 0;
-        if (currentActive >= next.length) return next.length - 1;
-        if (currentActive > index) return currentActive - 1;
+      setActive(currentActive => {
+        if (currentActive.kind !== 'entry') return currentActive;
+        if (next.length === 0) return { kind: 'entry', idx: 0 };
+        const idx = currentActive.idx;
+        if (idx >= next.length) return { kind: 'entry', idx: next.length - 1 };
+        if (idx > index) return { kind: 'entry', idx: idx - 1 };
         return currentActive;
       });
       return next;
@@ -239,7 +257,11 @@ export function BudgetAutomationsBody({
       const templatesToSave = entries.map(({ template }) => template);
       await send('budget/set-category-automations', {
         categoriesWithTemplates: [
-          { id: categoryId, templates: templatesToSave },
+          {
+            id: categoryId,
+            templates: templatesToSave,
+            cleanup: configToCleanup(cleanup),
+          },
         ],
         source: 'ui',
       });
@@ -257,13 +279,14 @@ export function BudgetAutomationsBody({
           options: {
             categoryId,
             templates: entries.map(({ template }) => template),
+            cleanup: configToCleanup(cleanup),
           },
         },
       }),
     );
   };
 
-  const templates = entries.map(e => e.template);
+  const templates = useMemo(() => entries.map(e => e.template), [entries]);
 
   const validPercentageSources = new Set<string>([
     'all income',
@@ -338,7 +361,12 @@ export function BudgetAutomationsBody({
   );
   const optionEntries = indexedEntries.filter(({ entry }) => isOption(entry));
 
-  const safeActiveIdx = Math.min(activeIdx, Math.max(0, entries.length - 1));
+  const safeActiveIdx =
+    active.kind === 'entry'
+      ? Math.min(active.idx, Math.max(0, entries.length - 1))
+      : -1;
+  const cleanupActive = active.kind === 'cleanup';
+  const setActiveIdx = (idx: number) => setActive({ kind: 'entry', idx });
 
   return (
     <View style={{ flex: 1, flexDirection: 'column', minHeight: 0 }}>
@@ -446,6 +474,7 @@ export function BudgetAutomationsBody({
             borderRight: `1px solid ${theme.tableBorder}`,
             padding: 10,
             overflowY: 'scroll',
+            gap: 4,
           }}
         >
           <SidebarSectionHeader>
@@ -492,13 +521,63 @@ export function BudgetAutomationsBody({
               + <Trans>Add long-term goal</Trans>
             </SidebarAddButton>
           )}
-          <SidebarPlaceholderRow>
-            <Trans>End of month cleanup (coming soon)</Trans>
-          </SidebarPlaceholderRow>
+          {isConfigActive(cleanup) ? (
+            <CleanupListRow
+              config={cleanup}
+              groups={cleanupGroups}
+              isActive={cleanupActive}
+              onSelect={() => setActive({ kind: 'cleanup' })}
+            />
+          ) : (
+            <SidebarAddButton onPress={onAddCleanup}>
+              + <Trans>Add end of month cleanup</Trans>
+            </SidebarAddButton>
+          )}
         </View>
 
         <View style={{ flex: 1, minWidth: 0 }}>
-          {entries.length === 0 ? (
+          {cleanupActive ? (
+            <View
+              style={{
+                flex: 1,
+                padding: 20,
+                overflowY: 'auto',
+                gap: 14,
+              }}
+            >
+              <CleanupAutomation
+                config={cleanup}
+                groups={cleanupGroups}
+                onChange={setCleanup}
+                onCreateGroup={createCleanupGroup}
+              />
+              <View
+                style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}
+              >
+                <View style={{ flex: 1 }} />
+                <Button
+                  variant="bare"
+                  onPress={onDeleteCleanup}
+                  style={{ color: theme.errorText }}
+                >
+                  <span
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 6,
+                    }}
+                  >
+                    <SvgDelete
+                      width={10}
+                      height={10}
+                      style={{ color: 'inherit' }}
+                    />
+                    <Trans>Remove cleanup</Trans>
+                  </span>
+                </Button>
+              </View>
+            </View>
+          ) : entries.length === 0 ? (
             <EmptyState onAdd={onAddAutomation} />
           ) : (
             <AutomationEditorPane

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -40,21 +40,23 @@ export function BudgetAutomationsModal({
     setParsedTemplates(result[categoryId] ?? []);
   };
 
+  const { data: currentCategory } = useCategory(categoryId);
+  const needsMigration = currentCategory?.template_settings?.source !== 'ui';
+  const source = needsMigration ? 'notes' : 'ui';
+
   const { loading: templatesLoading } = useBudgetAutomations({
     categoryId,
+    source,
     onLoaded,
   });
 
   const { schedules } = useSchedules({ query: q('schedules').select('*') });
 
   const categories = useBudgetAutomationCategories();
-  const { data: currentCategory } = useCategory(categoryId);
-
-  const needsMigration = currentCategory?.template_settings?.source !== 'ui';
 
   const { loading: cleanupLoading } = useCategoryCleanup({
     categoryId,
-    source: needsMigration ? 'notes' : 'ui',
+    source,
     onLoaded: setParsedCleanup,
   });
   const loading = templatesLoading || cleanupLoading;

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -4,21 +4,19 @@ import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { View } from '@actual-app/components/view';
 import { currentMonth } from '@actual-app/core/shared/months';
 import { q } from '@actual-app/core/shared/query';
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
 import type { Template } from '@actual-app/core/types/models/templates';
 
 import { useBudgetAutomationCategories } from '#components/budget/goals/useBudgetAutomationCategories';
 import { Modal } from '#components/common/Modal';
 import { useBudgetAutomations } from '#hooks/useBudgetAutomations';
 import { useCategory } from '#hooks/useCategory';
-import { useNotes } from '#hooks/useNotes';
+import { useCategoryCleanup } from '#hooks/useCategoryCleanup';
 import { useSchedules } from '#hooks/useSchedules';
 
 import { BudgetAutomationsBody } from './BudgetAutomationsBody';
 import { migrateTemplatesToAutomations } from './migrateTemplatesToAutomations';
-import {
-  hasCleanupLine,
-  UnsupportedDirectivesNotice,
-} from './UnsupportedDirectivesNotice';
+import { UnsupportedDirectivesNotice } from './UnsupportedDirectivesNotice';
 
 const MODAL_WIDTH = 960;
 const MODAL_HEIGHT = 760;
@@ -33,32 +31,39 @@ export function BudgetAutomationsModal({
   const [parsedTemplates, setParsedTemplates] = useState<Template[] | null>(
     null,
   );
+  const [parsedCleanup, setParsedCleanup] = useState<CleanupTemplate[] | null>(
+    null,
+  );
   const effectiveMonth = month ?? currentMonth();
 
   const onLoaded = (result: Record<string, Template[]>) => {
     setParsedTemplates(result[categoryId] ?? []);
   };
 
-  const { loading } = useBudgetAutomations({ categoryId, onLoaded });
+  const { loading: templatesLoading } = useBudgetAutomations({
+    categoryId,
+    onLoaded,
+  });
 
   const { schedules } = useSchedules({ query: q('schedules').select('*') });
 
   const categories = useBudgetAutomationCategories();
   const { data: currentCategory } = useCategory(categoryId);
-  const notes = useNotes(categoryId);
 
   const needsMigration = currentCategory?.template_settings?.source !== 'ui';
+
+  const { loading: cleanupLoading } = useCategoryCleanup({
+    categoryId,
+    source: needsMigration ? 'notes' : 'ui',
+    onLoaded: setParsedCleanup,
+  });
+  const loading = templatesLoading || cleanupLoading;
 
   const hasErrorTemplate =
     parsedTemplates?.some(t => t.type === 'error') ?? false;
   const hasSpendTemplate =
     parsedTemplates?.some(t => t.type === 'spend') ?? false;
-  // Only surface stale `#cleanup` lines for categories that haven't been
-  // migrated to UI-managed automations; once `source === 'ui'`, the notes
-  // are no longer the source of truth.
-  const hasCleanupDirective = needsMigration && hasCleanupLine(notes);
-  const hasUnsupportedDirective =
-    hasErrorTemplate || hasSpendTemplate || hasCleanupDirective;
+  const hasUnsupportedDirective = hasErrorTemplate || hasSpendTemplate;
 
   const incomeNameToId = new Map<string, string>();
   for (const group of categories) {
@@ -94,7 +99,7 @@ export function BudgetAutomationsModal({
     >
       {({ state }) => (
         <View style={{ flex: 1, minHeight: 0 }}>
-          {loading || parsedTemplates === null ? (
+          {loading || parsedTemplates === null || parsedCleanup === null ? (
             <View
               style={{
                 flex: 1,
@@ -107,7 +112,6 @@ export function BudgetAutomationsModal({
           ) : hasUnsupportedDirective ? (
             <UnsupportedDirectivesNotice
               hasErrorTemplate={hasErrorTemplate}
-              hasSpendTemplate={hasSpendTemplate}
               onClose={() => state.close()}
             />
           ) : (
@@ -116,6 +120,7 @@ export function BudgetAutomationsModal({
               categoryName={currentCategory?.name ?? ''}
               needsMigration={needsMigration}
               initialEntries={initialEntries ?? []}
+              initialCleanup={parsedCleanup}
               schedules={schedules}
               categories={categories}
               month={effectiveMonth}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -41,7 +41,11 @@ export function BudgetAutomationsModal({
   };
 
   const { data: currentCategory } = useCategory(categoryId);
-  const needsMigration = currentCategory?.template_settings?.source !== 'ui';
+  // default to 'ui' while the category is still resolving so we don't fire a
+  // notes-mode migration on a category that may turn out to be ui-managed
+  const needsMigration =
+    currentCategory != null &&
+    currentCategory.template_settings?.source !== 'ui';
   const source = needsMigration ? 'notes' : 'ui';
 
   const { loading: templatesLoading } = useBudgetAutomations({

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/CleanupListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/CleanupListRow.tsx
@@ -28,7 +28,15 @@ export function CleanupListRow({
 
   return (
     <View
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
       aria-label={t('Select cleanup')}
       style={{
         flexShrink: 0,

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/CleanupListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/CleanupListRow.tsx
@@ -1,0 +1,84 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import { SvgRefresh } from '@actual-app/components/icons/v1';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
+import { CleanupAutomationReadOnly } from '#components/budget/goals/editor/CleanupAutomationReadOnly';
+import type { CleanupGroup } from '#hooks/useCleanupGroups';
+
+type CleanupListRowProps = {
+  config: CleanupConfig;
+  groups: CleanupGroup[];
+  isActive: boolean;
+  onSelect: () => void;
+};
+
+export function CleanupListRow({
+  config,
+  groups,
+  isActive,
+  onSelect,
+}: CleanupListRowProps) {
+  const { t } = useTranslation();
+  const borderColor = isActive ? theme.tableBorderSelected : 'transparent';
+  const backgroundColor = isActive ? theme.upcomingBackground : 'transparent';
+
+  return (
+    <View
+      onClick={onSelect}
+      aria-label={t('Select cleanup')}
+      style={{
+        flexShrink: 0,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 10,
+        padding: 10,
+        borderRadius: 6,
+        border: `1px solid ${borderColor}`,
+        backgroundColor,
+        cursor: 'pointer',
+      }}
+    >
+      <View
+        style={{
+          width: 28,
+          height: 28,
+          borderRadius: 6,
+          backgroundColor: isActive
+            ? theme.upcomingBackground
+            : theme.pillBackground,
+          color: isActive ? theme.pageTextPositive : theme.pageTextSubdued,
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+        }}
+      >
+        <SvgRefresh width={14} height={14} style={{ color: 'inherit' }} />
+      </View>
+      <View style={{ minWidth: 0, flex: 1 }}>
+        <Text
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: theme.pageText,
+            display: 'block',
+          }}
+        >
+          <Trans>End of month cleanup</Trans>
+        </Text>
+        <Text
+          style={{
+            fontSize: 11,
+            color: theme.pageTextSubdued,
+            display: 'block',
+          }}
+        >
+          <CleanupAutomationReadOnly config={config} groups={groups} />
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
@@ -8,11 +8,9 @@ import { View } from '@actual-app/components/view';
 
 export function UnsupportedDirectivesNotice({
   hasErrorTemplate,
-  hasSpendTemplate,
   onClose,
 }: {
   hasErrorTemplate: boolean;
-  hasSpendTemplate: boolean;
   onClose: () => void;
 }) {
   return (
@@ -54,15 +52,9 @@ export function UnsupportedDirectivesNotice({
             notes couldn&rsquo;t be parsed. Fix them as text first, then re-open
             this modal to migrate.
           </Trans>
-        ) : hasSpendTemplate ? (
-          <Trans>
-            This category uses a <code>spend from</code> template, which the
-            budget automations UI doesn&rsquo;t handle yet. Keep editing it as
-            text in the category&rsquo;s notes.
-          </Trans>
         ) : (
           <Trans>
-            This category uses a <code>#cleanup</code> directive, which the
+            This category uses a <code>spend from</code> template, which the
             budget automations UI doesn&rsquo;t handle yet. Keep editing it as
             text in the category&rsquo;s notes.
           </Trans>
@@ -73,11 +65,4 @@ export function UnsupportedDirectivesNotice({
       </Button>
     </View>
   );
-}
-
-const CLEANUP_DIRECTIVE = /^\s*#cleanup\b/;
-
-export function hasCleanupLine(notes: string | null | undefined): boolean {
-  if (!notes) return false;
-  return notes.split('\n').some(line => CLEANUP_DIRECTIVE.test(line));
 }

--- a/packages/desktop-client/src/components/modals/UnmigrateBudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/UnmigrateBudgetAutomationsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -6,13 +6,16 @@ import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
 import type { Template } from '@actual-app/core/types/models/templates';
 
+import { cleanupToNotes } from '#components/budget/goals/cleanupModel';
 import { Link } from '#components/common/Link';
 import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
 import { Notes } from '#components/Notes';
 import { useCategories } from '#hooks/useCategories';
 import { useCategory } from '#hooks/useCategory';
+import { useCleanupGroups } from '#hooks/useCleanupGroups';
 import { useNotes } from '#hooks/useNotes';
 
 // The UI's CategoryAutocomplete stores the income category id on a
@@ -34,13 +37,16 @@ function sanitizePercentageCategoriesForNotes(
 export function UnmigrateBudgetAutomationsModal({
   categoryId,
   templates,
+  cleanup,
 }: {
   categoryId: string;
   templates: Template[];
+  cleanup: CleanupTemplate[];
 }) {
   const { t } = useTranslation();
   const { data: category } = useCategory(categoryId);
   const { data: categoryData } = useCategories();
+  const { groups: cleanupGroups } = useCleanupGroups();
   const existingNotes = useNotes(categoryId) || '';
   const [editedNotes, setEditedNotes] = useState<string>('');
 
@@ -54,6 +60,8 @@ export function UnmigrateBudgetAutomationsModal({
       idToName.set(cat.id, cat.name);
     }
     const sanitized = sanitizePercentageCategoriesForNotes(templates, idToName);
+    const groupName = (groupId: string) =>
+      cleanupGroups.find(g => g.id === groupId)?.name ?? null;
     let mounted = true;
     void (async () => {
       try {
@@ -61,7 +69,9 @@ export function UnmigrateBudgetAutomationsModal({
           'budget/render-note-templates',
           sanitized,
         );
-        if (mounted) setRendered(text);
+        const cleanupText = cleanupToNotes(cleanup, groupName);
+        const combined = [text, cleanupText].filter(Boolean).join('\n');
+        if (mounted) setRendered(combined);
       } catch {
         if (mounted) setRendered('');
       }
@@ -69,7 +79,7 @@ export function UnmigrateBudgetAutomationsModal({
     return () => {
       mounted = false;
     };
-  }, [templates, categoryData]);
+  }, [templates, cleanup, categoryData, cleanupGroups]);
 
   // Seed editable notes once templates rendered
   useEffect(() => {
@@ -102,12 +112,14 @@ export function UnmigrateBudgetAutomationsModal({
         setEditedNotes(
           base +
             needsNewline +
-            '\nExport from automations UI:\n' +
+            '\n' +
+            t('Export from automations UI:') +
+            '\n' +
             newLines.join('\n'),
         );
       }
     }
-  }, [rendered, existingNotes]);
+  }, [rendered, existingNotes, t]);
 
   async function onSave(close: () => void) {
     setSaving(true);
@@ -118,10 +130,13 @@ export function UnmigrateBudgetAutomationsModal({
       // re-derive goal_def from the notes the next time it runs (e.g. on
       // modal open or when applying templates).
       await send('budget/set-category-automations', {
-        categoriesWithTemplates: [{ id: categoryId, templates: [] }],
+        categoriesWithTemplates: [
+          { id: categoryId, templates: [], cleanup: [] },
+        ],
         source: 'notes',
       });
       await send('budget/store-note-templates');
+      await send('budget/store-note-cleanups');
       close();
     } finally {
       setSaving(false);

--- a/packages/desktop-client/src/components/modals/UnmigrateBudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/UnmigrateBudgetAutomationsModal.tsx
@@ -108,11 +108,10 @@ export function UnmigrateBudgetAutomationsModal({
       if (newLines.length === 0) {
         setEditedNotes(base);
       } else {
-        const needsNewline = base && !base.endsWith('\n') ? '\n' : '';
+        const separator = base ? (base.endsWith('\n') ? '\n' : '\n\n') : '';
         setEditedNotes(
           base +
-            needsNewline +
-            '\n' +
+            separator +
             t('Export from automations UI:') +
             '\n' +
             newLines.join('\n'),

--- a/packages/desktop-client/src/hooks/useBudgetAutomations.ts
+++ b/packages/desktop-client/src/hooks/useBudgetAutomations.ts
@@ -5,9 +5,11 @@ import type { Template } from '@actual-app/core/types/models/templates';
 
 export function useBudgetAutomations({
   categoryId,
+  source,
   onLoaded,
 }: {
   categoryId: string;
+  source: 'notes' | 'ui';
   onLoaded: (automations: Record<string, Template[]>) => void;
 }) {
   const [automations, setAutomations] = useState<Record<string, Template[]>>(
@@ -20,8 +22,11 @@ export function useBudgetAutomations({
     async function fetchAutomations() {
       setLoading(true);
 
-      // Always import notes first; the query will automatically ignore UI-based categories.
-      await send('budget/store-note-templates');
+      // notes based #template/#goal lines may have been edited since they were
+      // last parsed into the DB. ui-managed categories own goal_def directly, so skip.
+      if (source !== 'ui') {
+        await send('budget/store-note-templates', [categoryId]);
+      }
 
       const result = await send('budget/get-category-automations', categoryId);
       if (mounted) {
@@ -34,7 +39,7 @@ export function useBudgetAutomations({
     return () => {
       mounted = false;
     };
-  }, [categoryId, onLoaded]);
+  }, [categoryId, source, onLoaded]);
 
   return { automations, loading };
 }

--- a/packages/desktop-client/src/hooks/useCategoryCleanup.ts
+++ b/packages/desktop-client/src/hooks/useCategoryCleanup.ts
@@ -22,8 +22,8 @@ export function useCategoryCleanup({
     let mounted = true;
     async function load() {
       setLoading(true);
-      // notes-managed categories may have edited #cleanup lines since the
-      // last migration ran, so re-parse before reading cleanup_def
+      // notes based #cleanup lines may have been edited since they were last
+      // parsed into the DB. ui-managed categories own cleanup_def directly, so skip.
       if (source !== 'ui') {
         await send('budget/store-note-cleanups', [categoryId]);
       }

--- a/packages/desktop-client/src/hooks/useCategoryCleanup.ts
+++ b/packages/desktop-client/src/hooks/useCategoryCleanup.ts
@@ -22,7 +22,8 @@ export function useCategoryCleanup({
     let mounted = true;
     async function load() {
       setLoading(true);
-      // skip the notes refresh for ui-managed categories — cleanup_def is canonical
+      // notes-managed categories may have edited #cleanup lines since the
+      // last migration ran, so re-parse before reading cleanup_def
       if (source !== 'ui') {
         await send('budget/store-note-cleanups', [categoryId]);
       }

--- a/packages/desktop-client/src/hooks/useCategoryCleanup.ts
+++ b/packages/desktop-client/src/hooks/useCategoryCleanup.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+import { send } from '@actual-app/core/platform/client/connection';
+import { q } from '@actual-app/core/shared/query';
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
+
+import { aqlQuery } from '#queries/aqlQuery';
+
+export function useCategoryCleanup({
+  categoryId,
+  source,
+  onLoaded,
+}: {
+  categoryId: string;
+  source: 'notes' | 'ui';
+  onLoaded?: (cleanup: CleanupTemplate[]) => void;
+}) {
+  const [cleanup, setCleanup] = useState<CleanupTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      setLoading(true);
+      // skip the notes refresh for ui-managed categories — cleanup_def is canonical
+      if (source !== 'ui') {
+        await send('budget/store-note-cleanups', [categoryId]);
+      }
+
+      const result = await aqlQuery(
+        q('categories').filter({ id: categoryId }).select(['cleanup_def']),
+      );
+      const row = Array.isArray(result.data) ? result.data[0] : null;
+      const raw =
+        row && typeof row.cleanup_def === 'string' ? row.cleanup_def : null;
+      const parsed: CleanupTemplate[] = raw ? JSON.parse(raw) : [];
+      if (mounted) {
+        setCleanup(parsed);
+        onLoaded?.(parsed);
+        setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      mounted = false;
+    };
+  }, [categoryId, source, onLoaded]);
+
+  return { cleanup, loading };
+}

--- a/packages/desktop-client/src/hooks/useCleanupGroups.ts
+++ b/packages/desktop-client/src/hooks/useCleanupGroups.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { send } from '@actual-app/core/platform/client/connection';
 import { q } from '@actual-app/core/shared/query';
@@ -11,7 +11,7 @@ export function useCleanupGroups() {
   const [groups, setGroups] = useState<CleanupGroup[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const reload = useCallback(async () => {
+  async function reload() {
     const result = await aqlQuery(
       q('cleanup_groups').filter({ tombstone: false }).select(['id', 'name']),
     );
@@ -24,20 +24,17 @@ export function useCleanupGroups() {
       ),
     );
     setLoading(false);
-  }, []);
+  }
 
   useEffect(() => {
     void reload();
-  }, [reload]);
+  }, []);
 
-  const createGroup = useCallback(
-    async (name: string) => {
-      const { id } = await send('budget/create-cleanup-group', { name });
-      await reload();
-      return id;
-    },
-    [reload],
-  );
+  async function createGroup(name: string) {
+    const { id } = await send('budget/create-cleanup-group', { name });
+    await reload();
+    return id;
+  }
 
   return { groups, loading, createGroup };
 }

--- a/packages/desktop-client/src/hooks/useCleanupGroups.ts
+++ b/packages/desktop-client/src/hooks/useCleanupGroups.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { send } from '@actual-app/core/platform/client/connection';
+import { q } from '@actual-app/core/shared/query';
+
+import { aqlQuery } from '#queries/aqlQuery';
+
+export type CleanupGroup = { id: string; name: string };
+
+export function useCleanupGroups() {
+  const [groups, setGroups] = useState<CleanupGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    const result = await aqlQuery(
+      q('cleanup_groups').filter({ tombstone: false }).select(['id', 'name']),
+    );
+    const rows = Array.isArray(result.data) ? result.data : [];
+    setGroups(
+      rows.flatMap(row =>
+        row && typeof row.id === 'string' && typeof row.name === 'string'
+          ? [{ id: row.id, name: row.name }]
+          : [],
+      ),
+    );
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const createGroup = useCallback(
+    async (name: string) => {
+      const { id } = await send('budget/create-cleanup-group', { name });
+      await reload();
+      return id;
+    },
+    [reload],
+  );
+
+  return { groups, loading, createGroup };
+}

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -16,6 +16,7 @@ import type {
   UserAccessEntity,
   UserEntity,
 } from '@actual-app/core/types/models';
+import type { CleanupTemplate } from '@actual-app/core/types/models/cleanup-templates';
 import type { Template } from '@actual-app/core/types/models/templates';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
@@ -644,6 +645,7 @@ export type Modal =
       options: {
         categoryId: CategoryEntity['id'];
         templates: Template[];
+        cleanup: CleanupTemplate[];
       };
     };
 

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -14,7 +14,9 @@ import type { CategoryEntity, CategoryGroupEntity } from '#types/models';
 
 import * as actions from './actions';
 import * as budget from './base';
+import * as cleanupGroupActions from './cleanup-groups';
 import * as cleanupActions from './cleanup-template';
+import { storeNoteCleanups } from './cleanup-template-notes';
 import * as goalActions from './goal-template';
 import * as goalNoteActions from './template-notes';
 
@@ -60,7 +62,9 @@ export type BudgetHandlers = {
   'budget/set-category-automations': typeof goalActions.storeTemplates;
   'budget/dry-run-category-template': typeof goalActions.dryRunCategoryTemplate;
   'budget/store-note-templates': typeof goalNoteActions.storeNoteTemplates;
+  'budget/store-note-cleanups': typeof storeNoteCleanups;
   'budget/render-note-templates': typeof goalNoteActions.unparse;
+  'budget/create-cleanup-group': typeof cleanupGroupActions.createCleanupGroup;
 };
 
 export const app = createApp<BudgetHandlers>();
@@ -167,7 +171,12 @@ app.method(
   'budget/store-note-templates',
   mutator(goalNoteActions.storeNoteTemplates),
 );
+app.method('budget/store-note-cleanups', mutator(storeNoteCleanups));
 app.method('budget/render-note-templates', goalNoteActions.unparse);
+app.method(
+  'budget/create-cleanup-group',
+  mutator(undoable(cleanupGroupActions.createCleanupGroup)),
+);
 
 // Server must return AQL entities not the raw DB data
 async function getCategories({ hidden }: { hidden?: boolean } = {}) {

--- a/packages/loot-core/src/server/budget/cleanup-groups.ts
+++ b/packages/loot-core/src/server/budget/cleanup-groups.ts
@@ -1,0 +1,54 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import * as db from '#server/db';
+
+export async function resolveCleanupGroup(name: string): Promise<string> {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new Error('Cleanup group name cannot be empty');
+  }
+  const key = trimmed.toLowerCase();
+  const existing = await db.first<{ id: string; tombstone: 0 | 1 }>(
+    `SELECT id, tombstone FROM cleanup_groups WHERE lower(name) = ? LIMIT 1`,
+    [key],
+  );
+  if (existing) {
+    if (existing.tombstone === 1) {
+      await db.update('cleanup_groups', { id: existing.id, tombstone: 0 });
+    }
+    return existing.id;
+  }
+  const id = uuidv4();
+  await db.insertWithSchema('cleanup_groups', {
+    id,
+    name: trimmed,
+    tombstone: 0,
+  });
+  return id;
+}
+
+export async function createCleanupGroup({
+  name,
+}: {
+  name: string;
+}): Promise<{ id: string }> {
+  const id = await resolveCleanupGroup(name);
+  return { id };
+}
+
+export async function tombstoneOrphanCleanupGroups(): Promise<void> {
+  await db.run(
+    `
+      UPDATE cleanup_groups
+      SET tombstone = 1
+      WHERE tombstone = 0
+        AND id NOT IN (
+          SELECT json_extract(je.value, '$.groupId') AS group_id
+          FROM categories c, json_each(c.cleanup_def) je
+          WHERE c.tombstone = 0
+            AND c.cleanup_def IS NOT NULL
+            AND json_extract(je.value, '$.groupId') IS NOT NULL
+        )
+    `,
+  );
+}

--- a/packages/loot-core/src/server/budget/cleanup-groups.ts
+++ b/packages/loot-core/src/server/budget/cleanup-groups.ts
@@ -13,7 +13,7 @@ export async function resolveCleanupGroup(name: string): Promise<string> {
     [key],
   );
   if (existing) {
-    if (existing.tombstone === 1) {
+    if (existing.tombstone) {
       await db.update('cleanup_groups', { id: existing.id, tombstone: 0 });
     }
     return existing.id;

--- a/packages/loot-core/src/server/budget/cleanup-template-notes.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template-notes.ts
@@ -1,8 +1,10 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import * as db from '#server/db';
 import type { CleanupTemplate } from '#types/models/cleanup-templates';
 
+import {
+  resolveCleanupGroup,
+  tombstoneOrphanCleanupGroups,
+} from './cleanup-groups';
 import { parse } from './cleanup-template.pegjs';
 
 export const CLEANUP_PREFIX = '#cleanup ';
@@ -121,41 +123,10 @@ async function resolveCleanupGroups(
 ): Promise<Map<string, string>> {
   const map = new Map<string, string>();
   for (const name of names) {
-    const key = name.toLowerCase();
-    const existing = await db.first<{ id: string; tombstone: 0 | 1 }>(
-      `SELECT id, tombstone FROM cleanup_groups WHERE lower(name) = ? LIMIT 1`,
-      [key],
-    );
-    if (existing) {
-      // Resurrect a tombstoned row so the id stays stable across edits.
-      if (existing.tombstone === 1) {
-        await db.update('cleanup_groups', { id: existing.id, tombstone: 0 });
-      }
-      map.set(key, existing.id);
-      continue;
-    }
-    const id = uuidv4();
-    await db.insertWithSchema('cleanup_groups', { id, name, tombstone: 0 });
-    map.set(key, id);
+    const id = await resolveCleanupGroup(name);
+    map.set(name.toLowerCase(), id);
   }
   return map;
-}
-
-async function tombstoneOrphanCleanupGroups(): Promise<void> {
-  await db.run(
-    `
-      UPDATE cleanup_groups
-      SET tombstone = 1
-      WHERE tombstone = 0
-        AND id NOT IN (
-          SELECT json_extract(je.value, '$.groupId') AS group_id
-          FROM categories c, json_each(c.cleanup_def) je
-          WHERE c.tombstone = 0
-            AND c.cleanup_def IS NOT NULL
-            AND json_extract(je.value, '$.groupId') IS NOT NULL
-        )
-    `,
-  );
 }
 
 // Scoped to non-ui-managed categories so a migrated category is not

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -49,7 +49,6 @@ export async function storeTemplates({
   categoriesWithTemplates: {
     id: string;
     templates: Template[];
-    // omitted = leave cleanup_def as-is; [] = clear; non-empty = replace
     cleanup?: CleanupTemplate[];
   }[];
   source: 'notes' | 'ui';

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -5,11 +5,12 @@ import { batchMessages } from '#server/sync';
 import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
 import type { CategoryEntity, CategoryGroupEntity } from '#types/models';
+import type { CleanupTemplate } from '#types/models/cleanup-templates';
 import type { Template } from '#types/models/templates';
 
 import { getSheetValue, isTrackingBudget, setBudget, setGoal } from './actions';
 import { CategoryTemplateContext } from './category-template-context';
-import { storeNoteCleanups } from './cleanup-template-notes';
+import { tombstoneOrphanCleanupGroups } from './cleanup-groups';
 import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
 
 export function distributeRemainder(
@@ -48,21 +49,31 @@ export async function storeTemplates({
   categoriesWithTemplates: {
     id: string;
     templates: Template[];
+    // omitted = leave cleanup_def as-is; [] = clear; non-empty = replace
+    cleanup?: CleanupTemplate[];
   }[];
   source: 'notes' | 'ui';
 }): Promise<void> {
-  await storeNoteCleanups(categoriesWithTemplates.map(c => c.id));
+  let touchedCleanup = false;
   await batchMessages(async () => {
-    for (const { id, templates } of categoriesWithTemplates) {
+    for (const { id, templates, cleanup } of categoriesWithTemplates) {
       const goalDefs = templates.length > 0 ? JSON.stringify(templates) : null;
-
-      await db.updateWithSchema('categories', {
+      const update: Record<string, unknown> = {
         id,
         goal_def: goalDefs,
         template_settings: { source },
-      });
+      };
+      if (cleanup !== undefined) {
+        update.cleanup_def =
+          cleanup.length > 0 ? JSON.stringify(cleanup) : null;
+        touchedCleanup = true;
+      }
+      await db.updateWithSchema('categories', update);
     }
   });
+  if (touchedCleanup) {
+    await tombstoneOrphanCleanupGroups();
+  }
 }
 
 export async function applyTemplate({

--- a/packages/loot-core/src/server/budget/statements.ts
+++ b/packages/loot-core/src/server/budget/statements.ts
@@ -3,7 +3,13 @@ import type { DbSchedule } from '#server/db';
 
 import { GOAL_PREFIX, TEMPLATE_PREFIX } from './template-notes';
 
-export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
+export async function resetCategoryGoalDefsWithNoTemplates(
+  categoryIds?: string[],
+): Promise<void> {
+  if (categoryIds?.length === 0) return;
+  const scopeClause = categoryIds
+    ? `AND id IN (${categoryIds.map(() => '?').join(',')})`
+    : '';
   await db.run(
     `
       UPDATE categories
@@ -13,7 +19,9 @@ export async function resetCategoryGoalDefsWithNoTemplates(): Promise<void> {
                        WHERE lower(note) LIKE '%${TEMPLATE_PREFIX}%'
                           OR lower(note) LIKE '%${GOAL_PREFIX}%')
         AND COALESCE(JSON_EXTRACT(template_settings, '$.source'), 'notes') <> 'ui'
+        ${scopeClause}
     `,
+    categoryIds ?? [],
   );
 }
 
@@ -23,9 +31,13 @@ export type CategoryWithTemplateNote = {
   note: string;
 };
 
-export async function getCategoriesWithTemplateNotes(): Promise<
-  CategoryWithTemplateNote[]
-> {
+export async function getCategoriesWithTemplateNotes(
+  categoryIds?: string[],
+): Promise<CategoryWithTemplateNote[]> {
+  if (categoryIds?.length === 0) return [];
+  const scopeClause = categoryIds
+    ? `AND c.id IN (${categoryIds.map(() => '?').join(',')})`
+    : '';
   return await db.all<
     Pick<db.DbCategory, 'id' | 'name'> & Pick<db.DbNote, 'note'>
   >(
@@ -38,7 +50,9 @@ export async function getCategoriesWithTemplateNotes(): Promise<
         AND COALESCE(JSON_EXTRACT(c.template_settings, '$.source'), 'notes') <> 'ui'
         AND (lower(note) LIKE '%${TEMPLATE_PREFIX}%'
         OR lower(note) LIKE '%${GOAL_PREFIX}%')
+        ${scopeClause}
     `,
+    categoryIds ?? [],
   );
 }
 

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -19,12 +19,14 @@ type Notification = {
 export const TEMPLATE_PREFIX = '#template';
 export const GOAL_PREFIX = '#goal';
 
-export async function storeNoteTemplates(): Promise<void> {
-  const categoriesWithTemplates = await getCategoriesWithTemplates();
+export async function storeNoteTemplates(
+  categoryIds?: string[],
+): Promise<void> {
+  const categoriesWithTemplates = await getCategoriesWithTemplates(categoryIds);
 
   await storeTemplates({ categoriesWithTemplates, source: 'notes' });
 
-  await resetCategoryGoalDefsWithNoTemplates();
+  await resetCategoryGoalDefsWithNoTemplates(categoryIds);
 }
 
 type CategoryWithTemplateNotes = {
@@ -71,11 +73,11 @@ export async function checkTemplateNotes(): Promise<Notification> {
   };
 }
 
-async function getCategoriesWithTemplates(): Promise<
-  CategoryWithTemplateNotes[]
-> {
+async function getCategoriesWithTemplates(
+  categoryIds?: string[],
+): Promise<CategoryWithTemplateNotes[]> {
   const templatesForCategory: CategoryWithTemplateNotes[] = [];
-  const templateNotes = await getCategoriesWithTemplateNotes();
+  const templateNotes = await getCategoriesWithTemplateNotes(categoryIds);
 
   templateNotes.forEach(({ id, name, note }: CategoryWithTemplateNote) => {
     if (!note) {

--- a/upcoming-release-notes/7815.md
+++ b/upcoming-release-notes/7815.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: add end-of-month cleanup functionality


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

AI disclaimer: I used claude to orchestrate quite a bit of this, but I've done a thorough review and made quite a few tweaks from what it came up with.

Cleanup is reasonably complicated, and nailing it into a UI was pretty tough. Open to opinions here, but I have tried many iterations and this one works the best of them.

Note:
Technically, the engine supports a single category spanning multiple groups, but I have disallowed this in the UI because it's undefined behaviour (depends on what order the groups run, which is hard to predict if I'm reading it correctly). It's not hard to re-allow it if we reckon that breaks workflows, but I'm reasonably doubtful that there are many (if any) using that.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested locally with this budget file, it's got some groups and some global config in it. To use it:

[2026-05-12-Cleanup Test.zip](https://github.com/user-attachments/files/27657223/2026-05-12-Cleanup.Test.zip)

- set budgets to 0
- overwrite with templates
- run end of month cleanup

also migrated, and unmigrated to check everything is working as expected.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.91 MB → 13.94 MB (+30.11 kB) | +0.21%
loot-core | 1 | 5.31 MB → 5.31 MB (+1.12 kB) | +0.02%
api | 2 | 3.94 MB → 3.94 MB (+1.1 kB) | +0.03%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.91 MB → 13.94 MB (+30.11 kB) | +0.21%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/editor/CleanupAutomation.tsx` | 🆕 +12.65 kB | 0 B → 12.65 kB
`src/components/budget/goals/editor/CleanupGroupPicker.tsx` | 🆕 +5.66 kB | 0 B → 5.66 kB
`src/components/modals/BudgetAutomationsModal/CleanupListRow.tsx` | 🆕 +3.39 kB | 0 B → 3.39 kB
`src/components/budget/goals/cleanupModel.ts` | 🆕 +2.45 kB | 0 B → 2.45 kB
`src/components/budget/goals/editor/CleanupAutomationReadOnly.tsx` | 🆕 +1.83 kB | 0 B → 1.83 kB
`src/hooks/useCategoryCleanup.ts` | 🆕 +965 B | 0 B → 965 B
`src/hooks/useCleanupGroups.ts` | 🆕 +809 B | 0 B → 809 B
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +2.14 kB (+15.13%) | 14.12 kB → 16.26 kB
`src/hooks/useBudgetAutomations.ts` | 📈 +60 B (+8.26%) | 726 B → 786 B
`src/components/modals/UnmigrateBudgetAutomationsModal.tsx` | 📈 +352 B (+6.22%) | 5.52 kB → 5.87 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📈 +295 B (+5.90%) | 4.88 kB → 5.17 kB
`src/components/budget/SidebarCategoryButtons.tsx` | 📈 +36 B (+1.67%) | 2.11 kB → 2.14 kB
`src/components/budget/goals/CategoryAutomationButton.tsx` | 📈 +34 B (+1.33%) | 2.5 kB → 2.53 kB
`package.json` | 📈 +91 B (+0.98%) | 9.04 kB → 9.13 kB
`src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx` | 📉 -20 B (-0.30%) | 6.45 kB → 6.43 kB
`src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx` | 📉 -582 B (-17.63%) | 3.22 kB → 2.66 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.97 MB → 2 MB (+30.11 kB) | +1.49%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.72 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.38 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 189.97 kB | 0%
static/js/es.js | 178.83 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.71 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.13 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.19 kB | 0%
static/js/nl.js | 106.34 kB | 0%
static/js/pt-BR.js | 189.39 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.56 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.75 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB → 5.31 MB (+1.12 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-groups.ts` | 🆕 +1.18 kB | 0 B → 1.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/statements.ts` | 📈 +385 B (+34.38%) | 1.09 kB → 1.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +169 B (+2.33%) | 7.08 kB → 7.24 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +160 B (+1.72%) | 9.08 kB → 9.24 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +55 B (+0.85%) | 6.35 kB → 6.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template-notes.ts` | 📉 -827 B (-20.70%) | 3.9 kB → 3.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.jUVFVkaN.js | 0 B → 5.31 MB (+5.31 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cozwd3bP.js | 5.31 MB → 0 B (-5.31 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+1.1 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-groups.ts` | 🆕 +1.15 kB | 0 B → 1.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/statements.ts` | 📈 +381 B (+34.29%) | 1.08 kB → 1.46 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +164 B (+2.32%) | 6.91 kB → 7.07 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +158 B (+1.73%) | 8.91 kB → 9.07 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +55 B (+0.87%) | 6.18 kB → 6.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template-notes.ts` | 📉 -809 B (-20.83%) | 3.79 kB → 3 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+1.1 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->