### PR TITLE
:cherries: [Cherry pick] :iphone: Fallback to direct worker on ios (#7971)

### DIFF
--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -260,9 +260,14 @@ function createBackendWorker() {
   // Each budget gets its own leader tab running a dedicated Worker. All other
   // tabs on the same budget are followers — their messages are routed through
   // the SharedWorker to the leader's Worker.
-  // The SharedWorker never touches SharedArrayBuffer, so this works on all
-  // platforms including iOS/Safari.
-  if (typeof SharedWorker !== 'undefined' && !Platform.isPlaywright) {
+  // iOS is excluded: navigation to an OIDC provider and back creates a new
+  // SharedWorker port connection, leaving the returning tab stuck as UNASSIGNED
+  // with no backend Worker. The direct Worker fallback avoids this entirely.
+  if (
+    typeof SharedWorker !== 'undefined' &&
+    !Platform.isPlaywright &&
+    !Platform.isIOS
+  ) {
     try {
       const sharedWorker = new SharedBrowserServerWorker({
         name: 'actual-backend',
@@ -303,8 +308,12 @@ function createBackendWorker() {
     }
   }
 
-  // Fallback: regular Worker (Playwright, no SharedWorker support, or failure)
-  console.log('[WorkerBridge] No SharedWorker available, using direct Worker');
+  // Fallback: regular Worker (Playwright, iOS, no SharedWorker support, or failure)
+  console.log(
+    Platform.isIOS
+      ? '[WorkerBridge] iOS detected, using direct Worker'
+      : '[WorkerBridge] No SharedWorker available, using direct Worker',
+  );
   worker = new Worker(backendWorkerUrl);
   initSQLBackend(worker);
 

--- a/packages/loot-core/src/shared/platform.electron.ts
+++ b/packages/loot-core/src/shared/platform.electron.ts
@@ -19,3 +19,4 @@ export const env: typeof T.env = 'unknown';
 export const isBrowser: typeof T.isBrowser = false;
 
 export const isIOSAgent: typeof T.isIOSAgent = false;
+export const isIOS: typeof T.isIOS = false;

--- a/packages/loot-core/src/shared/platform.ts
+++ b/packages/loot-core/src/shared/platform.ts
@@ -18,3 +18,5 @@ export const isBrowser: boolean = true;
 
 const agent = UAParser(navigator.userAgent);
 export const isIOSAgent = agent.browser.name === 'Mobile Safari';
+// True for all browsers on iOS (iPhone/iPad/iPod) — not macOS.
+export const isIOS = agent.os.name === 'iOS';

--- a/upcoming-release-notes/7971.md
+++ b/upcoming-release-notes/7971.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MikesGlitch]
+---
+
+Fix OIDC login on iOS


### PR DESCRIPTION
* fallback to old worker on ios

* release note

* Correct spelling of 'iOS' in release notes

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Original: https://github.com/actualbudget/actual/pull/7971

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 → 33 | 14.02 MB → 14.02 MB (+143 B) | +0.00%
loot-core | 1 | 5.34 MB → 5.34 MB (-635 B) | -0.01%
api | 2 | 3.96 MB → 3.96 MB (-460 B) | -0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 → 33 | 14.02 MB → 14.02 MB (+143 B) | +0.00%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`src/components/responsive/wide.ts` | 🆕 +453 B | 0 B → 453 B
`src/components/util/accountValidation.ts` | 📈 +132 B (+30.14%) | 438 B → 570 B
`node_modules/immer/dist/immer.mjs` | 📈 +3.5 kB (+20.09%) | 17.44 kB → 20.94 kB
`node_modules/react-is/index.js` | 📈 +23 B (+11.79%) | 195 B → 218 B
`node_modules/react-dnd/dist/hooks/useCollector.js` | 📈 +86 B (+11.68%) | 736 B → 822 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +37 B (+7.60%) | 487 B → 524 B
`src/auth/AuthProvider.tsx` | 📈 +40 B (+2.89%) | 1.35 kB → 1.39 kB
`src/browser-preload.js` | 📈 +81 B (+0.82%) | 9.69 kB → 9.77 kB
`node_modules/react-dnd/dist/hooks/useDrag/useDragSourceConnector.js` | 📈 +4 B (+0.53%) | 750 B → 754 B
`node_modules/react-dnd/dist/hooks/useDrop/useDropTargetConnector.js` | 📈 +2 B (+0.42%) | 480 B → 482 B
`node_modules/lodash/isArrayLike.js` | 📈 +4 B (+0.41%) | 972 B → 976 B
`node_modules/react-dnd/dist/hooks/useMonitorOutput.js` | 📈 +2 B (+0.39%) | 509 B → 511 B
`node_modules/lodash/isArguments.js` | 📈 +4 B (+0.34%) | 1.14 kB → 1.15 kB
`src/components/DevelopmentTopBar.tsx` | 📈 +4 B (+0.33%) | 1.19 kB → 1.2 kB
`node_modules/lodash/_assocIndexOf.js` | 📈 +2 B (+0.32%) | 616 B → 618 B
`node_modules/react-dnd/dist/internals/wrapConnectorHooks.js` | 📈 +6 B (+0.32%) | 1.81 kB → 1.82 kB
`node_modules/react-dnd/dist/hooks/useDrop/useRegisteredDropTarget.js` | 📈 +2 B (+0.32%) | 626 B → 628 B
`node_modules/react-dnd/dist/hooks/useDrag/useRegisteredDragSource.js` | 📈 +2 B (+0.31%) | 635 B → 637 B
`node_modules/lodash/_baseIsArguments.js` | 📈 +2 B (+0.31%) | 641 B → 643 B
`node_modules/lodash/_arrayLikeKeys.js` | 📈 +4 B (+0.28%) | 1.4 kB → 1.4 kB
`node_modules/lodash/toString.js` | 📈 +2 B (+0.28%) | 723 B → 725 B
`src/components/ManageRulesPage.tsx` | 📈 +2 B (+0.26%) | 761 B → 763 B
`node_modules/lodash/isTypedArray.js` | 📈 +2 B (+0.25%) | 798 B → 800 B
`node_modules/lodash/eq.js` | 📈 +2 B (+0.21%) | 931 B → 933 B
`node_modules/lodash/isLength.js` | 📈 +2 B (+0.21%) | 945 B → 947 B
`node_modules/lodash/isFunction.js` | 📈 +2 B (+0.21%) | 956 B → 958 B
`src/components/modals/EnvelopeBudgetSummaryModal.tsx` | 📈 +12 B (+0.21%) | 5.68 kB → 5.69 kB
`node_modules/lodash/keys.js` | 📈 +2 B (+0.20%) | 1005 B → 1007 B
`src/components/payees/ManagePayees.tsx` | 📈 +30 B (+0.19%) | 15.12 kB → 15.15 kB
`src/hooks/useTransactionBatchActions.ts` | 📈 +16 B (+0.18%) | 8.67 kB → 8.69 kB
`src/components/transactions/SelectedTransactionsButton.tsx` | 📈 +32 B (+0.18%) | 17.63 kB → 17.67 kB
`node_modules/lodash/_baseIsTypedArray.js` | 📈 +4 B (+0.18%) | 2.23 kB → 2.23 kB
`node_modules/lodash/_baseIsEqual.js` | 📈 +2 B (+0.18%) | 1.11 kB → 1.12 kB
`src/hooks/useThemeCatalog.ts` | 📈 +2 B (+0.17%) | 1.15 kB → 1.15 kB
`src/components/budget/tracking/TrackingBudgetComponents.tsx` | 📈 +30 B (+0.15%) | 19.14 kB → 19.17 kB
`src/components/banksync/index.tsx` | 📈 +8 B (+0.15%) | 5.24 kB → 5.25 kB
`src/components/accounts/BalanceHistoryGraph.tsx` | 📈 +14 B (+0.15%) | 9.38 kB → 9.4 kB
`node_modules/lodash/_baseIsNative.js` | 📈 +2 B (+0.13%) | 1.48 kB → 1.48 kB
`src/components/budget/DynamicBudgetTable.tsx` | 📈 +8 B (+0.11%) | 7.33 kB → 7.34 kB
`src/components/filters/FilterExpression.tsx` | 📈 +6 B (+0.10%) | 5.72 kB → 5.73 kB
`src/components/budget/BudgetSummaries.tsx` | 📈 +4 B (+0.09%) | 4.44 kB → 4.44 kB
`src/components/schedules/SchedulesTable.tsx` | 📈 +16 B (+0.08%) | 18.42 kB → 18.43 kB
`src/components/budget/tracking/budgetsummary/BudgetTotal.tsx` | 📈 +2 B (+0.07%) | 2.66 kB → 2.66 kB
`src/components/admin/UserDirectory/UserDirectory.tsx` | 📈 +10 B (+0.07%) | 13.33 kB → 13.34 kB
`src/components/payees/PayeeTable.tsx` | 📈 +2 B (+0.07%) | 2.82 kB → 2.82 kB
`node_modules/lodash/_baseIsEqualDeep.js` | 📈 +2 B (+0.07%) | 2.87 kB → 2.87 kB
`src/components/modals/EnvelopeBalanceMenuModal.tsx` | 📈 +2 B (+0.07%) | 2.88 kB → 2.89 kB
`node_modules/lodash/_equalByTag.js` | 📈 +2 B (+0.06%) | 3.11 kB → 3.11 kB
`src/components/schedules/index.tsx` | 📈 +4 B (+0.06%) | 6.34 kB → 6.35 kB
`src/components/settings/Export.tsx` | 📈 +2 B (+0.06%) | 3.48 kB → 3.49 kB
`src/components/accounts/Header.tsx` | 📈 +14 B (+0.05%) | 28 kB → 28.01 kB
`src/components/budget/BudgetCategories.tsx` | 📈 +6 B (+0.05%) | 12.01 kB → 12.01 kB
`src/components/filters/FiltersMenu.tsx` | 📈 +10 B (+0.05%) | 21.67 kB → 21.67 kB
`src/components/banksync/AccountRow.tsx` | 📈 +2 B (+0.04%) | 4.44 kB → 4.44 kB
`src/components/sort.tsx` | 📈 +2 B (+0.04%) | 4.45 kB → 4.45 kB
`src/components/sidebar/Sidebar.tsx` | 📈 +2 B (+0.04%) | 4.76 kB → 4.76 kB
`src/components/budget/tracking/budgetsummary/Saved.tsx` | 📈 +2 B (+0.04%) | 4.77 kB → 4.77 kB
`src/components/budget/BudgetTable.tsx` | 📈 +4 B (+0.04%) | 9.89 kB → 9.9 kB
`src/components/accounts/Balance.tsx` | 📈 +4 B (+0.04%) | 10.14 kB → 10.15 kB
`src/components/modals/ImportTransactionsModal/utils.ts` | 📈 +2 B (+0.04%) | 5.35 kB → 5.35 kB
`src/components/modals/EnvelopeBudgetMenuModal.tsx` | 📈 +2 B (+0.03%) | 6.39 kB → 6.4 kB
`src/components/banksync/BuiltInProviders.tsx` | 📈 +2 B (+0.03%) | 6.53 kB → 6.53 kB
`src/components/accounts/Account.tsx` | 📈 +12 B (+0.03%) | 44.09 kB → 44.1 kB
`src/components/budget/BudgetTotals.tsx` | 📈 +2 B (+0.03%) | 7.38 kB → 7.38 kB
`src/components/tags/ManageTags.tsx` | 📈 +2 B (+0.03%) | 7.48 kB → 7.48 kB
`src/components/modals/EditFieldModal.tsx` | 📈 +2 B (+0.02%) | 8.24 kB → 8.25 kB
`src/components/App.tsx` | 📈 +2 B (+0.02%) | 8.28 kB → 8.28 kB
`src/components/accounts/Reconcile.tsx` | 📈 +2 B (+0.02%) | 9.11 kB → 9.11 kB
`src/components/budget/SidebarGroup.tsx` | 📈 +2 B (+0.02%) | 9.11 kB → 9.11 kB
`src/components/admin/UserAccess/UserAccess.tsx` | 📈 +2 B (+0.02%) | 9.98 kB → 9.98 kB
`src/components/CommandBar.tsx` | 📈 +2 B (+0.02%) | 10.16 kB → 10.16 kB
`src/components/budget/tracking/budgetsummary/BudgetSummary.tsx` | 📈 +2 B (+0.02%) | 10.45 kB → 10.45 kB
`src/components/modals/CategoryGroupMenuModal.tsx` | 📈 +2 B (+0.02%) | 10.55 kB → 10.55 kB
`src/components/settings/ThemeInstaller.tsx` | 📈 +2 B (+0.02%) | 10.97 kB → 10.97 kB
`src/components/budget/index.tsx` | 📈 +2 B (+0.02%) | 11.54 kB → 11.54 kB
`src/components/Notifications.tsx` | 📈 +2 B (+0.01%) | 14.78 kB → 14.79 kB
`src/components/FinancesApp.tsx` | 📈 +2 B (+0.01%) | 19.02 kB → 19.02 kB
`src/components/schedules/DiscoverSchedules.tsx` | 📉 -2 B (-0.02%) | 9.31 kB → 9.31 kB
`src/components/modals/TrackingBudgetMenuModal.tsx` | 📉 -2 B (-0.03%) | 6.5 kB → 6.5 kB
`src/components/schedules/ScheduleEditModal.tsx` | 📉 -2 B (-0.04%) | 5.33 kB → 5.33 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📉 -2 B (-0.04%) | 4.82 kB → 4.82 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📉 -24 B (-0.06%) | 42.53 kB → 42.51 kB
`src/components/modals/TrackingBudgetMonthMenuModal.tsx` | 📉 -4 B (-0.06%) | 6.48 kB → 6.48 kB
`src/components/modals/ScheduledTransactionMenuModal.tsx` | 📉 -4 B (-0.06%) | 6.01 kB → 6.01 kB
`src/components/modals/TrackingBalanceMenuModal.tsx` | 📉 -2 B (-0.07%) | 2.71 kB → 2.71 kB
`src/components/schedules/ScheduleLink.tsx` | 📉 -4 B (-0.09%) | 4.43 kB → 4.42 kB
`src/index.tsx` | 📉 -2 B (-0.11%) | 1.71 kB → 1.71 kB
`node_modules/es-toolkit/dist/compat/util/toPath.js` | 📉 -2 B (-0.14%) | 1.41 kB → 1.41 kB
`src/hooks/useCategoryCleanup.ts` | 📉 -2 B (-0.21%) | 967 B → 965 B
`src/hooks/useCleanupGroups.ts` | 📉 -2 B (-0.25%) | 811 B → 809 B
`node_modules/es-toolkit/dist/compat/util/toString.js` | 📉 -2 B (-0.36%) | 554 B → 552 B
`src/components/budget/goals/editor/CleanupGroupPicker.tsx` | 📉 -67 B (-1.14%) | 5.72 kB → 5.66 kB
`src/components/budget/MonthPicker.tsx` | 📉 -165 B (-1.88%) | 8.59 kB → 8.43 kB
`src/hooks/usePreviewTransactions.ts` | 📉 -61 B (-2.44%) | 2.44 kB → 2.38 kB
`node_modules/react-dnd/dist/core/DndProvider.js` | 📉 -112 B (-4.61%) | 2.37 kB → 2.26 kB
`src/components/payees/PayeeRuleCountLabel.tsx` | 📉 -106 B (-10.24%) | 1.01 kB → 929 B
`node_modules/react-dnd-html5-backend/dist/utils/js_utils.js` | 📉 -96 B (-13.62%) | 705 B → 609 B
`src/components/filters/ConditionsOpMenu.tsx` | 📉 -165 B (-16.37%) | 1008 B → 843 B
`node_modules/react-dnd/dist/hooks/useIsomorphicLayoutEffect.js` | 📉 -82 B (-27.80%) | 295 B → 213 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/async.ts` | 📉 -132 B (-33.50%) | 394 B → 262 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/merge.js | 0 B → 5.08 MB (+5.08 MB) | -
static/js/chart-theme.js | 0 B → 803.05 kB (+803.05 kB) | -
static/js/bankSyncUtils.js | 0 B → 54.15 kB (+54.15 kB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.07 MB → 0 B (-5.07 MB) | -100%
static/js/toString.js | 705.14 kB → 0 B (-705.14 kB) | -100%
static/js/SchedulesTable.js | 202.7 kB → 0 B (-202.7 kB) | -100%
static/js/_baseIsEqual.js | 98.02 kB → 0 B (-98.02 kB) | -100%
static/js/ManageRules.js | 46.98 kB → 0 B (-46.98 kB) | -100%
static/js/useTransactionBatchActions.js | 9.71 kB → 0 B (-9.71 kB) | -100%
static/js/PayeeRuleCountLabel.js | 7.33 kB → 0 B (-7.33 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB → 2.03 MB (+498.72 kB) | +31.58%
static/js/extends.js | 500.57 kB → 500.6 kB (+37 B) | +0.01%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 296.1 kB → 453 B (-295.66 kB) | -99.85%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.45 kB | 0%
static/js/TransactionEdit.js | 89.65 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/ca.js | 186.78 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.17 kB | 0%
static/js/de.js | 170.79 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.13 kB | 0%
static/js/es.js | 178.71 kB | 0%
static/js/fr.js | 178.61 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165.02 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.08 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.77 kB | 0%
static/js/uk.js | 207.49 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (-635 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +38 B (+9.13%) | 416 B → 454 B
`node_modules/bn.js/lib/bn.js` | 📉 -81 B (-0.10%) | 76.48 kB → 76.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -511 B (-4.01%) | 12.46 kB → 11.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BodMNOBH.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C_UHYSJL.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.96 MB (-460 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +37 B (+9.54%) | 388 B → 425 B
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -497 B (-3.98%) | 12.19 kB → 11.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.96 MB (-460 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->