### PR TITLE
[AI] feat(currencies): decimal-aware amount handling in server

### DIFF
--- a/packages/desktop-client/e2e/onboarding.test.ts
+++ b/packages/desktop-client/e2e/onboarding.test.ts
@@ -60,10 +60,14 @@ test.describe('Onboarding', () => {
     await expect(budgetPage.budgetTable).toBeVisible({ timeout: 30000 });
 
     const accountPage = await navigation.goToAccountPage('Checking');
-    await expect(accountPage.accountBalance).toHaveText('2,600.00');
+    // The nYNAB demo file declares a USD currency, so importing it sets the
+    // default currency and account balances render with the currency symbol.
+    // The symbol is wrapped in Unicode bidi isolates by the formatter, so the
+    // pattern tolerates those marks between the symbol and the amount.
+    await expect(accountPage.accountBalance).toHaveText(/\$\D*2,600\.00/);
 
     await navigation.goToAccountPage('Saving');
-    await expect(accountPage.accountBalance).toHaveText('250.00');
+    await expect(accountPage.accountBalance).toHaveText(/\$\D*250\.00/);
 
     await navigation.goToSchedulesPage();
     const scheduleRows = page.getByTestId('table').getByTestId('row');

--- a/packages/loot-core/src/server/accounts/app.test.ts
+++ b/packages/loot-core/src/server/accounts/app.test.ts
@@ -1,0 +1,54 @@
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import { runMutator } from '#server/mutators';
+import { setDefaultCurrencyCode } from '#server/util/currency';
+
+import { app } from './app';
+
+const createAccountHandler = app.handlers['account-create'];
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+});
+
+describe('createAccount starting balance encoding', () => {
+  it('USD (2dp): balance 12.34 stores as integer 1234', async () => {
+    await setDefaultCurrencyCode('USD');
+    const id = await runMutator(() =>
+      createAccountHandler({ name: 'Checking', balance: 12.34 }),
+    );
+    const txns = db.runQuery<{ amount: number }>(
+      'SELECT amount FROM transactions WHERE acct = ? AND starting_balance_flag = 1',
+      [id],
+      true,
+    );
+    expect(txns[0].amount).toBe(1234);
+  });
+
+  it('JPY (0dp): balance 50000 stores as integer 50000, not 5000000', async () => {
+    await setDefaultCurrencyCode('JPY');
+    const id = await runMutator(() =>
+      createAccountHandler({ name: 'Savings', balance: 50000 }),
+    );
+    const txns = db.runQuery<{ amount: number }>(
+      'SELECT amount FROM transactions WHERE acct = ? AND starting_balance_flag = 1',
+      [id],
+      true,
+    );
+    expect(txns[0].amount).toBe(50000);
+  });
+
+  it('unset currency (empty string): treats as 2dp', async () => {
+    await setDefaultCurrencyCode('');
+    const id = await runMutator(() =>
+      createAccountHandler({ name: 'Generic', balance: 10.5 }),
+    );
+    const txns = db.runQuery<{ amount: number }>(
+      'SELECT amount FROM transactions WHERE acct = ? AND starting_balance_flag = 1',
+      [id],
+      true,
+    );
+    expect(txns[0].amount).toBe(1050);
+  });
+});

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -18,10 +18,11 @@ import { get, post } from '#server/post';
 import { getServer } from '#server/server-config';
 import { batchMessages } from '#server/sync';
 import { undoable, withUndo } from '#server/undo';
+import { getDefaultCurrencyCode } from '#server/util/currency';
 import { isNonProductionEnvironment } from '#shared/environment';
 import { dayFromDate } from '#shared/months';
 import * as monthUtils from '#shared/months';
