### PR TITLE
[AI] Move UserDirectoryPage to admin directory

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -22,6 +22,7 @@ import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch, useSelector } from '#redux';
 
 import { UserAccessPage } from './admin/UserAccess/UserAccessPage';
+import { UserDirectoryPage } from './admin/UserDirectory/UserDirectoryPage';
 import { BankSyncStatus } from './BankSyncStatus';
 import { CommandBar } from './CommandBar';
 import { EnableBankingCallback } from './EnableBankingCallback';
@@ -35,7 +36,6 @@ import { MobilePageHeaderProvider, MobilePageHeaderSlot } from './Page';
 import { Reports } from './reports';
 import { LoadingIndicator } from './reports/LoadingIndicator';
 import { NarrowAlternate, WideComponent } from './responsive';
-import { UserDirectoryPage } from './responsive/wide';
 import { useMultiuserEnabled } from './ServerContext';
 import { Settings } from './settings';
 import { FloatableSidebar } from './sidebar';

--- a/upcoming-release-notes/7951.md
+++ b/upcoming-release-notes/7951.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Fix ineffective dynamic import warning for `responsive/wide` by removing the static barrel import from `FinancesApp`.


### PR DESCRIPTION
## Description

Fix a build warning

```
[INEFFECTIVE_DYNAMIC_IMPORT] Warning: src/components/responsive/wide.ts is dynamically imported by src/components/responsive/index.tsx but also statically imported by src/components/FinancesApp.tsx, dynamic import will not move module into another chunk.
```

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A

