### PR TITLE
[AI] Fix split double-counting in balance forecast

### DIFF
--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -341,6 +341,50 @@ describe('forecast app', () => {
     expect(balanceByDate['2024-03-31']).toBe(-25);
   });
 
+  it('does not double-count split parents in posted transaction balances', async () => {
+    const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
+
+    const parentId = await db.insertTransaction({
+      id: 'split-parent',
+      account: accountId,
+      amount: 100,
+      date: '2024-03-10',
+      is_parent: true,
+      category: null,
+    });
+
+    await db.insertTransaction({
+      id: 'split-child-1',
+      account: accountId,
+      amount: 60,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+    await db.insertTransaction({
+      id: 'split-child-2',
+      account: accountId,
+      amount: 40,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+
+    const result = await generateForecast({
+      accountIds: [accountId],
+      startDate: '2024-03-01',
+      endDate: '2024-03-31',
+    });
+
+    const balanceByDate = Object.fromEntries(
+      result.dataPoints.map(({ date, balance }) => [date, balance]),
+    );
+
+    expect(balanceByDate['2024-03-09']).toBe(0);
+    expect(balanceByDate['2024-03-10']).toBe(100);
+    expect(balanceByDate['2024-03-31']).toBe(100);
+  });
+
   it('filters future schedule occurrences using rule-derived fields like category', async () => {
     const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
     const groupId = await db.insertCategoryGroup({ name: 'Bills' });

--- a/packages/loot-core/src/server/forecast/forecast-filters.ts
+++ b/packages/loot-core/src/server/forecast/forecast-filters.ts
@@ -1,7 +1,6 @@
 import { aqlQuery } from '#server/aql';
 import { conditionsToAQL } from '#server/transactions/transaction-rules';
 import { q } from '#shared/query';
-import { ungroupTransactions } from '#shared/transactions';
 import type { RuleConditionEntity, TransactionEntity } from '#types/models';
 
 import { getAccountRestrictionMode } from './forecast-accounts';
@@ -81,7 +80,7 @@ export async function getTransactions(
   let query = q('transactions')
     .filter({ tombstone: false })
     .select('*')
-    .options({ splits: 'grouped' });
+    .options({ splits: 'inline' });
 
   if (accountIds !== undefined) {
     if (accountIds.length === 0) {
@@ -96,7 +95,7 @@ export async function getTransactions(
   }
 
   const { data } = await aqlQuery(query);
-  return ungroupTransactions(data);
+  return data;
 }
 
 function escapeRegex(value: string) {

--- a/upcoming-release-notes/7955.md
+++ b/upcoming-release-notes/7955.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Fix Balance Forecast double-counting posted split transactions.


### PR DESCRIPTION
## Description

Fix a Balance Forecast bug where posted split transactions were counted twice in historical running balances. The forecast query was loading grouped splits and then flattening them, which let both the parent transaction amount and child split amounts flow into the running balance calculation.

This change switches the forecast posted-transaction query to inline splits, which matches how the projection code consumes historical transactions. It also adds a regression test that reproduces the bug with a split parent and two child rows.

## Related issue(s)

- Relates to #7669
- Fixes the split double-counting bug reported in https://github.com/actualbudget/actual/issues/7669#issuecomment-4537773045

## Testing

- yarn workspace @actual-app/core run vitest src/server/forecast/app.test.ts
- yarn workspace @actual-app/core run vitest src/server/forecast/forecast-filters.test.ts src/server/forecast/forecast-projection.test.ts

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 33 | 14.02 MB | 0%
loot-core | 1 | 5.34 MB → 5.34 MB (-22 B) | -0.00%
api | 2 | 3.96 MB → 3.96 MB (-22 B) | -0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
33 | 14.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 2.03 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/bankSyncUtils.js | 54.15 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/chart-theme.js | 803.05 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 197.86 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/merge.js | 5.08 MB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/wide.js | 453 B | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (-22 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-filters.ts` | 📉 -22 B (-0.27%) | 7.84 kB → 7.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BYZy5hD3.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DmTjMQ8O.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.96 MB (-22 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-filters.ts` | 📉 -22 B (-0.28%) | 7.73 kB → 7.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.96 MB (-22 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->