### PR TITLE
[AI] Fix shift-click range selection including hidden reconciled transactions

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -56,6 +56,71 @@ test.describe('Accounts', () => {
     await expect(page).toMatchThemeScreenshots();
   });
 
+  test('shift-click range selection skips hidden reconciled transactions', async () => {
+    accountPage = await navigation.createAccount({
+      name: 'Range Select',
+      offBudget: false,
+      balance: 0,
+    });
+    await accountPage.waitFor();
+
+    // Newest transactions are shown first, so the rows read
+    // 'range-five' through 'range-one' from top to bottom.
+    for (const note of ['one', 'two', 'three', 'four', 'five']) {
+      await accountPage.createSingleTransaction({
+        payee: '',
+        notes: `range-${note}`,
+        category: 'Food',
+        debit: '10.00',
+      });
+    }
+
+    // Mark two transactions in the middle of the list as cleared and
+    // lock them via reconciliation so they become reconciled.
+    for (const note of ['range-two', 'range-four']) {
+      await accountPage.transactionTableRow
+        .filter({ hasText: note })
+        .getByTestId('cleared')
+        .click();
+    }
+
+    await page.getByRole('button', { name: 'Reconcile' }).click();
+    // The reconciliation amount is pre-filled with the cleared balance,
+    // so submitting right away results in a zero difference.
+    const reconcilePopover = page.locator('[data-popover]');
+    await reconcilePopover.getByRole('textbox').waitFor();
+    await reconcilePopover.getByRole('button', { name: 'Reconcile' }).click();
+    await page.getByRole('button', { name: 'Lock transactions' }).click();
+
+    // Showing the running balance keeps reconciled transactions loaded
+    // even when they are hidden; they must still be excluded from
+    // range selection.
+    await accountPage.accountMenuButton.click();
+    await page.getByRole('button', { name: 'Show running balance' }).click();
+    await accountPage.accountMenuButton.click();
+    await page
+      .getByRole('button', { name: 'Hide reconciled transactions' })
+      .click();
+
+    await expect(
+      accountPage.transactionTableRow.filter({ hasText: 'range-two' }),
+    ).not.toBeVisible();
+
+    // Shift-click from the first to the last visible transaction.
+    await accountPage.transactionTableRow
+      .filter({ hasText: 'range-five' })
+      .getByTestId('select')
+      .click();
+    await accountPage.transactionTableRow
+      .filter({ hasText: 'range-one' })
+      .getByTestId('select')
+      .click({ modifiers: ['Shift'] });
+
+    // Only the three visible transactions should be selected — not the
+    // hidden reconciled ones in between.
+    await expect(accountPage.selectButton).toHaveText('3 transactions');
+  });
+
   test.describe('On Budget Accounts', () => {
     // Reset filters
     test.afterEach(async () => {

--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -65,24 +65,21 @@ test.describe('Accounts', () => {
     await accountPage.waitFor();
 
     // Newest transactions are shown first, so the rows read
-    // 'range-five' through 'range-one' from top to bottom.
-    for (const note of ['one', 'two', 'three', 'four', 'five']) {
+    // 'range-three' through 'range-one' from top to bottom.
+    for (const note of ['one', 'two', 'three']) {
       await accountPage.createSingleTransaction({
         payee: '',
         notes: `range-${note}`,
-        category: 'Food',
         debit: '10.00',
       });
     }
 
-    // Mark two transactions in the middle of the list as cleared and
-    // lock them via reconciliation so they become reconciled.
-    for (const note of ['range-two', 'range-four']) {
-      await accountPage.transactionTableRow
-        .filter({ hasText: note })
-        .getByTestId('cleared')
-        .click();
-    }
+    // Mark the middle transaction as cleared and lock it via
+    // reconciliation so it becomes reconciled.
+    await accountPage.transactionTableRow
+      .filter({ hasText: 'range-two' })
+      .getByTestId('cleared')
+      .click();
 
     await page.getByRole('button', { name: 'Reconcile' }).click();
     // The reconciliation amount is pre-filled with the cleared balance,
@@ -108,7 +105,7 @@ test.describe('Accounts', () => {
 
     // Shift-click from the first to the last visible transaction.
     await accountPage.transactionTableRow
-      .filter({ hasText: 'range-five' })
+      .filter({ hasText: 'range-three' })
       .getByTestId('select')
       .click();
     await accountPage.transactionTableRow
@@ -116,9 +113,9 @@ test.describe('Accounts', () => {
       .getByTestId('select')
       .click({ modifiers: ['Shift'] });
 
-    // Only the three visible transactions should be selected — not the
-    // hidden reconciled ones in between.
-    await expect(accountPage.selectButton).toHaveText('3 transactions');
+    // Only the two visible transactions should be selected — not the
+    // hidden reconciled one in between.
+    await expect(accountPage.selectButton).toHaveText('2 transactions');
   });
 
   test.describe('On Budget Accounts', () => {

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1771,7 +1771,16 @@ class AccountInternal extends PureComponent<
         {(allTransactions, allBalances) => (
           <SelectedProviderWithItems
             name="transactions"
-            items={allTransactions}
+            // When reconciled transactions are hidden they are still
+            // loaded (e.g. to calculate running balances), but they must
+            // not be selectable. Mirror the filtering the transaction
+            // table applies when rendering so that range selection
+            // (shift+click) only covers visible transactions.
+            items={
+              showReconciled
+                ? allTransactions
+                : allTransactions.filter(t => !t.reconciled)
+            }
             fetchAllIds={this.fetchAllIds}
             registerDispatch={dispatch => (this.dispatchSelected = dispatch)}
             selectAllFilter={selectAllFilter}

--- a/packages/desktop-client/src/hooks/useSelected.test.ts
+++ b/packages/desktop-client/src/hooks/useSelected.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useSelected } from './useSelected';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+type TestItem = { id: string };
+
+function renderUseSelected(initialItems: TestItem[]) {
+  return renderHook(
+    ({ items }: { items: TestItem[] }) => useSelected('test', items, []),
+    { initialProps: { items: initialItems } },
+  );
+}
+
+describe('useSelected', () => {
+  it('selects and deselects a single item', () => {
+    const { result } = renderUseSelected([{ id: 'one' }, { id: 'two' }]);
+
+    act(() => result.current.dispatch({ type: 'select', id: 'one' }));
+    expect(result.current.items).toEqual(new Set(['one']));
+
+    act(() => result.current.dispatch({ type: 'select', id: 'one' }));
+    expect(result.current.items).toEqual(new Set());
+  });
+
+  it('range selection covers only the items passed to the hook', () => {
+    // The account register passes only the visible transactions as
+    // `items` (e.g. hidden reconciled transactions are excluded).
+    // Range selection operates on indexes of `items`, so it must
+    // select exactly the visible transactions in the range.
+    const visibleItems = [{ id: 'one' }, { id: 'three' }, { id: 'five' }];
+    const { result } = renderUseSelected(visibleItems);
+
+    act(() => result.current.dispatch({ type: 'select', id: 'one' }));
+    act(() =>
+      result.current.dispatch({
+        type: 'select',
+        id: 'five',
+        isRangeSelect: true,
+      }),
+    );
+
+    expect(result.current.items).toEqual(new Set(['one', 'three', 'five']));
+  });
+
+  it('removes selected ids that are no longer in items', () => {
+    // Simulates hiding transactions (e.g. toggling “hide reconciled
+    // transactions”) while they are selected: the selection must be
+    // pruned to the items that are still visible.
+    const allItems = [{ id: 'one' }, { id: 'two' }, { id: 'three' }];
+    const { result, rerender } = renderUseSelected(allItems);
+
+    act(() => result.current.dispatch({ type: 'select', id: 'one' }));
+    act(() =>
+      result.current.dispatch({
+        type: 'select',
+        id: 'three',
+        isRangeSelect: true,
+      }),
+    );
+    expect(result.current.items).toEqual(new Set(['one', 'two', 'three']));
+
+    rerender({ items: [{ id: 'one' }, { id: 'three' }] });
+
+    expect(result.current.items).toEqual(new Set(['one', 'three']));
+  });
+});

--- a/upcoming-release-notes/8177.md
+++ b/upcoming-release-notes/8177.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [augustocbx]
+---
+
+Fix shift-click selection including hidden reconciled transactions in the account view


### PR DESCRIPTION
## Summary

- Fix shift-click range selection in the account register including transactions hidden by "Hide reconciled transactions". The selection count was wrong and batch actions (e.g. delete) silently operated on the hidden reconciled transactions.
- Root cause: when the running balance is shown, reconciled transactions stay loaded (they are needed to calculate the running balance) and are only filtered out at render time in `TransactionsTable`. The selection provider (`SelectedProviderWithItems`) still received the full transaction list, and range selection in `useSelected` selects every item between two indexes of that list — including the hidden rows. This is also why #6015 could not be reproduced at the time: without the running balance enabled, reconciled transactions are filtered out at the query level and the bug never manifests.
- Fix: pass only the visible transactions to `SelectedProviderWithItems`, mirroring the filtering the transaction table applies when rendering. This also prunes hidden reconciled transactions from an existing selection when "Hide reconciled transactions" is toggled on.

Fixes #6579

## Tests

- New e2e regression test (`accounts.test.ts`): reconciles two transactions in the middle of a register, hides reconciled transactions, shows the running balance, then shift-click selects across the range. Verified it fails without the fix (selects 5 transactions) and passes with it (selects 3).
- New unit tests for the `useSelected` hook covering range selection bounds and pruning of selected ids that are removed from the visible items.
- Commands run:
  - `yarn typecheck` ✅
  - `yarn lint:fix` ✅
  - `yarn test` ✅ (all workspaces)
  - `yarn workspace @actual-app/web run playwright test accounts.test.ts --browser=chromium` ✅

## AI assistance disclosure

This pull request was authored with the assistance of an AI agent (Claude Code), in accordance with the repository's AI usage policy. The change was reviewed, tested, and verified locally.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.14 MB → 14.14 MB (+64 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.14 MB → 14.14 MB (+64 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Account.tsx` | 📈 +64 B (+0.14%) | 43.94 kB → 44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 298.88 kB → 298.95 kB (+64 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 181.63 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.71 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->