### PR TITLE
[AI] Fix hsl donut chart colors

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.test.ts
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.test.ts
@@ -2,9 +2,7 @@ import { shadeColor } from './DonutGraph';
 
 describe('shadeColor', () => {
   it('shades hsl colors without falling back to black', () => {
-    expect(shadeColor('hsl(228, 100%, 33%)', 0.15)).toBe(
-      'rgb(38, 67, 181)',
-    );
+    expect(shadeColor('hsl(228, 100%, 33%)', 0.15)).toBe('rgb(38, 67, 181)');
   });
 
   it('keeps unsupported color formats unchanged', () => {

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.test.ts
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.test.ts
@@ -1,0 +1,13 @@
+import { shadeColor } from './DonutGraph';
+
+describe('shadeColor', () => {
+  it('shades hsl colors without falling back to black', () => {
+    expect(shadeColor('hsl(228, 100%, 33%)', 0.15)).toBe(
+      'rgb(38, 67, 181)',
+    );
+  });
+
+  it('keeps unsupported color formats unchanged', () => {
+    expect(shadeColor('currentColor', 0.15)).toBe('currentColor');
+  });
+});

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -85,9 +85,7 @@ const parseHexColor = (hex: string): RGBColor | null => {
     };
   }
 
-  const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
-    normalizedHex,
-  );
+  const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(normalizedHex);
   return result
     ? {
         r: parseInt(result[1], 16),

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -72,19 +72,104 @@ const resolveCSSVariable = (color: string): string => {
     .trim();
 };
 
-const hexToRgb = (hex: string) => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+type RGBColor = { r: number; g: number; b: number };
+
+const parseHexColor = (hex: string): RGBColor | null => {
+  const normalizedHex = hex.replace(/^#/, '');
+
+  if (/^[a-f\d]{3}$/i.test(normalizedHex)) {
+    return {
+      r: parseInt(normalizedHex[0] + normalizedHex[0], 16),
+      g: parseInt(normalizedHex[1] + normalizedHex[1], 16),
+      b: parseInt(normalizedHex[2] + normalizedHex[2], 16),
+    };
+  }
+
+  const result = /^([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(
+    normalizedHex,
+  );
   return result
     ? {
         r: parseInt(result[1], 16),
         g: parseInt(result[2], 16),
         b: parseInt(result[3], 16),
       }
-    : { r: 0, g: 0, b: 0 };
+    : null;
 };
 
-const shadeColor = (resolvedHex: string, percent: number): string => {
-  const { r, g, b } = hexToRgb(resolvedHex);
+const parseRgbComponent = (value: string): number => {
+  const trimmed = value.trim();
+  if (trimmed.endsWith('%')) {
+    return Math.round((parseFloat(trimmed) / 100) * 255);
+  }
+  return parseFloat(trimmed);
+};
+
+const parseRgbColor = (color: string): RGBColor | null => {
+  const match = /^rgba?\((.+)\)$/i.exec(color);
+  if (!match) return null;
+
+  const [r, g, b] = match[1]
+    .replace(/\s*\/\s*.+$/, '')
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map(parseRgbComponent);
+
+  return [r, g, b].every(Number.isFinite) ? { r, g, b } : null;
+};
+
+const parseHslColor = (color: string): RGBColor | null => {
+  const match = /^hsla?\((.+)\)$/i.exec(color);
+  if (!match) return null;
+
+  const [hRaw, sRaw, lRaw] = match[1]
+    .replace(/\s*\/\s*.+$/, '')
+    .split(/[,\s]+/)
+    .filter(Boolean);
+  const h = parseFloat(hRaw);
+  const s = parseFloat(sRaw) / 100;
+  const l = parseFloat(lRaw) / 100;
+
+  if (![h, s, l].every(Number.isFinite)) return null;
+
+  const chroma = (1 - Math.abs(2 * l - 1)) * s;
+  const huePrime = (((h % 360) + 360) % 360) / 60;
+  const x = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const [r1, g1, b1] =
+    huePrime < 1
+      ? [chroma, x, 0]
+      : huePrime < 2
+        ? [x, chroma, 0]
+        : huePrime < 3
+          ? [0, chroma, x]
+          : huePrime < 4
+            ? [0, x, chroma]
+            : huePrime < 5
+              ? [x, 0, chroma]
+              : [chroma, 0, x];
+  const m = l - chroma / 2;
+
+  return {
+    r: Math.round((r1 + m) * 255),
+    g: Math.round((g1 + m) * 255),
+    b: Math.round((b1 + m) * 255),
+  };
+};
+
+const parseColor = (color: string): RGBColor | null => {
+  const normalizedColor = color.trim();
+  return (
+    parseHexColor(normalizedColor) ??
+    parseRgbColor(normalizedColor) ??
+    parseHslColor(normalizedColor)
+  );
+};
+
+export const shadeColor = (color: string, percent: number): string => {
+  const parsedColor = parseColor(color);
+  if (!parsedColor) return color;
+
+  const { r, g, b } = parsedColor;
   const adjust = (c: number) =>
     Math.min(255, Math.max(0, Math.round(c + (255 - c) * percent)));
   return `rgb(${adjust(r)}, ${adjust(g)}, ${adjust(b)})`;

--- a/upcoming-release-notes/7873.md
+++ b/upcoming-release-notes/7873.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Fix concentric donut report colors when custom themes use HSL color values.


### PR DESCRIPTION
Fixes #7820.

## Summary
- parse hsl/rgb/hex report colors before shading category donut slices
- keep unsupported color formats unchanged instead of falling back to black
- add coverage for hsl donut shading

## Testing
- yarn workspace @actual-app/web test src/components/reports/graphs/DonutGraph.test.ts
- git diff --cached --check

Note: full typecheck could not be completed in this isolated worktree because the local dependency install hit disk-space limits; the targeted test passed.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.98 MB (+1.83 kB) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.98 MB (+1.83 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +1.83 kB (+8.08%) | 22.7 kB → 24.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.26 MB (+1.83 kB) | +0.14%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->