-import { amountToInteger } from '#shared/util';
+import { amountToCurrencyInteger } from '#shared/util';
 import type { ImportTransactionsOpts } from '#types/api-handlers';
 import type {
   AccountEntity,
@@ -567,10 +568,11 @@ async function createAccount({
 
   if (balance != null && balance !== 0) {
     const payee = await getStartingBalancePayee();
+    const defaultCurrencyCode = await getDefaultCurrencyCode();
 
     await db.insertTransaction({
       account: id,
-      amount: amountToInteger(balance),
+      amount: amountToCurrencyInteger(balance, defaultCurrencyCode),
       category: offBudget ? null : payee.category,
       payee: payee.id,
       date: monthUtils.currentDay(),

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -14,6 +14,7 @@ import { getServer } from '#server/server-config';
 import { batchMessages } from '#server/sync';
 import { batchUpdateTransactions } from '#server/transactions';
 import { runRules } from '#server/transactions/transaction-rules';
+import { getDefaultCurrencyCode } from '#server/util/currency';
 import {
   defaultMappings,
   mappingsFromString,
@@ -25,7 +26,7 @@ import {
   recalculateSplit,
 } from '#shared/transactions';
 import {
-  amountToInteger,
+  amountToCurrencyInteger,
   hasFieldsChanged,
   integerToAmount,
 } from '#shared/util';
@@ -484,23 +485,25 @@ async function normalizeTransactions(
 async function normalizeBankSyncTransactions(transactions, acctId) {
   const payeesToCreate = new Map();
 
-  const [customMappingsRaw, importPending, importNotes] = await Promise.all([
-    aqlQuery(
-      q('preferences')
-        .filter({ id: `custom-sync-mappings-${acctId}` })
-        .select('value'),
-    ).then(data => data?.data?.[0]?.value),
-    aqlQuery(
-      q('preferences')
-        .filter({ id: `sync-import-pending-${acctId}` })
-        .select('value'),
-    ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true'),
-    aqlQuery(
-      q('preferences')
-        .filter({ id: `sync-import-notes-${acctId}` })
-        .select('value'),
-    ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true'),
-  ]);
+  const [customMappingsRaw, importPending, importNotes, defaultCurrencyCode] =
+    await Promise.all([
+      aqlQuery(
+        q('preferences')
+          .filter({ id: `custom-sync-mappings-${acctId}` })
+          .select('value'),
+      ).then(data => data?.data?.[0]?.value),
+      aqlQuery(
+        q('preferences')
+          .filter({ id: `sync-import-pending-${acctId}` })
+          .select('value'),
+      ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true'),
+      aqlQuery(
+        q('preferences')
+          .filter({ id: `sync-import-notes-${acctId}` })
+          .select('value'),
+      ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true'),
+      getDefaultCurrencyCode(),
+    ]);
 
   const mappings = customMappingsRaw
     ? mappingsFromString(customMappingsRaw)
@@ -551,7 +554,7 @@ async function normalizeBankSyncTransactions(transactions, acctId) {
     normalized.push({
       payee_name: payeeName,
       trans: {
-        amount: amountToInteger(trans.amount),
+        amount: amountToCurrencyInteger(trans.amount, defaultCurrencyCode),
         payee: trans.payee,
         account: trans.account,
         date,
@@ -1035,17 +1038,20 @@ async function processBankSyncDownload(
   // that account sync sources can give two different transaction IDs even though it's the same transaction.
   const useStrictIdChecking = !acctRow.account_sync_source;
 
-  const importTransactions = await aqlQuery(
-    q('preferences')
-      .filter({ id: `sync-import-transactions-${id}` })
-      .select('value'),
-  ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true');
-
-  const updateDates = await aqlQuery(
-    q('preferences')
-      .filter({ id: `sync-update-dates-${id}` })
-      .select('value'),
-  ).then(data => String(data?.data?.[0]?.value ?? 'false') === 'true');
+  const [importTransactions, updateDates, defaultCurrencyCode] =
+    await Promise.all([
+      aqlQuery(
+        q('preferences')
+          .filter({ id: `sync-import-transactions-${id}` })
+          .select('value'),
+      ).then(data => String(data?.data?.[0]?.value ?? 'true') === 'true'),
+      aqlQuery(
+        q('preferences')
+          .filter({ id: `sync-update-dates-${id}` })
+          .select('value'),
+      ).then(data => String(data?.data?.[0]?.value ?? 'false') === 'true'),
+      getDefaultCurrencyCode(),
+    ]);
 
   /** Starting balance is actually the current balance of the account. */
   const {
@@ -1063,14 +1069,23 @@ async function processBankSyncDownload(
     } else if (acctRow.account_sync_source === 'simpleFin') {
       const previousBalance = transactions.reduce((total, trans) => {
         return (
-          total - parseInt(trans.transactionAmount.amount.replace('.', ''))
+          total -
+          amountToCurrencyInteger(
+            parseFloat(trans.transactionAmount.amount),
+            defaultCurrencyCode,
+          )
         );
       }, currentBalance);
       balanceToUse = previousBalance;
     } else if (acctRow.account_sync_source === 'pluggyai') {
       const currentBalance = download.startingBalance;
       const previousBalance = transactions.reduce(
-        (total, trans) => total - trans.transactionAmount.amount * 100,
+        (total, trans) =>
+          total -
+          amountToCurrencyInteger(
+            trans.transactionAmount.amount,
+            defaultCurrencyCode,
+          ),
         currentBalance,
       );
       balanceToUse = Math.round(previousBalance);
@@ -1084,14 +1099,24 @@ async function processBankSyncDownload(
         ? transactions
         : transactions.filter(trans => Boolean(trans.booked));
       const previousBalance = importable.reduce((total, trans) => {
-        return total - amountToInteger(trans.transactionAmount.amount);
+        return (
+          total -
+          amountToCurrencyInteger(
+            trans.transactionAmount.amount,
+            defaultCurrencyCode,
+          )
+        );
       }, currentBalance);
       balanceToUse = previousBalance;
     } else if (acctRow.account_sync_source === 'akahu') {
       const currentBalance = download.startingBalance;
       const previousBalance = transactions.reduce(
         (total, trans) =>
-          total - amountToInteger(trans.transactionAmount.amount),
+          total -
+          amountToCurrencyInteger(
+            trans.transactionAmount.amount,
+            defaultCurrencyCode,
+          ),
         currentBalance,
       );
       balanceToUse = Math.round(previousBalance);

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -16,7 +16,7 @@ import {
   ungroupTransactions,
   updateTransaction,
 } from '#shared/transactions';
-import { integerToAmount } from '#shared/util';
+import { integerToCurrencyAmount } from '#shared/util';
 import type { Handlers } from '#types/handlers';
 import type {
   AccountEntity,
@@ -47,6 +47,7 @@ import { runMutator } from './mutators';
 import * as prefs from './prefs';
 import * as sheet from './sheet';
 import { batchMessages, setSyncingMode } from './sync';
+import { getDefaultCurrencyCode } from './util/currency';
 
 let IMPORT_MODE = false;
 
@@ -601,13 +602,20 @@ handlers['api/account-create'] = withMutation(async function ({
   initialBalance = null,
 }) {
   checkFileOpen();
+  let balance: number | null = null;
+  if (initialBalance != null) {
+    // Currently the API expects an amount but it really should expect
+    // an integer
+    balance = integerToCurrencyAmount(
+      initialBalance,
+      await getDefaultCurrencyCode(),
+    );
+  }
   return handlers['account-create']({
     name: account.name,
     offBudget: account.offbudget,
     closed: account.closed,
-    // Current the API expects an amount but it really should expect
-    // an integer
-    balance: initialBalance != null ? integerToAmount(initialBalance) : null,
+    balance,
   });
 });
 

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -4,8 +4,9 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { logger } from '#platform/server/log';
 import { send } from '#server/main-app';
+import { setDefaultCurrencyCode } from '#server/util/currency';
 import * as monthUtils from '#shared/months';
-import { amountToInteger, groupBy, sortByKey } from '#shared/util';
+import { amountToCurrencyInteger, groupBy, sortByKey } from '#shared/util';
 
 import type * as YNAB4 from './ynab4-types';
 
@@ -133,6 +134,7 @@ async function importTransactions(
   data: YNAB4.YFull,
   entityIdMap: Map<string, string>,
 ) {
+  const currencyCode = data.budgetMetaData.currencyISOSymbol ?? '';
   const categories = await send('api/categories-get', {
     grouped: false,
   });
@@ -213,7 +215,7 @@ async function importTransactions(
 
           const newTransaction = {
             id,
-            amount: amountToInteger(transaction.amount),
+            amount: amountToCurrencyInteger(transaction.amount, currencyCode),
             category: isOffBudget(entityIdMap.get(accountId))
               ? null
               : getCategory(transaction.categoryId),
@@ -232,7 +234,7 @@ async function importTransactions(
                 .map(t => {
                   return {
                     id: entityIdMap.get(t.entityId),
-                    amount: amountToInteger(t.amount),
+                    amount: amountToCurrencyInteger(t.amount, currencyCode),
                     category: getCategory(t.categoryId),
                     notes: t.memo || null,
                     ...transferProperties(t),
@@ -288,6 +290,7 @@ async function importBudgets(
   data: YNAB4.YFull,
   entityIdMap: Map<string, string>,
 ) {
+  const currencyCode = data.budgetMetaData.currencyISOSymbol ?? '';
   const budgets = sortByKey(data.monthlyBudgets, 'month');
 
   await send('api/batch-budget-start');
@@ -300,7 +303,10 @@ async function importBudgets(
 
       await Promise.all(
         filled.map(async catBudget => {
-          const amount = amountToInteger(catBudget.budgeted);
+          const amount = amountToCurrencyInteger(
+            catBudget.budgeted,
+            currencyCode,
+          );
           const catId = entityIdMap.get(catBudget.categoryId);
           const month = monthUtils.monthFromDate(budget.month);
           if (!catId) {
@@ -375,6 +381,11 @@ function findLatestDevice(zipped: AdmZip, entries: AdmZip.IZipEntry[]): string {
 
 export async function doImport(data: YNAB4.YFull) {
   const entityIdMap = new Map<string, string>();
+
+  const currencyCode = data.budgetMetaData.currencyISOSymbol ?? '';
+  if (currencyCode) {
+    await setDefaultCurrencyCode(currencyCode);
+  }
 
   logger.log('Importing Accounts...');
   await importAccounts(data, entityIdMap);

--- a/packages/loot-core/src/server/importers/ynab5.test.ts
+++ b/packages/loot-core/src/server/importers/ynab5.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { amountToCurrencyInteger } from '#shared/util';
+
 import { getBudgetName, parseFile } from './ynab5';
 
 function toBuffer(obj: unknown): Buffer {
@@ -29,5 +31,34 @@ describe('ynab5 parseFile', () => {
     const data = parseFile(toBuffer({ name: 'Bare', accounts: [] }));
 
     expect(data.name).toBe('Bare');
+  });
+});
+
+// Tests for the YNAB5 milliunit conversion used by amountFromYnab.
+// YNAB5 stores all amounts as milliunits: 1 major unit = 1000 milliunits.
+// The conversion is: amountToCurrencyInteger(milliamount / 1000, currency)
+describe('YNAB5 milliunit conversion', () => {
+  it('converts USD 12340 milliunits to 1234', () => {
+    // $12.34 = 12340 milliunits; stored as 1234 (cents)
+    expect(amountToCurrencyInteger(12340 / 1000, 'USD')).toBe(1234);
+  });
+
+  it('converts JPY 1234000 milliunits to 1234 not 123400', () => {
+    // Old formula: Math.round(1234000 / 10) = 123400 (×100 inflation)
+    // New formula: amountToCurrencyInteger(1234000 / 1000, 'JPY') = 1234
+    expect(amountToCurrencyInteger(1234000 / 1000, 'JPY')).toBe(1234);
+  });
+
+  it('converts IRR 5678000 milliunits to 5678', () => {
+    expect(amountToCurrencyInteger(5678000 / 1000, 'IRR')).toBe(5678);
+  });
+
+  it('converts KRW 99000 milliunits to 99', () => {
+    expect(amountToCurrencyInteger(99000 / 1000, 'KRW')).toBe(99);
+  });
+
+  it('falls back to 2dp for unknown currency', () => {
+    // 12340 milliunits = 12.34 major units; 2dp → stored as 1234
+    expect(amountToCurrencyInteger(12340 / 1000, 'XYZ')).toBe(1234);
   });
 });

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -4,9 +4,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { logger } from '#platform/server/log';
 import { send } from '#server/main-app';
 import { ruleModel } from '#server/transactions/transaction-rules';
+import { setDefaultCurrencyCode } from '#server/util/currency';
 import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
-import { groupBy, sortByKey } from '#shared/util';
+import { amountToCurrencyInteger, groupBy, sortByKey } from '#shared/util';
 import type { RecurConfig, RecurPattern, RuleEntity } from '#types/models';
 
 import type {
@@ -68,10 +69,10 @@ function findIdByName<T extends { id: string; name: string }>(
   return findByNameIgnoreCase<T>(categories, name)?.id;
 }
 
-function amountFromYnab(amount: number) {
-  // YNAB multiplies amount by 1000 and Actual by 100
-  // so, this function divides by 10
-  return Math.round(amount / 10);
+function amountFromYnab(amount: number, currency: string) {
+  // YNAB stores amounts as milliunits (÷1000 = major unit). Convert to
+  // Actual's integer encoding for the given currency's decimal precision.
+  return amountToCurrencyInteger(amount / 1000, currency);
 }
 
 function getDayOfMonth(date: string) {
@@ -571,6 +572,7 @@ async function importTransactions(
   entityIdMap: Map<string, string>,
   flagNameConflicts: Set<string>,
 ) {
+  const currencyCode = data.currency_format?.iso_code ?? '';
   const payees = await send('api/payees-get');
   const categories = await send('api/categories-get', {
     grouped: false,
@@ -760,7 +762,7 @@ async function importTransactions(
             id: entityIdMap.get(transaction.id),
             account: entityIdMap.get(transaction.account_id),
             date: transaction.date,
-            amount: amountFromYnab(transaction.amount),
+            amount: amountFromYnab(transaction.amount, currencyCode),
             category: entityIdMap.get(transaction.category_id) || null,
             cleared: ['cleared', 'reconciled'].includes(transaction.cleared),
             reconciled: transaction.cleared === 'reconciled',
@@ -774,7 +776,7 @@ async function importTransactions(
               ? subtransactions.map(subtrans => {
                   return {
                     id: entityIdMap.get(subtrans.id),
-                    amount: amountFromYnab(subtrans.amount),
+                    amount: amountFromYnab(subtrans.amount, currencyCode),
                     category: entityIdMap.get(subtrans.category_id) || null,
                     notes: subtrans.memo,
                     transfer_id:
@@ -852,6 +854,7 @@ async function importScheduledTransactions(
   entityIdMap: Map<string, string>,
   flagNameConflicts: Set<string>,
 ) {
+  const currencyCode = data.currency_format?.iso_code ?? '';
   const scheduledTransactions = data.scheduled_transactions;
   const scheduledSubtransactionsGrouped = groupBy(
     data.scheduled_subtransactions,
@@ -956,7 +959,7 @@ async function importScheduledTransactions(
       posts_transaction: false,
       payee: mappedPayeeId,
       account: mappedAccountId,
-      amount: amountFromYnab(scheduled.amount),
+      amount: amountFromYnab(scheduled.amount, currencyCode),
       amountOp: 'is',
       date: scheduleDate,
     });
@@ -1027,7 +1030,7 @@ async function importScheduledTransactions(
 
         actions.push({
           op: 'set-split-amount',
-          value: amountFromYnab(subtransaction.amount),
+          value: amountFromYnab(subtransaction.amount, currencyCode),
           options: { splitIndex, method: 'fixed-amount' },
         });
 
@@ -1103,6 +1106,7 @@ async function importBudgets(data: Budget, entityIdMap: Map<string, string>) {
   // Also, there could be a way to set rollover using
   // Deferred Income Subcat and Immediate Income Subcat
 
+  const currencyCode = data.currency_format?.iso_code ?? '';
   const budgets = sortByKey(data.months, 'month');
 
   const internalCatIdYnab = findIdByName(
@@ -1122,7 +1126,7 @@ async function importBudgets(data: Budget, entityIdMap: Map<string, string>) {
       await Promise.all(
         budget.categories.map(async catBudget => {
           const catId = entityIdMap.get(catBudget.id);
-          const amount = Math.round(catBudget.budgeted / 10);
+          const amount = amountFromYnab(catBudget.budgeted, currencyCode);
 
           if (
             !catId ||
@@ -1168,6 +1172,11 @@ export function getBudgetName(_filepath: string, data: Budget) {
 export async function doImport(data: Budget) {
   const entityIdMap = new Map<string, string>();
   const flagNameConflicts = getFlagNameConflicts(data);
+
+  const currencyCode = data.currency_format?.iso_code ?? '';
+  if (currencyCode) {
+    await setDefaultCurrencyCode(currencyCode);
+  }
 
   logger.log('Importing Accounts...');
   await importAccounts(data, entityIdMap);

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -6,13 +6,15 @@ import enUS from 'hyperformula/i18n/languages/enUS';
 
 import { logger } from '#platform/server/log';
 import type { TransactionForRules } from '#server/transactions/transaction-rules';
+import { getDefaultCurrencyCodeSync } from '#server/util/currency';
+import { getDecimalPlaces } from '#shared/currencies';
 import {
   CustomFunctionsPlugin,
   customFunctionsTranslations,
 } from '#shared/formulas/customFunctions';
 import { currentDay, format, parseDate } from '#shared/months';
 import { FIELD_TYPES } from '#shared/rules';
-import { amountToInteger } from '#shared/util';
+import { amountToCurrencyInteger } from '#shared/util';
 
 import { assert } from './rule-utils';
 
@@ -357,7 +359,13 @@ export class Action {
       }
 
       if (typeof cellValue === 'number') {
-        return amountToInteger(Math.round(cellValue * 100) / 100);
+        const code = getDefaultCurrencyCodeSync();
+        const dp = getDecimalPlaces(code);
+        const scale = Math.pow(10, dp);
+        return amountToCurrencyInteger(
+          Math.round(cellValue * scale) / scale,
+          code,
+        );
       }
 
       return cellValue;

--- a/packages/loot-core/src/server/transactions/export/export-to-csv.ts
+++ b/packages/loot-core/src/server/transactions/export/export-to-csv.ts
@@ -2,7 +2,8 @@
 import { stringify as csvStringify } from 'csv-stringify/sync';
 
 import { aqlQuery } from '#server/aql';
-import { integerToAmount } from '#shared/util';
+import { getDefaultCurrencyCode } from '#server/util/currency';
+import { integerToCurrencyAmount } from '#shared/util';
 
 const FORMULA_TRIGGERS = /^[=+\-@\t\r]/;
 
@@ -20,6 +21,7 @@ export async function exportToCSV(
   categoryGroups,
   payees,
 ) {
+  const currencyCode = await getDefaultCurrencyCode();
   const accountNamesById = accounts.reduce((reduced, { id, name }) => {
     reduced[id] = name;
     return reduced;
@@ -57,7 +59,8 @@ export async function exportToCSV(
       Payee: payeeNamesById[payee],
       Notes: notes,
       Category: categoryNamesById[category],
-      Amount: amount == null ? 0 : integerToAmount(amount),
+      Amount:
+        amount == null ? 0 : integerToCurrencyAmount(amount, currencyCode),
       Cleared: cleared,
       Reconciled: reconciled,
     }),
@@ -67,6 +70,7 @@ export async function exportToCSV(
 }
 
 export async function exportQueryToCSV(query) {
+  const currencyCode = await getDefaultCurrencyCode();
   const { data: transactions } = await aqlQuery(
     query
       .select([
@@ -127,8 +131,10 @@ export async function exportQueryToCSV(query) {
         ? 0
         : trans.Amount == null
           ? 0
-          : integerToAmount(trans.Amount),
-      Split_Amount: trans.IsParent ? integerToAmount(trans.Amount) : 0,
+          : integerToCurrencyAmount(trans.Amount, currencyCode),
+      Split_Amount: trans.IsParent
+        ? integerToCurrencyAmount(trans.Amount, currencyCode)
+        : 0,
       Cleared:
         trans.Reconciled === true
           ? 'Reconciled'

--- a/packages/loot-core/src/server/util/currency.ts
+++ b/packages/loot-core/src/server/util/currency.ts
@@ -1,0 +1,27 @@
+import * as db from '#server/db';
+
+export async function getDefaultCurrencyCode(): Promise<string> {
+  try {
+    const row = await db.first<{ value: string }>(
+      "SELECT value FROM preferences WHERE id = 'defaultCurrencyCode'",
+    );
+    return row?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export async function setDefaultCurrencyCode(code: string): Promise<void> {
+  await db.update('preferences', { id: 'defaultCurrencyCode', value: code });
+}
+
+export function getDefaultCurrencyCodeSync(): string {
+  try {
+    const row = db.firstSync<{ value: string }>(
+      "SELECT value FROM preferences WHERE id = 'defaultCurrencyCode'",
+    );
+    return row?.value ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/packages/loot-core/src/shared/util.ts
+++ b/packages/loot-core/src/shared/util.ts
@@ -486,6 +486,13 @@ export function amountToCurrencyInteger(amount: number, code: string): number {
   return amountToInteger(amount, getDecimalPlaces(code));
 }
 
+export function integerToCurrencyAmount(
+  integerAmount: IntegerAmount,
+  code: string,
+): Amount {
+  return integerToAmount(integerAmount, getDecimalPlaces(code));
+}
+
 export function amountToCurrency(amount: Amount): CurrencyAmount {
   return getNumberFormat().formatter.format(amount);
 }

--- a/upcoming-release-notes/currency-decimal-server.md
+++ b/upcoming-release-notes/currency-decimal-server.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [StephenBrown2]
+---
+
+Server-side amount encoding now respects each currency's decimal precision.


### PR DESCRIPTION
## Description

Second part of the multi-currency implementation (i.e. [DP-2]). Implements decimal-aware amount encoding through all loot-core server paths so that currencies with non-standard decimal places (e.g. JPY at 0dp, KWD at 3dp) are stored and exported correctly rather than being assumed to be 2dp like USD.

**PR stack:** https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc

- [DP-1]: Currency metadata and decimal helper functions — [#8064](https://github.com/actualbudget/actual/pull/8064)
- **[DP-2]: Server-side decimal-aware amount handling — This PR**
- [DP-3]: desktop-client: transaction table and search — TBD
- [DP-4]: desktop-client: budget UI components — TBD
- [DP-5]: desktop-client: modals, mobile, settings, and E2E — TBD
- [DP-6]: Historical data migration for non-2dp currencies — TBD
- [DP-7]: desktop-client: remove "hide decimal places" setting — TBD

**Changes:**

- New `packages/loot-core/src/server/util/currency.ts` — shared helpers (`getDefaultCurrencyCode`, `getDefaultCurrencyCodeSync`, `setDefaultCurrencyCode`) that read/write the `defaultCurrencyCode` preference, replacing duplicated inline queries across server files.
- New `integerToCurrencyAmount(integer, code)` in `#shared/util` — symmetric companion to the existing `amountToCurrencyInteger`.
- YNAB5 importer: updates `amountFromYnab` to convert milliunits using the budget's currency precision, and sets `defaultCurrencyCode` from the budget's ISO code on import.
- YNAB4 importer: uses `amountToCurrencyInteger` with the budget's currency instead of a hardcoded scale.
- `accounts/app.ts`, `accounts/sync.ts`, `rules/action.ts`, `transactions/export/export-to-csv.ts`, `api.ts`: all replaced ad-hoc `getDecimalPlaces` + `amountToInteger` patterns with the new shared helpers.

No behavior change for existing 2dp budgets (USD, EUR, GBP, etc.).

### Regression analysis for non-2dp budgets

Before this PR, all server paths hardcoded 2dp regardless of `defaultCurrencyCode`. The preference existed in the schema and was already exposed in the Settings UI (`Currency.tsx`) for client-side display formatting, but was never read by the server. This PR makes the server read it and apply the correct precision.

- **Existing budgets with no currency set**: zero risk. Empty string falls back to 2dp via `getDecimalPlaces`, identical behavior to before.
- **Existing budgets with `defaultCurrencyCode = 'JPY'` (or other 0dp currency)**: Historical transactions were stored at 100x inflation by the old server code (¥1234 → integer `123400`). The client masked this by combining 2dp display with the `hideFraction` pref (set automatically to `true` when a 0dp currency is selected in Settings), so ¥1234 stored as `123400` rendered as `1234.00` → `1234` — appearing correct. After this PR, new server writes produce correctly-encoded integers (¥1234 → `1234`). The same client path then renders `1234` as `12.34` → `12` via `hideFraction`, showing 1/100 of the correct value. So display was silently masked before; after this PR it visibly breaks for new transactions until [DP-3] lands.
- **Client-side input ([DP-3] not yet landed)**: the transaction entry UI still parses user input with 2dp assumptions. A JPY user typing ¥1234 in the UI will still produce integer `123400` via the client path, even though server-side writes (bank sync, YNAB import) now produce `1234`. [DP-3] is a fast-follow requirement to close this gap.
- **Budget templates** (`schedule-template.ts`, `category-template-context.ts`, `budget/actions.ts`): not updated in this PR. Template amounts remain at 2dp while transaction amounts use the correct precision for non-2dp budgets.
- **[DP-6]** (historical data migration) is the safety net: it rescales all stored integers for non-2dp budgets. For correctness, [DP-6] must only rescale transactions that were encoded at 2dp, not ones already correctly encoded by this PR's server paths. A `% 100 === 0` heuristic is not reliable — round JPY amounts (¥500, ¥1000, ¥10000) are extremely common and would be incorrectly rescaled. The only clean solution is to land [DP-2] through [DP-6] within the same release so that no 0dp-correct transactions exist in the wild before the migration runs. Reviewers should flag this PR if the release timeline cannot guarantee that.

### AI Disclaimer

AI generated (Claude Sonnet 4.6 via Claude Code).

## Related issue(s)

<!-- Relates to multi-currency tracking issue -->

## Testing

- Added unit tests for `amountFromYnab` covering USD, JPY, IRR/KRW (0dp), and unknown currency fallback (`src/server/importers/ynab5.test.ts`).
- Added integration tests for `createAccount` starting balance encoding for USD (2dp), JPY (0dp), and empty/default currency (`src/server/accounts/app.test.ts`).
- Full loot-core test suite passes (874 tests).

## Checklist

- [x] Release notes added (see link above)
- [!] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed


[DP-1]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-1--core-utility-helpers
[DP-2]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-2--loot-core-server-decimal-aware-amount-handling
[DP-3]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-3--desktop-client-transaction-table-and-search
[DP-4]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-4--desktop-client-budget-ui-components
[DP-5]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-5--desktop-client-modals-mobile-settings-and-e2e
[DP-6]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-6--historical-data-migration-for-non-2dp-budget-currencies
[DP-7]: https://gist.github.com/StephenBrown2/a1c3a0cd19f8f2fac0c76c2b93ed20fc#pr-dp-7--remove-hide-decimal-places-setting

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.52 MB (+423.95 kB) | +3.16%
loot-core | 1 | 4.9 MB → 4.91 MB (+2.36 kB) | +0.05%
api | 2 | 3.94 MB → 3.94 MB (+2.29 kB) | +0.06%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.52 MB (+423.95 kB) | +3.16%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/@jlongster/sql.js/dist/sql-wasm.js` | 🆕 +89.77 kB | 0 B → 89.77 kB
`node_modules/@bufbuild/protobuf/dist/esm/wkt/gen/google/protobuf/descriptor_pb.js` | 🆕 +45.48 kB | 0 B → 45.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 🆕 +24.03 kB | 0 B → 24.03 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 🆕 +18.95 kB | 0 B → 18.95 kB
`node_modules/@bufbuild/protobuf/dist/esm/registry.js` | 🆕 +18.87 kB | 0 B → 18.87 kB
`node_modules/adm-zip/adm-zip.js` | 🆕 +17.31 kB | 0 B → 17.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 🆕 +12.82 kB | 0 B → 12.82 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/reflect.js` | 🆕 +10.45 kB | 0 B → 10.45 kB
`node_modules/adm-zip/zipEntry.js` | 🆕 +10.41 kB | 0 B → 10.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 🆕 +9.56 kB | 0 B → 9.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/envelope.ts` | 🆕 +8.9 kB | 0 B → 8.9 kB
`node_modules/adm-zip/zipFile.js` | 🆕 +8.81 kB | 0 B → 8.81 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 🆕 +7.88 kB | 0 B → 7.88 kB
`node_modules/adm-zip/headers/entryHeader.js` | 🆕 +7.53 kB | 0 B → 7.53 kB
`node_modules/@bufbuild/protobuf/dist/esm/wire/binary-encoding.js` | 🆕 +7.41 kB | 0 B → 7.41 kB
`node_modules/adm-zip/util/utils.js` | 🆕 +7.13 kB | 0 B → 7.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/tracking.ts` | 🆕 +6.72 kB | 0 B → 6.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 🆕 +6.14 kB | 0 B → 6.14 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/reflect-check.js` | 🆕 +5.72 kB | 0 B → 5.72 kB
`node_modules/@bufbuild/protobuf/dist/esm/from-binary.js` | 🆕 +5.09 kB | 0 B → 5.09 kB
`home/runner/work/actual/actual/packages/crdt/src/crdt/timestamp.ts` | 🆕 +5.02 kB | 0 B → 5.02 kB
`node_modules/@bufbuild/protobuf/dist/esm/to-binary.js` | 🆕 +4.62 kB | 0 B → 4.62 kB
`node_modules/@bufbuild/protobuf/dist/esm/create.js` | 🆕 +4.38 kB | 0 B → 4.38 kB
`node_modules/@bufbuild/protobuf/dist/esm/wire/varint.js` | 🆕 +4.37 kB | 0 B → 4.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema-helpers.ts` | 🆕 +3.91 kB | 0 B → 3.91 kB
`node_modules/@bufbuild/protobuf/dist/esm/wire/text-format.js` | 🆕 +3.38 kB | 0 B → 3.38 kB
`node_modules/adm-zip/methods/zipcrypto.js` | 🆕 +3.14 kB | 0 B → 3.14 kB
`node_modules/@bufbuild/protobuf/dist/esm/codegenv2/boot.js` | 🆕 +2.93 kB | 0 B → 2.93 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/sort.ts` | 🆕 +2.89 kB | 0 B → 2.89 kB
`node_modules/murmurhash/murmurhash.js` | 🆕 +2.86 kB | 0 B → 2.86 kB
`node_modules/adm-zip/headers/mainHeader.js` | 🆕 +2.75 kB | 0 B → 2.75 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/models.ts` | 🆕 +2.69 kB | 0 B → 2.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/index.ts` | 🆕 +2.67 kB | 0 B → 2.67 kB
`node_modules/@bufbuild/protobuf/dist/esm/proto-int64.js` | 🆕 +2.52 kB | 0 B → 2.52 kB
`node_modules/adm-zip/util/errors.js` | 🆕 +2.47 kB | 0 B → 2.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/encoder.ts` | 🆕 +2.29 kB | 0 B → 2.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/path-join.ts` | 🆕 +2.23 kB | 0 B → 2.23 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/unsafe.js` | 🆕 +2 kB | 0 B → 2 kB
`node_modules/adm-zip/util/constants.js` | 🆕 +1.91 kB | 0 B → 1.91 kB
`home/runner/work/actual/actual/packages/crdt/src/crdt/merkle.ts` | 🆕 +1.91 kB | 0 B → 1.91 kB
`node_modules/@bufbuild/protobuf/dist/esm/wire/base64-encoding.js` | 🆕 +1.77 kB | 0 B → 1.77 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/guard.js` | 🆕 +1.65 kB | 0 B → 1.65 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/exec.ts` | 🆕 +1.61 kB | 0 B → 1.61 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sheet.ts` | 🆕 +1.56 kB | 0 B → 1.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/index.ts` | 🆕 +1.52 kB | 0 B → 1.52 kB
`node_modules/adm-zip/util/fattr.js` | 🆕 +1.49 kB | 0 B → 1.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/app.ts` | 🆕 +1.23 kB | 0 B → 1.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/encryption-internals.ts` | 🆕 +1.2 kB | 0 B → 1.2 kB
`node_modules/adm-zip/methods/inflater.js` | 🆕 +1019 B | 0 B → 1019 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts` | 🆕 +995 B | 0 B → 995 B
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 🆕 +994 B | 0 B → 994 B
`node_modules/@bufbuild/protobuf/dist/esm/descriptors.js` | 🆕 +918 B | 0 B → 918 B
`node_modules/adm-zip/methods/deflater.js` | 🆕 +906 B | 0 B → 906 B
`home/runner/work/actual/actual/packages/crdt/src/proto/sync_pb.ts` | 🆕 +895 B | 0 B → 895 B
`node_modules/@bufbuild/protobuf/dist/esm/reflect/scalar.js` | 🆕 +813 B | 0 B → 813 B
`node_modules/@bufbuild/protobuf/dist/esm/reflect/names.js` | 🆕 +812 B | 0 B → 812 B
`home/runner/work/actual/actual/packages/loot-core/src/server/undo.ts` | 🆕 +805 B | 0 B → 805 B
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 🆕 +774 B | 0 B → 774 B
`node_modules/@bufbuild/protobuf/dist/esm/wire/text-encoding.js` | 🆕 +758 B | 0 B → 758 B
`home/runner/work/actual/actual/packages/loot-core/src/server/prefs.ts` | 🆕 +682 B | 0 B → 682 B
`node_modules/@bufbuild/protobuf/dist/esm/wkt/wrappers.js` | 🆕 +625 B | 0 B → 625 B
`node_modules/@bufbuild/protobuf/dist/esm/codegenv2/file.js` | 🆕 +571 B | 0 B → 571 B
`node_modules/@bufbuild/protobuf/dist/esm/reflect/nested-types.js` | 🆕 +543 B | 0 B → 543 B
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 🆕 +526 B | 0 B → 526 B
`node_modules/mitt/dist/mitt.mjs` | 🆕 +513 B | 0 B → 513 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/index.ts` | 🆕 +512 B | 0 B → 512 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/shared.ts` | 🆕 +498 B | 0 B → 498 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/util.ts` | 🆕 +403 B | 0 B → 403 B
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/index.ts` | 🆕 +393 B | 0 B → 393 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fetch/index.ts` | 🆕 +373 B | 0 B → 373 B
`node_modules/adm-zip/util/index.js` | 🆕 +358 B | 0 B → 358 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/repair.ts` | 🆕 +340 B | 0 B → 340 B
`node_modules/@bufbuild/protobuf/dist/esm/is-message.js` | 🆕 +320 B | 0 B → 320 B
`node_modules/@bufbuild/protobuf/dist/esm/codegenv2/restore-json-names.js` | 🆕 +298 B | 0 B → 298 B
`node_modules/@bufbuild/protobuf/dist/esm/reflect/error.js` | 🆕 +278 B | 0 B → 278 B
`node_modules/adm-zip/util/decoder.js` | 🆕 +273 B | 0 B → 273 B
`node_modules/adm-zip/methods/index.js` | 🆕 +262 B | 0 B → 262 B
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/globals.ts` | 🆕 +262 B | 0 B → 262 B
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/index.ts` | 🆕 +258 B | 0 B → 258 B
`node_modules/adm-zip/headers/index.js` | 🆕 +230 B | 0 B → 230 B
`node_modules/@bufbuild/protobuf/dist/esm/codegenv2/message.js` | 🆕 +220 B | 0 B → 220 B
`home/runner/work/actual/actual/packages/loot-core/src/server/db/util.ts` | 🆕 +195 B | 0 B → 195 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/normalise.ts` | 🆕 +168 B | 0 B → 168 B
`__vite-browser-external` | 🆕 +166 B | 0 B → 166 B
`home/runner/work/actual/actual/packages/loot-core/src/server/main-app.ts` | 🆕 +149 B | 0 B → 149 B
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/util.ts` | 🆕 +133 B | 0 B → 133 B
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 🆕 +129 B | 0 B → 129 B
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +430 B (+223.96%) | 192 B → 622 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/asyncStorage/index.ts` | 📈 +706 B (+155.16%) | 455 B → 1.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/async.ts` | 📈 +578 B (+146.70%) | 394 B → 972 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/indexeddb/index.ts` | 📈 +348 B (+25.87%) | 1.31 kB → 1.65 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/normalisation.ts` | 📈 +67 B (+20.36%) | 329 B → 396 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📈 +417 B (+4.51%) | 9.04 kB → 9.45 kB
`src/queries/pagedQuery.ts` | 📈 +132 B (+4.12%) | 3.13 kB → 3.26 kB
`src/queries/aqlQuery.ts` | 📈 +4 B (+3.23%) | 124 B → 128 B
`src/undo/index.ts` | 📈 +4 B (+0.72%) | 557 B → 561 B
`src/tags/queries.ts` | 📈 +2 B (+0.71%) | 282 B → 284 B
`node_modules/chevrotain/lib_esm/src/parse/grammar/first.js` | 📈 +8 B (+0.62%) | 1.27 kB → 1.28 kB
`src/components/manager/subscribe/OpenIdCallback.ts` | 📈 +2 B (+0.60%) | 336 B → 338 B
`src/hooks/useMetadataPref.ts` | 📈 +2 B (+0.57%) | 352 B → 354 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB → 8.03 MB (+423.8 kB) | +5.44%
static/js/extends.js | 478.23 kB → 478.64 kB (+417 B) | +0.09%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 298.4 kB → 298.15 kB (-262 B) | -0.09%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.39 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB → 4.91 MB (+2.36 kB) | +0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/util/currency.ts` | 🆕 +569 B | 0 B → 569 B
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/export/export-to-csv.ts` | 📈 +176 B (+6.13%) | 2.81 kB → 2.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📈 +236 B (+3.58%) | 6.43 kB → 6.66 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📈 +334 B (+3.47%) | 9.4 kB → 9.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +156 B (+1.89%) | 8.06 kB → 8.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +411 B (+1.62%) | 24.76 kB → 25.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +102 B (+1.49%) | 6.7 kB → 6.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +270 B (+1.06%) | 24.8 kB → 25.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +92 B (+0.30%) | 30.04 kB → 30.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +70 B (+0.29%) | 23.51 kB → 23.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BL_njOsd.js | 0 B → 4.91 MB (+4.91 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTfCF_Gu.js | 4.9 MB → 0 B (-4.9 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+2.29 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/util/currency.ts` | 🆕 +549 B | 0 B → 549 B
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/export/export-to-csv.ts` | 📈 +168 B (+5.97%) | 2.75 kB → 2.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📈 +234 B (+3.67%) | 6.22 kB → 6.45 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📈 +324 B (+3.44%) | 9.19 kB → 9.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +149 B (+1.91%) | 7.6 kB → 7.75 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +406 B (+1.64%) | 24.15 kB → 24.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +99 B (+1.53%) | 6.33 kB → 6.42 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +260 B (+1.04%) | 24.32 kB → 24.57 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +89 B (+0.29%) | 29.5 kB → 29.58 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +66 B (+0.28%) | 22.89 kB → 22.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+2.29 kB) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->