### PR TITLE
[AI] Add npm minimal age gate for supply-chain defense

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -11,3 +11,8 @@ yarnPath: .yarn/releases/yarn-4.13.0.cjs
 # Secure default: don't run postinstall scripts.
 # If a new package requires them, add it to dependenciesMeta in package.json.
 enableScripts: false
+
+# Supply-chain defense: don't install package versions published less than 3
+# days ago, giving the community time to catch compromised releases. Trusted
+# packages that need immediate updates can be listed in npmPreapprovedPackages.
+npmMinimalAgeGate: "3d"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,4 +15,4 @@ enableScripts: false
 # Supply-chain defense: don't install package versions published less than 3
 # days ago, giving the community time to catch compromised releases. Trusted
 # packages that need immediate updates can be listed in npmPreapprovedPackages.
-npmMinimalAgeGate: "3d"
+npmMinimalAgeGate: '3d'

--- a/upcoming-release-notes/8011.md
+++ b/upcoming-release-notes/8011.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add a 3-day minimum age gate for npm dependencies to harden against supply-chain attacks


### PR DESCRIPTION
## Description

Extra protection when we are doing dependency upgrades.

Plus should make the upgrade ergonomics slightly better as we won't need to manually check the release date for the version bumps.

## Related issue(s)

<!-- Add any related issue numbers here if applicable -->

n/a

## Testing

N/A 
## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_01SVxxPz4Ku8GmkYzTLrLQWo