### PR TITLE
[AI] Validate invalid regex rule conditions

### DIFF
--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -26,6 +26,18 @@ import {
   parseRecurDate,
 } from './rule-utils';
 
+function assertValidRegex(value, fieldName) {
+  try {
+    new RegExp(value);
+  } catch {
+    assert(
+      false,
+      'invalid-regex',
+      `Invalid regular expression (field: ${fieldName})`,
+    );
+  }
+}
+
 export const CONDITION_TYPES = {
   date: {
     ops: ['is', 'isapprox', 'gt', 'gte', 'lt', 'lte'],
@@ -86,6 +98,19 @@ export const CONDITION_TYPES = {
         );
         return value;
       }
+      if (op === 'matches') {
+        assert(
+          typeof value === 'string',
+          'not-string',
+          `Invalid string value (field: ${fieldName})`,
+        );
+        assert(
+          value.length > 0,
+          'no-empty-string',
+          `${op} must have non-empty string (field: ${fieldName})`,
+        );
+        assertValidRegex(value, fieldName);
+      }
       return value;
     },
   },
@@ -138,7 +163,13 @@ export const CONDITION_TYPES = {
         return value;
       }
 
-      return value.toLowerCase();
+      const normalizedValue = value.toLowerCase();
+
+      if (op === 'matches') {
+        assertValidRegex(normalizedValue, fieldName);
+      }
+
+      return normalizedValue;
     },
   },
   number: {

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -228,9 +228,10 @@ describe('Condition', () => {
     expect(cond.eval({ notes: 'f o o' })).toBe(false);
   });
 
-  test('matches handles invalid regex', () => {
-    const cond = new Condition('matches', 'notes', 'fo**', null);
-    expect(cond.eval({ notes: 'foo' })).toBe(false);
+  test('matches validates regex', () => {
+    expect(() => {
+      new Condition('matches', 'notes', 'fo**', null);
+    }).toThrow('Invalid regular expression');
   });
 
   test('number validates value', () => {

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -712,6 +712,15 @@ describe('Transaction rules', () => {
       },
     ]);
   });
+
+  test('invalid matches regex returns a condition error instead of an AQL filter', () => {
+    const { errors, filters } = conditionsToAQL([
+      { field: 'notes', op: 'matches', value: 'asdf\\' },
+    ]);
+
+    expect(errors).toEqual(['invalid-regex']);
+    expect(filters).toEqual([]);
+  });
 });
 
 describe('Learning categories', () => {

--- a/packages/loot-core/src/shared/rules.test.ts
+++ b/packages/loot-core/src/shared/rules.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getValidOps, isValidOp } from './rules';
+import { getFieldError, getValidOps, isValidOp } from './rules';
 
 describe('rules', () => {
   describe('isValidOp', () => {
@@ -53,6 +53,12 @@ describe('rules', () => {
       const validOps = getValidOps('payee');
       expect(validOps).toContain('oneOf');
       expect(validOps).toContain('notOneOf');
+    });
+  });
+
+  describe('getFieldError', () => {
+    it('should return a friendly invalid regex message', () => {
+      expect(getFieldError('invalid-regex')).toBe('Invalid regular expression');
     });
   });
 });

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -284,6 +284,8 @@ export function getFieldError(type) {
       return 'Please choose a valid field for this type of rule';
     case 'invalid-template':
       return 'Invalid handlebars template';
+    case 'invalid-regex':
+      return 'Invalid regular expression';
     default:
       return 'Internal error, sorry! Please get in touch https://actualbudget.org/contact/ for support';
   }

--- a/upcoming-release-notes/8004.md
+++ b/upcoming-release-notes/8004.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kikiminyes]
+---
+
+Show a field error for invalid rule `matches` regular expressions instead of letting the rule preview fail.


### PR DESCRIPTION
Fixes #6317.

This validates `matches` condition values before they are converted into AQL filters. Invalid regular expressions now surface as rule field errors instead of letting the rule preview run a broken `$regexp` query.

Validation run locally:

- `corepack yarn workspace @actual-app/core test:node src/server/rules/index.test.ts`
- `corepack yarn workspace @actual-app/core test:node src/server/transactions/transaction-rules.test.ts`
- `corepack yarn workspace @actual-app/core test:node src/shared/rules.test.ts`
- `corepack yarn workspace @actual-app/core typecheck`
- `corepack yarn oxfmt --check upcoming-release-notes/8004.md packages/loot-core/src/server/rules/condition.ts packages/loot-core/src/server/rules/index.test.ts packages/loot-core/src/server/transactions/transaction-rules.test.ts packages/loot-core/src/shared/rules.ts packages/loot-core/src/shared/rules.test.ts`
- `PR_NUMBER=8004 node packages/ci-actions/bin/release-notes-check.mjs`

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB → 14.03 MB (+630 B) | +0.00%
loot-core | 1 | 5.34 MB → 5.34 MB (+583 B) | +0.01%
api | 2 | 3.92 MB → 3.97 MB (+42.87 kB) | +1.07%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB → 14.03 MB (+630 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +569 B (+6.60%) | 8.41 kB → 8.97 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +61 B (+0.82%) | 7.24 kB → 7.3 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.08 MB → 5.08 MB (+630 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.48 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/extends.js | 500.96 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.28 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 297.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+583 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +583 B (+6.40%) | 8.89 kB → 9.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.VRl8eXpj.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.92 MB → 3.97 MB (+42.87 kB) | +1.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/ua-parser-js/src/main/ua-parser.mjs` | 🆕 +41.87 kB | 0 B → 41.87 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 🆕 +431 B | 0 B → 431 B
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +569 B (+6.61%) | 8.41 kB → 8.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +21 B (+0.41%) | 5.06 kB → 5.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.92 MB → 3.97 MB (+42.87 kB) | +1.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->