### PR TITLE
[WIP] fix(fs): handle EPERM/EPERM gracefully in listDir

### DIFF
--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -55,7 +55,14 @@ export const listDir: typeof T.listDir = filepath =>
   new Promise((resolve, reject) => {
     fs.readdir(filepath, (err, files) => {
       if (err) {
-        reject(err);
+        // EPERM/EPERM: Operation not permitted - usually means no read permission
+        // Return empty array instead of crashing so the UI can handle it gracefully
+        if (err.code === 'EPERM' || err.code === 'EACCES') {
+          logger.warn(`No permission to read directory: ${filepath}`);
+          resolve([]);
+        } else {
+          reject(err);
+        }
       } else {
         resolve(files);
       }


### PR DESCRIPTION
Fixes #7824.

Previously, listDir would crash with EPERM (operation not permitted) when the app tries to scan a directory without read permissions.

Now handles EPERM/EPERM gracefully by:
  1. Logging a warning
  2. Returning an empty array instead of crashing

This allows the UI to handle missing permissions gracefully.
### Issue Reference
Fixes #7824

### Problem Description
On macOS/Windows, when the app tries to scan a directory it doesn't have permission to access, it crashes with:
```
EPERM: operation not permitted, scandir '/Users/userd...'
```

This happens because `fs.readdir()` fails with `EPERM` or `EACCES` when the app tries to read a restricted directory.

### Root Cause
In `packages/loot-core/src/platform/server/fs/index.electron.ts`, the `listDir` function did not handle permission errors, causing the app to crash.

### Solution
Modified `listDir` to gracefully handle `EPERM` and `EACCES` errors:
1. Catch `EPERM` and `EACCES` error codes
2. Log a warning message
3. Return an empty array instead of crashing

```typescript
if (err.code === 'EPERM' || err.code === 'EACCES') {
  logger.warn(`No permission to read directory: ${filepath}`);
  resolve([]);
} else {
  reject(err);
}
```

### Impact
- App no longer crashes when encountering restricted directories
- Users see an empty file list instead of an error
- More graceful handling of file system permission issues

### Testing
- [ ] Tested on macOS with restricted directories
- [ ] Tested on Windows with protected folders
- [x] Code review - error handling logic is correct

### Checklist
- [x] Code follows project coding style
- [x] Commit message follows Conventional Commits
- [ ] Tests added/updated (error handling is hard to unit test)
- [ ] Documentation updated (if needed)


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 14 MB → 14 MB (+1010 B) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 14 MB → 14 MB (+1010 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +1.05 kB (+0.54%) | 195.88 kB → 196.93 kB
`locale/uk.json` | 📉 -68 B (-0.03%) | 207.45 kB → 207.38 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 195.88 kB → 196.93 kB (+1.05 kB) | +0.54%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/uk.js | 207.45 kB → 207.38 kB (-68 B) | -0.03%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.02 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 86.89 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 187.62 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 10.01 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 189.28 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.65 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkJq0HmC.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->