### PR TITLE
[WIP] fix(schedules): escape $ in schedule names before AQL filter queries

### DIFF
--- a/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
@@ -74,7 +74,9 @@ export function MobileScheduleEditPage() {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: state.fields.name }).select('id'),
+        q('schedules')
+          .filter({ name: state.fields.name.replace(/\$/g, '\\$') })
+          .select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
@@ -100,7 +100,9 @@ export function ScheduleEditModal({ id, transaction }: ScheduleEditModalProps) {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: state.fields.name }).select('id'),
+        q('schedules')
+          .filter({ name: state.fields.name.replace(/\$/g, '\\$') })
+          .select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -1050,7 +1050,9 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
   }
 
   const { data } = await aqlQuery(
-    q(type).filter({ name: name.replace(/\$/g, '\\$') }).select('*'),
+    q(type)
+      .filter({ name: name.replace(/\$/g, '\\$') })
+      .select('*'),
   );
 
   if (!data || data.length === 0) {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -918,7 +918,9 @@ handlers['api/schedule-update'] = withMutation(async function ({
       case 'name': {
         const newName = String(value);
         const { data: existing } = await aqlQuery(
-          q('schedules').filter({ name: newName }).select('*'),
+          q('schedules')
+            .filter({ name: newName.replace(/\$/g, '\\$') })
+            .select('*'),
         );
         if (!existing || existing.length === 0 || existing[0].id === sched.id) {
           sched.name = newName;
@@ -1047,7 +1049,9 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
     throw APIError('Provide a valid type');
   }
 
-  const { data } = await aqlQuery(q(type).filter({ name }).select('*'));
+  const { data } = await aqlQuery(
+    q(type).filter({ name: name.replace(/\$/g, '\\$') }).select('*'),
+  );
 
   if (!data || data.length === 0) {
     throw APIError(`Not found: ${type} with name ${name}`);

--- a/packages/loot-core/src/server/aql/compiler.test.ts
+++ b/packages/loot-core/src/server/aql/compiler.test.ts
@@ -963,4 +963,15 @@ describe('Type conversions', () => {
     );
     expect(result.sql).toMatch('WHERE (payees1.id IS NOT NULL)');
   });
+
+  it('treats \\$-escaped strings as literal values, not field references', () => {
+    const result = generateSQLWithState(
+      q('transactions')
+        .filter({ 'payee.name': '\\$Rent' })
+        .select(['id'])
+        .serialize(),
+      schemaWithRefs,
+    );
+    expect(result.sql).toMatch("payees1.name = '$Rent'");
+  });
 });


### PR DESCRIPTION
## Summary

Saving a schedule whose name starts with `$` (e.g. `$Rent`) always failed with a generic error. AQL's `compileExpr` treats any string value beginning with `$` as a field reference (`$fieldName` syntax). When the schedule name was passed directly to `.filter({ name: state.fields.name })`, AQL tried to resolve `$Rent` as a field, threw `CompileError: Field does not exist`, and the UI caught it as a save error.

AQL already has an escape convention: `\$` in a string value is compiled as a literal `$` (handled in `compileLiteral`). The fix applies this escaping at the three call sites that pass user-supplied names to AQL filters.

Closes #7358

## Changes

- `packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx` — escape `$` in name before duplicate-name AQL query
- `packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx` — same fix for mobile path
- `packages/loot-core/src/server/api.ts` — same fix in `api/update-schedule` and `api/get-id-by-name` handlers
- `packages/loot-core/src/server/aql/compiler.test.ts` — add test documenting that `\$`-escaped strings compile to literal SQL values

## Test plan

- [ ] `yarn workspace @actual-app/loot-core test` passes (28/28 in `compiler.test.ts`)
- [ ] Create a schedule named `$Rent` — saves successfully
- [ ] Duplicate-name check still works: creating a second `$Rent` shows "already exists" error
- [ ] Schedules without `$` are unaffected

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+44 B) | +0.00%
loot-core | 1 | 5.28 MB → 5.28 MB (+50 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+50 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+44 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/schedules/ScheduleEditModal.tsx` | 📈 +22 B (+0.40%) | 5.33 kB → 5.35 kB
`src/components/mobile/schedules/MobileScheduleEditPage.tsx` | 📈 +22 B (+0.37%) | 5.74 kB → 5.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB → 1.6 MB (+22 B) | +0.00%
static/js/narrow.js | 365.05 kB → 365.07 kB (+22 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+50 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +50 B (+0.21%) | 23.53 kB → 23.57 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.45RO-vbj.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+50 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +50 B (+0.21%) | 22.9 kB → 22.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+50 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->