### PR TITLE
[AI] update contributor guidelines for AI usage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@
 
 <!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->
 
+<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->
+
 ## Related issue(s)
 
 <!-- e.g. Fixes #123, Relates to #456 -->
@@ -16,6 +18,6 @@
 
 - [ ] Release notes added (see link above)
 - [ ] No obvious regressions in affected areas
-- [ ] Self-review has been performed - I understand what each change in the code does and why it is needed
+- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
 
 <!--- actual-bot-sections --->

--- a/.github/workflows/fork-pr-welcome.yml
+++ b/.github/workflows/fork-pr-welcome.yml
@@ -45,6 +45,14 @@ jobs:
             - ✅ The "[WIP]" prefix is removed from the PR title
             - ✅ All CodeRabbit code review comments are resolved (if you disagree with anything - reply to the bot with your reasoning so we can read through it). The bot will eventually approve the PR.
 
+            **Before you ask for a human review,** please reply on this PR with:
+
+            - 👀 Confirmation that you have read every line of your own diff and can explain *why* each change is needed. See ["You are responsible for what you submit"](https://actualbudget.org/docs/contributing/ai-usage-policy#you-are-responsible-for-what-you-submit).
+            - 🧪 In your own words, what you actually ran or tested, and what you observed.
+            - 🤖 If AI tools wrote a significant part of this change, please say so — see our [AI Usage Policy](https://actualbudget.org/docs/contributing/ai-usage-policy).
+
+            A quick note on volume: please get one PR reviewed and merged before opening several more. A stack of simultaneous, similar PRs from one author is reviewed slowly, and low-effort, untested, or undisclosed-AI PRs may be closed without a detailed review.
+
             We do this to reduce the TOIL the core contributor team has to go through for each PR and to allow for speedy reviews and merges.
 
             For more information, please see our [Contributing Guide](https://actualbudget.org/docs/contributing/).

--- a/.github/workflows/fork-pr-welcome.yml
+++ b/.github/workflows/fork-pr-welcome.yml
@@ -45,6 +45,7 @@ jobs:
             - ✅ The "[WIP]" prefix is removed from the PR title
             - ✅ The PR description follows the provided template, with all checklist boxes filled in
             - ✅ All CodeRabbit code review comments are resolved (if you disagree with anything - reply to the bot with your reasoning so we can read through it). The bot will eventually approve the PR.
+            - ✅ Any AI usage is disclosed (see our [AI Usage Policy](https://actualbudget.org/docs/contributing/ai-usage-policy))
 
             A quick note on volume: please get one PR reviewed and merged before opening several more. A stack of simultaneous, similar PRs from one author is reviewed slowly, and low-effort, untested, or undisclosed-AI PRs may be closed without a detailed review.
 

--- a/.github/workflows/fork-pr-welcome.yml
+++ b/.github/workflows/fork-pr-welcome.yml
@@ -43,13 +43,8 @@ jobs:
             - ✅ All CI checks pass
             - ✅ The PR is moved from draft to open (if applicable)
             - ✅ The "[WIP]" prefix is removed from the PR title
+            - ✅ The PR description follows the provided template, with all checklist boxes filled in
             - ✅ All CodeRabbit code review comments are resolved (if you disagree with anything - reply to the bot with your reasoning so we can read through it). The bot will eventually approve the PR.
-
-            **Before you ask for a human review,** please reply on this PR with:
-
-            - 👀 Confirmation that you have read every line of your own diff and can explain *why* each change is needed. See ["You are responsible for what you submit"](https://actualbudget.org/docs/contributing/ai-usage-policy#you-are-responsible-for-what-you-submit).
-            - 🧪 In your own words, what you actually ran or tested, and what you observed.
-            - 🤖 If AI tools wrote a significant part of this change, please say so — see our [AI Usage Policy](https://actualbudget.org/docs/contributing/ai-usage-policy).
 
             A quick note on volume: please get one PR reviewed and merged before opening several more. A stack of simultaneous, similar PRs from one author is reviewed slowly, and low-effort, untested, or undisclosed-AI PRs may be closed without a detailed review.
 

--- a/packages/docs/docs/contributing/ai-usage-policy.md
+++ b/packages/docs/docs/contributing/ai-usage-policy.md
@@ -35,6 +35,14 @@ If AI was used to generate a significant portion of an issue, PR, or the code it
 
 Issues and pull requests that appear to be AI-generated but do not disclose it may be closed without review. Contributors who repeatedly submit undisclosed AI content, or who ignore this policy, may be blocked from contributing.
 
+## Quality Over Quantity
+
+Modern AI tools make it easy to generate a large number of changes very quickly. Please resist the temptation to open many pull requests at once — for example, by pointing an AI tool at the codebase and submitting whatever it produces.
+
+A stack of simultaneous, similar pull requests from one author takes much longer for us to review than a single, well-tested change, and it is often a sign that the work has not been read or tested by a human. We would much rather receive one change that you understand and have verified than ten that you have not.
+
+A good rhythm is to open one pull request, work with us to get it reviewed and merged, and only then open the next one. Pull requests that are low-effort, untested, or undisclosed AI output may be closed without a detailed review, and authors who repeatedly submit them may be blocked from contributing.
+
 ## You are responsible for what you submit
 
 Before you open an issue or a PR, you should:

--- a/upcoming-release-notes/llm-pr-guardrails.md
+++ b/upcoming-release-notes/llm-pr-guardrails.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Surface the AI usage and self-review expectations to contributors when they open a pull request


### PR DESCRIPTION
Update some workflows for AI usage. To strengthen our case when we bulk-close Drive-by PRs that are clearly AI generated with no human oversight or reviews. 