### PR TITLE
[Maintenance] Add scoped ErrorBoundaries to all reports components

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -27,6 +28,7 @@ import type {
 import * as d from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
@@ -58,7 +60,11 @@ export function AgeOfMoney() {
     return <LoadingIndicator />;
   }
 
-  return <AgeOfMoneyInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <AgeOfMoneyInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type AgeOfMoneyInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
@@ -1,5 +1,6 @@
 // oxlint-disable typescript-paths/absolute-parent-import
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -27,6 +28,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
 import { Container } from '#components/reports/Container';
@@ -64,7 +66,11 @@ export function BalanceForecast() {
     return <LoadingIndicator />;
   }
 
-  return <BalanceForecastInner key={widget?.id ?? 'new'} widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <BalanceForecastInner key={widget?.id ?? 'new'} widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type BalanceForecastInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -21,6 +22,7 @@ import type {
 import * as d from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -54,7 +56,11 @@ export function BudgetAnalysis() {
     return <LoadingIndicator />;
   }
 
-  return <BudgetAnalysisInternal widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <BudgetAnalysisInternal widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type BudgetAnalysisInternalProps = {

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Ref } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams, useSearchParams } from 'react-router';
 import { animated, config, useSpring } from 'react-spring';
@@ -31,6 +32,7 @@ import { useDrag } from '@use-gesture/react';
 import { format as formatDate, parseISO } from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { TransactionList as TransactionListMobile } from '#components/mobile/transactions/TransactionList';
@@ -84,7 +86,11 @@ export function Calendar() {
     return <LoadingIndicator />;
   }
 
-  return <CalendarInner widget={widget} parameters={searchParams} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CalendarInner widget={widget} parameters={searchParams} />
+    </ErrorBoundary>
+  );
 }
 
 type CalendarInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -20,6 +21,7 @@ import type {
 import * as d from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -58,7 +60,11 @@ export function CashFlow() {
     return <LoadingIndicator />;
   }
 
-  return <CashFlowInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CashFlowInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type CashFlowInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -24,6 +25,7 @@ import type {
 
 import { Link } from '#components/common/Link';
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { Checkbox } from '#components/forms';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -66,7 +68,11 @@ export function Crossover() {
     return <LoadingIndicator />;
   }
 
-  return <CrossoverInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CrossoverInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type CrossoverInnerProps = { widget?: CrossoverWidget };

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
@@ -25,6 +26,7 @@ import type { TransObjectLiteral } from '@actual-app/core/types/util';
 import * as d from 'date-fns';
 
 import { Warning } from '#components/alerts';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -126,11 +128,13 @@ export function CustomReport() {
   }
 
   return (
-    <CustomReportInner
-      key={report?.id}
-      report={report}
-      budgetType={budgetType}
-    />
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <CustomReportInner
+        key={report?.id}
+        report={report}
+        budgetType={budgetType}
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/packages/desktop-client/src/components/reports/reports/Formula.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Formula.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -13,6 +14,7 @@ import { View } from '@actual-app/components/view';
 import type { FormulaWidget } from '@actual-app/core/types/models';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { QueryManager } from '#components/formula/QueryManager';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -43,7 +45,11 @@ export function Formula() {
     return <LoadingIndicator />;
   }
 
-  return <FormulaInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <FormulaInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type FormulaInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/MarkdownCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/MarkdownCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { TextArea } from 'react-aria-components';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 
@@ -12,6 +13,7 @@ import { css } from '@emotion/css';
 import rehypeExternalLinks from 'rehype-external-links';
 import remarkGfm from 'remark-gfm';
 
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { NON_DRAGGABLE_AREA_CLASS_NAME } from '#components/reports/constants';
 import { ReportCard } from '#components/reports/ReportCard';
 import { useDashboardWidgetCopyMenu } from '#components/reports/useDashboardWidgetCopyMenu';
@@ -56,118 +58,120 @@ export function MarkdownCard({
     useDashboardWidgetCopyMenu(onCopy);
 
   return (
-    <ReportCard
-      isEditing={isEditing}
-      disableClick={isVisibleTextArea}
-      menuItems={[
-        {
-          type: Menu.label,
-          name: t('Text position:'),
-          text: '',
-        },
-        {
-          name: 'text-left',
-          text: t('Left'),
-        },
-        {
-          name: 'text-center',
-          text: t('Center'),
-        },
-        {
-          name: 'text-right',
-          text: t('Right'),
-        },
-        Menu.line,
-        {
-          name: 'edit',
-          text: t('Edit content'),
-        },
-        {
-          name: 'remove',
-          text: t('Remove'),
-        },
-        ...copyMenuItems,
-      ]}
-      onMenuSelect={item => {
-        if (handleCopyMenuSelect(item)) return;
-        switch (item) {
-          case 'text-left':
-            onMetaChange({
-              ...meta,
-              text_align: 'left',
-            });
-            break;
-          case 'text-center':
-            onMetaChange({
-              ...meta,
-              text_align: 'center',
-            });
-            break;
-          case 'text-right':
-            onMetaChange({
-              ...meta,
-              text_align: 'right',
-            });
-            break;
-          case 'edit':
-            setIsVisibleTextArea(true);
-            break;
-          case 'remove':
-            onRemove();
-            break;
-          default:
-            throw new Error(`Unrecognized selection: ${item}`);
-        }
-      }}
-    >
-      <View
-        style={{
-          flex: 1,
-          paddingTop: 5,
-          paddingLeft: 20,
-          overflowY: 'auto',
-          height: '100%',
-          textAlign: meta.text_align,
-        }}
-      >
-        {isVisibleTextArea ? (
-          <TextArea
-            style={{
-              height: '100%',
-              border: 0,
-              marginTop: 11,
-              marginBottom: 11,
-              marginRight: 20,
-              color: theme.formInputText,
-              backgroundColor: theme.tableBackground,
-            }}
-            className={NON_DRAGGABLE_AREA_CLASS_NAME}
-            autoFocus
-            defaultValue={meta.content}
-            onBlur={event => {
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <ReportCard
+        isEditing={isEditing}
+        disableClick={isVisibleTextArea}
+        menuItems={[
+          {
+            type: Menu.label,
+            name: t('Text position:'),
+            text: '',
+          },
+          {
+            name: 'text-left',
+            text: t('Left'),
+          },
+          {
+            name: 'text-center',
+            text: t('Center'),
+          },
+          {
+            name: 'text-right',
+            text: t('Right'),
+          },
+          Menu.line,
+          {
+            name: 'edit',
+            text: t('Edit content'),
+          },
+          {
+            name: 'remove',
+            text: t('Remove'),
+          },
+          ...copyMenuItems,
+        ]}
+        onMenuSelect={item => {
+          if (handleCopyMenuSelect(item)) return;
+          switch (item) {
+            case 'text-left':
               onMetaChange({
                 ...meta,
-                content: event.currentTarget.value,
+                text_align: 'left',
               });
-              setIsVisibleTextArea(false);
-            }}
-          />
-        ) : (
-          <Text className={markdownStyles}>
-            <ReactMarkdown
-              remarkPlugins={remarkPlugins}
-              rehypePlugins={[
-                [
-                  rehypeExternalLinks,
-                  { target: '_blank', rel: ['noopener', 'noreferrer'] },
-                ],
-              ]}
-            >
-              {meta.content}
-            </ReactMarkdown>
-          </Text>
-        )}
-      </View>
-    </ReportCard>
+              break;
+            case 'text-center':
+              onMetaChange({
+                ...meta,
+                text_align: 'center',
+              });
+              break;
+            case 'text-right':
+              onMetaChange({
+                ...meta,
+                text_align: 'right',
+              });
+              break;
+            case 'edit':
+              setIsVisibleTextArea(true);
+              break;
+            case 'remove':
+              onRemove();
+              break;
+            default:
+              throw new Error(`Unrecognized selection: ${item}`);
+          }
+        }}
+      >
+        <View
+          style={{
+            flex: 1,
+            paddingTop: 5,
+            paddingLeft: 20,
+            overflowY: 'auto',
+            height: '100%',
+            textAlign: meta.text_align,
+          }}
+        >
+          {isVisibleTextArea ? (
+            <TextArea
+              style={{
+                height: '100%',
+                border: 0,
+                marginTop: 11,
+                marginBottom: 11,
+                marginRight: 20,
+                color: theme.formInputText,
+                backgroundColor: theme.tableBackground,
+              }}
+              className={NON_DRAGGABLE_AREA_CLASS_NAME}
+              autoFocus
+              defaultValue={meta.content}
+              onBlur={event => {
+                onMetaChange({
+                  ...meta,
+                  content: event.currentTarget.value,
+                });
+                setIsVisibleTextArea(false);
+              }}
+            />
+          ) : (
+            <Text className={markdownStyles}>
+              <ReactMarkdown
+                remarkPlugins={remarkPlugins}
+                rehypePlugins={[
+                  [
+                    rehypeExternalLinks,
+                    { target: '_blank', rel: ['noopener', 'noreferrer'] },
+                  ],
+                ]}
+              >
+                {meta.content}
+              </ReactMarkdown>
+            </Text>
+          )}
+        </View>
+      </ReportCard>
+    </ErrorBoundary>
   );
 }

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -23,6 +24,7 @@ import type { NetWorthWidget, TimeFrame } from '@actual-app/core/types/models';
 import * as d from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { FinancialText } from '#components/FinancialText';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
@@ -58,7 +60,11 @@ export function NetWorth() {
     return <LoadingIndicator />;
   }
 
-  return <NetWorthInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <NetWorthInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type NetWorthInnerProps = {

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -31,6 +32,7 @@ import debounce from 'lodash/debounce';
 import type { SankeyData } from 'recharts/types/chart/Sankey';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { SankeyGraph } from '#components/reports/graphs/SankeyGraph';
@@ -70,7 +72,11 @@ export function Sankey() {
     return <LoadingIndicator />;
   }
 
-  return <SankeyInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SankeyInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 export function topNNodes(cardHeight: number): number {

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -23,6 +24,7 @@ import type {
 import * as d from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { MobileBackButton } from '#components/mobile/MobileBackButton';
@@ -57,7 +59,11 @@ export function Spending() {
     return <LoadingIndicator />;
   }
 
-  return <SpendingInternal widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SpendingInternal widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type SpendingInternalProps = {

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import type { CSSProperties } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -24,6 +25,7 @@ import type {
 import { parseISO } from 'date-fns';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
+import { FeatureErrorFallback } from '#components/FeatureErrorFallback';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { FinancialText } from '#components/FinancialText';
@@ -59,7 +61,11 @@ export function Summary() {
     return <LoadingIndicator />;
   }
 
-  return <SummaryInner widget={widget} />;
+  return (
+    <ErrorBoundary FallbackComponent={FeatureErrorFallback}>
+      <SummaryInner widget={widget} />
+    </ErrorBoundary>
+  );
 }
 
 type SummaryInnerProps = {

--- a/upcoming-release-notes/enhancements-error-boundry.md
+++ b/upcoming-release-notes/enhancements-error-boundry.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [awaissaeed530]
+---
+
+[Maintenance] Add scoped ErrorBoundaries to all reports components


### PR DESCRIPTION
## Description

Adds scoped error-boundary to all reports components

## Related issue(s)

Relates to #7391 

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB → 14.05 MB (+1.42 kB) | +0.01%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB → 14.05 MB (+1.42 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/MarkdownCard.tsx` | 📈 +117 B (+2.24%) | 5.11 kB → 5.23 kB
`src/components/reports/reports/CashFlow.tsx` | 📈 +111 B (+1.17%) | 9.27 kB → 9.37 kB
`src/components/reports/reports/Formula.tsx` | 📈 +111 B (+1.08%) | 9.99 kB → 10.1 kB
`src/components/reports/reports/NetWorth.tsx` | 📈 +111 B (+0.77%) | 14.16 kB → 14.27 kB
`src/components/reports/reports/BalanceForecast.tsx` | 📈 +111 B (+0.73%) | 14.85 kB → 14.96 kB
`src/components/reports/reports/AgeOfMoney.tsx` | 📈 +111 B (+0.61%) | 17.68 kB → 17.79 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +111 B (+0.54%) | 19.92 kB → 20.03 kB
`src/components/reports/reports/Spending.tsx` | 📈 +111 B (+0.48%) | 22.8 kB → 22.91 kB
`src/components/reports/reports/Summary.tsx` | 📈 +111 B (+0.42%) | 25.57 kB → 25.68 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +114 B (+0.40%) | 27.58 kB → 27.7 kB
`src/components/reports/reports/Sankey.tsx` | 📈 +111 B (+0.34%) | 31.75 kB → 31.86 kB
`src/components/reports/reports/Crossover.tsx` | 📈 +111 B (+0.26%) | 41.16 kB → 41.27 kB
`src/components/reports/reports/CustomReport.tsx` | 📈 +114 B (+0.26%) | 42.34 kB → 42.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.26 MB → 1.26 MB (+1.42 kB) | +0.11%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.26 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.8 kB | 0%
static/js/de.js | 170.65 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.02 kB | 0%
static/js/es.js | 178.21 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/fr.js | 178.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.53 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 147.72 kB | 0%
static/js/nl.js | 106.82 kB | 0%
static/js/pt-BR.js | 187.97 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 208.65 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.84 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->