### PR TITLE
[AI] Fix broken link to migration/nynab in API docs

### DIFF
--- a/packages/docs/docs/api/index.md
+++ b/packages/docs/docs/api/index.md
@@ -86,7 +86,7 @@ The API communicates with the server using Node's built-in `fetch`. There are a 
 
 ## Writing Data Importers
 
-If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](../migration/nynab.md) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
+If you are using another app, like YNAB or Mint, you might want to migrate your data into Actual. Right now, Actual officially supports [importing YNAB4 data](../migration/ynab4.md) and [importing nYNAB data](../migration/nynab.mdx) (and it works very well). But if you want to import all of your data into Actual, you can write a custom importer.
 
 Note that this is not about importing transactions. If all you want to do is add transactions from a custom source (like your bank's API), use [`importTransactions`](./reference.md#importtransactions). In this context, a custom importer is something that takes _all_ of your data (budgets, transactions, payees, etc) and dumps them all into a new file in Actual.
 


### PR DESCRIPTION
## Description

PR #8155 renamed `packages/docs/docs/migration/nynab.md` to `nynab.mdx`, but the cross-reference in `packages/docs/docs/api/index.md` ("Writing Data Importers" section) was not updated and still pointed to `../migration/nynab.md`. Since Docusaurus is configured to throw on broken links, the docs site build aborts on `master`, which makes the `netlify/actualbudget-website/deploy-preview` check fail on all open pull requests.

This PR updates the link to `../migration/nynab.mdx` so the docs build succeeds again.

Fixes #8178

## Testing

- `yarn workspace docs build` — fails on `master` with "Docusaurus found broken links" pointing at this link; succeeds with this change (`[SUCCESS] Generated static files in "build"`).
- Verified no other stale references to `migration/nynab.md` remain in the repo (`docs-sidebar.js` and `migration/index.md` use the doc ID / URL path, which are unaffected by the rename).

## AI assistance disclosure

This PR was implemented with the assistance of an AI tool (Claude Code), under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)