### PR TITLE
[AI] feat(budget analysis report): show hidden categories

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -381,13 +381,19 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
           <Tooltip
             content={
               showHiddenCategories
-                ? t('Hide hidden categories')
-                : t('Show hidden categories')
+                ? t('Click to hide hidden categories')
+                : t('Click to show hidden categories')
             }
           >
             <Button
               variant="bare"
+              aria-pressed={showHiddenCategories}
               onPress={() => setShowHiddenCategories(state => !state)}
+              style={
+                showHiddenCategories
+                  ? { backgroundColor: theme.buttonBareBackgroundActive }
+                  : undefined
+              }
             >
               {showHiddenCategories ? (
                 <SvgViewHide style={{ width: 16, height: 16 }} />

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -6,16 +6,10 @@ import { AlignedText } from '@actual-app/components/aligned-text';
 import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
-import {
-  SvgChart,
-  SvgChartBar,
-  SvgViewHide,
-  SvgViewShow,
-} from '@actual-app/components/icons/v1';
+import { Menu } from '@actual-app/components/menu';
 import { Paragraph } from '@actual-app/components/paragraph';
-import { Select } from '@actual-app/components/select';
+import { Popover } from '@actual-app/components/popover';
 import { theme } from '@actual-app/components/theme';
-import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
@@ -49,10 +43,82 @@ import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
-type BalanceMode =
-  | 'balance-only'
-  | 'balance-and-categories'
-  | 'categories-only';
+type OptionsButtonProps = {
+  graphType: 'Line' | 'Bar';
+  onToggleGraphType: () => void;
+  showBalance: boolean;
+  onToggleShowBalance: () => void;
+  showCategories: boolean;
+  onToggleShowCategories: () => void;
+  showHiddenCategories: boolean;
+  onToggleShowHiddenCategories: () => void;
+};
+
+function OptionsButton({
+  graphType,
+  onToggleGraphType,
+  showBalance,
+  onToggleShowBalance,
+  showCategories,
+  onToggleShowCategories,
+  showHiddenCategories,
+  onToggleShowHiddenCategories,
+}: OptionsButtonProps) {
+  const { t } = useTranslation();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button ref={triggerRef} onPress={() => setIsOpen(true)}>
+        <Trans>Options</Trans>
+      </Button>
+      <Popover
+        triggerRef={triggerRef}
+        placement="bottom end"
+        isOpen={isOpen}
+        onOpenChange={() => setIsOpen(false)}
+      >
+        <Menu
+          onMenuSelect={item => {
+            if (item === 'graph-type') onToggleGraphType();
+            if (item === 'show-balance') onToggleShowBalance();
+            if (item === 'show-categories') onToggleShowCategories();
+            if (item === 'show-hidden-categories') {
+              onToggleShowHiddenCategories();
+            }
+          }}
+          items={[
+            {
+              name: 'graph-type',
+              text:
+                graphType === 'Bar'
+                  ? t('Switch to line chart')
+                  : t('Switch to bar chart'),
+            },
+            Menu.line,
+            {
+              name: 'show-balance',
+              text: t('Show balance'),
+              toggle: showBalance,
+            },
+            {
+              name: 'show-categories',
+              text: t('Show categories'),
+              toggle: showCategories,
+            },
+            Menu.line,
+            {
+              name: 'show-hidden-categories',
+              text: t('Show hidden categories'),
+              toggle: showHiddenCategories,
+            },
+          ]}
+        />
+      </Popover>
+    </>
+  );
+}
 
 export function BudgetAnalysis() {
   const params = useParams();
@@ -104,15 +170,14 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
   const [showBalance, setShowBalance] = useState(
     widget?.meta?.showBalance ?? true,
   );
-  const [balanceOnly, setBalanceOnly] = useState(
-    widget?.meta?.balanceOnly ?? false,
+  const [showCategories, setShowCategories] = useState(
+    !(widget?.meta?.balanceOnly ?? false),
   );
   const [showHiddenCategories, setShowHiddenCategories] = useState(
     widget?.meta?.showHiddenCategories ?? false,
   );
   const [latestTransaction, setLatestTransaction] = useState('');
   const [isConcise, setIsConcise] = useState(() => {
-    // Default to concise (monthly) view until we load the actual date range
     return true;
   });
 
@@ -243,7 +308,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             },
             graphType,
             showBalance,
-            balanceOnly,
+            balanceOnly: !showCategories,
             showHiddenCategories,
           },
         },
