### PR TITLE
[AI] fix(reports): apply correct filters when drilling down from Transfer/Uncategorized bars

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -329,6 +329,7 @@ export function BarGraph({
                     endDate: data.endDate,
                     field: groupBy.toLowerCase(),
                     id: item.id,
+                    uncategorized_id: item.uncategorized_id,
                   })
                 }
                 shape={(props: BarShapeProps) => (

--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -313,25 +313,30 @@ export function BarGraph({
                   !['Group', 'Interval'].includes(groupBy) &&
                   setPointer('pointer')
                 }
-                onClick={item =>
-                  ((compact && showTooltip) || !compact) &&
-                  !['Group', 'Interval'].includes(groupBy) &&
-                  showActivity({
-                    navigate,
-                    categories,
-                    accounts,
-                    balanceTypeOp,
-                    filters,
-                    showHiddenCategories,
-                    showOffBudget,
-                    type: 'totals',
-                    startDate: data.startDate,
-                    endDate: data.endDate,
-                    field: groupBy.toLowerCase(),
-                    id: item.id,
-                    uncategorized_id: item.uncategorized_id,
-                  })
-                }
+                onClick={item => {
+                  const groupItem = (data.data ?? []).find(
+                    d => d.id === item.id,
+                  );
+                  return (
+                    ((compact && showTooltip) || !compact) &&
+                    !['Group', 'Interval'].includes(groupBy) &&
+                    showActivity({
+                      navigate,
+                      categories,
+                      accounts,
+                      balanceTypeOp,
+                      filters,
+                      showHiddenCategories,
+                      showOffBudget,
+                      type: 'totals',
+                      startDate: data.startDate,
+                      endDate: data.endDate,
+                      field: groupBy.toLowerCase(),
+                      id: item.id,
+                      uncategorized_id: groupItem?.uncategorized_id,
+                    })
+                  );
+                }}
                 shape={(props: BarShapeProps) => (
                   <Rectangle
                     {...props}

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -31,7 +31,10 @@ const RADIAN = Math.PI / 180;
 
 const canDeviceHover = () => window.matchMedia('(hover: hover)').matches;
 
-type ClickablePieItem = PieSectorDataItem & { id?: string };
+type ClickablePieItem = PieSectorDataItem & {
+  id?: string;
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
+};
 
 // ---------------------------------------------------------------------------
 // Dimension helpers

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -600,6 +600,7 @@ export function DonutGraph({
                           endDate: data.endDate,
                           field: 'category',
                           id: item.id,
+                          uncategorized_id: item.uncategorized_id,
                         });
                       }
                     }}
@@ -707,6 +708,10 @@ export function DonutGraph({
                             ? 'category'
                             : groupBy.toLowerCase(),
                         id: groupBy === 'Group' ? groupCategoryIds : item.id,
+                        uncategorized_id:
+                          groupBy === 'Group'
+                            ? undefined
+                            : item.uncategorized_id,
                       });
                     }
                   }}

