### PR TITLE
docs: fix docs build & broken anchors, migrate to consistent link format

### DIFF
--- a/.claude/skills/writing-actual-docs/SKILL.md
+++ b/.claude/skills/writing-actual-docs/SKILL.md
@@ -16,7 +16,7 @@ It is the authoritative source for front matter, heading rules, folder structure
 1. Read `writing-docs.md` in full before drafting.
 2. When the guide does not cover something, match the closest existing document in the same section rather than inventing a new pattern — site-wide consistency matters more than a marginally better local choice.
 3. For new screenshots, follow both the placement rule (`/static/img/<section>/<doc-prefix>-...png`) and the annotation guidance from the guide. Annotate any screenshot showing more than one element the reader needs to distinguish.
-4. Before declaring the work done, sanity-check the file against the guide's structural rules: exactly one H1, Title Case headings, no time-bound phrasing, images referenced from the correct path, and any new technical terms added to `.github/actions/spelling/allow/keywords.txt` so the spell-check bot passes.
+4. Before declaring the work done, sanity-check the file against the guide's structural rules: exactly one H1, Title Case headings, no time-bound phrasing, internal links written as relative file paths with the `.md` extension (not `/docs/...` URLs), images referenced from the correct path, and any new technical terms added to `.github/actions/spelling/allow/keywords.txt` so the spell-check bot passes.
 
 ## Why this matters
 

--- a/.claude/skills/writing-actual-docs/SKILL.md
+++ b/.claude/skills/writing-actual-docs/SKILL.md
@@ -16,7 +16,7 @@ It is the authoritative source for front matter, heading rules, folder structure
 1. Read `writing-docs.md` in full before drafting.
 2. When the guide does not cover something, match the closest existing document in the same section rather than inventing a new pattern — site-wide consistency matters more than a marginally better local choice.
 3. For new screenshots, follow both the placement rule (`/static/img/<section>/<doc-prefix>-...png`) and the annotation guidance from the guide. Annotate any screenshot showing more than one element the reader needs to distinguish.
-4. Before declaring the work done, sanity-check the file against the guide's structural rules: exactly one H1, Title Case headings, no time-bound phrasing, internal links written as relative file paths with the `.md` extension (not `/docs/...` URLs), images referenced from the correct path, and any new technical terms added to `.github/actions/spelling/allow/keywords.txt` so the spell-check bot passes.
+4. Before declaring the work done, sanity-check the file against the guide's structural rules: exactly one H1, Title Case headings, no time-bound phrasing, internal links written as relative file paths with the `.md` extension (not `/docs/...` URLs), images referenced from the correct path, and any new technical terms added to `.github/actions/docs-spelling/allow/keywords.txt` so the spell-check bot passes.
 
 ## Why this matters
 

--- a/.github/actions/docs-spelling/expect.txt
+++ b/.github/actions/docs-spelling/expect.txt
@@ -95,7 +95,6 @@ Hampel
 healthcheck
 HELADEF
 HLOOKUP
-Hostim
 HUF
 IFERROR
 IFNA
@@ -192,6 +191,7 @@ THB
 TIMEFRAME
 touchscreen
 triaging
+trustedauthproxies
 tsgo
 tsgolint
 TWD

--- a/packages/docs/blog/2024-03-25-automate-twist.md
+++ b/packages/docs/blog/2024-03-25-automate-twist.md
@@ -8,7 +8,7 @@ hide_table_of_contents: false
 
 Hello budgeters!
 
-I hope you all enjoyed the last blog post focused on how to use goal templates. If you haven't read it yet, you might want to start [here](/blog/2023-12-15-automate.md). While we always recommend embracing the envelope system and [getting a month ahead](/blog/2023-12-15-automate.md#month-ahead) on your budget, there are some situations where that just isn't possible right away. I'm going to introduce a method here that uses the goal template system that uses your income as you receive it throughout the month using priorities.
+I hope you all enjoyed the last blog post focused on how to use goal templates. If you haven't read it yet, you might want to start [here](./2023-12-15-automate.md). While we always recommend embracing the envelope system and [getting a month ahead](./2023-12-15-automate.md#month-ahead) on your budget, there are some situations where that just isn't possible right away. I'm going to introduce a method here that uses the goal template system that uses your income as you receive it throughout the month using priorities.
 
 <!--truncate-->
 
@@ -18,7 +18,7 @@ Goal templates are an experimental feature within Actual that allow you to auto-
 
 In this scenario, my income will be $500 per week, starting on the first of the month. I have certain priorities that need to be met. For example, I like to eat so I'm going to prioritize food for the first pay period. I'm going to set up my mortgage to be paid at the end of the month, saving a little each week. I'm going to budget for several bills that happen throughout the month where I know which week they'll need to be paid. I'm also going to use a simple template with priorities to illustrate this method. Feel free to use other template types.
 
