### PR TITLE
Remove environment from release notes workflow

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -19,7 +19,6 @@ jobs:
       && github.head_ref != 'release'
       && startsWith(github.head_ref, 'release-notes/') == false
     runs-on: ubuntu-latest
-    environment: pr-automation
     permissions:
       contents: read
     steps:

--- a/upcoming-release-notes/release-notes-env.md
+++ b/upcoming-release-notes/release-notes-env.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+ci: remove no longer necessary "environment" from release-notes ci job.


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

No longer necessary since it does not carry any secrets.

It was unnecessarily spamming PRs with..
<img width="796" height="94" alt="Screenshot 2026-06-04 at 22 35 30" src="https://github.com/user-attachments/assets/26c2b5b7-8bb5-48ab-90bf-a9f6be1f6db3" />


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
