### PR TITLE
[AI] Replace GitHub Actions with native gh CLI commands

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -116,25 +116,18 @@ jobs:
               <a href="https://flathub.org/apps/com.actualbudget.actual"><img width="165" style="margin-left:12px;" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en" /></a>
             </p>
         run: |
-          # Create the draft release if it doesn't exist yet. Matrix jobs run
-          # in parallel against the same tag, so ignore the "already exists"
-          # error that the losers of the race will hit.
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --draft --title "$TAG" --notes "$RELEASE_NOTES" || true
-          fi
+          # The matrix runs three OS jobs in parallel against one release, so
+          # ignore the "already exists" error that the race losers will hit.
+          gh release create "$TAG" --draft --title "$TAG" --notes "$RELEASE_NOTES" 2>/dev/null || true
 
-          shopt -s nullglob
+          shopt -s extglob nullglob
           files=(
             packages/desktop-electron/dist/*.dmg
+            packages/desktop-electron/dist/!(Actual-windows).exe
             packages/desktop-electron/dist/*.AppImage
             packages/desktop-electron/dist/*.flatpak
             packages/desktop-electron/dist/*.appx
           )
-          for f in packages/desktop-electron/dist/*.exe; do
-            [[ "$(basename "$f")" == "Actual-windows.exe" ]] && continue
-            files+=("$f")
-          done
-
           if [ ${#files[@]} -gt 0 ]; then
             gh release upload "$TAG" --clobber "${files[@]}"
           fi

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -100,10 +100,11 @@ jobs:
           path: |
             packages/desktop-electron/dist/*.appx
       - name: Add to new release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
-        with:
-          draft: true
-          body: |
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+          RELEASE_NOTES: |
             :link: [View release notes](https://actualbudget.org/blog/release-${{ steps.process_version.outputs.version }})
 
             ## Desktop releases
@@ -114,13 +115,29 @@ jobs:
               <img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" width="12" height="1" alt="" />
               <a href="https://flathub.org/apps/com.actualbudget.actual"><img width="165" style="margin-left:12px;" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en" /></a>
             </p>
-          files: |
+        run: |
+          # Create the draft release if it doesn't exist yet. Matrix jobs run
+          # in parallel against the same tag, so ignore the "already exists"
+          # error that the losers of the race will hit.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --draft --title "$TAG" --notes "$RELEASE_NOTES" || true
+          fi
+
+          shopt -s nullglob
+          files=(
             packages/desktop-electron/dist/*.dmg
-            packages/desktop-electron/dist/*.exe
-            !packages/desktop-electron/dist/Actual-windows.exe
             packages/desktop-electron/dist/*.AppImage
             packages/desktop-electron/dist/*.flatpak
             packages/desktop-electron/dist/*.appx
+          )
+          for f in packages/desktop-electron/dist/*.exe; do
+            [[ "$(basename "$f")" == "Actual-windows.exe" ]] && continue
+            files+=("$f")
+          done
+
+          if [ ${#files[@]} -gt 0 ]; then
+            gh release upload "$TAG" --clobber "${files[@]}"
+          fi
 
     outputs:
       version: ${{ steps.process_version.outputs.version }}

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -116,9 +116,14 @@ jobs:
               <a href="https://flathub.org/apps/com.actualbudget.actual"><img width="165" style="margin-left:12px;" alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en" /></a>
             </p>
         run: |
-          # The matrix runs three OS jobs in parallel against one release, so
-          # ignore the "already exists" error that the race losers will hit.
-          gh release create "$TAG" --draft --title "$TAG" --notes "$RELEASE_NOTES" 2>/dev/null || true
+          # The matrix runs three OS jobs in parallel against one release;
+          # only ignore the "already exists" error that the race losers hit.
+          if ! create_output=$(gh release create "$TAG" --draft --title "$TAG" --notes "$RELEASE_NOTES" 2>&1); then
+            if [[ "$create_output" != *already_exists* ]]; then
+              echo "$create_output" >&2
+              exit 1
+            fi
+          fi
 
           shopt -s extglob nullglob
           files=(

--- a/.github/workflows/issues-close-feature-requests.yml
+++ b/.github/workflows/issues-close-feature-requests.yml
@@ -11,21 +11,21 @@ jobs:
   needs-votes:
     if: ${{ github.event.label.name == 'feature' }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
     steps:
-      - uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7f8 # v1.1.0
-        with:
-          labels: needs votes
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add needs votes label
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "needs votes"
       - name: Add reactions
         uses: aidan-mundy/react-to-issue@109392cac5159c2df6c47c8ab3b5d6b708852fe5 # v1.1.2
         with:
           issue-number: ${{ github.event.issue.number }}
           reactions: '+1'
       - name: Create comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
+        env:
+          COMMENT_BODY: |
             :sparkles: Thanks for sharing your idea! :sparkles:
 
             This repository uses a voting-based system for feature requests. While enhancement issues are automatically closed, we still welcome feature requests! The voting system helps us gauge community interest in potential features. We also encourage community contributions for any feature requests marked as needing votes (just post a comment first so we can help guide you toward a successful contribution).
@@ -35,7 +35,6 @@ jobs:
             Don't forget to upvote the top comment with 👍!
 
             <!-- feature-auto-close-comment -->
+        run: gh issue comment "$ISSUE_NUMBER" --body "$COMMENT_BODY"
       - name: Close Issue
-        run: gh issue close "https://github.com/actualbudget/actual/issues/${{ github.event.issue.number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue close "$ISSUE_NUMBER"

--- a/upcoming-release-notes/7852.md
+++ b/upcoming-release-notes/7852.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Refactor workflows to utilize native `gh` CLI commands instead of third-party GitHub Actions.


### PR DESCRIPTION
## Description

Patching a few more issues caught by zizmor.

## Related issue(s)

N/A

## Testing

The changes are workflow configuration updates. Verification will occur when these workflows run in CI/CD:
- Desktop release workflow will test the new `gh release create/upload` logic
- Feature request workflow will test the new label, comment, and close operations

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed

https://claude.ai/code/session_013WRPAHxFfC3XWh3pQh4daz