### PR TITLE
feat: add SharedArrayBuffer warning indicator in title bar

### DIFF
--- a/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
+++ b/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
@@ -4,6 +4,7 @@ import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
 import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
+import { css } from '@emotion/css';
 
 import { Link } from '#components/common/Link';
 
@@ -35,7 +36,15 @@ export function SharedArrayBufferWarning() {
       <Link
         variant="external"
         to="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
-        styles={{ color: theme.warningText, textDecoration: 'none' }}
+        className={css({
+          color: `${theme.warningText} !important`,
+          textDecoration: 'none',
+          padding: '4px 6px',
+          borderRadius: 4,
+          display: 'flex',
+          alignItems: 'center',
+          ':hover': { backgroundColor: theme.buttonBareBackgroundHover },
+        })}
       >
         <Trans>Warning</Trans>
         <SvgAlertTriangle width={13} style={{ marginLeft: '6px' }} />

--- a/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
+++ b/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
@@ -1,9 +1,10 @@
 import { Trans } from 'react-i18next';
 
-import { Button } from '@actual-app/components/button';
 import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
+
+import { Link } from '#components/common/Link';
 
 export function SharedArrayBufferWarning() {
   const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
@@ -12,14 +13,6 @@ export function SharedArrayBufferWarning() {
   if (hasSharedArrayBuffer) {
     return null;
   }
-
-  const handlePress = () => {
-    window.open(
-      'https://actualbudget.org/docs/troubleshooting/shared-array-buffer',
-      '_blank',
-      'noopener,noreferrer',
-    );
-  };
 
   return (
     <Tooltip
@@ -36,14 +29,14 @@ export function SharedArrayBufferWarning() {
         width: '300px',
       }}
     >
-      <Button
-        variant="bare"
-        style={{ color: theme.warningText }}
-        onPress={handlePress}
+      <Link
+        variant="external"
+        to="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
+        styles={{ color: theme.warningText, textDecoration: 'none' }}
       >
         <Trans>Warning</Trans>
         <SvgAlertTriangle width={13} style={{ marginLeft: '6px' }} />
-      </Button>
+      </Link>
     </Tooltip>
   );
 }

--- a/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
+++ b/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
@@ -1,0 +1,49 @@
+import { Trans } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
+import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
+import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
+
+export function SharedArrayBufferWarning() {
+  const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
+
+  // Only show warning if SharedArrayBuffer is not supported
+  if (hasSharedArrayBuffer) {
+    return null;
+  }
+
+  const handlePress = () => {
+    window.open(
+      'https://actualbudget.org/docs/troubleshooting/shared-array-buffer',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  };
+
+  return (
+    <Tooltip
+      placement="bottom start"
+      content={
+        <Trans>
+          Your environment does not support SharedArrayBuffer. You may
+          experience data loss or degraded functionality. Click to learn more.
+        </Trans>
+      }
+      style={{
+        lineHeight: 1.5,
+        padding: '6px 10px',
+        width: '300px',
+      }}
+    >
+      <Button
+        variant="bare"
+        style={{ color: theme.warningText }}
+        onPress={handlePress}
+      >
+        <Trans>Warning</Trans>
+        <SvgAlertTriangle width={13} style={{ marginLeft: '6px' }} />
+      </Button>
+    </Tooltip>
+  );
+}

--- a/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
+++ b/packages/desktop-client/src/components/SharedArrayBufferWarning.tsx
@@ -1,6 +1,7 @@
 import { Trans } from 'react-i18next';
 
 import { SvgAlertTriangle } from '@actual-app/components/icons/v2';
+import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 
@@ -24,8 +25,10 @@ export function SharedArrayBufferWarning() {
         </Trans>
       }
       style={{
+        ...styles.tooltip,
         lineHeight: 1.5,
         padding: '6px 10px',
+        marginTop: '10px',
         width: '300px',
       }}
     >

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -281,12 +281,17 @@ function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
     <Tooltip
       placement="bottom start"
       content={<Text>{warningMessage}</Text>}
-      style={{ ...styles.tooltip, lineHeight: 1.5, padding: '6px 10px' }}
+      style={{
+        ...styles.tooltip,
+        lineHeight: 1.5,
+        padding: '6px 10px',
+        width: '300px',
+      }}
     >
       <Button
         variant="bare"
         aria-label={warningMessage}
-        style={{ ...style, color: theme.errorTextDark }}
+        style={{ ...style, color: theme.warningTextDark }}
         onPress={handlePress}
       >
         <SvgAlertTriangle width={13} />

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -13,10 +13,11 @@ import {
   SvgViewShow,
 } from '@actual-app/components/icons/v2';
 import { SpaceBetween } from '@actual-app/components/space-between';
-import { styles } from '@actual-app/components/styles';
 import type { CSSProperties } from '@actual-app/components/styles';
+import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
 import { isDevelopmentEnvironment } from '@actual-app/core/shared/environment';
@@ -250,6 +251,50 @@ function ServerSyncButton({ style, isMobile = false }: ServerSyncButtonProps) {
   );
 }
 
+type SharedArrayBufferWarningProps = {
+  style?: CSSProperties;
+};
+
+function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
+  const { t } = useTranslation();
+  const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
+  const isOverrideEnabled = localStorage.getItem('SharedArrayBufferOverride');
+
+  // Only show warning if SharedArrayBuffer is not supported but user has overridden the warning
+  if (hasSharedArrayBuffer || !isOverrideEnabled) {
+    return null;
+  }
+
+  const warningMessage = t(
+    'Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Click to learn more.',
+  );
+
+  const handlePress = () => {
+    window.open(
+      'https://actualbudget.org/docs/troubleshooting/shared-array-buffer',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  };
+
+  return (
+    <Tooltip
+      placement="bottom start"
+      content={<Text>{warningMessage}</Text>}
+      style={{ ...styles.tooltip, lineHeight: 1.5, padding: '6px 10px' }}
+    >
+      <Button
+        variant="bare"
+        aria-label={warningMessage}
+        style={{ ...style, color: theme.errorTextDark }}
+        onPress={handlePress}
+      >
+        <SvgAlertTriangle width={13} />
+      </Button>
+    </Tooltip>
+  );
+}
+
 function BudgetTitlebar() {
   const [maxMonths, setMaxMonthsPref] = useGlobalPref('maxMonths');
 
@@ -344,6 +389,7 @@ export function Titlebar({ style }: TitlebarProps) {
         {isDevelopmentEnvironment() && !isTestEnv && <ThemeSelector />}
         <PrivacyButton />
         {serverURL ? <ServerSyncButton /> : null}
+        <SharedArrayBufferWarning />
         <LoggedInUser />
         <HelpMenu />
       </SpaceBetween>

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -291,10 +291,11 @@ function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
       <Button
         variant="bare"
         aria-label={warningMessage}
-        style={{ ...style, color: theme.warningTextDark }}
+        style={{ ...style, color: theme.warningText }}
         onPress={handlePress}
       >
-        <SvgAlertTriangle width={13} />
+        <Trans>Warning</Trans>
+        <SvgAlertTriangle width={13} style={{ marginLeft: '6 px' }} />
       </Button>
     </Tooltip>
   );

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -295,7 +295,7 @@ function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
         onPress={handlePress}
       >
         <Trans>Warning</Trans>
-        <SvgAlertTriangle width={13} style={{ marginLeft: '6 px' }} />
+        <SvgAlertTriangle width={13} style={{ marginLeft: '6px' }} />
       </Button>
     </Tooltip>
   );

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -17,7 +17,6 @@ import type { CSSProperties } from '@actual-app/components/styles';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
-import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
 import { isDevelopmentEnvironment } from '@actual-app/core/shared/environment';
@@ -25,6 +24,7 @@ import * as Platform from '@actual-app/core/shared/platform';
 import { css } from '@emotion/css';
 
 import { sync } from '#app/appSlice';
+import { SharedArrayBufferWarning } from '#components/SharedArrayBufferWarning';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useIsTestEnv } from '#hooks/useIsTestEnv';
 import { useMetadataPref } from '#hooks/useMetadataPref';