--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -190,6 +190,7 @@ export function LineGraph({
     : [];
 
   const onShowActivity = (item, id, payload) => {
+    const legendEntry = data.legend.find(e => e.id === id || e.dataKey === id);
     showActivity({
       navigate,
       categories,
@@ -203,6 +204,7 @@ export function LineGraph({
       endDate: payload.payload.intervalEndDate,
       field: groupBy.toLowerCase(),
       id,
+      uncategorized_id: legendEntry?.uncategorized_id,
       interval,
     });
   };

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -303,6 +303,7 @@ export function StackedBarGraph({
                         endDate: e.payload?.intervalEndDate,
                         field: groupBy.toLowerCase(),
                         id: entry.id,
+                        uncategorized_id: entry.uncategorized_id,
                         interval,
                       })
                     }

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.ts
@@ -24,6 +24,7 @@ type showActivityProps = {
   endDate?: string;
   field?: string;
   id?: string | string[]; // changed: supports array for oneOf
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
   interval?: string;
 };
 
@@ -40,6 +41,7 @@ export function showActivity({
   endDate,
   field,
   id,
+  uncategorized_id,
   interval = 'Day',
 }: showActivityProps) {
   const isOutFlow =
@@ -53,15 +55,31 @@ export function showActivity({
           'FromDate') as 'dayFromDate' | 'monthFromDate' | 'yearFromDate');
   const isDateOp = interval === 'Weekly' || type !== 'time';
 
+  // Pseudo-category drill-downs: `id` is '' for transfer/off_budget/other groups.
+  // Build the correct filter based on uncategorized_id instead of the empty id.
+  const pseudoCategoryFilters =
+    uncategorized_id === 'transfer'
+      ? [{ field: 'transfer', op: 'is', value: true }]
+      : uncategorized_id === 'other'
+        ? [
+            { field: 'category', op: 'is', value: null, type: 'id' },
+            { field: 'transfer', op: 'is', value: false },
+          ]
+        : [];
+
   const filterConditions = [
     ...filters,
-    id && {
-      // changed: use oneOf when id is an array, is when it's a string
-      field,
-      op: Array.isArray(id) ? 'oneOf' : 'is',
-      value: id,
-      type: 'id',
-    },
+    // Skip the generic id-based category filter for pseudo-categories; their
+    // filters are handled by pseudoCategoryFilters above.
+    !uncategorized_id &&
+      id && {
+        // changed: use oneOf when id is an array, is when it's a string
+        field,
+        op: Array.isArray(id) ? 'oneOf' : 'is',
+        value: id,
+        type: 'id',
+      },
+    ...pseudoCategoryFilters,
     {
       field: 'date',
       op: isDateOp ? 'gte' : 'is',

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -178,6 +178,7 @@ export const ReportTableRow = memo(
                         endDate: intervalItem.intervalEndDate || '',
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                         interval,
                       })
                     }
@@ -235,6 +236,7 @@ export const ReportTableRow = memo(
                         endDate,
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                       })
                     }
                   />
@@ -285,6 +287,7 @@ export const ReportTableRow = memo(
                         endDate,
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                       })
                     }
                   />
@@ -334,6 +337,7 @@ export const ReportTableRow = memo(
                 endDate,
                 field: groupBy.toLowerCase(),
                 id: item.id,
+                uncategorized_id: item.uncategorized_id,
               })
             }
             width="flex"