-Priorities allow you to decide which goals are funded first. Check out our last [blog post](/blog/2023-12-15-automate.md#how-priorities-work) or the section in the [documentation](../../docs/experimental/goal-templates#template-priorities) that explains in much greater detail on how to use them. In this example, I've decided to use the following priority levels
+Priorities allow you to decide which goals are funded first. Check out our last [blog post](./2023-12-15-automate.md#how-priorities-work) or the section in the [documentation](../../docs/experimental/goal-templates#template-priorities) that explains in much greater detail on how to use them. In this example, I've decided to use the following priority levels
 
 - Week 1: 10-19
 - Week 2: 20-29

--- a/packages/docs/blog/2024-07-01-ynab_v_actual.md
+++ b/packages/docs/blog/2024-07-01-ynab_v_actual.md
@@ -22,7 +22,7 @@ Lets see how Actual stacks up!
 I will structure this comparison as follows.
 First I will go over some of the fundamentals individually, then at the end have a quick comparison of some of the smaller features.
 I will go in depth in the basics like how Actual is installed and run, how the budgeting basics compare, and then the other exciting features.
-Along with this blog post you can look around at our [documentation](../../docs), or our [main feature list](../../#features).
+Along with this blog post you can look around at our [documentation](../../docs/), or our [main feature list](../../#features).
 
 ### tl;dr
 
@@ -74,8 +74,8 @@ This can be found in your browser settings when viewing the web page.
 
 Actual has two parts: the client (the stuff you see and interact with), and an optional sync server.
 The server is what allows syncing your budget file between devices and allows for bank syncing.
-A full list of what does and does not require the sync server can be found [in this table](../../docs/install).
-The [docs page](../../docs/install) also includes information about options for hosting a sync server.
+A full list of what does and does not require the sync server can be found [in this table](../../docs/install/).
+The [docs page](../../docs/install/) also includes information about options for hosting a sync server.
 
 The quickest way to host a sync server is [to use PikaPods](https://www.pikapods.com/pods?run=actual).
 PikaPods is a hosting service that costs just over one dollar a month to host a personal sync server[^1].
@@ -89,7 +89,7 @@ Other options include hosting your own with docker or node.js, or using some oth
 The core budgeting style is where Actual and YNAB are the most similar.
 Both use envelope style budgeting, sometimes referred to zero-sum budgeting.
 This means that all your funds are assigned to categories, or "jobs" in YNAB vernacular.
-The budgeting styles are so similar you can [import your YNAB data into Actual](../../docs/migration) and move on like almost nothing changed.
+The budgeting styles are so similar you can [import your YNAB data into Actual](../../docs/migration/) and move on like almost nothing changed.
 
 How accounts and transactions are handled is very similar. There are transactions with payees, notes, categories, etc.
 Just like you are used to.
@@ -107,7 +107,7 @@ Some users prefer this approach while others find it annoying.
 
 The way YNAB handles this can make it a bit too easy to hold onto credit card debt and let it build up.
 Actual needs some more deliberate handling of that debt.
-Our docs [show how to do this in Actual](../../docs/budgeting/credit-cards).
+Our docs [show how to do this in Actual](../../docs/budgeting/credit-cards/).
 The tl;dr is that you put your existing debt in a category on your budget and any new debt has to be manually added into that category.
 Principal and interest payments, get categorized into this category.
 If you use credit cards, but don't carry any debt, then don't worry, you don't have to do anything special.
@@ -170,7 +170,7 @@ Goal templates is under active development so expect it to be even better as tim
 
 ### Other Features
 
-This will be a rapid fire view of feature comparison. For a full view of these features you can read up [in our documentation](../../docs).
+This will be a rapid fire view of feature comparison. For a full view of these features you can read up [in our documentation](../../docs/).
 Don't worry the docs aren't too long to read. I will also be including the already mentioned features.
 
 | Feature                | Actual |  YNAB   |                                                                    Notes                                                                    |

--- a/packages/docs/blog/2025-10-06-continuing-to-reward-contributors.md
+++ b/packages/docs/blog/2025-10-06-continuing-to-reward-contributors.md
@@ -8,7 +8,7 @@ hide_table_of_contents: false
 authors: MatissJanis
 ---
 
-[Three months ago](/blog/spending-community-funds), we launched an experiment: using community donations to directly support the people who keep this project running. The idea was simple — compensate core contributors for the invisible but essential work of reviewing pull requests, triaging issues, and preparing releases.
+[Three months ago](./2025-06-08-spending-community-funds.md), we launched an experiment: using community donations to directly support the people who keep this project running. The idea was simple — compensate core contributors for the invisible but essential work of reviewing pull requests, triaging issues, and preparing releases.
 
 Today, we're excited to share that the trial has been a success. 🎉
 

--- a/packages/docs/blog/2025-11-15-fighting-ai-slop.md
+++ b/packages/docs/blog/2025-11-15-fighting-ai-slop.md
@@ -40,7 +40,7 @@ If you're using AI to help with contributions, that's perfectly fine! Just make 
 - **Take responsibility** - you're the one submitting it, so make sure it's something you stand behind
 - **Tag them with "ai generated"** (This isn't something we can truly enforce, but it's a gesture of good will — it helps everyone in the review process know when AI was involved.)
 
-For more details on how to contribute, see our [contributing guidelines](/docs/contributing/).
+For more details on how to contribute, see our [contributing guidelines](../../docs/contributing/).
 
 ## A Silver Lining
 

--- a/packages/docs/blog/2026-04-06-release-26-4-0.md
+++ b/packages/docs/blog/2026-04-06-release-26-4-0.md
@@ -14,7 +14,7 @@ This release contains the following notable improvements, along with numerous fi
 - Concentric donut charts that show category groups in an outer ring
 - Smarter autocomplete with an improved search algorithm for payees and categories
 - Experimental: Payee Locations: Actual can now remember where you've used a payee and suggest payees based on nearby locations
-- Experimental: Actual CLI: a new command-line tool for interacting with your budget, see [the docs](/docs/api/cli) to get started
+- Experimental: Actual CLI: a new command-line tool for interacting with your budget, see [the docs](../../docs/api/cli) to get started
 
 <!--truncate-->
 

--- a/packages/docs/blog/2026-06-01-release-26-6-0.md
+++ b/packages/docs/blog/2026-06-01-release-26-6-0.md
@@ -10,17 +10,17 @@ authors: matt-fidd
 
 This release adds new reports, a new bank sync provider, a UI for budget automations (goal templates) and releases custom themes as stable, as well as numerous other fixes.
 
-- [Crossover report](/docs/reports/#crossover-point) released as a first-party feature
-- [Custom themes](/docs/custom-themes) released as a first-party feature
+- [Crossover report](../../docs/reports/#crossover-point) released as a first-party feature
+- [Custom themes](../../docs/custom-themes) released as a first-party feature
 - Redesigned bank sync configuration and account linking process
 - Add Tag autocomplete when editing transaction notes
-- Experimental: Add a [UI for budget automations](/docs/experimental/budget-automation) (goal templates)
-- Experimental: Add [Enable Banking integration](/docs/advanced/bank-sync/enable-banking) as a bank sync provider
-- Experimental: Add [Balance Forecast report](/docs/experimental/balance-forecast-report)
+- Experimental: Add a [UI for budget automations](../../docs/experimental/budget-automation) (goal templates)
+- Experimental: Add [Enable Banking integration](../../docs/advanced/bank-sync/enable-banking) as a bank sync provider
+- Experimental: Add [Balance Forecast report](../../docs/experimental/balance-forecast-report)
 
 :::warning Deprecation
 
-Starting this release, rule action templating is deprecated in favour of formulae and will be removed in a future release. For more information, see [Rule Action Templating](/docs/experimental/rule-templating).
+Starting this release, rule action templating is deprecated in favour of formulae and will be removed in a future release. For more information, see [Rule Action Templating](../../docs/experimental/rule-templating).
 
 :::
 

--- a/packages/docs/docs/actual-server-repo-move.md
+++ b/packages/docs/docs/actual-server-repo-move.md
@@ -49,13 +49,13 @@ The reasons for this change are as follows:
   yarn build:server
   ```
 
-  5. If you have a [config.json](/docs/config/) file you will need to copy it into the following directory:
+  5. If you have a [config.json](./config/index.md) file you will need to copy it into the following directory:
 
   ```
   packages/sync-server
   ```
 
-  You may need to make some adjustments (e.g., `ACTUAL_DATA_DIR` becomes `dataDir`), please refer to [troubleshooting the server](/docs/troubleshooting/server) for some help 6. Copy over the data from your `actual-server` directory (`user-files`, `server-files`, and `.migrate`) into the `packages/sync-server` directory. 7. Run the server with:
+  You may need to make some adjustments (e.g., `ACTUAL_DATA_DIR` becomes `dataDir`), please refer to [troubleshooting the server](./troubleshooting/server.md) for some help 6. Copy over the data from your `actual-server` directory (`user-files`, `server-files`, and `.migrate`) into the `packages/sync-server` directory. 7. Run the server with:
 
   ```
   yarn start:server

--- a/packages/docs/docs/advanced/bank-sync.md
+++ b/packages/docs/docs/advanced/bank-sync.md
@@ -7,16 +7,16 @@ Here are a couple of considerations to know about before making the decision to 
 
 - The integration only works if you are using actual-server.
 
-- The API secrets and keys for bank sync are stored on the server and are **not** covered by [end-to-end encryption](/docs/getting-started/sync/#end-to-end-encryption). End-to-end encryption only protects your budget data. Server administrators or hosting providers with direct access to the server's database can read bank sync tokens. If this is a concern, consider self-hosting your server.
+- The API secrets and keys for bank sync are stored on the server and are **not** covered by [end-to-end encryption](../getting-started/sync.md#end-to-end-encryption). End-to-end encryption only protects your budget data. Server administrators or hosting providers with direct access to the server's database can read bank sync tokens. If this is a concern, consider self-hosting your server.
 
 - You will need to add a config file to your installation.
 
 ## Supported Providers
 
-- [Enable Banking](/docs/advanced/bank-sync/enable-banking) (European Banks)
-- GoCardless [BankAccountData](/docs/advanced/bank-sync/gocardless/) (European Banks, **not accepting new accounts**)
-- [SimpleFIN Bridge](/docs/advanced/bank-sync/simplefin) (North American Banks)
-- [Pluggy.ai](/docs/advanced/bank-sync/pluggyai) (Brazilian Banks)
+- [Enable Banking](./bank-sync/enable-banking.md) (European Banks)
+- GoCardless [BankAccountData](./bank-sync/gocardless.md) (European Banks, **not accepting new accounts**)
+- [SimpleFIN Bridge](./bank-sync/simplefin.md) (North American Banks)
+- [Pluggy.ai](./bank-sync/pluggyai.md) (Brazilian Banks)
 
 ### Retrieve Transactions
 

--- a/packages/docs/docs/advanced/bank-sync/enable-banking.md
+++ b/packages/docs/docs/advanced/bank-sync/enable-banking.md
@@ -4,7 +4,7 @@
 This is an **experimental feature**. That means we're still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
 :::
 :::warning
-All functionality described here may not be available in the latest stable release. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](../../experimental/index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
 To set up Enable Banking, start by creating and signing in to your account: https://enablebanking.com/sign-in/

--- a/packages/docs/docs/advanced/http-header-auth.md
+++ b/packages/docs/docs/advanced/http-header-auth.md
@@ -17,7 +17,7 @@ Be careful! A misconfiguration on this next step could make your instance availa
 
 The SSO provider then needs to be configured to pass an extra HTTP header to Actual. The details on how to do this are unique to the SSO provider, but the header `x-actual-password` needs to be set to your actual password.
 
-If your setup needs it, it is possible to configure trusted proxies for authentication. See [`trustedAuthProxies` configuration](../config/index.md#trustedAuthProxies) for details.
+If your setup needs it, it is possible to configure trusted proxies for authentication. See [`trustedAuthProxies` configuration](../config/index.md#trustedauthproxies) for details.
 
 :::note
 This feature is not an HTTP basic auth, but a different form of using a password. For HTTP basic auth or user accounts see [this issue](https://github.com/actualbudget/actual/issues/524)

--- a/packages/docs/docs/advanced/restart.md
+++ b/packages/docs/docs/advanced/restart.md
@@ -4,10 +4,10 @@ If you've fallen behind on your budgeting and want to start fresh without starti
 
 This means that you want to reset your budget while keeping your categories, payees, rules and schedules. Below we have described two methods to restart your budget: one by deleting all transactions and another without deleting any transactions.
 
-If you're ok with truly starting completely from scratch, [just make a new file](/docs/getting-started/starting-fresh/).
+If you're ok with truly starting completely from scratch, [just make a new file](../getting-started/starting-fresh.md).
 
 :::caution
-Remember to [back up your budget](/docs/backup-restore/backup) before making any significant changes to your budget.
+Remember to [back up your budget](../backup-restore/backup.md) before making any significant changes to your budget.
 :::
 
 ## Restarting Your Budget by Deleting Transactions

--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -86,7 +86,7 @@ The API communicates with the server using Node's built-in `fetch`. There are a 
 
 ## Writing Data Importers
 
-If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](/docs/migration/nynab) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
+If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](../migration/nynab.mdx) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
 
 Note that this is not about importing transactions. If all you want to do is add transactions from a custom source (like your bank's API), use [`importTransactions`](./reference.md#importtransactions). In this context, a custom importer is something that takes _all_ of your data (budgets, transactions, payees, etc) and dumps them all into a new file in Actual.
 

--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -86,7 +86,7 @@ The API communicates with the server using Node's built-in `fetch`. There are a 
 
 ## Writing Data Importers
 
-If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](../migration/nynab.md) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
+If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](/docs/migration/nynab) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
 
 Note that this is not about importing transactions. If all you want to do is add transactions from a custom source (like your bank's API), use [`importTransactions`](./reference.md#importtransactions). In this context, a custom importer is something that takes _all_ of your data (budgets, transactions, payees, etc) and dumps them all into a new file in Actual.
 

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -276,7 +276,7 @@ This method has the following optional flags (passed as the `opts` object):
 
 - `defaultCleared`: whether imported transactions should be marked as cleared (defaults to `true`)
 - `dryRun`: if `true`, returns what would be added/updated without actually modifying the database (defaults to `false`)
-- `reimportDeleted`: if `true`, transactions that were previously imported and then deleted will be reimported; if `false`, they will be skipped (defaults to `true` for backward compatibility — note that the [file import UI](/docs/transactions/importing#avoiding-duplicate-transactions) defaults to `false`)
+- `reimportDeleted`: if `true`, transactions that were previously imported and then deleted will be reimported; if `false`, they will be skipped (defaults to `true` for backward compatibility — note that the [file import UI](../transactions/importing.md#avoiding-duplicate-transactions) defaults to `false`)
 
 Example using opts:
 

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -522,7 +522,7 @@ Create a category group. Returns the `id` of the new group.
 
 <Method name="updateCategoryGroup" args={[{ name: 'id', type: 'id' }, { name: 'fields', type: 'object' }]} returns="Promise<id>" />
 
-Update fields of a category group. `fields` can specify any field described in [`CategoryGroup`](#categorygroup).
+Update fields of a category group. `fields` can specify any field described in [`CategoryGroup`](#category-group).
 
 #### `deleteCategoryGroup`
 
@@ -737,7 +737,7 @@ Create schedule based on information filled in the schedule object. Please refer
 
 <Method name="updateSchedule" args={[{ name: 'id', type: 'id' }, { name: 'fields', type: 'object' }]} returns="Promise<schedule>" />
 
-Update fields of a rule. `fields` can specify any field described in [`Schedule`](#Schedule). Returns the updated rule.
+Update fields of a rule. `fields` can specify any field described in [`Schedule`](#schedule). Returns the updated rule.
 
 #### `deleteSchedule`
 

--- a/packages/docs/docs/budgeting/categories.md
+++ b/packages/docs/docs/budgeting/categories.md
@@ -3,7 +3,7 @@
 You can manage your categories in the budget page. Actual supports both expense and income categories.
 
 Get some background information and recommendations on budget categories in our
-[starting fresh](/docs/getting-started/starting-fresh#3-setting-up-your-budget-categories) guide.
+[starting fresh](../getting-started/starting-fresh.md#3-setting-up-your-budget-categories) guide.
 
 ## Add a Category
 

--- a/packages/docs/docs/budgeting/categories.md
+++ b/packages/docs/docs/budgeting/categories.md
@@ -3,7 +3,7 @@
 You can manage your categories in the budget page. Actual supports both expense and income categories.
 
 Get some background information and recommendations on budget categories in our
-[starting fresh](/docs/getting-started/starting-fresh#2-setting-up-your-budget-categories) guide.
+[starting fresh](/docs/getting-started/starting-fresh#3-setting-up-your-budget-categories) guide.
 
 ## Add a Category
 

--- a/packages/docs/docs/budgeting/credit-cards/carrying-debt.md
+++ b/packages/docs/docs/budgeting/credit-cards/carrying-debt.md
@@ -35,7 +35,7 @@ Before we get started, check the settings for your Credit Card accounts to make 
 - When we use the "Uncleared total" or account "Balance" from Actual we will use the absolute value, the positive value without the (-) sign. So, if Actual shows "Uncleared total: -2553.86", then we will use 2553.86.
 - For our purposes here, we will be paying the credit card from a checking account.
 - While you are paying off your credit card(s), it is best to use a debit card or cash. If that is not possible, and you have a card with no debt, use that one to make new purchases so you can pay it in full every month using [Paying in Full - Within the Budget](./paying-in-full.md) and work to pay off another. In any case, use _**only one credit card**_ for new purchases and pay off the one with the highest interest first.
-- We recommend doing this On Budget. If you will not use the card again after it's completely paid off and you have received a statement with a $0 balance, you can [close](/docs/accounts/index.md#closing-or-deleting-an-account) the account.
+- We recommend doing this On Budget. If you will not use the card again after it's completely paid off and you have received a statement with a $0 balance, you can [close](../../accounts/index.md#closing-or-deleting-an-account) the account.
 
 ### Setting Up Actual Budget for Credit Card Debt
 
@@ -64,12 +64,12 @@ If you have been paying the statement balance in full every month, but need to i
 
 - If you are _not_ paying off the debt on this card:
   - When your statement arrives, create the Interest & Fees transaction in the Credit Card account and categorize it to **Bank Card Debt**.
-  - [Reconcile](/docs/accounts/reconciliation.md) your account.
+  - [Reconcile](../../accounts/reconciliation.md) your account.
   - Make sure the amount in the **Budgeted** column for **Bank Card Debt** is at least the statement Minimum Payment. If you need to add to it to reach the Minimum Payment, _cover_ any overspending by transferring from another category with a positive balance.
   - Use _Make Transfer_ to transfer the amount in the **Budgeted** column from your Checking account to the Credit Card account. Send that amount to the Credit Card Bank to pay your bill.
 - If you _are_ paying off the debt:
   - When your statement arrives, create the Interest & Fees transaction in the Credit Card account and categorize it to **Bank Card Debt**.
-  - [Reconcile](/docs/accounts/reconciliation.md) your account.
+  - [Reconcile](../../accounts/reconciliation.md) your account.
   - Make sure the amount in the **Budgeted** category is higher than the statement Minimum Payment. One day your Minimum Payment will pay off the card completely! Happy Day!
   - Use _Make Transfer_ to transfer the amount in the **Budgeted** column from your Checking account to the Credit Card account. Send that amount to the Credit Card Bank to pay your bill.
 
@@ -79,7 +79,7 @@ If you have been paying the statement balance in full every month, but need to i
 - When your statement arrives, find the following information:
   - New Balance, Minimum Payment, Interest & Fees, Returns/Credits and New Purchases. We will use this information to reconcile and calculate your payment.
   - In the Credit Card account, create a transaction for Interest & Fees and categorize it to **Bank Card Debt**.
-  - [Reconcile](/docs/accounts/reconciliation.md) the account. Clear each and every transaction with your statement, including the Interest & Fees and Return Credits. Fix any problems before you move on. We do not advocate using a Reconciliation Transaction to fix any problems, especially when you are carrying debt. Before you "complete" the reconciliation, you can add up your cleared purchases and make sure the sum matches the "New Purchases" amount from your statement. The first month will be the most difficult - it will get easier!
+  - [Reconcile](../../accounts/reconciliation.md) the account. Clear each and every transaction with your statement, including the Interest & Fees and Return Credits. Fix any problems before you move on. We do not advocate using a Reconciliation Transaction to fix any problems, especially when you are carrying debt. Before you "complete" the reconciliation, you can add up your cleared purchases and make sure the sum matches the "New Purchases" amount from your statement. The first month will be the most difficult - it will get easier!
 - Looking at your statement, the very least amount you need to pay to not increase your debt is the Interest & Fees and your New Purchases minus the Return Credits. Remember, you accounted for and funded the interest at the beginning of the month when you budgeted for the expected Minimum Payment and you were setting aside funds to pay for New Purchases each time you categorized them! You can pay for them all without worry.
   - If you are _not_ paying off any original debt on this card, make sure the **Budgeted** column is at least the Minimum Payment. The Minimum Payment you budgeted for at the beginning of the month should have this covered. If the Minimum Payment is more than you expected due to Interest or Fees, add an amount to the **Budgeted** column to equal the statement Minimum Payment. _Cover_ any additions to the **Budgeted** amount by transferring from another category with a positive balance.
   - If you _are_ paying off the debt on this card, make sure the current **Budgeted** column is more than the Minimum Payment. It should be at least the sum of the Interest & Fees plus the extra amount you want to pay off, but it will probably be a bit more and that's OK!

--- a/packages/docs/docs/budgeting/credit-cards/index.md
+++ b/packages/docs/docs/budgeting/credit-cards/index.md
@@ -7,7 +7,7 @@ Any Revolving Credit Account that has both purchases and payments in any month s
 :::
 
 :::warning
-We recommend that you place all your credit card accounts **On Budget**. You can [close](/docs/accounts/index.md#closing-or-deleting-an-account) an On Budget account when you are through with it (and reopen, if necessary) but you **cannot** change an Off Budget account to On Budget! _Only_ set a credit card account to Off Budget and treat it as a loan if there will be _no_ new purchases and the account will be closed once it's paid off.
+We recommend that you place all your credit card accounts **On Budget**. You can [close](../../accounts/index.md#closing-or-deleting-an-account) an On Budget account when you are through with it (and reopen, if necessary) but you **cannot** change an Off Budget account to On Budget! _Only_ set a credit card account to Off Budget and treat it as a loan if there will be _no_ new purchases and the account will be closed once it's paid off.
 :::
 
 If you pay off your credit card statement every month, then you will want to use the [Paying in Full](./paying-in-full.md) page to understand how Actual helps you work with your credit card to stay _Within the Budget_.

--- a/packages/docs/docs/budgeting/credit-cards/paying-in-full.md
+++ b/packages/docs/docs/budgeting/credit-cards/paying-in-full.md
@@ -56,7 +56,7 @@ If necessary, remember to enter a transaction for any interest and or fees charg
 
 <br />
 
-When we [reconcile](/docs/accounts/reconciliation.md) our account for this first month, we clear all of the June purchases and payments (which should be part of the "Starting Balance") in one lump. In our case their lump sum is $35.00.
+When we [reconcile](../../accounts/reconciliation.md) our account for this first month, we clear all of the June purchases and payments (which should be part of the "Starting Balance") in one lump. In our case their lump sum is $35.00.
 
 <img width="100%" height="100%" alt="Chase Reconcile July" src="/img/credit-cards/CC-IND-04.webp" />
 
@@ -93,7 +93,7 @@ We continue to spend and categorize each transaction _Within the Budget_ and whe
 - Interest Charged: $0.00
 - New Balance: $213.15
 
-We [reconcile](/docs/accounts/reconciliation.md) our Chase account and it now looks like this:
+We [reconcile](../../accounts/reconciliation.md) our Chase account and it now looks like this:
 
 <img width="100%" height="100%" alt="Chase August Reconcile" src="/img/credit-cards/CC-IND-08.webp" />
 

--- a/packages/docs/docs/budgeting/index.md
+++ b/packages/docs/docs/budgeting/index.md
@@ -4,7 +4,7 @@ The purpose of a budget is to answer simple questions: how much money did I save
 
 There are many approaches to budgeting. Some of the approaches that seem simple at first end up causing more work to keep an accurate budget, or make it easy for hidden expenses to drain your savings.
 
-We find the best way to track your money is rooted in something called **[envelope budgeting](/docs/getting-started/envelope-budgeting.md)**. Instead of predicting how much you'll make and spend and trying to reconcile that with what actually happened, envelope budgeting embraces real income as the source of your budget instead. This means you can only budget money that you already have.
+We find the best way to track your money is rooted in something called **[envelope budgeting](../getting-started/envelope-budgeting.md)**. Instead of predicting how much you'll make and spend and trying to reconcile that with what actually happened, envelope budgeting embraces real income as the source of your budget instead. This means you can only budget money that you already have.
 
 You can think of categories as little funds that you deposit money into. Combined with our rollover system, it provides an intuitive way to handle a lot of things that come up in life. And you know it's always accurately depicting your finances — there's no made up numbers.
 
@@ -60,7 +60,7 @@ It is possible to hold money multiple months ahead. If you do this, those dollar
 If you enter a new month and have a negative "To Be Budgeted" amount and you're sure it should be positive, try resetting next month's buffer to bring money that may be held back to the current month.
 :::
 :::note
-If you hold funds regularly, you can [automatically hold funds from specific income categories](./#automatic-holding-of-funds).
+If you hold funds regularly, you can [automatically hold funds from specific income categories](./index.md#automatic-holding-of-funds).
 :::
 
 ### Overspending

--- a/packages/docs/docs/budgeting/joint-accounts.md
+++ b/packages/docs/docs/budgeting/joint-accounts.md
@@ -11,7 +11,7 @@ One approach is maintaining a common budget where both partners share a single b
 This method promotes transparency and ensures both parties agree regarding financial goals, expenses, and income.
 A shared budget fosters collaboration but requires consistent communication to keep everything current. It will help
 you both set clear boundaries for individual and shared expenses while working together toward common financial objectives.
-See [Multi-user](/docs/getting-started/sync#multi-user-support) regarding simultaneous edits.
+See [Multi-user](../getting-started/sync.md#multi-user-support) regarding simultaneous edits.
 
 Alternatively, you can track your partner's contributions within your personal Actual Budget file. This allows you to
 maintain individual control over your finances while still acknowledging and accounting for your partner's financial
@@ -31,7 +31,7 @@ budgeting in particular. Not everyone is prepared for this kind of visibility an
 
 Also, stop using cash for common expenses, as this makes tracking so much more complicated.
 
-When your partner is ready to embrace your true joint expenses, use our [Starting Fresh guide](/docs/getting-started/starting-fresh) to get
+When your partner is ready to embrace your true joint expenses, use our [Starting Fresh guide](../getting-started/starting-fresh.md) to get
 started. If your partner is new to budgeting, consider skipping the part about using historical data to find
 your initial budget numbers. Another tip is to set aside time each week by going through last week's spending; avoid doing
 this late in the evening when your energies are low.
@@ -44,7 +44,7 @@ Another tip is to let your partner be the primary account holder for your joint 
 2. Get two debit cards attached to the joint account, one for you and one for your partner.
 3. Create a joint Actual Budget file on a server that is also reachable by your partner.
 4. Decide how big each partner's contribution to the joint account should be (see below).
-5. Follow the [Starting Fresh guide](/docs/getting-started/starting-fresh) with your partner.
+5. Follow the [Starting Fresh guide](../getting-started/starting-fresh.md) with your partner.
 
 ### Deciding on how big each partner's contribution should be
 

--- a/packages/docs/docs/budgeting/rules/custom.md
+++ b/packages/docs/docs/budgeting/rules/custom.md
@@ -1,6 +1,6 @@
 # Rules Examples
 
-This page has examples of custom rules that some of our users have found useful for their own budgets. If you have any custom rules you're proud of, click the "Edit this page" button below to propose adding them to this page [tell us about them](/contact)!
+This page has examples of custom rules that some of our users have found useful for their own budgets. If you have any custom rules you're proud of, click the "Edit this page" button below to propose adding them to this page [tell us about them](../../../../contact)!
 
 ### Q: How do I set the payee when the payee name changes between transactions
 

--- a/packages/docs/docs/budgeting/rules/index.md
+++ b/packages/docs/docs/budgeting/rules/index.md
@@ -63,7 +63,7 @@ Actions can also prepend or append text to the `notes` field.
 
 ## Experimental: rule formulas
 
-Actual also has an experimental “Excel formula mode” that lets some **Set** actions compute their value from a formula (toggle with the **ƒ** button in the rule editor). See [Excel Formula Mode](/docs/experimental/formulas).
+Actual also has an experimental “Excel formula mode” that lets some **Set** actions compute their value from a formula (toggle with the **ƒ** button in the rule editor). See [Excel Formula Mode](../../experimental/formulas.md).
 
 ## Automatic Rules
 

--- a/packages/docs/docs/config/https.md
+++ b/packages/docs/docs/config/https.md
@@ -6,7 +6,7 @@ You'll need to enable HTTPS on your server in order to safely use all of Actual'
 
 ## 1. Acquire a certificate to use on your server
 
-There are two methods to do this and both refer to not exposing Actual on the internet. If access from the internet is desired, refer to [Using a Reverse Proxy](/docs/config/reverse-proxies).
+There are two methods to do this and both refer to not exposing Actual on the internet. If access from the internet is desired, refer to [Using a Reverse Proxy](./reverse-proxies.md).
 
 ### Use a self-signed certificate
 
@@ -34,7 +34,7 @@ Once you have the certificate, you'll need to configure Actual to use it. There 
 
 ### Configuring with `config.json`
 
-Create a `config.json` file in the same folder where you run the Actual Sync Server. If you are [building from source](/docs/install/build-from-source) this will be in `packages/sync-server/`. Put the paths to the `.key` and `.crt` files in the config file. Note: if you're using Docker or a similar container environment, make sure the paths are accessible to the container.
+Create a `config.json` file in the same folder where you run the Actual Sync Server. If you are [building from source](../install/build-from-source.md) this will be in `packages/sync-server/`. Put the paths to the `.key` and `.crt` files in the config file. Note: if you're using Docker or a similar container environment, make sure the paths are accessible to the container.
 
 If using a Docker container, this folder is `/data` within the container. If you mounted a volume for the container, the folder on the host where `/data` is mounted is where you can place the `config.json` file.
 

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -2,7 +2,7 @@
 title: Configuring the Server
 ---
 
-When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are [building from source](/docs/install/build-from-source) this will be in `packages/sync-server/`. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
+When it starts up, Actual looks for an optional `config.json` file in the same directory as the sync-server's `package.json`. If you are [building from source](../install/build-from-source.md) this will be in `packages/sync-server/`. If present, any keys you define there will override the default values. All values can also be specified as environment variables, which will override the values in the `config.json` file.
 
 :::caution
 Observe that the environmental variables do not map 1:1 to keys in the config.json file. In case of doubt, check the source schema at [/packages/sync-server/src/load-config.js](https://github.com/actualbudget/actual/blob/45530638feaacf74c28fddb846ae91170a99d94e/packages/sync-server/src/load-config.js#L43)
@@ -10,7 +10,7 @@ Observe that the environmental variables do not map 1:1 to keys in the config.js
 
 :::info
 
-Running into issues with your configuration not being interpreted correctly? Check out our documentation for [troubleshooting the server](/docs/troubleshooting/server.md) for information on how to enable debug logging to track down the issue.
+Running into issues with your configuration not being interpreted correctly? Check out our documentation for [troubleshooting the server](../troubleshooting/server.md) for information on how to enable debug logging to track down the issue.
 
 :::
 
@@ -57,7 +57,7 @@ If you want Actual to serve over HTTPS, you can set this key to an object with t
 - `cert`: The path to the certificate file. (environment variable: `ACTUAL_HTTPS_CERT`)
 - any other options from Node's [`tls.createServer()`](https://nodejs.org/api/tls.html#tlscreateserveroptions-secureconnectionlistener), [`tls.createSecureContext()`](https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions), or [`http.createServer()`](https://nodejs.org/api/http.html#httpcreateserveroptions-requestlistener) functions (optional, most people won't need to set any of these).
 
-See [Activating HTTPS](/config/https.md) for more information on how to get HTTPS working.
+See [Activating HTTPS](./https.md) for more information on how to get HTTPS working.
 
 <!-- ## `mode`
 

--- a/packages/docs/docs/config/multi-user.md
+++ b/packages/docs/docs/config/multi-user.md
@@ -2,7 +2,7 @@
 
 :::caution
 
-This feature requires you to have set up an [OpenID Provider](/docs/config/oauth-auth). The usernames which people will log into your Actual instance will be fetched from the provider.
+This feature requires you to have set up an [OpenID Provider](./oauth-auth.md). The usernames which people will log into your Actual instance will be fetched from the provider.
 
 :::
 

--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -186,5 +186,5 @@ Use `oauth2` for providers like GitHub that don't fully support OpenID discovery
   **Possible Values:** `manual` or `login` (default is `manual`)
 
 :::tip
-Configuring the OpenID provider from options supports discovery; otherwise, use [file configuration](oauth-auth#config-using-configuration-file)
+Configuring the OpenID provider from options supports discovery; otherwise, use [file configuration](oauth-auth#configuration-using-a-configuration-file)
 :::

--- a/packages/docs/docs/config/oauth-auth.md
+++ b/packages/docs/docs/config/oauth-auth.md
@@ -3,12 +3,12 @@
 ## Setup
 
 :::info
-This feature requires use of [Actual Server](../config/)
+This feature requires use of [Actual Server](./index.md)
 :::
 
 If you require a more robust authentication method than a server password, it is recommended to use an OpenID provider. Most OpenID providers support multi-factor authentication, enhancing your application's security. Additionally, if you need support for multiple users, you must enable this feature.
 
-To enable this feature, you can use a [configuration file](/docs/config/) `config.json` on the Actual server, or use the UI.
+To enable this feature, you can use a [configuration file](./index.md) `config.json` on the Actual server, or use the UI.
 
 ### Configuration Using a Configuration File
 
@@ -186,5 +186,5 @@ Use `oauth2` for providers like GitHub that don't fully support OpenID discovery
   **Possible Values:** `manual` or `login` (default is `manual`)
 
 :::tip
-Configuring the OpenID provider from options supports discovery; otherwise, use [file configuration](oauth-auth#configuration-using-a-configuration-file)
+Configuring the OpenID provider from options supports discovery; otherwise, use [file configuration](./oauth-auth.md#configuration-using-a-configuration-file)
 :::

--- a/packages/docs/docs/contributing/writing-docs.md
+++ b/packages/docs/docs/contributing/writing-docs.md
@@ -157,6 +157,24 @@ If you have never used Markdown, please consult [CommonMark](https://commonmark.
 [Docusaurus Markdown Features](https://docusaurus.io/docs/markdown-features) guide. You can learn more about Markdown in
 [The Markdown Guide](https://www.markdownguide.org/).
 
+### Linking Between Pages
+
+When linking from one documentation page to another, use a relative file path that includes the `.md` extension, not the page's URL:
+
+```markdown
+Read our [Starting Fresh](../getting-started/starting-fresh.md) guide.
+```
+
+instead of
+
+```markdown
+Read our [Starting Fresh](/docs/getting-started/starting-fresh) guide.
+```
+
+Docusaurus resolves file paths at build time and converts them to the published URLs, so links that point at a missing file or heading fail the build (`onBrokenLinks` and `onBrokenAnchors` are both set to `throw`) instead of silently breaking for readers. When linking to a specific section, place the anchor after the extension: `../api/reference.md#importtransactions`.
+
+Blog posts and the standalone pages in `src/pages/` live outside the `docs/` folder and can't reference documentation by file path. Use relative URLs from those files instead, for example `../../docs/install/` from a blog post.
+
 ### Keyboard Shortcuts
 
 ```markdown

--- a/packages/docs/docs/contributing/writing-docs.md
+++ b/packages/docs/docs/contributing/writing-docs.md
@@ -263,7 +263,7 @@ As part of the build process, GitHub actions runs a spell checker bot on the doc
 
 ![Image of spelling bot error](/img/repo/spellingbot-example.webp)
 
-If the bot mistakes a word, you can add it to the `/.github/actions/spelling/allow/keywords.txt` file.
+If the bot mistakes a word, you can add it to the `/.github/actions/docs-spelling/allow/keywords.txt` file.
 This will prevent the bot from reporting this word as a spelling error in the future.
 
 ## Naming Standards

--- a/packages/docs/docs/experimental/balance-forecast-report.md
+++ b/packages/docs/docs/experimental/balance-forecast-report.md
@@ -42,5 +42,5 @@ For each forecast day, Actual updates the running balance with posted transactio
 
 ## Related
 
-- [Reports index](/docs/reports/index.md) — other report types and tips.
-- [Schedules](/docs/schedules) — manage the scheduled transactions used by the forecast.
+- [Reports index](../reports/index.md) — other report types and tips.
+- [Schedules](../schedules.md) — manage the scheduled transactions used by the forecast.

--- a/packages/docs/docs/experimental/budget-analysis-report.md
+++ b/packages/docs/docs/experimental/budget-analysis-report.md
@@ -35,5 +35,5 @@ It tracks four separate series: **Budgeted**, **Spent**, **Overspending Adjustme
 
 ## Related
 
-- [Budget page](/docs/tour/budget.md) — configure budgets and rollover settings.
-- [Reports index](/docs/reports/index.md) — other report types and tips.
+- [Budget page](../tour/budget.md) — configure budgets and rollover settings.
+- [Reports index](../reports/index.md) — other report types and tips.

--- a/packages/docs/docs/experimental/budget-automation.md
+++ b/packages/docs/docs/experimental/budget-automation.md
@@ -5,7 +5,7 @@ This is an **experimental feature**. That means we're still working on finishing
 :::
 
 :::warning
-All functionality described here may not be available in the latest stable release. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
 Budget automations allow you to automate your budgeting step every month.
@@ -21,7 +21,7 @@ Here are a few examples of what you can do, all with a single click!
 - Budget 10% of your income for savings or charity
 - Budget the average you spend over the last 6 months
 - Save up for a big purchase many months or years in the future, and let Actual dynamically figure out how much to budget every month
-- And much more! Check out this [blog entry from 2023!](/blog/2023-12-15-automate-your-budget-with-goal-templates) Although it was written in the early days of note templates, it's still pertinent today!
+- And much more! Check out this [blog entry from 2023!](../../../blog/2023-12-15-automate-your-budget-with-goal-templates) Although it was written in the early days of note templates, it's still pertinent today!
 
 ---
 
@@ -121,7 +121,7 @@ For weeks, the number of weeks in a month is based on the weekday of your start 
 :::tip
 You can give different priorities to multiple _Fixed amount_ automations in the same category and they will be respected when the budget fills.
 
-This [blog post using note templates](/blog/2024-03-25-goal-templates-with-a-twist) from 2024 goes into this in more detail.
+This [blog post using note templates](../../../blog/2024-03-25-goal-templates-with-a-twist) from 2024 goes into this in more detail.
 :::
 
 ### Save by Date {#save-by-date}

--- a/packages/docs/docs/experimental/formulas.md
+++ b/packages/docs/docs/experimental/formulas.md
@@ -5,7 +5,7 @@ This is an **experimental feature**. That means we’re still working on finishi
 ::::
 
 ::::warning
-All functionality described here may not be available in the latest stable release. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 ::::
 
 Excel formula mode adds two related features:

--- a/packages/docs/docs/experimental/goal-templates.md
+++ b/packages/docs/docs/experimental/goal-templates.md
@@ -4,7 +4,7 @@
 This is an **experimental feature**. That means we're still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
 :::
 :::warning
-All functionality described here may not be available in the latest stable release. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
 Budget templates allow you to automate your budgeting step every month.

--- a/packages/docs/docs/experimental/monthly-cleanup.md
+++ b/packages/docs/docs/experimental/monthly-cleanup.md
@@ -1,7 +1,7 @@
 # End of Month Cleanup
 
 :::warning
-This is an **experimental feature**. That means we're still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features.
+This is an **experimental feature**. That means we're still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord. See [Experimental Features](./index.md) for instructions to enable experimental features.
 :::
 
 Create a template by adding a note to a category and adding a line that begins with `#cleanup`.

--- a/packages/docs/docs/experimental/rule-templating.md
+++ b/packages/docs/docs/experimental/rule-templating.md
@@ -1,14 +1,14 @@
 # Rule Action Templating
 
 :::danger Deprecated
-Rule action templating is **deprecated** and will be removed in a future release. New rules should use [Rule formulae](/docs/experimental/formulas#rule-formulas) instead, which cover the same use cases with a more powerful Excel-style syntax. If you have existing rules that use templating, please migrate them to formulae.
+Rule action templating is **deprecated** and will be removed in a future release. New rules should use [Rule formulae](./formulas.md#rule-formulas) instead, which cover the same use cases with a more powerful Excel-style syntax. If you have existing rules that use templating, please migrate them to formulae.
 :::
 
 :::warning
 This is an **experimental feature**. That means we're still working on finishing it. There may be bugs, missing functionality or incomplete documentation, and we may decide to remove the feature in a future release. If you have any feedback, please [open an issue](https://github.com/actualbudget/actual/issues) or post a message in the Discord.
 :::
 :::warning
-All functionality described here may not be available in the latest stable release. See [Experimental Features](/docs/experimental/) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+All functionality described here may not be available in the latest stable release. See [Experimental Features](./index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
 Rule action templating allows rules to dynamically set fields based on transaction data via meta programming inside the rule.

--- a/packages/docs/docs/faq.md
+++ b/packages/docs/docs/faq.md
@@ -12,7 +12,7 @@
 
 - **Q.** _Can I import my Actual Budget from the hosted instance of Actual to my Self Hosted version_.
 
-  **A.** The hosted subscription service was shut down in 2024, but if you are still using the old Actual Budget Desktop App, we have a [migration guide in place for this](/docs/migration/#migration-from-the-old-actual-budget-desktop-app).
+  **A.** The hosted subscription service was shut down in 2024, but if you are still using the old Actual Budget Desktop App, we have a [migration guide in place for this](./migration/index.md#migration-from-the-old-actual-budget-desktop-app).
 
 - **Q.** _How do I update my version of Actual after it has been updated?_
 

--- a/packages/docs/docs/getting-started/envelope-budgeting.md
+++ b/packages/docs/docs/getting-started/envelope-budgeting.md
@@ -60,7 +60,7 @@ zero. When you get a paycheck, or other income, continue filling in where the fu
 As you go along you will start to get a good view of where your money is going. If you don't like how things
 are going, make changes. If you're happy, great! Keep budgeting to keep track of your progress on your goals.
 
-A more detailed breakdown of how budgeting in Actual works is provided in the [budgeting page](/docs/budgeting/).
+A more detailed breakdown of how budgeting in Actual works is provided in the [budgeting page](../budgeting/index.md).
 
 ### The Month Ahead Strategy
 
@@ -69,7 +69,7 @@ paychecks per month. One way to handle this is called the _month ahead_ method. 
 you make this month and only budgeting it next month. The goal is to not need any of this month's income for this
 month's bills, but pay all of this month's bills with last month's income. Actual makes this easy by allowing you
 to hold your available funds for the next month by clicking the _To Budget_ amount at the top of the budgeting screen
-and selecting the _Hold for next month_ option. You can read more about this on [the budgeting page](/docs/budgeting/).
+and selecting the _Hold for next month_ option. You can read more about this on [the budgeting page](../budgeting/index.md).
 
 For example, if you make $ 3,000 this month, instead of spending it on this month's bills, you save it and use it to
 cover next month's expenses. Most people cannot achieve this in one month, so the way forward is to build up a
@@ -77,7 +77,7 @@ buffer. Instead of aiming to save the full $ 3,000 in one go, begin by setting a
 For example, if you can set aside $ 200 each month, gradually build your buffer over several months. As you save
 more, you'll start to pay some of next month's bills with this reserve.
 
-You can also read about this strategy in [one of our blog posts](/blog/2023-12-15-automate-your-budget-with-goal-templates).
+You can also read about this strategy in [one of our blog posts](../../../blog/2023-12-15-automate-your-budget-with-goal-templates).
 
 ### Pay-Yourself-First Strategy
 
@@ -85,8 +85,8 @@ The Pay-Yourself-First strategy focuses on saving a portion of your income befor
 By making savings the top priority, this approach helps individuals build financial stability and prepare for unexpected
 events. Automating savings, such as setting up automatic transfers, ensures consistency and reduces the temptation
 to overspend. The strategy also encourages a balanced approach, addressing both immediate needs and long-term
-financial security. Actual has functionality for [Schedules](/docs/schedules)
-and [Budget Goal Templates](/docs/experimental/goal-templates#goal-directive) that can help you with this strategy.
+financial security. Actual has functionality for [Schedules](../schedules.md)
+and [Budget Goal Templates](../experimental/goal-templates.md#goal-directive) that can help you with this strategy.
 
 For example, if you earn $ 3,000 a month, you might decide to save 20%, or $ 600, as soon as you receive your paycheck.
 You set up an automatic transfer to move this amount into a savings account, ensuring it is set aside before you
@@ -97,15 +97,15 @@ having to rely on what's left at the end of the month.
 ### Credit Cards
 
 If you currently are carrying credit card debt in an on budget account you will need to capture that debt in a category.
-A guide on how to handle that can be found in [the credit card guide](/docs/budgeting/credit-cards/).
+A guide on how to handle that can be found in [the credit card guide](../budgeting/credit-cards/index.md).
 
 ### Shared accounts
 
-We have a guide on what to do when it comes to [strategies for handling joint accounts](/docs/budgeting/joint-accounts).
+We have a guide on what to do when it comes to [strategies for handling joint accounts](../budgeting/joint-accounts.md).
 
 ### Returns and Reimbursements
 
-You can read more about these in the [returns and reimbursements guides](/docs/budgeting/returns-and-reimbursements).
+You can read more about these in the [returns and reimbursements guides](../budgeting/returns-and-reimbursements.md).
 
 ## How to set up and use an envelope system with Actual Budget
 
@@ -114,7 +114,7 @@ if you're new to budgeting. Here's a checklist for getting started:
 
 ### 1. Establish budget categories
 
-The first step is deciding which expense and income  [categories to include in your budget](/docs/budgeting/categories).
+The first step is deciding which expense and income  [categories to include in your budget](../budgeting/categories.md).
 Tailor each category to fit your specific budget and spending habits, giving you the power to customize
 the system to your needs for the most accurate tracking.
 
@@ -205,7 +205,7 @@ necessary adjustments.
    Flexibility is key. Adjusting your budget is a normal part of the process.
 
 You can also set up Actual Budget to
-[automatically deduct the overspending](/docs/budgeting/#rollover-negative-category-balances) from next month's funds. Be aware that
+[automatically deduct the overspending](../budgeting/index.md#rollover-negative-category-balances) from next month's funds. Be aware that
 even if you _can_ do something, it does not mean that you _should_ do it.
 
 You maintain control over your budget by reallocating funds and avoiding unnecessary stress. This process helps
@@ -256,13 +256,13 @@ in your bank statement. Bank and credit card statements provide a detailed histo
 transactions, including the date, amount, and merchant. This makes it much easier to track your spending without
 having (to remember) to manually enter each transaction whenever you make a purchase or get income.
 Most financial institutions will let you export your transactions as CSV files,
-which can be [imported into Actual Budget](/docs/transactions/importing). Using cards will save you time and reduce the risk of errors.
+which can be [imported into Actual Budget](../transactions/importing.md). Using cards will save you time and reduce the risk of errors.
 
-**Automatic import**: Actual Budget can [sync directly with your bank accounts](/docs/advanced/bank-sync).
+**Automatic import**: Actual Budget can [sync directly with your bank accounts](../advanced/bank-sync.md).
 Every time you use your debit or credit card, the transaction details are automatically imported into
 your budget categories. You no longer need to keep physical receipts or manually log each expense.
 
-Read more about [managing credit cards](/docs/budgeting/credit-cards) with Actual Budget.
+Read more about [managing credit cards](../budgeting/credit-cards/index.md) with Actual Budget.
 
 ## A detailed example of how to do Zero-Sum budgeting
 

--- a/packages/docs/docs/getting-started/roadmap-for-new-users.md
+++ b/packages/docs/docs/getting-started/roadmap-for-new-users.md
@@ -10,7 +10,7 @@ Below, we have outlined various use cases and, under each use case, give pointer
 
 ## I just want to look at screenshots before doing anything.
 
-Please take a look at our [Tour of Actual](/docs/tour/).
+Please take a look at our [Tour of Actual](../tour/index.md).
 
 ## I want to test out Actual without committing to any work or installations.
 
@@ -25,9 +25,9 @@ you can [download the stand-alone software](https://github.com/actualbudget/actu
 ## I want the complete package but do not know how to run a server.
 
 In this case, you can use a service provider called PikaPods. Setup only takes a few minutes.
-We have written a thorough [step-by-step guide for PikaPods](/docs/install/pikapods).
+We have written a thorough [step-by-step guide for PikaPods](../install/pikapods.md).
 However, if you are adventurous or somewhat technical, please go directly to the [Actual Budget setup in PikaPod](https://www.pikapods.com/pods?run=actual).
 
 ## I am technical and have no issues running a service on my own.
 
-Check out [Running a Server](/docs/install/#running-a-server) from the Installation guide.
+Check out [Running a Server](../install/index.md#running-a-server) from the Installation guide.

--- a/packages/docs/docs/getting-started/starting-fresh.md
+++ b/packages/docs/docs/getting-started/starting-fresh.md
@@ -4,10 +4,10 @@ title: 'Starting Fresh'
 
 For most users it's best to start fresh with a blank file.
 This guide will walk through setting up a budget file fresh without migrating from a previous budget software export.
-Before continuing, it might be a good idea to read about the [envelope method](/docs/getting-started/envelope-budgeting), or zero-sum
+Before continuing, it might be a good idea to read about the [envelope method](./envelope-budgeting.md), or zero-sum
 budgeting as it's also called.
 
-If you want to restart an existing budget while keeping your categories, payees, rules, and schedules, you can follow the guide on [Restarting Your Budget](/docs/advanced/restart).
+If you want to restart an existing budget while keeping your categories, payees, rules, and schedules, you can follow the guide on [Restarting Your Budget](../advanced/restart.md).
 
 ## 1. Setting up Accounts
 
@@ -106,7 +106,7 @@ You may also want a category for interest and dividends.
 Actual has a nifty and useful feature where you can organize your expense categories into groups.
 This not only provides more visibility and control over your spending but also empowers you
 to make informed financial decisions.
-When using the [envelope method](/docs/getting-started/envelope-budgeting), one will move available funds between categories when
+When using the [envelope method](./envelope-budgeting.md), one will move available funds between categories when
 needed. However, there are some categories that you should be very wary about moving funds away
 from. By grouping, you'll get an extra visual indication that moving funds from the Electricity 
 category, for instance, may not be the wisest choice. Another reason is to have a more convenient
@@ -124,7 +124,7 @@ way of reporting your spending habits.
    categories in this group are Mortgage, Car Payments, Student Loans, Short Term Credit.
    Should you put your credit card debts in this category?
    The answer is *it depends*. For some input on this, please read our article on 
-   [Carrying Debt](/docs/budgeting/credit-cards/carrying-debt).
+   [Carrying Debt](../budgeting/credit-cards/carrying-debt.md).
 
 3. **Daily expenses**. Group your everyday expenses for a more organized and convenient way
    of tracking. This makes it easy to report on expenditures that fluctuate from month to month.
@@ -263,16 +263,16 @@ Shortly this method goes like this:
 
 :::info
 
-This topic is so important on how to actually use Actual, that we have devoted a separate page on **[envelope budgeting](/docs/getting-started/envelope-budgeting)**.
+This topic is so important on how to actually use Actual, that we have devoted a separate page on **[envelope budgeting](./envelope-budgeting.md)**.
 
 :::
 
 ## The next step in your budgeting journey
 
 A good next step is to read through the "Using Actual" section of the documentation. This section has detailed explanations on the
-features of Actual and how to use them. Some of the most useful features are [Rules](/docs/budgeting/rules/index.md),
-[Schedules](/docs/schedules.md), [Reconciliation](/docs/accounts/reconciliation.md),
-and [Reports](/docs/reports/index.md).
+features of Actual and how to use them. Some of the most useful features are [Rules](../budgeting/rules/index.md),
+[Schedules](../schedules.md), [Reconciliation](../accounts/reconciliation.md),
+and [Reports](../reports/index.md).
 
 If you feel a bit overwhelmed, don't worry.
 

--- a/packages/docs/docs/getting-started/sync.md
+++ b/packages/docs/docs/getting-started/sync.md
@@ -23,7 +23,7 @@ End-to-end encryption offers the ability for you to generate a key based on a pa
 This guarantees that only you will ever have access to your budget data. This is optional and using it requires you to enter a password whenever downloading [cloud files](#this-file-is-not-a-cloud-file) (this only needs to be done once per device). The password you enter should be different from the main server password.
 
 :::note
-End-to-end encryption applies only to your budget data. If you use [bank sync](/docs/advanced/bank-sync), the bank sync tokens (e.g. SimpleFIN, GoCardless, or Pluggy credentials) are stored separately on the server and are **not** covered by end-to-end encryption. Server administrators or hosting providers with direct access to the server's database can read these tokens. If this is a concern, consider self-hosting your server.
+End-to-end encryption applies only to your budget data. If you use [bank sync](../advanced/bank-sync.md), the bank sync tokens (e.g. SimpleFIN, GoCardless, or Pluggy credentials) are stored separately on the server and are **not** covered by end-to-end encryption. Server administrators or hosting providers with direct access to the server's database can read these tokens. If this is a concern, consider self-hosting your server.
 :::
 
 Data on your local device is still unencrypted. We recommend full disk encryption if you are interested in local encryption.
@@ -71,7 +71,7 @@ After resetting, all other devices are now out-of-date. What happens when you tr
 
 When Actual detects a problem during syncing, you will see a notification with details and actions to solve the problem. Below are all the notifications you might see, with some greater detail about them.
 
-**You will rarely see these messages**, and if you do Actual will guide you through how to fix the problem. If you are still having problems, please [reach out to us](/contact).
+**You will rarely see these messages**, and if you do Actual will guide you through how to fix the problem. If you are still having problems, please [reach out to us](../../../contact).
 
 ### This File is not a Cloud File
 

--- a/packages/docs/docs/getting-started/tips-tricks.md
+++ b/packages/docs/docs/getting-started/tips-tricks.md
@@ -72,7 +72,7 @@ through the list of available commands. You can also quickly move to any of the 
 :::important
 Transaction(s) must be selected for the following shortcuts, or as noted.
 
-See [Bulk Actions](/docs/transactions/bulk-editing.md) for guidance on working with multiple transactions.
+See [Bulk Actions](../transactions/bulk-editing.md) for guidance on working with multiple transactions.
 :::
 
 - <Key k="e" /> Open date picker and set date for selected transactions.
@@ -86,8 +86,8 @@ See [Bulk Actions](/docs/transactions/bulk-editing.md) for guidance on working w
 - <Key k="f" /> Show only selected transactions. If no transaction is selected, it brings up the Filter dropdown menu.
 - <Key k="d" /> Delete selected transactions.
 - <Key k="u" /> Duplicate selected transactions.
-- <Key k="g" /> Merge selected transactions. Only _two_ transactions with equal amounts can be selected. [Learn more.](/docs/transactions/merging.md)
-- <Key k="r" /> Make transfer from selected transactions. Only _two_ valid conjugate transactions can be selected. [Learn more.](/docs/transactions/transfers.md)
+- <Key k="g" /> Merge selected transactions. Only _two_ transactions with equal amounts can be selected. [Learn more.](../transactions/merging.md)
+- <Key k="r" /> Make transfer from selected transactions. Only _two_ valid conjugate transactions can be selected. [Learn more.](../transactions/transfers.md)
 
 ## How to View Multiple Months at Once
 

--- a/packages/docs/docs/getting-started/tracking-budget.md
+++ b/packages/docs/docs/getting-started/tracking-budget.md
@@ -80,5 +80,5 @@ All the non-budgeting features of Actual can be used with the **Tracking Budget*
 Experimental features may not work with the **Tracking Budget** yet.
 If not please let us know in the feature feedback.
 :::note
-If you find critical functionality missing that you need, please submit a request on [GitHub](/contact).
+If you find critical functionality missing that you need, please submit a request on [GitHub](../../../contact).
 :::

--- a/packages/docs/docs/index.md
+++ b/packages/docs/docs/index.md
@@ -16,14 +16,14 @@ If you aren't sure where to look for information, an entry in the search bar wil
 
 ## Where to Begin?
 
-If you're new to Actual, consult the [roadmap for new users](/docs/getting-started/roadmap-for-new-users).
+If you're new to Actual, consult the [roadmap for new users](./getting-started/roadmap-for-new-users.md).
 
-If you're new to budgeting, read about [envelope budgeting](/docs/getting-started/envelope-budgeting).
+If you're new to budgeting, read about [envelope budgeting](./getting-started/envelope-budgeting.md).
 
-For help and support, [reach out to the maintainers and community](/contact).
+For help and support, [reach out to the maintainers and community](../contact).
 
 ## Want to Contribute?
 
 The Actual application is actively maintained and updated by a dedicated group of contributors and maintainers who do their best to keep these documents synchronized with the changes. If you notice anything incorrect you can [open an issue](https://github.com/actualbudget/actual/issues/new/choose) in github or note it in the [`#Documentation` channel](https://discord.com/channels/937901803608096828/1027831463103696928) in Discord.
 
-If you'd like to contribute to Actual Budget's documentation, start by reading the documentation standards, local setup, and guidelines on using images and screenshots located in the [contributing guide](/docs/contributing/writing-docs) and in the documentation's [github README file](https://github.com/actualbudget/actual/tree/master/packages/docs#actual-budget-community-documentation). We use Docusaurus to build our website. You can click on _Edit this page_ at the bottom left of every page to open that page's Markdown document.
+If you'd like to contribute to Actual Budget's documentation, start by reading the documentation standards, local setup, and guidelines on using images and screenshots located in the [contributing guide](./contributing/writing-docs.md) and in the documentation's [github README file](https://github.com/actualbudget/actual/tree/master/packages/docs#actual-budget-community-documentation). We use Docusaurus to build our website. You can click on _Edit this page_ at the bottom left of every page to open that page's Markdown document.

--- a/packages/docs/docs/install/build-from-source.md
+++ b/packages/docs/docs/install/build-from-source.md
@@ -6,10 +6,10 @@ Installing Actual by building it from source is a highly technical process. We r
 
 For most cases, we suggest opting for one of the simpler alternatives:
 
-- [Pikapods](/docs/install/pikapods)
-- [Desktop Client](/download)
-- [Server CLI](/docs/install/cli-tool)
-- [Docker](/docs/install/docker)
+- [Pikapods](./pikapods.md)
+- [Desktop Client](../../../download)
+- [Server CLI](./cli-tool.md)
+- [Docker](./docker.md)
 
 :::
 

--- a/packages/docs/docs/install/desktop-app.md
+++ b/packages/docs/docs/install/desktop-app.md
@@ -2,7 +2,7 @@
 title: 'Desktop app'
 ---
 
-The simplest way to get started with Actual is by [downloading the desktop app](/download). This app bundles Actual's full budgeting capabilities into a streamlined application that's perfect for users looking for a smooth, hassle-free experience.
+The simplest way to get started with Actual is by [downloading the desktop app](../../../download). This app bundles Actual's full budgeting capabilities into a streamlined application that's perfect for users looking for a smooth, hassle-free experience.
 
 ## Who should use the desktop app?
 
@@ -27,7 +27,7 @@ In the server selection area, click **Change** as shown below:
 ![](/img/install/change-server.webp)
 <br />
 
-The server runs on `localhost` by default and mostly uses the default [server configuration](./../config/index.md). You can modify the port if necessary.
+The server runs on `localhost` by default and mostly uses the default [server configuration](../config/index.md). You can modify the port if necessary.
 
 Click **Start** to run the server.
 

--- a/packages/docs/docs/install/index.md
+++ b/packages/docs/docs/install/index.md
@@ -19,9 +19,9 @@ The standard way of using Actual is to set up a personal server and use a web br
 
 If you are okay with not having sync, auto-save, or backups then the easiest and fastest way to get started is by using the Actual [web app](https://app.actualbudget.org). This solution requires less setup but more maintenance.
 
-All data is saved to your local browser. The Actual web app never has access to any of your personal data. It is recommended that you save your data (from the [settings](/docs/backup-restore/backup) menu) after every session. If your browser memory is cleared, your data will be lost, so a backup is crucial.
+All data is saved to your local browser. The Actual web app never has access to any of your personal data. It is recommended that you save your data (from the [settings](../backup-restore/backup.md) menu) after every session. If your browser memory is cleared, your data will be lost, so a backup is crucial.
 
-Using a new device or browser requires you to [restore](/docs/backup-restore/restore) the saved file for each new device or browser. Remember that these new devices and browsers will not sync without a server set up, so anything you modify on one browser will not appear on others.
+Using a new device or browser requires you to [restore](../backup-restore/restore.md) the saved file for each new device or browser. Remember that these new devices and browsers will not sync without a server set up, so anything you modify on one browser will not appear on others.
 
 :::caution
 
@@ -45,12 +45,12 @@ The server provides a web-based version of Actual. This web app can be used in a
 
 While running a server can be a complicated endeavor, we've tried to make it fairly easy to set up and hands-off to maintain. Choose one of the following options to get started:
 
-- If you're not comfortable with the command line and are willing to pay a small amount of money to have your version of Actual hosted on the cloud for you, we recommend [PikaPods](pikapods.md).[^2]
+- If you're not comfortable with the command line and are willing to pay a small amount of money to have your version of Actual hosted on the cloud for you, we recommend [PikaPods](./pikapods.md).[^2]
 - If you're willing to run a few commands in the terminal:
-  - You can run the server with a simple command using the [Server CLI](cli-tool.md)
-  - [Fly.io](fly.md) also offers cloud hosting for a similar amount of money.
-  - If you want to use Docker, we have instructions for [using our provided Docker containers](docker.md).
-  - You could [build Actual from source](build-from-source.md) on macOS, Windows, or Linux if you don't want to use a tool like Docker. (This method is the best option if you want to contribute to Actual's development!)
+  - You can run the server with a simple command using the [Server CLI](./cli-tool.md)
+  - [Fly.io](./fly.md) also offers cloud hosting for a similar amount of money.
+  - If you want to use Docker, we have instructions for [using our provided Docker containers](./docker.md).
+  - You could [build Actual from source](./build-from-source.md) on macOS, Windows, or Linux if you don't want to use a tool like Docker. (This method is the best option if you want to contribute to Actual's development!)
 
 Once you've set up your server, you can [configure it](../config/index.md) to change a few of the ways it works.
 

--- a/packages/docs/docs/install/pikapods.md
+++ b/packages/docs/docs/install/pikapods.md
@@ -29,7 +29,7 @@ You can leave the resources at their lowest setting (although you will need a no
 
 _Your browser does most of Actual's computation,_ so purchasing more resources for the server won't necessarily result in a better experience.
 
-After setting up your Pod, head over to our [Starting Fresh](/docs/getting-started/starting-fresh) guide to get started with
+After setting up your Pod, head over to our [Starting Fresh](../getting-started/starting-fresh.md) guide to get started with
 Actual Budget.
 
 ## A step by step guide to setting up Actual Budget with PikaPods
@@ -68,7 +68,7 @@ Simply put, _a Pod is a very tiny computer running in the cloud_. Typically, a P
 
 Multiple budgets can reside in one Pod running Actual. You do not need to set up a new Pod for each budget you create. The number of budgets is limited only by the storage capacity you assign to your Pod.
 
-If you [connect to your bank](/docs/advanced/bank-sync.md), note that all budgets in the same Pod share a single bank sync key.
+If you [connect to your bank](../advanced/bank-sync.md), note that all budgets in the same Pod share a single bank sync key.
 
 :::
 
@@ -132,4 +132,4 @@ For other browsers or browser/OS combinations, most search engines or the browse
 
 ## Getting started with Actual Budget
 
-Go to our [Starting Fresh](/docs/getting-started/starting-fresh) guide to get started with Actual Budget.
+Go to our [Starting Fresh](../getting-started/starting-fresh.md) guide to get started with Actual Budget.

--- a/packages/docs/docs/migration/index.md
+++ b/packages/docs/docs/migration/index.md
@@ -2,13 +2,13 @@
 
 Keeping your existing transaction history is important. If you already use a different app, you probably want to migrate it over into Actual.
 
-Right now, only YNAB4 is officially supported. However, the [API](/docs/api/index.md) allows anyone to write a custom
+Right now, only YNAB4 is officially supported. However, the [API](../api/index.md) allows anyone to write a custom
 importer. We will work with the community to help write other importers soon.
 
 ## Migration from YNAB
 
-- [Migration from YNAB4](/docs/migration/ynab4)
-- [Migration from nYNAB](/docs/migration/nynab)
+- [Migration from YNAB4](./ynab4.md)
+- [Migration from nYNAB](./nynab.mdx)
 
 ## Migration from the old Actual Budget Desktop App
 
@@ -17,4 +17,4 @@ which doesn't have the export button. You can also create an equivalent zip arch
 The folder is at `~/Documents/Actual/My-Budget-abc123` by default on macOS and Linux. The the resulting zip file
 can be imported into Actual via the Web app.
 
-See [Restoring](/docs/backup-restore/restore.md) how to restore that data in the new open source version.
+See [Restoring](../backup-restore/restore.md) how to restore that data in the new open source version.

--- a/packages/docs/docs/migration/nynab.mdx
+++ b/packages/docs/docs/migration/nynab.mdx
@@ -229,7 +229,7 @@ To `hold` the leftover funds for the next month follow these steps:
 4. Click `Hold`.
 5. Repeat for all desired months.
 
-A full description of how funds rollover and the `hold` feature can be found in [this article.](../budgeting/#how-money-rolls-over)
+A full description of how funds rollover and the `hold` feature can be found in [this article.](../budgeting/index.md#how-money-rolls-over)
 
 ### Duplicate Categories or Groups
 

--- a/packages/docs/docs/releases.md
+++ b/packages/docs/docs/releases.md
@@ -6,17 +6,17 @@ Release date: 2026-06-01
 
 This release adds new reports, a new bank sync provider, a UI for budget automations (goal templates) and releases custom themes as stable, as well as numerous other fixes.
 
-- [Crossover report](/docs/reports/#crossover-point) released as a first-party feature
-- [Custom themes](/docs/custom-themes) released as a first-party feature
+- [Crossover report](./reports/index.md#crossover-point) released as a first-party feature
+- [Custom themes](./custom-themes.md) released as a first-party feature
 - Redesigned bank sync configuration and account linking process
 - Add Tag autocomplete when editing transaction notes
-- Experimental: Add a [UI for budget automations](/docs/experimental/budget-automation) (goal templates)
-- Experimental: Add [Enable Banking integration](/docs/advanced/bank-sync/enable-banking) as a bank sync provider
-- Experimental: Add [Balance Forecast report](/docs/experimental/balance-forecast-report)
+- Experimental: Add a [UI for budget automations](./experimental/budget-automation.md) (goal templates)
+- Experimental: Add [Enable Banking integration](./advanced/bank-sync/enable-banking.md) as a bank sync provider
+- Experimental: Add [Balance Forecast report](./experimental/balance-forecast-report.md)
 
 :::warning Deprecation
 
-Starting this release, rule action templating is deprecated in favour of formulae and will be removed in a future release. For more information, see [Rule Action Templating](/docs/experimental/rule-templating).
+Starting this release, rule action templating is deprecated in favour of formulae and will be removed in a future release. For more information, see [Rule Action Templating](./experimental/rule-templating.md).
 
 :::
 
@@ -364,7 +364,7 @@ This release contains the following notable improvements, along with numerous fi
 - Concentric donut charts that show category groups in an outer ring
 - Smarter autocomplete with an improved search algorithm for payees and categories
 - Experimental: Payee Locations: Actual can now remember where you've used a payee and suggest payees based on nearby locations
-- Experimental: Actual CLI: a new command-line tool for interacting with your budget, see [the docs](/docs/api/cli) to get started
+- Experimental: Actual CLI: a new command-line tool for interacting with your budget, see [the docs](./api/cli.md) to get started
 
 **Docker Tag: 26.4.0**
 

--- a/packages/docs/docs/reports/custom-reports.md
+++ b/packages/docs/docs/reports/custom-reports.md
@@ -44,7 +44,7 @@ Grayed out options in dropdown menus are not yet available for the chosen report
 
 ## Center Menu
 
-Icons in the first group of the center menu are used to select the displayed report, the second group is used to show graph legends, summary and labels. The funnel icon can be used to [filter transactions](/docs/transactions/filters.md). Finally, the menu on the right-hand side is used to Save a Custom Report to the Reports page.
+Icons in the first group of the center menu are used to select the displayed report, the second group is used to show graph legends, summary and labels. The funnel icon can be used to [filter transactions](../transactions/filters.md). Finally, the menu on the right-hand side is used to Save a Custom Report to the Reports page.
 
 ![Custom reports center menu](/img/reports/cr-center-menu.webp)
 

--- a/packages/docs/docs/reports/index.md
+++ b/packages/docs/docs/reports/index.md
@@ -20,13 +20,13 @@ Currently, Actual comes with the following built-in widgets and reports:
 - [Summary card](#summary-card)
 - [Calendar card](#calendar-card)
 - [Text widget](#text-widget)
-- [Custom Reports](/docs/reports/custom-reports)
+- [Custom Reports](./custom-reports.md)
 - [Crossover Point](#crossover-point)
 
 The following are available as experimental features:
 
-- [Budget Analysis report](/docs/experimental/budget-analysis-report)
-- [Balance Forecast report](/docs/experimental/balance-forecast-report)
+- [Budget Analysis report](../experimental/budget-analysis-report.md)
+- [Balance Forecast report](../experimental/balance-forecast-report.md)
 
 ## Cash Flow Graph
 

--- a/packages/docs/docs/schedules.md
+++ b/packages/docs/docs/schedules.md
@@ -159,7 +159,7 @@ You can resolve this issue in one of two ways.
 
 ## How To Use Rules With Schedules
 
-Many times it's desired to add notes to the scheduled transactions or to assign categories automatically. This is done with the [Rules](/docs/budgeting/rules) tool. The tool can be reached directly from the Schedules page by clicking on the **Edit as a rule** button in the edit dialog of a schedule.
+Many times it's desired to add notes to the scheduled transactions or to assign categories automatically. This is done with the [Rules](./budgeting/rules/index.md) tool. The tool can be reached directly from the Schedules page by clicking on the **Edit as a rule** button in the edit dialog of a schedule.
 
 When you edit a schedule, the **Edit as rule** button will appear in the dialog
 

--- a/packages/docs/docs/settings/index.md
+++ b/packages/docs/docs/settings/index.md
@@ -10,7 +10,7 @@ There is an option to "Display a notification when updates are available" here.
 
 ### Themes
 
-Themes change the user interface colors. Pick from the built-in **Light**, **Dark**, **Midnight**, or **Auto** themes, or install a community-built theme from the catalog. See [Custom Themes](/docs/custom-themes) for the full guide.
+Themes change the user interface colors. Pick from the built-in **Light**, **Dark**, **Midnight**, or **Auto** themes, or install a community-built theme from the catalog. See [Custom Themes](../custom-themes.md) for the full guide.
 
 ### Formatting
 
@@ -31,13 +31,13 @@ The language choice alters the display language of all text. If you encounter a 
 
 ### Authentication Method
 
-OpenID can be enabled here. [Learn more](/docs/config/oauth-auth)
+OpenID can be enabled here. [Learn more](../config/oauth-auth.md)
 
 ![Image of OpenID setting](/img/using-actual/actual-openid.webp)
 
 ### Encryption
 
-End-to-end encryption allows you to encrypt your budget data on the remote server with a password. If you don't trust the server's owners, enable this setting to encrypt your budget data. Note that [bank sync](/docs/advanced/bank-sync) tokens are stored separately on the server and are not covered by this encryption. [Learn more](/docs/getting-started/sync/#end-to-end-encryption)
+End-to-end encryption allows you to encrypt your budget data on the remote server with a password. If you don't trust the server's owners, enable this setting to encrypt your budget data. Note that [bank sync](../advanced/bank-sync.md) tokens are stored separately on the server and are not covered by this encryption. [Learn more](../getting-started/sync.md#end-to-end-encryption)
 
 ![Image of Encryption setting](/img/using-actual/settings-encryption.webp)
 
@@ -45,16 +45,16 @@ End-to-end encryption allows you to encrypt your budget data on the remote serve
 
 Either Envelope or Tracking Budgeting methods are available in Actual. Envelope Budgeting is recommended and most of the documentation refers to this method.
 
-[Learn more about Envelope Budgeting](/docs/getting-started/envelope-budgeting)
+[Learn more about Envelope Budgeting](../getting-started/envelope-budgeting.md)
 <br />
-[Learn more about Tracking Budgeting](/docs/getting-started/tracking-budget)
+[Learn more about Tracking Budgeting](../getting-started/tracking-budget.md)
 <br />
 <br />
 ![Image of budgeting methods setting](/img/using-actual/actual-budget-method.webp)
 
 ### Export
 
-This section allows you to download a `.zip` archive of all of your server data for easy backup or migration. [Learn more](/docs/backup-restore/backup)
+This section allows you to download a `.zip` archive of all of your server data for easy backup or migration. [Learn more](../backup-restore/backup.md)
 
 ![Image of Export setting](/img/using-actual/settings-export.webp)
 
@@ -92,6 +92,6 @@ If you are experiencing bugs relating to split transactions or transfers and the
 ### Experimental Features
 
 This section is where you can enable features that are still in development and testing.
-See [Experimental features](../experimental) for more information.
+See [Experimental features](../experimental/index.md) for more information.
 
 ![Image of Experimental setting](/img/using-actual/actual-experimental.webp)

--- a/packages/docs/docs/tour/accounts.md
+++ b/packages/docs/docs/tour/accounts.md
@@ -1,6 +1,6 @@
 # The Account Register
 
-This view lets you manage your transactions for an account. Consult [Accounts & Transactions](/docs/accounts/) for detailed information on how to work with this view.
+This view lets you manage your transactions for an account. Consult [Accounts & Transactions](../accounts/index.md) for detailed information on how to work with this view.
 
 ![Account register overview](/img/a-tour-of-actual/tour-account-register-overview.webp)
 
@@ -8,19 +8,19 @@ This view lets you manage your transactions for an account. Consult [Accounts & 
 
 To rename the account, click on the pencil icon that appears when you hover over the account name. Clicking on the note icon lets you add a note. Actual fully supports Markdown and the note will be rendered according to your Markdown when the cursor is hovering over the note.
 
-Below the account name, you'll see the current balance. Green indicates a positive account balance, and red indicates a negative balance. A chevron will appear if you hover over the balance with the cursor. Clicking on this will reveal the values for both cleared and uncleared totals. See [Reconciliation](/docs/accounts/reconciliation) for more information.
+Below the account name, you'll see the current balance. Green indicates a positive account balance, and red indicates a negative balance. A chevron will appear if you hover over the balance with the cursor. Clicking on this will reveal the values for both cleared and uncleared totals. See [Reconciliation](../accounts/reconciliation.md) for more information.
 
 The top section also gives you access to several functions like importing transactions, manually adding new transactions, and filtering what transactions you see. On the right side you'll find the _Search_ field which lets you quickly search all fields.
 
 It is possible to split a transaction into more than one category. By clicking on the expand/contract arrows, seen in the yellow box, you will be able to show or hide split transactions.
 
-The three horizontal dots, shown in the blue box, will allow you to perform various manipulations on the account. These range from reconciling and exporting your account to closing or [Connecting Your Bank](/docs/advanced/bank-sync) for transaction syncing. You can show or hide the account's running balance, previously reconciled transactions and the cleared checkbox column to the far right of the transaction's row.
+The three horizontal dots, shown in the blue box, will allow you to perform various manipulations on the account. These range from reconciling and exporting your account to closing or [Connecting Your Bank](../advanced/bank-sync.md) for transaction syncing. You can show or hide the account's running balance, previously reconciled transactions and the cleared checkbox column to the far right of the transaction's row.
 
 ![Account register header](/img/a-tour-of-actual/tour-account-register-header.webp)
 
-Clicking on **Import** will let you [import transactions](/docs/transactions/importing) from CSV, QIF, OFX, QFX or CAMT files.
+Clicking on **Import** will let you [import transactions](../transactions/importing.md) from CSV, QIF, OFX, QFX or CAMT files.
 
-Manually add transactions by clicking on **Add New**. The Payee and the Category fields will provide a dropdown menu of available options. You can add new payees directly from this view, but if you need to add a new category, you can only do so from the [Budget View](./budget).
+Manually add transactions by clicking on **Add New**. The Payee and the Category fields will provide a dropdown menu of available options. You can add new payees directly from this view, but if you need to add a new category, you can only do so from the [Budget View](./budget.md).
 
 ![Adding a transaction](/img/a-tour-of-actual/tour-account-register-adding-transaction.webp)
 
@@ -30,7 +30,7 @@ Clicking on **Filter** lets you filter on all the fields. In the screenshot, we 
 
 If you are filtering for the same things over and over, you can save your filter by clicking on the _Unsaved filter_ dropdown on the right side in the header. Provide a name to save the filter for future use.
 
-Consult [Filtering Transactions](/docs/transactions/filters) for more information.
+Consult [Filtering Transactions](../transactions/filters.md) for more information.
 
 ![Filtering transactions](/img/a-tour-of-actual/tour-account-register-filter.webp)
 
@@ -40,6 +40,6 @@ You can select transactions by clicking on the checkbox - just to the left of th
 
 The number of selected transactions is shown in the red box. If you click on this dropdown, you can perform various commands on these transactions.
 
-Another powerful feature allows you to perform [Bulk Actions](/docs/transactions/bulk-editing).
+Another powerful feature allows you to perform [Bulk Actions](../transactions/bulk-editing.md).
 
 ![Selecting transactions](/img/a-tour-of-actual/tour-account-register-selected-transactions.webp)

--- a/packages/docs/docs/tour/budget.md
+++ b/packages/docs/docs/tour/budget.md
@@ -1,6 +1,6 @@
 # The Budget
 
-This view lets you manage your budget. You'll find more information about envelope budgeting with Actual in [Budgeting](/docs/budgeting/).
+This view lets you manage your budget. You'll find more information about envelope budgeting with Actual in [Budgeting](../budgeting/index.md).
 
 ![Budget overview](/img/a-tour-of-actual/tour-budget-overview.webp)
 

--- a/packages/docs/docs/tour/index.md
+++ b/packages/docs/docs/tour/index.md
@@ -4,18 +4,18 @@ title: A Tour of Actual
 
 Welcome to the Actual tour, where we will give you insights into the Interface.
 
-This Tour of Actual is not meant to replace the user documentation. If you want to dive directly into how to install and use the software, please consult the [**Docs**](/docs).
+This Tour of Actual is not meant to replace the user documentation. If you want to dive directly into how to install and use the software, please consult the [**Docs**](../index.md).
 
-When you decide that Actual Budget is right for you, read our thorough [Starting Fresh](/docs/getting-started/starting-fresh) guide.
+When you decide that Actual Budget is right for you, read our thorough [Starting Fresh](../getting-started/starting-fresh.md) guide.
 
 ## Are you looking into using Actual as your budgeting software?
 
-It's worth noting that Actual has two budgeting methods included: [the envelope budgeting model](/docs/getting-started/envelope-budgeting) and the more traditional [tracking budget](/docs/getting-started/tracking-budget). The big difference between envelope budgeting and more common methods is that with envelope budgeting, you budget with the money you actually have, not the money you think you will get in the future. The tracking budget allows you to budget future income. Actual defaults to the envelope method and we suggest you start there.
+It's worth noting that Actual has two budgeting methods included: [the envelope budgeting model](../getting-started/envelope-budgeting.md) and the more traditional [tracking budget](../getting-started/tracking-budget.md). The big difference between envelope budgeting and more common methods is that with envelope budgeting, you budget with the money you actually have, not the money you think you will get in the future. The tracking budget allows you to budget future income. Actual defaults to the envelope method and we suggest you start there.
 
 Our tour will touch on the following topics. You can go directly to a topic using the left sidebar menu.
 
-- A [quick overview](./user-interface) of the Actual Budget interface.
-- The [budget view](./budget) is where you plan how to save and what you need to spend money on.
-- Without transactions in the [account register](./accounts), there would be no point in having a budget.
-- Actual also has a few other functions we will look at: [scheduling transactions](./schedules), managing [payees](./payees) and adding and editing [rules](./rules), which will help automate entering or importing transactions.
-- Lastly, we have [beautiful reports](./reports) to show you.
+- A [quick overview](./user-interface.md) of the Actual Budget interface.
+- The [budget view](./budget.md) is where you plan how to save and what you need to spend money on.
+- Without transactions in the [account register](./accounts.md), there would be no point in having a budget.
+- Actual also has a few other functions we will look at: [scheduling transactions](./schedules.md), managing [payees](./payees.md) and adding and editing [rules](./rules.md), which will help automate entering or importing transactions.
+- Lastly, we have [beautiful reports](./reports.md) to show you.

--- a/packages/docs/docs/tour/payees.md
+++ b/packages/docs/docs/tour/payees.md
@@ -1,8 +1,8 @@
 # Payees Management
 
-This view lets you manage your Payees. See [Payees](/docs/transactions/payees) for more details.
+This view lets you manage your Payees. See [Payees](../transactions/payees.md) for more details.
 
-In the overview, you can see which Payees you have used in your system and if they have any associated [rules](./rules).
+In the overview, you can see which Payees you have used in your system and if they have any associated [rules](./rules.md).
 
 If you have any unused payees, they are readily available by clicking on the _Show n unused payee_.
 

--- a/packages/docs/docs/tour/reports.md
+++ b/packages/docs/docs/tour/reports.md
@@ -10,13 +10,13 @@ All reports in this view are shown in their tiled version. Clicking on a tile wi
 
 **Cash flow** tracks your spending over time by focusing solely on budget accounts and displaying their balances. It includes separate visualizations for income and expenses, providing a quick overview of how these factors affect your available money over time. By considering your budgeted accounts as "cash on hand," cash flow clearly shows how your available funds fluctuate.
 
-See the [Reports Dashboard](/docs/reports/) for more detail on these and the other built-in reports.
+See the [Reports Dashboard](../reports/index.md) for more detail on these and the other built-in reports.
 
 ![Cashflow report](/img/a-tour-of-actual/tour-reports-cashflow.webp)
 
 ## Custom reports
 
-Actual's custom reports will allow you to create reports giving in-depth analyses on your spending habits and your income. You can find them thoroughly covered in [Custom Reports](/docs/reports/custom-reports).
+Actual's custom reports will allow you to create reports giving in-depth analyses on your spending habits and your income. You can find them thoroughly covered in [Custom Reports](../reports/custom-reports.md).
 
 Below are examples of reports covering *Daily Expenses* over the last six months. One report shows this as a graph, the other as a table. Note that the table version also shows the sum and average (over six months) for the various categories.
 

--- a/packages/docs/docs/tour/rules.md
+++ b/packages/docs/docs/tour/rules.md
@@ -4,6 +4,6 @@ Actual's robust rules system will help you automate many transaction management 
 
 Rules dictate how transactions are handled. When transactions are imported or synced, they follow rules that apply specific actions. For instance, a rule might process a transaction with the payee "PAYPAL \*LOWES.COM 8448964938 NC", recognize the keyword "lowes," and automatically set the payee to "Lowe's" and the category to "Home Improvement". Rules enable you to automate any workflow you choose.
 
-For detailed information, please see [Rules](/docs/budgeting/rules/).
+For detailed information, please see [Rules](../budgeting/rules/index.md).
 
 ![Rules overview](/img/a-tour-of-actual/tour-rules-overview.webp)

--- a/packages/docs/docs/tour/schedules.md
+++ b/packages/docs/docs/tour/schedules.md
@@ -9,6 +9,6 @@ The system is very flexible:
 - Recurring transactions can be set to one or multiple specific days of the month. For example, a single schedule can be created for a cell phone plan with multiple users and different payment cycles for each phone. If you have three cell phones that all get paid on different days of the month, each day can be defined in a single schedule.
 - Schedules have various options for the frequency of transactions, such as every month, every month on the 2nd Wednesday, every 2 months, every 2 years, etc.
 
-For more details, see [Schedules](/docs/schedules).
+For more details, see [Schedules](../schedules.md).
 
 ![Overview of the schedule screen](/img/a-tour-of-actual/tour-schedules-overview.webp)

--- a/packages/docs/docs/tour/user-interface.md
+++ b/packages/docs/docs/tour/user-interface.md
@@ -12,7 +12,7 @@ Standard on most screens:
 
 ## Top Right Corner
 
-- The eye icon will scramble the numbers on the screen. This is useful if you need to report a bug to the Actual team but want to keep your numbers private. There are some caveats to this, so please read [Scramble and Hide Data](/docs/getting-started/tips-tricks#scramble-and-hide-data) in the Tips & Tricks guide.
+- The eye icon will scramble the numbers on the screen. This is useful if you need to report a bug to the Actual team but want to keep your numbers private. There are some caveats to this, so please read [Scramble and Hide Data](/docs/getting-started/tips-tricks#scramble-hide) in the Tips & Tricks guide.
 - Clicking on the refresh icon will force a sync of your local file to the server. Note: it does **not** perform a bank sync.
 - Server status: _Server online_ shows the server is connected, _Server offline_ shows the server is disconnected, and _No server_ shows if you are not using a server. If you click on this text a server menu pops up.
 - The farthest right item is a Help menu.

--- a/packages/docs/docs/tour/user-interface.md
+++ b/packages/docs/docs/tour/user-interface.md
@@ -12,7 +12,7 @@ Standard on most screens:
 
 ## Top Right Corner
 
-- The eye icon will scramble the numbers on the screen. This is useful if you need to report a bug to the Actual team but want to keep your numbers private. There are some caveats to this, so please read [Scramble and Hide Data](/docs/getting-started/tips-tricks#scramble-hide) in the Tips & Tricks guide.
+- The eye icon will scramble the numbers on the screen. This is useful if you need to report a bug to the Actual team but want to keep your numbers private. There are some caveats to this, so please read [Scramble and Hide Data](../getting-started/tips-tricks.md#scramble-hide) in the Tips & Tricks guide.
 - Clicking on the refresh icon will force a sync of your local file to the server. Note: it does **not** perform a bank sync.
 - Server status: _Server online_ shows the server is connected, _Server offline_ shows the server is disconnected, and _No server_ shows if you are not using a server. If you click on this text a server menu pops up.
 - The farthest right item is a Help menu.

--- a/packages/docs/docs/transactions/filters.md
+++ b/packages/docs/docs/transactions/filters.md
@@ -25,7 +25,7 @@ The great thing is that you are not limited to just one Filter. You can select m
 
 There are further options within each area to narrow the filter further. Here are a couple to illustrate the choices – Dates and Categories:
 
-The `matches` operator uses _[regular expressions](https://regextutorial.org/)_, the other condition types are further explained at [Rules Page](../budgeting/rules/#condition-types).
+The `matches` operator uses _[regular expressions](https://regextutorial.org/)_, the other condition types are further explained at [Rules Page](../budgeting/rules/index.md#condition-types).
 
 ![](/img/filtering/conditions-1.webp)
 

--- a/packages/docs/docs/transactions/importing.md
+++ b/packages/docs/docs/transactions/importing.md
@@ -4,9 +4,9 @@ There are various ways to get transactions into Actual.
 
 ## Linked Bank Import
 
-Actual Budget supports [linking your bank accounts](/docs/advanced/bank-sync.md) to sync using SimpleFIN, GoCardless or Pluggy.ai.
+Actual Budget supports [linking your bank accounts](../advanced/bank-sync.md) to sync using SimpleFIN, GoCardless or Pluggy.ai.
 
-There are also [community projects](/docs/community-repos.md) that implement bank syncing.
+There are also [community projects](../community-repos.md) that implement bank syncing.
 
 ## Import Financial Files
 
@@ -54,5 +54,5 @@ It will always favor the imported transaction. If it matches a manually-entered 
 When "Merge with existing transactions" is enabled, a **Reimport deleted transactions** checkbox is also available. When checked (the default for file imports), any transactions that were previously imported and then deleted will be reimported. Disable this option if you do _not_ want deleted transactions to reappear during import.
 
 :::note
-The [API](/docs/api/reference#importtransactions) defaults `reimportDeleted` to `true` for backward compatibility. If you are importing via the API and want to skip deleted transactions, pass `reimportDeleted: false` explicitly.
+The [API](../api/reference.md#importtransactions) defaults `reimportDeleted` to `true` for backward compatibility. If you are importing via the API and want to skip deleted transactions, pass `reimportDeleted: false` explicitly.
 :::

--- a/packages/docs/docs/transactions/merging.md
+++ b/packages/docs/docs/transactions/merging.md
@@ -8,6 +8,6 @@ When two transactions are merged, one is determined to be the 'kept' transaction
 
 The following logic is used to determine which transaction is kept:
 
-1. If one transaction is imported through [bank sync](/docs/advanced/bank-sync) and the other is not, the synced transaction is kept. Otherwise, continue to the next step.
-2. If one transaction is imported through a [file import](/docs/transactions/importing) and the other is not, the imported transaction is kept. Otherwise, continue to the final step.
+1. If one transaction is imported through [bank sync](../advanced/bank-sync.md) and the other is not, the synced transaction is kept. Otherwise, continue to the next step.
+2. If one transaction is imported through a [file import](./importing.md) and the other is not, the imported transaction is kept. Otherwise, continue to the final step.
 3. The transaction with the earlier date is kept.

--- a/packages/docs/docs/transactions/payees.md
+++ b/packages/docs/docs/transactions/payees.md
@@ -20,7 +20,7 @@ When a payee is matched, if it has a **default category** the transaction will a
 
 :::tip[Category Learning]
 
-Actual defaults with Category Learning enabled. You can find this setting in the bottom left corner of the Payees page. A more in depth discussion of Payee Rules and Category Learning can be found in the [Rules](docs/budgeting/rules/index.md) documentation. You can turn this off for one, several or all Payees. [Learn more](docs/budgeting/rules/index.md#managing-rules)
+Actual defaults with Category Learning enabled. You can find this setting in the bottom left corner of the Payees page. A more in depth discussion of Payee Rules and Category Learning can be found in the [Rules](../budgeting/rules/index.md) documentation. You can turn this off for one, several or all Payees. [Learn more](../budgeting/rules/index.md#managing-rules)
 
 :::
 
@@ -31,7 +31,7 @@ Actual defaults with Category Learning enabled. You can find this setting in the
 3. To **delete** a payee, select it and press the **1 payee** button at the top-left, just under "Payees" and select **Delete**.
 4. To mark a payee as a **favorite**, select it and press the **1 payee** button in the top-left and select **Favorite**. This will make it appear at the top of the suggestions box when entering a payee in the account ledger.
 5. Edit the rules by clicking on the "associated rules" button and a box will appear with the list of rules to match this payee with.
-6. Create a new rule by clicking on the "Create rule" button and the [Rule](docs/budgeting/rules/index.md) creation box will appear.
+6. Create a new rule by clicking on the "Create rule" button and the [Rule](../budgeting/rules/index.md) creation box will appear.
 
 ## Merging Payees
 

--- a/packages/docs/docs/transactions/transfers.md
+++ b/packages/docs/docs/transactions/transfers.md
@@ -28,7 +28,7 @@ This process will only apply when the below conditions are met
 
 :::
 
-Make a transfer of existing transactions in the same way you [bulk-edit transactions](bulk-editing.md).
+Make a transfer of existing transactions in the same way you [bulk-edit transactions](./bulk-editing.md).
 
 ![](/img/transfers/make-transfer-tooltip.webp)
 

--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -15,6 +15,7 @@ module.exports = {
   url: 'https://actualbudget.org/',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
   favicon: 'img/favicon.ico',
 
   projectName: 'actualbudget.github.io',

--- a/packages/docs/src/pages/download.md
+++ b/packages/docs/src/pages/download.md
@@ -12,7 +12,7 @@ import { DownloadCard } from '../components/DownloadCard'
 
 # Downloads
 
-The simplest way to use Actual is to download the desktop application. This will give you access to all of Actual's budgeting features. For a breakdown of what features require a server in addition to the base app see the [Installation Guide](/docs/install).
+The simplest way to use Actual is to download the desktop application. This will give you access to all of Actual's budgeting features. For a breakdown of what features require a server in addition to the base app see the [Installation Guide](../docs/install).
 
 ## Desktop Client
 
@@ -74,12 +74,12 @@ url: 'https://github.com/actualbudget/actual/releases/latest/download/Actual-lin
 
 ## Server Download
 
-Actual has two parts, the client and a sync server. The primary task of the sync server is to sync your budget between devices, and to enable bank syncing. We have a full write up of [if you need a server or not](/docs/install/). We also have install guides on how to set up the server in the following ways
+Actual has two parts, the client and a sync server. The primary task of the sync server is to sync your budget between devices, and to enable bank syncing. We have a full write up of [if you need a server or not](../docs/install/). We also have install guides on how to set up the server in the following ways
 
-- [PikaPods](/docs/install/pikapods)
-- [Fly.io](/docs/install/fly)
-- [Server CLI](/docs/install/cli-tool)
-- [Docker Install](/docs/install/docker)
-- [Build from source](/docs/install/build-from-source)
+- [PikaPods](../docs/install/pikapods)
+- [Fly.io](../docs/install/fly)
+- [Server CLI](../docs/install/cli-tool)
+- [Docker Install](../docs/install/docker)
+- [Build from source](../docs/install/build-from-source)
 
 </div>

--- a/packages/docs/src/pages/index.jsx
+++ b/packages/docs/src/pages/index.jsx
@@ -1,4 +1,5 @@
 import Link from '@docusaurus/Link';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
 import Layout from '@theme/Layout';
 import ThemedImage from '@theme/ThemedImage';
 
@@ -7,6 +8,10 @@ import Button from '../components/Button';
 import classes from './index.module.css';
 
 export default function Hello() {
+  // register the #features anchor with the broken-link checker, which
+  // can't detect anchors in react pages
+  useBrokenLinks().collectAnchor('features');
+
   const title = 'Your Finances — made simple';
   const pageDescription =
     'Actual Budget is a super fast and privacy-focused app for managing your finances. At its heart is the well proven and much loved Envelope Budgeting methodology.';


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Fixes the broken docusaurus build. Also fixes the broken anchor warnings that show in the build and will now fail the build if new failing ones are added.

While I was looking at this I noticed we're really inconsistent about relative vs absolute links. Docusaurus recommend relative so I've migrated all absolute ones I could over.

Leaving off the release note, it adds nothing

Best to review by commit

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Docs builds locally, no broken anchors or links

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
