### PR TITLE
[AI] Drop ACTIONS_UPDATE_TOKEN from release workflows

### DIFF
--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -24,13 +24,14 @@ jobs:
     if: github.repository_owner == 'actualbudget'
     runs-on: ubuntu-latest
     environment: release
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
           fetch-depth: 0
-          token: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           persist-credentials: true
 
       - name: Set up environment
@@ -54,8 +55,6 @@ jobs:
 
       - name: Determine previous tag
         id: prev_tag
-        env:
-          GH_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN || github.token }}
         run: |
           prev_tag=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name' 2>/dev/null) || prev_tag=""
           echo "tag=${prev_tag:-master}" >> "$GITHUB_OUTPUT"
@@ -75,7 +74,6 @@ jobs:
 
       - name: Validate target version
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           TYPE: ${{ steps.version.outputs.type }}
         shell: bash
@@ -106,7 +104,6 @@ jobs:
       - name: Open release-notes branch and PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           commit-message: '🔖 (${{ steps.version.outputs.version }})'
           title: '🔖 (${{ steps.version.outputs.version }})'
           body: |
@@ -120,7 +117,6 @@ jobs:
 
       - name: Update release branch
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
           TYPE: ${{ steps.version.outputs.type }}
         shell: bash

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - release
+  workflow_run: # zizmor: ignore[dangerous-triggers]
+    workflows: ['Cut release branch']
+    types:
+      - completed
+    branches: [master]
 
 permissions: {}
 
@@ -67,7 +72,10 @@ jobs:
         uses: ./.github/actions/release-notes/check
 
   generate-release-notes:
-    if: github.event_name == 'push'
+    if: >-
+      github.event_name == 'push'
+      || (github.event_name == 'workflow_run'
+          && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -77,7 +85,7 @@ jobs:
       - name: Resolve version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.ACTIONS_UPDATE_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           version=$(gh api "repos/${GITHUB_REPOSITORY}/contents/packages/desktop-client/package.json?ref=release" --jq '.content' | base64 -d | jq -r .version)
           echo "version=$version" >> "$GITHUB_OUTPUT"
@@ -88,7 +96,6 @@ jobs:
         with:
           ref: ${{ steps.version.outputs.notes_branch }}
           fetch-depth: 0
-          token: ${{ secrets.ACTIONS_UPDATE_TOKEN || github.token }}
           persist-credentials: true
 
       - name: Generate release notes

--- a/upcoming-release-notes/8142.md
+++ b/upcoming-release-notes/8142.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Drop the `ACTIONS_UPDATE_TOKEN` PAT from the release workflows, chaining `release-notes` off `cut-release-branch` via `workflow_run` and using the built-in `GITHUB_TOKEN` instead.

--- a/upcoming-release-notes/8142.md
+++ b/upcoming-release-notes/8142.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MatissJanis]
 ---
 
-Drop the `ACTIONS_UPDATE_TOKEN` PAT from the release workflows, chaining `release-notes` off `cut-release-branch` via `workflow_run` and using the built-in `GITHUB_TOKEN` instead.
+Drop the `ACTIONS_UPDATE_TOKEN` PAT from the release workflows.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Removing `ACTIONS_UPDATE_TOKEN` env var usage from a few workflows. I don't think it is necessary anymore; we can find a different solution to achieve the same.

Spoilers: I have not fully tested this (testing gh actions is a pain..), but I _think_ it should work.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I understand what each change in the code does and why it is needed

<!--- actual-bot-sections --->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
