### PR TITLE
docs: add Hostim as a cloud hosting option

### DIFF
--- a/.github/actions/docs-spelling/expect.txt
+++ b/.github/actions/docs-spelling/expect.txt
@@ -94,6 +94,7 @@ Hampel
 healthcheck
 HELADEF
 HLOOKUP
+Hostim
 HUF
 IFERROR
 IFNA

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -62,7 +62,7 @@ const sidebars = {
               label: 'In the Cloud',
               collapsible: false,
               className: 'no-indent',
-              items: ['install/pikapods', 'install/fly'],
+              items: ['install/pikapods', 'install/fly', 'install/hostim'],
             },
             {
               type: 'category',

--- a/packages/docs/docs/install/hostim.md
+++ b/packages/docs/docs/install/hostim.md
@@ -1,0 +1,29 @@
+---
+title: 'Hostim'
+---
+
+[Hostim](https://hostim.dev/) offers one-click hosting for open source apps. You can run
+Actual Budget with Docker, a persistent volume, and automatic HTTPS without touching the
+command line.
+
+Hostim runs the official `actualbudget/actual-server` image, so you can redeploy to pull the
+latest release whenever you want.
+
+## Deploying Actual on Hostim
+
+[Click here to deploy Actual Budget on Hostim](https://hostim.dev/docs/templates/actual).
+
+1. Open the template and choose a resource plan (the lowest setting is fine — your browser
+   does most of Actual's computation).
+2. Deploy. Your app comes up with a free `*.hostim.dev` domain and HTTPS.
+3. On first visit, set a server password and create your budget file.
+
+:::warning
+
+Keep your Actual server password safe — it cannot be recovered. Your budget data is stored in
+the persistent `/data` volume.
+
+:::
+
+After setting up, head over to our [Starting Fresh](/docs/getting-started/starting-fresh)
+guide to get started with Actual Budget.

--- a/packages/docs/docs/install/index.md
+++ b/packages/docs/docs/install/index.md
@@ -46,6 +46,7 @@ The server provides a web-based version of Actual. This web app can be used in a
 While running a server can be a complicated endeavor, we've tried to make it fairly easy to set up and hands-off to maintain. Choose one of the following options to get started:
 
 - If you're not comfortable with the command line and are willing to pay a small amount of money to have your version of Actual hosted on the cloud for you, we recommend [PikaPods](pikapods.md).[^2]
+- [Hostim](hostim.md) also offers one-click managed hosting with Docker and free SSL, no command line required.
 - If you're willing to run a few commands in the terminal:
   - You can run the server with a simple command using the [Server CLI](cli-tool.md)
   - [Fly.io](fly.md) also offers cloud hosting for a similar amount of money.

--- a/upcoming-release-notes/8063.md
+++ b/upcoming-release-notes/8063.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [pavel1337]
+---
+
+Add Hostim as a one-click cloud hosting option in the documentation.


### PR DESCRIPTION
Adds a Hostim install page alongside PikaPods and Fly.io under "In the Cloud". Hostim provides one-click managed hosting for the official `actualbudget/actual-server` Docker image, with a persistent `/data` volume and automatic HTTPS.

Template/guide: https://hostim.dev/docs/templates/actual

- New page: `packages/docs/docs/install/hostim.md`
- Linked from `install/index.md` (Running a Server) and `docs-sidebar.js` (In the Cloud)