### PR TITLE
[WIP] [AI] fix(export): populate payee for split children when filtered export excludes parent

### DIFF
--- a/packages/loot-core/src/server/transactions/export/export-to-csv.ts
+++ b/packages/loot-core/src/server/transactions/export/export-to-csv.ts
@@ -2,6 +2,7 @@
 import { stringify as csvStringify } from 'csv-stringify/sync';
 
 import { aqlQuery } from '#server/aql';
+import { q } from '#shared/query';
 import { integerToAmount } from '#shared/util';
 
 const FORMULA_TRIGGERS = /^[=+\-@\t\r]/;
@@ -88,6 +89,37 @@ export async function exportQueryToCSV(query) {
       .options({ splits: 'all' }),
   );
 
+  // Build a payee map from parent transactions present in the result set.
+  // When a category filter is active, parent transactions are not included
+  // by the filter (parents have no category), so children may have null
+  // payee even though their parent has one. For those cases, fetch the
+  // missing parents in a separate query.
+  const parentPayeeById = new Map(
+    transactions.filter(t => t.IsParent && t.Payee).map(t => [t.Id, t.Payee]),
+  );
+
+  const missingParentIds = [
+    ...new Set(
+      transactions
+        .filter(t => t.IsChild && !t.Payee && !parentPayeeById.has(t.ParentId))
+        .map(t => t.ParentId),
+    ),
+  ];
+
+  if (missingParentIds.length > 0) {
+    const { data: parents } = await aqlQuery(
+      q('transactions')
+        .filter({ id: { $oneof: missingParentIds } })
+        .select([{ Id: 'id' }, { Payee: 'payee.name' }])
+        .options({ splits: 'all' }),
+    );
+    for (const parent of parents) {
+      if (parent.Payee) {
+        parentPayeeById.set(parent.Id, parent.Payee);
+      }
+    }
+  }
+
   // initialize a map to allow splits to have correct number of split from
   const parentsChildCount: Map<number, number> = new Map();
   const childSplitOrder: Map<number, number> = new Map();
@@ -107,7 +139,7 @@ export async function exportQueryToCSV(query) {
     return {
       Account: trans.Account,
       Date: trans.Date,
-      Payee: trans.Payee,
+      Payee: trans.Payee ?? parentPayeeById.get(trans.ParentId) ?? null,
       Notes: trans.IsParent
         ? '(SPLIT INTO ' +
           parentsChildCount.get(trans.Id) +

--- a/upcoming-release-notes/2219.md
+++ b/upcoming-release-notes/2219.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [64johnlee]
 ---
 
-Fix split transaction children missing payee in CSV export when parent is excluded by account filter
+Fix split transaction children missing payee in CSV export when parent is excluded by category filter

--- a/upcoming-release-notes/2219.md
+++ b/upcoming-release-notes/2219.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [64johnlee]
+---
+
+Fix split transaction children missing payee in CSV export when parent is excluded by account filter


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+634 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+632 B) | +0.02%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 172.1 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.14 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+634 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/export/export-to-csv.ts` | 📈 +634 B (+22.07%) | 2.81 kB → 3.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bvd8IfyX.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.lfNBY2TT.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+632 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/export/export-to-csv.ts` | 📈 +632 B (+22.47%) | 2.75 kB → 3.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+632 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->