### PR TITLE
[AI] Add scoped ErrorBoundaries to report and mobile pages

### DIFF
--- a/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountPage.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useCallback } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -13,6 +14,7 @@ import type { AccountEntity } from '@actual-app/core/types/models';
 
 import { useReopenAccountMutation, useUpdateAccountMutation } from '#accounts';
 import { isAccountFailedSync } from '#accounts/syncStatus';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { AddTransactionButton } from '#components/mobile/transactions/AddTransactionButton';
 import { MobilePageHeader, Page } from '#components/Page';
@@ -59,35 +61,37 @@ export function AccountPage() {
   );
 
   return (
-    <Page
-      header={
-        <MobilePageHeader
-          title={
-            account ? (
-              <AccountHeader account={account} />
-            ) : (
-              <NameOnlyHeader name={nameFromId(accountIdParam)} />
-            )
-          }
-          leftContent={<MobileBackButton />}
-          rightContent={<AddTransactionButton accountId={account?.id} />}
-        />
-      }
-      padding={0}
-    >
-      {/* This key forces the whole table rerender when the number format changes */}
-      <Fragment key={numberFormat + hideFraction}>
-        {account ? (
-          <AccountTransactions account={account} />
-        ) : accountIdParam === 'onbudget' ? (
-          <OnBudgetAccountTransactions />
-        ) : accountIdParam === 'offbudget' ? (
-          <OffBudgetAccountTransactions />
-        ) : (
-          <AllAccountTransactions />
-        )}
-      </Fragment>
-    </Page>
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <Page
+        header={
+          <MobilePageHeader
+            title={
+              account ? (
+                <AccountHeader account={account} />
+              ) : (
+                <NameOnlyHeader name={nameFromId(accountIdParam)} />
+              )
+            }
+            leftContent={<MobileBackButton />}
+            rightContent={<AddTransactionButton accountId={account?.id} />}
+          />
+        }
+        padding={0}
+      >
+        {/* This key forces the whole table rerender when the number format changes */}
+        <Fragment key={numberFormat + hideFraction}>
+          {account ? (
+            <AccountTransactions account={account} />
+          ) : accountIdParam === 'onbudget' ? (
+            <OnBudgetAccountTransactions />
+          ) : accountIdParam === 'offbudget' ? (
+            <OffBudgetAccountTransactions />
+          ) : (
+            <AllAccountTransactions />
+          )}
+        </Fragment>
+      </Page>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, useCallback, useRef } from 'react';
 import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 import type { DragItem } from 'react-aria';
-import { ErrorBoundary } from 'react-error-boundary';
 import {
   DropIndicator,
   ListBox,
   ListBoxItem,
   useDragAndDrop,
 } from 'react-aria-components';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -27,9 +27,9 @@ import { css } from '@emotion/css';
 import { useMoveAccountMutation, useSyncAndDownloadMutation } from '#accounts';
 import { isAccountFailedSync } from '#accounts/syncStatus';
 import { makeAmountFullStyle } from '#components/budget/util';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MOBILE_NAV_HEIGHT } from '#components/mobile/MobileNavTabs';
 import { PullToRefresh } from '#components/mobile/PullToRefresh';
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobilePageHeader, Page } from '#components/Page';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
 import { useAccounts } from '#hooks/useAccounts';

--- a/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
+++ b/packages/desktop-client/src/components/mobile/accounts/AccountsPage.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useCallback, useRef } from 'react';
 import type { ComponentPropsWithoutRef, CSSProperties } from 'react';
 import type { DragItem } from 'react-aria';
+import { ErrorBoundary } from 'react-error-boundary';
 import {
   DropIndicator,
   ListBox,
@@ -28,6 +29,7 @@ import { isAccountFailedSync } from '#accounts/syncStatus';
 import { makeAmountFullStyle } from '#components/budget/util';
 import { MOBILE_NAV_HEIGHT } from '#components/mobile/MobileNavTabs';
 import { PullToRefresh } from '#components/mobile/PullToRefresh';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobilePageHeader, Page } from '#components/Page';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
 import { useAccounts } from '#hooks/useAccounts';
@@ -521,21 +523,23 @@ export function AccountsPage() {
   }, [syncAndDownload]);
 
   return (
-    <View style={{ flex: 1 }}>
-      <AllAccountList
-        // This key forces the whole table rerender when the number
-        // format changes
-        key={numberFormat + hideFraction}
-        accounts={accounts}
-        getAccountBalance={bindings.accountBalance}
-        getAllAccountsBalance={bindings.allAccountBalance}
-        getOnBudgetBalance={bindings.onBudgetAccountBalance}
-        getOffBudgetBalance={bindings.offBudgetAccountBalance}
-        getClosedAccountsBalance={bindings.closedAccountBalance}
-        onAddAccount={onAddAccount}
-        onOpenAccount={onOpenAccount}
-        onSync={onSync}
-      />
-    </View>
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <View style={{ flex: 1 }}>
+        <AllAccountList
+          // This key forces the whole table rerender when the number
+          // format changes
+          key={numberFormat + hideFraction}
+          accounts={accounts}
+          getAccountBalance={bindings.accountBalance}
+          getAllAccountsBalance={bindings.allAccountBalance}
+          getOnBudgetBalance={bindings.onBudgetAccountBalance}
+          getOffBudgetBalance={bindings.offBudgetAccountBalance}
+          getClosedAccountsBalance={bindings.closedAccountBalance}
+          onAddAccount={onAddAccount}
+          onOpenAccount={onOpenAccount}
+          onSync={onSync}
+        />
+      </View>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -9,6 +10,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useUnlinkAccountMutation } from '#accounts';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { BankSyncCheckboxOptions } from '#components/banksync/BankSyncCheckboxOptions';
 import { FieldMapping } from '#components/banksync/FieldMapping';
 import { useBankSyncAccountSettings } from '#components/banksync/useBankSyncAccountSettings';
@@ -110,6 +112,7 @@ export function MobileBankSyncAccountEditPage() {
     mappings.get(transactionDirection) ?? new Map<string, string>();
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -192,5 +195,6 @@ export function MobileBankSyncAccountEditPage() {
         </View>
       </View>
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx
@@ -10,10 +10,10 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useUnlinkAccountMutation } from '#accounts';
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { BankSyncCheckboxOptions } from '#components/banksync/BankSyncCheckboxOptions';
 import { FieldMapping } from '#components/banksync/FieldMapping';
 import { useBankSyncAccountSettings } from '#components/banksync/useBankSyncAccountSettings';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useAccount } from '#hooks/useAccount';
@@ -113,88 +113,88 @@ export function MobileBankSyncAccountEditPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={account.name}
-          leftContent={<MobileBackButton onPress={handleCancel} />}
-        />
-      }
-      padding={0}
-    >
-      <View style={{ flex: 1, backgroundColor: theme.mobilePageBackground }}>
-        <View
-          style={{
-            flex: 1,
-            overflow: 'auto',
-          }}
-        >
-          <View style={{ padding: 16 }}>
-            <Text style={{ fontSize: 15, marginBottom: 10 }}>
-              <Trans>Field mapping</Trans>
-            </Text>
+      <Page
+        header={
+          <MobilePageHeader
+            title={account.name}
+            leftContent={<MobileBackButton onPress={handleCancel} />}
+          />
+        }
+        padding={0}
+      >
+        <View style={{ flex: 1, backgroundColor: theme.mobilePageBackground }}>
+          <View
+            style={{
+              flex: 1,
+              overflow: 'auto',
+            }}
+          >
+            <View style={{ padding: 16 }}>
+              <Text style={{ fontSize: 15, marginBottom: 10 }}>
+                <Trans>Field mapping</Trans>
+              </Text>
 
-            <FieldMapping
-              transactionDirection={transactionDirection}
-              setTransactionDirection={setTransactionDirection}
-              fields={fields}
-              mapping={mapping}
-              setMapping={setMapping}
-              isMobile
-            />
+              <FieldMapping
+                transactionDirection={transactionDirection}
+                setTransactionDirection={setTransactionDirection}
+                fields={fields}
+                mapping={mapping}
+                setMapping={setMapping}
+                isMobile
+              />
 
-            <Text style={{ fontSize: 15, marginTop: 20, marginBottom: 10 }}>
-              <Trans>Options</Trans>
-            </Text>
+              <Text style={{ fontSize: 15, marginTop: 20, marginBottom: 10 }}>
+                <Trans>Options</Trans>
+              </Text>
 
