### PR TITLE
prioritise category name matches over group matches in the category autocomplete

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import type {
   ComponentProps,
   ComponentPropsWithoutRef,
@@ -23,7 +23,6 @@ import type {
   CategoryGroupEntity,
 } from '@actual-app/core/types/models';
 import { css, cx } from '@emotion/css';
-import { Fzf } from 'fzf';
 
 import { useEnvelopeSheetValue } from '#components/budget/envelope/EnvelopeBudgetComponents';
 import { makeAmountFullStyle } from '#components/budget/util';
@@ -34,6 +33,7 @@ import { useSyncedPref } from '#hooks/useSyncedPref';
 import { envelopeBudget, trackingBudget } from '#spreadsheet/bindings';
 
 import { Autocomplete } from './Autocomplete';
+import { filterCategorySuggestions } from './filterCategorySuggestions';
 import { ItemHeader } from './ItemHeader';
 
 type CategoryAutocompleteItem = Omit<CategoryEntity, 'group'> & {
@@ -249,46 +249,6 @@ export function CategoryAutocomplete({
     showHiddenCategories,
   ]);
 
-  const filterSuggestions = useCallback(
-    (
-      suggestions: CategoryAutocompleteItem[],
-      value: string,
-    ): CategoryAutocompleteItem[] => {
-      const splitItem = suggestions.find(s => s.id === 'split');
-      const realSuggestions = suggestions.filter(s => s.id !== 'split');
-
-      if (!value) {
-        return suggestions;
-      }
-
-      const nameMatches = new Fzf(realSuggestions, {
-        selector: item => item.name,
-        limit: 100,
-        casing: 'case-insensitive',
-      })
-        .find(value)
-        .map(result => result.item);
-
-      const nameMatchIds = new Set(nameMatches.map(item => item.id));
-      const groupMatches = new Fzf(
-        realSuggestions.filter(item => !nameMatchIds.has(item.id)),
-        {
-          selector: item =>
-            item.group ? item.group.name + ' ' + item.name : item.name,
-          limit: 100,
-          casing: 'case-insensitive',
-        },
-      )
-        .find(value)
-        .map(result => result.item);
-
-      const filtered = [...nameMatches, ...groupMatches].slice(0, 100);
-
-      return splitItem ? [splitItem, ...filtered] : filtered;
-    },
-    [],
-  );
-
   return (
     <Autocomplete
       strict
@@ -304,7 +264,7 @@ export function CategoryAutocomplete({
         }
         return 0;
       }}
-      filterSuggestions={filterSuggestions}
+      filterSuggestions={filterCategorySuggestions}
       suggestions={categorySuggestions}
       renderItems={(items, getItemProps, highlightedIndex) => (
         <CategoryList

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -261,14 +261,28 @@ export function CategoryAutocomplete({
         return suggestions;
       }
 
-      const filtered = new Fzf(realSuggestions, {
-        selector: item =>
-          item.group ? item.group.name + ' ' + item.name : item.name,
+      const nameMatches = new Fzf(realSuggestions, {
+        selector: item => item.name,
         limit: 100,
         casing: 'case-insensitive',
       })
         .find(value)
         .map(result => result.item);
+
+      const nameMatchIds = new Set(nameMatches.map(item => item.id));
+      const groupMatches = new Fzf(
+        realSuggestions.filter(item => !nameMatchIds.has(item.id)),
+        {
+          selector: item =>
+            item.group ? item.group.name + ' ' + item.name : item.name,
+          limit: 100,
+          casing: 'case-insensitive',
+        },
+      )
+        .find(value)
+        .map(result => result.item);
+
+      const filtered = [...nameMatches, ...groupMatches].slice(0, 100);
 
       return splitItem ? [splitItem, ...filtered] : filtered;
     },

--- a/packages/desktop-client/src/components/autocomplete/filterCategorySuggestions.test.ts
+++ b/packages/desktop-client/src/components/autocomplete/filterCategorySuggestions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterCategorySuggestions } from './filterCategorySuggestions';
+
+const savings = { name: 'Savings' };
+const food = { name: 'Food' };
+const bills = { name: 'Bills' };
+
+const suggestions = [
+  { id: '1', name: 'Emergency Fund', group: savings },
+  { id: '2', name: 'Home Repairs', group: savings },
+  { id: '3', name: 'Savings Goals', group: savings },
+  { id: '4', name: 'New Car', group: savings },
+  { id: '5', name: 'Holidays', group: savings },
+  { id: '6', name: 'Groceries', group: food },
+  { id: '7', name: 'Restaurants', group: food },
+  { id: '8', name: 'Electric', group: bills },
+];
+
+function names(items: Array<{ name: string }>): string[] {
+  return items.map(item => item.name);
+}
+
+describe('filterCategorySuggestions', () => {
+  it('ranks category name matches above group-only matches', () => {
+    const result = filterCategorySuggestions(suggestions, 'sav');
+
+    expect(names(result)[0]).toBe('Savings Goals');
+  });
+
+  it('still includes categories whose group name matches', () => {
+    const result = filterCategorySuggestions(suggestions, 'sav');
+
+    expect(names(result)).toEqual([
+      'Savings Goals',
+      'Emergency Fund',
+      'Home Repairs',
+      'New Car',
+      'Holidays',
+    ]);
+  });
+
+  it('matches queries spanning group and category name', () => {
+    const result = filterCategorySuggestions(suggestions, 'food gro');
+
+    expect(names(result)).toEqual(['Groceries']);
+  });
+
+  it('matches case-insensitively', () => {
+    const result = filterCategorySuggestions(suggestions, 'GROC');
+
+    expect(names(result)).toEqual(['Groceries']);
+  });
+
+  it('returns all suggestions when the value is empty', () => {
+    expect(filterCategorySuggestions(suggestions, '')).toEqual(suggestions);
+  });
+
+  it('returns no suggestions when nothing matches', () => {
+    expect(filterCategorySuggestions(suggestions, 'zzz')).toEqual([]);
+  });
+
+  it('keeps the split option pinned to the top', () => {
+    const withSplit = [{ id: 'split', name: '' }, ...suggestions];
+    const result = filterCategorySuggestions(withSplit, 'sav');
+
+    expect(result[0].id).toBe('split');
+    expect(names(result.slice(1))[0]).toBe('Savings Goals');
+  });
+});

--- a/packages/desktop-client/src/components/autocomplete/filterCategorySuggestions.ts
+++ b/packages/desktop-client/src/components/autocomplete/filterCategorySuggestions.ts
@@ -1,0 +1,50 @@
+import { Fzf } from 'fzf';
+
+type CategorySuggestion = {
+  id: string;
+  name: string;
+  group?: { name: string };
+};
+
+function rankMatches<T extends CategorySuggestion>(
+  items: T[],
+  value: string,
+  selector: (item: CategorySuggestion) => string,
+): T[] {
+  const itemsById = new Map(items.map(item => [item.id, item]));
+  return new Fzf<CategorySuggestion[]>(items, {
+    selector,
+    limit: 100,
+    casing: 'case-insensitive',
+  })
+    .find(value)
+    .map(result => itemsById.get(result.item.id))
+    .filter(item => item != null);
+}
+
+export function filterCategorySuggestions<T extends CategorySuggestion>(
+  suggestions: T[],
+  value: string,
+): T[] {
+  const splitItem = suggestions.find(s => s.id === 'split');
+  const realSuggestions = suggestions.filter(s => s.id !== 'split');
+
+  if (!value) {
+    return suggestions;
+  }
+
+  // matches on the category name itself rank above matches that
+  // only hit the group name
+  const nameMatches = rankMatches(realSuggestions, value, item => item.name);
+
+  const nameMatchIds = new Set(nameMatches.map(item => item.id));
+  const groupMatches = rankMatches(
+    realSuggestions.filter(item => !nameMatchIds.has(item.id)),
+    value,
+    item => (item.group ? item.group.name + ' ' + item.name : item.name),
+  );
+
+  const filtered = [...nameMatches, ...groupMatches].slice(0, 100);
+
+  return splitItem ? [splitItem, ...filtered] : filtered;
+}

--- a/upcoming-release-notes/search-category-devalue-group.md
+++ b/upcoming-release-notes/search-category-devalue-group.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Prioritise category name matches over group matches in the category autocomplete


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Tests written by Claude

This was bugging me, I've got a group called savings, and a category within that called "Savings/Investments". Recently, it started showing me the whole group when I searched for "sav" instead of getting the category I wanted.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Using my budget file:
Before:
<img width="213" height="280" alt="image" src="https://github.com/user-attachments/assets/8f1a5888-9c90-4c0f-8273-885a2c6524a9" />

After:
<img width="216" height="279" alt="image" src="https://github.com/user-attachments/assets/896a6ba4-95d1-48c9-893d-9ba7961a4686" />


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB → 14.13 MB (+392 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB → 14.13 MB (+392 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/autocomplete/filterCategorySuggestions.ts` | 🆕 +1.01 kB | 0 B → 1.01 kB
`src/components/autocomplete/CategoryAutocomplete.tsx` | 📉 -646 B (-4.07%) | 15.52 kB → 14.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.08 MB → 5.08 MB (+392 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 173.68 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->