### PR TITLE
fix docker nightly tag naming

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -25,8 +25,8 @@ env:
   # - actual-server:nightly
   # - actual-server:edge (kept for backwards compatibility)
   TAGS: |
-    type=edge,value=nightly
-    type=edge,value=edge
+    type=raw,value=nightly,enable={{is_default_branch}}
+    type=raw,value=edge,enable={{is_default_branch}}
     type=sha
 
 jobs:

--- a/upcoming-release-notes/7901.md
+++ b/upcoming-release-notes/7901.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix Docker nightly tag naming


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

docker metadata appears not to support custom named edge tags, see https://github.com/actualbudget/actual/actions/runs/26108582037/job/76779226110#step:5:56

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Read the metadata source, this should work but it's hard to test before it's merged

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