-            <BankSyncCheckboxOptions
-              importPending={importPending}
-              setImportPending={setImportPending}
-              importNotes={importNotes}
-              setImportNotes={setImportNotes}
-              reimportDeleted={reimportDeleted}
-              setReimportDeleted={setReimportDeleted}
-              importTransactions={importTransactions}
-              setImportTransactions={setImportTransactions}
-              updateDates={updateDates}
-              setUpdateDates={setUpdateDates}
-              helpMode="mobile"
-            />
+              <BankSyncCheckboxOptions
+                importPending={importPending}
+                setImportPending={setImportPending}
+                importNotes={importNotes}
+                setImportNotes={setImportNotes}
+                reimportDeleted={reimportDeleted}
+                setReimportDeleted={setReimportDeleted}
+                importTransactions={importTransactions}
+                setImportTransactions={setImportTransactions}
+                updateDates={updateDates}
+                setUpdateDates={setUpdateDates}
+                helpMode="mobile"
+              />
+            </View>
+          </View>
+
+          <View
+            style={{
+              padding: 16,
+              paddingTop: 12,
+              borderTop: `1px solid ${theme.tableBorder}`,
+              backgroundColor: theme.mobilePageBackground,
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <Button
+              style={{
+                color: theme.errorText,
+              }}
+              onPress={handleUnlink}
+            >
+              <Trans>Unlink account</Trans>
+            </Button>
+
+            <SpaceBetween gap={10}>
+              <Button onPress={handleCancel}>
+                <Trans>Cancel</Trans>
+              </Button>
+              <Button variant="primary" onPress={handleSave}>
+                <Trans>Save</Trans>
+              </Button>
+            </SpaceBetween>
           </View>
         </View>
-
-        <View
-          style={{
-            padding: 16,
-            paddingTop: 12,
-            borderTop: `1px solid ${theme.tableBorder}`,
-            backgroundColor: theme.mobilePageBackground,
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <Button
-            style={{
-              color: theme.errorText,
-            }}
-            onPress={handleUnlink}
-          >
-            <Trans>Unlink account</Trans>
-          </Button>
-
-          <SpaceBetween gap={10}>
-            <Button onPress={handleCancel}>
-              <Trans>Cancel</Trans>
-            </Button>
-            <Button variant="primary" onPress={handleSave}>
-              <Trans>Save</Trans>
-            </Button>
-          </SpaceBetween>
-        </View>
-      </View>
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncPage.tsx
+++ b/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncPage.tsx
@@ -93,62 +93,62 @@ export function MobileBankSyncPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page header={<MobilePageHeader title={t('Bank Sync')} />} padding={0}>
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          backgroundColor: theme.mobilePageBackground,
-          padding: 10,
-          width: '100%',
-          borderBottomWidth: 2,
-          borderBottomStyle: 'solid',
-          borderBottomColor: theme.tableBorder,
-        }}
-      >
-        <Search
-          placeholder={t('Filter accounts…')}
-          value={filter}
-          onChange={onSearchChange}
-          width="100%"
-          height={styles.mobileMinHeight}
-          style={{
-            backgroundColor: theme.tableBackground,
-            borderColor: theme.formInputBorder,
-          }}
-        />
-      </View>
-
-      {openAccounts.length === 0 ? (
+      <Page header={<MobilePageHeader title={t('Bank Sync')} />} padding={0}>
         <View
           style={{
-            flex: 1,
+            flexDirection: 'row',
             alignItems: 'center',
-            justifyContent: 'center',
-            paddingHorizontal: 20,
-            paddingTop: 40,
+            backgroundColor: theme.mobilePageBackground,
+            padding: 10,
+            width: '100%',
+            borderBottomWidth: 2,
+            borderBottomStyle: 'solid',
+            borderBottomColor: theme.tableBorder,
           }}
         >
-          <Text
+          <Search
+            placeholder={t('Filter accounts…')}
+            value={filter}
+            onChange={onSearchChange}
+            width="100%"
+            height={styles.mobileMinHeight}
             style={{
-              fontSize: 16,
-              color: theme.pageTextSubdued,
-              textAlign: 'center',
+              backgroundColor: theme.tableBackground,
+              borderColor: theme.formInputBorder,
+            }}
+          />
+        </View>
+
+        {openAccounts.length === 0 ? (
+          <View
+            style={{
+              flex: 1,
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingHorizontal: 20,
+              paddingTop: 40,
             }}
           >
-            <Trans>
-              To use the bank syncing features, you must first add an account.
-            </Trans>
-          </Text>
-        </View>
-      ) : (
-        <BankSyncAccountsList
-          groupedAccounts={filteredGroupedAccounts}
-          syncSourceReadable={syncSourceReadable}
-          onAction={onAction}
-        />
-      )}
-    </Page>
+            <Text
+              style={{
+                fontSize: 16,
+                color: theme.pageTextSubdued,
+                textAlign: 'center',
+              }}
+            >
+              <Trans>
+                To use the bank syncing features, you must first add an account.
+              </Trans>
+            </Text>
+          </View>
+        ) : (
+          <BankSyncAccountsList
+            groupedAccounts={filteredGroupedAccounts}
+            syncSourceReadable={syncSourceReadable}
+            onAction={onAction}
+          />
+        )}
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncPage.tsx
+++ b/packages/desktop-client/src/components/mobile/banksync/MobileBankSyncPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -14,6 +15,7 @@ import {
 } from '#components/banksync/bankSyncUtils';
 import type { GroupedBankSyncAccounts } from '#components/banksync/bankSyncUtils';
 import { Search } from '#components/common/Search';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useAccounts } from '#hooks/useAccounts';
 import { useNavigate } from '#hooks/useNavigate';
@@ -90,6 +92,7 @@ export function MobileBankSyncPage() {
   }, []);
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page header={<MobilePageHeader title={t('Bank Sync')} />} padding={0}>
       <View
         style={{
@@ -146,5 +149,6 @@ export function MobileBankSyncPage() {
         />
       )}
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -1,5 +1,3 @@
-// @ts-strict-ignore
-import { ErrorBoundary } from 'react-error-boundary';
 import React, {
   useCallback,
   useEffect,
@@ -8,6 +6,8 @@ import React, {
   useState,
 } from 'react';
 import { GridList, GridListItem } from 'react-aria-components';
+// @ts-strict-ignore
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -545,79 +545,82 @@ export function BudgetPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      padding={0}
-      header={
-        <MobilePageHeader
-          title={
-            <MonthSelector
-              month={startMonth}
-              monthBounds={monthBounds}
-              onOpenMonthMenu={onOpenBudgetMonthMenu}
-              onPrevMonth={onPrevMonth}
-              onNextMonth={onNextMonth}
-            />
-          }
-          leftContent={
-            <Button
-              variant="bare"
-              style={{ margin: 10 }}
-              onPress={onOpenBudgetPageMenu}
-              aria-label={t('Budget page menu')}
-            >
-              <SvgLogo
-                style={{ color: theme.mobileHeaderText }}
-                width="20"
-                height="20"
+      <Page
+        padding={0}
+        header={
+          <MobilePageHeader
+            title={
+              <MonthSelector
+                month={startMonth}
+                monthBounds={monthBounds}
+                onOpenMonthMenu={onOpenBudgetMonthMenu}
+                onPrevMonth={onPrevMonth}
+                onNextMonth={onNextMonth}
               />
-              <SvgCheveronRight
-                style={{ flexShrink: 0, color: theme.mobileHeaderTextSubdued }}
-                width="14"
-                height="14"
-              />
-            </Button>
-          }
-          rightContent={
-            !monthUtils.isCurrentMonth(startMonth) && (
+            }
+            leftContent={
               <Button
                 variant="bare"
-                onPress={onCurrentMonth}
-                aria-label={t('Today')}
                 style={{ margin: 10 }}
+                onPress={onOpenBudgetPageMenu}
+                aria-label={t('Budget page menu')}
               >
-                <SvgCalendar width={20} height={20} />
+                <SvgLogo
+                  style={{ color: theme.mobileHeaderText }}
+                  width="20"
+                  height="20"
+                />
+                <SvgCheveronRight
+                  style={{
+                    flexShrink: 0,
+                    color: theme.mobileHeaderTextSubdued,
+                  }}
+                  width="14"
+                  height="14"
+                />
               </Button>
-            )
-          }
-        />
-      }
-    >
-      <SheetNameProvider name={monthUtils.sheetForMonth(startMonth)}>
-        <SyncRefresh
-          onSync={async () => {
-            void dispatch(sync());
-          }}
-        >
-          {({ onRefresh }) => (
-            <>
-              <Banners month={startMonth} onBudgetAction={onBudgetAction} />
-              <BudgetTable
-                // This key forces the whole table rerender when the number
-                // format changes
-                key={`${numberFormat}${hideFraction}`}
-                categoryGroups={categoryGroups}
-                month={startMonth}
-                onShowBudgetSummary={onShowBudgetSummary}
-                onBudgetAction={onBudgetAction}
-                onRefresh={onRefresh}
-                onEditCategoryGroup={onOpenCategoryGroupMenuModal}
-                onEditCategory={onOpenCategoryMenuModal}
-              />
-            </>
-          )}
-        </SyncRefresh>
-      </SheetNameProvider>
-    </Page>
+            }
+            rightContent={
+              !monthUtils.isCurrentMonth(startMonth) && (
+                <Button
+                  variant="bare"
+                  onPress={onCurrentMonth}
+                  aria-label={t('Today')}
+                  style={{ margin: 10 }}
+                >
+                  <SvgCalendar width={20} height={20} />
+                </Button>
+              )
+            }
+          />
+        }
+      >
+        <SheetNameProvider name={monthUtils.sheetForMonth(startMonth)}>
+          <SyncRefresh
+            onSync={async () => {
+              void dispatch(sync());
+            }}
+          >
+            {({ onRefresh }) => (
+              <>
+                <Banners month={startMonth} onBudgetAction={onBudgetAction} />
+                <BudgetTable
+                  // This key forces the whole table rerender when the number
+                  // format changes
+                  key={`${numberFormat}${hideFraction}`}
+                  categoryGroups={categoryGroups}
+                  month={startMonth}
+                  onShowBudgetSummary={onShowBudgetSummary}
+                  onBudgetAction={onBudgetAction}
+                  onRefresh={onRefresh}
+                  onEditCategoryGroup={onOpenCategoryGroupMenuModal}
+                  onEditCategory={onOpenCategoryMenuModal}
+                />
+              </>
+            )}
+          </SyncRefresh>
+        </SheetNameProvider>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -1,4 +1,5 @@
 // @ts-strict-ignore
+import { ErrorBoundary } from 'react-error-boundary';
 import React, {
   useCallback,
   useEffect,
@@ -44,6 +45,7 @@ import {
 } from '#budget';
 import { closeBudget } from '#budgetfiles/budgetfilesSlice';
 import { prewarmMonth } from '#components/budget/util';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobilePageHeader, Page } from '#components/Page';
 import { SyncRefresh } from '#components/SyncRefresh';
@@ -542,6 +544,7 @@ export function BudgetPage() {
   }
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       padding={0}
       header={
@@ -615,6 +618,7 @@ export function BudgetPage() {
         </SyncRefresh>
       </SheetNameProvider>
     </Page>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/mobile/budget/CategoryPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryPage.tsx
@@ -31,38 +31,38 @@ export function CategoryPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={
-            category ? (
-              <View>
-                <TextOneLine>{category.name}</TextOneLine>
+      <Page
+        header={
+          <MobilePageHeader
+            title={
+              category ? (
+                <View>
+                  <TextOneLine>{category.name}</TextOneLine>
+                  <TextOneLine>
+                    ({monthUtils.format(month, "MMMM ''yy", locale)})
+                  </TextOneLine>
+                </View>
+              ) : (
                 <TextOneLine>
-                  ({monthUtils.format(month, "MMMM ''yy", locale)})
+                  <Trans>Uncategorized</Trans>
                 </TextOneLine>
-              </View>
-            ) : (
-              <TextOneLine>
-                <Trans>Uncategorized</Trans>
-              </TextOneLine>
-            )
-          }
-          leftContent={<MobileBackButton />}
-          rightContent={<AddTransactionButton categoryId={category?.id} />}
-        />
-      }
-      padding={0}
-    >
-      {/* This key forces the whole table rerender when the number format changes */}
-      <Fragment key={numberFormat + hideFraction}>
-        {category ? (
-          <CategoryTransactions category={category} month={month} />
-        ) : (
-          <UncategorizedTransactions />
-        )}
-      </Fragment>
-    </Page>
+              )
+            }
+            leftContent={<MobileBackButton />}
+            rightContent={<AddTransactionButton categoryId={category?.id} />}
+          />
+        }
+        padding={0}
+      >
+        {/* This key forces the whole table rerender when the number format changes */}
+        <Fragment key={numberFormat + hideFraction}>
+          {category ? (
+            <CategoryTransactions category={category} month={month} />
+          ) : (
+            <UncategorizedTransactions />
+          )}
+        </Fragment>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/CategoryPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryPage.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 
@@ -6,6 +7,7 @@ import { TextOneLine } from '@actual-app/components/text-one-line';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { AddTransactionButton } from '#components/mobile/transactions/AddTransactionButton';
 import { MobilePageHeader, Page } from '#components/Page';
@@ -28,6 +30,7 @@ export function CategoryPage() {
   const { data: category } = useCategory(categoryIdParam);
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -60,5 +63,6 @@ export function CategoryPage() {
         )}
       </Fragment>
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/CategoryTransactions.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 
 import { q } from '@actual-app/core/shared/query';
 import { isPreviewId } from '@actual-app/core/shared/transactions';
@@ -7,6 +8,7 @@ import type {
   TransactionEntity,
 } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { TransactionListWithBalances } from '#components/mobile/transactions/TransactionListWithBalances';
 import { SchedulesProvider } from '#hooks/useCachedSchedules';
 import { useCategoryPreviewTransactions } from '#hooks/useCategoryPreviewTransactions';
@@ -28,9 +30,11 @@ export function CategoryTransactions({
   const schedulesQuery = useMemo(() => q('schedules').select('*'), []);
 
   return (
-    <SchedulesProvider query={schedulesQuery}>
-      <TransactionListWithPreviews category={category} month={month} />
-    </SchedulesProvider>
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SchedulesProvider query={schedulesQuery}>
+        <TransactionListWithPreviews category={category} month={month} />
+      </SchedulesProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeeEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeeEditPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -10,6 +11,7 @@ import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import type { PayeeEntity } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { InputField } from '#components/mobile/MobileForms';
 import { MobilePageHeader, Page } from '#components/Page';
@@ -109,6 +111,7 @@ export function MobilePayeeEditPage() {
   }
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -147,5 +150,6 @@ export function MobilePayeeEditPage() {
         />
       </View>
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeeEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeeEditPage.tsx
@@ -112,44 +112,44 @@ export function MobilePayeeEditPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={t('Edit Payee')}
-          leftContent={<MobileBackButton onPress={handleCancel} />}
-        />
-      }
-      footer={
-        <View
-          style={{
-            paddingLeft: styles.mobileEditingPadding,
-            paddingRight: styles.mobileEditingPadding,
-            paddingTop: 10,
-            paddingBottom: 'calc(10px + env(safe-area-inset-bottom))',
-            backgroundColor: theme.tableHeaderBackground,
-            borderTopWidth: 1,
-            borderColor: theme.tableBorder,
-          }}
-        >
-          <Button
-            variant="primary"
-            onPress={handleSave}
-            isDisabled={!editedPayeeName.trim()}
-            style={{ height: styles.mobileMinHeight }}
+      <Page
+        header={
+          <MobilePageHeader
+            title={t('Edit Payee')}
+            leftContent={<MobileBackButton onPress={handleCancel} />}
+          />
+        }
+        footer={
+          <View
+            style={{
+              paddingLeft: styles.mobileEditingPadding,
+              paddingRight: styles.mobileEditingPadding,
+              paddingTop: 10,
+              paddingBottom: 'calc(10px + env(safe-area-inset-bottom))',
+              backgroundColor: theme.tableHeaderBackground,
+              borderTopWidth: 1,
+              borderColor: theme.tableBorder,
+            }}
           >
-            <Trans>Save</Trans>
-          </Button>
+            <Button
+              variant="primary"
+              onPress={handleSave}
+              isDisabled={!editedPayeeName.trim()}
+              style={{ height: styles.mobileMinHeight }}
+            >
+              <Trans>Save</Trans>
+            </Button>
+          </View>
+        }
+      >
+        <View style={{ paddingTop: 20 }}>
+          <InputField
+            placeholder={t('Payee name')}
+            value={editedPayeeName}
+            onChangeValue={setEditedPayeeName}
+          />
         </View>
-      }
-    >
-      <View style={{ paddingTop: 20 }}>
-        <InputField
-          placeholder={t('Payee name')}
-          value={editedPayeeName}
-          onChangeValue={setEditedPayeeName}
-        />
-      </View>
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
@@ -112,41 +112,41 @@ export function MobilePayeesPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page header={<MobilePageHeader title={t('Payees')} />} padding={0}>
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          backgroundColor: theme.mobilePageBackground,
-          padding: 10,
-          width: '100%',
-          borderBottomWidth: 2,
-          borderBottomStyle: 'solid',
-          borderBottomColor: theme.tableBorder,
-        }}
-      >
-        <Search
-          placeholder={t('Filter payees…')}
-          value={filter}
-          onChange={onSearchChange}
-          width="100%"
-          height={styles.mobileMinHeight}
+      <Page header={<MobilePageHeader title={t('Payees')} />} padding={0}>
+        <View
           style={{
-            backgroundColor: theme.tableBackground,
-            borderColor: theme.formInputBorder,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: theme.mobilePageBackground,
+            padding: 10,
+            width: '100%',
+            borderBottomWidth: 2,
+            borderBottomStyle: 'solid',
+            borderBottomColor: theme.tableBorder,
           }}
+        >
+          <Search
+            placeholder={t('Filter payees…')}
+            value={filter}
+            onChange={onSearchChange}
+            width="100%"
+            height={styles.mobileMinHeight}
+            style={{
+              backgroundColor: theme.tableBackground,
+              borderColor: theme.formInputBorder,
+            }}
+          />
+        </View>
+        <PayeesList
+          payees={filteredPayees}
+          ruleCounts={ruleCounts}
+          isRuleCountsLoading={isRuleCountsLoading}
+          isLoading={isPending}
+          onPayeePress={handlePayeePress}
+          onPayeeDelete={handlePayeeDelete}
+          onPayeeRuleAction={handlePayeeRuleAction}
         />
-      </View>
-      <PayeesList
-        payees={filteredPayees}
-        ruleCounts={ruleCounts}
-        isRuleCountsLoading={isRuleCountsLoading}
-        isLoading={isPending}
-        onPayeePress={handlePayeePress}
-        onPayeeDelete={handlePayeeDelete}
-        onPayeeRuleAction={handlePayeeRuleAction}
-      />
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/payees/MobilePayeesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -9,6 +10,7 @@ import { getNormalisedString } from '@actual-app/core/shared/normalisation';
 import type { PayeeEntity, RuleEntity } from '@actual-app/core/types/models';
 
 import { Search } from '#components/common/Search';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useNavigate } from '#hooks/useNavigate';
 import { usePayeeRuleCounts } from '#hooks/usePayeeRuleCounts';
@@ -109,6 +111,7 @@ export function MobilePayeesPage() {
   );
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page header={<MobilePageHeader title={t('Payees')} />} padding={0}>
       <View
         style={{
@@ -144,5 +147,6 @@ export function MobilePayeesPage() {
         onPayeeRuleAction={handlePayeeRuleAction}
       />
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
@@ -182,27 +182,27 @@ export function MobileRuleEditPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={pageTitle}
-          leftContent={<MobileBackButton onPress={handleCancel} />}
+      <Page
+        header={
+          <MobilePageHeader
+            title={pageTitle}
+            leftContent={<MobileBackButton onPress={handleCancel} />}
+          />
+        }
+        padding={0}
+      >
+        <RuleEditor
+          rule={defaultRule}
+          onSave={handleSave}
+          onCancel={handleCancel}
+          onDelete={isEditing && !isLinkedToSchedule ? handleDelete : undefined}
+          style={{
+            paddingTop: 10,
+            flex: 1,
+            backgroundColor: theme.mobilePageBackground,
+          }}
         />
-      }
-      padding={0}
-    >
-      <RuleEditor
-        rule={defaultRule}
-        onSave={handleSave}
-        onCancel={handleCancel}
-        onDelete={isEditing && !isLinkedToSchedule ? handleDelete : undefined}
-        style={{
-          paddingTop: 10,
-          flex: 1,
-          backgroundColor: theme.mobilePageBackground,
-        }}
-      />
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRuleEditPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
@@ -9,6 +10,7 @@ import { send } from '@actual-app/core/platform/client/connection';
 import { q } from '@actual-app/core/shared/query';
 import type { NewRuleEntity, RuleEntity } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page } from '#components/Page';
 import { RuleEditor } from '#components/rules/RuleEditor';
@@ -179,6 +181,7 @@ export function MobileRuleEditPage() {
   }
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -200,5 +203,6 @@ export function MobileRuleEditPage() {
         }}
       />
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
@@ -169,43 +169,46 @@ export function MobileRulesPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader title={t('Rules')} rightContent={<AddRuleButton />} />
-      }
-      padding={0}
-    >
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          backgroundColor: theme.mobilePageBackground,
-          padding: 10,
-          width: '100%',
-          borderBottomWidth: 2,
-          borderBottomStyle: 'solid',
-          borderBottomColor: theme.tableBorder,
-        }}
+      <Page
+        header={
+          <MobilePageHeader
+            title={t('Rules')}
+            rightContent={<AddRuleButton />}
+          />
+        }
+        padding={0}
       >
