### PR TITLE
Add per-automation notes and improve forecast split handling

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/api",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "description": "An API for Actual",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/cli",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "description": "CLI for Actual Budget",
   "license": "MIT",
   "repository": {

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -52,6 +52,7 @@
     "#components/budget/util": "./src/components/budget/util.ts",
     "#components/codemirror/autocompleteTabAccept": "./src/components/codemirror/autocompleteTabAccept.ts",
     "#components/mobile/utils": "./src/components/mobile/utils.ts",
+    "#components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations": "./src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts",
     "#components/reports/chart-theme": "./src/components/reports/chart-theme.ts",
     "#components/reports/constants": "./src/components/reports/constants.ts",
     "#components/reports/disabledList": "./src/components/reports/disabledList.ts",

--- a/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
+++ b/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
@@ -1,18 +1,66 @@
 import React, { useContext } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgChartPie } from '@actual-app/components/icons/v1';
 import type { CSSProperties } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
+import { View } from '@actual-app/components/view';
 import type { CategoryEntity } from '@actual-app/core/types/models';
+import type { Template } from '@actual-app/core/types/models/templates';
 import { css, cx } from '@emotion/css';
 
+import {
+  cleanupDefToEditor,
+  emptyCleanupConfig,
+} from '#components/budget/goals/cleanupModel';
+import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
 import { MonthsContext } from '#components/budget/MonthsContext';
+import { migrateTemplatesToAutomations } from '#components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations';
+import { useCategories } from '#hooks/useCategories';
 import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { pushModal } from '#modals/modalsSlice';
 import { useDispatch } from '#redux';
