### PR TITLE
fix zizmor issues with release workflows

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -30,6 +30,7 @@ jobs:
           ref: master
           fetch-depth: 0
           token: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
+          persist-credentials: true
 
       - name: Set up environment
         uses: ./.github/actions/setup

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - release
 
-permissions:
-  contents: write
-  pull-requests: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +20,8 @@ jobs:
       && startsWith(github.head_ref, 'release-notes/') == false
     runs-on: ubuntu-latest
     environment: pr-automation
+    permissions:
+      contents: read
     steps:
       - name: Check if triggered by bot
         id: bot-check
@@ -71,6 +71,9 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - name: Resolve version
         id: version

--- a/upcoming-release-notes/7908.md
+++ b/upcoming-release-notes/7908.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix zizmor issues with release workflows


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

The zizmor rule wants it to be explicit when we persist credentials.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/security/code-scanning/550

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
