### PR TITLE
[WIP] fix(compiler): escape single quotes in $oneof and id literals to prevent SQL injection

### DIFF
--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -341,7 +341,7 @@ function val(state, expr, type?: string) {
 
   if (castedExpr.literal) {
     if (castedExpr.type === 'id') {
-      return `'${castedExpr.value}'`;
+      return `'${String(castedExpr.value).replace(/'/g, "''")}'`;
     } else if (castedExpr.type === 'string') {
       // Escape quotes
       const value = castedExpr.value.replace(/'/g, "''");
@@ -717,7 +717,7 @@ const compileOp = saveStack('op', (state, fieldRef, opData) => {
 
       return (
         `${String(left)} IN (` +
-        ids.map(id => `'${String(id)}'`).join(',') +
+        ids.map(id => "'" + String(id).replace(/'/g, "''") + "'").join(',') +
         ')'
       );
     }


### PR DESCRIPTION
## Description

This PR fixes a SQL injection vulnerability (CWE-89) in the AQL query compiler. Two code paths in `packages/loot-core/src/server/aql/compiler.ts` interpolate user-supplied values into SQL strings without escaping single quotes:

1. **`val()` function, `id` literal branch (line 343):** When an expression has `type === 'id'` and `literal === true`, its value is placed directly into a SQL string as `'${castedExpr.value}'` — without any escaping. The adjacent `string` literal branch (line 346) already escapes quotes with `.replace(/'/g, "''")`, but this was missing for `id` literals.

2. **`$oneof` operator (line 720):** The array of IDs passed to the `$oneof` / `IN (...)` clause is interpolated as `'${String(id)}'` per element — again without escaping single quotes.

In both cases, a value containing a single quote (e.g., `O'Malley` or a crafted payload like `'; DROP TABLE ...--`) breaks out of the SQL string literal. The `api/query` endpoint accepts arbitrary AQL queries from authenticated API consumers, making these paths reachable with user-controlled input. In multiuser deployments, authenticated users are not necessarily trusted administrators.

## Related issue(s)

N/A — submitting fix directly.

## Testing

**Verified the fix by inspecting the generated SQL output for both code paths:**

- An `id` literal value of `test'val` now produces `'test''val'` instead of `'test'val'`.
- A `$oneof` array containing `["abc", "x'y"]` now produces `IN ('abc','x''y')` instead of `IN ('abc','x'y')`.
- The fix follows the identical escaping pattern already used for `string` literals at line 347, so it is consistent with the existing codebase conventions.

**Reproduction (PoC):**

An authenticated API consumer can send a query like:

```js
// Via the api/query endpoint
{
  "query": {
    "table": "transactions",
    "filter": {
      "category": { "$oneof": ["normal-id", "'; DELETE FROM transactions; --"] }
    }
  }
}
```

Before this fix, the generated SQL would be:
```sql
... IN ('normal-id',''; DELETE FROM transactions; --')
```

The injected single quote closes the SQL string literal, allowing arbitrary SQL to execute. After this fix, the quote is doubled:
```sql
... IN ('normal-id','''; DELETE FROM transactions; --')
```

This keeps the entire value inside the string literal, neutralizing the injection.

The same issue applies to `id` literals — any query path that produces `{type: 'id', literal: true, value: <user-input>}` would be vulnerable.

**Adversarial review:** Before submitting, we considered whether this is actually exploitable. The key question was whether user input can reach these code paths. It can — the `api/query` endpoint accepts arbitrary AQL filter expressions from authenticated clients, and both the `$oneof` operator and `id`-typed literal values flow directly to the vulnerable interpolation without sanitization. We also verified that the underlying database layer (better-sqlite3) does not independently escape these values, since they are baked into the SQL string before the query is executed, not passed as bound parameters.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

Release notes: **Security: Fix SQL injection in AQL query compiler** — escape single quotes in `$oneof` IDs and `id` literal values to prevent SQL injection via the query API.

---



<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.95 MB → 13.95 MB (+3.45 kB) | +0.02%
loot-core | 1 | 5.31 MB → 5.31 MB (+53 B) | +0.00%
api | 2 | 3.94 MB → 3.94 MB (+53 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.95 MB → 13.95 MB (+3.45 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +3.45 kB (+1.81%) | 189.97 kB → 193.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 189.97 kB → 193.42 kB (+3.45 kB) | +1.81%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.72 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.38 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/es.js | 178.83 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.71 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.13 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.19 kB | 0%
static/js/nl.js | 106.34 kB | 0%
static/js/pt-BR.js | 189.39 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.56 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.75 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.31 MB → 5.31 MB (+53 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +53 B (+0.21%) | 24.71 kB → 24.76 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DRjcAY2x.js | 0 B → 5.31 MB (+5.31 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.jUVFVkaN.js | 5.31 MB → 0 B (-5.31 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+53 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +53 B (+0.22%) | 24.07 kB → 24.12 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+53 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->