-        <Search
-          placeholder={t('Filter rules…')}
-          value={filter}
-          onChange={onSearchChange}
-          width="100%"
-          height={styles.mobileMinHeight}
+        <View
           style={{
-            backgroundColor: theme.tableBackground,
-            borderColor: theme.formInputBorder,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: theme.mobilePageBackground,
+            padding: 10,
+            width: '100%',
+            borderBottomWidth: 2,
+            borderBottomStyle: 'solid',
+            borderBottomColor: theme.tableBorder,
           }}
+        >
+          <Search
+            placeholder={t('Filter rules…')}
+            value={filter}
+            onChange={onSearchChange}
+            width="100%"
+            height={styles.mobileMinHeight}
+            style={{
+              backgroundColor: theme.tableBackground,
+              borderColor: theme.formInputBorder,
+            }}
+          />
+        </View>
+        <RulesList
+          rules={filteredRules}
+          isLoading={isLoading}
+          onRulePress={handleRulePress}
+          onRuleDelete={handleRuleDelete}
         />
-      </View>
-      <RulesList
-        rules={filteredRules}
-        isLoading={isLoading}
-        onRulePress={handleRulePress}
-        onRuleDelete={handleRuleDelete}
-      />
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/rules/MobileRulesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -11,6 +12,7 @@ import { q } from '@actual-app/core/shared/query';
 import type { RuleEntity } from '@actual-app/core/types/models';
 
 import { Search } from '#components/common/Search';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { ruleToString } from '#components/ManageRules';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useAccounts } from '#hooks/useAccounts';
