### PR TITLE
[AI] Fix hsl colors in donut chart shading

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -72,7 +72,13 @@ const resolveCSSVariable = (color: string): string => {
     .trim();
 };
 
-const hexToRgb = (hex: string) => {
+type RgbColor = {
+  r: number;
+  g: number;
+  b: number;
+};
+
+const hexToRgb = (hex: string): RgbColor | null => {
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result
     ? {
@@ -80,11 +86,46 @@ const hexToRgb = (hex: string) => {
         g: parseInt(result[2], 16),
         b: parseInt(result[3], 16),
       }
-    : { r: 0, g: 0, b: 0 };
+    : null;
 };
 
-const shadeColor = (resolvedHex: string, percent: number): string => {
-  const { r, g, b } = hexToRgb(resolvedHex);
+const hslToRgb = (color: string): RgbColor | null => {
+  const result =
+    /^hsla?\(\s*([\d.]+)(?:deg)?[\s,]+([\d.]+)%[\s,]+([\d.]+)%(?:\s*[,/]\s*[\d.]+%?)?\s*\)$/i.exec(
+      color,
+    );
+
+  if (!result) return null;
+
+  const hue = (Number(result[1]) % 360) / 360;
+  const saturation = Number(result[2]) / 100;
+  const lightness = Number(result[3]) / 100;
+
+  const toRgb = (offset: number) => {
+    const factor = (offset + hue * 12) % 12;
+    const chroma = saturation * Math.min(lightness, 1 - lightness);
+    return Math.round(
+      255 *
+        (lightness -
+          chroma * Math.max(-1, Math.min(factor - 3, 9 - factor, 1))),
+    );
+  };
+
+  return {
+    r: toRgb(0),
+    g: toRgb(8),
+    b: toRgb(4),
+  };
+};
+
+const parseColor = (color: string): RgbColor | null =>
+  hexToRgb(color) ?? hslToRgb(color);
+
+export const shadeColor = (color: string, percent: number): string => {
+  const parsed = parseColor(color);
+  if (!parsed) return color;
+
+  const { r, g, b } = parsed;
   const adjust = (c: number) =>
     Math.min(255, Math.max(0, Math.round(c + (255 - c) * percent)));
   return `rgb(${adjust(r)}, ${adjust(g)}, ${adjust(b)})`;

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.web.test.ts
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.web.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { shadeColor } from './DonutGraph';
+
+describe('shadeColor', () => {
+  it('lightens hex colors', () => {
+    expect(shadeColor('#000000', 0.5)).toBe('rgb(128, 128, 128)');
+  });
+
+  it('lightens hsl colors without falling back to black', () => {
+    expect(shadeColor('hsl(37, 100%, 21%)', 0.15)).toBe('rgb(129, 94, 38)');
+  });
+});

--- a/upcoming-release-notes/7866.md
+++ b/upcoming-release-notes/7866.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Fix donut chart colors when report themes use HSL color values.


### PR DESCRIPTION
## Description

Fixes the Category+Group donut chart color shading when report/theme colors are provided as `hsl(...)` values. The chart previously only parsed hex values before deriving lighter category colors, so hsl values fell back to black-derived shades.

This adds hsl/hsla parsing for the existing shade helper while preserving hex behavior and leaving unrecognized colors unchanged.

AI disclosure: The implementation was prepared with AI assistance and reviewed/tested locally before submission.

## Related issue(s)

Fixes #7820

## Testing

- `yarn workspace @actual-app/web test src/components/reports/graphs/DonutGraph.web.test.ts`
- `yarn workspace @actual-app/web typecheck`
- `yarn typecheck --scope=@actual-app/web` (ran the repo typecheck task successfully across queued workspaces)
- `yarn lint`
- `yarn lint upcoming-release-notes/7866.md`
- `git diff --check`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.98 MB (+694 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.98 MB (+694 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +694 B (+2.99%) | 22.7 kB → 23.38 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.26 MB (+694 B) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->