### PR TITLE
fix: show scheduled split transfers as upcoming on destination accounts

### DIFF
--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -64,8 +64,9 @@ export function useAccountPreviewTransactions({
     (schedule: ScheduleEntity) => {
       if (!accountId) return true;
       if (schedule._account === accountId) return true;
-      if (getTransferAccountByPayee(schedule._payee)?.id === accountId)
-        {return true;}
+      if (getTransferAccountByPayee(schedule._payee)?.id === accountId) {
+        return true;
+      }
       // A split-child action may set a transfer payee pointing to this account
       // even when the parent payee does not. Check each split set-payee action.
       const actions = schedule._actions as Array<{

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -61,10 +61,27 @@ export function useAccountPreviewTransactions({
   );
 
   const accountSchedulesFilter = useCallback(
-    (schedule: ScheduleEntity) =>
-      !accountId ||
-      schedule._account === accountId ||
-      getTransferAccountByPayee(schedule._payee)?.id === accountId,
+    (schedule: ScheduleEntity) => {
+      if (!accountId) return true;
+      if (schedule._account === accountId) return true;
+      if (getTransferAccountByPayee(schedule._payee)?.id === accountId)
+        {return true;}
+      // A split-child action may set a transfer payee pointing to this account
+      // even when the parent payee does not. Check each split set-payee action.
+      const actions = schedule._actions as Array<{
+        op: string;
+        field?: string;
+        value?: string;
+        options?: { splitIndex?: number };
+      }>;
+      return actions.some(
+        action =>
+          action.op === 'set' &&
+          action.field === 'payee' &&
+          action.options?.splitIndex != null &&
+          getTransferAccountByPayee(action.value)?.id === accountId,
+      );
+    },
     [accountId, getTransferAccountByPayee],
   );
 

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -5,6 +5,7 @@ import type { IntegerAmount } from '@actual-app/core/shared/util';
 import type {
   AccountEntity,
   PayeeEntity,
+  RuleActionEntity,
   ScheduleEntity,
   TransactionEntity,
 } from '@actual-app/core/types/models';
@@ -69,18 +70,14 @@ export function useAccountPreviewTransactions({
       }
       // A split-child action may set a transfer payee pointing to this account
       // even when the parent payee does not. Check each split set-payee action.
-      const actions = schedule._actions as Array<{
-        op: string;
-        field?: string;
-        value?: string;
-        options?: { splitIndex?: number };
-      }>;
+      const actions = schedule._actions as RuleActionEntity[];
       return actions.some(
         action =>
           action.op === 'set' &&
           action.field === 'payee' &&
           action.options?.splitIndex != null &&
-          getTransferAccountByPayee(action.value)?.id === accountId,
+          getTransferAccountByPayee(action.value as PayeeEntity['id'])?.id ===
+            accountId,
       );
     },
     [accountId, getTransferAccountByPayee],

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -619,6 +619,128 @@ describe('schedules', () => {
     });
   });
 
+  describe('split-child transfer filter', () => {
+    function makeSchedule(
+      overrides: Partial<ScheduleEntity> &
+        Pick<ScheduleEntity, 'id' | 'next_date' | '_conditions'>,
+    ): ScheduleEntity {
+      return {
+        rule: 'rule-1',
+        completed: false,
+        posts_transaction: false,
+        tombstone: false,
+        _payee: 'payee-employer',
+        _account: 'acct-checking',
+        _amount: 500000,
+        _amountOp: 'is',
+        _date: overrides.next_date,
+        _actions: [],
+        ...overrides,
+      };
+    }
+
+    // Maps a payee id to the account it transfers to, simulating the payeesById
+    // lookup used by getTransferAccountByPayee in useAccountPreviewTransactions.
+    const transferPayees: Record<string, string> = {
+      'payee-transfer-to-savings': 'acct-savings',
+    };
+
+    function getTransferAccountId(payeeId?: string | null): string | null {
+      if (!payeeId) return null;
+      return transferPayees[payeeId] ?? null;
+    }
+
+    // This filter mirrors the fixed accountSchedulesFilter in
+    // useAccountPreviewTransactions: it includes a schedule when any split-child
+    // set-payee action points to a transfer payee for the viewed account.
+    function makeFilter(accountId: string) {
+      return (schedule: ScheduleEntity) => {
+        if (schedule._account === accountId) return true;
+        if (getTransferAccountId(schedule._payee) === accountId) return true;
+        const actions = schedule._actions as Array<{
+          op: string;
+          field?: string;
+          value?: string;
+          options?: { splitIndex?: number };
+        }>;
+        return actions.some(
+          action =>
+            action.op === 'set' &&
+            action.field === 'payee' &&
+            action.options?.splitIndex != null &&
+            getTransferAccountId(action.value) === accountId,
+        );
+      };
+    }
+
+    it('includes a split schedule when viewing the split-child transfer destination', () => {
+      const schedule = makeSchedule({
+        id: 'sched-paycheck',
+        next_date: '2017-01-03',
+        _conditions: [{ field: 'date', op: 'is', value: '2017-01-03' }],
+        _actions: [
+          // split child 1: transfer to savings
+          {
+            op: 'set',
+            field: 'payee',
+            value: 'payee-transfer-to-savings',
+            options: { splitIndex: 1 },
+          } as unknown,
+        ] as ScheduleEntity['_actions'],
+      });
+
+      const statuses: ScheduleStatuses = new Map([
+        ['sched-paycheck', 'upcoming'],
+      ]);
+
+      // Viewed from the source account - schedule is included
+      const fromSource = computeSchedulePreviewTransactions(
+        [schedule],
+        statuses,
+        '7',
+        makeFilter('acct-checking'),
+      );
+      expect(fromSource).toHaveLength(1);
+
+      // Viewed from the transfer destination - schedule must also be included
+      const fromDest = computeSchedulePreviewTransactions(
+        [schedule],
+        statuses,
+        '7',
+        makeFilter('acct-savings'),
+      );
+      expect(fromDest).toHaveLength(1);
+    });
+
+    it('excludes a split schedule when viewing an unrelated account', () => {
+      const schedule = makeSchedule({
+        id: 'sched-paycheck',
+        next_date: '2017-01-03',
+        _conditions: [{ field: 'date', op: 'is', value: '2017-01-03' }],
+        _actions: [
+          {
+            op: 'set',
+            field: 'payee',
+            value: 'payee-transfer-to-savings',
+            options: { splitIndex: 1 },
+          } as unknown,
+        ] as ScheduleEntity['_actions'],
+      });
+
+      const statuses: ScheduleStatuses = new Map([
+        ['sched-paycheck', 'upcoming'],
+      ]);
+
+      const result = computeSchedulePreviewTransactions(
+        [schedule],
+        statuses,
+        '7',
+        makeFilter('acct-unrelated'),
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+
   describe('getNextDate', () => {
     it('returns last occurrence for a recurring schedule with an end date in the past', () => {
       const dateCond = {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -2,7 +2,11 @@ import { enUS } from 'date-fns/locale';
 import i18next from 'i18next';
 import MockDate from 'mockdate';
 
-import type { ScheduleEntity } from '#types/models';
+import type {
+  RuleActionEntity,
+  ScheduleEntity,
+  SetRuleActionEntity,
+} from '#types/models';
 
 import * as monthUtils from './months';
 import {
@@ -657,18 +661,13 @@ describe('schedules', () => {
       return (schedule: ScheduleEntity) => {
         if (schedule._account === accountId) return true;
         if (getTransferAccountId(schedule._payee) === accountId) return true;
-        const actions = schedule._actions as Array<{
-          op: string;
-          field?: string;
-          value?: string;
-          options?: { splitIndex?: number };
-        }>;
+        const actions = schedule._actions as RuleActionEntity[];
         return actions.some(
           action =>
             action.op === 'set' &&
             action.field === 'payee' &&
             action.options?.splitIndex != null &&
-            getTransferAccountId(action.value) === accountId,
+            getTransferAccountId(action.value as string) === accountId,
         );
       };
     }
@@ -685,8 +684,8 @@ describe('schedules', () => {
             field: 'payee',
             value: 'payee-transfer-to-savings',
             options: { splitIndex: 1 },
-          } as unknown,
-        ] as ScheduleEntity['_actions'],
+          } satisfies SetRuleActionEntity,
+        ] as unknown as ScheduleEntity['_actions'],
       });
 
       const statuses: ScheduleStatuses = new Map([
@@ -723,8 +722,8 @@ describe('schedules', () => {
             field: 'payee',
             value: 'payee-transfer-to-savings',
             options: { splitIndex: 1 },
-          } as unknown,
-        ] as ScheduleEntity['_actions'],
+          } satisfies SetRuleActionEntity,
+        ] as unknown as ScheduleEntity['_actions'],
       });
 
       const statuses: ScheduleStatuses = new Map([
@@ -738,6 +737,35 @@ describe('schedules', () => {
         makeFilter('acct-unrelated'),
       );
       expect(result).toHaveLength(0);
+    });
+
+    it('includes a split schedule when the transfer is at splitIndex 0', () => {
+      const schedule = makeSchedule({
+        id: 'sched-paycheck',
+        next_date: '2017-01-03',
+        _conditions: [{ field: 'date', op: 'is', value: '2017-01-03' }],
+        _actions: [
+          {
+            op: 'set',
+            field: 'payee',
+            value: 'payee-transfer-to-savings',
+            options: { splitIndex: 0 },
+          } satisfies SetRuleActionEntity,
+        ] as unknown as ScheduleEntity['_actions'],
+      });
+
+      const statuses: ScheduleStatuses = new Map([
+        ['sched-paycheck', 'upcoming'],
+      ]);
+
+      // splitIndex 0 is falsy; a regression to a truthy check would drop it.
+      const fromDest = computeSchedulePreviewTransactions(
+        [schedule],
+        statuses,
+        '7',
+        makeFilter('acct-savings'),
+      );
+      expect(fromDest).toHaveLength(1);
     });
   });
 

--- a/upcoming-release-notes/7872.md
+++ b/upcoming-release-notes/7872.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [m4cd4r4]
+---
+
+Fix scheduled split transfers not appearing as upcoming transactions on destination accounts


### PR DESCRIPTION
## Summary

Fixes #7822 - scheduled split transactions with transfer children were not showing as upcoming transactions on the destination account.

## Root cause

`accountSchedulesFilter` in `useAccountPreviewTransactions.ts` checks two things to decide whether a schedule is relevant to the viewed account:

1. `schedule._account === accountId` - the schedule originates from this account
2. `schedule._payee` is a transfer payee pointing to this account - direct non-split transfer

For split schedules, the transfer to account B lives in a child rule action (op: set, field: payee, options.splitIndex: N) inside `schedule._actions`. The parent `_payee` is the employer or counterparty, not a transfer payee. So the filter returned false for account B, and no upcoming transaction appeared.

## Fix

Expand the filter to also inspect `schedule._actions` for set-payee actions that have a splitIndex option. If any of those payees is a transfer payee pointing to the viewed account, include the schedule.

Change is in `useAccountPreviewTransactions.ts` - 17 lines added to the filter callback.

## Testing

Added two unit tests in `packages/loot-core/src/shared/schedules.test.ts`:

- includes a split schedule when viewing the split-child transfer destination - asserts a schedule with a split-child transfer action is included when filtering for the destination account
- excludes a split schedule when viewing an unrelated account - asserts the same schedule is excluded for an account not involved in any split action

`yarn workspace @actual-app/core run vitest run src/shared/schedules.test.ts` - 43/43 pass.

`yarn workspace @actual-app/core typecheck` - all files passed.

`yarn workspace @actual-app/web typecheck` - all files passed.

`yarn lint:fix` - 0 errors.

## Notes

`getSchedulesQuery` in `useSchedules.ts` has a related filter that also misses split-child transfers - affects the Schedules page list view, not upcoming transactions. Left out of scope for this PR.

Drafted with AI assistance, reviewed and edited by me.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.98 MB (+252 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.98 MB (+252 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useAccountPreviewTransactions.ts` | 📈 +252 B (+6.56%) | 3.75 kB → 4 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/bankSyncUtils.js | 54.15 kB → 54.4 kB (+252 B) | +0.45%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->