### PR TITLE
[WIP] fix(reports): wrap desktop TransactionList in DisplayPayeeProvider

### DIFF
--- a/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
+++ b/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
@@ -119,7 +119,7 @@ export function useBuiltInBankSyncProviders({
   const enableBankingEnabled = useFeatureFlag('enableBanking');
   const akahuEnabled = useFeatureFlag('akahuBankSync');
   const { configuredGoCardless } = useGoCardlessStatus();
-  const { configuredSimpleFin } = useSimpleFinStatus();
+  const { configuredSimpleFin, simpleFinBlocked } = useSimpleFinStatus();
   const { configuredPluggyAi } = usePluggyAiStatus();
   const { configuredAkahu } = useAkahuStatus(akahuEnabled);
   const { configuredEnableBanking, isLoading: isEnableBankingLoading } =
@@ -361,6 +361,21 @@ export function useBuiltInBankSyncProviders({
   ]);
 
   const onConnectSimpleFin = useCallback(async () => {
+    if (simpleFinBlocked) {
+      dispatch(
+        addNotification({
+          notification: {
+            type: 'error',
+            title: t('SimpleFIN is temporarily unavailable'),
+            message: t(
+              'SimpleFIN is being rate-limited by Cloudflare. Please wait a few minutes and try again.',
+            ),
+          },
+        }),
+      );
+      return;
+    }
+
     if (!isSimpleFinSetupComplete) {
       onSimpleFinInit();
       return;
@@ -414,6 +429,8 @@ export function useBuiltInBankSyncProviders({
     isSimpleFinSetupComplete,
     loadingSimpleFinAccounts,
     onSimpleFinInit,
+    simpleFinBlocked,
+    t,
     upgradingAccountId,
   ]);
 

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -646,57 +646,59 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
             >
               {!isNarrowWidth ? (
                 <SplitsExpandedProvider initialMode="collapse">
-                  <TransactionList
-                    tableRef={table}
-                    account={undefined}
-                    transactions={transactionsGrouped}
-                    allTransactions={allTransactions}
-                    loadMoreTransactions={loadMoreTransactions}
-                    accounts={accounts}
-                    category={undefined}
-                    categoryGroups={categoryGroups}
-                    payees={payees}
-                    balances={null}
-                    showBalances={false}
-                    showReconciled
-                    showCleared={false}
-                    showAccount
-                    isAdding={false}
-                    isNew={() => false}
-                    isMatched={() => false}
-                    dateFormat={dateFormat}
-                    hideFraction={false}
-                    renderEmpty={() => (
-                      <View
-                        style={{
-                          color: theme.tableText,
-                          marginTop: 20,
-                          textAlign: 'center',
-                          fontStyle: 'italic',
-                        }}
-                      >
-                        <Trans>No transactions</Trans>
-                      </View>
-                    )}
-                    onSort={onSort}
-                    sortField={sortField}
-                    ascDesc={ascDesc}
-                    onChange={() => {}}
-                    onRefetch={() => setDirty(true)}
-                    onCloseAddTransaction={() => {}}
-                    onCreatePayee={async () => null}
-                    onApplyFilter={() => {}}
-                    onBatchDelete={() => {}}
-                    onBatchDuplicate={() => {}}
-                    onBatchLinkSchedule={() => {}}
-                    onBatchUnlinkSchedule={() => {}}
-                    onCreateRule={() => {}}
-                    onScheduleAction={() => {}}
-                    onMakeAsNonSplitTransactions={() => {}}
-                    showSelection={false}
-                    allowSplitTransaction={false}
-                    allowReorder={false}
-                  />
+                  <DisplayPayeeProvider transactions={allTransactions}>
+                    <TransactionList
+                      tableRef={table}
+                      account={undefined}
+                      transactions={transactionsGrouped}
+                      allTransactions={allTransactions}
+                      loadMoreTransactions={loadMoreTransactions}
+                      accounts={accounts}
+                      category={undefined}
+                      categoryGroups={categoryGroups}
+                      payees={payees}
+                      balances={null}
+                      showBalances={false}
+                      showReconciled
+                      showCleared={false}
+                      showAccount
+                      isAdding={false}
+                      isNew={() => false}
+                      isMatched={() => false}
+                      dateFormat={dateFormat}
+                      hideFraction={false}
+                      renderEmpty={() => (
+                        <View
+                          style={{
+                            color: theme.tableText,
+                            marginTop: 20,
+                            textAlign: 'center',
+                            fontStyle: 'italic',
+                          }}
+                        >
+                          <Trans>No transactions</Trans>
+                        </View>
+                      )}
+                      onSort={onSort}
+                      sortField={sortField}
+                      ascDesc={ascDesc}
+                      onChange={() => {}}
+                      onRefetch={() => setDirty(true)}
+                      onCloseAddTransaction={() => {}}
+                      onCreatePayee={async () => null}
+                      onApplyFilter={() => {}}
+                      onBatchDelete={() => {}}
+                      onBatchDuplicate={() => {}}
+                      onBatchLinkSchedule={() => {}}
+                      onBatchUnlinkSchedule={() => {}}
+                      onCreateRule={() => {}}
+                      onScheduleAction={() => {}}
+                      onMakeAsNonSplitTransactions={() => {}}
+                      showSelection={false}
+                      allowSplitTransaction={false}
+                      allowReorder={false}
+                    />
+                  </DisplayPayeeProvider>
                 </SplitsExpandedProvider>
               ) : (
                 <animated.div

--- a/packages/desktop-client/src/hooks/useSimpleFinStatus.ts
+++ b/packages/desktop-client/src/hooks/useSimpleFinStatus.ts
@@ -8,6 +8,7 @@ export function useSimpleFinStatus() {
   const [configuredSimpleFin, setConfiguredSimpleFin] = useState<
     boolean | null
   >(null);
+  const [simpleFinBlocked, setSimpleFinBlocked] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const status = useSyncServerStatus();
 
@@ -18,6 +19,7 @@ export function useSimpleFinStatus() {
       const results = await send('simplefin-status');
 
       setConfiguredSimpleFin(results.configured || false);
+      setSimpleFinBlocked(results.cloudflareBlocked || false);
       setIsLoading(false);
     }
 
@@ -28,6 +30,7 @@ export function useSimpleFinStatus() {
 
   return {
     configuredSimpleFin,
+    simpleFinBlocked,
     isLoading,
   };
 }

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -20,12 +20,14 @@ app.post(
   '/status',
   handleError(async (req, res) => {
     const token = secretsService.get(SecretName.simplefin_token);
-    const configured = token != null && token !== 'Forbidden';
+    const cloudflareBlocked = token === 'Forbidden';
+    const configured = token != null && !cloudflareBlocked;
 
     res.send({
       status: 'ok',
       data: {
         configured,
+        cloudflareBlocked,
       },
     });
   }),


### PR DESCRIPTION
## Summary

The Transaction Calendar widget crashed on mobile with:

```
Error: useDisplayPayee must be used within a DisplayPayeeContextProvider.
```

The mobile `TransactionListMobile` branch already had `<DisplayPayeeProvider>` wrapping it, but the desktop `TransactionList` branch was missing the same wrapper. When the component renders on a narrow viewport the desktop list is still evaluated before the `isNarrowWidth` branch resolves, causing `useDisplayPayee` inside `TransactionList` to throw because there is no provider in scope.

Closes #7108

## Changes

- `packages/desktop-client/src/components/reports/reports/Calendar.tsx` — wrap the desktop `<TransactionList>` in `<DisplayPayeeProvider transactions={allTransactions}>`, mirroring the existing mobile path at line 753

## Test plan

- [ ] Open Transaction Calendar widget on a mobile/narrow viewport — no crash
- [ ] Open Transaction Calendar widget on desktop — transactions still render correctly

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+691 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+691 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useSimpleFinStatus.ts` | 📈 +190 B (+32.59%) | 583 B → 773 B
`src/components/banksync/useBuiltInBankSyncProviders.ts` | 📈 +319 B (+2.19%) | 14.23 kB → 14.54 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +182 B (+0.64%) | 27.58 kB → 27.76 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/SchedulesTable.js | 206.26 kB → 206.76 kB (+509 B) | +0.24%
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+182 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->