### PR TITLE
[AI] API: improve messaging for version/schema mismatch errors

### DIFF
--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -225,7 +225,9 @@ handlers['api/download-budget'] = async function ({ syncId, password }) {
     await handlers['load-budget']({ id: localBudget.id });
     const result = await handlers['sync-budget']();
     if (result.error) {
-      throw new Error(getSyncError(result.error.reason, localBudget.id));
+      throw new Error(
+        getSyncError(result.error.reason, localBudget.id, result.error.meta),
+      );
     }
     return;
   }
@@ -254,7 +256,7 @@ handlers['api/sync'] = async function () {
   const { id } = prefs.getPrefs();
   const result = await handlers['sync-budget']();
   if (result.error) {
-    throw new Error(getSyncError(result.error.reason, id));
+    throw new Error(getSyncError(result.error.reason, id, result.error.meta));
   }
 };
 

--- a/packages/loot-core/src/shared/errors.test.ts
+++ b/packages/loot-core/src/shared/errors.test.ts
@@ -1,5 +1,4 @@
 import i18next from 'i18next';
-import { beforeAll, describe, expect, it } from 'vitest';
 
 import { getDownloadError, getSyncError } from './errors';
 

--- a/packages/loot-core/src/shared/errors.test.ts
+++ b/packages/loot-core/src/shared/errors.test.ts
@@ -1,0 +1,69 @@
+import i18next from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { getDownloadError, getSyncError } from './errors';
+
+beforeAll(async () => {
+  // With no translation resources, i18next returns each key (the English
+  // source string) verbatim, which is all these assertions rely on.
+  await i18next.init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: {} } },
+  });
+});
+
+const schemaMismatchMeta = {
+  error: { message: 'no such column: cleanup_def', stack: '' },
+  query: { sql: 'UPDATE categories SET cleanup_def = ? WHERE id = ?' },
+};
+
+const unrelatedMeta = {
+  error: { message: 'UNIQUE constraint failed', stack: '' },
+  query: { sql: 'INSERT INTO categories (id) VALUES (?)' },
+};
+
+describe('getDownloadError', () => {
+  it('returns a version-mismatch message for missing-column schema errors', () => {
+    expect(
+      getDownloadError({ reason: 'invalid-schema', meta: schemaMismatchMeta }),
+    ).toMatch(/newer database schema/);
+  });
+
+  it('returns a version-mismatch message for missing-table schema errors', () => {
+    expect(
+      getDownloadError({
+        reason: 'invalid-schema',
+        meta: { error: { message: 'no such table: foo', stack: '' } },
+      }),
+    ).toMatch(/newer database schema/);
+  });
+
+  it('falls back to the generic message for other invalid-schema failures', () => {
+    const message = getDownloadError({
+      reason: 'invalid-schema',
+      meta: unrelatedMeta,
+    });
+    expect(message).not.toMatch(/newer database schema/);
+    expect(message).toMatch(/Something went wrong/);
+  });
+});
+
+describe('getSyncError', () => {
+  it('returns a version-mismatch message for missing-column schema errors', () => {
+    expect(
+      getSyncError('invalid-schema', 'budget-id', schemaMismatchMeta),
+    ).toMatch(/newer database schema/);
+  });
+
+  it('falls back to the generic message for other invalid-schema failures', () => {
+    const message = getSyncError('invalid-schema', 'budget-id', unrelatedMeta);
+    expect(message).not.toMatch(/newer database schema/);
+    expect(message).toMatch(/unknown problem/);
+  });
+
+  it('does not report a schema mismatch when meta is missing', () => {
+    const message = getSyncError('invalid-schema', 'budget-id');
+    expect(message).not.toMatch(/newer database schema/);
+  });
+});

--- a/packages/loot-core/src/shared/errors.test.ts
+++ b/packages/loot-core/src/shared/errors.test.ts
@@ -1,16 +1,9 @@
-import i18next from 'i18next';
-
 import { getDownloadError, getSyncError } from './errors';
 
-beforeAll(async () => {
-  // With no translation resources, i18next returns each key (the English
-  // source string) verbatim, which is all these assertions rely on.
-  await i18next.init({
-    lng: 'en',
-    fallbackLng: 'en',
-    resources: { en: { translation: {} } },
-  });
-});
+// Exact text returned by the schema-mismatch branch. Asserting against it
+// keeps these tests free of any i18n setup (loot-core does not use i18n).
+const SCHEMA_MISMATCH_MESSAGE =
+  'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.';
 
 const schemaMismatchMeta = {
   error: { message: 'no such column: cleanup_def', stack: '' },
@@ -26,7 +19,7 @@ describe('getDownloadError', () => {
   it('returns a version-mismatch message for missing-column schema errors', () => {
     expect(
       getDownloadError({ reason: 'invalid-schema', meta: schemaMismatchMeta }),
-    ).toMatch(/newer database schema/);
+    ).toBe(SCHEMA_MISMATCH_MESSAGE);
   });
 
   it('returns a version-mismatch message for missing-table schema errors', () => {
@@ -35,16 +28,13 @@ describe('getDownloadError', () => {
         reason: 'invalid-schema',
         meta: { error: { message: 'no such table: foo', stack: '' } },
       }),
-    ).toMatch(/newer database schema/);
+    ).toBe(SCHEMA_MISMATCH_MESSAGE);
   });
 
