### PR TITLE
add back missing footnote

### DIFF
--- a/packages/docs/docs/getting-started/envelope-budgeting.md
+++ b/packages/docs/docs/getting-started/envelope-budgeting.md
@@ -402,3 +402,5 @@ Let's track the expenses in Week 4 and calculate the available amounts for next 
   deficit and need to cover it from other categories.
 
 The rest we put into our Savings category.
+
+[^1]: Another name for this type of budgeting is Zero-Based Budgeting.


### PR DESCRIPTION
This used to be around https://github.com/actualbudget/actual/blob/b704fbbf7c5c847d6b9f2ffa7a70bb26b13f4e1d/docs/getting-started/envelope-budgeting.md?plain=1#L445 but lost in subsequent commits.