### PR TITLE
[WIP] fix(reports): skip unsupported category ops in spending budget filter

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts
@@ -68,11 +68,18 @@ export function createSpendingSpreadsheet({
       conditions: conditions.filter(cond => !cond.customName),
     });
 
+    // Only pass category conditions whose ops generate direct ID comparisons
+    // (is/isNot/oneOf/notOneOf). Ops like contains/doesNotContain/matches
+    // append '.name' to the field path, which zero_budgets/reflect_budgets
+    // cannot resolve (those tables have no category join).
     const { filters: budgetFilters } = await send(
       'make-filters-from-conditions',
       {
         conditions: conditions.filter(
-          cond => !cond.customName && cond.field === 'category',
+          cond =>
+            !cond.customName &&
+            cond.field === 'category' &&
+            ['is', 'isNot', 'oneOf', 'notOneOf'].includes(cond.op),
         ),
         applySpecialCases: false,
       },
@@ -169,9 +176,11 @@ export function createSpendingSpreadsheet({
           .filter({
             $and: [{ month: { $eq: budgetMonth } }],
           })
-          .filter({
-            [conditionsOpKey]: budgetFilters,
-          })
+          .filter(
+            budgetFilters.length > 0
+              ? { [conditionsOpKey]: budgetFilters }
+              : {},
+          )
           .groupBy([{ $id: '$category' }])
           .select([
             { category: { $id: '$category' } },


### PR DESCRIPTION
## Summary

The spending report crashes when a condition like **category doesNotContain X** is applied. `createSpendingSpreadsheet` passes category conditions directly to the `zero_budgets`/`reflect_budgets` budget query. Operators like `doesNotContain`, `contains`, and `matches` on `id`-type fields append `.name` to the field path (e.g. `category.name`), requiring a join through the `categories` table. That join does not exist in the budget tables, so the AQL query fails.

Two-part fix:
1. Restrict `budgetFilters` to ops that generate direct ID comparisons: `is`, `isNot`, `oneOf`, `notOneOf`. These produce `{ category: { $eq: uuid } }` style filters that work on the budget table directly. Name-based ops are skipped (the budget total is unfiltered by category name in that case, which is a graceful degradation vs. a crash).
2. Guard the `.filter()` call so an empty `budgetFilters` array never generates `.filter({ $and: [] })`.

Closes #7897

## Changes

- `packages/desktop-client/src/components/reports/spreadsheets/spending-spreadsheet.ts` — filter `budgetFilters` conditions to direct-ID ops only; guard against empty filter array

## Test plan

- [ ] Add a spending report condition `category doesNotContain Rent` — report renders without crashing
- [ ] Add a spending report condition `category is <some category>` — budget line still filters correctly to that category
- [ ] No conditions — report renders normally

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+111 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+111 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📈 +111 B (+1.67%) | 6.49 kB → 6.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+111 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->