### PR TITLE
[AI] sync-server.Dockerfile: unbreak `yarn build:server` after lage migration

### DIFF
--- a/sync-server.Dockerfile
+++ b/sync-server.Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 
 # Copy only the files needed for installing dependencies
 COPY .yarn ./.yarn
-COPY yarn.lock package.json .yarnrc.yml tsconfig.json ./
+COPY yarn.lock package.json .yarnrc.yml tsconfig.json lage.config.js ./
 COPY packages/api/package.json packages/api/package.json
 COPY packages/component-library/package.json packages/component-library/package.json
 COPY packages/crdt/package.json packages/crdt/package.json
@@ -30,6 +30,13 @@ COPY packages/ ./packages/
 
 # Increase memory limit for the build process to 8GB
 ENV NODE_OPTIONS=--max_old_space_size=8192
+
+# lage's task hasher invokes `git ls-tree HEAD` during initialization, so it
+# needs a git repo even when individual targets disable caching. .dockerignore
+# omits the real .git, so seed a throwaway repo with a single commit here.
+RUN git -c init.defaultBranch=master init -q \
+    && git -c user.email=build@docker -c user.name=docker-build add -A \
+    && git -c user.email=build@docker -c user.name=docker-build commit -qm build
 
 RUN yarn build:server
 

--- a/upcoming-release-notes/7861.md
+++ b/upcoming-release-notes/7861.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Update Dockerfile to ensure `yarn build:server` works after lage migration.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Fixes
```
lage: no targets found that matches the given scope.
Error: building at STEP "RUN yarn build:server": while running runtime: exit status 1
```

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/pull/7835

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

on mac:
```
docker buildx build --platform=linux/amd64 -f sync-server.Dockerfile -t actual-server .
```

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->