### PR TITLE
Goal Templates keyboard shortcut

### DIFF
--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -126,7 +126,7 @@ const DynamicBudgetTable = ({
     [_onMonthSelect, startMonth, numMonths],
   );
   useHotkeys(
-    'ctrl+t, meta+t',
+    'shift+t',
     () => {
       onBudgetAction(startMonth, 'overwrite-goal-template', null);
     },

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -9,6 +9,7 @@ import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 
 import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 
 import { useBudgetMonthCount } from './BudgetMonthCountContext';
@@ -47,10 +48,12 @@ const DynamicBudgetTable = ({
   maxMonths = 3,
   monthBounds,
   onMonthSelect,
+  onBudgetAction,
   ...props
 }: DynamicBudgetTableProps) => {
   const { setDisplayMax } = useBudgetMonthCount();
   const [categoryExpandedStatePref] = useGlobalPref('categoryExpandedState');
+  const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const categoryExpandedState = categoryExpandedStatePref ?? 0;
 
   const numPossible = getNumPossibleMonths(
@@ -122,6 +125,18 @@ const DynamicBudgetTable = ({
     },
     [_onMonthSelect, startMonth, numMonths],
   );
+  useHotkeys(
+    't',
+    () => {
+      onBudgetAction(startMonth, 'overwrite-goal-template', null);
+    },
+    {
+      preventDefault: true,
+      scopes: ['app'],
+      enabled: isGoalTemplatesEnabled,
+    },
+    [onBudgetAction, startMonth, isGoalTemplatesEnabled],
+  );
 
   return (
     <View
@@ -146,6 +161,7 @@ const DynamicBudgetTable = ({
             startMonth={startMonth}
             numMonths={numMonths}
             monthBounds={monthBounds}
+            onBudgetAction={onBudgetAction}
             {...props}
           />
         </ErrorBoundary>

--- a/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/DynamicBudgetTable.tsx
@@ -126,7 +126,7 @@ const DynamicBudgetTable = ({
     [_onMonthSelect, startMonth, numMonths],
   );
   useHotkeys(
-    't',
+    'ctrl+t, meta+t',
     () => {
       onBudgetAction(startMonth, 'overwrite-goal-template', null);
     },

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -239,7 +239,7 @@ export function KeyboardShortcutModal() {
                 {
                   id: 'overwrite-with-templates',
                   shortcut: 'T',
-                  meta: ctrl,
+                  shift: true,
                   description: t('Overwrite with budget templates'),
                 },
               ]

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -13,6 +13,7 @@ import * as Platform from '@actual-app/core/shared/platform';
 
 import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
 import { Search } from '#components/common/Search';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 
 type KeyIconProps = {
   shortcut: string;
@@ -151,6 +152,7 @@ export function KeyboardShortcutModal() {
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
     null,
   );
+  const isGoalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
 
   // In future, we may move this to state and pull overrides from config/db
   // This would allow us to drive our shortcuts from state instead of hardcoding them
@@ -232,6 +234,15 @@ export function KeyboardShortcutModal() {
             shortcut: '→',
             description: t('View next month'),
           },
+          ...(isGoalTemplatesEnabled
+            ? [
+                {
+                  id: 'overwrite-with-templates',
+                  shortcut: 'T',
+                  description: t('Overwrite with budget templates'),
+                },
+              ]
+            : []),
         ],
       },
       {
@@ -417,7 +428,7 @@ export function KeyboardShortcutModal() {
         ],
       },
     ],
-    [t, ctrl],
+    [t, ctrl, isGoalTemplatesEnabled],
   );
 
   const { isSearching, isInCategory, currentCategory, itemsToShow } =

--- a/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
+++ b/packages/desktop-client/src/components/modals/KeyboardShortcutModal.tsx
@@ -239,6 +239,7 @@ export function KeyboardShortcutModal() {
                 {
                   id: 'overwrite-with-templates',
                   shortcut: 'T',
+                  meta: ctrl,
                   description: t('Overwrite with budget templates'),
                 },
               ]

--- a/upcoming-release-notes/7912.md
+++ b/upcoming-release-notes/7912.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [youngcw]
+---
+
+Add keyboard shortcut for overwrite templates


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
Add "Shift-T" shortcut on the budget page for triggering "overwrite with budget templates"


<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

Generated by Claude
<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 14 MB → 14 MB (+1.54 kB) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 14 MB → 14 MB (+1.54 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/DynamicBudgetTable.tsx` | 📈 +1.11 kB (+15.06%) | 7.34 kB → 8.45 kB
`src/components/modals/KeyboardShortcutModal.tsx` | 📈 +446 B (+1.63%) | 26.78 kB → 27.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.02 MB → 2.02 MB (+1.54 kB) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/chart-theme.js | 800.08 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.27 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.86 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cn6Jnyv4.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->