### PR TITLE
[AI] Fix bug when linking accounts

### DIFF
--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
@@ -147,42 +147,54 @@ export function SelectLinkedAccountsModal({
   const dispatch = useDispatch();
   const { data: allAccounts = [] } = useAccounts();
   const localAccounts = allAccounts.filter(a => a.closed === 0);
-  const [draftLinkAccounts, setDraftLinkAccounts] = useState<
-    Map<string, 'linking' | 'unlinking'>
-  >(() => {
-    const externalAccountIds = new Set(externalAccounts.map(a => a.account_id));
-    const initial = new Map<string, 'linking' | 'unlinking'>();
+  const { initialDraftLinkAccounts, initiallyChosenAccounts } = useMemo(() => {
+    const externalAccountIds = new Set(
+      externalAccounts?.map(a => a.account_id) || [],
+    );
+    const initialDraftLinkAccounts = new Map<string, 'linking' | 'unlinking'>();
     for (const acc of localAccounts) {
       if (acc.account_id && externalAccountIds.has(acc.account_id)) {
-        initial.set(acc.account_id, 'linking');
+        initialDraftLinkAccounts.set(acc.account_id, 'linking');
       }
     }
-    return initial;
-  });
-  const [chosenAccounts, setChosenAccounts] = useState<Record<string, string>>(
-    () => {
-      const initiallyChosenAccounts = Object.fromEntries(
-        localAccounts
-          .filter(acc => acc.account_id)
-          .map(acc => [acc.account_id, acc.id]),
+
+    const initiallyChosenAccounts = Object.fromEntries(
+      localAccounts
+        .filter(acc => acc.account_id)
+        .map(acc => [acc.account_id, acc.id]),
+    );
+
+    const preselectedExternalAccount =
+      propsWithSortedExternalAccounts.externalAccounts.find(
+        account => initiallyChosenAccounts[account.account_id] == null,
       );
 
-      const preselectedExternalAccount =
-        propsWithSortedExternalAccounts.externalAccounts.find(
-          account => initiallyChosenAccounts[account.account_id] == null,
-        );
+    if (
+      upgradingAccountId &&
+      preselectedExternalAccount &&
+      !Object.values(initiallyChosenAccounts).includes(upgradingAccountId)
+    ) {
+      initiallyChosenAccounts[preselectedExternalAccount.account_id] =
+        upgradingAccountId;
+      initialDraftLinkAccounts.set(
+        preselectedExternalAccount.account_id,
+        'linking',
+      );
+    }
 
-      if (
-        upgradingAccountId &&
-        preselectedExternalAccount &&
-        !Object.values(initiallyChosenAccounts).includes(upgradingAccountId)
-      ) {
-        initiallyChosenAccounts[preselectedExternalAccount.account_id] =
-          upgradingAccountId;
-      }
+    return { initialDraftLinkAccounts, initiallyChosenAccounts };
+  }, [
+    localAccounts,
+    externalAccounts,
+    propsWithSortedExternalAccounts.externalAccounts,
+    upgradingAccountId,
+  ]);
 
-      return initiallyChosenAccounts;
-    },
+  const [draftLinkAccounts, setDraftLinkAccounts] = useState<
+    Map<string, 'linking' | 'unlinking'>
+  >(initialDraftLinkAccounts);
+  const [chosenAccounts, setChosenAccounts] = useState<Record<string, string>>(
+    initiallyChosenAccounts,
   );
   const [customStartingDates, setCustomStartingDates] = useState<
     Record<string, StartingBalanceInfo>

--- a/upcoming-release-notes/8006.md
+++ b/upcoming-release-notes/8006.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mnil]
+---
+
+Fixes a bug where selecting Link Account from the account page required reselecting the same account in the modal even though it’s prepopulated.


### PR DESCRIPTION
## Description

Fixes a bug that when selecting Link Account from the account page one has to reselect the same account in the modal even though its prepopulated.

## Related issue(s)

- https://github.com/actualbudget/actual/issues/7799#issuecomment-4424675020
- https://github.com/actualbudget/actual/issues/7799#issuecomment-4544148340

## Testing

Tested working on my prod instance. Start to link an account from an account page, before this commit the "Link Account" button was greyed out until you reselected the account from the dropdown.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB → 14.03 MB (+544 B) | +0.00%
loot-core | 1 | 5.34 MB | 0%
api | 2 | 3.97 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB → 14.03 MB (+544 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +292 B (+0.67%) | 42.53 kB → 42.82 kB
`locale/en.json` | 📈 +252 B (+0.12%) | 198.24 kB → 198.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB → 1.54 MB (+292 B) | +0.02%
static/js/en.js | 198.24 kB → 198.48 kB (+252 B) | +0.12%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/extends.js | 500.96 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.24 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 297.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.89 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.97 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->