### PR TITLE
[AI] Fix append notes rules on new transactions

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -70,6 +70,7 @@
     "#components/reports/util": "./src/components/reports/util.ts",
     "#components/schedules": "./src/components/schedules/index.tsx",
     "#components/schedules/schedule-edit-utils": "./src/components/schedules/schedule-edit-utils.ts",
+    "#components/transactions/applyRuleDiff": "./src/components/transactions/applyRuleDiff.ts",
     "#components/util/accountValidation": "./src/components/util/accountValidation.ts",
     "#components/util/countries": "./src/components/util/countries.ts",
     "#components/util/localeToCountry": "./src/components/util/localeToCountry.ts",

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -85,6 +85,7 @@ import {
 } from '#components/mobile/MobileForms';
 import { getPrettyPayee } from '#components/mobile/utils';
 import { MobilePageHeader, Page } from '#components/Page';
+import { applyRuleDiffToTransaction } from '#components/transactions/applyRuleDiff';
 import { createSingleTimeScheduleFromTransaction } from '#components/transactions/TransactionList';
 import { AmountInput } from '#components/util/AmountInput';
 import { useAccounts } from '#hooks/useAccounts';
@@ -1787,7 +1788,7 @@ function TransactionEditUnconnected({
 
       // Run the rules to auto-fill in any data. Right now we only do
       // this on new transactions because that's how desktop works.
-      const newTransaction = { ...transaction };
+      let newTransaction = { ...transaction };
       if (isTemporary(newTransaction)) {
         const afterRules = await send('rules-run', {
           transaction: newTransaction,
@@ -1795,21 +1796,11 @@ function TransactionEditUnconnected({
         const diff = getChangedValues(newTransaction, afterRules);
 
         if (diff) {
-          Object.keys(diff).forEach(key => {
-            const field = key as keyof TransactionEntity;
-            // Update "empty" fields in general
-            // Or update all fields if the payee changes (assists location-based entry by
-            // applying rules to prefill category, notes, etc. based on the selected payee)
-            if (
-              newTransaction[field] == null ||
-              newTransaction[field] === '' ||
-              newTransaction[field] === 0 ||
-              newTransaction[field] === false ||
-              updatedField === 'payee'
-            ) {
-              (newTransaction as Record<string, unknown>)[field] = diff[field];
-            }
-          });
+          newTransaction = applyRuleDiffToTransaction(
+            newTransaction,
+            diff,
+            updatedField,
+          );
 
           // When a rule updates a parent transaction, overwrite all changes to the current field in subtransactions.
           if (

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -40,6 +40,7 @@ import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 
+import { applyRuleDiffToTransaction } from './applyRuleDiff';
 import { TransactionTable } from './TransactionsTable';
 import type { TransactionTableProps } from './TransactionsTable';
 // When data changes, there are two ways to update the UI:
@@ -532,19 +533,10 @@ export function TransactionList({
 
       const diff = getChangedValues(transaction, afterRules);
 
-      const newTransaction: TransactionEntity = { ...transaction };
+      const newTransaction: TransactionEntity = diff
+        ? applyRuleDiffToTransaction(transaction, diff, updatedFieldName)
+        : { ...transaction };
       if (diff) {
-        Object.keys(diff).forEach(field => {
-          if (
-            newTransaction[field] == null ||
-            newTransaction[field] === '' ||
-            newTransaction[field] === 0 ||
-            newTransaction[field] === false
-          ) {
-            newTransaction[field] = diff[field];
-          }
-        });
-
         // When a rule updates a parent transaction, overwrite all changes to the current field in subtransactions.
         if (
           transaction.is_parent &&

--- a/packages/desktop-client/src/components/transactions/applyRuleDiff.test.ts
+++ b/packages/desktop-client/src/components/transactions/applyRuleDiff.test.ts
@@ -1,0 +1,97 @@
+import type { TransactionEntity } from '@actual-app/core/types/models';
+
+import {
+  applyRuleDiffToTransaction,
+  shouldApplyRuleDiff,
+} from './applyRuleDiff';
+
+function transaction(overrides: Partial<TransactionEntity>): TransactionEntity {
+  return {
+    id: 'temp',
+    account: 'account',
+    amount: 0,
+    cleared: false,
+    date: '2026-01-01',
+    payee: null,
+    ...overrides,
+  };
+}
+
+describe('applyRuleDiffToTransaction', () => {
+  it('applies rule values to empty fields', () => {
+    const result = applyRuleDiffToTransaction(
+      transaction({ category: undefined }),
+      {
+        category: 'restaurants',
+      },
+    );
+
+    expect(result.category).toBe('restaurants');
+  });
+
+  it('leaves empty fields unchanged when they are absent from the diff', () => {
+    const result = applyRuleDiffToTransaction(transaction({ amount: 0 }), {
+      category: 'restaurants',
+    });
+
+    expect(result.amount).toBe(0);
+  });
+
+  it('does not overwrite existing notes with set-style rule values', () => {
+    const result = applyRuleDiffToTransaction(
+      transaction({ notes: 'Coffee and cake' }),
+      { notes: 'Rule note' },
+    );
+
+    expect(result.notes).toBe('Coffee and cake');
+  });
+
+  it('does not treat substring overlap as a notes merge', () => {
+    const result = applyRuleDiffToTransaction(transaction({ notes: 'fee' }), {
+      notes: 'coffee',
+    });
+
+    expect(result.notes).toBe('fee');
+  });
+
+  it('applies appended notes that preserve the existing user note', () => {
+    const result = applyRuleDiffToTransaction(
+      transaction({ notes: 'Coffee and cake' }),
+      { notes: 'Coffee and cake Appended Text' },
+    );
+
+    expect(result.notes).toBe('Coffee and cake Appended Text');
+  });
+
+  it('applies prepended notes that preserve the existing user note', () => {
+    const result = applyRuleDiffToTransaction(
+      transaction({ notes: 'Coffee and cake' }),
+      { notes: 'Prepended Text Coffee and cake' },
+    );
+
+    expect(result.notes).toBe('Prepended Text Coffee and cake');
+  });
+
+  it('allows non-empty fields to update after the payee changes', () => {
+    const result = applyRuleDiffToTransaction(
+      transaction({ notes: 'Existing note' }),
+      { notes: 'Rule note' },
+      'payee',
+    );
+
+    expect(result.notes).toBe('Rule note');
+  });
+});
+
+describe('shouldApplyRuleDiff', () => {
+  it('allows non-empty fields to update after the payee changes', () => {
+    expect(
+      shouldApplyRuleDiff(
+        transaction({ notes: 'Existing note' }),
+        'notes',
+        'Rule note',
+        'payee',
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/desktop-client/src/components/transactions/applyRuleDiff.ts
+++ b/packages/desktop-client/src/components/transactions/applyRuleDiff.ts
@@ -1,0 +1,103 @@
+import type { TransactionEntity } from '@actual-app/core/types/models';
+
+const transactionFields = [
+  'id',
+  'is_parent',
+  'is_child',
+  'parent_id',
+  'account',
+  'category',
+  'amount',
+  'payee',
+  'notes',
+  'date',
+  'imported_id',
+  'imported_payee',
+  'starting_balance_flag',
+  'transfer_id',
+  'sort_order',
+  'cleared',
+  'reconciled',
+  'tombstone',
+  'forceUpcoming',
+  'schedule',
+  'subtransactions',
+  '_unmatched',
+  '_deleted',
+  'error',
+  'raw_synced_data',
+  '_ruleErrors',
+] as const satisfies ReadonlyArray<keyof TransactionEntity>;
+
+function isEmptyRuleTarget(value: unknown) {
+  return value == null || value === '' || value === 0 || value === false;
+}
+
+function isNotesMerge(currentValue: unknown, nextValue: unknown) {
+  if (
+    typeof currentValue !== 'string' ||
+    currentValue === '' ||
+    typeof nextValue !== 'string' ||
+    nextValue === currentValue
+  ) {
+    return false;
+  }
+
+  if (nextValue.startsWith(currentValue)) {
+    return hasMergeBoundary(nextValue.slice(currentValue.length), 'start');
+  }
+
+  if (nextValue.endsWith(currentValue)) {
+    return hasMergeBoundary(
+      nextValue.slice(0, nextValue.length - currentValue.length),
+      'end',
+    );
+  }
+
+  return false;
+}
+
+function hasMergeBoundary(value: string, edge: 'start' | 'end') {
+  if (value === '') {
+    return false;
+  }
+
+  const boundary = edge === 'start' ? value[0] : value[value.length - 1];
+  return !/[A-Za-z0-9]/.test(boundary);
+}
+
+export function shouldApplyRuleDiff(
+  transaction: TransactionEntity,
+  field: keyof TransactionEntity,
+  nextValue: unknown,
+  updatedFieldName?: keyof TransactionEntity | string | null,
+) {
+  const currentValue = transaction[field];
+
+  return (
+    updatedFieldName === 'payee' ||
+    isEmptyRuleTarget(currentValue) ||
+    (field === 'notes' && isNotesMerge(currentValue, nextValue))
+  );
+}
+
+export function applyRuleDiffToTransaction(
+  transaction: TransactionEntity,
+  diff: Partial<TransactionEntity>,
+  updatedFieldName?: keyof TransactionEntity | string | null,
+) {
+  const newTransaction = { ...transaction };
+
+  transactionFields.forEach(field => {
+    if (!(field in diff)) {
+      return;
+    }
+
+    const nextValue = diff[field];
+    if (shouldApplyRuleDiff(transaction, field, nextValue, updatedFieldName)) {
+      (newTransaction as Record<string, unknown>)[field] = nextValue;
+    }
+  });
+
+  return newTransaction;
+}

--- a/upcoming-release-notes/8003.md
+++ b/upcoming-release-notes/8003.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kikiminyes]
+---
+
+Preserve existing transaction notes when rules append or prepend text while adding a new transaction.


### PR DESCRIPTION
Fixes #7303

## Summary
- centralize how rule diffs are applied to new transactions
- allow append/prepend notes rule results to update non-empty notes when they preserve the user-entered note
- reuse the same rule-diff behavior for desktop and mobile transaction entry

## Testing
- `corepack yarn workspace @actual-app/web test src/components/transactions/applyRuleDiff.test.ts`
- `corepack yarn workspace @actual-app/web typecheck`
- `corepack yarn oxfmt --check packages/desktop-client/package.json packages/desktop-client/src/components/transactions/applyRuleDiff.ts packages/desktop-client/src/components/transactions/applyRuleDiff.test.ts packages/desktop-client/src/components/transactions/TransactionList.tsx packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx upcoming-release-notes/8003.md`
- `corepack yarn oxlint --type-aware packages/desktop-client/src/components/transactions/applyRuleDiff.ts packages/desktop-client/src/components/transactions/applyRuleDiff.test.ts packages/desktop-client/src/components/transactions/TransactionList.tsx packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx` (0 errors; existing `no-unsafe-type-assertion` warnings remain in touched files)
- `PR_NUMBER=8003 node packages\ci-actions\bin\release-notes-check.mjs`

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB ? 14.03 MB (+1.83 kB) | +0.01%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.97 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB ? 14.03 MB (+1.83 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | ? | Size
---- | - | ----
`src/components/transactions/applyRuleDiff.ts` | ?? +1.8 kB | 0 B ? 1.8 kB
`package.json` | ?? +93 B (+0.98%) | 9.28 kB ? 9.38 kB
`locale/en.json` | ?? +252 B (+0.12%) | 198.24 kB ? 198.48 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | ?? -159 B (-0.22%) | 71.47 kB ? 71.32 kB
`src/components/transactions/TransactionList.tsx` | ?? -151 B (-0.85%) | 17.29 kB ? 17.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.08 MB ? 5.08 MB (+1.65 kB) | +0.03%
static/js/en.js | 198.24 kB ? 198.48 kB (+252 B) | +0.12%
static/js/index.js | 1.54 MB ? 1.54 MB (+93 B) | +0.01%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionEdit.js | 90.63 kB ? 90.47 kB (-159 B) | -0.17%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/extends.js | 500.96 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 297.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.89 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.97 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->
## Related work

Related to #7568, which also targets #7303. This PR keeps the fix in the transaction-entry diff application path and currently has a passing release note/check setup. Happy to close or adjust if maintainers prefer reviving the earlier PR.