@@ -289,17 +354,6 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
     });
   };
 
-  const balanceMode: BalanceMode = balanceOnly
-    ? 'balance-only'
-    : showBalance
-      ? 'balance-and-categories'
-      : 'categories-only';
-
-  function onBalanceModeChange(newMode: BalanceMode) {
-    setBalanceOnly(newMode === 'balance-only');
-    setShowBalance(newMode !== 'categories-only');
-  }
-
   return (
     <Page
       header={
@@ -344,64 +398,22 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         onDeleteFilter={onDeleteFilter}
         onConditionsOpChange={onConditionsOpChange}
         filterInclude={['category', 'saved']}
-        inlineContent={
-          <Tooltip
-            content={
-              graphType === 'Line'
-                ? t('Switch to bar chart')
-                : t('Switch to line chart')
-            }
-          >
-            <Button
-              variant="bare"
-              onPress={() =>
-                setGraphType(graphType === 'Line' ? 'Bar' : 'Line')
-              }
-            >
-              {graphType === 'Line' ? (
-                <SvgChartBar style={{ width: 12, height: 12 }} />
-              ) : (
-                <SvgChart style={{ width: 12, height: 12 }} />
-              )}
-            </Button>
-          </Tooltip>
-        }
       >
         <View style={{ flexDirection: 'row', gap: 10 }}>
-          <Select<BalanceMode>
-            value={balanceMode}
-            onChange={onBalanceModeChange}
-            options={[
-              ['balance-only', t('Balance only')],
-              ['balance-and-categories', t('Balance + Categories')],
-              ['categories-only', t('Categories only')],
-            ]}
-          />
-
-          <Tooltip
-            content={
-              showHiddenCategories
-                ? t('Click to hide hidden categories')
-                : t('Click to show hidden categories')
+          <OptionsButton
+            graphType={graphType}
+            onToggleGraphType={() =>
+              setGraphType(graphType === 'Line' ? 'Bar' : 'Line')
             }
-          >
-            <Button
-              variant="bare"
-              aria-pressed={showHiddenCategories}
-              onPress={() => setShowHiddenCategories(state => !state)}
-              style={
-                showHiddenCategories
-                  ? { backgroundColor: theme.buttonBareBackgroundActive }
-                  : undefined
-              }
-            >
-              {showHiddenCategories ? (
-                <SvgViewHide style={{ width: 16, height: 16 }} />
-              ) : (
-                <SvgViewShow style={{ width: 16, height: 16 }} />
-              )}
-            </Button>
-          </Tooltip>
+            showBalance={showBalance}
+            onToggleShowBalance={() => setShowBalance(v => !v)}
+            showCategories={showCategories}
+            onToggleShowCategories={() => setShowCategories(v => !v)}
+            showHiddenCategories={showHiddenCategories}
+            onToggleShowHiddenCategories={() =>
+              setShowHiddenCategories(v => !v)
+            }
+          />
 
           {widget && (
             <Button variant="primary" onPress={onSaveWidget}>
@@ -529,7 +541,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
                 data={data}
                 graphType={graphType}
                 showBalance={showBalance}
-                balanceOnly={balanceOnly}
+                balanceOnly={!showCategories}
                 isConcise={isConcise}
               />
               <View style={{ marginTop: 30 }}>
@@ -555,8 +567,9 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
                     changes in a specific area.
                   </Paragraph>
                   <Paragraph>
-                    Hint: You can use the icon in the header to toggle between
-                    line and bar chart views.
+                    Use the <strong>Options</strong> button to switch between
+                    line and bar chart, toggle balance and category series
+                    visibility, and include hidden budget categories.
                   </Paragraph>
                 </Trans>
               </View>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -102,6 +102,9 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
   const [balanceOnly, setBalanceOnly] = useState(
     widget?.meta?.balanceOnly ?? false,
   );
+  const [showHiddenCategories, setShowHiddenCategories] = useState(
+    widget?.meta?.showHiddenCategories ?? false,
+  );
   const [latestTransaction, setLatestTransaction] = useState('');
   const [isConcise, setIsConcise] = useState(() => {
     // Default to concise (monthly) view until we load the actual date range
@@ -192,8 +195,9 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         conditionsOp,
         startDate,
         endDate,
+        showHiddenCategories,
       }),
-    [conditions, conditionsOp, startDate, endDate],
+    [conditions, conditionsOp, startDate, endDate, showHiddenCategories],
   );
 
   const data = useReport('default', getGraphData);
@@ -235,6 +239,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             graphType,
             showBalance,
             balanceOnly,
+            showHiddenCategories,
           },
         },
       },
@@ -367,6 +372,12 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
               ['categories-only', t('Categories only')],
             ]}
           />
