### PR TITLE
[AI] Restrict secrets API access to admins in OpenID mode

### DIFF
--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -1,6 +1,6 @@
 import express from 'express';
 
-import { getAccountDb, isAdmin } from './account-db';
+import { getActiveLoginMethod, isAdmin } from './account-db';
 import { SecretName, secretsService } from './services/secrets-service';
 import {
   requestLoggerMiddleware,
@@ -14,28 +14,10 @@ app.use(express.json());
 app.use(requestLoggerMiddleware);
 app.use(validateSessionMiddleware);
 
-// Both reads and writes against the secrets store touch admin-managed
-// integration credentials. When OpenID multi-user mode is active, only
-// admins may interact with this store - otherwise non-admin users could
-// at minimum enumerate which integrations are configured.
+// Gate reads and writes alike: in OpenID mode, non-admins could otherwise
+// enumerate which admin-managed integrations are configured.
 function requireAdminWhenOpenId(res, action) {
-  let method;
-  try {
-    const result = getAccountDb().first(
-      'SELECT method FROM auth WHERE active = 1',
-    );
-    method = result?.method;
-  } catch (error) {
-    console.error('Failed to fetch auth method:', error);
-    res.status(500).send({
-      status: 'error',
-      reason: 'database-error',
-      details: 'Failed to validate authentication method',
-    });
-    return false;
-  }
-
-  if (method === 'openid' && !isAdmin(res.locals.user_id)) {
+  if (getActiveLoginMethod() === 'openid' && !isAdmin(res.locals.user_id)) {
     res.status(403).send({
       status: 'error',
       reason: 'not-admin',
@@ -60,18 +42,17 @@ app.post('/', async (req, res) => {
 });
 
 app.get('/:name', async (req, res) => {
-  if (!requireAdminWhenOpenId(res, 'read')) {
-    return;
-  }
-
   const name = req.params.name;
-  if (!Object.prototype.hasOwnProperty.call(SecretName, name)) {
+  if (!(name in SecretName)) {
     res.status(404).send('key not found');
     return;
   }
 
-  const keyExists = secretsService.exists(name);
-  if (keyExists) {
+  if (!requireAdminWhenOpenId(res, 'read')) {
+    return;
+  }
+
+  if (secretsService.exists(name)) {
     res.sendStatus(204);
   } else {
     res.status(404).send('key not found');

--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -1,7 +1,7 @@
 import express from 'express';
 
 import { getAccountDb, isAdmin } from './account-db';
-import { secretsService } from './services/secrets-service';
+import { SecretName, secretsService } from './services/secrets-service';
 import {
   requestLoggerMiddleware,
   validateSessionMiddleware,
@@ -14,7 +14,11 @@ app.use(express.json());
 app.use(requestLoggerMiddleware);
 app.use(validateSessionMiddleware);
 
-app.post('/', async (req, res) => {
+// Both reads and writes against the secrets store touch admin-managed
+// integration credentials. When OpenID multi-user mode is active, only
+// admins may interact with this store - otherwise non-admin users could
+// at minimum enumerate which integrations are configured.
+function requireAdminWhenOpenId(res, action) {
   let method;
   try {
     const result = getAccountDb().first(
@@ -23,27 +27,32 @@ app.post('/', async (req, res) => {
     method = result?.method;
   } catch (error) {
     console.error('Failed to fetch auth method:', error);
-    return res.status(500).send({
+    res.status(500).send({
       status: 'error',
       reason: 'database-error',
       details: 'Failed to validate authentication method',
     });
+    return false;
   }
+
+  if (method === 'openid' && !isAdmin(res.locals.user_id)) {
+    res.status(403).send({
+      status: 'error',
+      reason: 'not-admin',
+      details: `You have to be admin to ${action} secrets`,
+    });
+    return false;
+  }
+
+  return true;
+}
+
+app.post('/', async (req, res) => {
+  if (!requireAdminWhenOpenId(res, 'set')) {
+    return;
+  }
+
   const { name, value } = req.body || {};
-
-  if (method === 'openid') {
-    const canSaveSecrets = isAdmin(res.locals.user_id);
-
-    if (!canSaveSecrets) {
-      res.status(403).send({
-        status: 'error',
-        reason: 'not-admin',
-        details: 'You have to be admin to set secrets',
-      });
-
-      return;
-    }
-  }
 
   secretsService.set(name, value);
 
@@ -51,7 +60,16 @@ app.post('/', async (req, res) => {
 });
 
 app.get('/:name', async (req, res) => {
+  if (!requireAdminWhenOpenId(res, 'read')) {
+    return;
+  }
+
   const name = req.params.name;
+  if (!Object.prototype.hasOwnProperty.call(SecretName, name)) {
+    res.status(404).send('key not found');
+    return;
+  }
+
   const keyExists = secretsService.exists(name);
   if (keyExists) {
     res.sendStatus(204);

--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -33,24 +33,33 @@ app.post('/', async (req, res) => {
 
   const { name, value } = req.body || {};
 
+  if (!(name in SecretName)) {
+    res.status(400).send({
+      status: 'error',
+      reason: 'invalid-secret-name',
+      details: 'Unknown secret name',
+    });
+    return;
+  }
+
   secretsService.set(name, value);
 
   res.status(200).send({ status: 'ok' });
 });
 
 app.get('/:name', async (req, res) => {
-  const name = req.params.name;
-  if (!(name in SecretName)) {
-    res.status(404).send('key not found');
-    return;
-  }
-
   if (!canManageSecrets(res.locals.user_id)) {
     res.status(403).send({
       status: 'error',
       reason: 'not-admin',
       details: 'You have to be admin to read secrets',
     });
+    return;
+  }
+
+  const name = req.params.name;
+  if (!(name in SecretName)) {
+    res.status(404).send('key not found');
     return;
   }
 

--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -14,23 +14,20 @@ app.use(express.json());
 app.use(requestLoggerMiddleware);
 app.use(validateSessionMiddleware);
 
-// Gate reads and writes alike: in OpenID mode, non-admins could otherwise
-// enumerate which admin-managed integrations are configured.
-function requireAdminWhenOpenId(res, action) {
-  if (getActiveLoginMethod() === 'openid' && !isAdmin(res.locals.user_id)) {
-    res.status(403).send({
-      status: 'error',
-      reason: 'not-admin',
-      details: `You have to be admin to ${action} secrets`,
-    });
-    return false;
-  }
-
-  return true;
+// In OpenID mode the secrets store is admin-managed; non-admins must be
+// blocked from both reads and writes, otherwise they can enumerate which
+// integrations are configured.
+function canManageSecrets(userId) {
+  return getActiveLoginMethod() !== 'openid' || isAdmin(userId);
 }
 
 app.post('/', async (req, res) => {
-  if (!requireAdminWhenOpenId(res, 'set')) {
+  if (!canManageSecrets(res.locals.user_id)) {
+    res.status(403).send({
+      status: 'error',
+      reason: 'not-admin',
+      details: 'You have to be admin to set secrets',
+    });
     return;
   }
 
@@ -48,7 +45,12 @@ app.get('/:name', async (req, res) => {
     return;
   }
 
-  if (!requireAdminWhenOpenId(res, 'read')) {
+  if (!canManageSecrets(res.locals.user_id)) {
+    res.status(403).send({
+      status: 'error',
+      reason: 'not-admin',
+      details: 'You have to be admin to read secrets',
+    });
     return;
   }
 

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -1,7 +1,26 @@
 import request from 'supertest';
 
+import { getAccountDb } from './account-db';
 import { handlers as app } from './app-secrets';
-import { secretsService } from './services/secrets-service';
+import { SecretName, secretsService } from './services/secrets-service';
+
+const validSecretName = SecretName.simplefin_token;
+const validSecretValue = 'testValue';
+
+const setOpenIdActive = isActive => {
+  const db = getAccountDb();
+  db.mutate('DELETE FROM auth');
+  if (isActive) {
+    db.mutate(
+      "INSERT INTO auth (method, active, extra_data, display_name) VALUES ('openid', 1, '', 'OpenID')",
+    );
+  } else {
+    db.mutate(
+      "INSERT INTO auth (method, active, extra_data, display_name) VALUES ('password', 1, '', 'Password')",
+    );
+  }
+};
+
 describe('secretsService', () => {
   const testSecretName = 'testSecret';
   const testSecretValue = 'testValue';
@@ -38,9 +57,13 @@ describe('secretsService', () => {
   });
 
   describe('secrets api', () => {
+    afterEach(() => {
+      getAccountDb().mutate('DELETE FROM auth');
+    });
+
     it('returns 401 if the user is not authenticated', async () => {
-      secretsService.set(testSecretName, testSecretValue);
-      const res = await request(app).get(`/${testSecretName}`);
+      secretsService.set(validSecretName, validSecretValue);
+      const res = await request(app).get(`/${validSecretName}`);
 
       expect(res.statusCode).toEqual(401);
       expect(res.body).toEqual({
@@ -52,31 +75,80 @@ describe('secretsService', () => {
 
     it('returns 404 if secret does not exist', async () => {
       const res = await request(app)
-        .get(`/thiskeydoesnotexist`)
+        .get(`/${SecretName.gocardless_secretKey}`)
+        .set('x-actual-token', 'valid-token');
+
+      expect(res.statusCode).toEqual(404);
+    });
+
+    it('returns 404 for unknown secret names without revealing existence', async () => {
+      const res = await request(app)
+        .get('/thiskeydoesnotexist')
         .set('x-actual-token', 'valid-token');
 
       expect(res.statusCode).toEqual(404);
     });
 
     it('returns 204 if secret exists', async () => {
-      secretsService.set(testSecretName, testSecretValue);
+      secretsService.set(validSecretName, validSecretValue);
       const res = await request(app)
-        .get(`/${testSecretName}`)
+        .get(`/${validSecretName}`)
         .set('x-actual-token', 'valid-token');
 
       expect(res.statusCode).toEqual(204);
     });
 
     it('returns 200 if secret was set', async () => {
-      secretsService.set(testSecretName, testSecretValue);
       const res = await request(app)
         .post(`/`)
         .set('x-actual-token', 'valid-token')
-        .send({ name: testSecretName, value: testSecretValue });
+        .send({ name: validSecretName, value: validSecretValue });
 
       expect(res.statusCode).toEqual(200);
       expect(res.body).toEqual({
         status: 'ok',
+      });
+    });
+
+    describe('when OpenID is the active auth method', () => {
+      beforeEach(() => {
+        setOpenIdActive(true);
+        secretsService.set(validSecretName, validSecretValue);
+      });
+
+      it('GET returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .get(`/${validSecretName}`)
+          .set('x-actual-token', 'valid-token-user');
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body).toEqual({
+          status: 'error',
+          reason: 'not-admin',
+          details: 'You have to be admin to read secrets',
+        });
+      });
+
+      it('GET returns 204 for admin users when secret exists', async () => {
+        const res = await request(app)
+          .get(`/${validSecretName}`)
+          .set('x-actual-token', 'valid-token-admin');
+
+        expect(res.statusCode).toEqual(204);
+      });
+
+      it('POST returns 403 for non-admin users', async () => {
+        const res = await request(app)
+          .post('/')
+          .set('x-actual-token', 'valid-token-user')
+          .send({ name: validSecretName, value: validSecretValue });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body).toEqual({
+          status: 'error',
+          reason: 'not-admin',
+          details: 'You have to be admin to set secrets',
+        });
       });
     });
   });

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -4,9 +4,6 @@ import { getAccountDb } from './account-db';
 import { handlers as app } from './app-secrets';
 import { SecretName, secretsService } from './services/secrets-service';
 
-const validSecretName = SecretName.simplefin_token;
-const validSecretValue = 'testValue';
-
 const enableOpenIdAuth = () => {
   const db = getAccountDb();
   db.mutate('DELETE FROM auth');
@@ -16,7 +13,7 @@ const enableOpenIdAuth = () => {
 };
 
 describe('secretsService', () => {
-  const testSecretName = 'testSecret';
+  const testSecretName = SecretName.simplefin_token;
   const testSecretValue = 'testValue';
 
   it('should set a secret', () => {
@@ -56,8 +53,8 @@ describe('secretsService', () => {
     });
 
     it('returns 401 if the user is not authenticated', async () => {
-      secretsService.set(validSecretName, validSecretValue);
-      const res = await request(app).get(`/${validSecretName}`);
+      secretsService.set(testSecretName, testSecretValue);
+      const res = await request(app).get(`/${testSecretName}`);
 
       expect(res.statusCode).toEqual(401);
       expect(res.body).toEqual({
@@ -84,9 +81,9 @@ describe('secretsService', () => {
     });
 
     it('returns 204 if secret exists', async () => {
-      secretsService.set(validSecretName, validSecretValue);
+      secretsService.set(testSecretName, testSecretValue);
       const res = await request(app)
-        .get(`/${validSecretName}`)
+        .get(`/${testSecretName}`)
         .set('x-actual-token', 'valid-token');
 
       expect(res.statusCode).toEqual(204);
@@ -96,7 +93,7 @@ describe('secretsService', () => {
       const res = await request(app)
         .post(`/`)
         .set('x-actual-token', 'valid-token')
-        .send({ name: validSecretName, value: validSecretValue });
+        .send({ name: testSecretName, value: testSecretValue });
 
       expect(res.statusCode).toEqual(200);
       expect(res.body).toEqual({
@@ -107,12 +104,12 @@ describe('secretsService', () => {
     describe('when OpenID is the active auth method', () => {
       beforeEach(() => {
         enableOpenIdAuth();
-        secretsService.set(validSecretName, validSecretValue);
+        secretsService.set(testSecretName, testSecretValue);
       });
 
       it('GET returns 403 for non-admin users', async () => {
         const res = await request(app)
-          .get(`/${validSecretName}`)
+          .get(`/${testSecretName}`)
           .set('x-actual-token', 'valid-token-user');
 
         expect(res.statusCode).toEqual(403);
@@ -125,7 +122,7 @@ describe('secretsService', () => {
 
       it('GET returns 204 for admin users when secret exists', async () => {
         const res = await request(app)
-          .get(`/${validSecretName}`)
+          .get(`/${testSecretName}`)
           .set('x-actual-token', 'valid-token-admin');
 
         expect(res.statusCode).toEqual(204);
@@ -135,7 +132,7 @@ describe('secretsService', () => {
         const res = await request(app)
           .post('/')
           .set('x-actual-token', 'valid-token-user')
-          .send({ name: validSecretName, value: validSecretValue });
+          .send({ name: testSecretName, value: testSecretValue });
 
         expect(res.statusCode).toEqual(403);
         expect(res.body).toEqual({

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -7,18 +7,12 @@ import { SecretName, secretsService } from './services/secrets-service';
 const validSecretName = SecretName.simplefin_token;
 const validSecretValue = 'testValue';
 
-const setOpenIdActive = isActive => {
+const enableOpenIdAuth = () => {
   const db = getAccountDb();
   db.mutate('DELETE FROM auth');
-  if (isActive) {
-    db.mutate(
-      "INSERT INTO auth (method, active, extra_data, display_name) VALUES ('openid', 1, '', 'OpenID')",
-    );
-  } else {
-    db.mutate(
-      "INSERT INTO auth (method, active, extra_data, display_name) VALUES ('password', 1, '', 'Password')",
-    );
-  }
+  db.mutate(
+    "INSERT INTO auth (method, active, extra_data, display_name) VALUES ('openid', 1, '', 'OpenID')",
+  );
 };
 
 describe('secretsService', () => {
@@ -112,7 +106,7 @@ describe('secretsService', () => {
 
     describe('when OpenID is the active auth method', () => {
       beforeEach(() => {
-        setOpenIdActive(true);
+        enableOpenIdAuth();
         secretsService.set(validSecretName, validSecretValue);
       });
 

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -101,6 +101,20 @@ describe('secretsService', () => {
       });
     });
 
+    it('POST returns 400 for unknown secret names', async () => {
+      const res = await request(app)
+        .post('/')
+        .set('x-actual-token', 'valid-token')
+        .send({ name: 'thiskeydoesnotexist', value: 'whatever' });
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body).toEqual({
+        status: 'error',
+        reason: 'invalid-secret-name',
+        details: 'Unknown secret name',
+      });
+    });
+
     describe('when OpenID is the active auth method', () => {
       beforeEach(() => {
         enableOpenIdAuth();
@@ -140,6 +154,16 @@ describe('secretsService', () => {
           reason: 'not-admin',
           details: 'You have to be admin to set secrets',
         });
+      });
+
+      it('POST returns 200 for admin users', async () => {
+        const res = await request(app)
+          .post('/')
+          .set('x-actual-token', 'valid-token-admin')
+          .send({ name: testSecretName, value: 'newValue' });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toEqual({ status: 'ok' });
       });
     });
   });

--- a/upcoming-release-notes/7862.md
+++ b/upcoming-release-notes/7862.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Restrict the sync-server secrets API to admins in OpenID mode so non-admin users can no longer enumerate configured bank-sync integrations.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Restrict secret enumeration when using non-admin users.

A super low priority security issue, but.. simple enough to fix


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/security/advisories/GHSA-3f62-qv96-4p78

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a - unit tests cover this

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->