### PR TITLE
fix(reports): show correct tooltip entries in compact widget mode

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -104,10 +104,10 @@ const CustomTooltip = ({
             <strong>{payload[0].payload.date}</strong>
           </div>
           <div style={{ lineHeight: 1.5 }}>
-            {items.map((p: PayloadItem, index: number) => {
-              const displayName = dataKeyToName.get(p.dataKey) ?? p.dataKey;
-              return (
-                (compact ? index < 4 : true) && (
+            {(compact ? items.slice(0, 5) : items).map(
+              (p: PayloadItem, index: number) => {
+                const displayName = dataKeyToName.get(p.dataKey) ?? p.dataKey;
+                return (
                   <AlignedText
                     key={index}
                     left={displayName}
@@ -122,10 +122,10 @@ const CustomTooltip = ({
                         tooltip === p.dataKey ? 'underline' : 'inherit',
                     }}
                   />
-                )
-              );
-            })}
-            {payload.length > 5 && compact && '...'}
+                );
+              },
+            )}
+            {compact && items.length > 5 && '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -107,29 +107,31 @@ const CustomTooltip = ({
             <strong>{label}</strong>
           </div>
           <div style={{ lineHeight: 1.4 }}>
-            {items.map((pay, i) => {
+            {(compact
+              ? items.filter(pay => pay.value !== 0).slice(0, 5)
+              : items.filter(pay => pay.value !== 0)
+            ).map(pay => {
               const displayName = dataKeyToName.get(pay.name) ?? pay.name;
               return (
-                pay.value !== 0 &&
-                (compact ? i < 5 : true) && (
-                  <AlignedText
-                    key={pay.name}
-                    left={displayName}
-                    right={
-                      <FinancialText>
-                        {format(pay.value, 'financial')}
-                      </FinancialText>
-                    }
-                    style={{
-                      color: pay.color,
-                      textDecoration:
-                        tooltip === pay.name ? 'underline' : 'inherit',
-                    }}
-                  />
-                )
+                <AlignedText
+                  key={pay.name}
+                  left={displayName}
+                  right={
+                    <FinancialText>
+                      {format(pay.value, 'financial')}
+                    </FinancialText>
+                  }
+                  style={{
+                    color: pay.color,
+                    textDecoration:
+                      tooltip === pay.name ? 'underline' : 'inherit',
+                  }}
+                />
               );
             })}
-            {payload.length > 5 && compact && '...'}
+            {compact &&
+              items.filter(pay => pay.value !== 0).length > 5 &&
+              '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/upcoming-release-notes/7297.md
+++ b/upcoming-release-notes/7297.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [64johnlee]
+---
+
+Fix compact widget tooltips showing wrong number of entries when some categories have zero values


### PR DESCRIPTION
## Summary

In compact mode (dashboard widgets), the stacked-bar and line graph tooltips limited visible entries using the raw payload array index (`i < 5`). Zero-value items consume index slots without rendering, so the number of visible categories varied randomly month-to-month — sometimes showing zero entries even when non-zero categories existed at higher indices.

Fix: filter to non-zero items first, then slice to the 5-item cap. The `"..."` overflow indicator is now keyed on the count of non-zero items rather than total payload length. LineGraph's compact limit is also unified to 5 (was 4) to be consistent with StackedBarGraph.

Closes #7297

## Changes

- `StackedBarGraph.tsx` — filter zero-value payload entries before the compact 5-item slice; fix `"..."` threshold to count non-zero items
- `LineGraph.tsx` — same slice/threshold fix; unify compact limit from 4 → 5

## Test plan

- [ ] Create a custom report: stacked bar, split by category, ≥ 6 categories, monthly interval
- [ ] Add as dashboard widget; hover bars — tooltip should show up to 5 categories consistently across all months
- [ ] Same report in full view — tooltip unchanged (all categories shown)
- [ ] Line graph widget with ≥ 6 series — tooltip shows up to 5 with `"..."` indicator

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+274 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+274 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/StackedBarGraph.tsx` | 📈 +254 B (+2.52%) | 9.84 kB → 10.09 kB
`src/components/reports/graphs/LineGraph.tsx` | 📈 +18 B (+0.18%) | 9.89 kB → 9.91 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +2 B (+0.01%) | 27.58 kB → 27.59 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+274 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->