### PR TITLE
automation UI: add spend from functionality

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/TemplateSentence.tsx
+++ b/packages/desktop-client/src/components/budget/goals/TemplateSentence.tsx
@@ -42,13 +42,13 @@ export function TemplateSentence({
     case 'copy':
       return <HistoricalAutomationReadOnly template={template} />;
     case 'by':
+    case 'spend':
       return <BySaveAutomationReadOnly template={template} />;
     case 'remainder':
       return <RemainderAutomationReadOnly template={template} />;
     case 'goal':
       return <LongTermGoalAutomationReadOnly template={template} />;
     case 'simple':
-    case 'spend':
     case 'error': {
       const type = template.type;
       return (

--- a/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
+++ b/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
@@ -27,6 +27,10 @@ export function AutomationErrorTitle({
       return <Trans>Target month missing</Trans>;
     case 'by-target-past':
       return <Trans>Target is in the past</Trans>;
+    case 'spend-no-from':
+      return <Trans>Early-spending month missing</Trans>;
+    case 'spend-from-after-target':
+      return <Trans>Early spending starts after target</Trans>;
     case 'percentage-source-not-found':
       return <Trans>Source category not recognised</Trans>;
     default:
@@ -64,6 +68,10 @@ export function AutomationErrorShort({
           {{ month: formatMonthLabel(error.month, locale) }} has already passed
         </Trans>
       );
+    case 'spend-no-from':
+      return <Trans>Pick an early-spending start month</Trans>;
+    case 'spend-from-after-target':
+      return <Trans>Early spending must start before the target</Trans>;
     case 'percentage-source-not-found':
       return <Trans>Pick a valid income category</Trans>;
     default:
@@ -112,6 +120,20 @@ export function AutomationErrorDetail({
         <Trans>
           Pick a future month, or switch to a recurring annual goal to keep
           saving.
+        </Trans>
+      );
+    case 'spend-no-from':
+      return (
+        <Trans>
+          Early-spending templates need a start month. Pick when you want
+          spending to begin.
+        </Trans>
+      );
+    case 'spend-from-after-target':
+      return (
+        <Trans>
+          The early-spending month must be the same as or earlier than the
+          target month, since it marks when spending begins.
         </Trans>
       );
     case 'percentage-source-not-found':

--- a/packages/desktop-client/src/components/budget/goals/constants.ts
+++ b/packages/desktop-client/src/components/budget/goals/constants.ts
@@ -9,6 +9,7 @@ import type {
   RefillTemplate,
   RemainderTemplate,
   ScheduleTemplate,
+  SpendTemplate,
 } from '@actual-app/core/types/models/templates';
 
 export const displayTemplateTypes = [
@@ -51,7 +52,7 @@ export type ReducerState =
       displayType: 'historical';
     }
   | {
-      template: ByTemplate;
+      template: ByTemplate | SpendTemplate;
       displayType: 'by';
     }
   | {

--- a/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
+import { SvgInformationCircle } from '@actual-app/components/icons/v2';
 import { Input } from '@actual-app/components/input';
 import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
+import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
 import { amountToInteger, integerToAmount } from '@actual-app/core/shared/util';
-import type { ByTemplate } from '@actual-app/core/types/models/templates';
+import type {
+  ByTemplate,
+  SpendTemplate,
+} from '@actual-app/core/types/models/templates';
 
 import { updateTemplate } from '#components/budget/goals/actions';
 import type { Action } from '#components/budget/goals/actions';
@@ -16,7 +23,7 @@ import { GenericInput } from '#components/util/GenericInput';
 import { useFormat } from '#hooks/useFormat';
 
 type BySaveAutomationProps = {
-  template: ByTemplate;
+  template: ByTemplate | SpendTemplate;
   dispatch: (action: Action) => void;
 };
 
@@ -41,11 +48,13 @@ export const BySaveAutomation = ({
     const parsed = Math.max(1, Math.trunc(Number(rawRepeat)) || 1);
     setRawRepeat(String(parsed));
     if (parsed !== committedRepeat) {
-      dispatch(updateTemplate({ type: 'by', repeat: parsed }));
+      dispatch(updateTemplate({ type: template.type, repeat: parsed }));
     }
   };
 
   const repeats = !!template.repeat;
+  const spendDown = template.type === 'spend';
+  const fromMonth = template.type === 'spend' ? template.from : '';
 
   return (
     <>
@@ -59,7 +68,7 @@ export const BySaveAutomation = ({
             onUpdate={(value: number) =>
               dispatch(
                 updateTemplate({
-                  type: 'by',
+                  type: template.type,
                   amount: integerToAmount(value, format.currency.decimalPlaces),
                 }),
               )
@@ -67,15 +76,18 @@ export const BySaveAutomation = ({
           />
         </FormField>
         <FormField style={{ flex: 1 }}>
-          <FormLabel title={t('Target date')} htmlFor="by-month-field" />
+          <FormLabel title={t('Target month')} htmlFor="by-month-field" />
           <GenericInput
+            // remount when the stored month changes so the picker re-syncs
+            // to day 01 instead of lingering on whatever day the user picked
+            key={template.month}
             type="date"
             field="date"
             value={template.month ? `${template.month}-01` : ''}
             onChange={(value: string) =>
               dispatch(
                 updateTemplate({
-                  type: 'by',
+                  type: template.type,
                   month: value ? value.slice(0, 7) : '',
                 }),
               )
@@ -93,11 +105,15 @@ export const BySaveAutomation = ({
                 updateTemplate(
                   e.target.checked
                     ? {
-                        type: 'by',
+                        type: template.type,
                         annual: false,
                         repeat: template.repeat ?? 1,
                       }
-                    : { type: 'by', annual: undefined, repeat: undefined },
+                    : {
+                        type: template.type,
+                        annual: undefined,
+                        repeat: undefined,
+                      },
                 ),
               )
             }
@@ -131,7 +147,10 @@ export const BySaveAutomation = ({
                 value={template.annual ? 'year' : 'month'}
                 onChange={value =>
                   dispatch(
-                    updateTemplate({ type: 'by', annual: value === 'year' }),
+                    updateTemplate({
+                      type: template.type,
+                      annual: value === 'year',
+                    }),
                   )
                 }
                 options={[
@@ -141,6 +160,95 @@ export const BySaveAutomation = ({
               />
             </FormField>
           </>
+        )}
+      </SpaceBetween>
+      <SpaceBetween align="center" gap={10} style={{ marginTop: 10 }}>
+        <FormField style={{ flex: 1 }}>
+          <LabeledCheckbox
+            id="by-spend-down-field"
+            checked={spendDown}
+            onChange={e =>
+              dispatch(
+                updateTemplate(
+                  e.target.checked
+                    ? { type: 'spend', from: fromMonth || template.month }
+                    : { type: 'by' },
+                ),
+              )
+            }
+          >
+            <span
+              style={{
+                marginLeft: 6,
+                fontSize: 12,
+                whiteSpace: 'nowrap',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <Trans>Allow early spending</Trans>
+              {/* tooltip lives inside the checkbox label; stop the click
+                  from also toggling the checkbox */}
+              <span
+                onClick={e => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                }}
+                onMouseDown={e => e.stopPropagation()}
+                style={{ display: 'inline-flex' }}
+              >
+                <Tooltip
+                  content={
+                    <View style={{ maxWidth: 280 }}>
+                      <Trans>
+                        Without this, spending before the target month leaves a
+                        gap that the next month's contribution has to make up.
+                        Turn this on to tell Actual spending is expected from a
+                        chosen month onwards, so it doesn't budget more to
+                        recover the shortfall.
+                      </Trans>
+                      <View style={{ marginTop: 6, fontStyle: 'italic' }}>
+                        <Trans>
+                          Example: budget for Christmas presents by December,
+                          with shopping starting in March.
+                        </Trans>
+                      </View>
+                    </View>
+                  }
+                  placement="top start"
+                >
+                  <SvgInformationCircle
+                    width={12}
+                    height={12}
+                    style={{ color: theme.pageTextLight, cursor: 'help' }}
+                  />
+                </Tooltip>
+              </span>
+            </span>
+          </LabeledCheckbox>
+        </FormField>
+        {spendDown && (
+          <FormField style={{ flex: 1 }}>
+            <FormLabel
+              title={t('Start spending in')}
+              htmlFor="by-spend-from-field"
+            />
+            <GenericInput
+              key={fromMonth}
+              type="date"
+              field="date"
+              value={fromMonth ? `${fromMonth}-01` : ''}
+              onChange={(value: string) =>
+                dispatch(
+                  updateTemplate({
+                    type: 'spend',
+                    from: value ? value.slice(0, 7) : '',
+                  }),
+                )
+              }
+            />
+          </FormField>
         )}
       </SpaceBetween>
     </>

--- a/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomationReadOnly.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomationReadOnly.tsx
@@ -1,7 +1,10 @@
 import { Trans } from 'react-i18next';
 
 import { amountToInteger } from '@actual-app/core/shared/util';
-import type { ByTemplate } from '@actual-app/core/types/models/templates';
+import type {
+  ByTemplate,
+  SpendTemplate,
+} from '@actual-app/core/types/models/templates';
 import type { TransObjectLiteral } from '@actual-app/core/types/util';
 
 import { formatMonthLabel } from '#components/budget/goals/formatMonthLabel';
@@ -10,7 +13,7 @@ import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 
 type BySaveAutomationReadOnlyProps = {
-  template: ByTemplate;
+  template: ByTemplate | SpendTemplate;
 };
 
 export const BySaveAutomationReadOnly = ({
@@ -24,8 +27,19 @@ export const BySaveAutomationReadOnly = ({
   );
   const month = formatMonthLabel(template.month, locale);
   const repeat = template.repeat ?? 1;
+  const from =
+    template.type === 'spend' ? formatMonthLabel(template.from, locale) : null;
 
   if (template.annual) {
+    if (from) {
+      return (
+        <Trans count={repeat}>
+          Save <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>{' '}
+          by {{ month }}, early spending from {{ from }}, repeating every{' '}
+          {{ count: repeat }} years
+        </Trans>
+      );
+    }
     return (
       <Trans count={repeat}>
         Save <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>{' '}
@@ -35,10 +49,28 @@ export const BySaveAutomationReadOnly = ({
   }
 
   if (template.repeat && template.repeat > 0) {
+    if (from) {
+      return (
+        <Trans count={repeat}>
+          Save <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>{' '}
+          by {{ month }}, early spending from {{ from }}, repeating every{' '}
+          {{ count: repeat }} months
+        </Trans>
+      );
+    }
     return (
       <Trans count={repeat}>
         Save <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>{' '}
         by {{ month }}, repeating every {{ count: repeat }} months
+      </Trans>
+    );
+  }
+
+  if (from) {
+    return (
+      <Trans>
+        Save <FinancialText>{{ amount } as TransObjectLiteral}</FinancialText>{' '}
+        by {{ month }}, early spending from {{ from }}
       </Trans>
     );
   }

--- a/packages/desktop-client/src/components/budget/goals/reducer.ts
+++ b/packages/desktop-client/src/components/budget/goals/reducer.ts
@@ -47,9 +47,8 @@ export const getInitialState = (template: Template | null): ReducerState => {
         template,
         displayType: 'fixed',
       };
-    case 'spend':
-      throw new Error('Goal is not yet supported');
     case 'by':
+    case 'spend':
       return {
         template:
           template.annual !== undefined && template.repeat == null
@@ -187,7 +186,11 @@ const changeType = (
         },
       };
     case 'by':
-      if (prevState.template.type === 'by') {
+      // 'spend' shares displayType 'by'; preserve it instead of discarding
+      if (
+        prevState.template.type === 'by' ||
+        prevState.template.type === 'spend'
+      ) {
         return prevState;
       }
       return {
@@ -272,6 +275,50 @@ function mapTemplateTypesForUpdate(
               priority: state.template.priority,
             },
           };
+        default:
+          break;
+      }
+      break;
+    case 'by':
+      switch (template.type) {
+        case 'spend': {
+          // toggling spend-down on: carry the by template's fields into a
+          // spend template; default `from` to the target month if not given
+          const from =
+            'from' in template && typeof template.from === 'string'
+              ? template.from
+              : state.template.month;
+          return {
+            ...state,
+            displayType: 'by',
+            template: {
+              ...state.template,
+              ...template,
+              type: 'spend',
+              from,
+            },
+          };
+        }
+        default:
+          break;
+      }
+      break;
+    case 'spend':
+      switch (template.type) {
+        case 'by': {
+          // toggling spend-down off: drop `from`, keep everything else
+          const { from: _from, ...rest } = state.template;
+          void _from;
+          return {
+            ...state,
+            displayType: 'by',
+            template: {
+              ...rest,
+              ...template,
+              type: 'by',
+            },
+          };
+        }
         default:
           break;
       }

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
@@ -11,7 +11,9 @@ export type AutomationErrorKind =
   | { kind: 'percentage-no-source' }
   | { kind: 'percentage-source-not-found'; source: string }
   | { kind: 'by-no-month' }
-  | { kind: 'by-target-past'; month: string };
+  | { kind: 'by-target-past'; month: string }
+  | { kind: 'spend-no-from' }
+  | { kind: 'spend-from-after-target' };
 
 export type GlobalConflictKind =
   | { kind: 'over-income'; total: number; income: number }
@@ -67,7 +69,7 @@ export function validateAutomation(
       }
       return null;
     case 'by': {
-      if (template.type !== 'by') return null;
+      if (template.type !== 'by' && template.type !== 'spend') return null;
       if (!template.month || !monthUtils.isValidYearMonth(template.month)) {
         return { kind: 'by-no-month' };
       }
@@ -86,6 +88,16 @@ export function validateAutomation(
       // CategoryTemplateContext.checkByAndScheduleAndSpend.
       if (monthsRemaining < 0 && !template.annual && !template.repeat) {
         return { kind: 'by-target-past', month: targetMonth };
+      }
+      if (template.type === 'spend') {
+        if (!template.from || !monthUtils.isValidYearMonth(template.from)) {
+          return { kind: 'spend-no-from' };
+        }
+        if (
+          monthUtils.differenceInCalendarMonths(targetMonth, template.from) < 0
+        ) {
+          return { kind: 'spend-from-after-target' };
+        }
       }
       return null;
     }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -67,9 +67,7 @@ export function BudgetAutomationsModal({
 
   const hasErrorTemplate =
     parsedTemplates?.some(t => t.type === 'error') ?? false;
-  const hasSpendTemplate =
-    parsedTemplates?.some(t => t.type === 'spend') ?? false;
-  const hasUnsupportedDirective = hasErrorTemplate || hasSpendTemplate;
+  const hasUnsupportedDirective = hasErrorTemplate;
 
   const incomeNameToId = new Map<string, string>();
   for (const group of categories) {
@@ -116,10 +114,7 @@ export function BudgetAutomationsModal({
               <AnimatedLoading style={{ width: 20, height: 20 }} />
             </View>
           ) : hasUnsupportedDirective ? (
-            <UnsupportedDirectivesNotice
-              hasErrorTemplate={hasErrorTemplate}
-              onClose={() => state.close()}
-            />
+            <UnsupportedDirectivesNotice onClose={() => state.close()} />
           ) : (
             <BudgetAutomationsBody
               categoryId={categoryId}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx
@@ -7,10 +7,8 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 export function UnsupportedDirectivesNotice({
-  hasErrorTemplate,
   onClose,
 }: {
-  hasErrorTemplate: boolean;
   onClose: () => void;
 }) {
   return (
@@ -41,24 +39,16 @@ export function UnsupportedDirectivesNotice({
       <Text
         style={{
           fontSize: 13,
-          color: theme.pageTextSubdued,
+          color: theme.pageTextLight,
           maxWidth: 480,
           lineHeight: 1.5,
         }}
       >
-        {hasErrorTemplate ? (
-          <Trans>
-            One or more <code>#template</code> lines in this category&rsquo;s
-            notes couldn&rsquo;t be parsed. Fix them as text first, then re-open
-            this modal to migrate.
-          </Trans>
-        ) : (
-          <Trans>
-            This category uses a <code>spend from</code> template, which the
-            budget automations UI doesn&rsquo;t handle yet. Keep editing it as
-            text in the category&rsquo;s notes.
-          </Trans>
-        )}
+        <Trans>
+          One or more <code>#template</code> lines in this category&rsquo;s
+          notes couldn&rsquo;t be parsed. Fix them as text first, then re-open
+          this modal to migrate.
+        </Trans>
       </Text>
       <Button onPress={onClose}>
         <Trans>Close</Trans>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -22,13 +22,13 @@ function getDisplayTypeFromTemplate(template: Template): DisplayTemplateType {
     case 'copy':
       return 'historical';
     case 'by':
+    case 'spend':
       return 'by';
     case 'remainder':
       return 'remainder';
     case 'goal':
       return 'goal';
     case 'error':
-    case 'spend':
       // filtered upstream by hasUnsupportedDirective; surface if it ever isn't
       throw new Error(`Unsupported template type reached migration`);
     default: {

--- a/upcoming-release-notes/7823.md
+++ b/upcoming-release-notes/7823.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: add spend from functionality


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4434995642

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.94 MB → 13.95 MB (+10.03 kB) | +0.07%
loot-core | 1 | 5.31 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.94 MB → 13.95 MB (+10.03 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/editor/BySaveAutomationReadOnly.tsx` | 📈 +3.46 kB (+106.75%) | 3.24 kB → 6.7 kB
`src/components/budget/goals/editor/BySaveAutomation.tsx` | 📈 +4.74 kB (+65.67%) | 7.22 kB → 11.96 kB
`src/components/budget/goals/automationMessages.tsx` | 📈 +1.71 kB (+19.07%) | 8.95 kB → 10.65 kB
`src/components/budget/goals/validateAutomation.ts` | 📈 +276 B (+12.95%) | 2.08 kB → 2.35 kB
`src/components/budget/goals/reducer.ts` | 📈 +677 B (+11.94%) | 5.54 kB → 6.2 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📉 -360 B (-6.80%) | 5.17 kB → 4.82 kB
`src/components/modals/BudgetAutomationsModal/UnsupportedDirectivesNotice.tsx` | 📉 -467 B (-17.18%) | 2.66 kB → 2.2 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2 MB → 2.01 MB (+10.03 kB) | +0.49%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.72 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.38 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 189.97 kB | 0%
static/js/es.js | 178.83 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.71 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.13 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.19 kB | 0%
static/js/nl.js | 106.34 kB | 0%
static/js/pt-BR.js | 189.39 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.56 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.75 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.jUVFVkaN.js | 5.31 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->