@@ -248,56 +248,6 @@ function ServerSyncButton({ style, isMobile = false }: ServerSyncButtonProps) {
         {syncState === 'disabled' ? ` ${t('Disabled')}` : null}
       </Text>
     </Button>
-  );
-}
-
-type SharedArrayBufferWarningProps = {
-  style?: CSSProperties;
-};
-
-function SharedArrayBufferWarning({ style }: SharedArrayBufferWarningProps) {
-  const { t } = useTranslation();
-  const hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
-  const isOverrideEnabled = localStorage.getItem('SharedArrayBufferOverride');
-
-  // Only show warning if SharedArrayBuffer is not supported but user has overridden the warning
-  if (hasSharedArrayBuffer || !isOverrideEnabled) {
-    return null;
-  }
-
-  const warningMessage = t(
-    'Your environment does not support SharedArrayBuffer. You may experience data loss or degraded functionality. Click to learn more.',
-  );
-
-  const handlePress = () => {
-    window.open(
-      'https://actualbudget.org/docs/troubleshooting/shared-array-buffer',
-      '_blank',
-      'noopener,noreferrer',
-    );
-  };
-
-  return (
-    <Tooltip
-      placement="bottom start"
-      content={<Text>{warningMessage}</Text>}
-      style={{
-        ...styles.tooltip,
-        lineHeight: 1.5,
-        padding: '6px 10px',
-        width: '300px',
-      }}
-    >
-      <Button
-        variant="bare"
-        aria-label={warningMessage}
-        style={{ ...style, color: theme.warningText }}
-        onPress={handlePress}
-      >
-        <Trans>Warning</Trans>
-        <SvgAlertTriangle width={13} style={{ marginLeft: '6px' }} />
-      </Button>
-    </Tooltip>
   );
 }
 

