### PR TITLE
[AI] Fix split rule fixed amount sign

### DIFF
--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -193,7 +193,13 @@ export class Action {
       case 'set-split-amount':
         switch (this.options.method) {
           case 'fixed-amount':
-            object.amount = this.value;
+            object.amount =
+              typeof this.value === 'number' &&
+              typeof object.parent_amount === 'number' &&
+              object.parent_amount < 0 &&
+              this.value > 0
+                ? -this.value
+                : this.value;
             break;
           case 'formula':
             if (!object._ruleErrors) {

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -760,7 +760,7 @@ describe('Rule', () => {
       });
     });
 
-    test('fixed amount follows the parent transaction sign', () => {
+    it('fixed amount follows the parent transaction sign', () => {
       const rule = new Rule({
         conditionsOp: 'and',
         conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -760,6 +760,38 @@ describe('Rule', () => {
       });
     });
 
+    test('fixed amount follows the parent transaction sign', () => {
+      const rule = new Rule({
+        conditionsOp: 'and',
+        conditions: [{ op: 'is', field: 'imported_payee', value: 'James' }],
+        actions: [
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            value: 8500,
+            options: { splitIndex: 1, method: 'fixed-amount' },
+          },
+          {
+            op: 'set-split-amount',
+            field: 'amount',
+            options: { splitIndex: 2, method: 'remainder' },
+          },
+        ],
+      });
+
+      expect(
+        rule.exec({ imported_payee: 'James', amount: -10000 }),
+      ).toMatchObject({
+        subtransactions: [{ amount: -8500 }, { amount: -1500 }],
+      });
+
+      expect(
+        rule.exec({ imported_payee: 'James', amount: 10000 }),
+      ).toMatchObject({
+        subtransactions: [{ amount: 8500 }, { amount: 1500 }],
+      });
+    });
+
     test('remainder/percent goes negative if less than expected after fixed amounts', () => {
       // Remainder/percent goes negative if less than expected after fixed amounts
       expect(

--- a/upcoming-release-notes/8076.md
+++ b/upcoming-release-notes/8076.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [puneetdixit200]
+---
+
+Fixed split rules so fixed child amounts preserve the parent transaction sign.


### PR DESCRIPTION
## Description

Fixed fixed-amount split rules so child split amounts preserve the parent transaction sign. A positive fixed split amount is now negated when it is applied to a negative parent transaction, and the regression covers both negative and positive parent amounts.

This also adds the required release note and updates the new Vitest case to use the repo's `it(...)` convention.

## Related issue(s)

No linked issue.

## Testing

- `git diff --check`
- Existing PR CI before the release-note follow-up passed lint, typecheck, tests, builds, E2E shards, visual regression shards, CodeQL, and deploy previews.
- The follow-up only changes test naming convention and adds `upcoming-release-notes/8076.md`; release-note CI is expected to rerun on the pushed commit.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.04 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+137 B) | +0.00%
api | 2 | 3.86 MB → 3.86 MB (+137 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.04 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.64 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.09 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.02 kB | 0%
static/js/de.js | 170.87 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 199.23 kB | 0%
static/js/es.js | 178.57 kB | 0%
static/js/extends.js | 501.42 kB | 0%
static/js/fr.js | 178.44 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.87 kB | 0%
static/js/narrow.js | 364.5 kB | 0%
static/js/nb-NO.js | 147.94 kB | 0%
static/js/nl.js | 107 kB | 0%
static/js/pt-BR.js | 188.32 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 207.3 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 299.14 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+137 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +137 B (+1.66%) | 8.06 kB → 8.2 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.twkejo-W.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DC4epP6P.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+137 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +137 B (+1.76%) | 7.6 kB → 7.73 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+137 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->