### PR TITLE
iOS OIDC stale leader fix

### DIFF
--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -53,6 +53,10 @@ class WorkerBridge {
     this._isInitialized = false;
     this._currentBudgetId = null;
     this._wasHidden = document.visibilityState === 'hidden';
+    // Messages that arrive via __to-worker while localBackendWorker is not yet
+    // ready (e.g. during the UNASSIGNED→LEADER transition on a fresh iOS
+    // session) are buffered here and flushed once the new backend connects.
+    this._pendingToWorkerMsgs = [];
 
     this._onVisibilityChange = () => {
       if (document.visibilityState === 'hidden') {
@@ -119,6 +123,11 @@ class WorkerBridge {
     if (msg && msg.type === '__to-worker') {
       if (localBackendWorker) {
         localBackendWorker.postMessage(msg.msg);
+      } else {
+        // localBackendWorker is not yet created — this tab is transitioning from
+        // follower/unassigned to leader.  Buffer the message so it isn't lost;
+        // it will be replayed once the new backend Worker sends 'connect'.
+        this._pendingToWorkerMsgs.push(msg.msg);
       }
       return;
     }
@@ -190,6 +199,9 @@ class WorkerBridge {
 
     if (role !== 'LEADER') {
       terminateLocalBackendWorker();
+      // Discard any buffered __to-worker messages that arrived while we were
+      // transitioning to leader; they belong to a context we no longer own.
+      this._pendingToWorkerMsgs.splice(0);
     }
   }
 
@@ -246,6 +258,14 @@ class WorkerBridge {
           const toSend = pendingMsg;
           pendingMsg = null;
           localBackendWorker.postMessage(toSend);
+        }
+        // Flush any messages that were buffered while this tab was waiting
+        // to become leader (e.g. during the UNASSIGNED→LEADER transition).
+        if (this._pendingToWorkerMsgs.length > 0) {
+          const buffered = this._pendingToWorkerMsgs.splice(0);
+          for (const bufferedMsg of buffered) {
+            localBackendWorker.postMessage(bufferedMsg);
+          }
         }
       }
       sharedPort.postMessage({ type: '__from-worker', msg: workerMsg });

--- a/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
+++ b/packages/desktop-client/src/components/manager/subscribe/OpenIdCallback.ts
@@ -12,6 +12,6 @@ export function OpenIdCallback() {
     void send('subscribe-set-token', { token: token as string }).then(() => {
       void dispatch(loggedIn());
     });
-  });
+  }, [dispatch]);
   return null;
 }

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -1309,7 +1309,10 @@ describe('SharedWorker coordinator', () => {
       expect(callbackTab.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({
           type: '__to-worker',
-          msg: expect.objectContaining({ id: 'req-1', name: 'load-global-prefs' }),
+          msg: expect.objectContaining({
+            id: 'req-1',
+            name: 'load-global-prefs',
+          }),
         }),
       );
 

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -1245,5 +1245,83 @@ describe('SharedWorker coordinator', () => {
         coordinator.getState().budgetGroups.get('__lobby')!.leaderPort,
       ).toBe(callbackTab);
     });
+    it('replays in-flight requests to the new backend when the stale leader dies mid-request', () => {
+      // Stale leader from a previous navigation still holds the __lobby group
+      // with a connected backend.
+      const staleLeader = connectTab(coordinator);
+      sendInit(staleLeader);
+      simulateWorkerConnect(staleLeader);
+      // staleLeader is now LEADER with backendConnected = true
+
+      // OIDC callback page connects while the stale leader is still alive.
+      // It is assigned UNASSIGNED + connect (existing backend).
+      const callbackTab = connectTab(coordinator);
+      sendInit(callbackTab);
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: '__role-change', role: 'UNASSIGNED' }),
+      );
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'connect' }),
+      );
+      callbackTab.postMessage.mockClear();
+
+      // The app on callbackTab has resolved initConnection() and now sends
+      // load-global-prefs.  The SharedWorker routes it as __to-worker to
+      // staleLeader (the only group with backendConnected = true).
+      sendMsg(callbackTab, {
+        type: 'load-global-prefs',
+        id: 'req-1',
+        name: 'load-global-prefs',
+        args: {},
+      });
+
+      // Confirm the request was forwarded to staleLeader
+      expect(staleLeader.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__to-worker',
+          msg: expect.objectContaining({ id: 'req-1' }),
+        }),
+      );
+      staleLeader.postMessage.mockClear();
+
+      // Stale leader closes before the Worker replies — the in-flight request
+      // is lost unless we recover it.
+      sendMsg(staleLeader, { type: 'tab-closing' });
+
+      // callbackTab must be promoted to lobby leader.
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'LEADER',
+          budgetId: '__lobby',
+        }),
+      );
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: '__become-leader' }),
+      );
+      callbackTab.postMessage.mockClear();
+
+      // New backend on callbackTab boots up and sends connect.
+      simulateWorkerConnect(callbackTab);
+
+      // The SharedWorker must re-route the recovered request as __to-worker
+      // so the new backend can process it.
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__to-worker',
+          msg: expect.objectContaining({ id: 'req-1', name: 'load-global-prefs' }),
+        }),
+      );
+
+      // When the new backend replies, the SharedWorker must route the reply
+      // back to callbackTab (the original requester).
+      sendMsg(callbackTab, {
+        type: '__from-worker',
+        msg: { type: 'reply', id: 'req-1', result: { darkMode: false } },
+      });
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'reply', id: 'req-1' }),
+      );
+    });
   });
 });

