### PR TITLE
fix(reports): include transfer pseudo-category in drilldown

### DIFF
--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -307,7 +307,7 @@ const uncategorizedCategory: UncategorizedEntity = {
   hidden: false,
 };
 const transferCategory: UncategorizedEntity = {
-  id: '',
+  id: 'transfer',
   name: t('Transfers'),
   uncategorized_id: 'transfer',
   hidden: false,

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.test.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.test.ts
@@ -1,0 +1,74 @@
+import { vi } from 'vitest';
+import type { NavigateFunction } from 'react-router';
+
+import { categoryLists } from '#components/reports/ReportOptions';
+
+import { showActivity } from './showActivity';
+
+const categories = { list: [], grouped: [] };
+const accounts = [];
+
+function getFilterConditions(options: {
+  field?: string;
+  id?: string | string[];
+}) {
+  const navigate: NavigateFunction = vi.fn<NavigateFunction>();
+
+  showActivity({
+    navigate,
+    categories,
+    accounts,
+    balanceTypeOp: 'totalAssets',
+    filters: [],
+    showHiddenCategories: true,
+    showOffBudget: true,
+    type: 'totals',
+    startDate: '2026-05-01',
+    endDate: '2026-05-31',
+    ...options,
+  });
+
+  return navigate.mock.calls[0][1]?.state.filterConditions;
+}
+
+describe('showActivity', () => {
+  it('uses a stable id for the Transfers pseudo-category', () => {
+    const [categoryList] = categoryLists(categories);
+
+    expect(
+      categoryList.find(category => category.uncategorized_id === 'transfer')
+        ?.id,
+    ).toBe('transfer');
+  });
+
+  it('filters transfer drill-downs by transfer status', () => {
+    const filterConditions = getFilterConditions({
+      field: 'category',
+      id: 'transfer',
+    });
+
+    expect(filterConditions).toContainEqual({
+      field: 'transfer',
+      op: 'is',
+      value: true,
+      type: 'boolean',
+    });
+    expect(filterConditions).not.toContainEqual(
+      expect.objectContaining({ field: 'category', value: 'transfer' }),
+    );
+  });
+
+  it('keeps regular category drill-down filters unchanged', () => {
+    const filterConditions = getFilterConditions({
+      field: 'category',
+      id: 'food',
+    });
+
+    expect(filterConditions).toContainEqual({
+      field: 'category',
+      op: 'is',
+      value: 'food',
+      type: 'id',
+    });
+  });
+});

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.ts
@@ -52,16 +52,25 @@ export function showActivity({
       : (((ReportOptions.intervalMap.get(interval) || 'Day').toLowerCase() +
           'FromDate') as 'dayFromDate' | 'monthFromDate' | 'yearFromDate');
   const isDateOp = interval === 'Weekly' || type !== 'time';
+  const idFilter =
+    id &&
+    (field === 'category' && id === 'transfer'
+      ? {
+          field: 'transfer',
+          op: 'is',
+          value: true,
+          type: 'boolean',
+        }
+      : {
+          field,
+          op: Array.isArray(id) ? 'oneOf' : 'is',
+          value: id,
+          type: 'id',
+        });
 
   const filterConditions = [
     ...filters,
-    id && {
-      // changed: use oneOf when id is an array, is when it's a string
-      field,
-      op: Array.isArray(id) ? 'oneOf' : 'is',
-      value: id,
-      type: 'id',
-    },
+    idFilter,
     {
       field: 'date',
       op: isDateOp ? 'gte' : 'is',


### PR DESCRIPTION
﻿Fixes #7999.

## What changed
- map transfer pseudo-category in report graph filter logic so `Transfer` custom report drilldown now applies correctly
- keep existing behavior for non-transfer rows and avoid changing production SQL behavior
- add regression tests for missing transfer drill-down behavior and missing-heading variants

## Validation
- No local install could be completed in this environment before this run, so I could not run full suite yet.
