### PR TITLE
[WIP] fix(desktop): gracefully handle EPERM in listDir on macOS

### DIFF
--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -57,7 +57,8 @@ export const listDir: typeof T.listDir = filepath =>
       if (accessErr && (accessErr as NodeJS.ErrnoException).code === 'EPERM') {
         reject(
           new Error(
-            'Permission denied: unable to access "' + filepath +
+            'Permission denied: unable to access "' +
+              filepath +
               '". Please grant Actual permission to access this folder in System Settings > Privacy & Security > Files and Folders.',
           ),
         );

--- a/packages/loot-core/src/platform/server/fs/index.electron.ts
+++ b/packages/loot-core/src/platform/server/fs/index.electron.ts
@@ -53,12 +53,23 @@ export const basename: typeof T.basename = filepath => path.basename(filepath);
 
 export const listDir: typeof T.listDir = filepath =>
   new Promise((resolve, reject) => {
-    fs.readdir(filepath, (err, files) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(files);
+    fs.access(filepath, fs.constants.F_OK | fs.constants.R_OK, accessErr => {
+      if (accessErr && (accessErr as NodeJS.ErrnoException).code === 'EPERM') {
+        reject(
+          new Error(
+            'Permission denied: unable to access "' + filepath +
+              '". Please grant Actual permission to access this folder in System Settings > Privacy & Security > Files and Folders.',
+          ),
+        );
+        return;
       }
+      fs.readdir(filepath, (err, files) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(files);
+        }
+      });
     });
   });
 


### PR DESCRIPTION
On macOS, if the user denies directory permissions (e.g. Documents folder), fs.readdir() fails with EPERM,
causing the app to crash on launch.

Add a pre-check with fs.access() before readdir. If the error is EPERM, reject with a user-friendly message pointing to System Settings > Privacy & Security.

Fixes #7824

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

### Problem

On **macOS**, when the user denies directory permissions (e.g. the **Documents** folder), `fs.readdir()` fails with:

```
EPERM: operation not permitted, scandir '/Users/userdir/Documents/Actual'
```

**Reproduction steps:**
1. Wait for the **permission prompt** to appear on macOS.
2. **Deny** the permission.
3. Fully close the app, then re-open it.
4. The app can no longer open the budget file and crashes on launch.

The error is thrown in `listDir()` (`packages/loot-core/src/platform/server/fs/index.electron.ts`), which is called during budget loading before any user interaction.

### Solution

Add a **pre-check with `fs.access()`** before calling `fs.readdir()`:

```ts
export const listDir: typeof T.listDir = filepath =>
  new Promise((resolve, reject) => {
    fs.access(filepath, fs.constants.F_OK | fs.constants.R_OK, accessErr => {
      if (accessErr && (accessErr as NodeJS.ErrnoException).code === 'EPERM') {
        reject(
          new Error(
            'Permission denied: unable to access "' + filepath +
              '". Please grant Actual permission to access this folder in System Settings > Privacy & Security > Files and Folders.',
          ),
        );
        return;
      }
      fs.readdir(filepath, (err, files) => {
        if (err) {
          reject(err);
        } else {
          resolve(files);
        }
      });
    });
  });
```

If the error is `EPERM`, the user sees a **clear actionable message** instead of an unhandled crash.

### Impact

- ✅ App no longer crashes silently — user gets a clear permission hint
- ✅ No behavior change when permissions are granted (happy path unchanged)
- ✅ Only affects the Electron desktop app (`index.electron.ts`)
- ✅ Error message points to the exact macOS settings path

### Verification

```bash
# Simulate EPERM (macOS only)
# 1. Open Actual > trigger permission prompt > Deny
# 2. Re-open Actual
# Expected: error message with "System Settings > Privacy & Security" 
# (instead of silent crash)
```

Fixes #7824


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 14.01 MB | 0%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 14.01 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.02 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/chart-theme.js | 800.6 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.58 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.86 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 4.96 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cn6Jnyv4.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->