@@ -166,6 +168,7 @@ export function MobileRulesPage() {
   );
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader title={t('Rules')} rightContent={<AddRuleButton />} />
@@ -203,5 +206,6 @@ export function MobileRulesPage() {
         onRuleDelete={handleRuleDelete}
       />
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
@@ -229,54 +229,54 @@ export function MobileScheduleEditPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={pageTitle}
-          leftContent={<MobileBackButton onPress={() => navigate(-1)} />}
-        />
-      }
-      footer={
-        <View
-          style={{
-            paddingLeft: styles.mobileEditingPadding,
-            paddingRight: styles.mobileEditingPadding,
-            paddingTop: 10,
-            paddingBottom: 'calc(10px + env(safe-area-inset-bottom))',
-            backgroundColor: theme.tableHeaderBackground,
-            borderTopWidth: 1,
-            borderColor: theme.tableBorder,
-          }}
-        >
-          <Button
-            variant="primary"
-            onPress={onSave}
-            style={{ height: styles.mobileMinHeight }}
+      <Page
+        header={
+          <MobilePageHeader
+            title={pageTitle}
+            leftContent={<MobileBackButton onPress={() => navigate(-1)} />}
+          />
+        }
+        footer={
+          <View
+            style={{
+              paddingLeft: styles.mobileEditingPadding,
+              paddingRight: styles.mobileEditingPadding,
+              paddingTop: 10,
+              paddingBottom: 'calc(10px + env(safe-area-inset-bottom))',
+              backgroundColor: theme.tableHeaderBackground,
+              borderTopWidth: 1,
+              borderColor: theme.tableBorder,
+            }}
           >
-            <Trans>Save</Trans>
-          </Button>
-        </View>
-      }
-      padding={0}
-    >
-      <ScheduleEditForm
-        fields={state.fields}
-        dispatch={dispatch}
-        upcomingDates={state.upcomingDates}
-        repeats={repeats}
-        schedule={schedule}
-        adding={adding}
-        isCustom={state.isCustom ?? false}
-        onEditRule={onEditRule}
-        transactions={state.transactions}
-        transactionsMode={state.transactionsMode}
-        error={state.error}
-        selectedInst={selectedInst}
-        onSwitchTransactions={onSwitchTransactions}
-        onLinkTransactions={onLinkTransactions}
-        onUnlinkTransactions={onUnlinkTransactions}
-      />
-    </Page>
+            <Button
+              variant="primary"
+              onPress={onSave}
+              style={{ height: styles.mobileMinHeight }}
+            >
+              <Trans>Save</Trans>
+            </Button>
+          </View>
+        }
+        padding={0}
+      >
+        <ScheduleEditForm
+          fields={state.fields}
+          dispatch={dispatch}
+          upcomingDates={state.upcomingDates}
+          repeats={repeats}
+          schedule={schedule}
+          adding={adding}
+          isCustom={state.isCustom ?? false}
+          onEditRule={onEditRule}
+          transactions={state.transactions}
+          transactionsMode={state.transactionsMode}
+          error={state.error}
+          selectedInst={selectedInst}
+          onSwitchTransactions={onSwitchTransactions}
+          onLinkTransactions={onLinkTransactions}
+          onUnlinkTransactions={onUnlinkTransactions}
+        />
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -16,6 +17,7 @@ import type {
   ScheduleEntity,
 } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page } from '#components/Page';
 import { updateScheduleConditions } from '#components/schedules/schedule-edit-utils';
