### PR TITLE
docs: point users towards nightly desktop builds

### DIFF
--- a/packages/docs/docs/contributing/preview-builds.md
+++ b/packages/docs/docs/contributing/preview-builds.md
@@ -21,8 +21,22 @@ There is no sync server on preview builds so when asked "Where's the server" sel
 Nightly builds serve as a testing ground for upcoming features before they are included in official monthly releases.
 Explore nightly builds to access the latest features, but be aware that new features are added and removed regularly, which means that these builds are not always stable.
 
-If you want to try out the nightly builds, simply head over to [nightly.actualbudget.org](https://nightly.actualbudget.org/).
+### Nightly Web Builds
+
+If you want to try out the nightly build of the web app, simply head over to [nightly.actualbudget.org](https://nightly.actualbudget.org/).
 
 :::info
 There is no sync server on the nightly build, so when asked, "Where's the server?" select "Don't use a server." Alternatively, you can use your own self-hosted server. You should exercise caution when using a server with nightly builds because they are much more likely to have bugs that could damage your budget. Consider running a separate local server for nightly builds.
 :::
+
+### Nightly Desktop Builds
+
+The [desktop app](../install/desktop-app.md) is also built every night. The builds are published as downloadable artifacts on the [Publish nightly desktop app](https://github.com/actualbudget/actual/actions/workflows/publish-nightly-electron.yml) GitHub Actions workflow.
+
+To download the latest nightly desktop build:
+
+1. Sign in to [GitHub](https://github.com/login). You need a GitHub account (a free one is fine), as GitHub only lets signed-in users download workflow artifacts.
+2. Open the [list of nightly desktop builds](https://github.com/actualbudget/actual/actions/workflows/publish-nightly-electron.yml?query=is%3Asuccess) and click the most recent run at the top of the list.
+3. Scroll down to the **Artifacts** section at the bottom of the page.
+4. Download the artifact that matches your operating system and processor architecture.
+5. The artifact downloads as a `.zip` file. Extract it to get the installer, then install it as you would the regular desktop app.

--- a/packages/docs/docs/contributing/preview-builds.md
+++ b/packages/docs/docs/contributing/preview-builds.md
@@ -40,3 +40,7 @@ To download the latest nightly desktop build:
 3. Scroll down to the **Artifacts** section at the bottom of the page.
 4. Download the artifact that matches your operating system and processor architecture.
 5. The artifact downloads as a `.zip` file. Extract it to get the installer, then install it as you would the regular desktop app.
+
+### Nightly Docker Images
+
+If you run your own sync server with Docker, nightly images are also available. See the [`nightly` tag](../install/docker.md#nightly-tag) section of the Docker install guide for details.

--- a/packages/docs/docs/install/desktop-app.md
+++ b/packages/docs/docs/install/desktop-app.md
@@ -43,3 +43,7 @@ To access your local server from mobile devices or other networks, you'll need t
 For a practical walkthrough, check out the [Ngrok guide](../config/reverse-proxies.md#ngrok). If you plan to use your mobile device regularly while the desktop app is running, consider configuring the reverse proxy to launch automatically with your computer.
 
 When using a mobile device with Actual, installing the Web client as a Progressive Web App(PWA) is recommended so that it works when offline.
+
+## Trying the Nightly Builds
+
+If you want to preview upcoming features before they reach an official release, [nightly builds of the desktop app](../contributing/preview-builds.md#nightly-desktop-builds) are also available.

--- a/packages/docs/docs/install/index.md
+++ b/packages/docs/docs/install/index.md
@@ -37,6 +37,8 @@ Desktop applications are available for Windows, Mac, and Linux. These can be [do
 - Automated backups
 - Offline use is ready out of the box
 
+If you want to preview upcoming features before they reach an official release, [nightly builds of the desktop app](../contributing/preview-builds.md#nightly-desktop-builds) are also available.
+
 ## Server-Based Client Options
 
 The server provides a web-based version of Actual. This web app can be used in a browser as a standard web page to view and edit your budget. The web page can also be installed on your device. For mobile devices, an installed web page will work offline.

--- a/packages/docs/src/pages/download.md
+++ b/packages/docs/src/pages/download.md
@@ -72,6 +72,10 @@ url: 'https://github.com/actualbudget/actual/releases/latest/download/Actual-lin
 
 </div>
 
+:::tip Nightly Builds
+If you want to preview upcoming features before they reach an official release, [nightly builds of the desktop app](/docs/contributing/preview-builds#nightly-desktop-builds) are also available.
+:::
+
 ## Server Download
 
 Actual has two parts, the client and a sync server. The primary task of the sync server is to sync your budget between devices, and to enable bank syncing. We have a full write up of [if you need a server or not](../docs/install/). We also have install guides on how to set up the server in the following ways


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Makes nightly desktop builds more visible and easier to get.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
