### PR TITLE
[AI] Fix auto-post schedule catch-up

### DIFF
--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -2,15 +2,18 @@
 import MockDate from 'mockdate';
 
 import { aqlQuery } from '#server/aql';
+import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 import { loadRules, updateRule } from '#server/transactions/transaction-rules';
 import { q } from '#shared/query';
 import { getNextDate } from '#shared/schedules';
 
 import {
+  advanceSchedulesService,
   areConditionValuesEqual,
   createSchedule,
   deleteSchedule,
+  app as schedulesApp,
   setNextDate,
   skipNextDate,
   updateConditions,
@@ -546,6 +549,79 @@ describe('schedule app', () => {
       row = res.data[0];
 
       expect(row.next_date).toBe('2020-12-11');
+    });
+
+    it('auto-posts every missed recurring occurrence while catching up', async () => {
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            {
+              op: 'is',
+              field: 'account',
+              value: accountId,
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: -10000,
+            },
+            {
+              op: 'is',
+              field: 'date',
+              value: {
+                start: '2016-12-05',
+                frequency: 'weekly',
+                interval: 2,
+                patterns: [],
+              },
+            },
+          ],
+        });
+        const nextDateRow = await db.first<{
+          id: string;
+        }>('SELECT id FROM schedules_next_date WHERE schedule_id = ?', [id]);
+
+        await db.update('schedules_next_date', {
+          id: nextDateRow.id,
+          local_next_date: 20161205,
+          local_next_date_ts: Date.now(),
+          base_next_date: 20161205,
+          base_next_date_ts: Date.now(),
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions')
+            .filter({ schedule: id })
+            .select(['date', 'amount'])
+            .orderBy({ date: 'asc' }),
+        );
+
+        expect(
+          transactions.map(({ date, amount }) => ({ date, amount })),
+        ).toEqual([
+          { date: '2016-12-05', amount: -10000 },
+          { date: '2016-12-19', amount: -10000 },
+        ]);
+
+        const {
+          data: [schedule],
+        } = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
+
+        expect(schedule.next_date).toBe('2017-01-02');
+      } finally {
+        await schedulesApp.stopServices();
+      }
     });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -763,5 +763,52 @@ describe('schedule app', () => {
         await schedulesApp.stopServices();
       }
     });
+
+    it('auto-posts one-time schedules that are due', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            {
+              op: 'is',
+              field: 'account',
+              value: accountId,
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: -10000,
+            },
+            {
+              op: 'is',
+              field: 'date',
+              value: '2016-12-31',
+            },
+          ],
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['date', 'amount']),
+        );
+
+        expect(
+          transactions.map(({ date, amount }) => ({ date, amount })),
+        ).toEqual([{ date: '2016-12-31', amount: -10000 }]);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -552,6 +552,7 @@ describe('schedule app', () => {
     });
 
     it('auto-posts every missed recurring occurrence while catching up', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
       schedulesApp.startServices();
 
       try {
@@ -620,6 +621,88 @@ describe('schedule app', () => {
 
         expect(schedule.next_date).toBe('2017-01-02');
       } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
+
+    it('continues auto-post catch-up after an already paid occurrence', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            {
+              op: 'is',
+              field: 'account',
+              value: accountId,
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: -10000,
+            },
+            {
+              op: 'is',
+              field: 'date',
+              value: {
+                start: '2016-12-05',
+                frequency: 'weekly',
+                interval: 2,
+                patterns: [],
+              },
+            },
+          ],
+        });
+        const nextDateRow = await db.first<{
+          id: string;
+        }>('SELECT id FROM schedules_next_date WHERE schedule_id = ?', [id]);
+
+        await db.update('schedules_next_date', {
+          id: nextDateRow.id,
+          local_next_date: 20161205,
+          local_next_date_ts: Date.now(),
+          base_next_date: 20161205,
+          base_next_date_ts: Date.now(),
+        });
+        await db.insertTransaction({
+          account: accountId,
+          amount: -10000,
+          date: '2016-12-05',
+          schedule: id,
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions')
+            .filter({ schedule: id })
+            .select(['date', 'amount'])
+            .orderBy({ date: 'asc' }),
+        );
+
+        expect(
+          transactions.map(({ date, amount }) => ({ date, amount })),
+        ).toEqual([
+          { date: '2016-12-05', amount: -10000 },
+          { date: '2016-12-19', amount: -10000 },
+        ]);
+
+        const {
+          data: [schedule],
+        } = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
+
+        expect(schedule.next_date).toBe('2017-01-02');
+      } finally {
+        MockDate.reset();
         await schedulesApp.stopServices();
       }
     });

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -706,5 +706,62 @@ describe('schedule app', () => {
         await schedulesApp.stopServices();
       }
     });