--- a/packages/desktop-client/src/shared-browser-server-core.test.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.test.ts
@@ -1134,4 +1134,116 @@ describe('SharedWorker coordinator', () => {
       expect(coordinator.getState().budgetGroups.has('budget-1')).toBe(false);
     });
   });
+
+  // ── iOS Safari / stale-leader race condition ────────────────────────
+  // On iOS, beforeunload is unreliable so the old leader tab may stay
+  // connected to the SharedWorker while the new OIDC-callback tab connects.
+  // The new tab becomes UNASSIGNED (a lobby group already exists).  When the
+  // stale leader is eventually cleaned up (heartbeat or explicit tab-closing),
+  // the coordinator must promote the waiting UNASSIGNED tab to lobby leader so
+  // that it can connect a backend and complete the token write.
+
+  describe('iOS Safari stale-leader promotion', () => {
+    it('promotes an unassigned tab to lobby leader when the stale lobby leader closes', () => {
+      // Stale leader from previous navigation
+      const staleLeader = connectTab(coordinator);
+      sendInit(staleLeader);
+      // staleLeader is elected lobby leader
+
+      // New tab (OIDC callback page) connects while stale lobby is still alive
+      const callbackTab = connectTab(coordinator);
+      sendInit(callbackTab);
+      // callbackTab should be UNASSIGNED because __lobby already exists
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ type: '__role-change', role: 'UNASSIGNED' }),
+      );
+      callbackTab.postMessage.mockClear();
+
+      // Stale leader closes (without beforeunload on iOS this happens via
+      // heartbeat timeout, but can also happen via explicit tab-closing)
+      sendMsg(staleLeader, { type: 'tab-closing' });
+
+      // callbackTab must be promoted to lobby leader so it can boot a backend
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'LEADER',
+          budgetId: '__lobby',
+        }),
+      );
+      const state = coordinator.getState();
+      expect(state.budgetGroups.has('__lobby')).toBe(true);
+      expect(state.budgetGroups.get('__lobby')!.leaderPort).toBe(callbackTab);
+      expect(state.unassignedPorts.has(callbackTab)).toBe(false);
+    });
+
+    it('promotes an unassigned tab via heartbeat when the stale leader stops responding', () => {
+      const staleLeader = connectTab(coordinator);
+      sendInit(staleLeader);
+
+      const callbackTab = connectTab(coordinator);
+      sendInit(callbackTab);
+      callbackTab.postMessage.mockClear();
+
+      // First heartbeat: both ports are pinged
+      vi.advanceTimersByTime(10_000);
+      // Only callbackTab responds
+      sendMsg(callbackTab, { type: '__heartbeat-pong' });
+      // Second heartbeat: staleLeader has not ponged, so it is evicted
+      vi.advanceTimersByTime(10_000);
+
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'LEADER',
+          budgetId: '__lobby',
+        }),
+      );
+      expect(
+        coordinator.getState().budgetGroups.get('__lobby')!.leaderPort,
+      ).toBe(callbackTab);
+    });
+
+    it('promotes an unassigned tab to lobby leader when it resumes with no groups remaining', () => {
+      const staleLeader = connectTab(coordinator);
+      sendInit(staleLeader);
+
+      const callbackTab = connectTab(coordinator);
+      sendInit(callbackTab);
+      // callbackTab is UNASSIGNED
+      callbackTab.postMessage.mockClear();
+
+      // Stale leader closes
+      sendMsg(staleLeader, { type: 'tab-closing' });
+      // At this point callbackTab is promoted via removePort — reset mock
+      callbackTab.postMessage.mockClear();
+
+      // Simulate the tab becoming visible again (triggers __resume-tab).
+      // Even though it was already promoted by removePort, the resume path
+      // must not regress: if somehow the tab is still UNASSIGNED and there
+      // are no groups (e.g. a slightly different ordering), resume should
+      // also trigger promotion.
+      //
+      // To test the resumePort path specifically, put the tab back to
+      // unassigned and remove all groups manually, then send __resume-tab.
+      const state = coordinator.getState();
+      // Manually remove the group to simulate the edge-case ordering
+      state.budgetGroups.delete('__lobby');
+      state.portToBudget.delete(callbackTab);
+      state.unassignedPorts.add(callbackTab);
+
+      sendMsg(callbackTab, { type: '__resume-tab', budgetId: null });
+
+      expect(callbackTab.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: '__role-change',
+          role: 'LEADER',
+          budgetId: '__lobby',
+        }),
+      );
+      expect(
+        coordinator.getState().budgetGroups.get('__lobby')!.leaderPort,
+      ).toBe(callbackTab);
+    });
+  });
 });

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -191,7 +191,15 @@ export function createCoordinator({
     }
 
     if (alreadyUnassigned) {
-      logState('Tab resume confirmed while unassigned');
+      // If no groups remain the tab needs to become the lobby leader so it can
+      // connect a backend.  Without this, an UNASSIGNED tab that was promoted
+      // after the old leader left would never receive a 'connect' event.
+      if (budgetGroups.size === 0) {
+        electLeader('__lobby', port);
+        logState('Promoted unassigned tab to lobby leader on resume');
+      } else {
+        logState('Tab resume confirmed while unassigned');
+      }
       return;
     }
 
@@ -284,6 +292,17 @@ export function createCoordinator({
           `[SharedWorker] Last tab left budget "${budgetId}" — removing group`,
         );
         budgetGroups.delete(budgetId);
+        // If no groups remain and unassigned tabs are waiting, promote one to
+        // lobby leader so they can connect a backend.  This covers the iOS
+        // Safari case where the old leader navigates away without firing
+        // beforeunload, leaving the new OIDC-callback tab stranded as
+        // UNASSIGNED with no group to route messages through.
+        if (budgetGroups.size === 0 && unassignedPorts.size > 0) {
+          const candidate = unassignedPorts.values().next()
+            .value as CoordinatorPort;
+          electLeader('__lobby', candidate);
+          logState('Promoted unassigned tab to lobby leader after last group removed');
+        }
       }
     } else {
       group.followers.delete(port);

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -24,6 +24,13 @@ type BudgetGroup = {
   requestToPort: Map<string, CoordinatorPort>;
   requestNames: Map<string, string>;
   requestBudgetIds: Map<string, string>;
+  /** Original messages stored for request recovery when a leader dies. */
+  requestMessages: Map<string, Record<string, unknown>>;
+  /**
+   * Requests that were in-flight against the old leader when this tab was
+   * promoted.  Flushed as __to-worker once the new backend sends connect.
+   */
+  pendingRequests: Array<Record<string, unknown>>;
 };
 
 type CoordinatorOptions = {
@@ -96,6 +103,8 @@ export function createCoordinator({
       requestToPort: new Map(),
       requestNames: new Map(),
       requestBudgetIds: new Map(),
+      requestMessages: new Map(),
+      pendingRequests: [],
     };
   }
 
@@ -291,6 +300,23 @@ export function createCoordinator({
         console.log(
           `[SharedWorker] Last tab left budget "${budgetId}" — removing group`,
         );
+
+        // Before deleting the group, collect any in-flight requests that came
+        // from unassigned ports (e.g. load-global-prefs from the iOS OIDC
+        // callback tab).  We'll re-enqueue them for the new leader so they
+        // aren't silently dropped.
+        const survivingRequests: Array<{
+          id: string;
+          requester: CoordinatorPort;
+          msg: Record<string, unknown>;
+        }> = [];
+        for (const [id, requester] of group.requestToPort) {
+          const origMsg = group.requestMessages.get(id);
+          if (origMsg && requester !== port && unassignedPorts.has(requester)) {
+            survivingRequests.push({ id, requester, msg: origMsg });
+          }
+        }
+
         budgetGroups.delete(budgetId);
         // If no groups remain and unassigned tabs are waiting, promote one to
         // lobby leader so they can connect a backend.  This covers the iOS
@@ -301,6 +327,23 @@ export function createCoordinator({
           const candidate = unassignedPorts.values().next()
             .value as CoordinatorPort;
           electLeader('__lobby', candidate);
+
+          // Re-enqueue the surviving in-flight requests in the new leader's
+          // group so they are sent to the new backend once it connects.
+          if (survivingRequests.length > 0) {
+            const newGroup = budgetGroups.get('__lobby');
+            if (newGroup) {
+              for (const { id, requester, msg } of survivingRequests) {
+                newGroup.requestToPort.set(id, requester);
+                if (msg.name) {
+                  newGroup.requestNames.set(id, msg.name as string);
+                }
+                newGroup.requestMessages.set(id, msg);
+                newGroup.pendingRequests.push(msg);
+              }
+            }
+          }
+
           logState(
             'Promoted unassigned tab to lobby leader after last group removed',
           );
@@ -312,6 +355,7 @@ export function createCoordinator({
         if (p === port) {
           group.requestToPort.delete(id);
           group.requestNames.delete(id);
+          group.requestMessages.delete(id);
         }
       }
     }
@@ -337,6 +381,8 @@ export function createCoordinator({
       group.requestToPort.clear();
       group.requestNames.clear();
       group.requestBudgetIds.clear();
+      group.requestMessages.clear();
+      group.pendingRequests = [];
     }
     if (!group.restoreBudgetId && budgetToRestore) {
       group.restoreBudgetId = budgetToRestore;
@@ -397,6 +443,7 @@ export function createCoordinator({
       if (p === port) {
         group.requestToPort.delete(id);
         group.requestNames.delete(id);
+        group.requestMessages.delete(id);
       }
     }
   }
@@ -638,6 +685,7 @@ export function createCoordinator({
 
               group.requestToPort.delete(workerMsg.id as string);
               group.requestNames.delete(workerMsg.id as string);
+              group.requestMessages.delete(workerMsg.id as string);
             }
           } else if (workerMsg.type === 'connect') {
             if (group.restoreBudgetId) {
@@ -645,6 +693,18 @@ export function createCoordinator({
             } else {
               group.backendConnected = true;
               broadcastConnect(portBudget!);
+              // Flush any requests that were in-flight against the old leader
+              // when this tab was promoted (e.g. load-global-prefs from the
+              // iOS OIDC callback flow).
+              if (group.pendingRequests.length > 0) {
+                const toReplay = group.pendingRequests.splice(0);
+                for (const pendingMsg of toReplay) {
+                  group.leaderPort.postMessage({
+                    type: '__to-worker',
+                    msg: pendingMsg,
+                  });
+                }
+              }
             }
           } else if (workerMsg.type === 'app-init-failure') {
             lastAppInitFailure = workerMsg;
@@ -874,6 +934,9 @@ export function createCoordinator({
                 msg.name as string,
               );
             }
+            // Store the original message so it can be re-routed to a new
+            // leader if this group's leader dies before replying.
+            targetGroup.requestMessages.set(msg.id as string, msg);
             if (
               msg.name === 'load-budget' &&
               msg.args &&

--- a/packages/desktop-client/src/shared-browser-server-core.ts
+++ b/packages/desktop-client/src/shared-browser-server-core.ts
@@ -301,7 +301,9 @@ export function createCoordinator({
           const candidate = unassignedPorts.values().next()
             .value as CoordinatorPort;
           electLeader('__lobby', candidate);
-          logState('Promoted unassigned tab to lobby leader after last group removed');
+          logState(
+            'Promoted unassigned tab to lobby leader after last group removed',
+          );
         }
       }
     } else {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Aint working

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Fixes issue that only appeared on IOS when OIDC was enabled.

Before

<img width="1440" height="916" alt="ezgif-15e28cdc6f1629fd" src="https://github.com/user-attachments/assets/4ab3b544-af16-479d-b851-64048d62f61e" />


After


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.02 MB → 14.02 MB (+343 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.02 MB → 14.02 MB (+343 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/manager/subscribe/OpenIdCallback.ts` | 📈 +12 B (+3.57%) | 336 B → 348 B
`src/browser-preload.js` | 📈 +331 B (+3.34%) | 9.69 kB → 10.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB → 1.54 MB (+343 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.07 MB | 0%
static/js/_baseIsEqual.js | 98.02 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.13 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.49 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 296.1 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C_UHYSJL.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->