### PR TITLE
[AI] Fix desktop PWA title bar theme color

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -88,7 +88,7 @@ function RouterBehaviors() {
 
 export function FinancesApp() {
   const { isNarrowWidth } = useResponsive();
-  useMetaThemeColor(isNarrowWidth ? theme.mobileViewTheme : undefined);
+  useMetaThemeColor(theme.mobileViewTheme);
 
   const location = useLocation();
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/manager/ManagementApp.tsx
+++ b/packages/desktop-client/src/components/manager/ManagementApp.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react';
 import { Trans } from 'react-i18next';
 import { Navigate, Route, Routes } from 'react-router';
 
-import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
@@ -65,10 +64,7 @@ function Version() {
 }
 
 export function ManagementApp() {
-  const { isNarrowWidth } = useResponsive();
-  useMetaThemeColor(
-    isNarrowWidth ? theme.mobileConfigServerViewTheme : undefined,
-  );
+  useMetaThemeColor(theme.mobileConfigServerViewTheme);
 
   const files = useSelector(state => state.budgetfiles.allFiles);
   const isLoading = useSelector(state => state.app.loadingText !== null);

--- a/packages/desktop-client/src/hooks/useMetaThemeColor.test.ts
+++ b/packages/desktop-client/src/hooks/useMetaThemeColor.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { usePreferredDarkTheme, useTheme } from '#style/theme';
@@ -6,6 +6,7 @@ import { usePreferredDarkTheme, useTheme } from '#style/theme';
 import { useMetaThemeColor } from './useMetaThemeColor';
 
 const DEFAULT_THEME_COLOR = '#5c3dbb';
+const originalMatchMedia = window.matchMedia;
 
 vi.mock('#style/theme', () => ({
   useTheme: vi.fn(),
@@ -40,6 +41,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
 });
 
 describe('useMetaThemeColor', () => {
@@ -117,6 +123,47 @@ describe('useMetaThemeColor', () => {
       vi.mocked(usePreferredDarkTheme).mockReturnValue(['midnight', vi.fn()]);
       rerender();
       expect(document.body.style.backgroundColor).toBe('rgb(187, 187, 187)');
+    });
+
+    it('re-runs effect when system color scheme changes', async () => {
+      let matches = false;
+      const listeners = new Set<() => void>();
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          get matches() {
+            return matches;
+          },
+          media: query,
+          onchange: null,
+          addEventListener: vi.fn((event: string, listener: () => void) => {
+            if (event === 'change') {
+              listeners.add(listener);
+            }
+          }),
+          removeEventListener: vi.fn((event: string, listener: () => void) => {
+            if (event === 'change') {
+              listeners.delete(listener);
+            }
+          }),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+
+      setCssVar('--color-mobileViewTheme', '#111');
+      renderHook(() => useMetaThemeColor('var(--color-mobileViewTheme)'));
+      expect(document.body.style.backgroundColor).toBe('rgb(17, 17, 17)');
+      expect(listeners.size).toBe(1);
+
+      setCssVar('--color-mobileViewTheme', '#222');
+      matches = true;
+      act(() => {
+        listeners.forEach(listener => listener());
+      });
+
+      await waitFor(() => {
+        expect(document.body.style.backgroundColor).toBe('rgb(34, 34, 34)');
+      });
     });
   });
 });

--- a/packages/desktop-client/src/hooks/useMetaThemeColor.ts
+++ b/packages/desktop-client/src/hooks/useMetaThemeColor.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { usePreferredDarkTheme, useTheme } from '#style/theme';
 
@@ -8,11 +8,13 @@ const DEFAULT_THEME_COLOR = '#5c3dbb';
 /**
  * Sets the theme-color meta tag (for browsers that use it) and document.body
  * background-color (for Safari 26+, which derives status bar tint from body).
- * Re-runs when theme changes so the status bar follows the app theme.
+ * Re-runs when theme or system color scheme changes so the status bar follows
+ * the app theme.
  */
 export function useMetaThemeColor(color?: string) {
   const [activeTheme] = useTheme();
   const [darkThemePreference] = usePreferredDarkTheme();
+  const systemColorScheme = useSystemColorScheme();
 
   useEffect(() => {
     if (!color) return;
@@ -23,7 +25,42 @@ export function useMetaThemeColor(color?: string) {
     ensureThemeColorMetaTag();
     setThemeColorMetaContent(resolved);
     document.body.style.backgroundColor = resolved;
-  }, [color, activeTheme, darkThemePreference]);
+  }, [color, activeTheme, darkThemePreference, systemColorScheme]);
+}
+
+function useSystemColorScheme() {
+  const [systemColorScheme, setSystemColorScheme] = useState(() =>
+    getSystemColorScheme(),
+  );
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+
+    const darkThemeMediaQuery = window.matchMedia(
+      '(prefers-color-scheme: dark)',
+    );
+    const handleColorSchemeChange = () => {
+      setSystemColorScheme(darkThemeMediaQuery.matches ? 'dark' : 'light');
+    };
+
+    darkThemeMediaQuery.addEventListener('change', handleColorSchemeChange);
+    handleColorSchemeChange();
+
+    return () => {
+      darkThemeMediaQuery.removeEventListener(
+        'change',
+        handleColorSchemeChange,
+      );
+    };
+  }, []);
+
+  return systemColorScheme;
+}
+
+function getSystemColorScheme() {
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
 }
 
 function ensureThemeColorMetaTag() {

--- a/upcoming-release-notes/fix-pwa-titlebar-theme-color.md
+++ b/upcoming-release-notes/fix-pwa-titlebar-theme-color.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [PaolinPaperin]
+---
+
+Fix the installed web app title bar color to follow the active app theme.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes the browser/PWA title-bar (theme) color on macOS desktop.

Previously only narrow/mobile layouts updated `<meta name="theme-color">`; on wide
desktop layouts both `FinancesApp` and `ManagementApp` passed `undefined` to
`useMetaThemeColor`, so the chrome kept the static `#5c3dbb` fallback from
`index.html`. In an installed Safari PWA that left the macOS title bar stuck on
purple instead of following the app.

This uses the app's mobile **header** color for the desktop title bar too —
`theme.mobileViewTheme` for the budget app and `theme.mobileConfigServerViewTheme`
for the file-manager/config screens — so the installed PWA and Safari's desktop
chrome match the mobile header consistently and stay theme-aware (the value
differs per theme). Thanks to @Juulz for suggesting the mobile header color over
the page/sidebar background.

It also updates `useMetaThemeColor` to listen for `prefers-color-scheme` changes,
so switching macOS appearance between light and dark updates the title bar without
a manual refresh.
## Screenshots

### Before 

#### Standard Light Theme - Before (Safari)
<img width="3260" height="2582" alt="before_dekstop_safari" src="https://github.com/user-attachments/assets/cff97813-f5ea-4faf-b2a2-895731034caa" />

#### Standard Light Theme - Before (PWA)
<img width="3274" height="2202" alt="before_desktop" src="https://github.com/user-attachments/assets/95799860-fc4d-448b-a79e-c3ab8d860301" />

#### Custom Theme - Before (PWA)
<img width="3274" height="2202" alt="before_desktop2" src="https://github.com/user-attachments/assets/aa63ce75-d3c8-4453-b908-5eacc0f4dc6a" />

### After 

#### Standard Light Theme - After (Safari) 
<img width="3524" height="2724" alt="safari_light_mobile" src="https://github.com/user-attachments/assets/0064ae36-cc0d-4673-b808-2501a0050fc8" />


#### Custom Theme - After (Safari) 
<img width="3524" height="2724" alt="safari_custom_theme_mobile" src="https://github.com/user-attachments/assets/f6c3fb8f-a7fc-4784-81a8-58fdaa0a272f" />

#### Custom Themes - After (PWA)
<img width="3442" height="2412" alt="pwa_custom_theme-mobile" src="https://github.com/user-attachments/assets/35b6408d-75e9-48b0-a97c-1eb642e22e95" />

<img width="3442" height="2412" alt="pwa_custom_theme-mobile-dark" src="https://github.com/user-attachments/assets/82160810-e622-413d-91fa-f1a843999892" />

<img width="3442" height="2412" alt="pwa_custom_theme_mobile" src="https://github.com/user-attachments/assets/7ff2fdb9-ada2-4fc2-b478-ddde589ab173" />



<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Verified with:

- `corepack yarn workspace @actual-app/web run test useMetaThemeColor.test.ts`
- `corepack yarn typecheck`
- `corepack yarn lint:fix`
- `corepack yarn test`

Manual testing:

- Installed Actual as a Safari PWA on macOS.
- Confirmed the PWA title bar follows the active app theme instead of staying purple.
- Confirmed normal Safari's toolbar now follows the active app theme instead of staying visually separate from the page.
- Confirmed switching macOS system appearance between light and dark updates the title/browser chrome without requiring a refresh.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.14 MB → 14.14 MB (+739 B) | +0.00%
loot-core | 1 | 5.28 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.14 MB → 14.14 MB (+739 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useMetaThemeColor.ts` | 📈 +833 B (+52.49%) | 1.55 kB → 2.36 kB
`src/components/FinancesApp.tsx` | 📉 -25 B (-0.13%) | 19.02 kB → 18.99 kB
`src/components/manager/ManagementApp.tsx` | 📉 -69 B (-0.89%) | 7.56 kB → 7.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB → 1.6 MB (+739 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 181.63 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.71 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3iXgrGb.js | 5.28 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->