+
+    it('completes one-time auto-post schedules that are already paid', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            {
+              op: 'is',
+              field: 'account',
+              value: accountId,
+            },
+            {
+              op: 'is',
+              field: 'amount',
+              value: -10000,
+            },
+            {
+              op: 'is',
+              field: 'date',
+              value: '2016-12-05',
+            },
+          ],
+        });
+        await db.insertTransaction({
+          account: accountId,
+          amount: -10000,
+          date: '2016-12-05',
+          schedule: id,
+        });
+
+        await advanceSchedulesService(true);
+
+        const {
+          data: [schedule],
+        } = await aqlQuery(q('schedules').filter({ id }).select(['completed']));
+
+        expect(schedule.completed).toBe(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['date']),
+        );
+
+        expect(transactions).toHaveLength(1);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -526,9 +526,60 @@ async function postTransactionForSchedule({
   }
 }
 
+async function getSchedule(id: string): Promise<ScheduleEntity | null> {
+  const {
+    data: [schedule],
+  } = await aqlQuery(q('schedules').filter({ id }).select('*'));
+
+  return schedule ?? null;
+}
+
+async function hasTransactionForSchedule(
+  schedule: ScheduleEntity,
+): Promise<boolean> {
+  const { data } = await aqlQuery(getHasTransactionsQuery([schedule]));
+
+  return data.filter(Boolean).some(row => row.schedule === schedule.id);
+}
+
+async function advanceRecurringScheduleFromNextDate(
+  schedule: ScheduleEntity,
+): Promise<ScheduleEntity | null> {
+  if (
+    schedule._date == null ||
+    typeof schedule._date !== 'object' ||
+    !('frequency' in schedule._date)
+  ) {
+    return null;
+  }
+
+  const previousNextDate = schedule.next_date;
+
+  try {
+    await setNextDate({
+      id: schedule.id,
+      start: nextDate => d.addDays(parseDate(nextDate), 1),
+    });
+  } catch {
+    // This might error if the rule is corrupted and it can't find the rule.
+    return null;
+  }
+
+  const updatedSchedule = await getSchedule(schedule.id);
+
+  if (
+    updatedSchedule == null ||
+    updatedSchedule.next_date === previousNextDate
+  ) {
+    return null;
+  }
+
+  return updatedSchedule;
+}
+
 // TODO: make this sequential
 
