### PR TITLE
add warning when schedule/save by automation priorities don't match

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
+++ b/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
@@ -187,6 +187,13 @@ export function GlobalConflictTitle({
           income
         </Trans>
       );
+    case 'schedule-priority-mismatch':
+      return (
+        <Trans>
+          All cover schedule and save by date automations must use the same
+          priority
+        </Trans>
+      );
     default:
       conflict satisfies never;
       return null;
@@ -216,6 +223,8 @@ export function GlobalConflictDetail({
           at 100%.
         </Trans>
       );
+    case 'schedule-priority-mismatch':
+      return null;
     default:
       conflict satisfies never;
       return null;

--- a/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
+++ b/packages/desktop-client/src/components/budget/goals/automationMessages.tsx
@@ -190,8 +190,8 @@ export function GlobalConflictTitle({
     case 'schedule-priority-mismatch':
       return (
         <Trans>
-          All cover schedule and save by date automations must use the same
-          priority
+          All <i>cover schedule</i> and <i>save by date</i> automations must use
+          the same priority
         </Trans>
       );
     default:

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   validateAutomation,
   validatePercentageAllocation,
+  validateSchedulePriorities,
 } from './validateAutomation';
 
 function percent(
@@ -209,5 +210,55 @@ describe('validateAutomation adjustment range', () => {
         today,
       ),
     ).toEqual({ kind: 'schedule-not-found', name: 'Rent' });
+  });
+});
+
+describe('validateSchedulePriorities', () => {
+  function scheduleAt(name: string, priority: number): Template {
+    return { type: 'schedule', name, directive: 'template', priority };
+  }
+  function byAt(priority: number): Template {
+    return {
+      type: 'by',
+      amount: 100,
+      month: '2026-12',
+      directive: 'template',
+      priority,
+    };
+  }
+
+  it('returns null when there are no schedule or by templates', () => {
+    expect(validateSchedulePriorities([])).toBeNull();
+  });
+
+  it('returns null for a single schedule', () => {
+    expect(validateSchedulePriorities([scheduleAt('Rent', 1)])).toBeNull();
+  });
+
+  it('returns null when all schedules share a priority', () => {
+    expect(
+      validateSchedulePriorities([scheduleAt('Rent', 2), scheduleAt('Gym', 2)]),
+    ).toBeNull();
+  });
+
+  it('flags schedules with mismatched priorities', () => {
+    expect(
+      validateSchedulePriorities([scheduleAt('Rent', 1), scheduleAt('Gym', 2)]),
+    ).toEqual({ kind: 'schedule-priority-mismatch' });
+  });
+
+  it('flags a schedule and a by-date with mismatched priorities', () => {
+    expect(
+      validateSchedulePriorities([scheduleAt('Rent', 1), byAt(2)]),
+    ).toEqual({ kind: 'schedule-priority-mismatch' });
+  });
+
+  it('ignores priorities of other automation types', () => {
+    expect(
+      validateSchedulePriorities([
+        scheduleAt('Rent', 1),
+        percent('Salary', 10),
+      ]),
+    ).toBeNull();
   });
 });

--- a/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
+++ b/packages/desktop-client/src/components/budget/goals/validateAutomation.ts
@@ -30,7 +30,8 @@ function isAdjustmentOutOfRange(template: Template): boolean {
 
 export type GlobalConflictKind =
   | { kind: 'over-income'; total: number; income: number }
-  | { kind: 'percent-over-100'; total: number };
+  | { kind: 'percent-over-100'; total: number }
+  | { kind: 'schedule-priority-mismatch' };
 
 export function validateAutomation(
   template: Template,
@@ -149,4 +150,20 @@ export function validatePercentageAllocation(
   return maxPercent > 100
     ? { kind: 'percent-over-100', total: maxPercent }
     : null;
+}
+
+// The engine (CategoryTemplateContext.checkByAndScheduleAndSpend) requires
+// every schedule and by-date template in a category to share one priority; if
+// they don't, none of them budget. Surface that as a conflict so it can't be
+// saved.
+export function validateSchedulePriorities(
+  templates: readonly Template[],
+): GlobalConflictKind | null {
+  const priorities = new Set<number>();
+  for (const t of templates) {
+    if (t.type === 'schedule' || t.type === 'by') {
+      priorities.add(t.priority);
+    }
+  }
+  return priorities.size > 1 ? { kind: 'schedule-priority-mismatch' } : null;
 }

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -35,6 +35,7 @@ import { formatMonthLabel } from '#components/budget/goals/formatMonthLabel';
 import {
   validateAutomation,
   validatePercentageAllocation,
+  validateSchedulePriorities,
 } from '#components/budget/goals/validateAutomation';
 import { Link } from '#components/common/Link';
 import { useCleanupGroups } from '#hooks/useCleanupGroups';
@@ -348,7 +349,10 @@ export function BudgetAutomationsBody({
     dryRun?.perTemplate?.[i] != null ? dryRun.perTemplate[i] : null,
   );
   const hasErrors = automationErrors.some(error => error !== null);
-  const conflict = validatePercentageAllocation(templates);
+  const conflicts = [
+    validatePercentageAllocation(templates),
+    validateSchedulePriorities(templates),
+  ].filter(conflict => conflict !== null);
 
   const categoryNameMap: Record<string, string> = {};
   for (const group of categories) {
@@ -465,7 +469,9 @@ export function BudgetAutomationsBody({
         />
       )}
 
-      {conflict && <ConflictBanner conflict={conflict} />}
+      {conflicts.map((conflict, i) => (
+        <ConflictBanner key={i} conflict={conflict} />
+      ))}
 
       <View
         style={{
@@ -627,7 +633,7 @@ export function BudgetAutomationsBody({
         <Button
           variant="primary"
           onPress={onSave}
-          isDisabled={hasErrors || conflict !== null || saving}
+          isDisabled={hasErrors || conflicts.length > 0 || saving}
         >
           <Trans>Save</Trans>
         </Button>

--- a/upcoming-release-notes/8088.md
+++ b/upcoming-release-notes/8088.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Automation UI: Add warning when schedule/save by automation priorities don't match


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

As the comment says, the engine doesn't allow it, so let's block it!

I got claude to verify the cases in the engine we were actually disallowing, hence the more verbose comment, but i think it's useful in this case

Claude helped with the tests

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4618874807

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

<img width="952" height="286" alt="image" src="https://github.com/user-attachments/assets/8c960236-f557-4f46-b23a-465274fbdeda" />


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+1.04 kB) | +0.01%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+1.04 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/goals/validateAutomation.ts` | 📈 +277 B (+9.07%) | 2.98 kB → 3.25 kB
`src/components/budget/goals/automationMessages.tsx` | 📈 +663 B (+5.22%) | 12.41 kB → 13.05 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +126 B (+0.75%) | 16.33 kB → 16.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB → 1.56 MB (+1.04 kB) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.26 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.8 kB | 0%
static/js/de.js | 170.65 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.02 kB | 0%
static/js/es.js | 178.21 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/fr.js | 178.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.53 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 147.72 kB | 0%
static/js/nl.js | 106.82 kB | 0%
static/js/pt-BR.js | 187.97 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 208.65 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.84 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->