### PR TITLE
[WIP] fix(category-learning): treat NULL learn_categories as enabled (default)

### DIFF
--- a/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
+++ b/packages/desktop-client/src/components/payees/PayeeTableRow.tsx
@@ -176,7 +176,7 @@ export const PayeeTableRow = memo(
                 text: t('Create rule'),
               },
               isLearnCategoriesEnabled &&
-                (payee.learn_categories
+                (payee.learn_categories !== 0
                   ? {
                       name: 'learn',
                       text: t('Disable learning'),
@@ -242,7 +242,7 @@ export const PayeeTableRow = memo(
             return (
               <>
                 {payee.favorite ? <SvgBookmark style={{ width: 10 }} /> : null}
-                {isLearnCategoriesEnabled && !payee.learn_categories && (
+                {isLearnCategoriesEnabled && payee.learn_categories === 0 && (
                   <Tooltip content={t('Category learning disabled')}>
                     <SvgLightBulb style={{ color: 'red', width: 10 }} />
                   </Tooltip>

--- a/packages/loot-core/migrations/1780311918000_fix_learn_categories_null.sql
+++ b/packages/loot-core/migrations/1780311918000_fix_learn_categories_null.sql
@@ -1,0 +1,5 @@
+BEGIN TRANSACTION;
+
+UPDATE payees SET learn_categories = 1 WHERE learn_categories IS NULL;
+
+COMMIT;

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -911,7 +911,7 @@ export async function updateCategoryRules(transactions) {
     `SELECT t.* FROM v_transactions t
      LEFT JOIN accounts a ON a.id = t.account
      LEFT JOIN payees p ON p.id = t.payee
-     WHERE date >= ? AND date <= ? AND is_parent = 0 AND a.closed = 0 AND p.learn_categories = 1
+     WHERE date >= ? AND date <= ? AND is_parent = 0 AND a.closed = 0 AND COALESCE(p.learn_categories, 1) = 1
      ORDER BY date DESC`,
     [toDateRepr(oldestDate), toDateRepr(addDays(currentDay(), 180))],
   );


### PR DESCRIPTION
Fixes #8009

The migration 1737158400000 added learn_categories with DEFAULT 1, but existing payees had NULL values. The SQL query used 'p.learn_categories = 1' which doesn't match NULL, and the UI used a truthy check that treated NULL as disabled.

Changes:
- Add migration to set NULL learn_categories to 1
- Use COALESCE(p.learn_categories, 1) = 1 in SQL as safety net
- Fix UI truthy check to use '!== 0' (NULL/1 = enabled, 0 = disabled)

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Summary

Fix category learning not creating rules when transactions are assigned categories. The root cause: payees created before migration `1737158400000_add_learn_categories_to_payees.sql` have `learn_categories = NULL`, which is treated as "disabled" by both the SQL query and the UI.

## Root Cause

1. **SQL query** (`transaction-rules.ts:914`): `p.learn_categories = 1` doesn't match `NULL` values
2. **UI truthy check** (`PayeeTableRow.tsx:179`): `payee.learn_categories ? ...` treats `NULL`/undefined as falsy

The migration added `learn_categories` with `DEFAULT 1`, but existing rows have `NULL`, not `1`.

## Changes

1. **Migration** (`1780311918000_fix_learn_categories_null.sql`): Set `learn_categories = 1` for all NULL rows
2. **SQL fix** (`transaction-rules.ts`): Use `COALESCE(p.learn_categories, 1) = 1` as safety net
3. **UI fix** (`PayeeTableRow.tsx`): Change truthy check to `payee.learn_categories !== 0` (NULL/1 = enabled, 0 = disabled)

## Testing

1. Create a new payee by importing a transaction
2. Assign a category to a transaction with that payee
3. Add more transactions with same payee + category
4. Verify a category rule is automatically created

## Related Issues

Fixes #8009

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [contributing guide](https://github.com/actualbudget/actual/blob/master/.github/CONTRIBUTING.md)
- [x] I have signed the CLA (or am covered by my company's CLA)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.03 MB → 14.03 MB (+11 B) | +0.00%
loot-core | 1 | 5.34 MB → 5.34 MB (+13 B) | +0.00%
api | 2 | 3.92 MB → 3.97 MB (+42.33 kB) | +1.05%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.03 MB → 14.03 MB (+11 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/payees/PayeeTableRow.tsx` | 📈 +11 B (+0.09%) | 12.46 kB → 12.47 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 297.21 kB → 297.22 kB (+11 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.98 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.75 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.15 kB | 0%
static/js/de.js | 170.77 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 198.48 kB | 0%
static/js/es.js | 178.68 kB | 0%
static/js/extends.js | 500.96 kB | 0%
static/js/fr.js | 178.57 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 165 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 148.05 kB | 0%
static/js/nl.js | 106.28 kB | 0%
static/js/pt-BR.js | 188.43 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.48 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.46 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 5.34 MB (+13 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +13 B (+0.06%) | 21.17 kB → 21.19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.xSbHbrIS.js | 0 B → 5.34 MB (+5.34 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker._bwMMgjb.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.92 MB → 3.97 MB (+42.33 kB) | +1.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/ua-parser-js/src/main/ua-parser.mjs` | 🆕 +41.87 kB | 0 B → 41.87 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 🆕 +431 B | 0 B → 431 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +21 B (+0.41%) | 5.06 kB → 5.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +13 B (+0.06%) | 20.66 kB → 20.67 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.92 MB → 3.97 MB (+42.33 kB) | +1.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->