### PR TITLE
[AI] Fix CLI server version without open budget

### DIFF
--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -27,7 +27,6 @@ describe('API handlers', () => {
       await expect(handlers['api/get-server-version']()).resolves.toEqual({
         version: '26.6.0',
       });
-      expect(handlers['get-server-version']).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -14,6 +14,23 @@ vi.mock('#shared/errors', () => ({
 describe('API handlers', () => {
   const handlers = installAPI({} as unknown as ServerHandlers);
 
+  describe('api/get-server-version', () => {
+    beforeEach(() => {
+      prefs.unloadPrefs();
+    });
+
+    it('does not require an open budget', async () => {
+      handlers['get-server-version'] = vi
+        .fn()
+        .mockResolvedValue({ version: '26.6.0' });
+
+      await expect(handlers['api/get-server-version']()).resolves.toEqual({
+        version: '26.6.0',
+      });
+      expect(handlers['get-server-version']).toHaveBeenCalledOnce();
+    });
+  });
+
   describe('api/bank-sync', () => {
     it('should sync a single account when accountId is provided', async () => {
       handlers['accounts-bank-sync'] = vi

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -1057,7 +1057,6 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
 };
 
 handlers['api/get-server-version'] = async function () {
-  checkFileOpen();
   return handlers['get-server-version']();
 };
 

--- a/upcoming-release-notes/cli-server-version-open-budget.md
+++ b/upcoming-release-notes/cli-server-version-open-budget.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [tifandotme]
+---
+
+Fix `actual server version` so it works without an open budget.


### PR DESCRIPTION
## Description

Fix `actual server version` so it can run without an open budget.

The CLI already marks this command with `skipBudget: true`, but the API handler still called `checkFileOpen()`. That caused the command to fail with `No budget file is open` before it could fetch the server version.

This removes the budget check from `api/get-server-version` and adds a regression test.

AI assistance was used to diagnose and prepare this change.

## Testing

- `corepack yarn workspace @actual-app/core exec vitest run src/server/api.test.ts`
- `corepack yarn workspace @actual-app/core typecheck`
- `corepack yarn lint`

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (-19 B) | -0.00%
api | 2 | 3.87 MB → 3.87 MB (-18 B) | -0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (-19 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📉 -19 B (-0.08%) | 23.53 kB → 23.51 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.COd5U_ND.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (-18 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📉 -18 B (-0.08%) | 22.9 kB → 22.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (-18 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->