### PR TITLE
[AI] feat(budget analysis report): allow selecting future months in date range

### DIFF
--- a/packages/component-library/src/theme.ts
+++ b/packages/component-library/src/theme.ts
@@ -223,4 +223,5 @@ export const theme = {
   tooltipBorder: 'var(--color-tooltipBorder)',
   calendarCellBackground: 'var(--color-calendarCellBackground)',
   overlayBackground: 'var(--color-overlayBackground)',
+  colorScheme: 'var(--color-scheme)',
 };

--- a/packages/component-library/src/themes/dark.css
+++ b/packages/component-library/src/themes/dark.css
@@ -250,4 +250,5 @@
   --color-chartQual7: var(--palette-chartQual7);
   --color-chartQual8: var(--palette-chartQual8);
   --color-chartQual9: var(--palette-chartQual9);
+  --color-scheme: dark;
 }

--- a/packages/component-library/src/themes/light.css
+++ b/packages/component-library/src/themes/light.css
@@ -250,4 +250,5 @@
   --color-chartQual7: var(--palette-chartQual7);
   --color-chartQual8: var(--palette-chartQual8);
   --color-chartQual9: var(--palette-chartQual9);
+  --color-scheme: light;
 }

--- a/packages/component-library/src/themes/midnight.css
+++ b/packages/component-library/src/themes/midnight.css
@@ -252,4 +252,5 @@
   --color-chartQual7: var(--palette-chartQual7);
   --color-chartQual8: var(--palette-chartQual8);
   --color-chartQual9: var(--palette-chartQual9);
