### PR TITLE
show the bank sync error banner on the accounts based on persisted status

### DIFF
--- a/packages/desktop-client/src/accounts/syncStatus.test.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.test.ts
@@ -1,12 +1,13 @@
 import type { AccountEntity } from '@actual-app/core/types/models';
 import { describe, expect, it } from 'vitest';
 
-import { isAccountFailedSync } from './syncStatus';
+import { getFailedSyncError, isAccountFailedSync } from './syncStatus';
 
 function makeAccount(
   bank_sync_status: AccountEntity['bank_sync_status'],
-): Pick<AccountEntity, 'bank_sync_status'> {
-  return { bank_sync_status };
+  account_sync_source: AccountEntity['account_sync_source'] = null,
+): Pick<AccountEntity, 'bank_sync_status' | 'account_sync_source'> {
+  return { bank_sync_status, account_sync_source };
 }
 
 describe('syncStatus', () => {
@@ -21,5 +22,38 @@ describe('syncStatus', () => {
     expect(isAccountFailedSync(makeAccount('sync-requested'))).toBe(false);
     expect(isAccountFailedSync(makeAccount('ok'))).toBe(false);
     expect(isAccountFailedSync(makeAccount(null))).toBe(false);
+  });
+
+  it('maps persisted failure statuses to error type/code pairs', () => {
+    expect(getFailedSyncError(makeAccount('reauth-required'))).toEqual({
+      type: 'ITEM_ERROR',
+      code: 'ITEM_LOGIN_REQUIRED',
+    });
+    expect(
+      getFailedSyncError(makeAccount('reauth-required', 'simpleFin')),
+    ).toEqual({
+      type: 'INVALID_ACCESS_TOKEN',
+      code: 'INVALID_ACCESS_TOKEN',
+    });
+    expect(getFailedSyncError(makeAccount('attention-required'))).toEqual({
+      type: 'ACCOUNT_NEEDS_ATTENTION',
+      code: 'ACCOUNT_NEEDS_ATTENTION',
+    });
+    expect(getFailedSyncError(makeAccount('rate-limit-exceeded'))).toEqual({
+      type: 'RATE_LIMIT_EXCEEDED',
+      code: 'RATE_LIMIT_EXCEEDED',
+    });
+    expect(getFailedSyncError(makeAccount('timed-out'))).toEqual({
+      type: 'TIMED_OUT',
+      code: 'TIMED_OUT',
+    });
+    expect(getFailedSyncError(makeAccount('account-missing'))).toEqual({
+      type: 'ACCOUNT_MISSING',
+      code: 'ACCOUNT_MISSING',
+    });
+    expect(getFailedSyncError(makeAccount('failed'))).toEqual({
+      type: 'SYNC_ERROR',
+      code: 'SYNC_ERROR',
+    });
   });
 });

