### PR TITLE
[AI] Fix monthly spending category group budgets

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
@@ -1,0 +1,55 @@
+import type {
+  CategoryEntity,
+  CategoryGroupEntity,
+  RuleConditionEntity,
+} from '@actual-app/core/types/models';
+import { describe, expect, it } from 'vitest';
+
+import { getSpendingBudgetFilters } from './spending-spreadsheet';
+
+const categoryGroups = [
+  { id: 'group-bills', name: 'Bills' },
+  { id: 'group-fun', name: 'Fun Money' },
+] as CategoryGroupEntity[];
+
+const categories = [
+  { id: 'cat-rent', name: 'Rent', group: 'group-bills' },
+  { id: 'cat-electric', name: 'Electric', group: 'group-bills' },
+  { id: 'cat-dining', name: 'Dining Out', group: 'group-fun' },
+] as CategoryEntity[];
+
+describe('getSpendingBudgetFilters', () => {
+  it('filters budget categories by category group', () => {
+    const result = getSpendingBudgetFilters({
+      categories,
+      categoryGroups,
+      conditions: [
+        {
+          field: 'category_group',
+          op: 'is',
+          value: 'group-bills',
+        } as RuleConditionEntity,
+      ],
+    });
+
+    expect(result).toEqual([
+      { category: { $oneof: ['cat-rent', 'cat-electric'] } },
+    ]);
+  });
+
+  it('does not filter budgets when no category condition is present', () => {
+    const result = getSpendingBudgetFilters({
+      categories,
+      categoryGroups,
+      conditions: [
+        {
+          field: 'account',
+          op: 'is',
+          value: 'account-checking',
+        } as RuleConditionEntity,
+      ],
+    });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
@@ -10,13 +10,13 @@ import { getSpendingBudgetFilters } from './spending-spreadsheet';
 const categoryGroups = [
   { id: 'group-bills', name: 'Bills' },
   { id: 'group-fun', name: 'Fun Money' },
-] as CategoryGroupEntity[];
+] satisfies CategoryGroupEntity[];
 
 const categories = [
   { id: 'cat-rent', name: 'Rent', group: 'group-bills' },
   { id: 'cat-electric', name: 'Electric', group: 'group-bills' },
   { id: 'cat-dining', name: 'Dining Out', group: 'group-fun' },
-] as CategoryEntity[];
+] satisfies CategoryEntity[];
 
 describe('getSpendingBudgetFilters', () => {
   it('filters budget categories by category group', () => {
@@ -28,8 +28,8 @@ describe('getSpendingBudgetFilters', () => {
           field: 'category_group',
           op: 'is',
           value: 'group-bills',
-        } as RuleConditionEntity,
-      ],
+        },
+      ] satisfies RuleConditionEntity[],
     });
 
     expect(result).toEqual([
@@ -46,8 +46,8 @@ describe('getSpendingBudgetFilters', () => {
           field: 'account',
           op: 'is',
           value: 'account-checking',
-        } as RuleConditionEntity,
-      ],
+        },
+      ] satisfies RuleConditionEntity[],
     });
 
     expect(result).toEqual([]);

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -2,6 +2,8 @@ import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { q } from '@actual-app/core/shared/query';
 import type {
+  CategoryEntity,
+  CategoryGroupEntity,
   RuleConditionEntity,
   SpendingEntity,
   SpendingMonthEntity,
@@ -12,6 +14,7 @@ import keyBy from 'lodash/keyBy';
 import type { useSpreadsheet } from '#hooks/useSpreadsheet';
 import { aqlQuery } from '#queries/aqlQuery';
 
+import { filterCategoriesByConditions } from './budgetDataQuery';
 import { makeQuery } from './makeQuery';
 
 type createSpendingSpreadsheetProps = {
@@ -21,6 +24,37 @@ type createSpendingSpreadsheetProps = {
   compareTo?: string;
   budgetType?: 'envelope' | 'tracking';
 };
+
+export function getSpendingBudgetFilters({
+  categories,
+  categoryGroups,
+  conditions,
+  conditionsOp,
+}: {
+  categories: CategoryEntity[];
+  categoryGroups: CategoryGroupEntity[];
+  conditions: RuleConditionEntity[];
+  conditionsOp?: string;
+}) {
+  const budgetConditions = conditions.filter(
+    cond =>
+      !cond.customName &&
+      (cond.field === 'category' || cond.field === 'category_group'),
+  );
+
+  if (budgetConditions.length === 0) {
+    return [];
+  }
+
+  const matchingCategoryIds = filterCategoriesByConditions(
+    categories,
+    categoryGroups,
+    budgetConditions,
+    conditionsOp === 'or' ? 'or' : 'and',
+  ).map(category => category.id);
+
+  return [{ category: { $oneof: matchingCategoryIds } }];
+}
 
 export function createSpendingSpreadsheet({
   conditions = [],
@@ -46,16 +80,6 @@ export function createSpendingSpreadsheet({
     const { filters } = await send('make-filters-from-conditions', {
       conditions: conditions.filter(cond => !cond.customName),
     });
-
-    const { filters: budgetFilters } = await send(
-      'make-filters-from-conditions',
-      {
-        conditions: conditions.filter(
-          cond => !cond.customName && cond.field === 'category',
-        ),
-        applySpecialCases: false,
-      },
-    );
 
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
 
@@ -116,14 +140,26 @@ export function createSpendingSpreadsheet({
     const budgetMonth = parseInt(compare.replace('-', ''));
     const budgetTable =
       budgetType === 'tracking' ? 'reflect_budgets' : 'zero_budgets';
+    const hasBudgetConditions = conditions.some(
+      cond =>
+        !cond.customName &&
+        (cond.field === 'category' || cond.field === 'category_group'),
+    );
+    const budgetFilters = hasBudgetConditions
+      ? await send('get-categories').then(({ list, grouped }) =>
+          getSpendingBudgetFilters({
+            categories: list,
+            categoryGroups: grouped,
+            conditions,
+            conditionsOp,
+          }),
+        )
+      : [];
     const [budgets] = await Promise.all([
       aqlQuery(
         q(budgetTable)
           .filter({
-            $and: [{ month: { $eq: budgetMonth } }],
-          })
-          .filter({
-            [conditionsOpKey]: budgetFilters,
+            $and: [{ month: { $eq: budgetMonth } }, ...budgetFilters],
           })
           .groupBy([{ $id: '$category' }])
           .select([

--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -19,7 +19,7 @@ import { makeQuery } from './makeQuery';
 
 type createSpendingSpreadsheetProps = {
   conditions?: RuleConditionEntity[];
-  conditionsOp?: string;
+  conditionsOp?: 'and' | 'or';
   compare?: string;
   compareTo?: string;
   budgetType?: 'envelope' | 'tracking';
@@ -34,7 +34,7 @@ export function getSpendingBudgetFilters({
   categories: CategoryEntity[];
   categoryGroups: CategoryGroupEntity[];
   conditions: RuleConditionEntity[];
-  conditionsOp?: string;
+  conditionsOp?: 'and' | 'or';
 }) {
   const budgetConditions = conditions.filter(
     cond =>
@@ -50,7 +50,7 @@ export function getSpendingBudgetFilters({
     categories,
     categoryGroups,
     budgetConditions,
-    conditionsOp === 'or' ? 'or' : 'and',
+    conditionsOp ?? 'and',
   ).map(category => category.id);
 
   return [{ category: { $oneof: matchingCategoryIds } }];

--- a/upcoming-release-notes/7877.md
+++ b/upcoming-release-notes/7877.md
@@ -1,1 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
 Fix monthly spending reports to correctly filter budgets by category groups.

--- a/upcoming-release-notes/7877.md
+++ b/upcoming-release-notes/7877.md
@@ -1,0 +1,1 @@
+Fix monthly spending reports to correctly filter budgets by category groups.


### PR DESCRIPTION
## Summary
- apply category and category group report conditions to the Monthly Spending budget line
- reuse the existing category condition helper so category-group filters expand to matching budget categories
- add coverage for budget filter generation

Fixes #7627

## Testing
- yarn install --immutable
- yarn workspace @actual-app/web test src/components/reports/spreadsheets/spending-spreadsheet.test.ts src/components/reports/spreadsheets/budgetDataQuery.test.ts
- yarn lint packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.test.ts
- yarn workspace @actual-app/web typecheck
- git diff --check origin/master...HEAD

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.98 MB (+526 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.98 MB (+526 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📈 +526 B (+9.24%) | 5.56 kB → 6.07 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.26 MB (+526 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->