-async function advanceSchedulesService(syncSuccess) {
+export async function advanceSchedulesService(syncSuccess) {
   // Move all paid schedules
   const { data: schedules } = await aqlQuery(
     q('schedules')
@@ -584,13 +635,62 @@ async function advanceSchedulesService(syncSuccess) {
       schedule.posts_transaction &&
       schedule._account
     ) {
-      // Automatically create a transaction for due schedules
-      if (syncSuccess) {
-        await postTransactionForSchedule({ id: schedule.id });
+      let currentSchedule = schedule;
+      let currentStatus = status;
 
-        didPost = true;
-      } else {
-        failedToPost.push(schedule._payee);
+      while (
+        currentSchedule.posts_transaction &&
+        currentSchedule._account &&
+        (currentStatus === 'paid' ||
+          currentStatus === 'due' ||
+          currentStatus === 'missed')
+      ) {
+        if (currentStatus === 'paid') {
+          const updatedSchedule =
+            await advanceRecurringScheduleFromNextDate(currentSchedule);
+
+          if (updatedSchedule == null) {
+            break;
+          }
+
+          currentSchedule = updatedSchedule;
+          currentStatus = getStatus(
+            currentSchedule.next_date,
+            currentSchedule.completed,
+            await hasTransactionForSchedule(currentSchedule),
+            currentSchedule.custom_upcoming_length ??
+              upcomingLength[0]?.value ??
+              '7',
+          );
+          continue;
+        }
+
+        // Automatically create a transaction for due schedules.
+        if (syncSuccess) {
+          await postTransactionForSchedule({ id: currentSchedule.id });
+
+          didPost = true;
+        } else {
+          failedToPost.push(currentSchedule._payee);
+          break;
+        }
+
+        const updatedSchedule =
+          await advanceRecurringScheduleFromNextDate(currentSchedule);
+
+        if (updatedSchedule == null) {
+          break;
+        }
+
+        currentSchedule = updatedSchedule;
+        currentStatus = getStatus(
+          currentSchedule.next_date,
+          currentSchedule.completed,
+          await hasTransactionForSchedule(currentSchedule),
+          currentSchedule.custom_upcoming_length ??
+            upcomingLength[0]?.value ??
+            '7',
+        );
       }
     }
   }

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -611,29 +611,10 @@ export async function advanceSchedulesService(syncSuccess) {
       schedule.custom_upcoming_length ?? upcomingLength[0]?.value ?? '7',
     );
 
-    if (status === 'paid') {
-      if (schedule._date) {
-        // Move forward recurring schedules
-        if (schedule._date.frequency) {
-          try {
-            await setNextDate({ id: schedule.id });
-          } catch {
-            // This might error if the rule is corrupted and it can't
-            // find the rule
-          }
-        } else {
-          if (schedule._date < currentDay()) {
-            // Complete any single schedules
-            await updateSchedule({
-              schedule: { id: schedule.id, completed: true },
-            });
-          }
-        }
-      }
-    } else if (
-      (status === 'due' || status === 'missed') &&
+    if (
       schedule.posts_transaction &&
-      schedule._account
+      schedule._account &&
+      (status === 'paid' || status === 'due' || status === 'missed')
     ) {
       let currentSchedule = schedule;
       let currentStatus = status;
@@ -691,6 +672,25 @@ export async function advanceSchedulesService(syncSuccess) {
             upcomingLength[0]?.value ??
             '7',
         );
+      }
+    } else if (status === 'paid') {
+      if (schedule._date) {
+        // Move forward recurring schedules
+        if (schedule._date.frequency) {
+          try {
+            await setNextDate({ id: schedule.id });
+          } catch {
+            // This might error if the rule is corrupted and it can't
+            // find the rule
+          }
+        } else {
+          if (schedule._date < currentDay()) {
+            // Complete any single schedules
+            await updateSchedule({
+              schedule: { id: schedule.id, completed: true },
+            });
+          }
+        }
       }
     }
   }

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -618,7 +618,7 @@ export async function advanceSchedulesService(syncSuccess) {
     if (
       schedule.posts_transaction &&
       schedule._account &&
-      isRecurringSchedule(schedule) &&
+      (status !== 'paid' || isRecurringSchedule(schedule)) &&
       (status === 'paid' || status === 'due' || status === 'missed')
     ) {
       let currentSchedule = schedule;
@@ -627,7 +627,6 @@ export async function advanceSchedulesService(syncSuccess) {
       while (
         currentSchedule.posts_transaction &&
         currentSchedule._account &&
-        isRecurringSchedule(currentSchedule) &&
         (currentStatus === 'paid' ||
           currentStatus === 'due' ||
           currentStatus === 'missed')
@@ -662,6 +661,10 @@ export async function advanceSchedulesService(syncSuccess) {
           break;
         }
 
+        if (!isRecurringSchedule(currentSchedule)) {
+          break;
+        }
+
         const updatedSchedule =
           await advanceRecurringScheduleFromNextDate(currentSchedule);
 
@@ -682,7 +685,7 @@ export async function advanceSchedulesService(syncSuccess) {
     } else if (status === 'paid') {
       if (schedule._date) {
         // Move forward recurring schedules
-        if (schedule._date.frequency) {
+        if (isRecurringSchedule(schedule)) {
           try {
             await setNextDate({ id: schedule.id });
           } catch {

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -542,14 +542,18 @@ async function hasTransactionForSchedule(
   return data.filter(Boolean).some(row => row.schedule === schedule.id);
 }
 
+function isRecurringSchedule(schedule: ScheduleEntity): boolean {
+  return (
+    schedule._date != null &&
+    typeof schedule._date === 'object' &&
+    'frequency' in schedule._date
+  );
+}
+
 async function advanceRecurringScheduleFromNextDate(
   schedule: ScheduleEntity,
 ): Promise<ScheduleEntity | null> {
-  if (
-    schedule._date == null ||
-    typeof schedule._date !== 'object' ||
-    !('frequency' in schedule._date)
-  ) {
+  if (!isRecurringSchedule(schedule)) {
     return null;
   }
 
@@ -614,6 +618,7 @@ export async function advanceSchedulesService(syncSuccess) {
     if (
       schedule.posts_transaction &&
       schedule._account &&
+      isRecurringSchedule(schedule) &&
       (status === 'paid' || status === 'due' || status === 'missed')
     ) {
       let currentSchedule = schedule;
@@ -622,6 +627,7 @@ export async function advanceSchedulesService(syncSuccess) {
       while (
         currentSchedule.posts_transaction &&
         currentSchedule._account &&
+        isRecurringSchedule(currentSchedule) &&
         (currentStatus === 'paid' ||
           currentStatus === 'due' ||
           currentStatus === 'missed')

--- a/upcoming-release-notes/7997.md
+++ b/upcoming-release-notes/7997.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [sjh9714]
+---
+
+Post every missed auto-post scheduled transaction when catching up.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB | 0%
loot-core | 1 | 5.34 MB → 5.35 MB (+2.21 kB) | +0.04%
api | 2 | 3.97 MB → 3.97 MB (+2.17 kB) | +0.05%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.48 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/extends.js | 500.96 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.28 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 297.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.35 MB (+2.21 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +2.21 kB (+17.74%) | 12.46 kB → 14.67 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Br1XGNCP.js | 0 B → 5.35 MB (+5.35 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.97 MB → 3.97 MB (+2.17 kB) | +0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +2.17 kB (+17.79%) | 12.19 kB → 14.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.97 MB → 3.97 MB (+2.17 kB) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->