@@ -226,6 +228,7 @@ export function MobileScheduleEditPage() {
   }
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -274,5 +277,6 @@ export function MobileScheduleEditPage() {
         onUnlinkTransactions={onUnlinkTransactions}
       />
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
@@ -120,54 +120,54 @@ export function MobileSchedulesPage() {
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <Page
-      header={
-        <MobilePageHeader
-          title={
-            <Text style={{ ...styles.underlinedText, fontSize: 16 }}>
-              <Trans>Schedules</Trans>
-            </Text>
-          }
-          rightContent={<AddScheduleButton />}
-        />
-      }
-      padding={0}
-    >
-      <View
-        style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          backgroundColor: theme.mobilePageBackground,
-          padding: 10,
-          width: '100%',
-          borderBottomWidth: 2,
-          borderBottomStyle: 'solid',
-          borderBottomColor: theme.tableBorder,
-        }}
+      <Page
+        header={
+          <MobilePageHeader
+            title={
+              <Text style={{ ...styles.underlinedText, fontSize: 16 }}>
+                <Trans>Schedules</Trans>
+              </Text>
+            }
+            rightContent={<AddScheduleButton />}
+          />
+        }
+        padding={0}
       >
-        <Search
-          placeholder={t('Filter schedules…')}
-          value={filter}
-          onChange={setFilter}
-          width="100%"
-          height={styles.mobileMinHeight}
+        <View
           style={{
-            backgroundColor: theme.tableBackground,
-            borderColor: theme.formInputBorder,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: theme.mobilePageBackground,
+            padding: 10,
+            width: '100%',
+            borderBottomWidth: 2,
+            borderBottomStyle: 'solid',
+            borderBottomColor: theme.tableBorder,
           }}
+        >
+          <Search
+            placeholder={t('Filter schedules…')}
+            value={filter}
+            onChange={setFilter}
+            width="100%"
+            height={styles.mobileMinHeight}
+            style={{
+              backgroundColor: theme.tableBackground,
+              borderColor: theme.formInputBorder,
+            }}
+          />
+        </View>
+        <SchedulesList
+          schedules={filteredSchedules}
+          isLoading={isSchedulesLoading}
+          statuses={statuses}
+          onSchedulePress={handleSchedulePress}
+          onScheduleDelete={handleScheduleDelete}
+          hasCompletedSchedules={hasCompletedSchedules}
+          showCompleted={showCompleted}
+          onShowCompleted={() => setShowCompleted(true)}
         />
-      </View>
-      <SchedulesList
-        schedules={filteredSchedules}
-        isLoading={isSchedulesLoading}
-        statuses={statuses}
-        onSchedulePress={handleSchedulePress}
-        onScheduleDelete={handleScheduleDelete}
-        hasCompletedSchedules={hasCompletedSchedules}
-        showCompleted={showCompleted}
-        onShowCompleted={() => setShowCompleted(true)}
-      />
-    </Page>
+      </Page>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileSchedulesPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { styles } from '@actual-app/components/styles';
@@ -13,6 +14,7 @@ import { getScheduledAmount } from '@actual-app/core/shared/schedules';
 import type { ScheduleEntity } from '@actual-app/core/types/models';
 
 import { Search } from '#components/common/Search';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobilePageHeader, Page } from '#components/Page';
 import { useAccounts } from '#hooks/useAccounts';
 import { useDateFormat } from '#hooks/useDateFormat';
