### PR TITLE
[AI] Skip posted schedule occurrences in balance forecast

### DIFF
--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -449,19 +449,6 @@ describe('forecast app', () => {
     expect(dataPointByDate['2024-03-10'].transactions).toEqual([]);
   });
 
-  it('does not double-count schedule occurrences posted early within the lookback window', async () => {
-    const { salaryAmount, balanceByDate } =
-      await createForecastWithPostedMonthlySchedule({
-        txId: 'posted-salary-early',
-        txDate: '2024-03-09',
-      });
-
-    expect(balanceByDate['2024-03-08']).toBe(0);
-    expect(balanceByDate['2024-03-09']).toBe(salaryAmount);
-    expect(balanceByDate['2024-03-10']).toBe(salaryAmount);
-    expect(balanceByDate['2024-04-10']).toBe(salaryAmount * 2);
-  });
-
   it('filters future schedule occurrences using rule-derived fields like category', async () => {
     const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
     const groupId = await db.insertCategoryGroup({ name: 'Bills' });

--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -20,6 +20,56 @@ const createSchedule = createScheduleBase as (args: {
   conditions: RuleConditionEntity[];
 }) => Promise<string>;
 
+async function createForecastWithPostedMonthlySchedule({
+  txId,
+  txDate,
+}: {
+  txId: string;
+  txDate: string;
+}) {
+  const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
+  const salaryAmount = 500_000;
+
+  const scheduleId = await createSchedule({
+    conditions: [
+      { op: 'is', field: 'account', value: accountId },
+      { op: 'is', field: 'amount', value: salaryAmount },
+      {
+        op: 'is',
+        field: 'date',
+        value: {
+          start: '2024-03-10',
+          frequency: 'monthly',
+        },
+      },
+    ] satisfies RuleConditionEntity[],
+  });
+
+  await db.insertTransaction({
+    id: txId,
+    account: accountId,
+    amount: salaryAmount,
+    date: txDate,
+    schedule: scheduleId,
+  });
+
+  const result = await generateForecast({
+    accountIds: [accountId],
+    startDate: '2024-03-01',
+    endDate: '2024-04-30',
+  });
+
+  return {
+    salaryAmount,
+    balanceByDate: Object.fromEntries(
+      result.dataPoints.map(({ date, balance }) => [date, balance]),
+    ),
+    dataPointByDate: Object.fromEntries(
+      result.dataPoints.map(dataPoint => [dataPoint.date, dataPoint]),
+    ),
+  };
+}
+
 beforeEach(async () => {
   await emptyDatabase()();
   await loadMappings();
@@ -383,6 +433,33 @@ describe('forecast app', () => {
     expect(balanceByDate['2024-03-09']).toBe(0);
     expect(balanceByDate['2024-03-10']).toBe(100);
     expect(balanceByDate['2024-03-31']).toBe(100);
+  });
+
+  it('does not double-count schedule occurrences already posted on the due date', async () => {
+    const { salaryAmount, balanceByDate, dataPointByDate } =
+      await createForecastWithPostedMonthlySchedule({
+        txId: 'posted-salary',
+        txDate: '2024-03-10',
+      });
+
+    expect(balanceByDate['2024-03-09']).toBe(0);
+    expect(balanceByDate['2024-03-10']).toBe(salaryAmount);
+    expect(balanceByDate['2024-04-09']).toBe(salaryAmount);
+    expect(balanceByDate['2024-04-10']).toBe(salaryAmount * 2);
+    expect(dataPointByDate['2024-03-10'].transactions).toEqual([]);
+  });
+
+  it('does not double-count schedule occurrences posted early within the lookback window', async () => {
+    const { salaryAmount, balanceByDate } =
+      await createForecastWithPostedMonthlySchedule({
+        txId: 'posted-salary-early',
+        txDate: '2024-03-09',
+      });
+
+    expect(balanceByDate['2024-03-08']).toBe(0);
+    expect(balanceByDate['2024-03-09']).toBe(salaryAmount);
+    expect(balanceByDate['2024-03-10']).toBe(salaryAmount);
+    expect(balanceByDate['2024-04-10']).toBe(salaryAmount * 2);
   });
 
   it('filters future schedule occurrences using rule-derived fields like category', async () => {

--- a/packages/loot-core/src/server/forecast/app.test.ts
+++ b/packages/loot-core/src/server/forecast/app.test.ts
@@ -70,6 +70,56 @@ async function createForecastWithPostedMonthlySchedule({
   };
 }
 
+async function createForecastWithPostedDailySchedule({
+  txId,
+  txDate,
+}: {
+  txId: string;
+  txDate: string;
+}) {
+  const accountId = await db.insertAccount({ id: 'acct', name: 'Checking' });
+  const amount = -5_000;
+
+  const scheduleId = await createSchedule({
+    conditions: [
+      { op: 'is', field: 'account', value: accountId },
+      { op: 'is', field: 'amount', value: amount },
+      {
+        op: 'is',
+        field: 'date',
+        value: {
+          start: '2024-03-10',
+          frequency: 'daily',
+        },
+      },
+    ] satisfies RuleConditionEntity[],
+  });
+
+  await db.insertTransaction({
+    id: txId,
+    account: accountId,
+    amount,
+    date: txDate,
+    schedule: scheduleId,
+  });
+
+  const result = await generateForecast({
+    accountIds: [accountId],
+    startDate: '2024-03-10',
+    endDate: '2024-03-12',
+  });
+
+  return {
+    amount,
+    balanceByDate: Object.fromEntries(
+      result.dataPoints.map(({ date, balance }) => [date, balance]),
+    ),
+    dataPointByDate: Object.fromEntries(
+      result.dataPoints.map(dataPoint => [dataPoint.date, dataPoint]),
+    ),
+  };
+}
+
 beforeEach(async () => {
   await emptyDatabase()();
   await loadMappings();
@@ -447,6 +497,25 @@ describe('forecast app', () => {
     expect(balanceByDate['2024-04-09']).toBe(salaryAmount);
     expect(balanceByDate['2024-04-10']).toBe(salaryAmount * 2);
     expect(dataPointByDate['2024-03-10'].transactions).toEqual([]);
+  });
+
+  it('does not double-count daily recurring schedule occurrences with op is posted on the due date', async () => {
+    const { amount, balanceByDate, dataPointByDate } =
+      await createForecastWithPostedDailySchedule({
+        txId: 'posted-daily',
+        txDate: '2024-03-10',
+      });
+
+    expect(balanceByDate['2024-03-10']).toBe(amount);
+    expect(dataPointByDate['2024-03-10'].transactions).toEqual([]);
+    expect(dataPointByDate['2024-03-11']).toMatchObject({
+      balance: amount * 2,
+      transactions: [{ amount }],
+    });
+    expect(dataPointByDate['2024-03-12']).toMatchObject({
+      balance: amount * 3,
+      transactions: [{ amount }],
+    });
   });
 
   it('filters future schedule occurrences using rule-derived fields like category', async () => {

--- a/packages/loot-core/src/server/forecast/app.ts
+++ b/packages/loot-core/src/server/forecast/app.ts
@@ -115,6 +115,7 @@ export async function generateForecast({
     dateContext.endDateObj,
     accountsById,
     ruleAccountsById,
+    transactions,
   );
   const { dataPoints, lowestBalance } = projectForecastData({
     accounts,

--- a/packages/loot-core/src/server/forecast/forecast-schedules.ts
+++ b/packages/loot-core/src/server/forecast/forecast-schedules.ts
@@ -9,6 +9,8 @@ import {
   extractScheduleConds,
   getNextDate,
   getScheduledAmount,
+  indexPostedScheduleTransactions,
+  isScheduleOccurrencePosted,
 } from '#shared/schedules';
 import type { RuleConditionEntity, TransactionEntity } from '#types/models';
 import type { RecurConfig } from '#types/models/schedule';
@@ -28,6 +30,8 @@ type ScheduleDataBase = {
   name: string | null;
   next_date: string;
   rule?: string | null;
+  posts_transaction: boolean;
+  _conditions: RuleConditionEntity[];
   _payee: string | null;
   _account: string;
   _amount: number;
@@ -42,6 +46,7 @@ type RawScheduleData = {
   name: string | null;
   next_date: string;
   rule?: string | null;
+  posts_transaction?: boolean;
   _payee?: string | null;
   _account?: string | null;
   _amount?: number | { num1: number; num2: number } | null;
@@ -94,6 +99,8 @@ export function normalizeSchedule(
     name: schedule.name,
     next_date: schedule.next_date,
     rule: schedule.rule,
+    posts_transaction: schedule.posts_transaction ?? false,
+    _conditions: schedule._conditions ?? [],
     _payee: schedule._payee ?? conditions.payee?.value ?? null,
     _account: accountId,
     _amount: getScheduledAmount(amountValue),
@@ -178,7 +185,10 @@ export async function buildFutureScheduleOccurrences(
   endDateObj: Date,
   accountsById: Map<string, AccountWithComputedBalance>,
   ruleAccountsById: Map<string, DbAccountForRules>,
+  postedTransactions: TransactionEntity[],
 ) {
+  const postedByScheduleId =
+    indexPostedScheduleTransactions(postedTransactions);
   const transferPayeesByAccountId = await getTransferPayeesByAccountIds([
     ...ruleAccountsById.keys(),
   ]);
@@ -196,6 +206,17 @@ export async function buildFutureScheduleOccurrences(
     const scheduleName = schedule.name ?? 'Unknown';
 
     for (const date of getFutureOccurrenceDates(schedule, endDateObj)) {
+      if (
+        isScheduleOccurrencePosted({
+          schedule,
+          scheduleId: schedule.id,
+          occurrenceDate: date,
+          postedTransactions: postedByScheduleId.get(schedule.id) ?? [],
+        })
+      ) {
+        continue;
+      }
+
       const baseTransaction: TransactionEntity = {
         id: `forecast-${schedule.id}-${date}`,
         account: schedule._account,

--- a/packages/loot-core/src/server/forecast/forecast-schedules.ts
+++ b/packages/loot-core/src/server/forecast/forecast-schedules.ts
@@ -164,12 +164,9 @@ export function getFutureOccurrenceDates(
       break;
     }
 
-    if (parsedNextDate <= day) {
-      if (seenDates.has(nextDate)) {
-        day = monthUtils.parseDate(monthUtils.addDays(day, 1));
-        continue;
-      }
-      break;
+    if (seenDates.has(nextDate)) {
+      day = monthUtils.parseDate(monthUtils.addDays(day, 1));
+      continue;
     }
 
     dates.push(nextDate);

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -1,6 +1,6 @@
 import MockDate from 'mockdate';
 
-import type { ScheduleEntity } from '#types/models';
+import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 
 import * as monthUtils from './months';
 import {
@@ -9,6 +9,8 @@ import {
   getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
+  indexPostedScheduleTransactions,
+  isScheduleOccurrencePosted,
 } from './schedules';
 import type { ScheduleStatuses } from './schedules';
 
@@ -315,6 +317,97 @@ describe('schedules', () => {
           occurrenceDate,
         ),
       ).toBe('2024-03-08');
+    });
+  });
+
+  describe('indexPostedScheduleTransactions', () => {
+    it('groups schedule-linked transactions by schedule id', () => {
+      const indexed = indexPostedScheduleTransactions([
+        { schedule: 'sched-1', date: '2024-03-09' },
+        { schedule: 'sched-2', date: '2024-03-10' },
+        { schedule: 'sched-1', date: '2024-04-10' },
+        { date: '2024-03-11' },
+      ]);
+
+      expect(indexed.get('sched-1')).toEqual([
+        { schedule: 'sched-1', date: '2024-03-09' },
+        { schedule: 'sched-1', date: '2024-04-10' },
+      ]);
+      expect(indexed.get('sched-2')).toEqual([
+        { schedule: 'sched-2', date: '2024-03-10' },
+      ]);
+      expect(indexed.has('missing')).toBe(false);
+    });
+  });
+
+  describe('isScheduleOccurrencePosted', () => {
+    const scheduleId = 'sched-1';
+    const occurrenceDate = '2024-03-10';
+    const manualRecurringSchedule = { posts_transaction: false };
+    const autoPostSchedule = { posts_transaction: true };
+    const oneTimeSchedule = {
+      _conditions: [
+        { op: 'is', field: 'date', value: occurrenceDate } as const,
+      ],
+    };
+    const manualRecurringWithIsOp = {
+      posts_transaction: false,
+      _conditions: [
+        {
+          op: 'is',
+          field: 'date',
+          value: { start: occurrenceDate, frequency: 'monthly' },
+        },
+      ] satisfies RuleConditionEntity[],
+    };
+
+    function expectPosted(
+      schedule: Parameters<typeof getScheduleOccurrenceMatchStartDate>[0],
+      txDate: string,
+      expected: boolean,
+    ) {
+      expect(
+        isScheduleOccurrencePosted({
+          schedule,
+          scheduleId,
+          occurrenceDate,
+          postedTransactions: [{ schedule: scheduleId, date: txDate }],
+        }),
+      ).toBe(expected);
+    }
+
+    it.each([
+      [
+        'same-day manual recurring',
+        manualRecurringSchedule,
+        occurrenceDate,
+        true,
+      ],
+      [
+        'early pay within 2 days for recurring date cond',
+        manualRecurringWithIsOp,
+        '2024-03-09',
+        true,
+      ],
+      ['early pay within 2 days', manualRecurringSchedule, '2024-03-09', true],
+      [
+        'early pay outside window',
+        manualRecurringSchedule,
+        '2024-03-07',
+        false,
+      ],
+      ['auto-post day before due', autoPostSchedule, '2024-03-09', false],
+      ['auto-post on due date', autoPostSchedule, occurrenceDate, true],
+      ['one-time on due date', oneTimeSchedule, occurrenceDate, true],
+      ['one-time day before due', oneTimeSchedule, '2024-03-09', false],
+      [
+        'later month tx does not satisfy earlier occurrence',
+        manualRecurringSchedule,
+        '2024-04-10',
+        false,
+      ],
+    ] as const)('%s', (_label, schedule, txDate, expected) => {
+      expectPosted(schedule, txDate, expected);
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -301,7 +301,7 @@ describe('schedules', () => {
       ).toBe('2024-03-08');
     });
 
-    it('uses a 2-day lookback for recurring schedules with op is', () => {
+    it('uses exact date for recurring schedules with op is', () => {
       expect(
         getScheduleOccurrenceMatchStartDate(
           {
@@ -316,7 +316,25 @@ describe('schedules', () => {
           },
           occurrenceDate,
         ),
-      ).toBe('2024-03-08');
+      ).toBe(occurrenceDate);
+    });
+
+    it('uses exact date for daily recurring schedules with op is', () => {
+      expect(
+        getScheduleOccurrenceMatchStartDate(
+          {
+            posts_transaction: false,
+            _conditions: [
+              {
+                op: 'is',
+                field: 'date',
+                value: { start: occurrenceDate, frequency: 'daily' },
+              },
+            ],
+          },
+          occurrenceDate,
+        ),
+      ).toBe(occurrenceDate);
     });
   });
 
@@ -384,10 +402,10 @@ describe('schedules', () => {
         true,
       ],
       [
-        'early pay within 2 days for recurring date cond',
+        'early pay day before due for recurring date cond',
         manualRecurringWithIsOp,
         '2024-03-09',
-        true,
+        false,
       ],
       ['early pay within 2 days', manualRecurringSchedule, '2024-03-09', true],
       [

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -6,6 +6,7 @@ import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
   getNextDate,
+  getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
 } from './schedules';
@@ -263,6 +264,57 @@ describe('schedules', () => {
 
       // Should not crash; schedule with past end date produces its next_date entry only
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('getScheduleOccurrenceMatchStartDate', () => {
+    const occurrenceDate = '2024-03-10';
+
+    it('uses exact date for one-time schedules', () => {
+      expect(
+        getScheduleOccurrenceMatchStartDate(
+          {
+            _conditions: [{ op: 'is', field: 'date', value: occurrenceDate }],
+          },
+          occurrenceDate,
+        ),
+      ).toBe(occurrenceDate);
+    });
+
+    it('uses exact date for auto-posted recurring schedules', () => {
+      expect(
+        getScheduleOccurrenceMatchStartDate(
+          { posts_transaction: true },
+          occurrenceDate,
+        ),
+      ).toBe(occurrenceDate);
+    });
+
+    it('uses a 2-day lookback for manual recurring schedules', () => {
+      expect(
+        getScheduleOccurrenceMatchStartDate(
+          { posts_transaction: false },
+          occurrenceDate,
+        ),
+      ).toBe('2024-03-08');
+    });
+
+    it('uses a 2-day lookback for recurring schedules with op is', () => {
+      expect(
+        getScheduleOccurrenceMatchStartDate(
+          {
+            posts_transaction: false,
+            _conditions: [
+              {
+                op: 'is',
+                field: 'date',
+                value: { start: occurrenceDate, frequency: 'monthly' },
+              },
+            ],
+          },
+          occurrenceDate,
+        ),
+      ).toBe('2024-03-08');
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -3,7 +3,7 @@ import type { IRuleOptions } from '@rschedule/core';
 import * as d from 'date-fns';
 
 import { Condition } from '#server/rules';
-import type { ScheduleEntity } from '#types/models';
+import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 
 import * as monthUtils from './months';
 import { q } from './query';
@@ -34,29 +34,55 @@ export function getStatus(
   }
 }
 
+export type ScheduleOccurrenceMatchInput = {
+  posts_transaction?: boolean;
+  _conditions?: RuleConditionEntity[];
+};
+
+/**
+ * Lower bound for matching a posted transaction to a schedule occurrence date.
+ *
+ * Used by getHasTransactionsQuery for `next_date` (lower bound only). Forecast
+ * occurrence dedup also applies an upper bound of `occurrenceDate`; see
+ * isScheduleOccurrencePosted.
+ */
+export function getScheduleOccurrenceMatchStartDate(
+  schedule: ScheduleOccurrenceMatchInput,
+  occurrenceDate: string,
+): string {
+  const dateCond = schedule._conditions?.find(c => c.field === 'date');
+  // Recurring schedules also use `op: 'is'` with a RecurConfig value.
+  if (dateCond?.op === 'is' && typeof dateCond.value === 'string') {
+    return occurrenceDate;
+  }
+  if (schedule.posts_transaction) {
+    return occurrenceDate;
+  }
+  return monthUtils.subDays(occurrenceDate, 2);
+}
+
 /**
  * Builds a query to check if each schedule already has a matching transaction.
  *
  * The date lower-bound varies:
- * - `dateCond.op === 'is'` (one-time): exact `next_date`, no lookback.
+ * - `dateCond.op === 'is'` with a string value (one-time): exact `next_date`,
+ *   no lookback.
  * - `posts_transaction` (auto-posted recurring): exact `next_date`, since
  *   auto-posted dates are always precise. A lookback here would cause
  *   yesterday's transaction to falsely match today's occurrence.
- * - Otherwise (manual recurring): 2-day lookback to catch early payments.
+ * - Otherwise (manual recurring, including `op: 'is'` with a RecurConfig):
+ *   2-day lookback to catch early payments.
  */
 export function getHasTransactionsQuery(schedules) {
   const filters = schedules.map(schedule => {
-    const dateCond = schedule._conditions?.find(c => c.field === 'date');
     return {
       $and: {
         schedule: schedule.id,
         date: {
-          $gte:
-            dateCond && dateCond.op === 'is'
-              ? schedule.next_date
-              : schedule.posts_transaction
-                ? schedule.next_date
-                : monthUtils.subDays(schedule.next_date, 2),
+          $gte: getScheduleOccurrenceMatchStartDate(
+            schedule,
+            schedule.next_date,
+          ),
         },
       },
     };

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -61,6 +61,56 @@ export function getScheduleOccurrenceMatchStartDate(
   return monthUtils.subDays(occurrenceDate, 2);
 }
 
+export type PostedScheduleTransaction = {
+  schedule?: string | null;
+  date: string;
+};
+
+export function indexPostedScheduleTransactions(
+  transactions: PostedScheduleTransaction[],
+): Map<string, PostedScheduleTransaction[]> {
+  const byScheduleId = new Map<string, PostedScheduleTransaction[]>();
+
+  for (const transaction of transactions) {
+    if (!transaction.schedule) {
+      continue;
+    }
+
+    const existing = byScheduleId.get(transaction.schedule);
+    if (existing) {
+      existing.push(transaction);
+    } else {
+      byScheduleId.set(transaction.schedule, [transaction]);
+    }
+  }
+
+  return byScheduleId;
+}
+
+export function isScheduleOccurrencePosted({
+  schedule,
+  scheduleId,
+  occurrenceDate,
+  postedTransactions,
+}: {
+  schedule: ScheduleOccurrenceMatchInput;
+  scheduleId: string;
+  occurrenceDate: string;
+  postedTransactions: PostedScheduleTransaction[];
+}): boolean {
+  const matchStartDate = getScheduleOccurrenceMatchStartDate(
+    schedule,
+    occurrenceDate,
+  );
+
+  return postedTransactions.some(
+    tx =>
+      tx.schedule === scheduleId &&
+      tx.date >= matchStartDate &&
+      tx.date <= occurrenceDate,
+  );
+}
+
 /**
  * Builds a query to check if each schedule already has a matching transaction.
  *

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -51,8 +51,7 @@ export function getScheduleOccurrenceMatchStartDate(
   occurrenceDate: string,
 ): string {
   const dateCond = schedule._conditions?.find(c => c.field === 'date');
-  // Recurring schedules also use `op: 'is'` with a RecurConfig value.
-  if (dateCond?.op === 'is' && typeof dateCond.value === 'string') {
+  if (dateCond?.op === 'is') {
     return occurrenceDate;
   }
   if (schedule.posts_transaction) {
@@ -115,13 +114,12 @@ export function isScheduleOccurrencePosted({
  * Builds a query to check if each schedule already has a matching transaction.
  *
  * The date lower-bound varies:
- * - `dateCond.op === 'is'` with a string value (one-time): exact `next_date`,
- *   no lookback.
+ * - `dateCond.op === 'is'` (one-time or recurring): exact `next_date`, no lookback.
  * - `posts_transaction` (auto-posted recurring): exact `next_date`, since
  *   auto-posted dates are always precise. A lookback here would cause
  *   yesterday's transaction to falsely match today's occurrence.
- * - Otherwise (manual recurring, including `op: 'is'` with a RecurConfig):
- *   2-day lookback to catch early payments.
+ * - Otherwise (manual recurring with `isapprox`, etc.): 2-day lookback to catch
+ *   early payments.
  */
 export function getHasTransactionsQuery(schedules) {
   const filters = schedules.map(schedule => {

--- a/upcoming-release-notes/8029.md
+++ b/upcoming-release-notes/8029.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Fix Balance Forecast double-counting scheduled transactions that were already posted.


### PR DESCRIPTION
## Summary

- Adds shared helpers to detect when a schedule occurrence is already satisfied by a posted transaction, using the same date-matching rules as the schedules UI.
- Skips simulated schedule occurrences in the Balance Forecast when a matching posted transaction exists, fixing double-counting when salary (or other schedules) are posted on the due date.
- Adds regression tests for same-day posting and early payment within the 2-day lookback window.

Fixes the issue reported in https://github.com/actualbudget/actual/issues/7669#issuecomment-4578985011

## Test plan

- [x] `yarn workspace @actual-app/core run test -- forecast schedules.test`
- [x] `yarn typecheck`
- [x] `yarn lint:fix`

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+1.86 kB) | +0.01%
loot-core | 1 | 5.28 MB → 5.28 MB (+1.48 kB) | +0.03%
api | 2 | 3.87 MB → 3.87 MB (+1.44 kB) | +0.04%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+1.86 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +428 B (+5.80%) | 7.21 kB → 7.63 kB
`locale/de.json` | 📈 +1.44 kB (+0.84%) | 172.1 kB → 173.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/de.js | 172.1 kB → 173.54 kB (+1.44 kB) | +0.84%
static/js/Value.js | 5.08 MB → 5.08 MB (+428 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+1.48 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.12 kB (+20.84%) | 5.39 kB → 6.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +347 B (+5.57%) | 6.08 kB → 6.42 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +14 B (+0.57%) | 2.4 kB → 2.41 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BuloPXUY.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.COd5U_ND.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+1.44 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.1 kB (+20.86%) | 5.26 kB → 6.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +341 B (+5.60%) | 5.95 kB → 6.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +14 B (+0.58%) | 2.34 kB → 2.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+1.44 kB) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->