### PR TITLE
[AI] Enable "do not merge" check on merge queue events

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -3,6 +3,7 @@ name: Block PRs with "do not merge" label
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
 
 permissions:
   contents: read

--- a/upcoming-release-notes/fix-merge-queue-release-notes.md
+++ b/upcoming-release-notes/fix-merge-queue-release-notes.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Run the "do not merge" label check on merge_group events so it can be a required check in the merge queue.


### PR DESCRIPTION
## Description

Running the "do not merge" ci check also in merge queue so that we could make it a blocking CI job.

## Related issue(s)

N/A

## Testing

N/A

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

https://claude.ai/code/session_01AcsJ57hWAdBdLHbtp195nQ