### PR TITLE
automation UI: various tweaks and fixes

### DIFF
--- a/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
+++ b/packages/desktop-client/src/components/budget/BalanceWithCarryover.tsx
@@ -193,7 +193,7 @@ export function BalanceWithCarryover({
               <div>
                 {
                   {
-                    type: longGoalValue === 1 ? t('Long') : t('Template'),
+                    type: longGoalValue === 1 ? t('Goal') : t('Automation'),
                   } as TransObjectLiteral
                 }
               </div>

--- a/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
+++ b/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
@@ -55,7 +55,7 @@ export function AutomationErrorShort({
         <Trans>Pick a schedule</Trans>
       );
     case 'refill-no-cap':
-      return <Trans>Add a balance cap above</Trans>;
+      return <Trans>Add a balance cap</Trans>;
     case 'limit-no-contributor':
       return <Trans>Add an automation that contributes funds</Trans>;
     case 'percentage-out-of-range':

--- a/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
+++ b/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
@@ -19,6 +19,8 @@ export function AutomationErrorTitle({
       return <Trans>Schedule not found</Trans>;
     case 'refill-no-cap':
       return <Trans>Refill needs a balance cap</Trans>;
+    case 'limit-no-contributor':
+      return <Trans>Balance cap needs a contributing automation</Trans>;
     case 'percentage-out-of-range':
       return <Trans>Percentage out of range</Trans>;
     case 'percentage-no-source':
@@ -54,6 +56,8 @@ export function AutomationErrorShort({
       );
     case 'refill-no-cap':
       return <Trans>Add a balance cap above</Trans>;
+    case 'limit-no-contributor':
+      return <Trans>Add an automation that contributes funds</Trans>;
     case 'percentage-out-of-range':
       return (
         <Trans>{{ percent: error.percent }}% must be between 0 and 100</Trans>
@@ -98,6 +102,14 @@ export function AutomationErrorDetail({
         <Trans>
           Refill automations must have a &ldquo;Balance cap&rdquo; automation
           added to use as the target.
+        </Trans>
+      );
+    case 'limit-no-contributor':
+      return (
+        <Trans>
+          A balance cap on its own does nothing. Add a contributing automation
+          (such as a fixed amount, save by date, or whatever is left) so the cap
+          has something to clamp.
         </Trans>
       );
     case 'percentage-out-of-range':

--- a/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
+++ b/packages/desktop-client/src/components/budget/goals/displayTemplateMeta.ts
@@ -38,7 +38,7 @@ export function getDisplayTemplateMeta(
     case 'schedule':
       return {
         label: t('Cover schedule'),
-        description: t('Save up for a recurring scheduled transaction.'),
+        description: t('Save up for a scheduled transaction.'),
         icon: SvgCalendar3,
       };
     case 'by':

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
@@ -7,6 +7,7 @@ import type { DisplayTemplateType } from './constants';
 export type AutomationErrorKind =
   | { kind: 'schedule-not-found'; name: string }
   | { kind: 'refill-no-cap' }
+  | { kind: 'limit-no-contributor' }
   | { kind: 'percentage-out-of-range'; percent: number }
   | { kind: 'percentage-no-source' }
   | { kind: 'percentage-source-not-found'; source: string }
@@ -46,6 +47,15 @@ export function validateAutomation(
     case 'refill':
       if (!allTemplates.some(t => t.type === 'limit')) {
         return { kind: 'refill-no-cap' };
+      }
+      return null;
+    case 'limit':
+      if (
+        !allTemplates.some(
+          t => t.type !== 'limit' && t.type !== 'goal' && t.type !== 'error',
+        )
+      ) {
+        return { kind: 'limit-no-contributor' };
       }
       return null;
     case 'percentage':

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 
 import type { AutomationEntry } from '#components/budget/goals/automationExamples';
@@ -126,18 +127,24 @@ export function AutomationListRow({
             />
           )}
         </View>
-        <Text
-          style={{
-            fontSize: 11,
-            color: subtitleColor,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            display: 'block',
-          }}
+        <Tooltip
+          content={
+            <Text style={{ display: 'block', maxWidth: 320 }}>{subtitle}</Text>
+          }
         >
-          {subtitle}
-        </Text>
+          <Text
+            style={{
+              fontSize: 11,
+              color: subtitleColor,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              display: 'block',
+            }}
+          >
+            {subtitle}
+          </Text>
+        </Tooltip>
       </View>
       {!NON_CONTRIBUTION_TYPES.has(entry.displayType) && (
         <View

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
@@ -100,6 +100,31 @@ describe('migrateTemplatesToAutomations', () => {
     });
   });
 
+  it('expands `#template 0 up to N` into limit + fixed-zero (not refill)', () => {
+    const simpleTemplate = {
+      type: 'simple',
+      directive: 'template',
+      priority: 4,
+      monthly: 0,
+      limit: {
+        amount: 1000,
+        hold: false,
+        period: 'monthly',
+      },
+    } satisfies Template;
+
+    const result = migrateTemplatesToAutomations([simpleTemplate]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(entry => entry.displayType)).toEqual(['limit', 'fixed']);
+    expect(result[1].template).toMatchObject({
+      type: 'periodic',
+      amount: 0,
+      directive: 'template',
+      priority: 4,
+    });
+  });
+
   it('expands a simple template with both limit and monthly into limit + periodic (no implicit refill)', () => {
     // `#template 20 up to 200 per week` budgets 20/month and caps at the
     // limit — the engine's runSimple returns just the monthly value, so

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -47,7 +47,7 @@ export function migrateTemplatesToAutomations(
   templates.forEach(template => {
     if (template.type === 'simple') {
       const monthly = template.monthly;
-      const hasMonthly = monthly != null && monthly !== 0;
+      const hasMonthly = monthly != null;
 
       if (template.limit) {
         entries.push(
@@ -64,10 +64,7 @@ export function migrateTemplatesToAutomations(
             'limit',
           ),
         );
-        // The implicit refill only applies to a limit-only simple template
-        // (e.g. `#template up to 200`). When a monthly amount is also set
-        // (`#template 50 up to 200`), the engine just budgets the monthly
-        // amount and clamps to the cap — no top-up to the limit.
+
         if (!hasMonthly) {
           entries.push(
             createAutomationEntry(
@@ -81,6 +78,7 @@ export function migrateTemplatesToAutomations(
           );
         }
       }
+
       if (hasMonthly) {
         entries.push(
           createAutomationEntry(

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -47,7 +47,8 @@ export function migrateTemplatesToAutomations(
   templates.forEach(template => {
     if (template.type === 'simple') {
       const monthly = template.monthly;
-      const hasMonthly = monthly != null;
+      const hasMonthly =
+        monthly != null && (monthly !== 0 || template.limit != null);
 
       if (template.limit) {
         entries.push(

--- a/packages/desktop-client/src/components/util/AmountInput.tsx
+++ b/packages/desktop-client/src/components/util/AmountInput.tsx
@@ -220,6 +220,7 @@ export function AmountInput({
         onFocus={e => {
           setIsFocused(true);
           setValue(format.forEdit(Math.abs(initialValue ?? 0)));
+          setTimeout(() => innerRef.current?.select(), 0);
           onFocus?.(e);
         }}
         onBlur={e => {

--- a/upcoming-release-notes/7832.md
+++ b/upcoming-release-notes/7832.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Automation UI: various tweaks and fixes


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Addresses:
- https://github.com/actualbudget/actual/issues/7692#issuecomment-4440244643
- https://github.com/actualbudget/actual/issues/7692#issuecomment-4440878618
- https://github.com/actualbudget/actual/issues/7692#issuecomment-4441238884
- https://github.com/actualbudget/actual/issues/7692#issuecomment-4442723925

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.95 MB → 13.96 MB (+1.73 kB) | +0.01%
loot-core | 1 | 5.31 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.95 MB → 13.96 MB (+1.73 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/automationMessages.tsx` | 📈 +953 B (+8.74%) | 10.65 kB → 11.58 kB
`src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx` | 📈 +571 B (+8.68%) | 6.42 kB → 6.98 kB
`src/components/budget/goals/validateAutomation.ts` | 📈 +170 B (+7.06%) | 2.35 kB → 2.52 kB
`src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts` | 📈 +28 B (+1.55%) | 1.76 kB → 1.79 kB
`src/components/util/AmountInput.tsx` | 📈 +53 B (+0.82%) | 6.34 kB → 6.39 kB
`src/components/budget/BalanceWithCarryover.tsx` | 📈 +2 B (+0.02%) | 9.26 kB → 9.26 kB
`src/components/budget/goals/displayTemplateMeta.ts` | 📉 -10 B (-0.56%) | 1.74 kB → 1.73 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB → 2.01 MB (+1.67 kB) | +0.08%
static/js/Value.js | 4.96 MB → 4.96 MB (+55 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.72 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.38 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 193.42 kB | 0%
static/js/es.js | 178.83 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.71 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.13 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.19 kB | 0%
static/js/nl.js | 106.34 kB | 0%
static/js/pt-BR.js | 189.39 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.56 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.75 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.jUVFVkaN.js | 5.31 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->