--- a/packages/desktop-client/src/components/common/Link.tsx
+++ b/packages/desktop-client/src/components/common/Link.tsx
@@ -47,6 +47,7 @@ type ExternalLinkProps = {
   to?: string;
   linkColor?: keyof typeof externalLinkColors;
   onClick?: MouseEventHandler;
+  styles?: CSSProperties;
 };
 
 const ExternalLink = ({
@@ -54,6 +55,7 @@ const ExternalLink = ({
   to,
   linkColor = 'blue',
   onClick,
+  styles,
 }: ExternalLinkProps) => {
   return (
     // we can't use <ExternalLink /> here for obvious reasons
@@ -61,7 +63,7 @@ const ExternalLink = ({
       href={to ?? ''}
       target="_blank"
       rel="noopener noreferrer"
-      style={{ color: externalLinkColors[linkColor] }}
+      style={{ color: externalLinkColors[linkColor], ...styles }}
       onClick={onClick}
     >
       {children}

--- a/packages/desktop-client/src/components/common/Link.tsx
+++ b/packages/desktop-client/src/components/common/Link.tsx
@@ -47,7 +47,7 @@ type ExternalLinkProps = {
   to?: string;
   linkColor?: keyof typeof externalLinkColors;
   onClick?: MouseEventHandler;
-  styles?: CSSProperties;
+  className?: string;
 };
 
 const ExternalLink = ({
@@ -55,7 +55,7 @@ const ExternalLink = ({
   to,
   linkColor = 'blue',
   onClick,
-  styles,
+  className,
 }: ExternalLinkProps) => {
   return (
     // we can't use <ExternalLink /> here for obvious reasons
@@ -63,7 +63,8 @@ const ExternalLink = ({
       href={to ?? ''}
       target="_blank"
       rel="noopener noreferrer"
-      style={{ color: externalLinkColors[linkColor], ...styles }}
+      style={{ color: externalLinkColors[linkColor] }}
+      className={className}
       onClick={onClick}
     >
       {children}

--- a/upcoming-release-notes/7922.md
+++ b/upcoming-release-notes/7922.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [awaissaeed530]
+---
+
+Display a warning indicator in titlebar when browser does not support SharedArrayBuffer


### PR DESCRIPTION
## Description

Adds a persistent warning indicator in the titlebar when SharedArrayBuffer is not supported but the user has overridden the warning. This addresses the issue where users can circumvent the initial warning and then have no indication they are running in a degraded state.

This is a slightly modified implementation of #7764, which was closed.

## Related issue(s)
Fixes #7747

## Testing
Tested on Firefox by disabling the `javascript.options.shared_memory` flag

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+1.83 kB) | +0.01%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+1.83 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/SharedArrayBufferWarning.tsx` | 🆕 +1.68 kB | 0 B → 1.68 kB
`src/components/common/Link.tsx` | 📈 +67 B (+1.08%) | 6.04 kB → 6.11 kB
`src/components/Titlebar.tsx` | 📈 +81 B (+0.66%) | 11.93 kB → 12.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB → 1.56 MB (+1.76 kB) | +0.11%
static/js/Value.js | 5.08 MB → 5.08 MB (+67 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.26 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.8 kB | 0%
static/js/de.js | 170.65 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.02 kB | 0%
static/js/es.js | 178.21 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/fr.js | 178.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.53 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 147.72 kB | 0%
static/js/nl.js | 106.82 kB | 0%
static/js/pt-BR.js | 187.97 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 208.65 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.84 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->