### PR TITLE
[AI] Upgrade vite-plugin-node-polyfills to 0.27.0

### DIFF
--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -220,7 +220,7 @@
     "ts-node": "^10.9.2",
     "util": "^0.12.5",
     "vite": "^8.0.5",
-    "vite-plugin-node-polyfills": "^0.26.0",
+    "vite-plugin-node-polyfills": "^0.27.0",
     "vite-plugin-peggy-loader": "^2.0.1",
     "vitest": "^4.1.2",
     "yargs": "^18.0.0"

--- a/packages/loot-core/vite.config.mts
+++ b/packages/loot-core/vite.config.mts
@@ -62,7 +62,6 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [
       peggyLoader(),
-      // https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/142
       nodePolyfills({
         include: [
           'process',

--- a/upcoming-release-notes/7860.md
+++ b/upcoming-release-notes/7860.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Upgrade `vite-plugin-node-polyfills` to 0.27.0.

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,7 +148,7 @@ __metadata:
     util: "npm:^0.12.5"
     uuid: "npm:^14.0.0"
     vite: "npm:^8.0.5"
-    vite-plugin-node-polyfills: "npm:^0.26.0"
+    vite-plugin-node-polyfills: "npm:^0.27.0"
     vite-plugin-peggy-loader: "npm:^2.0.1"
     vitest: "npm:^4.1.2"
     xml2js: "npm:^0.6.2"
@@ -28441,15 +28441,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite-plugin-node-polyfills@npm:^0.26.0":
-  version: 0.26.0
-  resolution: "vite-plugin-node-polyfills@npm:0.26.0"
+"vite-plugin-node-polyfills@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "vite-plugin-node-polyfills@npm:0.27.0"
   dependencies:
     "@rollup/plugin-inject": "npm:^5.0.5"
     node-stdlib-browser: "npm:^1.3.1"
   peerDependencies:
     vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 10/538076561ccfe16e6aa24f7fe9fdb86e0e23ac066fc42b4a6e8af491b2c5d7e3e4a5344694355015d684e2faa69f92e20978b1a1b944770e0d3b8acfea53cbe8
+  checksum: 10/d3c795f144af2e6806948b6ed6e1842d56310bdcbfe17ca1efcbf6c297f2fd31994f4626cc138df39b2069d38b791960e1dd0f46efd8c7ca8d8c009697ab1721
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `vite-plugin-node-polyfills` from `^0.26.0` to `^0.27.0` in
`packages/loot-core`.

Changelog: https://github.com/davidmyersdev/vite-plugin-node-polyfills/releases/tag/v0.27.0
Related upstream issue (already referenced from `vite.config.mts`):
https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/142

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.99 MB → 13.99 MB (-890 B) | -0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.99 MB → 13.99 MB (-890 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +452 B (+0.23%) | 195.44 kB → 195.88 kB
`locale/uk.json` | 📉 -117 B (-0.06%) | 207.56 kB → 207.45 kB
`locale/ca.json` | 📉 -107 B (-0.06%) | 187.72 kB → 187.62 kB
`locale/fr.json` | 📉 -103 B (-0.06%) | 178.71 kB → 178.61 kB
`locale/pt-BR.json` | 📉 -112 B (-0.06%) | 189.39 kB → 189.28 kB
`locale/es.json` | 📉 -114 B (-0.06%) | 178.83 kB → 178.71 kB
`locale/it.json` | 📉 -107 B (-0.06%) | 165.13 kB → 165.02 kB
`locale/de.json` | 📉 -112 B (-0.06%) | 170.38 kB → 170.27 kB
`locale/nb-NO.json` | 📉 -113 B (-0.07%) | 148.19 kB → 148.08 kB
`locale/th.json` | 📉 -135 B (-0.08%) | 174.62 kB → 174.48 kB
`locale/zh-Hans.json` | 📉 -110 B (-0.09%) | 117.75 kB → 117.65 kB
`locale/nl.json` | 📉 -100 B (-0.09%) | 106.34 kB → 106.24 kB
`locale/da.json` | 📉 -112 B (-0.11%) | 101.28 kB → 101.17 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 195.44 kB → 195.88 kB (+452 B) | +0.23%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 174.62 kB → 174.48 kB (-135 B) | -0.08%
static/js/uk.js | 207.56 kB → 207.45 kB (-117 B) | -0.06%
static/js/es.js | 178.83 kB → 178.71 kB (-114 B) | -0.06%
static/js/nb-NO.js | 148.19 kB → 148.08 kB (-113 B) | -0.07%
static/js/da.js | 101.28 kB → 101.17 kB (-112 B) | -0.11%
static/js/de.js | 170.38 kB → 170.27 kB (-112 B) | -0.06%
static/js/pt-BR.js | 189.39 kB → 189.28 kB (-112 B) | -0.06%
static/js/zh-Hans.js | 117.75 kB → 117.65 kB (-110 B) | -0.09%
static/js/ca.js | 187.72 kB → 187.62 kB (-107 B) | -0.06%
static/js/it.js | 165.13 kB → 165.02 kB (-107 B) | -0.06%
static/js/fr.js | 178.71 kB → 178.61 kB (-103 B) | -0.06%
static/js/nl.js | 106.34 kB → 106.24 kB (-100 B) | -0.09%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/extends.js | 519.29 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C0Ijh3nP.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->