--- a/packages/desktop-client/src/accounts/syncStatus.test.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.test.ts
@@ -10,10 +10,13 @@ function makeAccount(
 }
 
 describe('syncStatus', () => {
-  it('treats failed, attention-required and reauth-required as failed', () => {
+  it('treats any durable non-ok status as failed', () => {
     expect(isAccountFailedSync(makeAccount('failed'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('attention-required'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('reauth-required'))).toBe(true);
+    expect(isAccountFailedSync(makeAccount('rate-limit-exceeded'))).toBe(true);
+    expect(isAccountFailedSync(makeAccount('timed-out'))).toBe(true);
+    expect(isAccountFailedSync(makeAccount('account-missing'))).toBe(true);
     expect(isAccountFailedSync(makeAccount('pending'))).toBe(false);
     expect(isAccountFailedSync(makeAccount('sync-requested'))).toBe(false);
     expect(isAccountFailedSync(makeAccount('ok'))).toBe(false);

--- a/packages/desktop-client/src/accounts/syncStatus.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.ts
@@ -5,8 +5,9 @@ export function isAccountFailedSync(
 ) {
   const status = account.bank_sync_status;
   return (
-    status === 'failed' ||
-    status === 'attention-required' ||
-    status === 'reauth-required'
+    status != null &&
+    status !== 'ok' &&
+    status !== 'pending' &&
+    status !== 'sync-requested'
   );
 }

--- a/packages/desktop-client/src/accounts/syncStatus.ts
+++ b/packages/desktop-client/src/accounts/syncStatus.ts
@@ -11,3 +11,28 @@ export function isAccountFailedSync(
     status !== 'sync-requested'
   );
 }
+
+export function getFailedSyncError(
+  account: Pick<AccountEntity, 'bank_sync_status' | 'account_sync_source'>,
+): { type: string; code: string } {
+  switch (account.bank_sync_status) {
+    case 'reauth-required':
+      if (account.account_sync_source === 'simpleFin') {
+        return { type: 'INVALID_ACCESS_TOKEN', code: 'INVALID_ACCESS_TOKEN' };
+      }
+      return { type: 'ITEM_ERROR', code: 'ITEM_LOGIN_REQUIRED' };
+    case 'attention-required':
+      return {
+        type: 'ACCOUNT_NEEDS_ATTENTION',
+        code: 'ACCOUNT_NEEDS_ATTENTION',
+      };
+    case 'rate-limit-exceeded':
+      return { type: 'RATE_LIMIT_EXCEEDED', code: 'RATE_LIMIT_EXCEEDED' };
+    case 'timed-out':
+      return { type: 'TIMED_OUT', code: 'TIMED_OUT' };
+    case 'account-missing':
+      return { type: 'ACCOUNT_MISSING', code: 'ACCOUNT_MISSING' };
+    default:
+      return { type: 'SYNC_ERROR', code: 'SYNC_ERROR' };
+  }
+}

--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
@@ -10,6 +10,7 @@ import { View } from '@actual-app/components/view';
 import type { AccountEntity } from '@actual-app/core/types/models';
 
 import { useUnlinkAccountMutation } from '#accounts';
+import { getFailedSyncError, isAccountFailedSync } from '#accounts/syncStatus';
 import { Link } from '#components/common/Link';
 import { authorizeBank as authorizeEnableBanking } from '#enablebanking';
 import { authorizeBank as authorizeGoCardless } from '#gocardless';
@@ -126,19 +127,18 @@ export function AccountSyncCheck() {
     [unlinkAccount],
   );
 
-  if (!failedAccounts || !id) {
-    return null;
-  }
-
-  const error = failedAccounts.get(id);
-  if (!error) {
+  if (!id) {
     return null;
   }
 
   const account = accounts.find(account => account.id === id);
-  if (!account) {
+  if (!account || !isAccountFailedSync(account)) {
     return null;
   }
+
+  // prefer the detailed error from the client that ran the sync, fall back
+  // to the persisted status for failures that happened on another client
+  const error = failedAccounts.get(id) ?? getFailedSyncError(account);
 
   const { type, code } = error;
   const showAuth =

--- a/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
+++ b/packages/loot-core/src/server/accounts/app-bank-sync.test.ts
@@ -198,6 +198,60 @@ describe('accountsBankSync', () => {
     expect(account!.bank_sync_status).toBe('reauth-required');
   });
 
+  it('persists rate-limit-exceeded status after a rate limit error', async () => {
+    insertBank({ id: 'bank1', bank_id: 'gc-bank', name: 'GoCardless' });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      bank: 'bank1',
+      account_id: 'ext-1',
+      account_sync_source: 'goCardless',
+    });
+
+    vi.mocked(bankSync.syncAccount).mockRejectedValue({
+      type: 'BankSyncError',
+      reason: 'rate limit exceeded',
+      category: 'RATE_LIMIT_EXCEEDED',
+      code: 'NORDIGEN_ERROR',
+      message: 'rate limit exceeded',
+    });
+
+    await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    expect(account!.bank_sync_status).toBe('rate-limit-exceeded');
+  });
+
+  it('persists timed-out status after a timeout error', async () => {
+    insertBank({ id: 'bank1', bank_id: 'sfin-bank', name: 'SimpleFin' });
+    await db.insertAccount({
+      id: 'acct1',
+      name: 'Checking',
+      bank: 'bank1',
+      account_id: 'ext-1',
+      account_sync_source: 'simpleFin',
+    });
+
+    vi.mocked(bankSync.syncAccount).mockRejectedValue({
+      type: 'BankSyncError',
+      reason: 'timed out',
+      category: 'TIMED_OUT',
+      code: 'TIMED_OUT',
+      message: 'timed out',
+    });
+
+    await accountsBankSyncHandler({ ids: ['acct1'] });
+
+    const account = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      ['acct1'],
+    );
+    expect(account!.bank_sync_status).toBe('timed-out');
+  });
+
   it('persists failed status after an operational sync error', async () => {
     insertBank({ id: 'bank1', bank_id: 'gc-bank', name: 'GoCardless' });
     await db.insertAccount({

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1369,6 +1369,18 @@ function getBankSyncStatusFromError(
     if (err.category === 'ACCOUNT_NEEDS_ATTENTION') {
       return 'attention-required';
     }
+
+    if (err.category === 'RATE_LIMIT_EXCEEDED') {
+      return 'rate-limit-exceeded';
+    }
+
+    if (err.category === 'TIMED_OUT') {
+      return 'timed-out';
+    }
+
+    if (err.category === 'ACCOUNT_MISSING') {
+      return 'account-missing';
+    }
   }
 
   return 'failed';

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -31,6 +31,9 @@ export type DbAccount = {
     | 'failed'
     | 'reauth-required'
     | 'attention-required'
+    | 'rate-limit-exceeded'
+    | 'timed-out'
+    | 'account-missing'
     | null;
 };
 

--- a/packages/loot-core/src/types/models/account.ts
+++ b/packages/loot-core/src/types/models/account.ts
@@ -32,4 +32,7 @@ export type BankSyncStatus =
   | 'sync-requested'
   | 'failed'
   | 'reauth-required'
-  | 'attention-required';
+  | 'attention-required'
+  | 'rate-limit-exceeded'
+  | 'timed-out'
+  | 'account-missing';

--- a/upcoming-release-notes/bank-sync-persist.md
+++ b/upcoming-release-notes/bank-sync-persist.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Show the bank sync error banner on the accounts even if the error occurred on a different device


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Assisted by Claude Fable (!)

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested with a local server by timing out GoCardless, reloading the page and seeing that the status and banner both show.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (-618 B) | -0.00%
loot-core | 1 | 5.28 MB → 5.28 MB (+203 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+200 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (-618 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/accounts/syncStatus.ts` | 📈 +780 B (+339.13%) | 230 B → 1010 B
`src/components/accounts/AccountSyncCheck.tsx` | 📉 -1.37 kB (-15.72%) | 8.68 kB → 7.32 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ManageRules.js | 46.63 kB → 47.39 kB (+780 B) | +1.63%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB → 1.6 MB (-1.37 kB) | -0.08%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 173.68 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+203 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +203 B (+0.66%) | 30.06 kB → 30.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DZC2MXga.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+200 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +200 B (+0.67%) | 29.3 kB → 29.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+200 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->