## Testing

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_015FCdAKB5tbwvugx212fs2Q

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 → 37 | 14.02 MB → 14.02 MB (-35 B) | -0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 → 37 | 14.02 MB → 14.02 MB (-35 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/react-is/cjs/react-is.production.min.js` | 📈 +1.33 kB (+319.76%) | 425 B → 1.74 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/async.ts` | 📈 +132 B (+50.38%) | 262 B → 394 B
`node_modules/react-dnd/dist/hooks/useIsomorphicLayoutEffect.js` | 📈 +82 B (+38.50%) | 213 B → 295 B
`src/components/filters/ConditionsOpMenu.tsx` | 📈 +165 B (+19.57%) | 843 B → 1008 B
`node_modules/react-dnd-html5-backend/dist/utils/js_utils.js` | 📈 +96 B (+15.76%) | 609 B → 705 B
`src/components/payees/PayeeRuleCountLabel.tsx` | 📈 +106 B (+11.41%) | 929 B → 1.01 kB
`node_modules/react-dnd/dist/core/DndProvider.js` | 📈 +112 B (+4.84%) | 2.26 kB → 2.37 kB
`src/hooks/usePreviewTransactions.ts` | 📈 +61 B (+2.50%) | 2.38 kB → 2.44 kB
`src/components/budget/MonthPicker.tsx` | 📈 +165 B (+1.91%) | 8.43 kB → 8.59 kB
`src/components/budget/goals/editor/CleanupGroupPicker.tsx` | 📈 +67 B (+1.16%) | 5.66 kB → 5.72 kB
`node_modules/es-toolkit/dist/compat/util/toString.js` | 📈 +2 B (+0.36%) | 552 B → 554 B
`src/hooks/useCleanupGroups.ts` | 📈 +2 B (+0.25%) | 809 B → 811 B
`src/hooks/useCategoryCleanup.ts` | 📈 +2 B (+0.21%) | 965 B → 967 B
`node_modules/es-toolkit/dist/compat/util/toPath.js` | 📈 +2 B (+0.14%) | 1.41 kB → 1.41 kB
`src/index.tsx` | 📈 +2 B (+0.11%) | 1.71 kB → 1.71 kB
`src/components/schedules/ScheduleLink.tsx` | 📈 +4 B (+0.09%) | 4.42 kB → 4.43 kB
`src/components/modals/TrackingBalanceMenuModal.tsx` | 📈 +2 B (+0.07%) | 2.71 kB → 2.71 kB
`src/components/modals/ScheduledTransactionMenuModal.tsx` | 📈 +4 B (+0.07%) | 6.01 kB → 6.01 kB
`src/components/modals/TrackingBudgetMonthMenuModal.tsx` | 📈 +4 B (+0.06%) | 6.48 kB → 6.48 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +24 B (+0.06%) | 42.51 kB → 42.53 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📈 +2 B (+0.04%) | 4.82 kB → 4.82 kB
`src/components/schedules/ScheduleEditModal.tsx` | 📈 +2 B (+0.04%) | 5.33 kB → 5.33 kB
`src/components/modals/TrackingBudgetMenuModal.tsx` | 📈 +2 B (+0.03%) | 6.5 kB → 6.5 kB
`src/components/schedules/DiscoverSchedules.tsx` | 📈 +2 B (+0.02%) | 9.31 kB → 9.31 kB
`src/components/FinancesApp.tsx` | 📉 -2 B (-0.01%) | 19.02 kB → 19.02 kB
`src/components/Notifications.tsx` | 📉 -2 B (-0.01%) | 14.79 kB → 14.78 kB
`src/components/budget/index.tsx` | 📉 -2 B (-0.02%) | 11.54 kB → 11.54 kB
`src/components/settings/ThemeInstaller.tsx` | 📉 -2 B (-0.02%) | 10.97 kB → 10.97 kB
`src/components/modals/CategoryGroupMenuModal.tsx` | 📉 -2 B (-0.02%) | 10.55 kB → 10.55 kB
`src/components/budget/tracking/budgetsummary/BudgetSummary.tsx` | 📉 -2 B (-0.02%) | 10.45 kB → 10.45 kB
`src/components/CommandBar.tsx` | 📉 -2 B (-0.02%) | 10.16 kB → 10.16 kB
`src/components/admin/UserAccess/UserAccess.tsx` | 📉 -2 B (-0.02%) | 9.98 kB → 9.98 kB
`src/components/budget/SidebarGroup.tsx` | 📉 -2 B (-0.02%) | 9.11 kB → 9.11 kB
`src/components/accounts/Reconcile.tsx` | 📉 -2 B (-0.02%) | 9.11 kB → 9.11 kB
`src/components/App.tsx` | 📉 -2 B (-0.02%) | 8.28 kB → 8.28 kB
`src/components/modals/EditFieldModal.tsx` | 📉 -2 B (-0.02%) | 8.25 kB → 8.24 kB
`src/components/tags/ManageTags.tsx` | 📉 -2 B (-0.03%) | 7.48 kB → 7.48 kB
`src/components/budget/BudgetTotals.tsx` | 📉 -2 B (-0.03%) | 7.38 kB → 7.38 kB
`src/components/accounts/Account.tsx` | 📉 -12 B (-0.03%) | 44.1 kB → 44.09 kB
`src/components/banksync/BuiltInProviders.tsx` | 📉 -2 B (-0.03%) | 6.53 kB → 6.53 kB
`src/components/modals/EnvelopeBudgetMenuModal.tsx` | 📉 -2 B (-0.03%) | 6.4 kB → 6.39 kB
`src/components/modals/ImportTransactionsModal/utils.ts` | 📉 -2 B (-0.04%) | 5.35 kB → 5.35 kB
`src/components/accounts/Balance.tsx` | 📉 -4 B (-0.04%) | 10.15 kB → 10.14 kB
`src/components/budget/BudgetTable.tsx` | 📉 -4 B (-0.04%) | 9.9 kB → 9.89 kB
`src/components/budget/tracking/budgetsummary/Saved.tsx` | 📉 -2 B (-0.04%) | 4.77 kB → 4.77 kB
`src/components/sidebar/Sidebar.tsx` | 📉 -2 B (-0.04%) | 4.76 kB → 4.76 kB
`src/components/sort.tsx` | 📉 -2 B (-0.04%) | 4.45 kB → 4.45 kB
`src/components/banksync/AccountRow.tsx` | 📉 -2 B (-0.04%) | 4.44 kB → 4.44 kB
`src/components/filters/FiltersMenu.tsx` | 📉 -10 B (-0.05%) | 21.67 kB → 21.67 kB
`src/components/budget/BudgetCategories.tsx` | 📉 -6 B (-0.05%) | 12.01 kB → 12.01 kB
`src/components/accounts/Header.tsx` | 📉 -14 B (-0.05%) | 28.01 kB → 28 kB
`src/components/settings/Export.tsx` | 📉 -2 B (-0.06%) | 3.49 kB → 3.48 kB
`src/components/schedules/index.tsx` | 📉 -4 B (-0.06%) | 6.35 kB → 6.34 kB
`node_modules/lodash/_equalByTag.js` | 📉 -2 B (-0.06%) | 3.11 kB → 3.11 kB
`src/components/modals/EnvelopeBalanceMenuModal.tsx` | 📉 -2 B (-0.07%) | 2.89 kB → 2.88 kB
`node_modules/lodash/_baseIsEqualDeep.js` | 📉 -2 B (-0.07%) | 2.87 kB → 2.87 kB
`src/components/payees/PayeeTable.tsx` | 📉 -2 B (-0.07%) | 2.82 kB → 2.82 kB
`src/components/admin/UserDirectory/UserDirectory.tsx` | 📉 -10 B (-0.07%) | 13.34 kB → 13.33 kB
`src/components/budget/tracking/budgetsummary/BudgetTotal.tsx` | 📉 -2 B (-0.07%) | 2.66 kB → 2.66 kB
`src/components/schedules/SchedulesTable.tsx` | 📉 -16 B (-0.08%) | 18.43 kB → 18.42 kB
`src/components/budget/BudgetSummaries.tsx` | 📉 -4 B (-0.09%) | 4.44 kB → 4.44 kB
`src/browser-preload.js` | 📉 -10 B (-0.10%) | 9.7 kB → 9.69 kB
`src/components/filters/FilterExpression.tsx` | 📉 -6 B (-0.10%) | 5.73 kB → 5.72 kB
`src/components/budget/DynamicBudgetTable.tsx` | 📉 -8 B (-0.11%) | 7.34 kB → 7.33 kB
`node_modules/lodash/_baseIsNative.js` | 📉 -2 B (-0.13%) | 1.48 kB → 1.48 kB
`src/components/accounts/BalanceHistoryGraph.tsx` | 📉 -14 B (-0.15%) | 9.4 kB → 9.38 kB
`src/components/banksync/index.tsx` | 📉 -8 B (-0.15%) | 5.25 kB → 5.24 kB
`src/components/budget/tracking/TrackingBudgetComponents.tsx` | 📉 -30 B (-0.15%) | 19.17 kB → 19.14 kB
`src/hooks/useThemeCatalog.ts` | 📉 -2 B (-0.17%) | 1.15 kB → 1.15 kB
`node_modules/lodash/_baseIsEqual.js` | 📉 -2 B (-0.17%) | 1.12 kB → 1.11 kB
`node_modules/lodash/_baseIsTypedArray.js` | 📉 -4 B (-0.18%) | 2.23 kB → 2.23 kB
`src/components/transactions/SelectedTransactionsButton.tsx` | 📉 -32 B (-0.18%) | 17.67 kB → 17.63 kB
`src/hooks/useTransactionBatchActions.ts` | 📉 -16 B (-0.18%) | 8.69 kB → 8.67 kB
`src/components/payees/ManagePayees.tsx` | 📉 -30 B (-0.19%) | 15.15 kB → 15.12 kB
`node_modules/lodash/keys.js` | 📉 -2 B (-0.20%) | 1007 B → 1005 B
`src/components/modals/EnvelopeBudgetSummaryModal.tsx` | 📉 -12 B (-0.21%) | 5.69 kB → 5.68 kB
`node_modules/lodash/isFunction.js` | 📉 -2 B (-0.21%) | 958 B → 956 B
`node_modules/lodash/isLength.js` | 📉 -2 B (-0.21%) | 947 B → 945 B
`node_modules/lodash/eq.js` | 📉 -2 B (-0.21%) | 933 B → 931 B
`node_modules/lodash/isTypedArray.js` | 📉 -2 B (-0.25%) | 800 B → 798 B
`src/components/ManageRulesPage.tsx` | 📉 -2 B (-0.26%) | 763 B → 761 B
`node_modules/lodash/toString.js` | 📉 -2 B (-0.28%) | 725 B → 723 B
`node_modules/lodash/_arrayLikeKeys.js` | 📉 -4 B (-0.28%) | 1.4 kB → 1.4 kB
`node_modules/lodash/_baseIsArguments.js` | 📉 -2 B (-0.31%) | 643 B → 641 B
`node_modules/react-dnd/dist/hooks/useDrag/useRegisteredDragSource.js` | 📉 -2 B (-0.31%) | 637 B → 635 B
`node_modules/react-dnd/dist/hooks/useDrop/useRegisteredDropTarget.js` | 📉 -2 B (-0.32%) | 628 B → 626 B
`node_modules/react-dnd/dist/internals/wrapConnectorHooks.js` | 📉 -6 B (-0.32%) | 1.82 kB → 1.81 kB
`node_modules/lodash/_assocIndexOf.js` | 📉 -2 B (-0.32%) | 618 B → 616 B
`src/components/DevelopmentTopBar.tsx` | 📉 -4 B (-0.33%) | 1.2 kB → 1.19 kB
`node_modules/lodash/isArguments.js` | 📉 -4 B (-0.34%) | 1.15 kB → 1.14 kB
`node_modules/react-dnd/dist/hooks/useMonitorOutput.js` | 📉 -2 B (-0.39%) | 511 B → 509 B
`node_modules/lodash/isArrayLike.js` | 📉 -4 B (-0.41%) | 976 B → 972 B
`node_modules/react-dnd/dist/hooks/useDrop/useDropTargetConnector.js` | 📉 -2 B (-0.41%) | 482 B → 480 B
`node_modules/react-dnd/dist/hooks/useDrag/useDragSourceConnector.js` | 📉 -4 B (-0.53%) | 754 B → 750 B
`src/auth/AuthProvider.tsx` | 📉 -40 B (-2.81%) | 1.39 kB → 1.35 kB
`node_modules/react-dnd/dist/hooks/useCollector.js` | 📉 -86 B (-10.46%) | 822 B → 736 B
`node_modules/react-is/index.js` | 📉 -23 B (-10.55%) | 218 B → 195 B
`node_modules/immer/dist/immer.mjs` | 📉 -3.5 kB (-16.73%) | 20.94 kB → 17.44 kB
`src/components/util/accountValidation.ts` | 📉 -132 B (-23.16%) | 570 B → 438 B
`src/components/responsive/wide.ts` | 🔥 -453 B (-100%) | 453 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 0 B → 5.07 MB (+5.07 MB) | -
static/js/toString.js | 0 B → 705.14 kB (+705.14 kB) | -
static/js/SchedulesTable.js | 0 B → 202.7 kB (+202.7 kB) | -
static/js/_baseIsEqual.js | 0 B → 98.02 kB (+98.02 kB) | -
static/js/ManageRules.js | 0 B → 46.98 kB (+46.98 kB) | -
static/js/useTransactionBatchActions.js | 0 B → 9.71 kB (+9.71 kB) | -
static/js/PayeeRuleCountLabel.js | 0 B → 7.33 kB (+7.33 kB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/merge.js | 5.08 MB → 0 B (-5.08 MB) | -100%
static/js/chart-theme.js | 803.05 kB → 0 B (-803.05 kB) | -100%
static/js/bankSyncUtils.js | 54.15 kB → 0 B (-54.15 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 453 B → 296.1 kB (+295.66 kB) | +66834.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.03 MB → 1.54 MB (-498.65 kB) | -24.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.86 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DmTjMQ8O.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->