### PR TITLE
automation UI: improve scaling

### DIFF
--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -159,209 +159,211 @@ export function AutomationEditorPane({
     <View
       style={{
         flex: 1,
-        padding: 20,
         overflowY: 'auto',
-        gap: 14,
+        overflowX: 'hidden',
+        scrollbarGutter: 'stable',
       }}
     >
-      {activeError && (
-        <View
-          style={{
-            padding: '10px 12px',
-            borderRadius: 6,
-            backgroundColor: theme.errorBackground,
-            border: `1px solid ${theme.errorBorder}`,
-            color: theme.errorText,
-            fontSize: 13,
-            flexDirection: 'row',
-            gap: 10,
-            alignItems: 'flex-start',
-          }}
-        >
-          <SvgAlertTriangle
-            width={14}
-            height={14}
-            style={{ marginTop: 2, color: 'inherit', flexShrink: 0 }}
-          />
-          <View style={{ minWidth: 0 }}>
-            <Text style={{ fontWeight: 600, color: 'inherit' }}>
-              <AutomationErrorTitle error={activeError} />
-            </Text>
-            <Text
-              style={{
-                fontSize: 12,
-                marginTop: 2,
-                color: 'inherit',
-                display: 'block',
-              }}
-            >
-              <AutomationErrorDetail error={activeError} />
-            </Text>
-          </View>
-        </View>
-      )}
-
-      {!NON_CONTRIBUTION_TYPES.has(state.displayType) && (
-        <>
-          <Text
-            style={{
-              fontSize: 11,
-              textTransform: 'uppercase',
-              color: theme.pageTextLight,
-              fontWeight: 600,
-              letterSpacing: '0.05em',
-            }}
-          >
-            <Trans>Automation type</Trans>
-          </Text>
-          <TypePicker
-            active={state.displayType}
-            disabledTypes={disabledTypes}
-            onPick={type => dispatch({ type: 'set-type', payload: type })}
-          />
-        </>
-      )}
-
-      {state.displayType !== 'refill' && (
-        <>
-          <Text
-            style={{
-              fontSize: 11,
-              textTransform: 'uppercase',
-              color: theme.pageTextLight,
-              fontWeight: 600,
-              letterSpacing: '0.05em',
-            }}
-          >
-            <Trans>Configuration</Trans>
-          </Text>
+      <View style={{ padding: 20, gap: 14, flexShrink: 0 }}>
+        {activeError && (
           <View
-            className={CONFIG_PANEL_CLASS}
             style={{
-              padding: 16,
-              backgroundColor: theme.tableBackground,
+              padding: '10px 12px',
               borderRadius: 6,
-              border: `1px solid ${theme.tableBorder}`,
+              backgroundColor: theme.errorBackground,
+              border: `1px solid ${theme.errorBorder}`,
+              color: theme.errorText,
+              fontSize: 13,
+              flexDirection: 'row',
+              gap: 10,
+              alignItems: 'flex-start',
             }}
           >
-            {NON_CONTRIBUTION_TYPES.has(state.displayType) && (
+            <SvgAlertTriangle
+              width={14}
+              height={14}
+              style={{ marginTop: 2, color: 'inherit', flexShrink: 0 }}
+            />
+            <View style={{ minWidth: 0 }}>
+              <Text style={{ fontWeight: 600, color: 'inherit' }}>
+                <AutomationErrorTitle error={activeError} />
+              </Text>
               <Text
                 style={{
                   fontSize: 12,
-                  color: theme.pageTextLight,
+                  marginTop: 2,
+                  color: 'inherit',
                   display: 'block',
-                  marginBottom: 4,
                 }}
               >
-                {getDisplayTemplateMeta(state.displayType).description}
+                <AutomationErrorDetail error={activeError} />
               </Text>
-            )}
-            <ActiveEditor
-              key={active.id}
-              state={state}
-              dispatch={dispatch}
-              schedules={schedules}
-              categories={categories}
-              hasLimitAutomation={hasLimitAutomation}
-              onAddLimitAutomation={onAddLimitAutomation}
-            />
+            </View>
           </View>
-        </>
-      )}
+        )}
 
-      {state.displayType === 'refill' && (
-        <ActiveEditor
-          key={active.id}
-          state={state}
-          dispatch={dispatch}
-          schedules={schedules}
-          categories={categories}
-          hasLimitAutomation={hasLimitAutomation}
-          onAddLimitAutomation={onAddLimitAutomation}
-        />
-      )}
-
-      <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
-        {'priority' in state.template &&
-          typeof state.template.priority === 'number' && (
-            <View
+        {!NON_CONTRIBUTION_TYPES.has(state.displayType) && (
+          <>
+            <Text
               style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 8,
+                fontSize: 11,
+                textTransform: 'uppercase',
+                color: theme.pageTextLight,
+                fontWeight: 600,
+                letterSpacing: '0.05em',
               }}
             >
-              <Text
-                style={{
-                  fontSize: 11,
-                  fontWeight: 600,
-                  color: theme.pageTextLight,
-                  letterSpacing: '0.04em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                <Trans>Priority</Trans>
-              </Text>
-              <Input
-                type="number"
-                style={{ width: 64 }}
-                value={String(state.template.priority)}
-                onChangeValue={value => {
-                  if (value === '') return;
-                  const parsed = Math.round(Number(value));
-                  if (Number.isNaN(parsed)) return;
-                  setPriority(Math.max(0, parsed));
-                }}
+              <Trans>Automation type</Trans>
+            </Text>
+            <TypePicker
+              active={state.displayType}
+              disabledTypes={disabledTypes}
+              onPick={type => dispatch({ type: 'set-type', payload: type })}
+            />
+          </>
+        )}
+
+        {state.displayType !== 'refill' && (
+          <>
+            <Text
+              style={{
+                fontSize: 11,
+                textTransform: 'uppercase',
+                color: theme.pageTextLight,
+                fontWeight: 600,
+                letterSpacing: '0.05em',
+              }}
+            >
+              <Trans>Configuration</Trans>
+            </Text>
+            <View
+              className={CONFIG_PANEL_CLASS}
+              style={{
+                padding: 16,
+                backgroundColor: theme.tableBackground,
+                borderRadius: 6,
+                border: `1px solid ${theme.tableBorder}`,
+              }}
+            >
+              {NON_CONTRIBUTION_TYPES.has(state.displayType) && (
+                <Text
+                  style={{
+                    fontSize: 12,
+                    color: theme.pageTextLight,
+                    display: 'block',
+                    marginBottom: 4,
+                  }}
+                >
+                  {getDisplayTemplateMeta(state.displayType).description}
+                </Text>
+              )}
+              <ActiveEditor
+                key={active.id}
+                state={state}
+                dispatch={dispatch}
+                schedules={schedules}
+                categories={categories}
+                hasLimitAutomation={hasLimitAutomation}
+                onAddLimitAutomation={onAddLimitAutomation}
               />
             </View>
-          )}
-        <View style={{ flex: 1 }} />
-        <Button
-          variant="bare"
-          onPress={() => onDelete(activeIdx)}
-          style={{ color: theme.errorText }}
-        >
-          <span
-            style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
-          >
-            <SvgDelete width={10} height={10} style={{ color: 'inherit' }} />
-            <Trans>Delete automation</Trans>
-          </span>
-        </Button>
-      </View>
+          </>
+        )}
 
-      <Text
-        style={{
-          fontSize: 11,
-          textTransform: 'uppercase',
-          color: theme.pageTextLight,
-          fontWeight: 600,
-          letterSpacing: '0.05em',
-        }}
-      >
-        <Trans>Note</Trans>
-      </Text>
-      <textarea
-        aria-label={t('Automation note')}
-        className={css({
-          width: '100%',
-          minHeight: 60,
-          resize: 'vertical',
-          fontFamily: 'inherit',
-          fontSize: 13,
-          lineHeight: 1.4,
-          padding: '8px 10px',
-          borderRadius: 6,
-          border: `1px solid ${theme.formInputBorder}`,
-          backgroundColor: theme.tableBackground,
-          color: theme.tableText,
-          '::placeholder': { color: theme.pageTextLight },
-        })}
-        value={active.template.description ?? ''}
-        onChange={e => setDescription(e.target.value)}
-        placeholder={t('Note')}
-        rows={3}
-      />
+        {state.displayType === 'refill' && (
+          <ActiveEditor
+            key={active.id}
+            state={state}
+            dispatch={dispatch}
+            schedules={schedules}
+            categories={categories}
+            hasLimitAutomation={hasLimitAutomation}
+            onAddLimitAutomation={onAddLimitAutomation}
+          />
+        )}
+
+        <View style={{ flexDirection: 'row', gap: 12, alignItems: 'center' }}>
+          {'priority' in state.template &&
+            typeof state.template.priority === 'number' && (
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+              >
+                <Text
+                  style={{
+                    fontSize: 11,
+                    fontWeight: 600,
+                    color: theme.pageTextLight,
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                  }}
+                >
+                  <Trans>Priority</Trans>
+                </Text>
+                <Input
+                  type="number"
+                  style={{ width: 64 }}
+                  value={String(state.template.priority)}
+                  onChangeValue={value => {
+                    if (value === '') return;
+                    const parsed = Math.round(Number(value));
+                    if (Number.isNaN(parsed)) return;
+                    setPriority(Math.max(0, parsed));
+                  }}
+                />
+              </View>
+            )}
+          <View style={{ flex: 1 }} />
+          <Button
+            variant="bare"
+            onPress={() => onDelete(activeIdx)}
+            style={{ color: theme.errorText }}
+          >
+            <span
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+            >
+              <SvgDelete width={10} height={10} style={{ color: 'inherit' }} />
+              <Trans>Delete automation</Trans>
+            </span>
+          </Button>
+        </View>
+
+        <Text
+          style={{
+            fontSize: 11,
+            textTransform: 'uppercase',
+            color: theme.pageTextLight,
+            fontWeight: 600,
+            letterSpacing: '0.05em',
+          }}
+        >
+          <Trans>Note</Trans>
+        </Text>
+        <textarea
+          aria-label={t('Automation note')}
+          className={css({
+            width: '100%',
+            minHeight: 60,
+            resize: 'vertical',
+            fontFamily: 'inherit',
+            fontSize: 13,
+            lineHeight: 1.4,
+            padding: '8px 10px',
+            borderRadius: 6,
+            border: `1px solid ${theme.formInputBorder}`,
+            backgroundColor: theme.tableBackground,
+            color: theme.tableText,
+            '::placeholder': { color: theme.pageTextLight },
+          })}
+          value={active.template.description ?? ''}
+          onChange={e => setDescription(e.target.value)}
+          placeholder={t('Note')}
+          rows={3}
+        />
+      </View>
     </View>
   );
 }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -542,13 +542,15 @@ export function BudgetAutomationsBody({
           )}
         </View>
 
