### PR TITLE
[release cherry-pick]: #7955 balance forecast fix

### DIFF
--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -341,6 +341,50 @@ describe('forecast app', () => {
     expect(balanceByDate['2024-03-31']).toBe(-25);
   });
 
+  it('does not double-count split parents in posted transaction balances', async () => {
+    const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
+
+    const parentId = await db.insertTransaction({
+      id: 'split-parent',
+      account: accountId,
+      amount: 100,
+      date: '2024-03-10',
+      is_parent: true,
+      category: null,
+    });
+
+    await db.insertTransaction({
+      id: 'split-child-1',
+      account: accountId,
+      amount: 60,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+    await db.insertTransaction({
+      id: 'split-child-2',
+      account: accountId,
+      amount: 40,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+
+    const result = await generateForecast({
+      accountIds: [accountId],
+      startDate: '2024-03-01',
+      endDate: '2024-03-31',
+    });
+
+    const balanceByDate = Object.fromEntries(
+      result.dataPoints.map(({ date, balance }) => [date, balance]),
+    );
+
+    expect(balanceByDate['2024-03-09']).toBe(0);
+    expect(balanceByDate['2024-03-10']).toBe(100);
+    expect(balanceByDate['2024-03-31']).toBe(100);
+  });
+
   it('filters future schedule occurrences using rule-derived fields like category', async () => {
     const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
     const groupId = await db.insertCategoryGroup({ name: 'Bills' });

--- a/packages/loot-core/src/server/forecast/forecast-filters.ts
+++ b/packages/loot-core/src/server/forecast/forecast-filters.ts
@@ -1,7 +1,6 @@
 import { aqlQuery } from '#server/aql';
 import { conditionsToAQL } from '#server/transactions/transaction-rules';
 import { q } from '#shared/query';
-import { ungroupTransactions } from '#shared/transactions';
 import type { RuleConditionEntity, TransactionEntity } from '#types/models';
 
 import { getAccountRestrictionMode } from './forecast-accounts';
@@ -81,7 +80,7 @@ export async function getTransactions(
   let query = q('transactions')
     .filter({ tombstone: false })
     .select('*')
-    .options({ splits: 'grouped' });
+    .options({ splits: 'inline' });
 
   if (accountIds !== undefined) {
     if (accountIds.length === 0) {
@@ -96,7 +95,7 @@ export async function getTransactions(
   }
 
   const { data } = await aqlQuery(query);
-  return ungroupTransactions(data);
+  return data;
 }
 
 function escapeRegex(value: string) {

--- a/upcoming-release-notes/7955.md
+++ b/upcoming-release-notes/7955.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Fix Balance Forecast double-counting posted split transactions.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

https://github.com/actualbudget/actual/pull/7955

Fixes double counting of split transactions, making the report unusable for people who use them

<!--- actual-bot-sections --->
