### PR TITLE
Fix Sankey Budgeted view, when an amount is left to budget.

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -650,7 +650,12 @@ export function createBudgetGraph(
   });
 
   if (aggregated.toBudget > 0) {
-    addNode(graph, SpecialNodeKeys.ToBudget, GraphLayers.Account, 'To budget');
+    addNode(
+      graph,
+      SpecialNodeKeys.ToBudget,
+      GraphLayers.CategoryGroup,
+      'To budget',
+    );
     addValueToLink(
       graph,
       SpecialNodeKeys.AvailableIncome,

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -650,11 +650,13 @@ export function createBudgetGraph(
   });
 
   if (aggregated.toBudget > 0) {
-    addNode(
+    addNodeWithLabel(
       graph,
       SpecialNodeKeys.ToBudget,
       GraphLayers.CategoryGroup,
       'To budget',
+      undefined,
+      false,
     );
     addValueToLink(
       graph,

--- a/upcoming-release-notes/sankey-fix-to-budget.md
+++ b/upcoming-release-notes/sankey-fix-to-budget.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [emiltb]
+---
+
+Sankey 'Budgeted' view no longer breaks when an amount is left to budget.


### PR DESCRIPTION
## Description

Fixes a regression, where the Budgeted view in the Sankey chart was broken, when amount was left to budget. 

## Related issue(s)

Fixes https://github.com/actualbudget/actual/issues/1919#issuecomment-4607500016.

## Testing

Manually verified, that Budgeted view works when an amount is left to budget.

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+30 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+30 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📈 +30 B (+0.10%) | 29.41 kB → 29.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.27 MB → 1.27 MB (+30 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 173.68 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->