### PR TITLE
[Docs] Revise fly.io deployment instructions for nightly builds

### DIFF
--- a/packages/docs/docs/install/fly.md
+++ b/packages/docs/docs/install/fly.md
@@ -182,4 +182,4 @@ With these settings, Fly.io will automatically stop your instance after a few mi
 
 - **Q.** _How can I try out a beta/unstable version of Actual?_
 
-  **A.** We publish unstable releases of Actual every day. These versions may have known or unknown issues that could corrupt your budget. If you'd like to try them out, follow the [instructions to update](#updating-actual) above, but change `actualbudget/actual-server:latest` to `actualbudget/actual-server:nightly`.
+  **A.** We publish unstable releases of Actual every day. These versions may have known or unknown issues that could corrupt your budget. If you'd like to try them out, re-deploy using `fly deploy --image actualbudget/actual-server:nightly --app fly-actual-your-app-name --remote-only --no-cache`.

--- a/packages/docs/docs/install/fly.md
+++ b/packages/docs/docs/install/fly.md
@@ -183,6 +183,7 @@ With these settings, Fly.io will automatically stop your instance after a few mi
 - **Q.** _How can I try out a beta/unstable version of Actual?_
 
   **A.** We publish unstable releases of Actual every day. These versions may have known or unknown issues that could corrupt your budget. If you'd like to try them out, re-deploy with the nightly version. For example, if your app is at `https://fly-actual-rushing-waters-9999.fly.dev`:
-```  
+
+```
 fly deploy --image actualbudget/actual-server:nightly --app fly-actual-rushing-waters-9999 --remote-only --no-cache
 ```

--- a/packages/docs/docs/install/fly.md
+++ b/packages/docs/docs/install/fly.md
@@ -150,7 +150,7 @@ Actual is now up and running. Congratulations! Consider checking out [our tour](
 When updates to Actual are released, you'll need to re-deploy your app to get the latest version.
 
 ```
-fly deploy --image actualbudget/actual-server:latest --app your-app-name
+fly deploy --image actualbudget/actual-server:latest your-app-name
 ```
 
 ### Local terminal
@@ -182,4 +182,7 @@ With these settings, Fly.io will automatically stop your instance after a few mi
 
 - **Q.** _How can I try out a beta/unstable version of Actual?_
 
-  **A.** We publish unstable releases of Actual every day. These versions may have known or unknown issues that could corrupt your budget. If you'd like to try them out, re-deploy using `fly deploy --image actualbudget/actual-server:nightly --app fly-actual-your-app-name --remote-only --no-cache`.
+  **A.** We publish unstable releases of Actual every day. These versions may have known or unknown issues that could corrupt your budget. If you'd like to try them out, re-deploy with the nightly version. For example, if your app is at `https://fly-actual-rushing-waters-9999.fly.dev`:
+```  
+fly deploy --image actualbudget/actual-server:nightly --app fly-actual-rushing-waters-9999 --remote-only --no-cache
+```


### PR DESCRIPTION


## Description

It seems that fly.io's cache may cause re-deployments of nightly to fail. Added instructions to the nightly deployment to make sure that doesn't happen. As it was no longer a single word change, the instruction to the full command was changed to an example rather than just the change so the link was no longer needed.

## Testing

Deployed successfully after failures when adding ` --remote-only --no-cache` to the full deploy command.

## Checklist

- [x] Release notes not needed
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
