### PR TITLE
[AI] Fix CSV preview category normalization

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -46,6 +46,7 @@ import {
   filterByStartDate,
   isDateFormat,
   parseAmountFields,
+  parseCategoryFields,
   parseDate,
   stripCsvImportTransaction,
 } from './utils';
@@ -158,19 +159,6 @@ function getInitialMappings(transactions) {
     inOut: inOutField,
     category: categoryField,
   };
-}
-
-function parseCategoryFields(trans, categories) {
-  let match = null;
-  categories.forEach(category => {
-    if (category.id === trans.category) {
-      return null;
-    }
-    if (category.name === trans.category) {
-      match = category.id;
-    }
-  });
-  return match;
 }
 
 export function ImportTransactionsModal({
@@ -317,9 +305,7 @@ export function ImportTransactionsModal({
         }
 
         const category_id = parseCategoryFields(trans, categories);
-        if (category_id != null) {
-          trans.category = category_id;
-        }
+        trans.category = category_id;
 
         const {
           inflow: _inflow,

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.test.ts
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.test.ts
@@ -1,4 +1,4 @@
-import { filterByStartDate, parseDate } from './utils';
+import { filterByStartDate, parseCategoryFields, parseDate } from './utils';
 import type { ImportTransaction } from './utils';
 
 describe('Import transactions', () => {
@@ -280,6 +280,25 @@ describe('Import transactions', () => {
       );
       expect(result).toHaveLength(1);
       expect(result[0].trx_id).toBe('1');
+    });
+  });
+
+  describe('parseCategoryFields', () => {
+    const categories = [
+      { id: 'cat-income', name: 'Income' },
+      { id: 'cat-deposits', name: 'Deposits' },
+    ];
+
+    it('returns the category id when CSV category text matches a category name', () => {
+      expect(parseCategoryFields({ category: 'Deposits' }, categories)).toBe(
+        'cat-deposits',
+      );
+    });
+
+    it('returns null for unresolved CSV category text', () => {
+      expect(
+        parseCategoryFields({ category: 'Missing category' }, categories),
+      ).toBeNull();
     });
   });
 });

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
@@ -139,6 +139,22 @@ export type ImportTransaction = {
   date?: string;
 } & Record<string, string | number | boolean>;
 
+type ImportCategory = {
+  id: string;
+  name: string;
+};
+
+export function parseCategoryFields(
+  trans: Pick<ImportTransaction, 'category'>,
+  categories: ImportCategory[],
+) {
+  const match = categories.find(
+    category =>
+      category.id !== trans.category && category.name === trans.category,
+  );
+  return match?.id ?? null;
+}
+
 export type FieldMapping = {
   date: string | null;
   amount: string | null;

--- a/upcoming-release-notes/7878.md
+++ b/upcoming-release-notes/7878.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mturac]
+---
+
+Fix CSV import previews showing false updates when a mapped category does not exist.


### PR DESCRIPTION
## Description

CSV import preview now normalizes unresolved category text the same way as final import. If a mapped CSV category does not match an Actual category, the preview sets `category` to `null` instead of keeping the raw CSV text, avoiding false update/no-op mismatches.

## Related issue(s)

Fixes #7677

## Testing

- `yarn workspace @actual-app/web test src/components/modals/ImportTransactionsModal/utils.test.ts`
- `yarn workspace @actual-app/web typecheck`
- `yarn typecheck`
- `yarn lint:fix packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.test.ts` (0 errors; 2 existing warnings)
- `git diff --check origin/master...HEAD`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.97 MB → 13.97 MB (-93 B) | -0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.97 MB → 13.97 MB (-93 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/ImportTransactionsModal/utils.ts` | 📈 +171 B (+3.22%) | 5.18 kB → 5.35 kB
`src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx` | 📉 -264 B (-0.80%) | 32.18 kB → 31.93 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.01 MB → 2.01 MB (-93 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 190.43 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 4.97 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/en.js | 195.88 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.45 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BDS7YpIF.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->