+
+          <Button onPress={() => setShowHiddenCategories(state => !state)}>
+            {showHiddenCategories
+              ? t('Hide hidden categories')
+              : t('Show hidden categories')}
+          </Button>
 
           {widget && (
             <Button variant="primary" onPress={onSaveWidget}>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -91,10 +91,8 @@ function OptionsButton({
           items={[
             {
               name: 'graph-type',
-              text:
-                graphType === 'Bar'
-                  ? t('Switch to line chart')
-                  : t('Switch to bar chart'),
+              text: t('Bar chart'),
+              toggle: graphType === 'Bar',
             },
             Menu.line,
             {

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -6,7 +6,7 @@ import { AlignedText } from '@actual-app/components/aligned-text';
 import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
-import { SvgChart, SvgChartBar } from '@actual-app/components/icons/v1';
+import { SvgChart, SvgChartBar, SvgViewHide, SvgViewShow } from '@actual-app/components/icons/v1';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { Select } from '@actual-app/components/select';
 import { theme } from '@actual-app/components/theme';
@@ -373,11 +373,24 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             ]}
           />
 
-          <Button onPress={() => setShowHiddenCategories(state => !state)}>
-            {showHiddenCategories
-              ? t('Hide hidden categories')
-              : t('Show hidden categories')}
-          </Button>
+          <Tooltip
+            content={
+              showHiddenCategories
+                ? t('Hide hidden categories')
+                : t('Show hidden categories')
+            }
+          >
+            <Button
+              variant="bare"
+              onPress={() => setShowHiddenCategories(state => !state)}
+            >
+              {showHiddenCategories ? (
+                <SvgViewHide style={{ width: 16, height: 16 }} />
+              ) : (
+                <SvgViewShow style={{ width: 16, height: 16 }} />
+              )}
+            </Button>
+          </Tooltip>
 
           {widget && (
             <Button variant="primary" onPress={onSaveWidget}>

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -6,7 +6,12 @@ import { AlignedText } from '@actual-app/components/aligned-text';
 import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
-import { SvgChart, SvgChartBar, SvgViewHide, SvgViewShow } from '@actual-app/components/icons/v1';
+import {
+  SvgChart,
+  SvgChartBar,
+  SvgViewHide,
+  SvgViewShow,
+} from '@actual-app/components/icons/v1';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { Select } from '@actual-app/components/select';
 import { theme } from '@actual-app/components/theme';

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysisCard.tsx
@@ -65,8 +65,15 @@ export function BudgetAnalysisCard({
       conditionsOp: meta?.conditionsOp,
       startDate,
       endDate,
+      showHiddenCategories: meta?.showHiddenCategories ?? false,
     });
-  }, [meta?.conditions, meta?.conditionsOp, startDate, endDate]);
+  }, [
+    meta?.conditions,
+    meta?.conditionsOp,
+    meta?.showHiddenCategories,
+    startDate,
+    endDate,
+  ]);
 
   const data = useReport('default', getGraphData);
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,4 +1,4 @@
-import type { CategoryEntity } from 'loot-core/types/models';
+import type { CategoryEntity } from '@actual-app/core/types/models';
 
 function filterBaseCategories(
   categories: CategoryEntity[],

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,0 +1,77 @@
+import type { CategoryEntity } from 'loot-core/types/models';
+
+function filterBaseCategories(
+  categories: CategoryEntity[],
+  showHiddenCategories: boolean,
+): CategoryEntity[] {
+  return categories.filter(
+    cat => !cat.is_income && (showHiddenCategories || !cat.hidden),
+  );
+}
+
+const makeCategory = (
+  overrides: Partial<CategoryEntity> & Pick<CategoryEntity, 'id' | 'name'>,
+): CategoryEntity => ({
+  is_income: false,
+  hidden: false,
+  group: 'group1',
+  ...overrides,
+});
+
+const visibleExpense = makeCategory({ id: 'c1', name: 'Groceries' });
+const hiddenExpense = makeCategory({
+  id: 'c2',
+  name: 'Car Fund',
+  hidden: true,
+});
+const incomeCategory = makeCategory({
+  id: 'c3',
+  name: 'Salary',
+  is_income: true,
+});
+const hiddenIncome = makeCategory({
+  id: 'c4',
+  name: 'Hidden Income',
+  is_income: true,
+  hidden: true,
+});
+
+const all = [visibleExpense, hiddenExpense, incomeCategory, hiddenIncome];
+
+describe('createBudgetAnalysisSpreadsheet', () => {
+  describe('hidden category filtering', () => {
+    it('excludes hidden categories when showHiddenCategories is false', () => {
+      const result = filterBaseCategories(all, false);
+      expect(result).toContain(visibleExpense);
+      expect(result).not.toContain(hiddenExpense);
+    });
+
+    it('includes hidden expense categories when showHiddenCategories is true', () => {
+      const result = filterBaseCategories(all, true);
+      expect(result).toContain(visibleExpense);
+      expect(result).toContain(hiddenExpense);
+    });
+
+    it('always excludes income categories regardless of showHiddenCategories', () => {
+      const resultFalse = filterBaseCategories(all, false);
+      const resultTrue = filterBaseCategories(all, true);
+      expect(resultFalse).not.toContain(incomeCategory);
+      expect(resultFalse).not.toContain(hiddenIncome);
+      expect(resultTrue).not.toContain(incomeCategory);
+      expect(resultTrue).not.toContain(hiddenIncome);
+    });
+
+    it('returns only visible expense categories by default', () => {
+      const result = filterBaseCategories(all, false);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(visibleExpense);
+    });
+
+    it('returns all expense categories when flag is true', () => {
+      const result = filterBaseCategories(all, true);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(visibleExpense);
+      expect(result).toContain(hiddenExpense);
+    });
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,13 +1,6 @@
 import type { CategoryEntity } from '@actual-app/core/types/models';
 
-function filterBaseCategories(
-  categories: CategoryEntity[],
-  showHiddenCategories: boolean,
-): CategoryEntity[] {
-  return categories.filter(
-    cat => !cat.is_income && (showHiddenCategories || !cat.hidden),
-  );
-}
+import { isBaseCategory } from './budget-analysis-spreadsheet';
 
 const makeCategory = (
   overrides: Partial<CategoryEntity> & Pick<CategoryEntity, 'id' | 'name'>,
@@ -37,6 +30,13 @@ const hiddenIncome = makeCategory({
 });
 
 const all = [visibleExpense, hiddenExpense, incomeCategory, hiddenIncome];
+
+function filterBaseCategories(
+  categories: CategoryEntity[],
+  showHiddenCategories: boolean,
+): CategoryEntity[] {
+  return categories.filter(cat => isBaseCategory(cat, showHiddenCategories));
+}
 
 describe('createBudgetAnalysisSpreadsheet', () => {
   describe('hidden category filtering', () => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -36,6 +36,13 @@ type createBudgetAnalysisSpreadsheetProps = {
   showHiddenCategories?: boolean;
 };
 
+export function isBaseCategory(
+  cat: CategoryEntity,
+  showHiddenCategories: boolean,
+): boolean {
+  return !cat.is_income && (showHiddenCategories || !cat.hidden);
+}
+
 export function createBudgetAnalysisSpreadsheet({
   conditions = [],
   conditionsOp = 'and',
@@ -68,9 +75,8 @@ export function createBudgetAnalysisSpreadsheet({
 
     // Base set: expense categories only; hidden categories are included when
     // showHiddenCategories is true so historic data is not misrepresented.
-    const baseCategories = allCategories.filter(
-      (cat: CategoryEntity) =>
-        !cat.is_income && (showHiddenCategories || !cat.hidden),
+    const baseCategories = allCategories.filter((cat: CategoryEntity) =>
+      isBaseCategory(cat, showHiddenCategories),
     );
 
     let categoriesToInclude: CategoryEntity[];

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -33,6 +33,7 @@ type createBudgetAnalysisSpreadsheetProps = {
   conditionsOp?: 'and' | 'or';
   startDate: string;
   endDate: string;
+  showHiddenCategories?: boolean;
 };
 
 export function createBudgetAnalysisSpreadsheet({
@@ -40,6 +41,7 @@ export function createBudgetAnalysisSpreadsheet({
   conditionsOp = 'and',
   startDate,
   endDate,
+  showHiddenCategories = false,
 }: createBudgetAnalysisSpreadsheetProps) {
   return async (
     spreadsheet: ReturnType<typeof useSpreadsheet>,
@@ -64,9 +66,11 @@ export function createBudgetAnalysisSpreadsheet({
         (cond.field === 'category' || cond.field === 'category_group'),
     );
 
-    // Base set: expense categories only (exclude income and hidden)
+    // Base set: expense categories only; hidden categories are included when
+    // showHiddenCategories is true so historic data is not misrepresented.
     const baseCategories = allCategories.filter(
-      (cat: CategoryEntity) => !cat.is_income && !cat.hidden,
+      (cat: CategoryEntity) =>
+        !cat.is_income && (showHiddenCategories || !cat.hidden),
     );
 
     let categoriesToInclude: CategoryEntity[];

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -95,6 +95,7 @@ export type BudgetAnalysisWidget = AbstractWidget<
     graphType?: 'Line' | 'Bar';
     showBalance?: boolean;
     balanceOnly?: boolean;
+    showHiddenCategories?: boolean;
   } | null
 >;
 export type CustomReportWidget = AbstractWidget<

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tabedzki]
+---
+
+[AI] feat(budget analysis report): show hidden categories

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [tabedzki]
 ---
 
-[AI] feat(budget analysis report): show hidden categories
+Budget analysis report: add "show hidden categories" option, group options into dropdown


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Allows the user to see hidden categories and selectively display them as part of the Budget Analysis report. 
Claude contributed to this feature.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->
Addresses @Hstep20's [comment](https://github.com/actualbudget/actual/issues/6742#issuecomment-4361492733). @Hstep20, can you confirm this is the desired functionality?

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Manually checked whether the numbers for a selected category were properly calculated. 
Claude wrote the tests.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.09 MB → 13.09 MB (+3.93 kB) | +0.03%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.09 MB → 13.09 MB (+3.93 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +2.84 kB (+13.46%) | 21.1 kB → 23.94 kB
`src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts` | 📈 +162 B (+3.12%) | 5.07 kB → 5.23 kB
`src/components/reports/reports/BudgetAnalysisCard.tsx` | 📈 +144 B (+1.97%) | 7.15 kB → 7.29 kB
`locale/pl.json` | 📈 +815 B (+0.80%) | 99.04 kB → 99.83 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.23 MB → 1.23 MB (+3.14 kB) | +0.25%
static/js/pl.js | 99.04 kB → 99.83 kB (+815 B) | +0.80%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 176.85 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 174.94 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.49 kB | 0%
static/js/es.js | 169.72 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 207.07 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.07 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 111.31 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->