### PR TITLE
Refresh akahu account if stale

### DIFF
--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -154,6 +154,10 @@ app.post(
         });
       }
 
+      if (shouldRefreshAkahuTransactions(account.refreshed?.transactions)) {
+        await akahu.accounts.refresh(userToken, accountId);
+      }
+
       const now = new Date();
       const endDate = new Date(
         now.getFullYear(),
@@ -338,4 +342,18 @@ function processTransaction(
     booked: true,
     transactionId: trans._id,
   };
+}
+
+const AKAHU_TRANSACTION_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+
+function shouldRefreshAkahuTransactions(refreshedAt?: string) {
+  if (!refreshedAt) {
+    return false;
+  }
+
+  const refreshedAtTime = Date.parse(refreshedAt);
+  return (
+    Number.isFinite(refreshedAtTime) &&
+    Date.now() - refreshedAtTime > AKAHU_TRANSACTION_REFRESH_INTERVAL_MS
+  );
 }

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -135,7 +135,7 @@ app.post(
     try {
       const akahu = new AkahuClient({ appToken });
 
-      const account = await akahu.accounts.get(userToken, accountId);
+      let account = await akahu.accounts.get(userToken, accountId);
       if (!account) {
         return res.send({
           status: 'error',
@@ -156,6 +156,17 @@ app.post(
 
       if (shouldRefreshAkahuTransactions(account.refreshed?.transactions)) {
         await akahu.accounts.refresh(userToken, accountId);
+
+        // wait for the refresh to complete
+        for (let i = 0; i < 5; i++) {
+          await new Promise(resolve => setTimeout(resolve, 1000));
+          account = await akahu.accounts.get(userToken, accountId);
+          if (
+            !shouldRefreshAkahuTransactions(account.refreshed?.transactions)
+          ) {
+            break;
+          }
+        }
       }
 
       const now = new Date();

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -286,6 +286,8 @@ async function getRefreshedAccount(
     if (!account) {
       return null;
     } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
+      // wait for transactions to settle
+      await new Promise(resolve => setTimeout(resolve, 3000));
       break;
     }
   }
@@ -368,7 +370,7 @@ function processTransaction(
   };
 }
 
-const AKAHU_TRANSACTION_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
+const AKAHU_TRANSACTION_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
 function shouldRefreshAccount(refreshedAt?: string) {
   if (!refreshedAt) {

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -17,6 +17,7 @@ import {
   requestLoggerMiddleware,
   validateSessionMiddleware,
 } from '#util/middlewares';
+import { createMutex } from '#util/mutex';
 
 type AkahuTransaction = {
   booked: boolean;
@@ -265,34 +266,39 @@ app.post(
   }),
 );
 
-async function getRefreshedAccount(
+// prevent race conditions when refreshing accounts
+const runRefresh = createMutex();
+
+function getRefreshedAccount(
   akahu: AkahuClient,
   userToken: string,
   accountId: string,
 ): Promise<Account | null> {
-  let account = await akahu.accounts.get(userToken, accountId);
-  if (!account) {
-    return null;
-  } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
-    return account;
-  }
-
-  await akahu.accounts.refresh(userToken, accountId);
-
-  // wait for the refresh to complete
-  for (let i = 0; i < 5; i++) {
-    await new Promise(resolve => setTimeout(resolve, 3000));
-    account = await akahu.accounts.get(userToken, accountId);
+  return runRefresh(async () => {
+    let account = await akahu.accounts.get(userToken, accountId);
     if (!account) {
       return null;
     } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
-      // wait for transactions to settle
-      await new Promise(resolve => setTimeout(resolve, 3000));
-      break;
+      return account;
     }
-  }
 
-  return account;
+    await akahu.accounts.refreshAll(userToken);
+
+    // wait for the refresh to complete
+    for (let i = 0; i < 5; i++) {
+      await new Promise(resolve => setTimeout(resolve, 3000));
+      account = await akahu.accounts.get(userToken, accountId);
+      if (!account) {
+        return null;
+      } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
+        // wait for transactions to settle
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        break;
+      }
+    }
+
+    return account;
+  });
 }
 
 function isEnriched(

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -135,7 +135,7 @@ app.post(
     try {
       const akahu = new AkahuClient({ appToken });
 
-      const account = await akahu.accounts.get(userToken, accountId);
+      const account = await getRefreshedAccount(akahu, userToken, accountId);
       if (!account) {
         return res.send({
           status: 'error',
@@ -152,24 +152,6 @@ app.post(
             error: 'Account balance unavailable',
           },
         });
-      }
-
-      if (shouldRefreshAccount(account.refreshed?.transactions)) {
-        await akahu.accounts.refresh(userToken, accountId);
-
-        // wait for the refresh to complete
-        for (let i = 0; i < 5; i++) {
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          const refreshedAccount = await akahu.accounts.get(
-            userToken,
-            accountId,
-          );
-          if (
-            !shouldRefreshAccount(refreshedAccount?.refreshed?.transactions)
-          ) {
-            break;
-          }
-        }
       }
 
       const now = new Date();
@@ -282,6 +264,34 @@ app.post(
     }
   }),
 );
+
+async function getRefreshedAccount(
+  akahu: AkahuClient,
+  userToken: string,
+  accountId: string,
+): Promise<Account | null> {
+  let account = await akahu.accounts.get(userToken, accountId);
+  if (!account) {
+    return null;
+  } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
+    return account;
+  }
+
+  await akahu.accounts.refresh(userToken, accountId);
+
+  // wait for the refresh to complete
+  for (let i = 0; i < 5; i++) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    account = await akahu.accounts.get(userToken, accountId);
+    if (!account) {
+      return null;
+    } else if (!shouldRefreshAccount(account.refreshed?.transactions)) {
+      break;
+    }
+  }
+
+  return account;
+}
 
 function isEnriched(
   trans:

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -281,7 +281,7 @@ async function getRefreshedAccount(
 
   // wait for the refresh to complete
   for (let i = 0; i < 5; i++) {
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 3000));
     account = await akahu.accounts.get(userToken, accountId);
     if (!account) {
       return null;

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -154,16 +154,22 @@ app.post(
         });
       }
 
-      if (shouldRefreshAkahuTransactions(account.refreshed?.transactions)) {
+      if (shouldRefreshAccount(account.refreshed?.transactions)) {
         await akahu.accounts.refresh(userToken, accountId);
 
         // wait for the refresh to complete
         for (let i = 0; i < 5; i++) {
           await new Promise(resolve => setTimeout(resolve, 1000));
           account = await akahu.accounts.get(userToken, accountId);
-          if (
-            !shouldRefreshAkahuTransactions(account.refreshed?.transactions)
-          ) {
+          if (!account) {
+            return res.send({
+              status: 'error',
+              data: {
+                error: 'Account not found',
+              },
+            });
+          }
+          if (!shouldRefreshAccount(account.refreshed?.transactions)) {
             break;
           }
         }
@@ -357,7 +363,7 @@ function processTransaction(
 
 const AKAHU_TRANSACTION_REFRESH_INTERVAL_MS = 30 * 60 * 1000;
 
-function shouldRefreshAkahuTransactions(refreshedAt?: string) {
+function shouldRefreshAccount(refreshedAt?: string) {
   if (!refreshedAt) {
     return false;
   }

--- a/packages/sync-server/src/app-akahu/app-akahu.ts
+++ b/packages/sync-server/src/app-akahu/app-akahu.ts
@@ -135,7 +135,7 @@ app.post(
     try {
       const akahu = new AkahuClient({ appToken });
 
-      let account = await akahu.accounts.get(userToken, accountId);
+      const account = await akahu.accounts.get(userToken, accountId);
       if (!account) {
         return res.send({
           status: 'error',
@@ -160,16 +160,13 @@ app.post(
         // wait for the refresh to complete
         for (let i = 0; i < 5; i++) {
           await new Promise(resolve => setTimeout(resolve, 1000));
-          account = await akahu.accounts.get(userToken, accountId);
-          if (!account) {
-            return res.send({
-              status: 'error',
-              data: {
-                error: 'Account not found',
-              },
-            });
-          }
-          if (!shouldRefreshAccount(account.refreshed?.transactions)) {
+          const refreshedAccount = await akahu.accounts.get(
+            userToken,
+            accountId,
+          );
+          if (
+            !shouldRefreshAccount(refreshedAccount?.refreshed?.transactions)
+          ) {
             break;
           }
         }

--- a/packages/sync-server/src/util/mutex.ts
+++ b/packages/sync-server/src/util/mutex.ts
@@ -1,0 +1,14 @@
+export const createMutex = (): (<A>(
+  operation: () => Promise<A>,
+) => Promise<A>) => {
+  let mutex = Promise.resolve();
+
+  return <A>(operation: () => Promise<A>) =>
+    new Promise<A>((resolve, reject) => {
+      mutex = mutex.finally(() => {
+        try {
+          return operation().then(resolve, reject);
+        } catch {}
+      });
+    });
+};

--- a/upcoming-release-notes/akahu-refresh.md
+++ b/upcoming-release-notes/akahu-refresh.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tim-smart]
+---
+
+Refresh akahu account if stale

--- a/upcoming-release-notes/akahu-refresh.md
+++ b/upcoming-release-notes/akahu-refresh.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [tim-smart]
 ---
 
-Refresh akahu account if stale
+Refresh Akahu account if stale


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

If an Akahu account is stale (60 minute cutoff), then trigger a refresh to ensure the data is recent.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->