+
+import type { AutomationEntry } from './automationExamples';
+import { TemplateSentence } from './TemplateSentence';
+
+function getAutomationEntries(
+  goalDef: string | null | undefined,
+): AutomationEntry[] {
+  if (!goalDef) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(goalDef);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    const templates: Template[] = parsed;
+    return migrateTemplatesToAutomations(
+      templates.filter(template => template.type !== 'error'),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function getCleanupConfig(
+  cleanupDef: string | null | undefined,
+): CleanupConfig {
+  if (!cleanupDef) {
+    return emptyCleanupConfig();
+  }
+  try {
+    const parsed = JSON.parse(cleanupDef);
+    return cleanupDefToEditor(Array.isArray(parsed) ? parsed : []);
+  } catch {
+    return emptyCleanupConfig();
+  }
+}
 
 type CategoryAutomationButtonProps = {
   category: CategoryEntity;
@@ -38,6 +86,7 @@ export function CategoryAutomationButton({
   const goalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
   const goalTemplatesUIEnabled = useFeatureFlag('goalTemplatesUIEnabled');
   const [budgetType = 'envelope'] = useSyncedPref('budgetType');
+  const { data: categoriesData } = useCategories();
   const hasAutomations =
     category.template_settings?.source === 'ui' &&
     (!!category.goal_def?.length || !!category.cleanup_def?.length);
@@ -52,7 +101,19 @@ export function CategoryAutomationButton({
     return null;
   }
 
-  return (
+  const automations = getAutomationEntries(category.goal_def);
+  const categoryNameMap: Record<string, string> = {};
+  for (const cat of categoriesData?.list ?? []) {
+    categoryNameMap[cat.id] = cat.name;
+  }
+
+  const cleanup = getCleanupConfig(category.cleanup_def);
+  const cleanupGlobal = cleanup.global.send || cleanup.global.take;
+  const cleanupScopeCount =
+    (cleanupGlobal ? 1 : 0) +
+    cleanup.groups.filter(group => group.send || group.take).length;
+
+  const button = (
     <Button
       variant="bare"
       aria-label={t('Change category automations')}
@@ -80,5 +141,56 @@ export function CategoryAutomationButton({
     >
       <SvgChartPie style={{ width, height, flexShrink: 0 }} />
     </Button>
+  );
+
+  if (automations.length === 0 && cleanupScopeCount === 0) {
+    return button;
+  }
+
+  return (
+    <Tooltip
+      placement="bottom start"
+      content={
+        <View style={{ maxWidth: 320, padding: 10, gap: 10 }}>
+          {automations.map(entry => (
+            <View key={entry.id} style={{ gap: 4 }}>
+              <Text style={{ display: 'block' }}>
+                <TemplateSentence
+                  template={entry.template}
+                  categoryNameMap={categoryNameMap}
+                />
+              </Text>
+              {entry.template.description && (
+                <Text
+                  style={{
+                    display: 'block',
+                    color: theme.pageTextLight,
+                    whiteSpace: 'pre-wrap',
+                  }}
+                >
+                  {entry.template.description}
+                </Text>
+              )}
+            </View>
+          ))}
+          {cleanupScopeCount > 0 && (
+            <Text style={{ display: 'block' }}>
+              <Trans>End of month cleanup</Trans>,{' '}
+              {cleanupScopeCount > 1 ? (
+                <Trans count={cleanupScopeCount}>
+                  active in {{ count: cleanupScopeCount }} scopes
+                </Trans>
+              ) : cleanupGlobal ? (
+                <Trans>active globally</Trans>
+              ) : (
+                <Trans>active in a pool</Trans>
+              )}
+            </Text>
+          )}
+        </View>
+      }
+    >
+      {button}
+    </Tooltip>
   );
 }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -1,4 +1,4 @@
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { SvgDelete } from '@actual-app/components/icons/v0';
@@ -76,6 +76,7 @@ export function AutomationEditorPane({
   setEntries,
   onDelete,
 }: AutomationEditorPaneProps) {
+  const { t } = useTranslation();
   const active = entries[activeIdx];
   const activeError = automationErrors[activeIdx];
 
@@ -89,10 +90,30 @@ export function AutomationEditorPane({
         const next = templateReducer(current, action);
         return {
           id: entry.id,
-          template: next.template,
+          template: {
+            ...next.template,
+            description: entry.template.description,
+          },
           displayType: next.displayType,
         };
       }),
+    );
+  };
+
+  const setDescription = (description: string) => {
+    setEntries(prev =>
+      prev.map((entry, i) =>
+        i === activeIdx
+          ? {
+              ...entry,
+              template: {
+                ...entry.template,
+                description:
+                  description.trim() === '' ? undefined : description,
+              },
+            }
+          : entry,
+      ),
     );
   };
 
@@ -308,6 +329,39 @@ export function AutomationEditorPane({
           </span>
         </Button>
       </View>
+
+      <Text
+        style={{
+          fontSize: 11,
+          textTransform: 'uppercase',
+          color: theme.pageTextLight,
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+        }}
+      >
+        <Trans>Note</Trans>
+      </Text>
+      <textarea
+        aria-label={t('Automation note')}
+        className={css({
+          width: '100%',
+          minHeight: 60,
+          resize: 'vertical',
+          fontFamily: 'inherit',
+          fontSize: 13,
+          lineHeight: 1.4,
+          padding: '8px 10px',
+          borderRadius: 6,
+          border: `1px solid ${theme.formInputBorder}`,
+          backgroundColor: theme.tableBackground,
+          color: theme.tableText,
+          '::placeholder': { color: theme.pageTextLight },
+        })}
+        value={active.template.description ?? ''}
+        onChange={e => setDescription(e.target.value)}
+        placeholder={t('Note')}
+        rows={3}
+      />
     </View>
   );
 }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationListRow.tsx
@@ -129,7 +129,21 @@ export function AutomationListRow({
         </View>
         <Tooltip
           content={
-            <Text style={{ display: 'block', maxWidth: 320 }}>{subtitle}</Text>
+            <View style={{ maxWidth: 320, gap: 4 }}>
+              <Text style={{ display: 'block' }}>{subtitle}</Text>
+              {entry.template.description && (
+                <Text
+                  style={{
+                    display: 'block',
+                    fontSize: 11,
+                    color: theme.pageTextLight,
+                    whiteSpace: 'pre-wrap',
+                  }}
+                >
+                  {entry.template.description}
+                </Text>
+              )}
+            </View>
           }
         >
           <Text

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -49,6 +49,7 @@ export function migrateTemplatesToAutomations(
       const monthly = template.monthly;
       const hasMonthly =
         monthly != null && (monthly !== 0 || template.limit != null);
+      const { description } = template;
 
       if (template.limit) {
         entries.push(
@@ -61,6 +62,9 @@ export function migrateTemplatesToAutomations(
               start: template.limit.start,
               directive: 'template',
               priority: null,
+              // a description on a limit-only simple template belongs to the
+              // limit; with a monthly amount it goes on that instead
+              ...(description && !hasMonthly ? { description } : {}),
             },
             'limit',
           ),
@@ -90,6 +94,7 @@ export function migrateTemplatesToAutomations(
               starting: dayFromDate(firstDayOfMonth(new Date())),
               directive: 'template',
               priority: template.priority,
+              ...(description ? { description } : {}),
             },
             'fixed',
           ),

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-electron",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "description": "A simple and powerful personal finance system",
   "author": "Actual",
   "main": "build/desktop-electron/index.js",

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/core",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "description": "",
   "license": "ISC",
   "repository": {

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -128,6 +128,92 @@ describe('storeNoteTemplates', () => {
       ],
       expectedTemplates: [],
     },
+    {
+      description: 'Captures a description above a template',
+      mockTemplateNotes: [
+        {
+          id: 'cat1',
+          name: 'Category 1',
+          note: 'Car insurance\n#template 10',
+        },
+      ],
+      expectedTemplates: [
+        {
+          type: 'simple',
+          monthly: 10,
+          limit: null,
+          priority: 0,
+          directive: 'template',
+          description: 'Car insurance',
+        },
+      ],
+    },
+    {
+      description: 'Captures a multi-line description above a template',
+      mockTemplateNotes: [
+        {
+          id: 'cat1',
+          name: 'Category 1',
+          note: 'Line one\nLine two\n#template 10',
+        },
+      ],
+      expectedTemplates: [
+        {
+          type: 'simple',
+          monthly: 10,
+          limit: null,
+          priority: 0,
+          directive: 'template',
+          description: 'Line one\nLine two',
+        },
+      ],
+    },
+    {
+      description: 'Ignores prose separated from the template by a blank line',
+      mockTemplateNotes: [
+        {
+          id: 'cat1',
+          name: 'Category 1',
+          note: 'Just a note\n\n#template 10',
+        },
+      ],
+      expectedTemplates: [
+        {
+          type: 'simple',
+          monthly: 10,
+          limit: null,
+          priority: 0,
+          directive: 'template',
+        },
+      ],
+    },
+    {
+      description: 'Only attaches a description to the template directly below',
+      mockTemplateNotes: [
+        {
+          id: 'cat1',
+          name: 'Category 1',
+          note: 'Groceries\n#template 10\n#template-2 20',
+        },
+      ],
+      expectedTemplates: [
+        {
+          type: 'simple',
+          monthly: 10,
+          limit: null,
+          priority: 0,
+          directive: 'template',
+          description: 'Groceries',
+        },
+        {
+          type: 'simple',
+          monthly: 20,
+          limit: null,
+          priority: 2,
+          directive: 'template',
+        },
+      ],
+    },
   ];
 
   it.each(testCases)(
@@ -393,5 +479,48 @@ describe('unparse limit templates', () => {
     ]);
 
     expect(serialized).toBe('#template 0 up to 200');
+  });
+});
+
+describe('unparse descriptions', () => {
+  it('writes a description above the template line', async () => {
+    const serialized = await unparse([
+      {
+        type: 'simple',
+        monthly: 10,
+        priority: 0,
+        directive: 'template',
+        description: 'Car insurance',
+      },
+    ]);
+
+    expect(serialized).toBe('Car insurance\n#template 10');
+  });
+
+  it('writes a multi-line description', async () => {
+    const serialized = await unparse([
+      {
+        type: 'goal',
+        amount: 100,
+        directive: 'goal',
+        description: 'Rainy day fund\nfor emergencies',
+      },
+    ]);
+
+    expect(serialized).toBe('Rainy day fund\nfor emergencies\n#goal 100');
+  });
+
+  it('drops blank lines so the note stays re-parseable', async () => {
+    const serialized = await unparse([
+      {
+        type: 'simple',
+        monthly: 10,
+        priority: 0,
+        directive: 'template',
+        description: 'first\n\nsecond',
+      },
+    ]);
+
+    expect(serialized).toBe('first\nsecond\n#template 10');
   });
 });

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -1,4 +1,4 @@
-import type { Template } from '#types/models/templates';
+import type { RefillTemplate, Template } from '#types/models/templates';
 
 import { storeTemplates } from './goal-template';
 import { parse } from './goal-template.pegjs';
@@ -18,6 +18,7 @@ type Notification = {
 
 export const TEMPLATE_PREFIX = '#template';
 export const GOAL_PREFIX = '#goal';
+const CLEANUP_PREFIX = '#cleanup';
 
 export async function storeNoteTemplates(
   categoryIds?: string[],
@@ -85,16 +86,29 @@ async function getCategoriesWithTemplates(
     }
 
     const parsedTemplates: Template[] = [];
+    // Non-directive lines directly above a template line are kept as that
+    // template's description. A blank line or a different directive ends the
+    // block.
+    let descriptionLines: string[] = [];
 
     note.split('\n').forEach(line => {
       const trimmedLine = line.substring(line.indexOf('#')).trim();
+      const isTemplateLine =
+        trimmedLine.startsWith(TEMPLATE_PREFIX) ||
+        trimmedLine.startsWith(GOAL_PREFIX);
 
-      if (
-        !trimmedLine.startsWith(TEMPLATE_PREFIX) &&
-        !trimmedLine.startsWith(GOAL_PREFIX)
-      ) {
+      if (!isTemplateLine) {
+        if (line.trim() === '' || trimmedLine.startsWith(CLEANUP_PREFIX)) {
+          descriptionLines = [];
+        } else {
+          descriptionLines.push(line.trimEnd());
+        }
         return;
       }
+
+      const description =
+        descriptionLines.length > 0 ? descriptionLines.join('\n') : undefined;
+      descriptionLines = [];
 
       try {
         const parsedTemplate: Template = parse(trimmedLine);
@@ -119,14 +133,19 @@ async function getCategoriesWithTemplates(
           }
         }
 
-        parsedTemplates.push(parsedTemplate);
+        parsedTemplates.push(
+          description ? { ...parsedTemplate, description } : parsedTemplate,
+        );
       } catch (e: unknown) {
-        parsedTemplates.push({
+        const errorTemplate: Template = {
           type: 'error',
           directive: 'error',
           line,
           error: (e as Error).message,
-        });
+        };
+        parsedTemplates.push(
+          description ? { ...errorTemplate, description } : errorTemplate,
+        );
       }
     });
 
@@ -151,6 +170,120 @@ function prefixFromPriority(priority: number | null): string {
     : `${TEMPLATE_PREFIX}-${priority}`;
 }
 
+function templateToLine(
+  template: Template,
+  refill: RefillTemplate | undefined,
+): string | null {
+  if (template.type === 'error') {
+    return null;
+  }
+
+  if (template.type === 'goal') {
+    return `${GOAL_PREFIX} ${template.amount}`;
+  }
+
+  const prefix = prefixFromPriority(template.priority);
+
+  switch (template.type) {
+    case 'simple': {
+      // Simple template syntax: #template[-prio] simple [monthly N] [limit]
+      let result = prefix;
+      if (template.monthly != null) {
+        result += ` ${template.monthly}`;
+      }
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result.trim();
+    }
+    case 'schedule': {
+      // schedule syntax: #template[-prio] schedule <name> [full] [ [increase/decrease N%] ]
+      let result = `${prefix} schedule`;
+      if (template.full) {
+        result += ' full';
+      }
+      result += ` ${template.name}`;
+      if (template.adjustment !== undefined) {
+        const adj = template.adjustment;
+        const op = adj >= 0 ? 'increase' : 'decrease';
+        const val = Math.abs(adj);
+        const type = template.adjustmentType === 'percent' ? '%' : '';
+        result += ` [${op} ${val}${type}]`;
+      }
+      return result;
+    }
+    case 'percentage': {
+      // #template[-prio] <percent>% of [previous ]<category>
+      const prev = template.previous ? 'previous ' : '';
+      return `${prefix} ${trimTrailingZeros(template.percent)}% of ${prev}${template.category}`.trim();
+    }
+    case 'periodic': {
+      // #template[-prio] <amount> repeat every <n> <period>(s) starting <date> [limit]
+      const periodPart = periodToString(template.period);
+      let result = `${prefix} ${template.amount} repeat every ${periodPart} starting ${template.starting}`;
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result;
+    }
+    case 'by':
+    case 'spend': {
+      // #template[-prio] <amount> by <month> [spend from <month>] [repeat every <...>]
+      let result = `${prefix} ${template.amount} by ${template.month}`;
+      if (template.type === 'spend' && template.from) {
+        result += ` spend from ${template.from}`;
+      }
+      // repeat info
+      if (template.annual !== undefined) {
+        const repeatInfo = repeatToString(template.annual, template.repeat);
+        if (repeatInfo) {
+          result += ` repeat every ${repeatInfo}`;
+        }
+      }
+      return result;
+    }
+    case 'remainder': {
+      // #template remainder [weight] [limit]
+      let result = `${prefix} remainder`;
+      if (template.weight !== undefined && template.weight !== 1) {
+        result += ` ${template.weight}`;
+      }
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result;
+    }
+    case 'average': {
+      // #template average <numMonths> months [increase/decrease {number|number%}]
+      let result = `${prefix} average ${template.numMonths} months`;
+      if (template.adjustment !== undefined) {
+        const adj = template.adjustment;
+        const op = adj >= 0 ? 'increase' : 'decrease';
+        const val = Math.abs(adj);
+        const type = template.adjustmentType === 'percent' ? '%' : '';
+        result += ` [${op} ${val}${type}]`;
+      }
+      return result;
+    }
+    case 'copy': {
+      // #template copy from <lookBack> months ago [limit]
+      return `${prefix} copy from ${template.lookBack} months ago`;
+    }
+    case 'limit': {
+      if (!refill) {
+        // #template 0 up to <limit>
+        return `${prefix} 0 ${limitToString(template)}`;
+      }
+      // #template up to <limit>
+      const mergedPrefix = prefixFromPriority(refill.priority);
+      return `${mergedPrefix} ${limitToString(template)}`;
+    }
+    // No 'refill' support since a refill requires a limit
+    default:
+      return null;
+  }
+}
+
 export async function unparse(templates: Template[]): Promise<string> {
   // Refill will be merged into the limit template if both exist
   // Assumption: at most one limit and one refill template per category
@@ -159,117 +292,15 @@ export async function unparse(templates: Template[]): Promise<string> {
 
   return withoutRefill
     .flatMap(template => {
-      if (template.type === 'error') {
+      const line = templateToLine(template, refill);
+      if (line == null) {
         return [];
       }
-
-      if (template.type === 'goal') {
-        return `${GOAL_PREFIX} ${template.amount}`;
-      }
-
-      const prefix = prefixFromPriority(template.priority);
-
-      switch (template.type) {
-        case 'simple': {
-          // Simple template syntax: #template[-prio] simple [monthly N] [limit]
-          let result = prefix;
-          if (template.monthly != null) {
-            result += ` ${template.monthly}`;
-          }
-          if (template.limit) {
-            result += ` ${limitToString(template.limit)}`;
-          }
-          return result.trim();
-        }
-        case 'schedule': {
-          // schedule syntax: #template[-prio] schedule <name> [full] [ [increase/decrease N%] ]
-          let result = `${prefix} schedule`;
-          if (template.full) {
-            result += ' full';
-          }
-          result += ` ${template.name}`;
-          if (template.adjustment !== undefined) {
-            const adj = template.adjustment;
-            const op = adj >= 0 ? 'increase' : 'decrease';
-            const val = Math.abs(adj);
-            const type = template.adjustmentType === 'percent' ? '%' : '';
-            result += ` [${op} ${val}${type}]`;
-          }
-          return result;
-        }
-        case 'percentage': {
-          // #template[-prio] <percent>% of [previous ]<category>
-          const prev = template.previous ? 'previous ' : '';
-          return `${prefix} ${trimTrailingZeros(template.percent)}% of ${prev}${template.category}`.trim();
-        }
-        case 'periodic': {
-          // #template[-prio] <amount> repeat every <n> <period>(s) starting <date> [limit]
-          const periodPart = periodToString(template.period);
-          let result = `${prefix} ${template.amount} repeat every ${periodPart} starting ${template.starting}`;
-          if (template.limit) {
-            result += ` ${limitToString(template.limit)}`;
-          }
-          return result;
-        }
-        case 'by':
-        case 'spend': {
-          // #template[-prio] <amount> by <month> [spend from <month>] [repeat every <...>]
-          let result = `${prefix} ${template.amount} by ${template.month}`;
-          if (template.type === 'spend' && template.from) {
-            result += ` spend from ${template.from}`;
-          }
-          // repeat info
-          if (template.annual !== undefined) {
-            const repeatInfo = repeatToString(template.annual, template.repeat);
-            if (repeatInfo) {
-              result += ` repeat every ${repeatInfo}`;
-            }
-          }
-          return result;
-        }
-        case 'remainder': {
-          // #template remainder [weight] [limit]
-          let result = `${prefix} remainder`;
-          if (template.weight !== undefined && template.weight !== 1) {
-            result += ` ${template.weight}`;
-          }
-          if (template.limit) {
-            result += ` ${limitToString(template.limit)}`;
-          }
-          return result;
-        }
-        case 'average': {
-          let result = `${prefix} average ${template.numMonths} months`;
-
-          if (template.adjustment !== undefined) {
-            const adj = template.adjustment;
-            const op = adj >= 0 ? 'increase' : 'decrease';
-            const val = Math.abs(adj);
-            const type = template.adjustmentType === 'percent' ? '%' : '';
-            result += ` [${op} ${val}${type}]`;
-          }
-
-          // #template average <numMonths> months [increase/decrease {number|number%}]
-          return result;
-        }
-        case 'copy': {
-          // #template copy from <lookBack> months ago [limit]
-          const result = `${prefix} copy from ${template.lookBack} months ago`;
-          return result;
-        }
-        case 'limit': {
-          if (!refill) {
-            // #template 0 up to <limit>
-            return `${prefix} 0 ${limitToString(template)}`;
-          }
-          // #template up to <limit>
-          const mergedPrefix = prefixFromPriority(refill.priority);
-          return `${mergedPrefix} ${limitToString(template)}`;
-        }
-        // No 'refill' support since a refill requires a limit
-        default:
-          return [];
-      }
+      const descriptionLines = (template.description ?? '')
+        .split('\n')
+        .map(descriptionLine => descriptionLine.trimEnd())
+        .filter(descriptionLine => descriptionLine !== '');
+      return [...descriptionLines, line];
     })
     .join('\n');
 }

--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -341,6 +341,50 @@ describe('forecast app', () => {
     expect(balanceByDate['2024-03-31']).toBe(-25);
   });
 
+  it('does not double-count split parents in posted transaction balances', async () => {
+    const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
+
+    const parentId = await db.insertTransaction({
+      id: 'split-parent',
+      account: accountId,
+      amount: 100,
+      date: '2024-03-10',
+      is_parent: true,
+      category: null,
+    });
+
+    await db.insertTransaction({
+      id: 'split-child-1',
+      account: accountId,
+      amount: 60,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+    await db.insertTransaction({
+      id: 'split-child-2',
+      account: accountId,
+      amount: 40,
+      date: '2024-03-10',
+      is_child: true,
+      parent_id: parentId,
+    });
+
+    const result = await generateForecast({
+      accountIds: [accountId],
+      startDate: '2024-03-01',
+      endDate: '2024-03-31',
+    });
+
+    const balanceByDate = Object.fromEntries(
+      result.dataPoints.map(({ date, balance }) => [date, balance]),
+    );
+
+    expect(balanceByDate['2024-03-09']).toBe(0);
+    expect(balanceByDate['2024-03-10']).toBe(100);
+    expect(balanceByDate['2024-03-31']).toBe(100);
+  });
+
   it('filters future schedule occurrences using rule-derived fields like category', async () => {
     const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
     const groupId = await db.insertCategoryGroup({ name: 'Bills' });

--- a/packages/loot-core/src/server/forecast/forecast-filters.ts
+++ b/packages/loot-core/src/server/forecast/forecast-filters.ts
@@ -1,7 +1,6 @@
 import { aqlQuery } from '#server/aql';
 import { conditionsToAQL } from '#server/transactions/transaction-rules';
 import { q } from '#shared/query';
-import { ungroupTransactions } from '#shared/transactions';
 import type { RuleConditionEntity, TransactionEntity } from '#types/models';
 
 import { getAccountRestrictionMode } from './forecast-accounts';
@@ -81,7 +80,7 @@ export async function getTransactions(
   let query = q('transactions')
     .filter({ tombstone: false })
     .select('*')
-    .options({ splits: 'grouped' });
+    .options({ splits: 'inline' });
 
   if (accountIds !== undefined) {
     if (accountIds.length === 0) {
@@ -96,7 +95,7 @@ export async function getTransactions(
   }
 
   const { data } = await aqlQuery(query);
-  return ungroupTransactions(data);
+  return data;
 }
 
 function escapeRegex(value: string) {

--- a/packages/loot-core/src/types/models/templates.ts
+++ b/packages/loot-core/src/types/models/templates.ts
@@ -1,6 +1,7 @@
 type BaseTemplate = {
   type: string;
   directive: 'template' | 'goal' | 'error';
+  description?: string;
 };
 type BaseTemplateWithPriority = {
   priority: number;

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/sync-server",
-  "version": "26.5.2",
+  "version": "26.6.0",
   "description": "actual syncing server",
   "license": "MIT",
   "repository": {

--- a/upcoming-release-notes/7906.md
+++ b/upcoming-release-notes/7906.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: Add per-automation notes and a tooltip for budget page

--- a/upcoming-release-notes/7955.md
+++ b/upcoming-release-notes/7955.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Fix Balance Forecast double-counting posted split transactions.


### PR DESCRIPTION
## Description

This PR adds support for per-automation notes/descriptions and improves the budget automation UI to display these notes in tooltips. It also fixes a bug in the forecast app where split parent transactions were being double-counted.

### Key Changes

**Automation Notes Feature:**
- Added `description` field to the `Template` type to store per-automation notes
- Updated template parsing in `getCategoriesWithTemplates()` to capture non-directive lines directly above template directives as descriptions
- Lines separated by blank lines or other directives are not attached as descriptions
- Updated `unparse()` to serialize descriptions back to the note format
- Added UI for editing automation notes in `AutomationEditorPane`
- Enhanced `CategoryAutomationButton` to display automation notes in a tooltip on the budget page
- Updated `AutomationListRow` to show notes in its tooltip

**Forecast Bug Fix:**
- Fixed double-counting of split parent transactions in posted transaction balances by removing unnecessary ungrouping logic in `forecast-filters.ts`

**Tests:**
- Added comprehensive test cases for description parsing (single-line, multi-line, blank line separation, multiple templates)
- Added test cases for description serialization including blank line handling
- Added test case for split transaction balance calculation

## Related issue(s)

Relates to budget automation enhancements and forecast accuracy improvements.

## Testing

- Added unit tests covering description parsing and serialization in `template-notes.test.ts`
- Added unit test for split transaction balance calculation in `forecast/app.test.ts`
- Existing automation tests continue to pass with the new description field
- Manual testing: Verify notes can be added/edited in the automation UI and display correctly in tooltips on the budget page

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed

https://claude.ai/code/session_01XGYzr6j3NKxpLUPAeYmQho

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.02 MB | 0%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.96 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.07 MB | 0%
static/js/_baseIsEqual.js | 98.02 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.13 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/extends.js | 500.57 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.49 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 296.1 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C_UHYSJL.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->