-        <View style={{ flex: 1, minWidth: 0 }}>
+        <View style={{ flex: 1, minWidth: 0, minHeight: 0 }}>
           {cleanupActive ? (
             <View
               style={{
                 flex: 1,
                 padding: 20,
                 overflowY: 'auto',
+                overflowX: 'hidden',
+                scrollbarGutter: 'stable',
                 gap: 14,
               }}
             >

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/EmptyState.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/EmptyState.tsx
@@ -66,7 +66,7 @@ export function EmptyState({ onAdd }: EmptyStateProps) {
       <View
         style={{
           display: 'grid',
-          gridTemplateColumns: '1fr 1fr 1fr',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
           gap: 10,
           textAlign: 'center',
         }}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/TypePicker.tsx
@@ -31,7 +31,7 @@ export function TypePicker({ active, disabledTypes, onPick }: TypePickerProps) {
     <View
       style={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(4, 1fr)',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
         gap: 8,
       }}
     >

--- a/upcoming-release-notes/8080.md
+++ b/upcoming-release-notes/8080.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: Improve scaling on various screen sizes and zoom levels


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Instead of forcing the column layout it's now allowed to flow and be scrollable, should make it better in the high DPI/zoom cases we've seen reported.

Best to review this with whitespace off

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4595200261
https://github.com/actualbudget/actual/issues/7692#issuecomment-4607860245

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested using responsive mode in the dev tools

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.04 MB → 14.05 MB (+2.57 kB) | +0.02%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.04 MB → 14.05 MB (+2.57 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx` | 📈 +529 B (+3.98%) | 12.97 kB → 13.49 kB
`locale/uk.json` | 📈 +1.71 kB (+0.83%) | 207.3 kB → 209.01 kB
`src/components/modals/BudgetAutomationsModal/TypePicker.tsx` | 📈 +22 B (+0.66%) | 3.27 kB → 3.29 kB
`src/components/modals/BudgetAutomationsModal/EmptyState.tsx` | 📈 +25 B (+0.54%) | 4.54 kB → 4.57 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +82 B (+0.49%) | 16.25 kB → 16.33 kB
`locale/en.json` | 📈 +224 B (+0.11%) | 199.23 kB → 199.45 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/uk.js | 207.3 kB → 209.01 kB (+1.71 kB) | +0.83%
static/js/index.js | 1.55 MB → 1.55 MB (+658 B) | +0.04%
static/js/en.js | 199.23 kB → 199.45 kB (+224 B) | +0.11%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.64 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.09 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.02 kB | 0%
static/js/de.js | 170.87 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/es.js | 178.57 kB | 0%
static/js/extends.js | 501.42 kB | 0%
static/js/fr.js | 178.44 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.87 kB | 0%
static/js/narrow.js | 364.5 kB | 0%
static/js/nb-NO.js | 147.94 kB | 0%
static/js/nl.js | 107 kB | 0%
static/js/pt-BR.js | 188.32 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 299.14 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DC4epP6P.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->