### PR TITLE
[AI] Add missing widget types to dashboard import validation

### DIFF
--- a/packages/loot-core/src/server/dashboard/app.test.ts
+++ b/packages/loot-core/src/server/dashboard/app.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DashboardWidgetEntity } from '#types/models';
+
+import { isWidgetType } from './app';
+
+function allWidgetTypes<T extends DashboardWidgetEntity['type'][]>(
+  ...types: T &
+    (DashboardWidgetEntity['type'] extends T[number] ? unknown : never)
+): T {
+  return types;
+}
+
+const ALL_WIDGET_TYPES = allWidgetTypes(
+  'net-worth-card',
+  'cash-flow-card',
+  'spending-card',
+  'crossover-card',
+  'budget-analysis-card',
+  'markdown-card',
+  'summary-card',
+  'calendar-card',
+  'formula-card',
+  'custom-report',
+  'sankey-card',
+  'balance-forecast-card',
+  'age-of-money-card',
+);
+
+describe('isWidgetType', () => {
+  it('all known widget types should be recognized', () => {
+    for (const type of ALL_WIDGET_TYPES) {
+      expect(isWidgetType(type)).toBe(true);
+    }
+  });
+
+  it('unknown widget types should be rejected', () => {
+    expect(isWidgetType('unknown-card')).toBe(false);
+  });
+});

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -28,7 +28,9 @@ function isExportedCustomReportWidget(
   return widget.type === 'custom-report';
 }
 
-function isWidgetType(type: string): type is DashboardWidgetEntity['type'] {
+export function isWidgetType(
+  type: string,
+): type is DashboardWidgetEntity['type'] {
   return [
     'net-worth-card',
     'cash-flow-card',
@@ -41,6 +43,8 @@ function isWidgetType(type: string): type is DashboardWidgetEntity['type'] {
     'formula-card',
     'custom-report',
     'sankey-card',
+    'balance-forecast-card',
+    'age-of-money-card',
   ].includes(type);
 }
 

--- a/upcoming-release-notes/dashboard-import-all-widgets.md
+++ b/upcoming-release-notes/dashboard-import-all-widgets.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [samaluk]
+---
+
+Dashboard import now supports all widget types, including balance-forecast and age-of-money cards.


### PR DESCRIPTION
## Description

The isWidgetType() validation function in the dashboard import logic was missing two widget types that are fully defined in the TypeScript type system and rendered in the UI: balance-forecast-card and age-of-money-card. This meant exporting a dashboard containing these widgets and re-importing it would fail validation with "Invalid widget type".
This PR adds both missing types to the validation list and introduces a regression test that verifies all 13 known widget types pass validation — ensuring future additions to the SpecializedWidget union don't get silently missed.
AI tools (OpenCode, Deepseek V4 Flash) assisted with writing the test scaffolding and release notes, under human direction.

## Related issue(s)

N/A

## Testing

- Added packages/loot-core/src/server/dashboard/app.test.ts with 2 tests:
- All 13 known widget types are accepted by isWidgetType()
- Unknown types are correctly rejected
- Ran yarn test — 2/2 passed
- Ran yarn lint:fix — 0 errors
- Ran yarn typecheck — all relevant packages pass (core, web, api)

## Checklist

- [x] Release notes added (see upcoming-release-notes/dashboard-import-all-widgets.md)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+52 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+50 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.26 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 173.68 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+52 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +52 B (+0.68%) | 7.44 kB → 7.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D_lQN6qp.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BuloPXUY.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+50 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +50 B (+0.67%) | 7.28 kB → 7.33 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+50 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->