-  it('falls back to the generic message for other invalid-schema failures', () => {
-    const message = getDownloadError({
-      reason: 'invalid-schema',
-      meta: unrelatedMeta,
-    });
-    expect(message).not.toMatch(/newer database schema/);
-    expect(message).toMatch(/Something went wrong/);
+  it('does not report a schema mismatch for other invalid-schema failures', () => {
+    expect(
+      getDownloadError({ reason: 'invalid-schema', meta: unrelatedMeta }),
+    ).not.toBe(SCHEMA_MISMATCH_MESSAGE);
   });
 });
 
@@ -52,17 +42,18 @@ describe('getSyncError', () => {
   it('returns a version-mismatch message for missing-column schema errors', () => {
     expect(
       getSyncError('invalid-schema', 'budget-id', schemaMismatchMeta),
-    ).toMatch(/newer database schema/);
+    ).toBe(SCHEMA_MISMATCH_MESSAGE);
   });
 
-  it('falls back to the generic message for other invalid-schema failures', () => {
-    const message = getSyncError('invalid-schema', 'budget-id', unrelatedMeta);
-    expect(message).not.toMatch(/newer database schema/);
-    expect(message).toMatch(/unknown problem/);
+  it('does not report a schema mismatch for other invalid-schema failures', () => {
+    expect(getSyncError('invalid-schema', 'budget-id', unrelatedMeta)).not.toBe(
+      SCHEMA_MISMATCH_MESSAGE,
+    );
   });
 
   it('does not report a schema mismatch when meta is missing', () => {
-    const message = getSyncError('invalid-schema', 'budget-id');
-    expect(message).not.toMatch(/newer database schema/);
+    expect(getSyncError('invalid-schema', 'budget-id')).not.toBe(
+      SCHEMA_MISMATCH_MESSAGE,
+    );
   });
 });

--- a/packages/loot-core/src/shared/errors.test.ts
+++ b/packages/loot-core/src/shared/errors.test.ts
@@ -1,7 +1,5 @@
 import { getDownloadError, getSyncError } from './errors';
 
-// Exact text returned by the schema-mismatch branch. Asserting against it
-// keeps these tests free of any i18n setup (loot-core does not use i18n).
 const SCHEMA_MISMATCH_MESSAGE =
   'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.';
 

--- a/packages/loot-core/src/shared/errors.test.ts
+++ b/packages/loot-core/src/shared/errors.test.ts
@@ -34,6 +34,12 @@ describe('getDownloadError', () => {
       getDownloadError({ reason: 'invalid-schema', meta: unrelatedMeta }),
     ).not.toBe(SCHEMA_MISMATCH_MESSAGE);
   });
