### PR TITLE
[AI] Reject decimal amounts in transaction imports

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -990,6 +990,33 @@ describe('API CRUD operations', () => {
     // Should create a new transaction since deleted ones are ignored
     expect(result2.added).toHaveLength(1);
   });
+
+  test('Transactions: import rejects decimal amount values', async () => {
+    const accountId = await api.createAccount({ name: 'test-account' }, 0);
+
+    const result = await api.importTransactions(accountId, [
+      {
+        account: accountId,
+        date: '2023-11-03',
+        imported_id: 'decimal-amount',
+        amount: 12.3,
+        payee_name: 'Test',
+      },
+    ]);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.updated).toHaveLength(0);
+    expect(result.errors).toEqual([
+      { message: 'Transaction 1 amount must be an integer' },
+    ]);
+
+    const transactions = await api.getTransactions(
+      accountId,
+      '2023-11-01',
+      '2023-11-30',
+    );
+    expect(transactions).toHaveLength(0);
+  });
 });
 
 //apis: createSchedule, getSchedules, updateSchedule, deleteSchedule

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1417,6 +1417,39 @@ export type ImportTransactionsResult = bankSync.ReconcileTransactionsResult & {
   }>;
 };
 
+function validateImportTransactionAmounts(
+  transactions: ImportTransactionEntity[],
+): ImportTransactionsResult['errors'] {
+  return transactions.flatMap((transaction, index) => {
+    const errors: ImportTransactionsResult['errors'] = [];
+
+    if (
+      transaction.amount != null &&
+      (!Number.isFinite(transaction.amount) ||
+        !Number.isInteger(transaction.amount))
+    ) {
+      errors.push({
+        message: `Transaction ${index + 1} amount must be an integer`,
+      });
+    }
+
+    for (const [subtransactionIndex, subtransaction] of (
+      transaction.subtransactions ?? []
+    ).entries()) {
+      if (
+        !Number.isFinite(subtransaction.amount) ||
+        !Number.isInteger(subtransaction.amount)
+      ) {
+        errors.push({
+          message: `Transaction ${index + 1} subtransaction ${subtransactionIndex + 1} amount must be an integer`,
+        });
+      }
+    }
+
+    return errors;
+  });
+}
+
 async function importTransactions({
   accountId,
   transactions,
@@ -1430,6 +1463,16 @@ async function importTransactions({
 }): Promise<ImportTransactionsResult> {
   if (typeof accountId !== 'string') {
     throw APIError('transactions-import: accountId must be an id');
+  }
+
+  const amountErrors = validateImportTransactionAmounts(transactions);
+  if (amountErrors.length > 0) {
+    return {
+      errors: amountErrors,
+      added: [],
+      updated: [],
+      updatedPreview: [],
+    };
   }
 
   try {

--- a/upcoming-release-notes/7867.md
+++ b/upcoming-release-notes/7867.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Return an import error instead of silently accepting API transactions with decimal amount values.


### PR DESCRIPTION
Fixes #7812.

## Summary
- validate imported transaction and subtransaction amounts before reconciliation
- return import errors for decimal, non-finite amounts instead of reporting them as added
- add API coverage to ensure invalid decimal amounts do not persist

## Testing
- yarn workspace @actual-app/api test methods.test.ts -t 'import rejects decimal amount values'
- git diff --check origin/master...HEAD