+  --color-scheme: dark;
 }

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -3,8 +3,8 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
-import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
+import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
@@ -15,7 +15,6 @@ import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
-import { useLocale } from '#hooks/useLocale';
 
 import { getLiveRange } from './getLiveRange';
 import {
@@ -24,8 +23,6 @@ import {
   getFullRange,
   getLatestRange,
   getNextRange,
-  validateEnd,
-  validateStart,
 } from './reportRanges';
 
 type HeaderProps = {
@@ -280,9 +277,19 @@ export function Header({
   filterExclude,
   filterInclude,
 }: HeaderProps) {
-  const locale = useLocale();
   const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
+
+  const monthInputStyle = {
+    fontSize: 13,
+    padding: '4px 10px',
+    color: theme.buttonNormalText,
+    backgroundColor: theme.buttonNormalBackground,
+    border: `1px solid ${theme.buttonNormalBorder}`,
+    borderRadius: 4,
+    boxShadow: `0 1px 2px ${theme.buttonNormalShadow}`,
+    outline: 'none',
+  };
 
   function convertToMonth(
     start: string,
@@ -335,36 +342,28 @@ export function Header({
             )}
 
             <SpaceBetween gap={5}>
-              <Select
-                onChange={newValue =>
-                  onChangeDates(
-                    ...validateStart(
-                      allMonths[allMonths.length - 1].name,
-                      allMonths[0].name,
-                      newValue,
-                      end,
-                    ),
-                  )
-                }
+              <input
+                type="month"
                 value={start}
-                defaultLabel={monthUtils.format(start, 'MMMM yyyy', locale)}
-                options={allMonths.map(({ name, pretty }) => [name, pretty])}
+                onChange={e => {
+                  if (!e.target.value) return;
+                  const newStart = e.target.value;
+                  const newEnd = newStart > end ? newStart : end;
+                  onChangeDates(newStart, newEnd, 'static');
+                }}
+                style={monthInputStyle}
               />
               <View>{t('to')}</View>
-              <Select
-                onChange={newValue =>
-                  onChangeDates(
-                    ...validateEnd(
-                      allMonths[allMonths.length - 1].name,
-                      allMonths[0].name,
-                      start,
-                      newValue,
-                    ),
-                  )
-                }
+              <input
+                type="month"
                 value={end}
-                options={allMonths.map(({ name, pretty }) => [name, pretty])}
-                style={{ marginRight: 10 }}
+                onChange={e => {
+                  if (!e.target.value) return;
+                  const newEnd = e.target.value;
+                  const newStart = newEnd < start ? newEnd : start;
+                  onChangeDates(newStart, newEnd, 'static');
+                }}
+                style={{ ...monthInputStyle, marginRight: 10 }}
               />
             </SpaceBetween>
           </SpaceBetween>

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -289,6 +289,7 @@ export function Header({
     borderRadius: 4,
     boxShadow: `0 1px 2px ${theme.buttonNormalShadow}`,
     outline: 'none',
+    colorScheme: theme.colorScheme,
   };
 
   function convertToMonth(

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -146,8 +146,13 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         earliestMonth = yearAgo;
       }
 
+      // Extend the selectable range to December of next year so users can
+      // plan ahead (e.g. June 2026 → December 2027).
+      const futureYear = String(Number(currentMonth.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
       const allMonthsData = monthUtils
-        .rangeInclusive(earliestMonth, latestMonth)
+        .rangeInclusive(earliestMonth, futureMonth)
         .map(month => ({
           name: month,
           pretty: monthUtils.format(month, 'MMMM, yyyy', locale),

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,0 +1,45 @@
+import * as monthUtils from 'loot-core/shared/months';
+
+describe('createBudgetAnalysisSpreadsheet', () => {
+  describe('future month range', () => {
+    it('future month is December of next year', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
+      expect(futureMonth).toBe('2027-12');
+    });
+
+    it('rangeInclusive from a mid-year month to December next year ends at December', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+      const range = monthUtils.rangeInclusive(current, futureMonth);
+
+      expect(range[0]).toBe('2026-06');
+      expect(range[range.length - 1]).toBe('2027-12');
+    });
+
+    it('future month is always in December regardless of current month', () => {
+      for (const month of ['2024-01', '2024-06', '2024-12']) {
+        const futureYear = String(Number(month.slice(0, 4)) + 1);
+        const futureMonth = `${futureYear}-12`;
+        expect(futureMonth.endsWith('-12')).toBe(true);
+      }
+    });
+
+    it('future months appear before current month in the reversed picker list', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
+      const allMonths = monthUtils
+        .rangeInclusive(current, futureMonth)
+        .map(month => ({ name: month }))
+        .reverse();
+
+      expect(allMonths[0].name).toBe(futureMonth);
+      expect(allMonths[allMonths.length - 1].name).toBe(current);
+    });
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,4 +1,4 @@
-import * as monthUtils from 'loot-core/shared/months';
+import * as monthUtils from '@actual-app/core/shared/months';
 
 describe('createBudgetAnalysisSpreadsheet', () => {
   describe('future month range', () => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -262,19 +262,18 @@ export function createBudgetAnalysisSpreadsheet({
       intervalData.push({
         date: month,
         budgeted,
-        spent, // Display as positive
+        spent,
         balance: monthBalance,
-        overspendingAdjustment: Math.abs(overspendingAdjustment), // Display as positive
+        overspendingAdjustment: Math.abs(overspendingAdjustment),
       });
 
-      // Only update running balance if this month had budget data.
-      // Future months with no budget entries return no cells; carrying
-      // carryoverToNextMonth=0 would silently wipe the accumulated balance.
-      const monthHasData = monthData.length > 0;
-      if (monthHasData) {
-        runningBalance = carryoverToNextMonth;
-        overspendingFromPrevMonth = overspendingThisMonth;
-      }
+      // For future months with no budget or transactions, category balances are
+      // all zero so carryoverToNextMonth=0, which would wipe the running balance.
+      // Use the computed monthBalance as the next month's starting balance instead,
+      // which correctly preserves the cumulative balance regardless of whether
+      // category cells have data.
+      runningBalance = monthBalance;
+      overspendingFromPrevMonth = overspendingThisMonth;
     }
 
     setData({

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -267,10 +267,14 @@ export function createBudgetAnalysisSpreadsheet({
         overspendingAdjustment: Math.abs(overspendingAdjustment), // Display as positive
       });
 
-      // Update running balance for next month
-      runningBalance = carryoverToNextMonth;
-      // Save this month's overspending to apply in next month
-      overspendingFromPrevMonth = overspendingThisMonth;
+      // Only update running balance if this month had budget data.
+      // Future months with no budget entries return no cells; carrying
+      // carryoverToNextMonth=0 would silently wipe the accumulated balance.
+      const monthHasData = monthData.length > 0;
+      if (monthHasData) {
+        runningBalance = carryoverToNextMonth;
+        overspendingFromPrevMonth = overspendingThisMonth;
+      }
     }
 
     setData({

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-allow-selecting-future-months-in-date-range.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-allow-selecting-future-months-in-date-range.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tabedzki]
+---
+
+[AI] feat(budget analysis report): allow selecting future months in date range


### PR DESCRIPTION
Extend the allMonths picker list to December of the next year so users can select future months for long-term goal planning.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds more months to the dropdown. 
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Claude was used to write the code and test. 

Also adds theme-aware styling to the `<input type="month">` date pickers in the reports Header. The browser's native date picker dropdown was not respecting the active theme (always rendering in light mode regardless of the selected dark/midnight/custom theme). To fix this properly without hardcoding theme names, a `--color-scheme` CSS variable (`light` or `dark`) was added to each built-in theme file (`light.css`, `dark.css`, `midnight.css`) and exposed as `theme.colorScheme` in `theme.ts`. Custom themes inherit the value from whichever base theme they extend and can override it if needed.

## Related issue(s)

Addresses @A5308Y's [comment](https://github.com/actualbudget/actual/issues/6742#issuecomment-4181817155). @A5308Y, can you please confirm this functionality work as desired?

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Used the dropdown feature itself.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.18 MB → 13.09 MB (-93.89 kB) | -0.70%
loot-core | 1 | 4.83 MB → 4.82 MB (-5.62 kB) | -0.11%
api | 2 | 3.88 MB → 3.87 MB (-6.57 kB) | -0.17%
cli | 1 | 8.02 MB → 8.02 MB (+26 B) | +0.00%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.18 MB → 13.09 MB (-93.89 kB) | -0.70%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`src/components/formula/queryModeFunctions.ts` | 🆕 +18.72 kB | 0 B → 18.72 kB
`src/components/formula/transactionModeFunctions.ts` | 🆕 +15.31 kB | 0 B → 15.31 kB
`src/components/transactions/TransactionMenu.tsx` | 🆕 +8.32 kB | 0 B → 8.32 kB
`src/components/reports/useDashboardWidgetCopyMenu.ts` | 🆕 +636 B | 0 B → 636 B
`src/components/reports/reports/MissingReportCard.tsx` | 📈 +555 B (+64.84%) | 856 B → 1.38 kB
`src/components/formula/codeMirror-excelLanguage.tsx` | 📈 +9.45 kB (+57.31%) | 16.49 kB → 25.94 kB
`src/components/sidebar/BudgetName.tsx` | 📈 +1.39 kB (+25.43%) | 5.48 kB → 6.88 kB
`src/components/reports/reports/FormulaCard.tsx` | 📈 +1.03 kB (+22.00%) | 4.7 kB → 5.74 kB
`src/components/reports/reports/SummaryCard.tsx` | 📈 +1.14 kB (+21.62%) | 5.26 kB → 6.39 kB
`src/components/reports/graphs/tableGraph/ReportTableRow.tsx` | 📈 +2.06 kB (+18.39%) | 11.19 kB → 13.25 kB
`src/components/budget/SidebarCategory.tsx` | 📈 +1.28 kB (+16.66%) | 7.65 kB → 8.93 kB
`src/components/reports/reports/NetWorthCard.tsx` | 📈 +1.11 kB (+16.48%) | 6.75 kB → 7.87 kB
`src/components/rules/RuleRow.tsx` | 📈 +1.41 kB (+16.34%) | 8.63 kB → 10.04 kB
`src/components/reports/reports/SpendingCard.tsx` | 📈 +1.13 kB (+16.21%) | 7 kB → 8.13 kB
`src/components/reports/reports/BudgetAnalysisCard.tsx` | 📈 +1016 B (+16.11%) | 6.16 kB → 7.15 kB
`src/components/reports/reports/CustomReportListCards.tsx` | 📈 +1.16 kB (+16.05%) | 7.22 kB → 8.37 kB
`src/components/reports/reports/AgeOfMoneyCard.tsx` | 📈 +1.11 kB (+15.86%) | 7.02 kB → 8.13 kB
`src/tags/mutations.ts` | 📈 +487 B (+14.79%) | 3.21 kB → 3.69 kB
`src/components/reports/reports/CashFlowCard.tsx` | 📈 +1.11 kB (+11.94%) | 9.32 kB → 10.44 kB
`src/components/reports/reports/CrossoverCard.tsx` | 📈 +1.11 kB (+11.87%) | 9.36 kB → 10.47 kB
`src/hooks/useFormulaExecution.ts` | 📈 +1.58 kB (+11.62%) | 13.63 kB → 15.21 kB
`src/hooks/useCursorPosition.ts` | 📈 +99 B (+11.24%) | 881 B → 980 B
`src/components/reports/reports/SankeyCard.tsx` | 📈 +493 B (+11.04%) | 4.36 kB → 4.84 kB
`src/components/reports/Overview.tsx` | 📈 +2.49 kB (+9.89%) | 25.18 kB → 27.67 kB
`src/components/tags/TagsList.tsx` | 📈 +106 B (+9.74%) | 1.06 kB → 1.17 kB
`src/components/schedules/SchedulesTable.tsx` | 📈 +1.09 kB (+6.07%) | 17.98 kB → 19.07 kB
`src/components/reports/reports/BalanceForecastCard.tsx` | 📈 +497 B (+4.50%) | 10.79 kB → 11.28 kB
`src/hooks/useRefEventListener.ts` | 📈 +17 B (+3.94%) | 432 B → 449 B
`src/components/reports/reports/CalendarCard.tsx` | 📈 +497 B (+3.91%) | 12.4 kB → 12.89 kB
`src/components/payees/PayeeTableRow.tsx` | 📈 +398 B (+3.22%) | 12.07 kB → 12.46 kB
`src/components/reports/graphs/DonutGraph.tsx` | 📈 +561 B (+2.46%) | 22.27 kB → 22.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/browser-preload/start.ts` | 📈 +28 B (+2.02%) | 1.35 kB → 1.38 kB
`src/hooks/useInputRefValue.ts` | 📈 +12 B (+1.95%) | 614 B → 626 B
`src/components/reports/reports/MarkdownCard.tsx` | 📈 +94 B (+1.83%) | 5.02 kB → 5.11 kB
`locale/zh-Hans.json` | 📈 +1.74 kB (+1.59%) | 109.57 kB → 111.31 kB
`locale/ca.json` | 📈 +2.21 kB (+1.27%) | 174.64 kB → 176.85 kB
`locale/uk.json` | 📈 +2.47 kB (+1.21%) | 204.6 kB → 207.07 kB
`locale/es.json` | 📈 +1.89 kB (+1.13%) | 167.82 kB → 169.72 kB
`src/components/reports/graphs/CashFlowGraph.tsx` | 📈 +52 B (+0.57%) | 8.98 kB → 9.03 kB
`src/components/transactions/TransactionsTable.tsx` | 📈 +495 B (+0.54%) | 89.99 kB → 90.47 kB
`src/components/reports/graphs/LineGraph.tsx` | 📈 +36 B (+0.36%) | 9.86 kB → 9.89 kB
`src/components/reports/graphs/BarGraph.tsx` | 📈 +38 B (+0.32%) | 11.46 kB → 11.5 kB
`home/runner/work/actual/actual/packages/component-library/src/theme.ts` | 📈 +37 B (+0.29%) | 12.39 kB → 12.42 kB
`locale/it.json` | 📈 +420 B (+0.26%) | 155.52 kB → 155.93 kB
`locale/fr.json` | 📈 +440 B (+0.25%) | 169.79 kB → 170.22 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/light.css?inline` | 📈 +21 B (+0.18%) | 11.44 kB → 11.46 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/dark.css?inline` | 📈 +20 B (+0.17%) | 11.42 kB → 11.44 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/midnight.css?inline` | 📈 +20 B (+0.17%) | 11.54 kB → 11.56 kB
`src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx` | 📈 +10 B (+0.16%) | 5.93 kB → 5.94 kB
`src/components/mobile/budget/BudgetPage.tsx` | 📈 +60 B (+0.16%) | 36.92 kB → 36.97 kB
`src/components/tags/TagRow.tsx` | 📈 +13 B (+0.15%) | 8.38 kB → 8.4 kB
`src/components/reports/spreadsheets/net-worth-spreadsheet.ts` | 📈 +6 B (+0.10%) | 5.62 kB → 5.63 kB
`locale/nb-NO.json` | 📈 +124 B (+0.09%) | 139.35 kB → 139.47 kB
`src/components/reports/graphs/CalendarGraph.tsx` | 📈 +8 B (+0.08%) | 10.04 kB → 10.04 kB
`src/components/reports/ReportSummary.tsx` | 📈 +2 B (+0.05%) | 3.81 kB → 3.81 kB
`locale/nl.json` | 📈 +49 B (+0.04%) | 116.92 kB → 116.97 kB
`src/components/reports/ReportSidebar.tsx` | 📈 +4 B (+0.02%) | 18.26 kB → 18.27 kB
`src/components/autocomplete/CategoryAutocomplete.tsx` | 📈 +2 B (+0.01%) | 14.9 kB → 14.9 kB
`src/components/reports/AccountSelector.tsx` | 📈 +2 B (+0.01%) | 15.56 kB → 15.57 kB
`src/components/reports/reports/Sankey.tsx` | 📈 +4 B (+0.01%) | 31.73 kB → 31.74 kB
`src/components/reports/reports/AgeOfMoney.tsx` | 📈 +2 B (+0.01%) | 17.96 kB → 17.96 kB
`src/components/reports/reports/CustomReport.tsx` | 📉 -2 B (-0.00%) | 42.29 kB → 42.29 kB
`src/components/reports/reports/Calendar.tsx` | 📉 -7 B (-0.02%) | 27.58 kB → 27.58 kB
`src/components/reports/reports/BalanceForecast.tsx` | 📉 -5 B (-0.03%) | 16.95 kB → 16.94 kB
`src/components/reports/spreadsheets/custom-spreadsheet.ts` | 📉 -2 B (-0.04%) | 5.53 kB → 5.53 kB
`src/components/mobile/transactions/TransactionListWithBalances.tsx` | 📉 -4 B (-0.04%) | 10.11 kB → 10.1 kB
`src/components/reports/reports/NetWorth.tsx` | 📉 -6 B (-0.04%) | 14.16 kB → 14.15 kB
`src/components/reports/reports/Spending.tsx` | 📉 -12 B (-0.05%) | 24.6 kB → 24.59 kB
`src/components/reports/spreadsheets/crossover-spreadsheet.ts` | 📉 -4 B (-0.05%) | 7.96 kB → 7.95 kB
`src/components/reports/reports/balanceForecastChartData.ts` | 📉 -2 B (-0.06%) | 3.24 kB → 3.24 kB
`src/components/reports/reports/Summary.tsx` | 📉 -26 B (-0.10%) | 25.59 kB → 25.56 kB
`src/components/reports/reports/CashFlow.tsx` | 📉 -10 B (-0.11%) | 9.27 kB → 9.26 kB
`src/components/reports/spreadsheets/calendar-spreadsheet.ts` | 📉 -6 B (-0.12%) | 5.05 kB → 5.04 kB
`src/components/reports/spreadsheets/age-of-money-spreadsheet.ts` | 📉 -12 B (-0.21%) | 5.7 kB → 5.69 kB
`src/components/reports/DateRange.tsx` | 📉 -8 B (-0.23%) | 3.34 kB → 3.33 kB
`src/components/banksync/EditSyncAccount.tsx` | 📉 -19 B (-0.24%) | 7.59 kB → 7.57 kB
`src/components/reports/spreadsheets/summary-spreadsheet.ts` | 📉 -16 B (-0.28%) | 5.57 kB → 5.56 kB
`src/components/table.tsx` | 📉 -124 B (-0.31%) | 38.5 kB → 38.38 kB
`home/runner/work/actual/actual/packages/component-library/src/Menu.tsx` | 📉 -16 B (-0.32%) | 4.95 kB → 4.93 kB
`src/components/reports/graphs/BudgetAnalysisGraph.tsx` | 📉 -79 B (-0.64%) | 12 kB → 11.93 kB
`src/components/sidebar/Account.tsx` | 📉 -88 B (-0.67%) | 12.8 kB → 12.71 kB
`src/components/tags/ManageTags.tsx` | 📉 -64 B (-1.13%) | 5.52 kB → 5.46 kB
`src/components/reports/Header.tsx` | 📉 -247 B (-1.36%) | 17.7 kB → 17.46 kB
`src/components/mobile/ActionableGridListItem.tsx` | 📉 -81 B (-1.40%) | 5.64 kB → 5.56 kB
`package.json` | 📉 -158 B (-1.60%) | 9.63 kB → 9.47 kB
`src/hooks/useTagCSS.ts` | 📉 -26 B (-1.78%) | 1.43 kB → 1.4 kB
`locale/en.json` | 📉 -3.9 kB (-1.94%) | 201.39 kB → 197.49 kB
`src/components/reports/reports/Crossover.tsx` | 📉 -861 B (-2.00%) | 42.05 kB → 41.21 kB
`locale/pt-BR.json` | 📉 -4.07 kB (-2.23%) | 182.8 kB → 178.74 kB
`src/redux/store.ts` | 📉 -23 B (-2.41%) | 954 B → 931 B
`src/components/modals/SimpleFinInitialiseModal.tsx` | 📉 -101 B (-2.68%) | 3.69 kB → 3.59 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📉 -2.17 kB (-2.92%) | 74.41 kB → 72.24 kB
`src/components/budget/SidebarGroup.tsx` | 📉 -305 B (-2.98%) | 10 kB → 9.7 kB
`src/components/budget/envelope/EnvelopeBudgetComponents.tsx` | 📉 -945 B (-3.14%) | 29.39 kB → 28.47 kB
`src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts` | 📉 -170 B (-3.17%) | 5.23 kB → 5.07 kB
`src/components/mobile/MobileForms.tsx` | 📉 -303 B (-3.50%) | 8.46 kB → 8.16 kB
`locale/de.json` | 📉 -6.99 kB (-3.84%) | 181.92 kB → 174.94 kB
`src/hooks/useContextMenu.ts` | 📉 -37 B (-4.08%) | 906 B → 869 B
`src/components/budget/envelope/budgetsummary/ToBudget.tsx` | 📉 -300 B (-4.97%) | 5.9 kB → 5.6 kB
`src/components/reports/graphs/StackedBarGraph.tsx` | 📉 -533 B (-5.02%) | 10.36 kB → 9.84 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/FormulaEditor.js | 730.27 kB → 735.67 kB (+5.4 kB) | +0.74%
static/js/uk.js | 204.6 kB → 207.07 kB (+2.47 kB) | +1.21%
static/js/ca.js | 174.64 kB → 176.85 kB (+2.21 kB) | +1.27%
static/js/es.js | 167.82 kB → 169.72 kB (+1.89 kB) | +1.13%
static/js/zh-Hans.js | 109.57 kB → 111.31 kB (+1.74 kB) | +1.59%
static/js/fr.js | 169.79 kB → 170.22 kB (+440 B) | +0.25%
static/js/it.js | 155.52 kB → 155.93 kB (+420 B) | +0.26%
static/js/wide.js | 304.69 kB → 305.07 kB (+390 B) | +0.13%
static/js/nb-NO.js | 139.35 kB → 139.47 kB (+124 B) | +0.09%
static/js/nl.js | 116.92 kB → 116.97 kB (+49 B) | +0.04%
static/js/theme.js | 31.02 kB → 31.06 kB (+37 B) | +0.12%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.28 MB → 1.23 MB (-48.86 kB) | -3.73%
static/js/pl.js | 139.95 kB → 99.04 kB (-40.91 kB) | -29.23%
static/js/de.js | 181.92 kB → 174.94 kB (-6.99 kB) | -3.84%
static/js/pt-BR.js | 182.8 kB → 178.74 kB (-4.07 kB) | -2.23%
static/js/en.js | 201.39 kB → 197.49 kB (-3.9 kB) | -1.94%
static/js/index.js | 7.64 MB → 7.63 MB (-2.33 kB) | -0.03%
static/js/en-GB.js | 11.1 kB → 9.19 kB (-1.91 kB) | -17.22%
static/js/extends.js | 435.59 kB → 435.54 kB (-47 B) | -0.01%
static/js/narrow.js | 358.81 kB → 358.79 kB (-25 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.82 MB (-5.62 kB) | -0.11%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -108 B (-0.42%) | 24.91 kB → 24.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -114 B (-0.45%) | 24.87 kB → 24.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -199 B (-0.64%) | 30.23 kB → 30.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -291 B (-1.32%) | 21.54 kB → 21.25 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/index.ts` | 📉 -106 B (-3.13%) | 3.31 kB → 3.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📉 -388 B (-3.32%) | 11.42 kB → 11.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📉 -108 B (-16.54%) | 653 B → 545 B
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📉 -4.33 kB (-17.55%) | 24.68 kB → 20.35 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.yR1ffGL9.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.87 MB (-6.57 kB) | -0.17%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -107 B (-0.43%) | 24.41 kB → 24.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -114 B (-0.46%) | 24.27 kB → 24.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -194 B (-0.64%) | 29.68 kB → 29.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -279 B (-1.29%) | 21.11 kB → 20.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📉 -383 B (-3.38%) | 11.05 kB → 10.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📉 -4.2 kB (-17.55%) | 23.91 kB → 19.71 kB
`methods.ts` | 📉 -1.32 kB (-18.90%) | 6.99 kB → 5.67 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.87 MB (-6.57 kB) | -0.17%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+26 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/strip-ansi/index.js` | 📈 +26 B (+9.09%) | 286 B → 312 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+26 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->