@@ -117,6 +119,7 @@ export function MobileSchedulesPage() {
   );
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <Page
       header={
         <MobilePageHeader
@@ -165,5 +168,6 @@ export function MobileSchedulesPage() {
         onShowCompleted={() => setShowCompleted(true)}
       />
     </Page>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import type { RefObject } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useParams, useSearchParams } from 'react-router';
 
@@ -73,6 +74,7 @@ import {
   parseISO,
 } from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import {
   FieldLabel,
@@ -2123,15 +2125,17 @@ export const TransactionEdit = (props: TransactionEditProps) => {
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
 
   return (
-    <SingleActiveEditFormProvider formName="mobile-transaction">
-      <TransactionEditUnconnected
-        {...props}
-        categories={categories}
-        payees={payees}
-        lastTransaction={lastTransaction}
-        accounts={accounts}
-        dateFormat={dateFormat}
-      />
-    </SingleActiveEditFormProvider>
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SingleActiveEditFormProvider formName="mobile-transaction">
+        <TransactionEditUnconnected
+          {...props}
+          categories={categories}
+          payees={payees}
+          lastTransaction={lastTransaction}
+          accounts={accounts}
+          dateFormat={dateFormat}
+        />
+      </SingleActiveEditFormProvider>
+    </ErrorBoundary>
   );
 };

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -1791,6 +1791,7 @@ function TransactionEditUnconnected({
           transaction: newTransaction,
         });
         const diff = getChangedValues(newTransaction, afterRules);
+        const forceApplyFields: string[] = afterRules._forceApplyFields || [];
 
         if (diff) {
           Object.keys(diff).forEach(key => {
@@ -1799,6 +1800,7 @@ function TransactionEditUnconnected({
             // Or update all fields if the payee changes (assists location-based entry by
             // applying rules to prefill category, notes, etc. based on the selected payee)
             if (
+              forceApplyFields.includes(field) ||
               newTransaction[field] == null ||
               newTransaction[field] === '' ||
               newTransaction[field] === 0 ||

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import type { CSSProperties } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import {
   Collection,
   Header,
@@ -39,6 +40,7 @@ import type {
   TransactionEntity,
 } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FloatingActionBar } from '#components/mobile/FloatingActionBar';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategoriesById } from '#hooks/useCategories';
@@ -156,6 +158,7 @@ export function TransactionList({
   );
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <View style={{ flex: 1 }}>
       {isLoading && (
         <Loading
@@ -265,6 +268,7 @@ export function TransactionList({
         />
       )}
     </View>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionList.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react';
 import type { CSSProperties } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
 import {
   Collection,
   Header,
@@ -16,6 +15,7 @@ import {
   ListLayout,
   Virtualizer,
 } from 'react-aria-components';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -159,115 +159,122 @@ export function TransactionList({
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <View style={{ flex: 1 }}>
-      {isLoading && (
-        <Loading
-          style={{ flex: 'none', paddingBottom: 8 }}
-          aria-label={t('Loading transactions...')}
-        />
-      )}
       <View style={{ flex: 1 }}>
-        <Virtualizer
-          layout={ListLayout}
-          layoutOptions={{
-            estimatedRowHeight: ROW_HEIGHT,
-            padding: 0,
-          }}
-        >
-          <ListBox
-            aria-label={t('Transaction list')}
-            selectionMode={
-              selectedTransactions.size > 0 ? 'multiple' : 'single'
-            }
-            style={{ flex: 1, overflow: 'auto' }}
-            selectedKeys={selectedTransactions}
-            dependencies={[
-              selectedTransactions,
-              locale,
-              onTransactionPress,
-              runningBalances,
-              showRunningBalances,
-              t,
-            ]}
-            renderEmptyState={() =>
-              !isLoading && (
-                <View
-                  style={{
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: theme.mobilePageBackground,
-                  }}
-                >
-                  <Text style={{ fontSize: 15 }}>
-                    <Trans>No transactions</Trans>
-                  </Text>
-                </View>
-              )
-            }
-            items={sections}
+        {isLoading && (
+          <Loading
+            style={{ flex: 'none', paddingBottom: 8 }}
+            aria-label={t('Loading transactions...')}
+          />
+        )}
+        <View style={{ flex: 1 }}>
+          <Virtualizer
+            layout={ListLayout}
+            layoutOptions={{
+              estimatedRowHeight: ROW_HEIGHT,
+              padding: 0,
+            }}
           >
-            {section => (
-              <ListBoxSection>
-                <Header
-                  style={{
-                    ...styles.smallText,
-                    backgroundColor: theme.pageBackground,
-                    color: theme.tableHeaderText,
-                    display: 'flex',
-                    justifyContent: 'center',
-                    paddingBottom: 4,
-                    paddingTop: 4,
-                    position: 'sticky',
-                    top: '0',
-                    width: '100%',
-                    zIndex: 10,
-                  }}
-                >
-                  {monthUtils.format(section.date, 'MMMM dd, yyyy', locale)}
-                </Header>
-                <Collection
-                  items={section.transactions.filter(
-                    t => !isPreviewId(t.id) || !t.is_child,
-                  )}
-                >
-                  {transaction => (
-                    <ListBoxItem textValue={transaction.id} value={transaction}>
-                      {itemProps => (
-                        <TransactionListItem
-                          {...itemProps}
-                          showRunningBalance={showRunningBalances}
-                          runningBalance={runningBalances?.get(transaction.id)}
-                          transaction={transaction}
-                          onPress={trans => onTransactionPress(trans)}
-                          onLongPress={trans => onTransactionPress(trans, true)}
-                        />
-                      )}
-                    </ListBoxItem>
-                  )}
-                </Collection>
-              </ListBoxSection>
-            )}
-          </ListBox>
-        </Virtualizer>
+            <ListBox
+              aria-label={t('Transaction list')}
+              selectionMode={
+                selectedTransactions.size > 0 ? 'multiple' : 'single'
+              }
+              style={{ flex: 1, overflow: 'auto' }}
+              selectedKeys={selectedTransactions}
+              dependencies={[
+                selectedTransactions,
+                locale,
+                onTransactionPress,
+                runningBalances,
+                showRunningBalances,
+                t,
+              ]}
+              renderEmptyState={() =>
+                !isLoading && (
+                  <View
+                    style={{
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: theme.mobilePageBackground,
+                    }}
+                  >
+                    <Text style={{ fontSize: 15 }}>
+                      <Trans>No transactions</Trans>
+                    </Text>
+                  </View>
+                )
+              }
+              items={sections}
+            >
+              {section => (
+                <ListBoxSection>
+                  <Header
+                    style={{
+                      ...styles.smallText,
+                      backgroundColor: theme.pageBackground,
+                      color: theme.tableHeaderText,
+                      display: 'flex',
+                      justifyContent: 'center',
+                      paddingBottom: 4,
+                      paddingTop: 4,
+                      position: 'sticky',
+                      top: '0',
+                      width: '100%',
+                      zIndex: 10,
+                    }}
+                  >
+                    {monthUtils.format(section.date, 'MMMM dd, yyyy', locale)}
+                  </Header>
+                  <Collection
+                    items={section.transactions.filter(
+                      t => !isPreviewId(t.id) || !t.is_child,
+                    )}
+                  >
+                    {transaction => (
+                      <ListBoxItem
+                        textValue={transaction.id}
+                        value={transaction}
+                      >
+                        {itemProps => (
+                          <TransactionListItem
+                            {...itemProps}
+                            showRunningBalance={showRunningBalances}
+                            runningBalance={runningBalances?.get(
+                              transaction.id,
+                            )}
+                            transaction={transaction}
+                            onPress={trans => onTransactionPress(trans)}
+                            onLongPress={trans =>
+                              onTransactionPress(trans, true)
+                            }
+                          />
+                        )}
+                      </ListBoxItem>
+                    )}
+                  </Collection>
+                </ListBoxSection>
+              )}
+            </ListBox>
+          </Virtualizer>
+        </View>
+
+        {isLoadingMore && (
+          <Loading
+            aria-label={t('Loading more transactions...')}
+            style={{
+              // Same height as transaction list item
+              height: ROW_HEIGHT,
+            }}
+          />
+        )}
+
+        {selectedTransactions.size > 0 && (
+          <SelectedTransactionsFloatingActionBar
+            transactions={transactions}
+            showMakeTransfer={showMakeTransfer}
+          />
+        )}
       </View>
-
-      {isLoadingMore && (
-        <Loading
-          aria-label={t('Loading more transactions...')}
-          style={{
-            // Same height as transaction list item
-            height: ROW_HEIGHT,
-          }}
-        />
-      )}
-
-      {selectedTransactions.size > 0 && (
-        <SelectedTransactionsFloatingActionBar
-          transactions={transactions}
-          showMakeTransfer={showMakeTransfer}
-        />
-      )}
-    </View>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 
 import { Label } from '@actual-app/components/label';
@@ -9,6 +10,7 @@ import { View } from '@actual-app/components/view';
 import type { IntegerAmount } from '@actual-app/core/shared/util';
 import type { TransactionEntity } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { Search } from '#components/common/Search';
 import { PullToRefresh } from '#components/mobile/PullToRefresh';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
@@ -105,6 +107,7 @@ export function TransactionListWithBalances({
   const selectedInst = useSelected('transactions', [...transactions], []);
 
   return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
     <DisplayPayeeProvider transactions={transactions}>
       <SelectedProvider instance={selectedInst}>
         <View
@@ -156,6 +159,7 @@ export function TransactionListWithBalances({
         </PullToRefresh>
       </SelectedProvider>
     </DisplayPayeeProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionListWithBalances.tsx
@@ -10,8 +10,8 @@ import { View } from '@actual-app/components/view';
 import type { IntegerAmount } from '@actual-app/core/shared/util';
 import type { TransactionEntity } from '@actual-app/core/types/models';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { Search } from '#components/common/Search';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { PullToRefresh } from '#components/mobile/PullToRefresh';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
 import { DisplayPayeeProvider } from '#hooks/useDisplayPayee';
@@ -108,57 +108,57 @@ export function TransactionListWithBalances({
 
   return (
     <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
-    <DisplayPayeeProvider transactions={transactions}>
-      <SelectedProvider instance={selectedInst}>
-        <View
-          style={{
-            flexShrink: 0,
-            marginTop: 10,
-          }}
-        >
+      <DisplayPayeeProvider transactions={transactions}>
+        <SelectedProvider instance={selectedInst}>
           <View
             style={{
-              flexDirection: 'row',
-              justifyContent: 'space-evenly',
+              flexShrink: 0,
+              marginTop: 10,
             }}
           >
-            {balanceCleared && balanceUncleared ? (
-              <BalanceWithCleared
-                balance={balance}
-                balanceCleared={balanceCleared}
-                balanceUncleared={balanceUncleared}
-              />
-            ) : (
-              <Balance balance={balance} />
-            )}
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'space-evenly',
+              }}
+            >
+              {balanceCleared && balanceUncleared ? (
+                <BalanceWithCleared
+                  balance={balance}
+                  balanceCleared={balanceCleared}
+                  balanceUncleared={balanceUncleared}
+                />
+              ) : (
+                <Balance balance={balance} />
+              )}
+            </View>
+            <TransactionSearchInput
+              placeholder={searchPlaceholder}
+              onSearch={onSearch}
+            />
           </View>
-          <TransactionSearchInput
-            placeholder={searchPlaceholder}
-            onSearch={onSearch}
-          />
-        </View>
-        <PullToRefresh
-          isPullable={!isLoading && !!onRefresh}
-          onRefresh={async () => onRefresh?.()}
-          style={{
-            '& .ptr__children': {
-              display: 'flex',
-            },
-          }}
-        >
-          <TransactionList
-            isLoading={isLoading}
-            transactions={transactions}
-            showRunningBalances={showRunningBalances}
-            runningBalances={runningBalances}
-            isLoadingMore={isLoadingMore}
-            onLoadMore={onLoadMore}
-            onOpenTransaction={onOpenTransaction}
-            showMakeTransfer={showMakeTransfer}
-          />
-        </PullToRefresh>
-      </SelectedProvider>
-    </DisplayPayeeProvider>
+          <PullToRefresh
+            isPullable={!isLoading && !!onRefresh}
+            onRefresh={async () => onRefresh?.()}
+            style={{
+              '& .ptr__children': {
+                display: 'flex',
+              },
+            }}
+          >
+            <TransactionList
+              isLoading={isLoading}
+              transactions={transactions}
+              showRunningBalances={showRunningBalances}
+              runningBalances={runningBalances}
+              isLoadingMore={isLoadingMore}
+              onLoadMore={onLoadMore}
+              onOpenTransaction={onOpenTransaction}
+              showMakeTransfer={showMakeTransfer}
+            />
+          </PullToRefresh>
+        </SelectedProvider>
+      </DisplayPayeeProvider>
     </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
@@ -27,8 +27,8 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';

--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -26,6 +27,7 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -58,7 +60,11 @@ export function AgeOfMoney() {
     return <LoadingIndicator />;
   }
 
-  return <AgeOfMoneyInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <AgeOfMoneyInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type AgeOfMoneyInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
@@ -1,5 +1,6 @@
 // oxlint-disable typescript-paths/absolute-parent-import
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -27,6 +28,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
 import { Container } from '#components/reports/Container';
@@ -64,7 +66,11 @@ export function BalanceForecast() {
     return <LoadingIndicator />;
   }
 
-  return <BalanceForecastInner key={widget?.id ?? 'new'} widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <BalanceForecastInner key={widget?.id ?? 'new'} widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type BalanceForecastInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -21,8 +21,8 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -20,6 +21,7 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -54,7 +56,11 @@ export function BudgetAnalysis() {
     return <LoadingIndicator />;
   }
 
-  return <BudgetAnalysisInternal widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <BudgetAnalysisInternal widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type BudgetAnalysisInternalProps = {

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Ref } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 import { animated, config, useSpring } from 'react-spring';
@@ -30,6 +31,7 @@ import { css } from '@emotion/css';
 import { useDrag } from '@use-gesture/react';
 import { format as formatDate, parseISO } from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -84,7 +86,11 @@ export function Calendar() {
     return <LoadingIndicator />;
   }
 
-  return <CalendarInner widget={widget} parameters={searchParams} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CalendarInner widget={widget} parameters={searchParams} />
+    </ErrorBoundary>
+  );
 }
 
 type CalendarInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -31,8 +31,8 @@ import { css } from '@emotion/css';
 import { useDrag } from '@use-gesture/react';
 import { format as formatDate, parseISO } from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { TransactionList as TransactionListMobile } from '#components/mobile/transactions/TransactionList';

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -19,6 +20,7 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -58,7 +60,11 @@ export function CashFlow() {
     return <LoadingIndicator />;
   }
 
-  return <CashFlowInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CashFlowInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type CashFlowInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -20,8 +20,8 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -24,8 +24,8 @@ import type {
 } from '@actual-app/core/types/models';
 
 import { Link } from '#components/common/Link';
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { Checkbox } from '#components/forms';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -23,6 +24,7 @@ import type {
 } from '@actual-app/core/types/models';
 
 import { Link } from '#components/common/Link';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { FinancialText } from '#components/FinancialText';
 import { Checkbox } from '#components/forms';
@@ -66,7 +68,11 @@ export function Crossover() {
     return <LoadingIndicator />;
   }
 
-  return <CrossoverInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CrossoverInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type CrossoverInnerProps = { widget?: CrossoverWidget };

--- a/packages/desktop-client/src/components/reports/reports/Formula.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Formula.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -12,6 +13,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import type { FormulaWidget } from '@actual-app/core/types/models';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { QueryManager } from '#components/formula/QueryManager';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -43,7 +45,11 @@ export function Formula() {
     return <LoadingIndicator />;
   }
 
-  return <FormulaInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <FormulaInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type FormulaInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/Formula.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Formula.tsx
@@ -13,8 +13,8 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import type { FormulaWidget } from '@actual-app/core/types/models';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { QueryManager } from '#components/formula/QueryManager';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -23,8 +23,8 @@ import * as monthUtils from '@actual-app/core/shared/months';
 import type { NetWorthWidget, TimeFrame } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -22,6 +23,7 @@ import * as monthUtils from '@actual-app/core/shared/months';
 import type { NetWorthWidget, TimeFrame } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -58,7 +60,11 @@ export function NetWorth() {
     return <LoadingIndicator />;
   }
 
-  return <NetWorthInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <NetWorthInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type NetWorthInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -31,8 +31,8 @@ import type { TFunction } from 'i18next';
 import debounce from 'lodash/debounce';
 import type { SankeyData } from 'recharts/types/chart/Sankey';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { SankeyGraph } from '#components/reports/graphs/SankeyGraph';

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -30,6 +31,7 @@ import type { TFunction } from 'i18next';
 import debounce from 'lodash/debounce';
 import type { SankeyData } from 'recharts/types/chart/Sankey';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -70,7 +72,11 @@ export function Sankey() {
     return <LoadingIndicator />;
   }
 
-  return <SankeyInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SankeyInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 export function topNNodes(cardHeight: number): number {

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -22,6 +23,7 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
@@ -65,7 +67,11 @@ export function Spending() {
     return <LoadingIndicator />;
   }
 
-  return <SpendingInternal widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SpendingInternal widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type SpendingInternalProps = {

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -23,8 +23,8 @@ import type {
 } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -24,8 +24,8 @@ import type {
 } from '@actual-app/core/types/models';
 import { parseISO } from 'date-fns';
 
-import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { FinancialText } from '#components/FinancialText';

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -23,6 +24,7 @@ import type {
 } from '@actual-app/core/types/models';
 import { parseISO } from 'date-fns';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
@@ -59,7 +61,11 @@ export function Summary() {
     return <LoadingIndicator />;
   }
 
-  return <SummaryInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SummaryInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type SummaryInnerProps = {

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -531,11 +531,13 @@ export function TransactionList({
       }
 
       const diff = getChangedValues(transaction, afterRules);
+      const forceApplyFields: string[] = afterRules._forceApplyFields || [];
 
       const newTransaction: TransactionEntity = { ...transaction };
       if (diff) {
         Object.keys(diff).forEach(field => {
           if (
+            forceApplyFields.includes(field) ||
             newTransaction[field] == null ||
             newTransaction[field] === '' ||
             newTransaction[field] === 0 ||

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -239,11 +239,19 @@ export class Action {
         object[this.field] = object[this.field]
           ? this.value + object[this.field]
           : this.value;
+        if (!object._forceApplyFields) {
+          object._forceApplyFields = [];
+        }
+        object._forceApplyFields.push(this.field);
         break;
       case 'append-notes':
         object[this.field] = object[this.field]
           ? object[this.field] + this.value
           : this.value;
+        if (!object._forceApplyFields) {
+          object._forceApplyFields = [];
+        }
+        object._forceApplyFields.push(this.field);
         break;
       case 'delete-transaction':
         object['tombstone'] = 1;

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -525,6 +525,66 @@ describe('Action', () => {
       spy.mockRestore();
     });
   });
+
+  describe('append-notes', () => {
+    test('appends text when notes is empty', () => {
+      const action = new Action('append-notes', null, ' Appended', null);
+      const item = { notes: '' };
+      action.exec(item);
+      expect(item.notes).toBe(' Appended');
+    });
+
+    test('appends text when notes is null', () => {
+      const action = new Action('append-notes', null, 'Appended', null);
+      const item = { notes: null };
+      action.exec(item);
+      expect(item.notes).toBe('Appended');
+    });
+
+    test('appends text to existing notes', () => {
+      const action = new Action('append-notes', null, ' Appended', null);
+      const item = { notes: 'Existing note' };
+      action.exec(item);
+      expect(item.notes).toBe('Existing note Appended');
+    });
+
+    test('sets _forceApplyFields when appending', () => {
+      const action = new Action('append-notes', null, ' Appended', null);
+      const item: Record<string, unknown> = { notes: 'Existing note' };
+      action.exec(item);
+      expect(item._forceApplyFields).toContain('notes');
+    });
+  });
+
+  describe('prepend-notes', () => {
+    test('prepends text when notes is empty', () => {
+      const action = new Action('prepend-notes', null, 'Prepended ', null);
+      const item = { notes: '' };
+      action.exec(item);
+      expect(item.notes).toBe('Prepended ');
+    });
+
+    test('prepends text when notes is null', () => {
+      const action = new Action('prepend-notes', null, 'Prepended', null);
+      const item = { notes: null };
+      action.exec(item);
+      expect(item.notes).toBe('Prepended');
+    });
+
+    test('prepends text to existing notes', () => {
+      const action = new Action('prepend-notes', null, 'Prepended ', null);
+      const item = { notes: 'Existing note' };
+      action.exec(item);
+      expect(item.notes).toBe('Prepended Existing note');
+    });
+
+    test('sets _forceApplyFields when prepending', () => {
+      const action = new Action('prepend-notes', null, 'Prepended ', null);
+      const item: Record<string, unknown> = { notes: 'Existing note' };
+      action.exec(item);
+      expect(item._forceApplyFields).toContain('notes');
+    });
+  });
 });
 
 describe('Rule', () => {

--- a/packages/loot-core/src/types/models/transaction.ts
+++ b/packages/loot-core/src/types/models/transaction.ts
@@ -36,4 +36,5 @@ export type TransactionEntity = {
   } | null;
   raw_synced_data?: string | undefined;
   _ruleErrors?: string[];
+  _forceApplyFields?: string[];
 };

--- a/upcoming-release-notes/7177.md
+++ b/upcoming-release-notes/7177.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix schedule link being lost when merging transactions

--- a/upcoming-release-notes/7568.md
+++ b/upcoming-release-notes/7568.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix append/prepend notes rule not applying when a transaction already has notes


### PR DESCRIPTION
Closes #7391

Wraps all remaining uncovered feature areas with `ErrorBoundary` from `react-error-boundary` (already a dependency), using the shared `FeatureErrorFallback` component.

**Reports (11 components):**
NetWorth, CashFlow, Spending, Calendar, BalanceForecast, Sankey, Summary, AgeOfMoney, Crossover, Formula, BudgetAnalysis

**Mobile (16 components):**
BudgetPage, CategoryPage, CategoryTransactions, AccountsPage, AccountPage, TransactionList, TransactionListWithBalances, TransactionEdit, MobileSchedulesPage, MobileScheduleEditPage, MobileRulesPage, MobileRuleEditPage, MobilePayeesPage, MobilePayeeEditPage, MobileBankSyncPage, MobileBankSyncAccountEditPage

Each boundary wraps the outermost return of the feature's entry-point component, so a single rendering error is contained to that feature area instead of crashing the whole app.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.06 MB → 14.07 MB (+9.36 kB) | +0.06%
loot-core | 1 | 5.28 MB → 5.28 MB (+230 B) | +0.00%
api | 2 | 3.86 MB → 3.86 MB (+226 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.06 MB → 14.07 MB (+9.36 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/budget/CategoryPage.tsx` | 📈 +297 B (+11.96%) | 2.43 kB → 2.72 kB
`locale/nl.json` | 📈 +12.48 kB (+11.68%) | 106.82 kB → 119.3 kB
`src/components/mobile/payees/MobilePayeesPage.tsx` | 📈 +142 B (+4.57%) | 3.03 kB → 3.17 kB
`src/components/mobile/rules/MobileRuleEditPage.tsx` | 📈 +125 B (+3.40%) | 3.59 kB → 3.72 kB
`src/components/mobile/rules/MobileRulesPage.tsx` | 📈 +142 B (+3.30%) | 4.2 kB → 4.34 kB
`src/components/mobile/schedules/MobileScheduleEditPage.tsx` | 📈 +148 B (+2.52%) | 5.74 kB → 5.89 kB
`src/components/mobile/budget/CategoryTransactions.tsx` | 📈 +117 B (+2.39%) | 4.78 kB → 4.89 kB
`src/components/mobile/banksync/MobileBankSyncPage.tsx` | 📈 +115 B (+2.32%) | 4.84 kB → 4.95 kB
`src/components/mobile/payees/MobilePayeeEditPage.tsx` | 📈 +115 B (+1.82%) | 6.17 kB → 6.28 kB
`src/components/mobile/schedules/MobileSchedulesPage.tsx` | 📈 +115 B (+1.70%) | 6.62 kB → 6.74 kB
`src/components/mobile/accounts/AccountPage.tsx` | 📈 +115 B (+1.25%) | 8.96 kB → 9.08 kB
`src/components/mobile/banksync/MobileBankSyncAccountEditPage.tsx` | 📈 +115 B (+1.24%) | 9.07 kB → 9.18 kB
`src/components/reports/reports/CashFlow.tsx` | 📈 +111 B (+1.17%) | 9.27 kB → 9.37 kB
`src/components/mobile/transactions/TransactionListWithBalances.tsx` | 📈 +114 B (+1.10%) | 10.1 kB → 10.21 kB
`src/components/reports/reports/Formula.tsx` | 📈 +111 B (+1.08%) | 9.99 kB → 10.1 kB
`src/components/reports/reports/NetWorth.tsx` | 📈 +111 B (+0.77%) | 14.16 kB → 14.27 kB
`src/components/reports/reports/BalanceForecast.tsx` | 📈 +111 B (+0.73%) | 14.85 kB → 14.96 kB
`src/components/mobile/transactions/TransactionList.tsx` | 📈 +119 B (+0.64%) | 18.04 kB → 18.15 kB
`src/components/reports/reports/AgeOfMoney.tsx` | 📈 +111 B (+0.61%) | 17.68 kB → 17.79 kB
`src/components/mobile/accounts/AccountsPage.tsx` | 📈 +124 B (+0.60%) | 20.23 kB → 20.35 kB
`src/components/transactions/TransactionList.tsx` | 📈 +100 B (+0.56%) | 17.29 kB → 17.38 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +111 B (+0.54%) | 19.92 kB → 20.03 kB
`src/components/reports/reports/Spending.tsx` | 📈 +111 B (+0.44%) | 24.58 kB → 24.69 kB
`src/components/reports/reports/Summary.tsx` | 📈 +111 B (+0.42%) | 25.57 kB → 25.68 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +114 B (+0.40%) | 27.58 kB → 27.7 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +255 B (+0.35%) | 71.47 kB → 71.72 kB
`src/components/reports/reports/Sankey.tsx` | 📈 +111 B (+0.34%) | 31.75 kB → 31.86 kB
`src/components/mobile/budget/BudgetPage.tsx` | 📈 +115 B (+0.31%) | 36.12 kB → 36.23 kB
`locale/en.json` | 📈 +590 B (+0.29%) | 200.02 kB → 200.59 kB
`src/components/reports/reports/Crossover.tsx` | 📈 +111 B (+0.26%) | 41.16 kB → 41.27 kB
`locale/de.json` | 📉 -569 B (-0.33%) | 170.65 kB → 170.1 kB
`locale/pt-BR.json` | 📉 -648 B (-0.34%) | 187.97 kB → 187.34 kB
`locale/ca.json` | 📉 -653 B (-0.34%) | 186.26 kB → 185.63 kB
`locale/zh-Hans.json` | 📉 -412 B (-0.34%) | 116.84 kB → 116.44 kB
`locale/es.json` | 📉 -646 B (-0.35%) | 178.21 kB → 177.58 kB
`locale/it.json` | 📉 -617 B (-0.37%) | 164.53 kB → 163.93 kB
`locale/uk.json` | 📉 -832 B (-0.39%) | 208.65 kB → 207.84 kB
`locale/fr.json` | 📉 -722 B (-0.40%) | 178.06 kB → 177.35 kB
`locale/nb-NO.json` | 📉 -663 B (-0.44%) | 147.72 kB → 147.07 kB
`locale/th.json` | 📉 -1006 B (-0.56%) | 174.31 kB → 173.33 kB
`locale/da.json` | 📉 -619 B (-0.60%) | 100.8 kB → 100.19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/nl.js | 106.82 kB → 119.3 kB (+12.48 kB) | +11.68%
static/js/narrow.js | 364.2 kB → 365.94 kB (+1.74 kB) | +0.48%
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+1.2 kB) | +0.09%
static/js/en.js | 200.02 kB → 200.59 kB (+590 B) | +0.29%
static/js/TransactionEdit.js | 90.63 kB → 90.88 kB (+255 B) | +0.27%
static/js/TransactionList.js | 85.81 kB → 85.93 kB (+119 B) | +0.14%
static/js/ScheduleEditForm.js | 146.44 kB → 146.56 kB (+115 B) | +0.08%
static/js/Value.js | 5.08 MB → 5.08 MB (+100 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 174.31 kB → 173.33 kB (-1006 B) | -0.56%
static/js/uk.js | 208.65 kB → 207.84 kB (-832 B) | -0.39%
static/js/fr.js | 178.06 kB → 177.35 kB (-722 B) | -0.40%
static/js/nb-NO.js | 147.72 kB → 147.07 kB (-663 B) | -0.44%
static/js/ca.js | 186.26 kB → 185.63 kB (-653 B) | -0.34%
static/js/pt-BR.js | 187.97 kB → 187.34 kB (-648 B) | -0.34%
static/js/es.js | 178.21 kB → 177.58 kB (-646 B) | -0.35%
static/js/da.js | 100.8 kB → 100.19 kB (-619 B) | -0.60%
static/js/it.js | 164.53 kB → 163.93 kB (-617 B) | -0.37%
static/js/de.js | 170.65 kB → 170.1 kB (-569 B) | -0.33%
static/js/zh-Hans.js | 116.84 kB → 116.44 kB (-412 B) | -0.34%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+230 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +230 B (+2.79%) | 8.06 kB → 8.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Db9PGarl.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+226 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +226 B (+2.90%) | 7.6 kB → 7.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+226 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->