### PR TITLE
[AI] Fix bank sync split child matching

### DIFF
--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -225,6 +225,41 @@ describe('Account sync', () => {
     expect(transactions2.length).toBe(2);
   });
 
+  test('reconcile does not fuzzy match split child transactions', async () => {
+    const { id: acctId } = await prepareDatabase();
+
+    const parentId = await db.insertTransaction({
+      id: 'split-parent',
+      account: acctId,
+      amount: -5000,
+      date: '2020-01-01',
+      is_parent: true,
+    });
+    await db.insertTransaction({
+      id: 'split-child',
+      account: acctId,
+      amount: -2948,
+      date: '2020-01-01',
+      is_child: true,
+      parent_id: parentId,
+    });
+
+    const result = await reconcileTransactions(acctId, [
+      { date: '2020-01-01', amount: -2948, imported_id: 'finid-split' },
+    ]);
+
+    expect(result.updated).toEqual([]);
+    expect(result.added).toHaveLength(1);
+
+    const transactions = await getAllTransactions();
+    expect(transactions.find(t => t.id === 'split-child')?.imported_id).toBe(
+      null,
+    );
+    expect(transactions.find(t => t.id === result.added[0])?.imported_id).toBe(
+      'finid-split',
+    );
+  });
+
   test('reimportDeleted override takes precedence over stored preference', async () => {
     const { id: acctId } = await prepareDatabase();
     const reimportKey =

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -790,7 +790,8 @@ export async function matchTransactions(
             -- If both ids are set, and we didn't match earlier then skip dedup
             (imported_id IS NULL OR ? IS NULL)
             AND date >= ? AND date <= ? AND amount = ?
-            AND account = ?`,
+            AND account = ?
+            AND is_child = 0`,
           [
             trans.imported_id || null,
             sevenDaysBefore,
@@ -818,7 +819,7 @@ export async function matchTransactions(
         >(
           `SELECT id, is_parent, date, imported_id, payee, imported_payee, category, notes, reconciled, cleared, amount
           FROM v_transactions
-          WHERE date >= ? AND date <= ? AND amount = ? AND account = ?`,
+          WHERE date >= ? AND date <= ? AND amount = ? AND account = ? AND is_child = 0`,
           [sevenDaysBefore, sevenDaysAfter, trans.amount || 0, acctId],
         );
       }

--- a/upcoming-release-notes/7876.md
+++ b/upcoming-release-notes/7876.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Fix bank sync to avoid matching imported transactions with split-child transactions.


### PR DESCRIPTION
Fixes #7855

This prevents bank-sync fuzzy matching from selecting split child transactions. Incoming imports with the same amount/date window now only match top-level transactions, so unrelated split children are not marked as imported.

## Testing
- yarn workspace @actual-app/core test:node src/server/accounts/sync.test.ts
- git diff --check

Note: I also tried repository format checks, but this checkout does not expose a prettier script or binary.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB | 0%
loot-core | 1 | 5.34 MB → 5.34 MB (+46 B) | +0.00%
api | 2 | 3.96 MB → 3.96 MB (+46 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+46 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +46 B (+0.19%) | 23.38 kB → 23.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.COSpBo38.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.96 MB (+46 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +46 B (+0.20%) | 22.85 kB → 22.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.96 MB (+46 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->