### PR TITLE
automation UI: rework balance cap and fix error when clearing fields

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/editor/HistoricalAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/HistoricalAutomation.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { Input } from '@actual-app/components/input';
 import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
 import type {
@@ -11,7 +13,6 @@ import { updateTemplate } from '#components/budget/goals/actions';
 import type { Action } from '#components/budget/goals/actions';
 import { AmountAdjustment } from '#components/budget/goals/editor/AmountAdjustment';
 import { FormField, FormLabel } from '#components/forms';
-import { GenericInput } from '#components/util/GenericInput';
 
 type HistoricalAutomationProps = {
   template: CopyTemplate | AverageTemplate;
@@ -23,6 +24,26 @@ export const HistoricalAutomation = ({
   dispatch,
 }: HistoricalAutomationProps) => {
   const { t } = useTranslation();
+
+  const months =
+    template.type === 'average' ? template.numMonths : template.lookBack;
+  const [rawMonths, setRawMonths] = useState(String(months));
+  useEffect(() => {
+    setRawMonths(String(months));
+  }, [months]);
+
+  const commitMonths = () => {
+    const parsed = Math.max(1, Math.trunc(Number(rawMonths)) || 1);
+    setRawMonths(String(parsed));
+    if (parsed === months) return;
+    dispatch(
+      updateTemplate(
+        template.type === 'average'
+          ? { type: 'average', numMonths: parsed }
+          : { type: 'copy', lookBack: parsed },
+      ),
+    );
+  };
 
   return (
     <>
@@ -45,23 +66,14 @@ export const HistoricalAutomation = ({
             title={t('Number of months back')}
             htmlFor="look-back-field"
           />
-          <GenericInput
-            key="look-back-input"
+          <Input
+            id="look-back-field"
             type="number"
-            value={
-              template.type === 'average'
-                ? template.numMonths
-                : template.lookBack
-            }
-            onChange={value =>
-              dispatch(
-                updateTemplate(
-                  template.type === 'average'
-                    ? { type: 'average', numMonths: value }
-                    : { type: 'copy', lookBack: value },
-                ),
-              )
-            }
+            min={1}
+            step={1}
+            value={rawMonths}
+            onChangeValue={setRawMonths}
+            onBlur={commitMonths}
           />
         </FormField>
       </SpaceBetween>

--- a/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
@@ -2,6 +2,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
+import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import {
   currentDate,
@@ -116,6 +117,42 @@ export const LimitAutomation = ({
         {amountField}
         {cadenceField}
       </SpaceBetween>
+
+      <Text
+        style={{
+          fontSize: 12,
+          color: theme.pageTextLight,
+          display: 'block',
+          marginTop: 8,
+        }}
+      >
+        <Trans>
+          A weekly or daily cap is multiplied by the number of weeks or days in
+          the month, so the effective monthly cap changes with each month. For
+          example, a{' '}
+          {{
+            weekly: format(
+              amountToInteger(50, format.currency.decimalPlaces),
+              'financial-no-decimals',
+            ),
+          }}
+          /week cap caps the balance at{' '}
+          {{
+            fourWeeks: format(
+              amountToInteger(200, format.currency.decimalPlaces),
+              'financial-no-decimals',
+            ),
+          }}{' '}
+          in months with 4 weeks and{' '}
+          {{
+            fiveWeeks: format(
+              amountToInteger(250, format.currency.decimalPlaces),
+              'financial-no-decimals',
+            ),
+          }}{' '}
+          in months with 5.
+        </Trans>
+      </Text>
 
       <SpaceBetween align="center" gap={10} style={{ marginTop: 10 }}>
         {period === 'weekly' && weekdayField}

--- a/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
@@ -90,31 +90,35 @@ export const LimitAutomation = ({
     </FormField>
   );
 
+  const cadenceField = (
+    <FormField key="cadence-field" style={{ flex: 1 }}>
+      <FormLabel title={t('Every')} htmlFor="cadence-field" />
+
+      <Select
+        id="cadence-field"
+        value={period}
+        onChange={cadence =>
+          dispatch(updateTemplate({ type: 'limit', period: cadence }))
+        }
+        options={[
+          ['daily', t('Day')],
+          ['weekly', t('Week')],
+          ['monthly', t('Month')],
+        ]}
+        className={selectButtonClassName}
+      />
+    </FormField>
+  );
+
   return (
     <>
       <SpaceBetween align="center" gap={10} style={{ marginTop: 10 }}>
-        <FormField key="cadence-field" style={{ flex: 1 }}>
-          <FormLabel title={t('Cadence')} htmlFor="cadence-field" />
-
-          <Select
-            id="cadence-field"
-            value={period}
-            onChange={cadence =>
-              dispatch(updateTemplate({ type: 'limit', period: cadence }))
-            }
-            options={[
-              ['daily', t('Daily')],
-              ['weekly', t('Weekly')],
-              ['monthly', t('Monthly')],
-            ]}
-            className={selectButtonClassName}
-          />
-        </FormField>
-        {period === 'weekly' ? weekdayField : amountField}
+        {amountField}
+        {cadenceField}
       </SpaceBetween>
 
       <SpaceBetween align="center" gap={10} style={{ marginTop: 10 }}>
-        {period === 'weekly' && amountField}
+        {period === 'weekly' && weekdayField}
         <FormField key="hold-overflow-field" style={{ flex: 1 }}>
           <LabeledCheckbox
             id="hold-overflow-field"

--- a/upcoming-release-notes/8082.md
+++ b/upcoming-release-notes/8082.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Automation UI: rework balance cap and fix error when clearing fields


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4607698641
https://github.com/actualbudget/actual/issues/7692#issuecomment-4618164581
https://github.com/actualbudget/actual/issues/7692#issuecomment-4622617997

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Full reports at the links above

Balance cap is a visual change, to test the safeNumber error clear out the "number of months back" field in the history automation.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+2.45 kB) | +0.02%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+2.45 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/editor/LimitAutomation.tsx` | 📈 +1.77 kB (+21.27%) | 8.34 kB → 10.12 kB
`src/components/budget/goals/editor/HistoricalAutomation.tsx` | 📈 +690 B (+17.00%) | 3.96 kB → 4.64 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB → 1.56 MB (+2.45 kB) | +0.15%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.64 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.09 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 101.02 kB | 0%
static/js/de.js | 170.87 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 199.45 kB | 0%
static/js/es.js | 178.57 kB | 0%
static/js/extends.js | 501.42 kB | 0%
static/js/fr.js | 178.44 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.87 kB | 0%
static/js/narrow.js | 364.5 kB | 0%
static/js/nb-NO.js | 147.94 kB | 0%
static/js/nl.js | 107 kB | 0%
static/js/pt-BR.js | 188.32 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 209.01 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 299.14 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 117.01 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.GgwvIuuL.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->