### PR TITLE
automations UI: reuse percentInput for adjustments

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/editor/AmountAdjustment.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/AmountAdjustment.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { Input } from '@actual-app/components/input';
 import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import { amountToInteger, integerToAmount } from '@actual-app/core/shared/util';
@@ -14,6 +12,7 @@ import { updateTemplate } from '#components/budget/goals/actions';
 import type { Action } from '#components/budget/goals/actions';
 import { FormField, FormLabel } from '#components/forms';
 import { AmountInput } from '#components/util/AmountInput';
+import { PercentInput } from '#components/util/PercentInput';
 import { useFormat } from '#hooks/useFormat';
 
 type AdjustableTemplate = ScheduleTemplate | AverageTemplate;
@@ -23,6 +22,8 @@ type Direction = 'increase' | 'decrease';
 
 // Seeded when an adjustment is first switched on.
 const DEFAULT_MAGNITUDE = 10;
+
+const MAX_PERCENT = 1000;
 
 type AmountAdjustmentProps = {
   template: AdjustableTemplate;
@@ -46,13 +47,6 @@ export const AmountAdjustment = ({
   const adjustment = template.adjustment ?? 0;
   const increasing = adjustment >= 0;
   const magnitude = Math.abs(adjustment);
-
-  const [rawMagnitude, setRawMagnitude] = useState(String(magnitude));
-  // Resync when a different automation row is selected (the component
-  // instance is reused across rows).
-  useEffect(() => {
-    setRawMagnitude(String(magnitude));
-  }, [magnitude]);
 
   const apply = (
     next: number | undefined,
@@ -89,13 +83,6 @@ export const AmountAdjustment = ({
 
   const changeDirection = (direction: Direction) => {
     apply(direction === 'decrease' ? -magnitude : magnitude, 'percent');
-  };
-
-  const commitMagnitude = () => {
-    const parsed = Number(rawMagnitude);
-    const size = Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
-    setRawMagnitude(String(size));
-    apply(increasing ? size : -size, 'percent');
   };
 
   return (
@@ -143,13 +130,14 @@ export const AmountAdjustment = ({
                   ]}
                   style={{ width: 150 }}
                 />
-                <Input
+                <PercentInput
                   id="adjustment-amount-field"
-                  inputMode="decimal"
-                  style={{ width: 120 }}
-                  value={rawMagnitude}
-                  onChangeValue={setRawMagnitude}
-                  onBlur={commitMagnitude}
+                  max={MAX_PERCENT}
+                  value={magnitude}
+                  onUpdatePercent={percent =>
+                    apply(increasing ? percent : -percent, 'percent')
+                  }
+                  style={{ flex: 'none', width: 120 }}
                 />
               </>
             ))}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -236,6 +236,7 @@ export function AutomationEditorPane({
               </Text>
             )}
             <ActiveEditor
+              key={active.id}
               state={state}
               dispatch={dispatch}
               schedules={schedules}
@@ -249,6 +250,7 @@ export function AutomationEditorPane({
 
       {state.displayType === 'refill' && (
         <ActiveEditor
+          key={active.id}
           state={state}
           dispatch={dispatch}
           schedules={schedules}

--- a/packages/desktop-client/src/components/util/PercentInput.tsx
+++ b/packages/desktop-client/src/components/util/PercentInput.tsx
@@ -18,9 +18,11 @@ type PercentInputProps = {
   style?: CSSProperties;
   focused?: boolean;
   disabled?: boolean;
+  max?: number;
 };
 
-const clampToPercent = (value: number) => Math.max(Math.min(value, 100), 0);
+const clampToPercent = (value: number, max: number) =>
+  Math.max(Math.min(value, max), 0);
 
 export function PercentInput({
   id,
@@ -33,19 +35,20 @@ export function PercentInput({
   style,
   focused,
   disabled = false,
+  max = 100,
 }: PercentInputProps) {
   const format = useFormat();
 
   const [value, setValue] = useState(() =>
-    format(clampToPercent(initialValue), 'percentage'),
+    format(clampToPercent(initialValue, max), 'percentage'),
   );
   useEffect(() => {
-    const clampedInitialValue = clampToPercent(initialValue);
+    const clampedInitialValue = clampToPercent(initialValue, max);
     if (clampedInitialValue !== initialValue) {
       setValue(format(clampedInitialValue, 'percentage'));
       onUpdatePercent?.(clampedInitialValue);
     }
-  }, [initialValue, onUpdatePercent, format]);
+  }, [initialValue, max, onUpdatePercent, format]);
 
   const ref = useRef<HTMLInputElement>(null);
   const mergedRef = useMergedRefs<HTMLInputElement>(inputRef, ref);
@@ -84,6 +87,7 @@ export function PercentInput({
   function fireUpdate() {
     const clampedValue = clampToPercent(
       evalArithmetic(value.replace('%', ''), 0) ?? 0,
+      max,
     );
     onUpdatePercent?.(clampedValue);
     onInputTextChange(String(clampedValue));

--- a/upcoming-release-notes/7905.md
+++ b/upcoming-release-notes/7905.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Make percentage inputs in budget automations more consistent


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes https://github.com/actualbudget/actual/pull/7881#issuecomment-4477068140

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 13.99 MB → 13.99 MB (-533 B) | -0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 13.99 MB → 13.99 MB (-533 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/util/PercentInput.tsx` | 📈 +177 B (+4.39%) | 3.94 kB → 4.11 kB
`src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx` | 📈 +60 B (+0.55%) | 10.62 kB → 10.68 kB
`src/components/budget/goals/editor/AmountAdjustment.tsx` | 📉 -770 B (-12.13%) | 6.2 kB → 5.45 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.08 MB → 5.08 MB (+177 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.02 MB → 2.02 MB (-710 B) | -0.03%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 86.89 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.83 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.36 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.67 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkJq0HmC.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->