### PR TITLE
Correct handling of negative budgeting and "positive" spending in Sankey chart

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -5,6 +5,7 @@ import {
   addNode,
   addPercentageLabels,
   addValueToLink,
+  buildSankeyData,
   cleanUpNodes,
   convertToSankeyData,
   createBudgetGraph,
@@ -472,6 +473,7 @@ describe('sankey-spreadsheet', () => {
           categoryId: 'c_salary',
           value: 5000,
           isIncome: true,
+          isNegative: false,
         },
         {
           categoryGroup: 'Food',
@@ -480,6 +482,7 @@ describe('sankey-spreadsheet', () => {
           categoryId: 'c_groceries',
           value: 500,
           isIncome: false,
+          isNegative: false,
         },
       ];
 
@@ -510,6 +513,7 @@ describe('sankey-spreadsheet', () => {
         categoryId: string;
         value: number;
         isIncome: boolean;
+        isNegative: false;
       }> = [];
 
       const aggregated = {
@@ -525,7 +529,7 @@ describe('sankey-spreadsheet', () => {
       const graph = createBudgetGraph(categoryData, aggregated);
       const toBudgetNode = graph.get('to_budget');
 
-      expect(toBudgetNode?.isOverbudgeted).toBe(true);
+      expect(toBudgetNode?.isNegative).toBe(true);
       expect(toBudgetNode?.labelKey).toBe('Overbudgeted');
     });
   });
@@ -540,6 +544,7 @@ describe('sankey-spreadsheet', () => {
           categoryId: 'c_groceries',
           value: 100,
           isIncome: false,
+          isNegative: false,
           accountName: 'Checking',
           accountId: 'a_checking',
         },
@@ -550,6 +555,7 @@ describe('sankey-spreadsheet', () => {
           categoryId: 'c_salary',
           value: 5000,
           isIncome: true,
+          isNegative: false,
           accountName: 'Checking',
           accountId: 'a_checking',
           payeeName: 'Employer',
@@ -718,6 +724,34 @@ describe('sankey-spreadsheet', () => {
 
       expect(graph.has('node1')).toBe(false);
       expect(graph.has('node2')).toBe(false);
+    });
+  });
+
+  describe('addHiddenNodes via buildSankeyData', () => {
+    it('adds one hidden child layer for category groups without children', () => {
+      const graph: Graph = new Map();
+
+      addNode(graph, 'account', GraphLayers.Account, 'Account');
+      addNode(graph, 'group-with-child', GraphLayers.CategoryGroup, 'Group A');
+      addNode(graph, 'category', GraphLayers.Category, 'Category A');
+      addValueToLink(graph, 'account', 'group-with-child', 100);
+      addValueToLink(graph, 'group-with-child', 'category', 100);
+
+      addNode(graph, 'group-no-child', GraphLayers.CategoryGroup, 'Group B');
+      addValueToLink(graph, 'account', 'group-no-child', 50);
+
+      const sankeyData = buildSankeyData(
+        graph,
+        100,
+        [],
+        'global',
+        GraphLayers.Account,
+        GraphLayers.Category,
+      );
+
+      const nodeKeys = sankeyData.nodes.map(node => node.key);
+      expect(nodeKeys).toContain('group-no-child_category__HIDDEN');
+      expect(nodeKeys).not.toContain('group-no-child_category_group__HIDDEN');
     });
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -544,7 +544,7 @@ describe('sankey-spreadsheet', () => {
           categoryId: 'c_groceries',
           value: 100,
           isIncome: false,
-          isNegative: false,
+          isNegative: true,
           accountName: 'Checking',
           accountId: 'a_checking',
         },

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -651,6 +651,26 @@ describe('sankey-spreadsheet', () => {
       expect(node1?.percentageLabel).toBe('25.0%');
       expect(node2?.percentageLabel).toBe('75.0%');
     });
+
+    it('normalizes percentages per GraphLayer, not computed depth', () => {
+      const graph: Graph = new Map();
+
+      addNode(graph, 'payee', GraphLayers.IncomePayee, 'Payee');
+      addNode(graph, 'income-cat', GraphLayers.IncomeCategory, 'Income Cat');
+      addNode(graph, 'account-incoming', GraphLayers.Account, 'Account A');
+
+      addNode(graph, 'account-root', GraphLayers.Account, 'Account B');
+      addNode(graph, 'group', GraphLayers.CategoryGroup, 'Group');
+
+      addValueToLink(graph, 'payee', 'income-cat', 300);
+      addValueToLink(graph, 'income-cat', 'account-incoming', 300);
+      addValueToLink(graph, 'account-root', 'group', 100);
+
+      addPercentageLabels(graph);
+
+      expect(graph.get('account-root')?.percentageLabel).toBe('25.0%');
+      expect(graph.get('account-incoming')?.percentageLabel).toBe('75.0%');
+    });
   });
 
   describe('filterGraphByLayers', () => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -1264,18 +1264,21 @@ export function getNodeValue(graph: Graph, key: NodeKey): number {
 }
 
 export function addPercentageLabels(graph: Graph): void {
-  const layerSums = new Map<number, number>();
+  const layerSums = new Map<GraphLayers, number>();
 
-  // First pass: Calculate layer sums
+  // First pass: calculate GraphLayer sums
   graph.forEach((_: NodeData, key: NodeKey) => {
-    const layer = getLayer(graph, key);
+    const layer = graph.get(key)?.type;
+    if (!layer) {
+      return;
+    }
     const nodeValue = getNodeValue(graph, key);
     layerSums.set(layer, (layerSums.get(layer) ?? 0) + nodeValue);
   });
 
-  // Second pass: Assign percentage label to each node
+  // Second pass: assign percentage label to each node
   graph.forEach((data: NodeData, key: NodeKey) => {
-    const layer = getLayer(graph, key);
+    const layer = data.type;
     const nodeValue = getNodeValue(graph, key);
     const layerTotal = layerSums.get(layer) ?? 1;
     const percentage = layerTotal ? (nodeValue / layerTotal) * 100 : 0;

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -74,6 +74,7 @@ type CategoryEntry = {
   categoryId: string;
   value: number;
   isIncome: boolean;
+  isNegative: boolean;
   accountName?: string;
   accountId?: string;
   payeeName?: string;
@@ -90,7 +91,7 @@ export type NodeData = {
   name?: string;
   labelKey?: string;
   labelParams?: Record<string, string>;
-  isOverbudgeted?: boolean;
+  isNegative?: boolean;
   tooltipInfo?: Array<{ name: string; value: number }>;
   percentageLabel?: string;
   color?: string;
@@ -112,6 +113,7 @@ const SpecialNodeKeys = {
   AllAccounts: 'all_income',
   OtherSuffix: '__OTHER_BUCKET',
   HiddenSuffix: '__HIDDEN',
+  NegativeSuffix: '__NEGATIVE',
 } as const;
 type SpecialNodeKeys = (typeof SpecialNodeKeys)[keyof typeof SpecialNodeKeys];
 
@@ -317,6 +319,7 @@ export function createBudgetSpreadsheet(
             category: cat.name,
             categoryId: cat.id,
             isIncome: group.is_income,
+            isNegative: rawValue < 0,
             value: rawValue,
           };
         }),
@@ -537,6 +540,7 @@ async function fetchCategoryData(
                 categoryId: category.id,
                 value: Math.abs(row.amount ?? 0),
                 isIncome: categoryGroup.is_income ?? false,
+                isNegative: row.amount !== undefined && row.amount < 0,
                 accountName: row.accountName ?? '',
                 accountId: row.accountId ?? '',
                 payeeName: row.payeeName ?? '',
@@ -549,6 +553,8 @@ async function fetchCategoryData(
     }),
   );
   const allCategoryData = nested.flat();
+  
+  console.log('allCategoryData', allCategoryData);
 
   if (groupAccounts) {
     allCategoryData.forEach(entry => {
@@ -738,50 +744,70 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
   categoryData.forEach(entry => {
     if (entry.accountId && entry.accountName && entry.categoryId) {
       if (entry.isIncome) {
-        // Payee > Income category > Account
-        addNode(
-          graph,
-          entry.categoryId,
-          GraphLayers.IncomeCategory,
-          entry.category,
-        );
-        addAccountNode(entry.accountId, entry.accountName);
-        addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
-        if (entry.payeeId) {
+        if (entry.isNegative) {
+          // Account > Income category
+          addAccountNode(entry.accountId, entry.accountName);
+          addNodeWithLabel(graph, entry.categoryId + SpecialNodeKeys.NegativeSuffix, GraphLayers.CategoryGroup, entry.category, undefined, true);
+          addValueToLink(graph, entry.accountId, entry.categoryId + SpecialNodeKeys.NegativeSuffix, entry.value);
+        } else {
+          // Payee > Income category > Account
           addNode(
             graph,
-            entry.payeeId,
-            GraphLayers.IncomePayee,
-            entry.payeeName,
+            entry.categoryId,
+            GraphLayers.IncomeCategory,
+            entry.category,
           );
-          addValueToLink(graph, entry.payeeId, entry.categoryId, entry.value);
+          addAccountNode(entry.accountId, entry.accountName);
+          addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
+          if (entry.payeeId) {
+            addNode(
+              graph,
+              entry.payeeId,
+              GraphLayers.IncomePayee,
+              entry.payeeName,
+            );
+            addValueToLink(graph, entry.payeeId, entry.categoryId, entry.value);
+          }
         }
       } else {
-        // Account > Category group > Category
-        addAccountNode(entry.accountId, entry.accountName);
-        addNode(
-          graph,
-          entry.categoryGroupId,
-          GraphLayers.CategoryGroup,
-          entry.categoryGroup,
-        );
-        addNode(graph, entry.categoryId, GraphLayers.Category, entry.category);
-        addValueToLink(
-          graph,
-          entry.accountId,
-          entry.categoryGroupId,
-          entry.value,
-        );
-        addValueToLink(
-          graph,
-          entry.categoryGroupId,
-          entry.categoryId,
-          entry.value,
-        );
+        if (entry.isNegative) {
+          // Account > Category group > Category
+          addAccountNode(entry.accountId, entry.accountName);
+          addNode(
+            graph,
+            entry.categoryGroupId,
+            GraphLayers.CategoryGroup,
+            entry.categoryGroup,
+          );
+          addNode(graph, entry.categoryId, GraphLayers.Category, entry.category);
+          addValueToLink(
+            graph,
+            entry.accountId,
+            entry.categoryGroupId,
+            entry.value,
+          );
+          addValueToLink(
+            graph,
+            entry.categoryGroupId,
+            entry.categoryId,
+            entry.value,
+          );
+        } else {
+          // Category > Account
+          addNode(
+            graph,
+            entry.categoryId,
+            GraphLayers.IncomeCategory,
+            entry.category,
+          );
+          addAccountNode(entry.accountId, entry.accountName);
+          addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
+        }
       }
     }
   });
 
+  console.log(graph)
   return graph;
 }
 
@@ -806,7 +832,7 @@ export function addNodeWithLabel(
   type: GraphLayers,
   labelKey: string,
   labelParams?: Record<string, string>,
-  isOverbudgeted?: boolean,
+  isNegative?: boolean,
 ) {
   if (!graph.has(key)) {
     graph.set(key, {
@@ -814,7 +840,7 @@ export function addNodeWithLabel(
       type,
       labelKey,
       labelParams,
-      isOverbudgeted,
+      isNegative,
     });
   }
 }
@@ -861,7 +887,7 @@ function groupOtherCategories(
       node &&
       !key.endsWith(SpecialNodeKeys.OtherSuffix) &&
       !structuralKeys.has(key) &&
-      !node.isOverbudgeted,
+      !node.isNegative,
     );
   }
 
@@ -1154,13 +1180,13 @@ export function sortGraph(
 
   // We always want certain nodes to be shown at the start/end of their layers
   sortedEntries
-    .filter(([, nodeData]) => nodeData.isOverbudgeted)
+    .filter(([, nodeData]) => nodeData.isNegative)
     .forEach(([key]) => {
       moveNodeToStart(sortedEntries, key);
     });
   const toBudgetNode = graph.get(SpecialNodeKeys.ToBudget);
   if (toBudgetNode) {
-    if (toBudgetNode.isOverbudgeted) {
+    if (toBudgetNode.isNegative) {
       moveNodeToStart(sortedEntries, SpecialNodeKeys.ToBudget);
     } else {
       moveNodeToEnd(sortedEntries, SpecialNodeKeys.ToBudget);
@@ -1256,7 +1282,7 @@ function addColors(graph: Graph) {
 
   setColor(graph, SpecialNodeKeys.ToBudget, theme.toBudgetPositive);
   graph.forEach((node, key) => {
-    if (node.isOverbudgeted) {
+    if (node.isNegative) {
       setColor(graph, key, theme.toBudgetNegative);
     }
   });
@@ -1527,13 +1553,16 @@ export function convertToSankeyData(
       if (targetKey === SpecialNodeKeys.LastMonthOverspent) {
         color = graph.get(SpecialNodeKeys.LastMonthOverspent)?.color;
       }
+      if (targetKey.endsWith(SpecialNodeKeys.NegativeSuffix)) {
+        color = graph.get(targetKey)?.color;
+      }
       if (targetKey === SpecialNodeKeys.ToBudget) {
         color = graph.get(SpecialNodeKeys.ToBudget)?.color;
       }
       if (targetKey === SpecialNodeKeys.ForNextMonth) {
         color = graph.get(SpecialNodeKeys.ForNextMonth)?.color;
       }
-      if (data.isOverbudgeted) {
+      if (data.isNegative) {
         color = data.color;
       }
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -553,8 +553,6 @@ async function fetchCategoryData(
     }),
   );
   const allCategoryData = nested.flat();
-  
-  console.log('allCategoryData', allCategoryData);
 
   if (groupAccounts) {
     allCategoryData.forEach(entry => {
@@ -747,8 +745,20 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
         if (entry.isNegative) {
           // Account > Income category
           addAccountNode(entry.accountId, entry.accountName);
-          addNodeWithLabel(graph, entry.categoryId + SpecialNodeKeys.NegativeSuffix, GraphLayers.CategoryGroup, entry.category, undefined, true);
-          addValueToLink(graph, entry.accountId, entry.categoryId + SpecialNodeKeys.NegativeSuffix, entry.value);
+          addNodeWithLabel(
+            graph,
+            entry.categoryId + SpecialNodeKeys.NegativeSuffix,
+            GraphLayers.CategoryGroup,
+            entry.payeeName ?? entry.category,
+            undefined,
+            true,
+          );
+          addValueToLink(
+            graph,
+            entry.accountId,
+            entry.categoryId + SpecialNodeKeys.NegativeSuffix,
+            entry.value,
+          );
         } else {
           // Payee > Income category > Account
           addNode(
@@ -779,7 +789,12 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
             GraphLayers.CategoryGroup,
             entry.categoryGroup,
           );
-          addNode(graph, entry.categoryId, GraphLayers.Category, entry.category);
+          addNode(
+            graph,
+            entry.categoryId,
+            GraphLayers.Category,
+            entry.category,
+          );
           addValueToLink(
             graph,
             entry.accountId,
@@ -798,7 +813,7 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
             graph,
             entry.categoryId,
             GraphLayers.IncomeCategory,
-            entry.category,
+            entry.payeeName ?? entry.category,
           );
           addAccountNode(entry.accountId, entry.accountName);
           addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
@@ -806,8 +821,6 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
       }
     }
   });
-
-  console.log(graph)
   return graph;
 }
 
@@ -1326,6 +1339,56 @@ function addHiddenNodes(graph: Graph) {
     nodesByType,
   );
 
+  const activeLayerOrder = GRAPH_LAYER_ORDER.filter(
+    layer => (nodesByType[layer]?.length ?? 0) > 0,
+  );
+  const layerIndex = new Map<GraphLayers, number>();
+  activeLayerOrder.forEach((layer, index) => {
+    layerIndex.set(layer, index);
+  });
+
+  function addHiddenParentChain(key: NodeKey, type: GraphLayers) {
+    const typeIndex = layerIndex.get(type);
+    if (typeIndex === undefined || typeIndex <= 0) {
+      return;
+    }
+
+    let childKey = key;
+    for (let i = typeIndex - 1; i >= 0; i--) {
+      const parentType = activeLayerOrder[i];
+      if (!parentType) {
+        continue;
+      }
+      const parentKey = `${key}_${parentType}${SpecialNodeKeys.HiddenSuffix}`;
+      addNode(graph, parentKey, parentType, '');
+      addValueToLink(graph, parentKey, childKey, -1);
+      childKey = parentKey;
+    }
+  }
+
+  function addHiddenChildChain(key: NodeKey, type: GraphLayers) {
+    const typeIndex = layerIndex.get(type);
+    if (
+      typeIndex === undefined ||
+      typeIndex < 0 ||
+      typeIndex >= activeLayerOrder.length - 1
+    ) {
+      return;
+    }
+
+    let parentKey = key;
+    for (let i = typeIndex + 1; i < activeLayerOrder.length; i++) {
+      const childType = activeLayerOrder[i];
+      if (!childType) {
+        continue;
+      }
+      const childKey = `${key}_${childType}${SpecialNodeKeys.HiddenSuffix}`;
+      addNode(graph, childKey, childType, '');
+      addValueToLink(graph, parentKey, childKey, -1);
+      parentKey = childKey;
+    }
+  }
+
   // Now: find and fix "problematic" nodes
   for (const typeStr in nodesByType) {
     if (!isGraphLayer(typeStr)) continue;
@@ -1336,73 +1399,12 @@ function addHiddenNodes(graph: Graph) {
       const nodeHasParent = hasParent(graph, key);
       const nodeHasChild = hasChild(node);
       if (!nodeHasParent && typeHasParent[type]) {
-        // This node is at a wrong layer and need hidden parents
-        if (type === GraphLayers.IncomeCategory) {
-          addNode(
-            graph,
-            key + '_payee' + SpecialNodeKeys.HiddenSuffix,
-            GraphLayers.IncomePayee,
-            '',
-          );
-          addValueToLink(
-            graph,
-            key + '_payee' + SpecialNodeKeys.HiddenSuffix,
-            key,
-            -1,
-          );
-        } else {
-          addNode(
-            graph,
-            key + '_account' + SpecialNodeKeys.HiddenSuffix,
-            GraphLayers.Account,
-            '',
-          );
-          addValueToLink(
-            graph,
-            key + '_account' + SpecialNodeKeys.HiddenSuffix,
-            key,
-            -1,
-          );
-          addNode(
-            graph,
-            key + '_payee' + SpecialNodeKeys.HiddenSuffix,
-            GraphLayers.IncomePayee,
-            '',
-          );
-          addValueToLink(
-            graph,
-            key + '_payee' + SpecialNodeKeys.HiddenSuffix,
-            key + '_account' + SpecialNodeKeys.HiddenSuffix,
-            -1,
-          );
-        }
+        // This node is at the wrong layer and needs hidden parents.
+        addHiddenParentChain(key, type);
       }
       if (!nodeHasChild && typeHasChild[type]) {
-        // This node is at a wrong layer and need hidden children
-        addNode(
-          graph,
-          key + '_category_group' + SpecialNodeKeys.HiddenSuffix,
-          GraphLayers.CategoryGroup,
-          '',
-        );
-        addNode(
-          graph,
-          key + '_category' + SpecialNodeKeys.HiddenSuffix,
-          GraphLayers.Category,
-          '',
-        );
-        addValueToLink(
-          graph,
-          key,
-          key + '_category_group' + SpecialNodeKeys.HiddenSuffix,
-          -1,
-        );
-        addValueToLink(
-          graph,
-          key + '_category_group' + SpecialNodeKeys.HiddenSuffix,
-          key + '_category' + SpecialNodeKeys.HiddenSuffix,
-          -1,
-        );
+        // This node is at the wrong layer and needs hidden children.
+        addHiddenChildChain(key, type);
       }
     }
   }

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -811,12 +811,17 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
           // Category > Account
           addNode(
             graph,
-            entry.categoryId,
+            entry.categoryId + SpecialNodeKeys.NegativeSuffix,
             GraphLayers.IncomeCategory,
             entry.payeeName ?? entry.category,
           );
           addAccountNode(entry.accountId, entry.accountName);
-          addValueToLink(graph, entry.categoryId, entry.accountId, entry.value);
+          addValueToLink(
+            graph,
+            entry.categoryId + SpecialNodeKeys.NegativeSuffix,
+            entry.accountId,
+            entry.value,
+          );
         }
       }
     }

--- a/upcoming-release-notes/7903.md
+++ b/upcoming-release-notes/7903.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [emiltb]
+---
+
+Fix handling of negative budgeting and "positive" spending in Sankey chart


### PR DESCRIPTION
## Description

Fixes previously unhandled edge-cases of negative budgeting and net positive transactions as spending. Also fixes a bug in percentage calculations, so now each layer always sums to 100%.

I wrote the handling of negative budgeting + positive spending and percentage calculation. Opencode / GPT5.3-Codex helped with fixing the layer placement and wrote the tests.

## Related issue(s)

Relates to #1919.

## Testing

Verified with a custom test budget ([2026-05-19-Test_Budget_negative.zip](https://github.com/user-attachments/files/28025365/2026-05-19-Test_Budget_negative.zip)), which contained all the targeted edge cases.

<img width="927" height="420" alt="2026-05-19T19:32:20,547844424+02:00" src="https://github.com/user-attachments/assets/c809bf3e-0f00-483f-9cfa-8ea8189989a0" />

<img width="925" height="416" alt="2026-05-19T19:32:13,586811070+02:00" src="https://github.com/user-attachments/assets/dfd78ebd-dd8b-44e8-ba39-61ac34e9081e" />

Existing unit tests pass and a few more have been added.

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->



<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.99 MB → 13.99 MB (+1.1 kB) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.99 MB → 13.99 MB (+1.1 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📈 +1.1 kB (+3.87%) | 28.31 kB → 29.41 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.25 MB (+1.1 kB) | +0.09%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.02 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 86.89 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.83 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkJq0HmC.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->