### PR TITLE
[AI] Add workflow to auto-label AI-generated PRs

### DIFF
--- a/.github/workflows/ai-generated-label.yml
+++ b/.github/workflows/ai-generated-label.yml
@@ -8,7 +8,8 @@ name: Add 'AI generated' label to '[AI]' PRs
 ##########################################################################################
 
 on:
-  pull_request_target:
+  # This workflow never checks out or runs PR code; it only reads the PR title and adds a label.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, reopened, edited]
 
 permissions:

--- a/.github/workflows/ai-generated-label.yml
+++ b/.github/workflows/ai-generated-label.yml
@@ -1,0 +1,26 @@
+name: Add 'AI generated' label to '[AI]' PRs
+
+##########################################################################################
+# This workflow uses the 'pull_request_target' event so it has a token that can add a    #
+# label to PRs from forks. It does NOT check out or execute any code from the PR, so it   #
+# is not vulnerable to the usual 'pull_request_target' code-injection concerns. Keep it   #
+# that way - do not add a checkout step or run any PR-provided scripts here.              #
+##########################################################################################
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  add-ai-generated-label:
+    name: Add 'AI generated' label
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.title, '[AI]')
+    steps:
+      - uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.0
+        with:
+          labels: AI generated
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/upcoming-release-notes/7817.md
+++ b/upcoming-release-notes/7817.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add a GitHub Actions workflow that labels `[AI]`-prefixed pull requests as "AI generated".


### PR DESCRIPTION
## Description

Outside collaborators cannot add PR labels. So lets add the "AI generated" label for them if we see title starting with "[AI]"

## Related issue(s)

n/a

## Testing

n/a

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - This is a new workflow file that adds automated labeling for AI-generated PRs using a safe, read-only approach with `pull_request_target`

https://claude.ai/code/session_018yp3BsEq1CyPcw8t57nLVu