### PR TITLE
[WIP] Exclude hidden categories and groups from envelope budget totals

### DIFF
--- a/packages/loot-core/src/server/budget/base.test.ts
+++ b/packages/loot-core/src/server/budget/base.test.ts
@@ -228,7 +228,7 @@ describe('Base budget', () => {
     expect(sheet.getCellValue(sheetName, 'total-spent')).toBe(-3000);
   });
 
-  it('Includes hidden categories in group totals for Envelope Budget', async () => {
+  it('Excludes hidden categories from group totals in Envelope Budget', async () => {
     await sheet.loadSpreadsheet(db);
     // Envelope is the default, but explicit for clarity
     sheet.get().meta().budgetType = 'envelope';
@@ -274,13 +274,32 @@ describe('Base budget', () => {
 
     await sheet.waitOnSpreadsheet();
 
-    // Verify group total includes both visible and hidden category amounts
+    // Each per-category cell still tracks its own activity
+    expect(sheet.getCellValue(sheetName, `sum-amount-${visibleCatId}`)).toBe(
+      -1000,
+    );
+    expect(sheet.getCellValue(sheetName, `sum-amount-${hiddenCatId}`)).toBe(
+      -2000,
+    );
+    // But the group total ignores hidden categories
+    expect(sheet.getCellValue(sheetName, `group-sum-amount-group1`)).toBe(
+      -1000,
+    );
+
+    // Toggle hidden -> visible: group total should recompute live
+    await db.updateCategory({
+      id: hiddenCatId,
+      name: 'Hidden Category',
+      cat_group: 'group1',
+      hidden: 0,
+    });
+    await sheet.waitOnSpreadsheet();
     expect(sheet.getCellValue(sheetName, `group-sum-amount-group1`)).toBe(
       -3000,
     );
   });
 
-  it('Includes hidden category groups in budget totals for Envelope Budget', async () => {
+  it('Excludes hidden category groups from budget totals in Envelope Budget', async () => {
     await sheet.loadSpreadsheet(db);
     // Envelope is the default, but explicit for clarity
     sheet.get().meta().budgetType = 'envelope';
@@ -334,7 +353,20 @@ describe('Base budget', () => {
 
     await sheet.waitOnSpreadsheet();
 
-    // Verify total spent includes both visible and hidden group amounts
+    // The hidden group still tracks its own internal activity
+    expect(
+      sheet.getCellValue(sheetName, `group-sum-amount-hidden-group`),
+    ).toBe(-2000);
+    // But the top-line total ignores the hidden group
+    expect(sheet.getCellValue(sheetName, 'total-spent')).toBe(-1000);
+
+    // Toggle hidden -> visible: top-line should update live
+    await db.updateCategoryGroup({
+      id: 'hidden-group',
+      name: 'Hidden Group',
+      hidden: 0,
+    });
+    await sheet.waitOnSpreadsheet();
     expect(sheet.getCellValue(sheetName, 'total-spent')).toBe(-3000);
   });
 });

--- a/packages/loot-core/src/server/budget/base.test.ts
+++ b/packages/loot-core/src/server/budget/base.test.ts
@@ -354,9 +354,9 @@ describe('Base budget', () => {
     await sheet.waitOnSpreadsheet();
 
     // The hidden group still tracks its own internal activity
-    expect(
-      sheet.getCellValue(sheetName, `group-sum-amount-hidden-group`),
-    ).toBe(-2000);
+    expect(sheet.getCellValue(sheetName, `group-sum-amount-hidden-group`)).toBe(
+      -2000,
+    );
     // But the top-line total ignores the hidden group
     expect(sheet.getCellValue(sheetName, 'total-spent')).toBe(-1000);
 

--- a/packages/loot-core/src/server/budget/envelope.ts
+++ b/packages/loot-core/src/server/budget/envelope.ts
@@ -76,20 +76,26 @@ export function createCategory(cat, sheetName, prevSheetName) {
 export function createCategoryGroup(group, sheetName) {
   sheet.get().createDynamic(sheetName, 'group-sum-amount-' + group.id, {
     initialValue: 0,
-    dependencies: group.categories.map(cat => `sum-amount-${cat.id}`),
+    dependencies: group.categories
+      .filter(cat => !cat.hidden)
+      .map(cat => `sum-amount-${cat.id}`),
     run: sumAmounts,
   });
 
   if (!group.is_income) {
     sheet.get().createDynamic(sheetName, 'group-budget-' + group.id, {
       initialValue: 0,
-      dependencies: group.categories.map(cat => `budget-${cat.id}`),
+      dependencies: group.categories
+        .filter(cat => !cat.hidden)
+        .map(cat => `budget-${cat.id}`),
       run: sumAmounts,
     });
 
     sheet.get().createDynamic(sheetName, 'group-leftover-' + group.id, {
       initialValue: 0,
-      dependencies: group.categories.map(cat => `leftover-${cat.id}`),
+      dependencies: group.categories
+        .filter(cat => !cat.hidden)
+        .map(cat => `leftover-${cat.id}`),
       run: sumAmounts,
     });
   }
@@ -150,7 +156,7 @@ export function createSummary(groups, categories, prevSheetName, sheetName) {
   sheet.get().createDynamic(sheetName, 'total-budgeted', {
     initialValue: 0,
     dependencies: groups
-      .filter(group => !group.is_income)
+      .filter(group => !group.is_income && !group.hidden)
       .map(group => `group-budget-${group.id}`),
     run: (...amounts) => {
       // Negate budgeted amount
@@ -211,7 +217,7 @@ export function createSummary(groups, categories, prevSheetName, sheetName) {
   sheet.get().createDynamic(sheetName, 'total-spent', {
     initialValue: 0,
     dependencies: groups
-      .filter(group => !group.is_income)
+      .filter(group => !group.is_income && !group.hidden)
       .map(group => `group-sum-amount-${group.id}`),
     run: sumAmounts,
   });
@@ -219,7 +225,7 @@ export function createSummary(groups, categories, prevSheetName, sheetName) {
   sheet.get().createDynamic(sheetName, 'total-leftover', {
     initialValue: 0,
     dependencies: groups
-      .filter(group => !group.is_income)
+      .filter(group => !group.is_income && !group.hidden)
       .map(group => `group-leftover-${group.id}`),
     run: sumAmounts,
   });
@@ -306,18 +312,22 @@ export function handleCategoryChange(months, oldValue, newValue) {
           `${prevSheetName}!carryover-${id}`,
         ]);
 
-      addDeps(sheetName, groupId, id);
-      if (newValue.is_income) {
-        sheet
-          .get()
-          .addDependencies(
-            sheetName,
-            'buffered-auto',
-            flatten2([
-              `${sheetName}!sum-amount-${id}`,
-              `${sheetName}!carryover-${id}`,
-            ]),
-          );
+      // Do not wire hidden categories into the group sum (parity with
+      // tracking.ts; fixes #2400 for envelope/rollover budgets).
+      if (!newValue.hidden) {
+        addDeps(sheetName, groupId, id);
+        if (newValue.is_income) {
+          sheet
+            .get()
+            .addDependencies(
+              sheetName,
+              'buffered-auto',
+              flatten2([
+                `${sheetName}!sum-amount-${id}`,
+                `${sheetName}!carryover-${id}`,
+              ]),
+            );
+        }
       }
     });
   } else if (oldValue && oldValue.cat_group !== newValue.cat_group) {
@@ -328,6 +338,44 @@ export function handleCategoryChange(months, oldValue, newValue) {
       const sheetName = monthUtils.sheetForMonth(month);
       removeDeps(sheetName, oldValue.cat_group, id);
       addDeps(sheetName, newValue.cat_group, id);
+    });
+  } else if (oldValue && oldValue.hidden !== newValue.hidden) {
+    // Visibility toggled -- wire/unwire the category from the group sum
+    // dynamically so it stops contributing to group totals when hidden.
+    const id = newValue.id;
+    const groupId = newValue.cat_group;
+
+    months.forEach(month => {
+      const sheetName = monthUtils.sheetForMonth(month);
+      if (newValue.hidden) {
+        removeDeps(sheetName, groupId, id);
+        if (newValue.is_income) {
+          sheet
+            .get()
+            .removeDependencies(
+              sheetName,
+              'buffered-auto',
+              flatten2([
+                `${sheetName}!sum-amount-${id}`,
+                `${sheetName}!carryover-${id}`,
+              ]),
+            );
+        }
+      } else {
+        addDeps(sheetName, groupId, id);
+        if (newValue.is_income) {
+          sheet
+            .get()
+            .addDependencies(
+              sheetName,
+              'buffered-auto',
+              flatten2([
+                `${sheetName}!sum-amount-${id}`,
+                `${sheetName}!carryover-${id}`,
+              ]),
+            );
+        }
+      }
     });
   }
 }
@@ -396,7 +444,26 @@ export function handleCategoryGroupChange(months, oldValue, newValue) {
         );
         createCategoryGroup({ ...group, categories }, sheetName);
 
-        addDeps(sheetName, group.id);
+        // Skip hidden groups so they do not feed into the total-* aggregates
+        // (parity with tracking.ts; fixes #2400 for envelope/rollover budgets).
+        if (!group.hidden) {
+          addDeps(sheetName, group.id);
+        }
+      });
+    }
+  } else if (oldValue && oldValue.hidden !== newValue.hidden) {
+    // Visibility toggled -- wire/unwire the group from total-* aggregates
+    // dynamically so it stops contributing to top-line totals when hidden.
+    const group = newValue;
+
+    if (!group.is_income) {
+      months.forEach(month => {
+        const sheetName = monthUtils.sheetForMonth(month);
+        if (newValue.hidden) {
+          removeDeps(sheetName, group.id);
+        } else {
+          addDeps(sheetName, group.id);
+        }
       });
     }
   }

--- a/upcoming-release-notes/fix-envelope-hidden.md
+++ b/upcoming-release-notes/fix-envelope-hidden.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Wizarck]
+---
+
+Bring envelope/rollover budgets to parity with tracking budgets: hidden categories and hidden groups no longer contribute to per-group totals (`group-sum-amount-*`, `group-budget-*`, `group-leftover-*`) or top-line aggregates (`total-spent`, `total-budgeted`, `total-leftover`). Toggling visibility re-wires dependencies live (issue #2400 / closed dup #4730).


### PR DESCRIPTION
## Summary

Bring envelope / rollover budgets to parity with the fix already applied to tracking budgets in #4567. Hidden categories (and hidden groups) no longer leak into per-group totals or top-line aggregates, and toggling visibility live re-wires the relevant dependencies.

This fixes the envelope side of #2400 (closed duplicate #4730), which #4567 only addressed for tracking budgets.

## What changed in `envelope.ts`

- `createCategoryGroup` filters hidden categories out of `group-sum-amount-*`, `group-budget-*`, and `group-leftover-*` deps.
- `createSummary` skips hidden groups in `total-budgeted`, `total-spent`, and `total-leftover` deps.
- `handleCategoryChange` now treats `oldValue.hidden !== newValue.hidden` and wires/unwires the per-category deps (including the income `buffered-auto` deps); the tombstone→0 branch no longer adds deps for a category that re-emerges as hidden.
- `handleCategoryGroupChange` treats group visibility toggles the same way and skips deps when a group is re-created hidden.

## What changed in `base.test.ts`

The two envelope tests added in #4567 asserted that hidden items *should* be counted (locking in the bug). They are flipped here to assert exclusion and each one now exercises the toggle branch by un-hiding the category/group mid-test:

- `Includes hidden categories in group totals for Envelope Budget` → `Excludes hidden categories from group totals in Envelope Budget` (asserts `group-sum-amount-group1` = -1000 with hidden cat = -2000, then un-hides and expects -3000).
- `Includes hidden category groups in budget totals for Envelope Budget` → `Excludes hidden category groups from budget totals in Envelope Budget` (asserts `total-spent` = -1000 with hidden group = -2000, then un-hides and expects -3000).

## Why this matters in practice

I hit this while scripting a category re-org via `@actual-app/api` against a 26.5.2 server: hiding old categories that still had budgeted amounts left phantom contributions in the group totals, surfacing in the UI as a group "Padres" showing −5616 € budgeted when only one visible category had −2808 € assigned (two hidden duplicates were silently summed). The fix matches what tracking budgets already do, so behaviour is now consistent across budget types.

## Test plan

- [ ] `yarn workspace loot-core test base.test.ts` (need to run in CI — no local yarn available where I authored this).
- [ ] CI green.
- [ ] Manual: create envelope budget, add tx to visible + hidden cat in the same group, confirm group total only shows visible amount; unhide and confirm recomputes live.