### PR TITLE
[AI] Fix category rules not applying when a rule renames the payee during transaction import

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -220,6 +220,38 @@ describe('Transaction rules', () => {
     expect(transaction.category).toBe(null);
   });
 
+  test('rules matching on payee apply after a rule renames the payee', async () => {
+    await loadRules();
+
+    await db.insertPayee({ id: 'amazon_id', name: 'Amazon' });
+
+    // This rule is ranked first (oneOf is less specific than is), so it
+    // runs before the renaming rule below ever sets the payee
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'oneOf', field: 'payee', value: ['amazon_id'] }],
+      actions: [{ op: 'set', field: 'category', value: 'shopping' }],
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [
+        { op: 'is', field: 'imported_payee', value: 'AMZN MKTP US' },
+      ],
+      actions: [{ op: 'set', field: 'payee', value: 'amazon_id' }],
+    });
+
+    const transaction = await runRules({
+      imported_payee: 'AMZN MKTP US',
+      payee: 'raw_payee_id',
+      category: null,
+    });
+    expect(transaction.payee).toBe('amazon_id');
+    expect(transaction.category).toBe('shopping');
+  });
+
   test('loadRules loads all the rules', async () => {
     await loadRules();
     await insertRule({

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -360,6 +360,15 @@ export async function runRules(
     formulaStrings,
   );
 
+  const appliedRules = new Set();
+  const applyRule = rule => {
+    const changes = rule.exec(finalTrans);
+    if (changes) {
+      appliedRules.add(rule);
+      finalTrans = Object.assign({}, finalTrans, changes);
+    }
+  };
+
   for (let i = 0; i < rules.length; i++) {
     // If there is a scheduleRuleID (meaning this transaction came from a schedule) then exclude rules linked to other schedules.
     if (scheduleRuleID !== '') {
@@ -367,16 +376,35 @@ export async function runRules(
         // bypass condition checking to run the rule even if the transaction date falls outside of the schedule's date range.
         const changes = rules[i].execActions(finalTrans);
         finalTrans = Object.assign({}, finalTrans, changes);
+        appliedRules.add(rules[i]);
       } else if (RuleIdsLinkedToSchedules.includes(rules[i].id)) {
         // skip all other rules that are linked to other schedules.
         continue;
       } else {
         // if a rule is not linked to a schedule, run it.
-        finalTrans = rules[i].apply(finalTrans);
+        applyRule(rules[i]);
       }
     } else {
       // if there is no scheduleRuleID then just run all rules.
-      finalTrans = rules[i].apply(finalTrans);
+      applyRule(rules[i]);
+    }
+  }
+
+  // A rule may have changed the payee (e.g. a renaming rule matching on
+  // imported_payee). Rules that match on the payee but ran before that
+  // rule never saw the final payee, so give them a second chance. Only
+  // rules that haven't applied yet are run, so no action runs twice.
+  if (finalTrans.payee !== trans.payee) {
+    for (const rule of rules) {
+      if (
+        appliedRules.has(rule) ||
+        (scheduleRuleID !== '' && RuleIdsLinkedToSchedules.includes(rule.id))
+      ) {
+        continue;
+      }
+      if (rule.conditions.some(cond => cond.field === 'payee')) {
+        applyRule(rule);
+      }
     }
   }
 

--- a/upcoming-release-notes/8176.md
+++ b/upcoming-release-notes/8176.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [junyuanz1]
+---
+
+Fix category rules not being applied when another rule renames the payee during transaction import


### PR DESCRIPTION
## Description

When importing transactions (e.g. via bank sync), rules run exactly once in ranked order. The ranking is based on condition specificity, with ties broken by random rule UUIDs. A rule that matches on `payee` (such as the category rules Actual learns automatically, or user-created "payee → category" rules) could be ranked **before** the renaming rule that sets that payee from `imported_payee`. In that case its condition was evaluated against the raw bank payee, failed, and was never re-checked — so the transaction was imported with the correct (renamed) payee but no category.

Because the ordering depends on specificity scores and UUID tie-breaking, this only affected some payees, which made it look intermittent: "sometimes the payee matches but the predefined category isn't applied."

This PR fixes it in `runRules`: after the main rule pass, if any rule changed the payee, rules that match on `payee` and did not apply in the first pass get a second chance, still in ranked order. Rules that already applied are skipped, so no action (e.g. note appending) ever runs twice.

This change was written by an AI tool: Claude Code (per the [AI usage policy](https://actualbudget.org/docs/contributing/ai-usage-policy)).

## Related issue(s)

None found.

## Testing

- Added a regression test in `packages/loot-core/src/server/transactions/transaction-rules.test.ts` that deterministically reproduces the broken ordering: a category rule using `payee oneOf [...]` (specificity score 18) is ranked before a renaming rule using `imported_payee is "..."` (score 20). Without the fix the test fails with the payee correctly renamed but `category: null`; with the fix it passes.
- All loot-core tests under `server/rules`, `server/transactions`, and `server/accounts` pass (236 tests).
- `yarn typecheck` introduces no new errors (3 pre-existing `akahu` errors in sync-server exist on master as well); `yarn lint` reports 0 errors.

To reproduce manually: create a rule "imported_payee is &lt;exact bank payee&gt; → set payee X" and a rule "payee oneOf [X] → set category Y", then sync/import a transaction with that bank payee. Before this fix the transaction gets payee X but no category.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.13 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+492 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+479 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.13 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 173.68 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.61 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+492 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +492 B (+2.26%) | 21.28 kB → 21.76 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BWkgdo9d.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+479 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +479 B (+2.25%) | 20.75 kB → 21.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+479 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->