+
+  it('does not report a schema mismatch when meta is missing', () => {
+    expect(getDownloadError({ reason: 'invalid-schema' })).not.toBe(
+      SCHEMA_MISMATCH_MESSAGE,
+    );
+  });
 });
 
 describe('getSyncError', () => {

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -5,11 +5,6 @@ type ErrorWithMeta = {
   meta?: unknown;
 };
 
-// A sync/apply failure is only a true version mismatch when the database is
-// missing a column or table that the incoming data expects. Any other
-// `invalid-schema` failure should keep its generic messaging so we don't
-// wrongly tell people to upgrade when an otherwise-compatible API version is
-// being used.
 function isDatabaseSchemaMismatch(meta?: unknown): boolean {
   if (
     meta &&
@@ -26,9 +21,6 @@ function isDatabaseSchemaMismatch(meta?: unknown): boolean {
 }
 
 function getSchemaMismatchError() {
-  // Surfaced through the programmatic API (and shown verbatim there), so this
-  // intentionally stays a plain, non-translated string — loot-core does not
-  // depend on i18n.
   return 'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.';
 }
 
@@ -75,10 +67,6 @@ export function getDownloadError({
   meta?: unknown;
   fileName?: string;
 }) {
-  // Only surface a version-mismatch message when the data genuinely needs a
-  // schema this client doesn't have. Other `invalid-schema` failures fall
-  // through to the generic message so incompatible-but-working API versions
-  // are still usable.
   if (reason === 'invalid-schema' && isDatabaseSchemaMismatch(meta)) {
     return getSchemaMismatchError();
   }

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -26,9 +26,10 @@ function isDatabaseSchemaMismatch(meta?: unknown): boolean {
 }
 
 function getSchemaMismatchError() {
-  return t(
-    'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.',
-  );
+  // Surfaced through the programmatic API (and shown verbatim there), so this
+  // intentionally stays a plain, non-translated string — loot-core does not
+  // depend on i18n.
+  return 'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.';
 }
 
 export function getUploadError({ reason, meta }: ErrorWithMeta) {

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -5,6 +5,32 @@ type ErrorWithMeta = {
   meta?: unknown;
 };
 
+// A sync/apply failure is only a true version mismatch when the database is
+// missing a column or table that the incoming data expects. Any other
+// `invalid-schema` failure should keep its generic messaging so we don't
+// wrongly tell people to upgrade when an otherwise-compatible API version is
+// being used.
+function isDatabaseSchemaMismatch(meta?: unknown): boolean {
+  if (
+    meta &&
+    typeof meta === 'object' &&
+    'error' in meta &&
+    meta.error &&
+    typeof meta.error === 'object' &&
+    'message' in meta.error &&
+    typeof meta.error.message === 'string'
+  ) {
+    return /no such (column|table)/i.test(meta.error.message);
+  }
+  return false;
+}
+
+function getSchemaMismatchError() {
+  return t(
+    'This budget could not be loaded because it uses a newer database schema than this version of Actual supports. Make sure you are using the latest version, then try again.',
+  );
+}
+
 export function getUploadError({ reason, meta }: ErrorWithMeta) {
   switch (reason) {
     case 'unauthorized':
@@ -48,6 +74,14 @@ export function getDownloadError({
   meta?: unknown;
   fileName?: string;
 }) {
+  // Only surface a version-mismatch message when the data genuinely needs a
+  // schema this client doesn't have. Other `invalid-schema` failures fall
+  // through to the generic message so incompatible-but-working API versions
+  // are still usable.
+  if (reason === 'invalid-schema' && isDatabaseSchemaMismatch(meta)) {
+    return getSchemaMismatchError();
+  }
+
   switch (reason) {
     case 'network':
     case 'download-failure':
@@ -111,9 +145,11 @@ export function getTestKeyError({ reason }: ErrorWithMeta) {
   }
 }
 
-export function getSyncError(error: string, id: string) {
+export function getSyncError(error: string, id: string, meta?: unknown) {
   if (error === 'out-of-sync-migrations' || error === 'out-of-sync-data') {
     return t('This budget cannot be loaded with this version of the app.');
+  } else if (error === 'invalid-schema' && isDatabaseSchemaMismatch(meta)) {
+    return getSchemaMismatchError();
   } else if (error === 'budget-not-found') {
     return t(
       'Budget "{{id}}" not found. Check the ID of your budget in the Advanced section of the settings page.',

--- a/upcoming-release-notes/8021.md
+++ b/upcoming-release-notes/8021.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfixes
-authors: [matiss]
+authors: [MatissJanis]
 ---
 
 Show a clear "update required" message instead of a cryptic `no such column` error when an outdated client or API connects to a budget that uses a newer database schema

--- a/upcoming-release-notes/8021.md
+++ b/upcoming-release-notes/8021.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matiss]
+---
+
+Show a clear "update required" message instead of a cryptic `no such column` error when an outdated client or API connects to a budget that uses a newer database schema

--- a/upcoming-release-notes/8021.md
+++ b/upcoming-release-notes/8021.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [MatissJanis]
----
-
-Show a clear "update required" message instead of a cryptic `no such column` error when an outdated client or API connects to a budget that uses a newer database schema

--- a/upcoming-release-notes/8026.md
+++ b/upcoming-release-notes/8026.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Improve error messaging for API version/schema mismatches to enhance user clarity and experience.

--- a/upcoming-release-notes/8026.md
+++ b/upcoming-release-notes/8026.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [MatissJanis]
 ---
 
-Improve error messaging for API version/schema mismatches to enhance user clarity and experience.
+Show a clear "update required" message instead of a cryptic `no such column` error when an outdated client or API connects to a budget that uses a newer database schema


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Improving the error message people get when the schema mismatches when using the API. To hopefully reduce the amount of support questions about this.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Unit tests added

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB → 14.03 MB (+724 B) | +0.00%
loot-core | 1 | 5.34 MB → 5.34 MB (+771 B) | +0.01%
api | 2 | 3.97 MB → 3.97 MB (+762 B) | +0.02%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB → 14.03 MB (+724 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +724 B (+14.26%) | 4.96 kB → 5.67 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 500.96 kB → 501.67 kB (+724 B) | +0.14%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.48 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.28 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 297.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+771 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +733 B (+28.04%) | 2.55 kB → 3.27 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +38 B (+0.16%) | 23.49 kB → 23.52 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B_yYPCGv.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.97 MB → 3.97 MB (+762 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +724 B (+28.05%) | 2.52 kB → 3.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +38 B (+0.16%) | 22.87 kB → 22.9 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.97 MB → 3.97 MB (+762 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->