### PR TITLE
[AI] Fix currency suffix amount imports

### DIFF
--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -14,10 +14,13 @@ describe('utility functions', () => {
     //  of amounts without decimal amounts included.
     expect(looselyParseAmount('3')).toBe(3);
     expect(looselyParseAmount('3.4')).toBe(3.4);
+    expect(looselyParseAmount('3.4 €')).toBe(3.4);
     expect(looselyParseAmount('3.45')).toBe(3.45);
+    expect(looselyParseAmount('3.45 USD')).toBe(3.45);
     // cant tell if this next case should be decimal or different format
     // so we set as full numbers
     expect(looselyParseAmount('3.456')).toBe(3456); // the expected failing case
+    expect(looselyParseAmount('3.456 €')).toBe(3456);
     expect(looselyParseAmount('3.4500')).toBe(3.45);
     expect(looselyParseAmount('3.45000')).toBe(3.45);
     expect(looselyParseAmount('3.450000')).toBe(3.45);
@@ -49,6 +52,7 @@ describe('utility functions', () => {
   test('looseParseAmount works with negative numbers', () => {
     expect(looselyParseAmount('-3')).toBe(-3);
     expect(looselyParseAmount('-3.45')).toBe(-3.45);
+    expect(looselyParseAmount('-110.7 €')).toBe(-110.7);
     expect(looselyParseAmount('-3,45')).toBe(-3.45);
     // Unicode minus
     expect(looselyParseAmount('−3')).toBe(-3);

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -570,14 +570,20 @@ export function looselyParseAmount(amount: string) {
   }
 
   // Look for a decimal marker, then look for either 1-2 or 4-9 decimal places.
-  // This avoids matching against 3 places which may not actually be decimal
-  const m = amount.match(/[.,]([^.,]{4,9}|[^.,]{1,2})$/);
+  // This avoids matching against 3 places which may not actually be decimal.
+  // Ignore trailing non-numeric currency symbols when counting decimal places.
+  const m = amount.match(/[.,]([^.,]*)$/);
   if (!m || m.index === undefined) {
     return safeNumber(parseFloat(extractNumbers(amount)));
   }
 
   const left = extractNumbers(amount.slice(0, m.index));
   const right = extractNumbers(amount.slice(m.index + 1));
+  if (
+    !([1, 2].includes(right.length) || (right.length >= 4 && right.length <= 9))
+  ) {
+    return safeNumber(parseFloat(extractNumbers(amount)));
+  }
 
   return safeNumber(parseFloat(left + '.' + right));
 }

--- a/upcoming-release-notes/7868.md
+++ b/upcoming-release-notes/7868.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Fix CSV import amount parsing when a one-decimal amount is followed by a currency suffix.


### PR DESCRIPTION
## Description

Fixes CSV import amount parsing when an amount has a one-decimal value followed by a trailing currency suffix, such as `3.4 €`. The parser now validates decimal precision using the numeric fractional digits before the suffix instead of counting the suffix as part of the decimal tail.

## Related issue(s)

Fixes #5020

## Testing

- `yarn workspace @actual-app/core vitest --run src/shared/util.test.ts --testNamePattern looseParseAmount`
- `yarn lint packages/loot-core/src/shared/util.ts packages/loot-core/src/shared/util.test.ts`
- `git diff --check`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed