### PR TITLE
fix(reports): parse hsl() colors in donut chart outer ring shading

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -78,13 +78,14 @@ const hslToRgb = (
   s: number,
   l: number,
 ): { r: number; g: number; b: number } => {
+  const normalizedHue = ((h % 360) + 360) % 360;
   if (s === 0) {
     const v = Math.round(l * 255);
     return { r: v, g: v, b: v };
   }
   const hue2rgb = (p: number, q: number, t: number) => {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
+    while (t < 0) t += 1;
+    while (t > 1) t -= 1;
     if (t < 1 / 6) return p + (q - p) * 6 * t;
     if (t < 0.5) return q;
     if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
@@ -93,16 +94,16 @@ const hslToRgb = (
   const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
   const p = 2 * l - q;
   return {
-    r: Math.round(hue2rgb(p, q, h / 360 + 1 / 3) * 255),
-    g: Math.round(hue2rgb(p, q, h / 360) * 255),
-    b: Math.round(hue2rgb(p, q, h / 360 - 1 / 3) * 255),
+    r: Math.round(hue2rgb(p, q, normalizedHue / 360 + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, normalizedHue / 360) * 255),
+    b: Math.round(hue2rgb(p, q, normalizedHue / 360 - 1 / 3) * 255),
   };
 };
 
 const hexToRgb = (color: string): { r: number; g: number; b: number } => {
   // Support hsl(h, s%, l%) and hsl(h s% l%) (with or without commas)
   const hslMatch = color.match(
-    /^hsla?\(\s*(\d+(?:\.\d+)?)\s*[,\s]\s*(\d+(?:\.\d+)?)%\s*[,\s]\s*(\d+(?:\.\d+)?)%/i,
+    /^hsla?\(\s*([+-]?\d+(?:\.\d+)?)\s*[,\s]\s*(\d+(?:\.\d+)?)%\s*[,\s]\s*(\d+(?:\.\d+)?)%/i,
   );
   if (hslMatch) {
     return hslToRgb(

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -73,8 +73,45 @@ const resolveCSSVariable = (color: string): string => {
     .trim();
 };
 
-const hexToRgb = (hex: string) => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+const hslToRgb = (
+  h: number,
+  s: number,
+  l: number,
+): { r: number; g: number; b: number } => {
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return { r: v, g: v, b: v };
+  }
+  const hue2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 0.5) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return {
+    r: Math.round(hue2rgb(p, q, h / 360 + 1 / 3) * 255),
+    g: Math.round(hue2rgb(p, q, h / 360) * 255),
+    b: Math.round(hue2rgb(p, q, h / 360 - 1 / 3) * 255),
+  };
+};
+
+const hexToRgb = (color: string): { r: number; g: number; b: number } => {
+  // Support hsl(h, s%, l%) and hsl(h s% l%) (with or without commas)
+  const hslMatch = color.match(
+    /^hsla?\(\s*(\d+(?:\.\d+)?)\s*[,\s]\s*(\d+(?:\.\d+)?)%\s*[,\s]\s*(\d+(?:\.\d+)?)%/i,
+  );
+  if (hslMatch) {
+    return hslToRgb(
+      parseFloat(hslMatch[1]),
+      parseFloat(hslMatch[2]) / 100,
+      parseFloat(hslMatch[3]) / 100,
+    );
+  }
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(color);
   return result
     ? {
         r: parseInt(result[1], 16),

--- a/upcoming-release-notes/7820.md
+++ b/upcoming-release-notes/7820.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [64johnlee]
+---
+
+Fix donut chart outer ring rendering black when group colors use `hsl()` syntax


### PR DESCRIPTION
## Summary

When report colors are set using `hsl(...)` syntax, the outer (group) rings of the concentric donut chart render solid black. The root cause is in `hexToRgb`: its regex only matches `#rrggbb` hex strings. For any other format it returns `{r:0, g:0, b:0}`, so `shadeColor` produces a shade of black regardless of the actual color.

The fix adds an `hslToRgb` helper (standard HSL→RGB algorithm) and extends `hexToRgb` to detect and parse both comma-separated `hsl(h, s%, l%)` and space-separated `hsl(h s% l%)` / `hsla(...)` before falling through to hex parsing. Hex colors and CSS-variable-resolved colors are unaffected.

Closes #7820

## Changes

- `packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx` — add `hslToRgb`; update `hexToRgb` to parse HSL/HSLA strings

## Test plan

- [ ] Set a category group color to `hsl(200, 60%, 45%)` and open a donut report in CategoryGroup mode — outer ring renders in the correct color, not black
- [ ] Hex colors (`#3498db`) still shade correctly
- [ ] CSS variable colors still shade correctly

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+914 B) | +0.01%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+914 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +914 B (+3.91%) | 22.82 kB → 23.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+914 B) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->