### PR TITLE
[AI] Fix incorrect schedule value when saving full amount

### DIFF
--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -273,6 +273,50 @@ describe('runSchedule', () => {
       defaultCurrency,
     );
     expect(result.to_budget).toBe(0);
+    expect(result.perScheduleMonthly.get('Insurance')).toBeUndefined();
+  });
+
+  it('only attributes contribution to schedules occurring this month when full: true is used', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'Schedule A',
+        full: true,
+        directive: 'template',
+        priority: 0,
+      } as const,
+      {
+        type: 'schedule',
+        name: 'Schedule B',
+        full: true,
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    mockSchedulesByName({
+      'Schedule A': {
+        spec: { start: '2024-08-01', amount: -10000, frequency: 'monthly' },
+      },
+      'Schedule B': {
+        spec: { start: '2024-09-01', amount: -20000, frequency: 'monthly' },
+      },
+    });
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.to_budget).toBe(10000);
+    expect(result.perScheduleMonthly.get('Schedule A')).toBe(10000);
+    expect(result.perScheduleMonthly.get('Schedule B')).toBeUndefined();
   });
 
   it('applies a percent adjustment to the schedule amount', async () => {

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -372,7 +372,11 @@ export async function runSchedule(
       numSubMonthly > 0)
   ) {
     to_budget += Math.round(totalPayMonthOf + totalSinkingBaseContribution);
-    for (const c of t_payMonthOf) addContribution(c.name, c.target);
+    for (const c of t_payMonthOf) {
+      if (c.num_months === 0) {
+        addContribution(c.name, c.target);
+      }
+    }
     for (const c of t_sinking) {
       addContribution(c.name, getMonthlyBaseContribution(c));
     }
@@ -386,7 +390,11 @@ export async function runSchedule(
     } else {
       to_budget += Math.round(totalPayMonthOf + totalSinkingContribution);
     }
-    for (const c of t_payMonthOf) addContribution(c.name, c.target);
+    for (const c of t_payMonthOf) {
+      if (c.num_months === 0) {
+        addContribution(c.name, c.target);
+      }
+    }
     for (const [name, amount] of sinkingPerSchedule) {
       addContribution(name, amount);
     }

--- a/upcoming-release-notes/8085.md
+++ b/upcoming-release-notes/8085.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mnil]
+---
+
+Fix incorrect schedule value when saving full amount for a yearly schedule.


### PR DESCRIPTION
## Description

If one has a yearly schedule and the budget template uses "Cover each occurence when it occurs", it still showed a value for the yearly schedule even though it's not the month where the schedule occurs.

<img width="638" height="243" alt="Screenshot-2026-06-04-20:32:58" src="https://github.com/user-attachments/assets/3d6d85a2-7213-4015-846d-760d9e0da0c9" />

## Related issue(s)

n/a

## Testing

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (-2.6 kB) | -0.02%
loot-core | 1 | 5.28 MB → 5.28 MB (+48 B) | +0.00%
api | 2 | 3.86 MB → 3.86 MB (+48 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (-2.6 kB) | -0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +587 B (+0.29%) | 199.45 kB → 200.02 kB
`locale/de.json` | 📉 -227 B (-0.13%) | 170.87 kB → 170.65 kB
`locale/zh-Hans.json` | 📉 -169 B (-0.14%) | 117.01 kB → 116.84 kB
`locale/nb-NO.json` | 📉 -229 B (-0.15%) | 147.94 kB → 147.72 kB
`locale/nl.json` | 📉 -181 B (-0.17%) | 107 kB → 106.82 kB
`locale/uk.json` | 📉 -367 B (-0.17%) | 209.01 kB → 208.65 kB
`locale/pt-BR.json` | 📉 -355 B (-0.18%) | 188.32 kB → 187.97 kB
`locale/ca.json` | 📉 -378 B (-0.20%) | 186.63 kB → 186.26 kB
`locale/es.json` | 📉 -374 B (-0.20%) | 178.57 kB → 178.21 kB
`locale/it.json` | 📉 -347 B (-0.21%) | 164.87 kB → 164.53 kB
`locale/fr.json` | 📉 -390 B (-0.21%) | 178.44 kB → 178.06 kB
`locale/da.json` | 📉 -229 B (-0.22%) | 101.02 kB → 100.8 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 199.45 kB → 200.02 kB (+587 B) | +0.29%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 178.44 kB → 178.06 kB (-390 B) | -0.21%
static/js/ca.js | 186.63 kB → 186.26 kB (-378 B) | -0.20%
static/js/es.js | 178.57 kB → 178.21 kB (-374 B) | -0.20%
static/js/uk.js | 209.01 kB → 208.65 kB (-367 B) | -0.17%
static/js/pt-BR.js | 188.32 kB → 187.97 kB (-355 B) | -0.18%
static/js/it.js | 164.87 kB → 164.53 kB (-347 B) | -0.21%
static/js/da.js | 101.02 kB → 100.8 kB (-229 B) | -0.22%
static/js/nb-NO.js | 147.94 kB → 147.72 kB (-229 B) | -0.15%
static/js/de.js | 170.87 kB → 170.65 kB (-227 B) | -0.13%
static/js/nl.js | 107 kB → 106.82 kB (-181 B) | -0.17%
static/js/zh-Hans.js | 117.01 kB → 116.84 kB (-169 B) | -0.14%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+48 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +48 B (+0.56%) | 8.31 kB → 8.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.8g6UP_wl.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+48 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +48 B (+0.58%) | 8.14 kB → 8.19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+48 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->