### PR TITLE
[AI] feat(budget analysis report): Add Balance & Category selector

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.test.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TestProviders } from '#mocks';
 
 import { BudgetAnalysisGraph } from './BudgetAnalysisGraph';
-
-import { TestProviders } from '@desktop-client/mocks';
 
 const sampleData = {
   intervalData: [
@@ -74,11 +75,7 @@ describe('BudgetAnalysisGraph – balanceOnly', () => {
     // When balanceOnly=true the component always renders a LineChart
     render(
       <TestProviders>
-        <BudgetAnalysisGraph
-          data={sampleData}
-          graphType="Bar"
-          balanceOnly
-        />
+        <BudgetAnalysisGraph data={sampleData} graphType="Bar" balanceOnly />
       </TestProviders>,
     );
     expect(document.querySelector('svg')).toBeInTheDocument();

--- a/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.test.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { BudgetAnalysisGraph } from './BudgetAnalysisGraph';
+
+import { TestProviders } from '@desktop-client/mocks';
+
+const sampleData = {
+  intervalData: [
+    {
+      date: '2024-01',
+      budgeted: 50000,
+      spent: -30000,
+      balance: 20000,
+      overspendingAdjustment: 0,
+    },
+    {
+      date: '2024-02',
+      budgeted: 50000,
+      spent: -40000,
+      balance: 30000,
+      overspendingAdjustment: 0,
+    },
+  ],
+};
+
+describe('BudgetAnalysisGraph – balanceOnly', () => {
+  it('renders the balance series label when balanceOnly is true', () => {
+    render(
+      <TestProviders>
+        <BudgetAnalysisGraph
+          data={sampleData}
+          graphType="Line"
+          balanceOnly
+          showBalance={false}
+        />
+      </TestProviders>,
+    );
+    // The LineChart should render without throwing; the balance dataKey should be present
+    // We verify by checking the container renders successfully
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders all series when balanceOnly is false', () => {
+    render(
+      <TestProviders>
+        <BudgetAnalysisGraph
+          data={sampleData}
+          graphType="Line"
+          balanceOnly={false}
+          showBalance
+        />
+      </TestProviders>,
+    );
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a bar chart when graphType is Bar and balanceOnly is false', () => {
+    render(
+      <TestProviders>
+        <BudgetAnalysisGraph
+          data={sampleData}
+          graphType="Bar"
+          balanceOnly={false}
+          showBalance
+        />
+      </TestProviders>,
+    );
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a line chart (balance-only) even when graphType is Bar', () => {
+    // When balanceOnly=true the component always renders a LineChart
+    render(
+      <TestProviders>
+        <BudgetAnalysisGraph
+          data={sampleData}
+          graphType="Bar"
+          balanceOnly
+        />
+      </TestProviders>,
+    );
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('hides balance line when showBalance is false and balanceOnly is false', () => {
+    render(
+      <TestProviders>
+        <BudgetAnalysisGraph
+          data={sampleData}
+          graphType="Line"
+          balanceOnly={false}
+          showBalance={false}
+        />
+      </TestProviders>,
+    );
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BudgetAnalysisGraph.tsx
@@ -56,6 +56,7 @@ type BudgetAnalysisGraphProps = {
   };
   graphType?: 'Line' | 'Bar';
   showBalance?: boolean;
+  balanceOnly?: boolean;
   isConcise?: boolean;
 };
 
@@ -65,6 +66,7 @@ type CustomTooltipProps = {
   isConcise: boolean;
   format: (value: unknown, type?: FormatType) => string;
   showBalance: boolean;
+  balanceOnly: boolean;
 };
 
 function CustomTooltip({
@@ -73,6 +75,7 @@ function CustomTooltip({
   isConcise,
   format,
   showBalance,
+  balanceOnly,
 }: CustomTooltipProps) {
   const locale = useLocale();
   const { t } = useTranslation();
@@ -105,65 +108,71 @@ function CustomTooltip({
           </strong>
         </div>
         <div style={{ lineHeight: 1.5 }}>
-          <AlignedText
-            left={
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    backgroundColor: theme.reportsNumberPositive,
-                    display: 'inline-block',
-                  }}
-                />
-                <Trans>Budgeted:</Trans>
-              </span>
-            }
-            right={
-              <FinancialText>
-                {format(data.budgeted, 'financial')}
-              </FinancialText>
-            }
-          />
-          <AlignedText
-            left={
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    backgroundColor: theme.reportsNumberNegative,
-                    display: 'inline-block',
-                  }}
-                />
-                <Trans>Spent:</Trans>
-              </span>
-            }
-            right={
-              <FinancialText>{format(data.spent, 'financial')}</FinancialText>
-            }
-          />
-          <AlignedText
-            left={
-              <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                <span
-                  style={{
-                    width: 10,
-                    height: 10,
-                    backgroundColor: theme.templateNumberUnderFunded,
-                    display: 'inline-block',
-                  }}
-                />
-                {t('Overspending Adjustment:')}
-              </span>
-            }
-            right={
-              <FinancialText>
-                {format(data.overspendingAdjustment, 'financial')}
-              </FinancialText>
-            }
-          />
-          {showBalance && (
+          {!balanceOnly && (
+            <AlignedText
+              left={
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                  <span
+                    style={{
+                      width: 10,
+                      height: 10,
+                      backgroundColor: theme.reportsNumberPositive,
+                      display: 'inline-block',
+                    }}
+                  />
+                  <Trans>Budgeted:</Trans>
+                </span>
+              }
+              right={
+                <FinancialText>
+                  {format(data.budgeted, 'financial')}
+                </FinancialText>
+              }
+            />
+          )}
+          {!balanceOnly && (
+            <AlignedText
+              left={
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                  <span
+                    style={{
+                      width: 10,
+                      height: 10,
+                      backgroundColor: theme.reportsNumberNegative,
+                      display: 'inline-block',
+                    }}
+                  />
+                  <Trans>Spent:</Trans>
+                </span>
+              }
+              right={
+                <FinancialText>{format(data.spent, 'financial')}</FinancialText>
+              }
+            />
+          )}
+          {!balanceOnly && (
+            <AlignedText
+              left={
+                <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                  <span
+                    style={{
+                      width: 10,
+                      height: 10,
+                      backgroundColor: theme.templateNumberUnderFunded,
+                      display: 'inline-block',
+                    }}
+                  />
+                  {t('Overspending Adjustment:')}
+                </span>
+              }
+              right={
+                <FinancialText>
+                  {format(data.overspendingAdjustment, 'financial')}
+                </FinancialText>
+              }
+            />
+          )}
+          {(showBalance || balanceOnly) && (
             <AlignedText
               left={
                 <span style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
@@ -196,6 +205,7 @@ export function BudgetAnalysisGraph({
   data,
   graphType = 'Line',
   showBalance = true,
+  balanceOnly = false,
   isConcise = true,
 }: BudgetAnalysisGraphProps) {
   const { t } = useTranslation();
@@ -244,8 +254,8 @@ export function BudgetAnalysisGraph({
       {(width, height) => {
         const chartProps = { ...commonProps, width, height };
 
-        return graphType === 'Bar' ? (
-          <ComposedChart {...chartProps}>
+        const sharedAxes = (
+          <>
             <CartesianGrid strokeDasharray="3 3" stroke={theme.pillBorder} />
             <XAxis
               dataKey="date"
@@ -272,10 +282,17 @@ export function BudgetAnalysisGraph({
                   isConcise={isConcise}
                   format={format}
                   showBalance={showBalance}
+                  balanceOnly={balanceOnly}
                 />
               }
               isAnimationActive={false}
             />
+          </>
+        );
+
+        return graphType === 'Bar' && !balanceOnly ? (
+          <ComposedChart {...chartProps}>
+            {sharedAxes}
             <Bar
               dataKey="budgeted"
               fill={theme.reportsNumberPositive}
@@ -308,64 +325,41 @@ export function BudgetAnalysisGraph({
           </ComposedChart>
         ) : (
           <LineChart {...chartProps}>
-            <CartesianGrid strokeDasharray="3 3" stroke={theme.pillBorder} />
-            <XAxis
-              dataKey="date"
-              tick={{ fill: theme.reportsLabel }}
-              tickFormatter={formatDate}
-              minTickGap={50}
-            />
-            <YAxis
-              tick={{ fill: theme.reportsLabel }}
-              tickCount={8}
-              tickFormatter={value =>
-                privacyMode && !yAxisIsHovered
-                  ? '...'
-                  : format(value, 'financial-no-decimals')
-              }
-              onMouseEnter={() => setYAxisIsHovered(true)}
-              onMouseLeave={() => setYAxisIsHovered(false)}
-              stroke={theme.pageTextSubdued}
-            />
-            <Tooltip
-              cursor={{ fill: 'transparent' }}
-              content={
-                <CustomTooltip
-                  isConcise={isConcise}
-                  format={format}
-                  showBalance={showBalance}
-                />
-              }
-              isAnimationActive={false}
-            />
-            <Line
-              type="monotone"
-              dataKey="budgeted"
-              stroke={theme.reportsNumberPositive}
-              strokeWidth={2}
-              name={budgetedLabel}
-              dot={false}
-              animationDuration={1000}
-            />
-            <Line
-              type="monotone"
-              dataKey="spent"
-              stroke={theme.reportsNumberNegative}
-              strokeWidth={2}
-              name={spentLabel}
-              dot={false}
-              animationDuration={1000}
-            />
-            <Line
-              type="monotone"
-              dataKey="overspendingAdjustment"
-              stroke={theme.templateNumberUnderFunded}
-              strokeWidth={2}
-              name={overspendingLabel}
-              dot={false}
-              animationDuration={1000}
-            />
-            {showBalance && (
+            {sharedAxes}
+            {!balanceOnly && (
+              <Line
+                type="monotone"
+                dataKey="budgeted"
+                stroke={theme.reportsNumberPositive}
+                strokeWidth={2}
+                name={budgetedLabel}
+                dot={false}
+                animationDuration={1000}
+              />
+            )}
+            {!balanceOnly && (
+              <Line
+                type="monotone"
+                dataKey="spent"
+                stroke={theme.reportsNumberNegative}
+                strokeWidth={2}
+                name={spentLabel}
+                dot={false}
+                animationDuration={1000}
+              />
+            )}
+            {!balanceOnly && (
+              <Line
+                type="monotone"
+                dataKey="overspendingAdjustment"
+                stroke={theme.templateNumberUnderFunded}
+                strokeWidth={2}
+                name={overspendingLabel}
+                dot={false}
+                animationDuration={1000}
+              />
+            )}
+            {(showBalance || balanceOnly) && (
               <Line
                 type="monotone"
                 dataKey="balance"

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -360,7 +360,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             onChange={onBalanceModeChange}
             options={[
               ['balance-only', t('Balance only')],
-              ['balance-and-categories', t('Balance + categories')],
+              ['balance-and-categories', t('Balance + Categories')],
               ['categories-only', t('Categories only')],
             ]}
           />

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -8,6 +8,7 @@ import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SvgChart, SvgChartBar } from '@actual-app/components/icons/v1';
 import { Paragraph } from '@actual-app/components/paragraph';
+import { Select } from '@actual-app/components/select';
 import { theme } from '@actual-app/components/theme';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
@@ -42,6 +43,8 @@ import { useSyncedPref } from '#hooks/useSyncedPref';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
+
+type BalanceMode = 'balance-only' | 'balance-and-categories' | 'categories-only';
 
 export function BudgetAnalysis() {
   const params = useParams();
@@ -273,6 +276,17 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
     });
   };
 
+  const balanceMode: BalanceMode = balanceOnly
+    ? 'balance-only'
+    : showBalance
+      ? 'balance-and-categories'
+      : 'categories-only';
+
+  function onBalanceModeChange(newMode: BalanceMode) {
+    setBalanceOnly(newMode === 'balance-only');
+    setShowBalance(newMode !== 'categories-only');
+  }
+
   return (
     <Page
       header={
@@ -341,15 +355,15 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         }
       >
         <View style={{ flexDirection: 'row', gap: 10 }}>
-          <Button onPress={() => setBalanceOnly(state => !state)}>
-            {balanceOnly ? t('Show all series') : t('Balance only')}
-          </Button>
-
-          {!balanceOnly && (
-            <Button onPress={() => setShowBalance(state => !state)}>
-              {showBalance ? t('Hide balance') : t('Show balance')}
-            </Button>
-          )}
+          <Select<BalanceMode>
+            value={balanceMode}
+            onChange={onBalanceModeChange}
+            options={[
+              ['balance-only', t('Balance only')],
+              ['balance-and-categories', t('Balance + categories')],
+              ['categories-only', t('Categories only')],
+            ]}
+          />
 
           {widget && (
             <Button variant="primary" onPress={onSaveWidget}>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -452,23 +452,21 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
                             </FinancialText>
                           }
                         />
-                        {showBalance && (
-                          <AlignedText
-                            style={{ marginBottom: 5, minWidth: 210 }}
-                            left={
-                              <Block>
-                                <Trans>Ending balance:</Trans>
-                              </Block>
-                            }
-                            right={
-                              <FinancialText style={{ fontWeight: 600 }}>
-                                <PrivacyFilter>
-                                  <Change amount={endingBalance} />
-                                </PrivacyFilter>
-                              </FinancialText>
-                            }
-                          />
-                        )}
+                        <AlignedText
+                          style={{ marginBottom: 5, minWidth: 210 }}
+                          left={
+                            <Block>
+                              <Trans>Ending balance:</Trans>
+                            </Block>
+                          }
+                          right={
+                            <FinancialText style={{ fontWeight: 600 }}>
+                              <PrivacyFilter>
+                                <Change amount={endingBalance} />
+                              </PrivacyFilter>
+                            </FinancialText>
+                          }
+                        />
                       </>
                     )}
                   </View>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -44,7 +44,10 @@ import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
-type BalanceMode = 'balance-only' | 'balance-and-categories' | 'categories-only';
+type BalanceMode =
+  | 'balance-only'
+  | 'balance-and-categories'
+  | 'categories-only';
 
 export function BudgetAnalysis() {
   const params = useParams();

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -93,6 +93,9 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
   const [showBalance, setShowBalance] = useState(
     widget?.meta?.showBalance ?? true,
   );
+  const [balanceOnly, setBalanceOnly] = useState(
+    widget?.meta?.balanceOnly ?? false,
+  );
   const [latestTransaction, setLatestTransaction] = useState('');
   const [isConcise, setIsConcise] = useState(() => {
     // Default to concise (monthly) view until we load the actual date range
@@ -225,6 +228,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             },
             graphType,
             showBalance,
+            balanceOnly,
           },
         },
       },
@@ -337,9 +341,15 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         }
       >
         <View style={{ flexDirection: 'row', gap: 10 }}>
-          <Button onPress={() => setShowBalance(state => !state)}>
-            {showBalance ? t('Hide balance') : t('Show balance')}
+          <Button onPress={() => setBalanceOnly(state => !state)}>
+            {balanceOnly ? t('Show all series') : t('Balance only')}
           </Button>
+
+          {!balanceOnly && (
+            <Button onPress={() => setShowBalance(state => !state)}>
+              {showBalance ? t('Hide balance') : t('Show balance')}
+            </Button>
+          )}
 
           {widget && (
             <Button variant="primary" onPress={onSaveWidget}>
@@ -469,6 +479,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
                 data={data}
                 graphType={graphType}
                 showBalance={showBalance}
+                balanceOnly={balanceOnly}
                 isConcise={isConcise}
               />
               <View style={{ marginTop: 30 }}>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
@@ -154,6 +154,7 @@ export function BudgetAnalysisCard({
             data={data}
             graphType={meta?.graphType || 'Bar'}
             showBalance={meta?.showBalance ?? true}
+            balanceOnly={meta?.balanceOnly ?? false}
           />
         ) : (
           <LoadingIndicator />

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -94,6 +94,7 @@ export type BudgetAnalysisWidget = AbstractWidget<
     interval?: 'Daily' | 'Weekly' | 'Monthly' | 'Yearly';
     graphType?: 'Line' | 'Bar';
     showBalance?: boolean;
+    balanceOnly?: boolean;
   } | null
 >;
 export type CustomReportWidget = AbstractWidget<

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-add-balance-category-selector.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-add-balance-category-selector.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tabedzki]
+---
+
+[AI] feat(budget analysis report): Add Balance & Category selector


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

This PR adds a dropdown to display Balance, Categories or a combination of the two. 
Claude was used. 

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Addresses [comment](https://github.com/actualbudget/actual/issues/6742#issuecomment-4138751824) from @marci-makes. @marci-makes, please confirm this works as desired.

## Testing

Use the dropdown feature to see the different styles.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (+48 B) | +0.00%
loot-core | 1 | 4.9 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (+48 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +1.18 kB (+5.90%) | 19.92 kB → 21.1 kB
`src/components/reports/reports/BudgetAnalysisCard.tsx` | 📈 +104 B (+1.44%) | 7.05 kB → 7.15 kB
`locale/en.json` | 📈 +69 B (+0.03%) | 200.33 kB → 200.39 kB
`src/components/reports/graphs/BudgetAnalysisGraph.tsx` | 📉 -1.3 kB (-9.76%) | 13.3 kB → 12 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 200.33 kB → 200.39 kB (+69 B) | +0.03%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.25 MB → 1.25 MB (-21 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.23 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.4 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTfCF_Gu.js | 4.9 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->