### PR TITLE
[AI] Fix balance forecast all future range

### DIFF
--- a/packages/desktop-client/src/components/reports/reportRanges.test.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.test.ts
@@ -1,8 +1,10 @@
+import * as monthUtils from '@actual-app/core/shared/months';
 import { describe, expect, it } from 'vitest';
 
 import {
   calculateSpendingReportTimeRange,
   calculateTimeRange,
+  getFullFutureRange,
 } from './reportRanges';
 
 // In test mode, monthUtils.currentMonth() returns '2017-01'
@@ -64,5 +66,28 @@ describe('calculateSpendingReportTimeRange', () => {
 
     expect(compare).toBe('2017-01');
     expect(compareTo).toBe('2017-01');
+  });
+});
+
+describe('getFullFutureRange', () => {
+  it('uses a future month as the end of the range', () => {
+    const start = monthUtils.currentMonth();
+    const futureMonth = monthUtils.addMonths(start, 36);
+
+    expect(getFullFutureRange(futureMonth)).toEqual([
+      start,
+      futureMonth,
+      'static',
+    ]);
+  });
+
+  it('falls back to a default future horizon without a future month', () => {
+    const start = monthUtils.currentMonth();
+
+    expect(getFullFutureRange()).toEqual([
+      start,
+      monthUtils.addMonths(start, 24),
+      'static',
+    ]);
   });
 });

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -184,12 +184,9 @@ export function getNextRange(offset: number) {
 export function getFullFutureRange(latestMonth?: string) {
   const start = monthUtils.currentMonth();
   const defaultEnd = monthUtils.addMonths(start, 24);
-  const latestMonthValue = latestMonth
-    ? monthUtils.monthFromDate(latestMonth)
-    : undefined;
   const end =
-    latestMonthValue && monthUtils.isAfter(latestMonthValue, start)
-      ? latestMonthValue
+    latestMonth && monthUtils.isAfter(latestMonth, start)
+      ? latestMonth
       : defaultEnd;
 
   return [start, end, 'static'] as const;

--- a/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
@@ -299,9 +299,7 @@ function BalanceForecastInner({ widget }: BalanceForecastInnerProps) {
         end={end}
         earliestTransaction={earliestTransaction}
         latestTransaction={
-          forecastData?.forecastEndDate
-            ? monthUtils.monthFromDate(forecastData.forecastEndDate)
-            : (allMonths[0]?.name ?? monthUtils.addMonths(currentMonth, 24))
+          allMonths[0]?.name ?? monthUtils.addMonths(currentMonth, 24)
         }
         mode={mode}
         onChangeDates={onChangeDates}

--- a/upcoming-release-notes/7849.md
+++ b/upcoming-release-notes/7849.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Fix the Balance Forecast report's All future range.


### PR DESCRIPTION
## Description

Fixes the Balance Forecast report's **All future** range behavior. The range helper was treating a month value as a date and normalizing it back to the start month, so the All future option could appear to do nothing even when future months were available.

This keeps the available future month value intact and uses it directly when it is after the current month.

## Related issue(s)

Relates to #7669

## Testing

- Added unit coverage for `getFullFutureRange` using a future month and the default fallback horizon.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.99 MB → 13.99 MB (+1.86 kB) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.99 MB → 13.99 MB (+1.86 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +2.02 kB (+1.05%) | 193.42 kB → 195.44 kB
`src/components/reports/reports/BalanceForecast.tsx` | 📉 -78 B (-0.58%) | 13.22 kB → 13.14 kB
`src/components/reports/reportRanges.ts` | 📉 -92 B (-1.80%) | 4.99 kB → 4.9 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 193.42 kB → 195.44 kB (+2.02 kB) | +1.05%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.25 MB (-170 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.96 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.72 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.28 kB | 0%
static/js/de.js | 170.38 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/es.js | 178.83 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/fr.js | 178.71 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.13 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.19 kB | 0%
static/js/nl.js | 106.34 kB | 0%
static/js/pt-BR.js | 189.39 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.62 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.56 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.75 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C0Ijh3nP.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->