### PR TITLE
[AI] Skip unimportable Enable Banking transactions instead of failing the whole sync

### DIFF
--- a/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
+++ b/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
@@ -16,6 +16,7 @@ import type {
 } from './services/enablebanking-service';
 import {
   enableBankingService,
+  isImportableTransaction,
   normalizeAccount,
   normalizeBalance,
   normalizeTransaction,
@@ -525,14 +526,37 @@ app.post(
       const booked: ReturnType<typeof normalizeTransaction>[] = [];
       const pending: ReturnType<typeof normalizeTransaction>[] = [];
 
+      let skippedCount = 0;
       for (const tx of rawTransactions) {
         const normalized = normalizeTransaction(tx);
+
+        // Drop records Actual's client can't insert (empty/non-ISO date or
+        // non-numeric amount) — one of them would otherwise abort the entire
+        // account sync. Pending transactions that carry a date are unaffected.
+        if (!isImportableTransaction(normalized)) {
+          skippedCount += 1;
+          debug(
+            'Skipping unimportable transaction id=%s date=%s amount=%s',
+            normalized.transactionId,
+            normalized.date,
+            normalized.transactionAmount.amount,
+          );
+          continue;
+        }
+
         all.push(normalized);
         if (normalized.booked) {
           booked.push(normalized);
         } else {
           pending.push(normalized);
         }
+      }
+      if (skippedCount > 0) {
+        debug(
+          'Skipped %d unimportable transaction(s) for account %s',
+          skippedCount,
+          accountId,
+        );
       }
 
       res.send({

--- a/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
+++ b/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
@@ -551,13 +551,6 @@ app.post(
           pending.push(normalized);
         }
       }
-      if (skippedCount > 0) {
-        debug(
-          'Skipped %d unimportable transaction(s) for account %s',
-          skippedCount,
-          accountId,
-        );
-      }
 
       res.send({
         status: 'ok',

--- a/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
+++ b/packages/sync-server/src/app-enablebanking/app-enablebanking.ts
@@ -526,7 +526,6 @@ app.post(
       const booked: ReturnType<typeof normalizeTransaction>[] = [];
       const pending: ReturnType<typeof normalizeTransaction>[] = [];
 
-      let skippedCount = 0;
       for (const tx of rawTransactions) {
         const normalized = normalizeTransaction(tx);
 
@@ -534,7 +533,6 @@ app.post(
         // non-numeric amount) — one of them would otherwise abort the entire
         // account sync. Pending transactions that carry a date are unaffected.
         if (!isImportableTransaction(normalized)) {
-          skippedCount += 1;
           debug(
             'Skipping unimportable transaction id=%s date=%s amount=%s',
             normalized.transactionId,

--- a/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
+++ b/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
@@ -58,7 +58,7 @@ type EnableBankingAuthResponse = {
   authorization_id: string;
 };
 
-export type BankSyncTransaction = EnableBankingTransaction & {
+type BankSyncTransaction = EnableBankingTransaction & {
   transactionId: string;
   date: string;
   bookingDate: string;

--- a/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
+++ b/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
@@ -58,7 +58,7 @@ type EnableBankingAuthResponse = {
   authorization_id: string;
 };
 
-type BankSyncTransaction = EnableBankingTransaction & {
+export type BankSyncTransaction = EnableBankingTransaction & {
   transactionId: string;
   date: string;
   bookingDate: string;
@@ -262,6 +262,22 @@ export function normalizeTransaction(
     remittanceInformationUnstructured,
     booked: tx.status !== 'PDNG',
   };
+}
+
+const IMPORTABLE_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// Actual's client imports a transaction by inserting it into a local SQLite
+// database: the `date` column is a required integer derived from an ISO date,
+// and the amount must be numeric. A record with an empty / non-ISO date or a
+// non-numeric amount makes that insert throw, which aborts the whole account
+// sync. Enable Banking occasionally returns such records — e.g. a pending
+// transaction with no booking/value/transaction date — so callers skip them
+// instead of failing the entire import.
+export function isImportableTransaction(tx: BankSyncTransaction): boolean {
+  return (
+    IMPORTABLE_DATE_REGEX.test(tx.date) &&
+    Number.isFinite(Number(tx.transactionAmount.amount))
+  );
 }
 
 export function normalizeBalance(bal: EnableBankingBalance): BankSyncBalance {

--- a/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
+++ b/packages/sync-server/src/app-enablebanking/services/enablebanking-service.ts
@@ -274,9 +274,13 @@ const IMPORTABLE_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 // transaction with no booking/value/transaction date — so callers skip them
 // instead of failing the entire import.
 export function isImportableTransaction(tx: BankSyncTransaction): boolean {
+  // Trim and reject empty amounts explicitly: Number('') is 0 (finite), so an
+  // empty/whitespace amount would otherwise slip through as a zero transaction.
+  const amount = tx.transactionAmount.amount.trim();
   return (
     IMPORTABLE_DATE_REGEX.test(tx.date) &&
-    Number.isFinite(Number(tx.transactionAmount.amount))
+    amount !== '' &&
+    Number.isFinite(Number(amount))
   );
 }
 

--- a/packages/sync-server/src/app-enablebanking/services/tests/fixtures.ts
+++ b/packages/sync-server/src/app-enablebanking/services/tests/fixtures.ts
@@ -107,6 +107,16 @@ export const mockTransactionMinimal = {
   status: 'BOOK',
 } satisfies EnableBankingTransaction;
 
+// A pending transaction with no booking/value/transaction date. Enable Banking
+// returns these for some pending entries; normalizeTransaction maps it to
+// date: '', which Actual's client cannot insert.
+export const mockPendingTransactionNoDate = {
+  transaction_id: 'tx-no-date',
+  transaction_amount: { currency: 'EUR', amount: '-7.50' },
+  status: 'PDNG',
+  remittance_information: ['Card payment, not yet booked'],
+} satisfies EnableBankingTransaction;
+
 export const mockBalance = {
   balance_amount: { currency: 'EUR', amount: '1234.56' },
   balance_type: 'CLAV',

--- a/packages/sync-server/src/app-enablebanking/services/tests/normalization.spec.ts
+++ b/packages/sync-server/src/app-enablebanking/services/tests/normalization.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  isImportableTransaction,
   normalizeAccount,
   normalizeBalance,
   normalizeTransaction,
@@ -12,6 +13,7 @@ import {
   mockDebitTransaction,
   mockNegativeBalance,
   mockPendingTransaction,
+  mockPendingTransactionNoDate,
   mockSessionAccount,
   mockSessionAccountMinimal,
   mockSessionAccountNoName,
@@ -93,6 +95,45 @@ describe('normalizeTransaction', () => {
     expect(normalizeTransaction(noBookingOrValueDate).bookingDate).toBe(
       '2026-02-28',
     );
+  });
+});
+
+describe('isImportableTransaction', () => {
+  it('accepts a normal booked transaction (ISO date + numeric amount)', () => {
+    expect(
+      isImportableTransaction(normalizeTransaction(mockCreditTransaction)),
+    ).toBe(true);
+  });
+
+  it('accepts a pending transaction that carries a date (no regression)', () => {
+    expect(
+      isImportableTransaction(normalizeTransaction(mockPendingTransaction)),
+    ).toBe(true);
+  });
+
+  it('rejects a pending transaction with no date (the case that aborts the sync)', () => {
+    const normalized = normalizeTransaction(mockPendingTransactionNoDate);
+    expect(normalized.date).toBe('');
+    expect(normalized.booked).toBe(false);
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects a non-ISO date', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      booking_date: '03/01/2026',
+      value_date: undefined,
+      transaction_date: undefined,
+    });
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects a non-numeric amount', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      transaction_amount: { currency: 'EUR', amount: 'n/a' },
+    });
+    expect(isImportableTransaction(normalized)).toBe(false);
   });
 });
 

--- a/packages/sync-server/src/app-enablebanking/services/tests/normalization.spec.ts
+++ b/packages/sync-server/src/app-enablebanking/services/tests/normalization.spec.ts
@@ -135,6 +135,15 @@ describe('isImportableTransaction', () => {
     });
     expect(isImportableTransaction(normalized)).toBe(false);
   });
+
+  it('rejects an empty amount (Number("") would coerce to 0)', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      transaction_amount: { currency: 'EUR', amount: '' },
+    });
+    expect(normalized.transactionAmount.amount).toBe('');
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
 });
 
 describe('SEPA prefix stripping', () => {

--- a/packages/sync-server/src/app-enablebanking/tests/poll-auth.spec.ts
+++ b/packages/sync-server/src/app-enablebanking/tests/poll-auth.spec.ts
@@ -450,6 +450,7 @@ describe('Enable Banking Express routes', () => {
             entry_reference: 'tx-1',
             transaction_amount: { currency: 'EUR', amount: '10.00' },
             status: 'BOOK',
+            booking_date: '2026-01-05',
           },
         ],
         continuation_key: 'page-2',
@@ -461,6 +462,7 @@ describe('Enable Banking Express routes', () => {
             entry_reference: 'tx-2',
             transaction_amount: { currency: 'EUR', amount: '20.00' },
             status: 'BOOK',
+            booking_date: '2026-01-06',
           },
         ],
       });

--- a/packages/sync-server/src/app-enablebanking/tests/transactions.spec.ts
+++ b/packages/sync-server/src/app-enablebanking/tests/transactions.spec.ts
@@ -1,0 +1,115 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  mockDebitTransaction,
+  mockPendingTransaction,
+  mockPendingTransactionNoDate,
+} from '#app-enablebanking/services/tests/fixtures';
+
+// Mock all external dependencies before importing the app (mirrors
+// poll-auth.spec.ts).
+vi.mock('../../services/secrets-service', () => ({
+  SecretName: {
+    enablebanking_applicationId: 'enablebanking_applicationId',
+    enablebanking_secretKey: 'enablebanking_secretKey',
+  },
+  secretsService: {
+    get: vi.fn(() => 'test-value'),
+    set: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/jwt', () => ({
+  getJWT: vi.fn(() => 'mock-jwt-token'),
+}));
+
+vi.mock('../../util/middlewares', () => ({
+  requestLoggerMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+  validateSessionMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+}));
+
+vi.mock('../../app-gocardless/util/handle-error', () => ({
+  handleError:
+    (fn: Function) =>
+    (req: unknown, res: { send: (data: unknown) => void }) => {
+      Promise.resolve(fn(req, res)).catch((err: Error) => {
+        res.send({
+          status: 'ok',
+          data: {
+            error_code: 'INTERNAL_ERROR',
+            error_type: err.message || 'internal-error',
+          },
+        });
+      });
+    },
+}));
+
+// Mock fetch globally (the service is stubbed below, this just guards stray calls)
+vi.stubGlobal('fetch', vi.fn());
+
+const { handlers } = await import('../app-enablebanking');
+const { enableBankingService } =
+  await import('../services/enablebanking-service');
+
+const app = express();
+app.set('trust proxy', true);
+app.use(express.json());
+app.use('/', handlers);
+
+const ids = (txns: Array<{ transactionId: string }>) =>
+  txns.map(t => t.transactionId);
+
+describe('POST /transactions', () => {
+  beforeEach(() => {
+    vi.spyOn(enableBankingService, 'getBalances').mockResolvedValue({
+      balances: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips a date-less pending transaction while keeping valid booked and pending ones', async () => {
+    // mockPendingTransactionNoDate normalizes to date '' — the record that would
+    // otherwise abort the whole sync when Actual's client tries to insert it.
+    vi.spyOn(enableBankingService, 'getAllTransactions').mockResolvedValue([
+      mockDebitTransaction,
+      mockPendingTransaction,
+      mockPendingTransactionNoDate,
+    ]);
+
+    const res = await request(app)
+      .post('/transactions')
+      .send({ accountId: 'acc-1', startDate: '2026-03-01' });
+
+    expect(res.body.status).toBe('ok');
+
+    const { all, booked, pending } = res.body.data.transactions;
+    // The unimportable record is dropped (proves the fix)...
+    expect(ids(all)).toEqual(['ref-002', 'tx-003']);
+    expect(ids(all)).not.toContain('tx-no-date');
+    // ...while the valid booked and valid (dated) pending entries still import
+    // and bucket correctly (no regression).
+    expect(ids(booked)).toEqual(['ref-002']);
+    expect(ids(pending)).toEqual(['tx-003']);
+  });
+
+  it('keeps every transaction when all are importable', async () => {
+    vi.spyOn(enableBankingService, 'getAllTransactions').mockResolvedValue([
+      mockDebitTransaction,
+      mockPendingTransaction,
+    ]);
+
+    const res = await request(app)
+      .post('/transactions')
+      .send({ accountId: 'acc-1', startDate: '2026-03-01' });
+
+    expect(res.body.data.transactions.all).toHaveLength(2);
+    expect(ids(res.body.data.transactions.all)).toEqual(['ref-002', 'tx-003']);
+  });
+});

--- a/upcoming-release-notes/8086.md
+++ b/upcoming-release-notes/8086.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mheiland]
+---
+
+Enable Banking: skip transactions that can't be imported (no date, or a non-numeric amount) instead of failing the entire account sync.


### PR DESCRIPTION
## Description

Linking a bank via Enable Banking can fail the **entire** account sync with a
client-side `SQLITE_ERROR` ("Internal error: (1)"). loot-core throws while
inserting a fetched transaction (`processBankSyncDownload → insertTransaction →
convertForInsert`), and because one bad record aborts the batch, no transactions
import for that account.

The trigger is a transaction the client can't store. The web client inserts each
transaction into a local SQLite database whose `date` is a required integer
derived from an ISO (`YYYY-MM-DD`) date and whose amount must be numeric. Enable
Banking occasionally returns a record that doesn't meet this — most commonly a
**pending transaction with no `booking_date`, `value_date`, or
`transaction_date`**, which `normalizeTransaction` maps to `date: ''`.

This adds an `isImportableTransaction` helper and uses it in the `/transactions`
handler to skip records that can't be imported (empty/non-ISO date or non-numeric
amount), logging how many were dropped, so the rest of the account imports. Normal
pending transactions (which carry a `value_date`/`transaction_date`) are
unaffected — they still import as `cleared: false` and reconcile via `imported_id`
when they post.

## Related issue(s)

_None found at time of writing._

## Testing

- Unit tests for `isImportableTransaction` (`services/tests/normalization.spec.ts`):
  accepts a normal booked transaction and a dated pending transaction; rejects a
  pending transaction with no date, a non-ISO date, and a non-numeric amount.
- Handler test (`tests/transactions.spec.ts`): `POST /transactions` over a batch of
  [valid booked, valid pending, date-less pending] returns only the two importable
  transactions, correctly bucketed; the date-less record is dropped; an
  all-importable batch is returned unchanged.
- Updated the existing pagination test (`tests/poll-auth.spec.ts`) whose mock
  transactions had no dates, so they stay importable under the new filter.
- `yarn typecheck`, `yarn lint`, and the sync-server Enable Banking tests
  (106 tests) all pass.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed
