### PR TITLE
[AI] Skip split children in bank sync fuzzy matching

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -633,6 +633,60 @@ describe('Account sync', () => {
       expect(transactions[0].amount).toBe(-1239);
     },
   );
+
+  test('reconcile does not fuzzy match imported transactions to split children', async () => {
+    const { id: acctId } = await prepareDatabase();
+    const splitPayeeId = await db.insertPayee({ name: 'Split' });
+
+    await db.insertTransaction({
+      id: 'parent',
+      account: acctId,
+      amount: -80000,
+      date: '2026-05-08',
+      payee: splitPayeeId,
+      is_parent: true,
+    });
+    await db.insertTransaction({
+      id: 'child-matching-amount',
+      account: acctId,
+      amount: -60000,
+      date: '2026-05-08',
+      payee: splitPayeeId,
+      is_child: true,
+      parent_id: 'parent',
+    });
+    await db.insertTransaction({
+      id: 'child-other-amount',
+      account: acctId,
+      amount: -20000,
+      date: '2026-05-08',
+      payee: splitPayeeId,
+      is_child: true,
+      parent_id: 'parent',
+    });
+
+    await reconcileTransactions(acctId, [
+      {
+        date: '2026-05-15',
+        amount: -60000,
+        payee_name: 'Sender',
+        imported_id: 'incoming-transfer',
+      },
+    ]);
+
+    const transactions = await getAllTransactions();
+    expect(transactions).toHaveLength(4);
+    expect(
+      transactions.find(t => t.id === 'child-matching-amount').imported_id,
+    ).toBeNull();
+    expect(
+      transactions.find(t => t.imported_id === 'incoming-transfer'),
+    ).toMatchObject({
+      amount: -60000,
+      date: 20260515,
+      parent_id: null,
+    });
+  });
 });
 
 describe('SimpleFin batch sync', () => {

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -790,7 +790,8 @@ export async function matchTransactions(
             -- If both ids are set, and we didn't match earlier then skip dedup
             (imported_id IS NULL OR ? IS NULL)
             AND date >= ? AND date <= ? AND amount = ?
-            AND account = ?`,
+            AND account = ?
+            AND parent_id IS NULL`,
           [
             trans.imported_id || null,
             sevenDaysBefore,
@@ -818,7 +819,7 @@ export async function matchTransactions(
         >(
           `SELECT id, is_parent, date, imported_id, payee, imported_payee, category, notes, reconciled, cleared, amount
           FROM v_transactions
-          WHERE date >= ? AND date <= ? AND amount = ? AND account = ?`,
+          WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND parent_id IS NULL`,
           [sevenDaysBefore, sevenDaysAfter, trans.amount || 0, acctId],
         );
       }

--- a/upcoming-release-notes/7875.md
+++ b/upcoming-release-notes/7875.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Prevent bank-sync fuzzy matching from reconciling new imports against split child transactions.


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB | 0%
loot-core | 1 | 5.34 MB → 5.34 MB (+56 B) | +0.00%
api | 2 | 3.96 MB → 3.96 MB (+56 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+56 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +56 B (+0.23%) | 23.38 kB → 23.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bk-I6khg.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.96 MB (+56 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +56 B (+0.24%) | 22.85 kB → 22.9 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.96 MB (+56 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->