--- a/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
@@ -66,12 +66,20 @@ export function calculateLegend(
   }
 
   const legend: LegendEntity[] = chooseData.map((item, index) => {
-    return {
+    const entry: LegendEntity = {
       id: item.id || '',
       name: item.name || '',
       color: getColor(item.data, index),
       dataKey: item.id || item.name || '', // Use id for unique data lookup
     };
+    const uncategorized_id =
+      groupBy !== 'Interval' &&
+      'uncategorized_id' in item.data &&
+      item.data.uncategorized_id;
+    if (uncategorized_id) {
+      entry.uncategorized_id = uncategorized_id;
+    }
+    return entry;
   });
   return legend;
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
@@ -115,5 +115,8 @@ export function recalculate({
     totalTotals,
     totalBudgeted: totalTotals,
     intervalData,
+    ...(item.uncategorized_id !== undefined && {
+      uncategorized_id: item.uncategorized_id,
+    }),
   };
 }

--- a/packages/loot-core/src/types/models/reports.ts
+++ b/packages/loot-core/src/types/models/reports.ts
@@ -90,6 +90,8 @@ export type LegendEntity = {
   id: string | null;
   color: string;
   dataKey: string; // Uses id for unique data lookup when categories have same name
+  /** Populated for pseudo-categories (transfer, off_budget, other) that share id: '' */
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
 };
 
 export type IntervalEntity = {
@@ -117,6 +119,8 @@ export type GroupedEntity = {
   netDebts: number;
   totalBudgeted: number;
   categories?: GroupedEntity[];
+  /** Populated for pseudo-categories (transfer, off_budget, other) that share id: '' */
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
 };
 
 export type Interval = {

--- a/upcoming-release-notes/7999.md
+++ b/upcoming-release-notes/7999.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix drill-down from Custom Report bar chart not applying Transfer/Uncategorized filters when clicking on pseudo-category rows


### PR DESCRIPTION
## Summary

Fixes #7999.

When clicking a **Transfers** (or Uncategorized/Off-budget) bar in a Custom Report chart, the drill-down navigated to the transactions page but applied no category filter — showing all transactions for the period instead of just transfers.

### Root cause

`Transfer`, `Off-budget`, and `Uncategorized (other)` are pseudo-categories defined with `id: ''`. In `showActivity.ts`, the filter construction uses:

```ts
id && { field, op: 'is', value: id, type: 'id' }
```

Since `'' && ...` is falsy, the filter is silently dropped and the drill-down shows everything.

### Fix

Threads `uncategorized_id` (`'transfer' | 'off_budget' | 'other'`) from `UncategorizedEntity` through the data pipeline:

`recalculate` → `GroupedEntity` → `calculateLegend` → `LegendEntity` → chart click handlers → `showActivity`

In `showActivity`, pseudo-categories now receive the correct filters:

| `uncategorized_id` | Filter applied |
|-|-|
| `transfer` | `{ field: 'transfer', op: 'is', value: true }` |
| `other` | `{ field: 'category', op: 'is', value: null }` + `{ field: 'transfer', op: 'is', value: false }` |
| `off_budget` | _(account-level filter already handles this; no category filter added)_ |

## Files changed

- `reports.ts` — add optional `uncategorized_id` to `GroupedEntity` and `LegendEntity`
- `recalculate.ts` — preserve `uncategorized_id` from source `UncategorizedEntity`
- `calculateLegend.ts` — pass through `uncategorized_id` to legend entries
- `showActivity.ts` — add `uncategorized_id` param and build correct filters
- `BarGraph`, `DonutGraph`, `LineGraph`, `StackedBarGraph`, `ReportTableRow` — pass `uncategorized_id` from legend entry to `showActivity`

## Testing

1. Create a Custom Report split by **Category**, type **Deposit**, interval **Weekly**
2. Click on the **Transfers** bar
3. Confirm the drill-down shows only transfer transactions (not all deposits)
4. Repeat for the **Uncategorized** bar — should show only truly uncategorized transactions

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+1.34 kB) | +0.01%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+1.34 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/showActivity.ts` | 📈 +347 B (+18.60%) | 1.82 kB → 2.16 kB
`src/components/reports/spreadsheets/calculateLegend.ts` | 📈 +206 B (+14.94%) | 1.35 kB → 1.55 kB
`src/components/reports/spreadsheets/recalculate.ts` | 📈 +86 B (+4.22%) | 1.99 kB → 2.08 kB
`src/components/reports/graphs/tableGraph/ReportTableRow.tsx` | 📈 +319 B (+2.41%) | 12.95 kB → 13.26 kB
`src/components/reports/graphs/LineGraph.tsx` | 📈 +186 B (+1.85%) | 9.84 kB → 10.03 kB
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +132 B (+0.57%) | 22.77 kB → 22.9 kB
`src/components/reports/graphs/StackedBarGraph.tsx` | 📈 +48 B (+0.48%) | 9.8 kB → 9.84 kB
`src/components/reports/graphs/BarGraph.tsx` | 📈 +47 B (+0.41%) | 11.21 kB → 11.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.26 MB → 1.26 MB (+1.34 kB) | +0.10%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.26 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.8 kB | 0%
static/js/de.js | 170.65 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.02 kB | 0%
static/js/es.js | 178.21 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/fr.js | 178.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.53 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 147.72 kB | 0%
static/js/nl.js | 106.82 kB | 0%
static/js/pt-BR.js | 187.97 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 208.65 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.84 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->