### PR TITLE
:iphone: Fallback to direct worker on ios

### DIFF
--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -260,9 +260,14 @@ function createBackendWorker() {
   // Each budget gets its own leader tab running a dedicated Worker. All other
   // tabs on the same budget are followers — their messages are routed through
   // the SharedWorker to the leader's Worker.
-  // The SharedWorker never touches SharedArrayBuffer, so this works on all
-  // platforms including iOS/Safari.
-  if (typeof SharedWorker !== 'undefined' && !Platform.isPlaywright) {
+  // iOS is excluded: navigation to an OIDC provider and back creates a new
+  // SharedWorker port connection, leaving the returning tab stuck as UNASSIGNED
+  // with no backend Worker. The direct Worker fallback avoids this entirely.
+  if (
+    typeof SharedWorker !== 'undefined' &&
+    !Platform.isPlaywright &&
+    !Platform.isIOS
+  ) {
     try {
       const sharedWorker = new SharedBrowserServerWorker({
         name: 'actual-backend',
@@ -303,8 +308,12 @@ function createBackendWorker() {
     }
   }
 
-  // Fallback: regular Worker (Playwright, no SharedWorker support, or failure)
-  console.log('[WorkerBridge] No SharedWorker available, using direct Worker');
+  // Fallback: regular Worker (Playwright, iOS, no SharedWorker support, or failure)
+  console.log(
+    Platform.isIOS
+      ? '[WorkerBridge] iOS detected, using direct Worker'
+      : '[WorkerBridge] No SharedWorker available, using direct Worker',
+  );
   worker = new Worker(backendWorkerUrl);
   initSQLBackend(worker);
 

--- a/packages/loot-core/src/shared/platform.electron.ts
+++ b/packages/loot-core/src/shared/platform.electron.ts
@@ -19,3 +19,4 @@ export const env: typeof T.env = 'unknown';
 export const isBrowser: typeof T.isBrowser = false;
 
 export const isIOSAgent: typeof T.isIOSAgent = false;
+export const isIOS: typeof T.isIOS = false;

--- a/packages/loot-core/src/shared/platform.ts
+++ b/packages/loot-core/src/shared/platform.ts
@@ -18,3 +18,5 @@ export const isBrowser: boolean = true;
 
 const agent = UAParser(navigator.userAgent);
 export const isIOSAgent = agent.browser.name === 'Mobile Safari';
+// True for all browsers on iOS (iPhone/iPad/iPod) — not macOS.
+export const isIOS = agent.os.name === 'iOS';

--- a/upcoming-release-notes/7971.md
+++ b/upcoming-release-notes/7971.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [MikesGlitch]
 ---
 
-Fix OIDC login on IOS
+Fix OIDC login on iOS

--- a/upcoming-release-notes/7971.md
+++ b/upcoming-release-notes/7971.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MikesGlitch]
+---
+
+Fix OIDC login on IOS


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Turning off the shared worker for IOS. IOS has functionality that aggressively suspends background tabs, which we've worked around in the past with polling/re-electing leader tabs, but I think it makes more sense to just turn off.

This should hopefully fix the OIDC issue that only affects IOS devices. 

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

#7754
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Verified the fix by running electron server and connecting via browserstack: 

<img width="1282" height="814" alt="record-2026-05-28_20-23-56" src="https://github.com/user-attachments/assets/bccdbbbc-29e2-49a2-81df-87294c67c6aa" />


<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.02 MB → 14.02 MB (+108 B) | +0.00%
loot-core | 1 | 5.34 MB → 5.34 MB (+549 B) | +0.01%
api | 2 | 3.96 MB → 3.96 MB (+534 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.02 MB → 14.02 MB (+108 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +37 B (+7.60%) | 487 B → 524 B
`src/browser-preload.js` | 📈 +71 B (+0.72%) | 9.69 kB → 9.76 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB → 1.54 MB (+71 B) | +0.00%
static/js/extends.js | 500.57 kB → 500.6 kB (+37 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.07 MB | 0%
static/js/_baseIsEqual.js | 98.02 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.13 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.38 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 296.1 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+549 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +38 B (+9.13%) | 416 B → 454 B
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +511 B (+4.17%) | 11.96 kB → 12.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CjAQSXvs.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BYZy5hD3.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.96 MB (+534 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +37 B (+9.54%) | 388 B → 425 B
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +497 B (+4.15%) | 11.71 kB → 12.19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.96 MB (+534 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->