### PR TITLE
[AI] feat(currencies): add currency-precision-aware helpers

### DIFF
--- a/packages/loot-core/src/shared/currencies.test.ts
+++ b/packages/loot-core/src/shared/currencies.test.ts
@@ -1,8 +1,4 @@
-import {
-  currencies,
-  getCurrencyPrecisionMultiplier,
-  getDecimalPlaces,
-} from './currencies';
+import { currencies, getDecimalPlaces } from './currencies';
 
 describe('getDecimalPlaces', () => {
   it('returns 2 for empty string (None)', () => {
@@ -27,30 +23,22 @@ describe('getDecimalPlaces', () => {
 });
 
 describe('currency metadata', () => {
-  it.each(currencies)('$name ($code) has a numeric decimalPlaces field', currency => {
-    expect(typeof currency.decimalPlaces).toBe('number');
-  });
+  it.each(currencies)(
+    '$name ($code) has a numeric decimalPlaces field',
+    currency => {
+      expect(typeof currency.decimalPlaces).toBe('number');
+    },
+  );
 
-  it.each(currencies)('$name ($code) has non-negative decimalPlaces', currency => {
-    expect(currency.decimalPlaces).toBeGreaterThanOrEqual(0);
-  });
+  it.each(currencies)(
+    '$name ($code) has non-negative decimalPlaces',
+    currency => {
+      expect(currency.decimalPlaces).toBeGreaterThanOrEqual(0);
+    },
+  );
 
   it('first entry is None with code empty string and decimalPlaces 2', () => {
     expect(currencies[0].code).toBe('');
     expect(currencies[0].decimalPlaces).toBe(2);
-  });
-});
-
-describe('getCurrencyPrecisionMultiplier', () => {
-  it('returns 1 for JPY (0dp)', () => {
-    expect(getCurrencyPrecisionMultiplier('JPY')).toBe(1);
-  });
-
-  it('returns 100 for USD (2dp)', () => {
-    expect(getCurrencyPrecisionMultiplier('USD')).toBe(100);
-  });
-
-  it('returns 1 for IRR (0dp)', () => {
-    expect(getCurrencyPrecisionMultiplier('IRR')).toBe(1);
   });
 });

--- a/packages/loot-core/src/shared/currencies.test.ts
+++ b/packages/loot-core/src/shared/currencies.test.ts
@@ -26,17 +26,13 @@ describe('getDecimalPlaces', () => {
   });
 });
 
-describe('currency metadata completeness', () => {
-  it('every entry has a decimalPlaces field', () => {
-    for (const currency of currencies) {
-      expect(typeof currency.decimalPlaces).toBe('number');
-    }
+describe('currency metadata', () => {
+  it.each(currencies)('$name ($code) has a numeric decimalPlaces field', currency => {
+    expect(typeof currency.decimalPlaces).toBe('number');
   });
 
-  it('no entry has a negative decimalPlaces', () => {
-    for (const currency of currencies) {
-      expect(currency.decimalPlaces).toBeGreaterThanOrEqual(0);
-    }
+  it.each(currencies)('$name ($code) has non-negative decimalPlaces', currency => {
+    expect(currency.decimalPlaces).toBeGreaterThanOrEqual(0);
   });
 
   it('first entry is None with code empty string and decimalPlaces 2', () => {

--- a/packages/loot-core/src/shared/currencies.test.ts
+++ b/packages/loot-core/src/shared/currencies.test.ts
@@ -1,0 +1,60 @@
+import {
+  currencies,
+  getCurrencyPrecisionMultiplier,
+  getDecimalPlaces,
+} from './currencies';
+
+describe('getDecimalPlaces', () => {
+  it('returns 2 for empty string (None)', () => {
+    expect(getDecimalPlaces('')).toBe(2);
+  });
+
+  it('returns 0 for zero-decimal currencies', () => {
+    expect(getDecimalPlaces('JPY')).toBe(0);
+    expect(getDecimalPlaces('KRW')).toBe(0);
+    expect(getDecimalPlaces('IRR')).toBe(0);
+  });
+
+  it('returns 2 for standard currencies', () => {
+    expect(getDecimalPlaces('USD')).toBe(2);
+    expect(getDecimalPlaces('EUR')).toBe(2);
+    expect(getDecimalPlaces('GBP')).toBe(2);
+  });
+
+  it('returns 2 as safe default for unknown codes', () => {
+    expect(getDecimalPlaces('XYZ')).toBe(2);
+  });
+});
+
+describe('currency metadata completeness', () => {
+  it('every entry has a decimalPlaces field', () => {
+    for (const currency of currencies) {
+      expect(typeof currency.decimalPlaces).toBe('number');
+    }
+  });
+
+  it('no entry has a negative decimalPlaces', () => {
+    for (const currency of currencies) {
+      expect(currency.decimalPlaces).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('first entry is None with code empty string and decimalPlaces 2', () => {
+    expect(currencies[0].code).toBe('');
+    expect(currencies[0].decimalPlaces).toBe(2);
+  });
+});
+
+describe('getCurrencyPrecisionMultiplier', () => {
+  it('returns 1 for JPY (0dp)', () => {
+    expect(getCurrencyPrecisionMultiplier('JPY')).toBe(1);
+  });
+
+  it('returns 100 for USD (2dp)', () => {
+    expect(getCurrencyPrecisionMultiplier('USD')).toBe(100);
+  });
+
+  it('returns 1 for IRR (0dp)', () => {
+    expect(getCurrencyPrecisionMultiplier('IRR')).toBe(1);
+  });
+});

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -76,7 +76,3 @@ export function getCurrency(code: string): Currency {
 export function getDecimalPlaces(currencyCode: string): number {
   return getCurrency(currencyCode)?.decimalPlaces ?? 2;
 }
-
-export function getCurrencyPrecisionMultiplier(currencyCode: string): number {
-  return Math.pow(10, getDecimalPlaces(currencyCode));
-}

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -72,3 +72,11 @@ export const currencies: Currency[] = [
 export function getCurrency(code: string): Currency {
   return currencies.find(c => c.code === code) || currencies[0];
 }
+
+export function getDecimalPlaces(currencyCode: string): number {
+  return getCurrency(currencyCode)?.decimalPlaces ?? 2;
+}
+
+export function getCurrencyPrecisionMultiplier(currencyCode: string): number {
+  return Math.pow(10, getDecimalPlaces(currencyCode));
+}

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -1,6 +1,6 @@
 import {
+  amountToCurrencyInteger,
   currencyToAmount,
-  encodeAmount,
   getNumberFormat,
   integerToCurrencyWithDecimal,
   looselyParseAmount,
@@ -271,34 +271,37 @@ describe('utility functions', () => {
     });
   });
 
-  describe('encodeAmount', () => {
+  describe('amountToCurrencyInteger', () => {
     test('empty string (None) uses 2dp', () => {
-      expect(encodeAmount(12.34, '')).toBe(1234);
+      expect(amountToCurrencyInteger(12.34, '')).toBe(1234);
     });
 
     test('USD uses 2dp', () => {
-      expect(encodeAmount(12.34, 'USD')).toBe(1234);
+      expect(amountToCurrencyInteger(12.34, 'USD')).toBe(1234);
     });
 
     test('JPY uses 0dp (multiply by 1)', () => {
-      expect(encodeAmount(1234, 'JPY')).toBe(1234);
+      expect(amountToCurrencyInteger(1234, 'JPY')).toBe(1234);
     });
 
     test('IRR uses 0dp (multiply by 1)', () => {
-      expect(encodeAmount(1234, 'IRR')).toBe(1234);
+      expect(amountToCurrencyInteger(1234, 'IRR')).toBe(1234);
     });
 
     it.each<[number, string]>([
       [12.34, 'USD'],
       [1234, 'JPY'],
       [5678, 'IRR'],
-    ])('round-trip encodeAmount/integerToCurrencyWithDecimal: %s %s', (amount, currency) => {
-      setNumberFormat({ format: 'comma-dot', hideFraction: false });
-      const encoded = encodeAmount(amount, currency);
-      const decoded = parseFloat(
-        integerToCurrencyWithDecimal(encoded, currency).replace(/,/g, ''),
-      );
-      expect(decoded).toBeCloseTo(amount, 8);
-    });
+    ])(
+      'round-trip amountToCurrencyInteger/integerToCurrencyWithDecimal: %s %s',
+      (amount, currency) => {
+        setNumberFormat({ format: 'comma-dot', hideFraction: false });
+        const encoded = amountToCurrencyInteger(amount, currency);
+        const decoded = parseFloat(
+          integerToCurrencyWithDecimal(encoded, currency).replace(/,/g, ''),
+        );
+        expect(decoded).toBeCloseTo(amount, 8);
+      },
+    );
   });
 });

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -1,6 +1,8 @@
 import {
   currencyToAmount,
+  encodeAmount,
   getNumberFormat,
+  integerToCurrencyWithDecimal,
   looselyParseAmount,
   setNumberFormat,
   stringToInteger,
@@ -236,5 +238,69 @@ describe('utility functions', () => {
     expect(stringToInteger('-3')).toBe(-3);
     // Unicode minus
     expect(stringToInteger('−3')).toBe(-3);
+  });
+
+  describe('integerToCurrencyWithDecimal with currency', () => {
+    beforeEach(() => {
+      setNumberFormat({ format: 'comma-dot', hideFraction: false });
+    });
+
+    test('empty string (None) uses 2dp', () => {
+      expect(integerToCurrencyWithDecimal(1234, '')).toBe('12.34');
+    });
+
+    test('USD uses 2dp', () => {
+      expect(integerToCurrencyWithDecimal(1234, 'USD')).toBe('12.34');
+    });
+
+    test('JPY uses 0dp', () => {
+      expect(integerToCurrencyWithDecimal(1234, 'JPY')).toBe('1,234');
+    });
+
+    test('IRR uses 0dp', () => {
+      expect(integerToCurrencyWithDecimal(1234, 'IRR')).toBe('1,234');
+    });
+
+    test('unknown currency XYZ defaults to 2dp', () => {
+      expect(integerToCurrencyWithDecimal(1234, 'XYZ')).toBe('12.34');
+    });
+
+    test('no currency argument preserves existing behavior', () => {
+      expect(integerToCurrencyWithDecimal(1234)).toBe('12.34');
+      expect(integerToCurrencyWithDecimal(1200)).toBe('12.00');
+    });
+  });
+
+  describe('encodeAmount', () => {
+    test('empty string (None) uses 2dp', () => {
+      expect(encodeAmount(12.34, '')).toBe(1234);
+    });
+
+    test('USD uses 2dp', () => {
+      expect(encodeAmount(12.34, 'USD')).toBe(1234);
+    });
+
+    test('JPY uses 0dp (multiply by 1)', () => {
+      expect(encodeAmount(1234, 'JPY')).toBe(1234);
+    });
+
+    test('IRR uses 0dp (multiply by 1)', () => {
+      expect(encodeAmount(1234, 'IRR')).toBe(1234);
+    });
+
+    test('round-trip with integerToCurrencyWithDecimal', () => {
+      setNumberFormat({ format: 'comma-dot', hideFraction: false });
+      for (const [amount, currency] of [
+        [12.34, 'USD'],
+        [1234, 'JPY'],
+        [5678, 'IRR'],
+      ] as const) {
+        const encoded = encodeAmount(amount, currency);
+        const decoded = parseFloat(
+          integerToCurrencyWithDecimal(encoded, currency).replace(/,/g, ''),
+        );
+        expect(decoded).toBeCloseTo(amount, 8);
+      }
+    });
   });
 });

--- a/packages/loot-core/src/shared/util.test.ts
+++ b/packages/loot-core/src/shared/util.test.ts
@@ -288,19 +288,17 @@ describe('utility functions', () => {
       expect(encodeAmount(1234, 'IRR')).toBe(1234);
     });
 
-    test('round-trip with integerToCurrencyWithDecimal', () => {
+    it.each<[number, string]>([
+      [12.34, 'USD'],
+      [1234, 'JPY'],
+      [5678, 'IRR'],
+    ])('round-trip encodeAmount/integerToCurrencyWithDecimal: %s %s', (amount, currency) => {
       setNumberFormat({ format: 'comma-dot', hideFraction: false });
-      for (const [amount, currency] of [
-        [12.34, 'USD'],
-        [1234, 'JPY'],
-        [5678, 'IRR'],
-      ] as const) {
-        const encoded = encodeAmount(amount, currency);
-        const decoded = parseFloat(
-          integerToCurrencyWithDecimal(encoded, currency).replace(/,/g, ''),
-        );
-        expect(decoded).toBeCloseTo(amount, 8);
-      }
+      const encoded = encodeAmount(amount, currency);
+      const decoded = parseFloat(
+        integerToCurrencyWithDecimal(encoded, currency).replace(/,/g, ''),
+      );
+      expect(decoded).toBeCloseTo(amount, 8);
     });
   });
 });

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -2,6 +2,8 @@
 import { formatDistanceToNow } from 'date-fns';
 import type { Locale } from 'date-fns';
 
+import { getCurrencyPrecisionMultiplier, getDecimalPlaces } from './currencies';
+
 export function last<T>(arr: Array<T>) {
   return arr[arr.length - 1];
 }
@@ -453,7 +455,19 @@ export function integerToCurrency(
   return formatter.format(amount);
 }
 
-export function integerToCurrencyWithDecimal(integerAmount: IntegerAmount) {
+export function integerToCurrencyWithDecimal(
+  integerAmount: IntegerAmount,
+  currencyCode?: string,
+) {
+  if (currencyCode !== undefined) {
+    const dp = getDecimalPlaces(currencyCode);
+    return integerToCurrency(
+      integerAmount,
+      getNumberFormat({ ...numberFormatConfig, decimalPlaces: dp }).formatter,
+      dp,
+    );
+  }
+
   // If decimal digits exist, keep them. Otherwise format them as usual.
   if (integerAmount % 100 !== 0) {
     return integerToCurrency(
@@ -466,6 +480,10 @@ export function integerToCurrencyWithDecimal(integerAmount: IntegerAmount) {
   }
 
   return integerToCurrency(integerAmount);
+}
+
+export function encodeAmount(amount: number, code: string): number {
+  return Math.round(amount * getCurrencyPrecisionMultiplier(code));
 }
 
 export function amountToCurrency(amount: Amount): CurrencyAmount {

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -2,7 +2,7 @@
 import { formatDistanceToNow } from 'date-fns';
 import type { Locale } from 'date-fns';
 
-import { getCurrencyPrecisionMultiplier, getDecimalPlaces } from './currencies';
+import { getDecimalPlaces } from './currencies';
 
 export function last<T>(arr: Array<T>) {
   return arr[arr.length - 1];
@@ -482,8 +482,8 @@ export function integerToCurrencyWithDecimal(
   return integerToCurrency(integerAmount);
 }
 
-export function encodeAmount(amount: number, code: string): number {
-  return Math.round(amount * getCurrencyPrecisionMultiplier(code));
+export function amountToCurrencyInteger(amount: number, code: string): number {
+  return amountToInteger(amount, getDecimalPlaces(code));
 }
 
 export function amountToCurrency(amount: Amount): CurrencyAmount {

--- a/upcoming-release-notes/8064.md
+++ b/upcoming-release-notes/8064.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [StephenBrown2]
 ---
 
-Adds internal curency aware helpers to `currencies.ts` and `util.ts`.
+Adds internal currency-aware helpers to `currencies.ts` and `util.ts`.

--- a/upcoming-release-notes/8064.md
+++ b/upcoming-release-notes/8064.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [StephenBrown2]
+---
+
+Adds internal curency aware helpers to `currencies.ts` and `util.ts`.


### PR DESCRIPTION
## Description

This PR lays the groundwork for multi-currency support by adding currency-precision-aware helpers to the shared utilities in `loot-core`.

Overall vision/plan: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc

I envision this being the first of many small PRs, slowly filling out the needed work to enable account-level currency support, at which point, we can then build budget-level support on top of that.

PR stack:

- **[DP-1]: Currency metadata and decimal helper functions — This PR**
- [DP-2]: Server-side decimal-aware amount handling — [#8167](https://github.com/actualbudget/actual/pull/8167)
- [DP-3]: desktop-client: transaction table and search — TBD
- [DP-4]: desktop-client: budget UI components — TBD
- [DP-5]: desktop-client: modals, mobile, settings, and E2E — TBD
- [DP-6]: Historical data migration for non-2dp currencies — TBD
- [DP-7]: desktop-client: remove "hide decimal places" setting — TBD

However, the first thing to address is the existing mistakes when handling currencies with zero (and eventually 3+) decimal places. This should eventually get us to the end state of #6954.

Changes:

- `currencies.ts`:
  - Added `getDecimalPlaces(currencyCode)`: returns the number of decimal places for a given currency (defaults to 2 for unknown codes)
  - Added `getCurrencyPrecisionMultiplier(currencyCode)`: returns the corresponding power-of-10 multiplier (1 for JPY, 100 for USD, etc.)
- `util.ts`:
  - Added optional `currencyCode` parameter to `integerToCurrencyWithDecimal`: when supplied it formats using that currency's precision; without it, existing behaviour is unchanged.
  - Added `encodeAmount(amount, code)`: converts a floating-point amount into the integer storage format for a given currency.

## Related issue(s)

Partially implements #6954

## Testing

Full unit test coverage added:

- `currencies.test.ts`: covers `getDecimalPlaces` and `getCurrencyPrecisionMultiplier` for zero-decimal currencies (JPY, KRW, IRR), standard currencies (USD, EUR, GBP), unknown currency codes, and the metadata completeness of the full currencies list.
- `util.test.ts`: covers the new `currencyCode` path in `integerToCurrencyWithDecimal`, the `encodeAmount` function, and a round-trip consistency check between `encodeAmount` and `integerToCurrencyWithDecimal` across JPY, USD, and IRR.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+321 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+321 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📈 +222 B (+2.46%) | 8.82 kB → 9.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +99 B (+1.53%) | 6.33 kB → 6.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 501.42 kB → 508.06 kB (+6.64 kB) | +1.32%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.09 MB → 5.08 MB (-6.33 kB) | -0.12%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.64 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.02 kB | 0%
static/js/de.js | 170.87 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 199.45 kB | 0%
static/js/es.js | 178.57 kB | 0%
static/js/fr.js | 178.44 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.87 kB | 0%
static/js/narrow.js | 364.5 kB | 0%
static/js/nb-NO.js | 147.94 kB | 0%
static/js/nl.js | 107 kB | 0%
static/js/pt-BR.js | 188.32 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 209.01 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 299.14 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CCn_Decu.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.GgwvIuuL.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->