### PR TITLE
[AI] Fix desktop settings resetting after an interrupted update

### DIFF
--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.test.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.test.ts
@@ -1,0 +1,98 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import * as asyncStorage from '#platform/server/asyncStorage';
+
+// Under the test config `#platform/server/asyncStorage` resolves to the
+// electron implementation, but it is globally mocked with an in-memory store in
+// the test setup. Undo that so we exercise the real on-disk persistence logic.
+vi.unmock('#platform/server/asyncStorage');
+
+let dataDir: string;
+const storePath = () => path.join(dataDir, 'global-store.json');
+
+beforeEach(() => {
+  dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'actual-global-store-'));
+  process.env.ACTUAL_DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  delete process.env.ACTUAL_DATA_DIR;
+});
+
+describe('electron asyncStorage', () => {
+  it('persists values as valid JSON and reads them back', async () => {
+    asyncStorage.init();
+    await asyncStorage.setItem('language', 'en');
+
+    // The on-disk file is complete, valid JSON.
+    const raw = fs.readFileSync(storePath(), 'utf8');
+    expect(JSON.parse(raw)).toEqual({ language: 'en' });
+
+    // A fresh init reads the persisted value.
+    asyncStorage.init();
+    expect(await asyncStorage.getItem('language')).toBe('en');
+  });
+
+  it('does not leave temp files behind after a write', async () => {
+    asyncStorage.init();
+    await asyncStorage.setItem('language', 'en');
+    await asyncStorage.setItem('theme', 'dark');
+
+    const leftovers = fs
+      .readdirSync(dataDir)
+      .filter(name => name.endsWith('.tmp'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('keeps the store valid under concurrent writes', async () => {
+    asyncStorage.init();
+
+    await Promise.all([
+      asyncStorage.setItem('language', 'en'),
+      asyncStorage.setItem('theme', 'dark'),
+      asyncStorage.multiSet([
+        ['max-months', '3'],
+        ['floating-sidebar', 'true'],
+      ]),
+    ]);
+
+    // The file is complete, valid JSON, retains every key (no write clobbered
+    // another), and leaves no temp files behind.
+    expect(JSON.parse(fs.readFileSync(storePath(), 'utf8'))).toEqual({
+      language: 'en',
+      theme: 'dark',
+      'max-months': '3',
+      'floating-sidebar': 'true',
+    });
+    expect(
+      fs.readdirSync(dataDir).filter(name => name.endsWith('.tmp')),
+    ).toEqual([]);
+  });
+
+  it('starts empty without a backup when no store file exists', () => {
+    asyncStorage.init();
+
+    expect(fs.existsSync(storePath())).toBe(false);
+    expect(fs.existsSync(`${storePath()}.corrupt`)).toBe(false);
+  });
+
+  it('backs up a corrupt store instead of silently wiping it', async () => {
+    // Simulate a truncated/corrupt file left behind by an interrupted write
+    // (e.g. the process was killed mid-write during an app update).
+    const corrupt = '{"language":"en"';
+    fs.writeFileSync(storePath(), corrupt, 'utf8');
+
+    // init must not throw, and must start from defaults.
+    expect(() => asyncStorage.init()).not.toThrow();
+    expect(await asyncStorage.getItem('language')).toBeUndefined();
+
+    // The corrupt content is preserved in a backup so it can be recovered,
+    // rather than being thrown away.
+    const backupPath = `${storePath()}.corrupt`;
+    expect(fs.existsSync(backupPath)).toBe(true);
+    expect(fs.readFileSync(backupPath, 'utf8')).toBe(corrupt);
+  });
+});

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.test.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.test.ts
@@ -95,4 +95,18 @@ describe('electron asyncStorage', () => {
     expect(fs.existsSync(backupPath)).toBe(true);
     expect(fs.readFileSync(backupPath, 'utf8')).toBe(corrupt);
   });
+
+  it('backs up valid JSON of the wrong shape instead of using it as the store', async () => {
+    // Parseable JSON, but not a plain object (e.g. `null` or an array) would
+    // break `store[key]` access if used directly.
+    const invalid = '[]';
+    fs.writeFileSync(storePath(), invalid, 'utf8');
+
+    expect(() => asyncStorage.init()).not.toThrow();
+    expect(await asyncStorage.getItem('language')).toBeUndefined();
+
+    const backupPath = `${storePath()}.corrupt`;
+    expect(fs.existsSync(backupPath)).toBe(true);
+    expect(fs.readFileSync(backupPath, 'utf8')).toBe(invalid);
+  });
 });

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { join } from 'path';
 
 import * as lootFs from '#platform/server/fs';
+import { logger } from '#platform/server/log';
 import type { GlobalPrefsJson } from '#types/prefs';
 
 import type * as T from './index-types';
@@ -11,13 +12,17 @@ const getStorePath = () => join(lootFs.getDataDir(), 'global-store.json');
 let store: GlobalPrefsJson;
 let persisted = true;
 
+// Gives each write a unique temp file so concurrent writes never interleave
+// into the same file before being atomically renamed into place.
+let writeCounter = 0;
+
+// Serializes disk writes. Without this, two in-flight writes could finish out
+// of order and let an older snapshot clobber a newer one on disk.
+let pendingSave: Promise<void> = Promise.resolve();
+
 export const init: T.Init = function ({ persist = true } = {}) {
   if (persist) {
-    try {
-      store = JSON.parse(fs.readFileSync(getStorePath(), 'utf8'));
-    } catch {
-      store = {};
-    }
+    store = loadStore(getStorePath());
   } else {
     store = {};
   }
@@ -25,18 +30,74 @@ export const init: T.Init = function ({ persist = true } = {}) {
   persisted = persist;
 };
 
-function _saveStore(): Promise<void> {
-  if (persisted) {
-    return new Promise(function (resolve, reject) {
-      fs.writeFile(
-        getStorePath(),
-        JSON.stringify(store),
-        'utf8',
-        function (err) {
-          return err ? reject(err) : resolve();
-        },
+function loadStore(storePath: string): GlobalPrefsJson {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(storePath, 'utf8');
+  } catch (err) {
+    // No store yet (first run) - start fresh. Anything other than a missing
+    // file is unexpected, so surface it but still fall back to defaults.
+    if (err?.code !== 'ENOENT') {
+      logger.error('Could not read global preferences, using defaults', err);
+    }
+    return {};
+  }
+
+  try {
+    return JSON.parse(contents);
+  } catch (err) {
+    // The file exists but is not valid JSON - most likely truncated by an
+    // interrupted write (e.g. the process was killed mid-write during an app
+    // update). Don't silently discard the user's preferences: back the file up
+    // so it can be recovered, and log loudly.
+    const backupPath = `${storePath}.corrupt`;
+    try {
+      fs.writeFileSync(backupPath, contents, 'utf8');
+      logger.error(
+        `Could not parse global preferences at ${storePath}; backed up the corrupt file to ${backupPath} and started with defaults`,
+        err,
       );
-    });
+    } catch (backupErr) {
+      logger.error(
+        `Could not parse global preferences at ${storePath}, and failed to back up the corrupt file; starting with defaults`,
+        backupErr,
+      );
+    }
+    return {};
+  }
+}
+
+function _saveStore(): Promise<void> {
+  if (!persisted) {
+    return Promise.resolve();
+  }
+
+  // Queue this write behind any in-flight one. Using `writeStore` for both
+  // outcomes means a failed write doesn't permanently block the queue. Each
+  // queued write snapshots the latest store when it actually runs, so the file
+  // always ends up reflecting the most recent state.
+  pendingSave = pendingSave.then(writeStore, writeStore);
+  return pendingSave;
+}
+
+async function writeStore(): Promise<void> {
+  const storePath = getStorePath();
+  // Write to a unique temp file and atomically rename it into place. This
+  // guarantees the store file is always either the old or the new complete
+  // contents - never a half-written file - even if the process is killed
+  // mid-write (such as during an app update).
+  const tmpPath = `${storePath}.${process.pid}.${writeCounter++}.tmp`;
+
+  try {
+    await fs.promises.writeFile(tmpPath, JSON.stringify(store), 'utf8');
+    await fs.promises.rename(tmpPath, storePath);
+  } catch (err) {
+    // Best-effort cleanup of the temp file; ignore failures (it may never have
+    // been created).
+    try {
+      await fs.promises.rm(tmpPath, { force: true });
+    } catch {}
+    throw err;
   }
 }
 

--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -44,12 +44,21 @@ function loadStore(storePath: string): GlobalPrefsJson {
   }
 
   try {
-    return JSON.parse(contents);
+    const parsed = JSON.parse(contents);
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error('Global preferences are not a JSON object');
+    }
+    return parsed;
   } catch (err) {
-    // The file exists but is not valid JSON - most likely truncated by an
-    // interrupted write (e.g. the process was killed mid-write during an app
-    // update). Don't silently discard the user's preferences: back the file up
-    // so it can be recovered, and log loudly.
+    // The file exists but isn't a usable preferences object - either invalid
+    // JSON (most likely truncated by an interrupted write, e.g. the process was
+    // killed mid-write during an app update) or valid JSON of the wrong shape.
+    // Don't silently discard the user's preferences: back the file up so it can
+    // be recovered, and log loudly.
     const backupPath = `${storePath}.corrupt`;
     try {
       fs.writeFileSync(backupPath, contents, 'utf8');

--- a/upcoming-release-notes/fix-global-prefs-reset-on-update.md
+++ b/upcoming-release-notes/fix-global-prefs-reset-on-update.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [MatissJanis]
+---
+
+Fixed desktop settings (such as the selected language) being reset to defaults after an interrupted app update.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Sometimes users abruptly quit the app or do other things that interrupt writes mid-process. This can corrupt the global prefs file and thus next time we load the app - the user loads without any prefs.

This PR changes how we do writes. We do them to a separate file and then once complete - copy the new file to replace the old one.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/8051

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.05 MB | 0%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.86 MB → 3.86 MB (+1.17 kB) | +0.03%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.05 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.6 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.26 MB | 0%
static/js/ScheduleEditForm.js | 146.44 kB | 0%
static/js/SchedulesTable.js | 202.7 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 186.26 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.8 kB | 0%
static/js/de.js | 170.65 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.02 kB | 0%
static/js/es.js | 178.21 kB | 0%
static/js/extends.js | 508.06 kB | 0%
static/js/fr.js | 178.06 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 164.53 kB | 0%
static/js/narrow.js | 364.2 kB | 0%
static/js/nb-NO.js | 147.72 kB | 0%
static/js/nl.js | 106.82 kB | 0%
static/js/pt-BR.js | 187.97 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 174.31 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 208.65 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.84 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BkkH_8jr.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+1.17 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts` | 📈 +1.17 kB (+103.11%) | 1.13 kB → 2.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+1.17 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->