### PR TITLE
Exclude hidden transactions from range selection

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1760,7 +1760,7 @@ class AccountInternal extends PureComponent<
         const children = transactions.filter(t => t.parent_id === item.id);
         return children.every(t => selectAllFilter(t));
       }
-      return !item._unmatched;
+      return !item._unmatched && (showReconciled || !item.reconciled);
     };
 
     return (

--- a/packages/desktop-client/src/hooks/useSelected.tsx
+++ b/packages/desktop-client/src/hooks/useSelected.tsx
@@ -94,7 +94,11 @@ export function useSelected<T extends Item>(
               }
             }
 
-            iterateRange(range, i => selectedItems.add(items[i].id));
+            iterateRange(range, i => {
+              if (!selectAllFilter || selectAllFilter(items[i])) {
+                selectedItems.add(items[i].id);
+              }
+            });
 
             if (deleteUntil) {
               iterateRange(deleteUntil, i => selectedItems.delete(items[i].id));

--- a/packages/desktop-client/src/hooks/useSelected.web.test.ts
+++ b/packages/desktop-client/src/hooks/useSelected.web.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSelected } from './useSelected';
+
+vi.mock('@actual-app/core/platform/client/connection', () => ({
+  listen: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@actual-app/core/platform/client/undo', () => ({
+  getTaggedState: vi.fn(),
+  getUndoState: vi.fn(),
+  setUndoState: vi.fn(),
+}));
+
+const items = [
+  { id: 'visible-1', visible: true },
+  { id: 'hidden-1', visible: false },
+  { id: 'visible-2', visible: true },
+];
+
+describe('useSelected', () => {
+  it('does not include filtered-out rows in range selection', () => {
+    const { result } = renderHook(() =>
+      useSelected('transactions', items, [], item => item.visible),
+    );
+
+    act(() => {
+      result.current.dispatch({ type: 'select', id: 'visible-1' });
+    });
+
+    act(() => {
+      result.current.dispatch({
+        type: 'select',
+        id: 'visible-2',
+        isRangeSelect: true,
+      });
+    });
+
+    expect([...result.current.items]).toEqual(['visible-1', 'visible-2']);
+  });
+});

--- a/upcoming-release-notes/7874.md
+++ b/upcoming-release-notes/7874.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Fix shift-click selection to skip transactions hidden by the current account filters.


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.98 MB (+109 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.98 MB (+109 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useSelected.tsx` | 📈 +69 B (+0.82%) | 8.22 kB → 8.28 kB
`src/components/accounts/Account.tsx` | 📈 +40 B (+0.09%) | 44.1 kB → 44.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 4.97 MB → 4.97 MB (+69 B) | +0.00%
static/js/index.js | 2.01 MB → 2.01 MB (+40 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->