### PR TITLE
 fix: ignore completed schedule rules in payee counts

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/TransferMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/TransferMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Form } from 'react-aria-components';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { InitialFocus } from '@actual-app/components/initial-focus';
@@ -31,6 +31,8 @@ export function TransferMenu({
   onSubmit,
   onClose,
 }: TransferMenuProps) {
+  const { t } = useTranslation();
+
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =
     useCategories();
   const filteredCategoryGroups = useMemo(() => {
@@ -83,7 +85,7 @@ export function TransferMenu({
           openOnFocus
           onSelect={(id: string | undefined) => setToCategoryId(id || null)}
           inputProps={{
-            placeholder: '(none)',
+            placeholder: t('(none)'),
           }}
           showHiddenCategories
         />

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,67 @@
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import {
+  insertRule,
+  loadRules,
+  resetState,
+} from '#server/transactions/transaction-rules';
+
+import { getPayeeRuleCounts, getPayeeRules } from './app';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  resetState();
+  await loadMappings();
+});
+
+function makePayeeRule(payeeId: string) {
+  return {
+    stage: 'pre',
+    conditionsOp: 'and',
+    conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+    actions: [],
+  } as const;
+}
+
+describe('payee rule counts', () => {
+  test('ignores rules that are only linked to completed schedules', async () => {
+    const payeeId = await db.insertPayee({ name: 'Estimated tax' });
+
+    const directRuleId = await insertRule(makePayeeRule(payeeId));
+    const completedScheduleRuleId = await insertRule(makePayeeRule(payeeId));
+    const activeScheduleRuleId = await insertRule(makePayeeRule(payeeId));
+
+    await db.insertWithUUID('schedules', {
+      name: 'Completed tax payment',
+      rule: completedScheduleRuleId,
+      active: 0,
+      completed: 1,
+      posts_transaction: 1,
+      custom_upcoming_length: null,
+      tombstone: 0,
+    });
+
+    await db.insertWithUUID('schedules', {
+      name: 'Active tax payment',
+      rule: activeScheduleRuleId,
+      active: 1,
+      completed: 0,
+      posts_transaction: 1,
+      custom_upcoming_length: null,
+      tombstone: 0,
+    });
+
+    await loadRules();
+
+    const counts = await getPayeeRuleCounts();
+    expect(counts[payeeId]).toBe(2);
+
+    const associatedRules = await getPayeeRules({ id: payeeId });
+    expect(associatedRules.map(rule => rule.id)).toEqual(
+      expect.arrayContaining([directRuleId, activeScheduleRuleId]),
+    );
+    expect(associatedRules.map(rule => rule.id)).not.toContain(
+      completedScheduleRuleId,
+    );
+  });
+});

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -53,6 +53,33 @@ app.method('payee-locations-get', getPayeeLocations);
 app.method('payee-location-delete', mutator(deletePayeeLocation));
 app.method('payees-get-nearby', getNearbyPayees);
 
+async function getScheduleRuleStatuses(): Promise<Map<string, boolean>> {
+  const rows = await db.all<Pick<db.DbSchedule, 'rule' | 'completed'>>(
+    'SELECT rule, completed FROM schedules WHERE rule IS NOT NULL AND tombstone = 0',
+  );
+
+  const scheduleRuleStatuses = new Map<string, boolean>();
+  for (const row of rows) {
+    if (row.completed === 0) {
+      scheduleRuleStatuses.set(row.rule, true);
+      continue;
+    }
+
+    if (!scheduleRuleStatuses.has(row.rule)) {
+      scheduleRuleStatuses.set(row.rule, false);
+    }
+  }
+
+  return scheduleRuleStatuses;
+}
+
+function shouldCountRule(
+  rule: { id: string },
+  scheduleRuleStatuses: Map<string, boolean>,
+) {
+  return scheduleRuleStatuses.get(rule.id) !== false;
+}
+
 async function createPayee({ name }: { name: PayeeEntity['name'] }) {
   return db.insertPayee({ name });
 }
@@ -71,10 +98,15 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
   return await db.syncGetOrphanedPayees();
 }
 
-async function getPayeeRuleCounts() {
+export async function getPayeeRuleCounts() {
+  const scheduleRuleStatuses = await getScheduleRuleStatuses();
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    if (!shouldCountRule(rule, scheduleRuleStatuses)) {
+      return;
+    }
+
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }
@@ -131,12 +163,16 @@ async function checkOrphanedPayees({
   return ids.filter(id => orphaned.has(id));
 }
 
-async function getPayeeRules({
+export async function getPayeeRules({
   id,
 }: {
   id: PayeeEntity['id'];
 }): Promise<RuleEntity[]> {
-  return rules.getRulesForPayee(id).map(rule => rule.serialize());
+  const scheduleRuleStatuses = await getScheduleRuleStatuses();
+  return rules
+    .getRulesForPayee(id)
+    .filter(rule => shouldCountRule(rule, scheduleRuleStatuses))
+    .map(rule => rule.serialize());
 }
 
 async function createPayeeLocation({

--- a/upcoming-release-notes/8154.md
+++ b/upcoming-release-notes/8154.md
@@ -1,0 +1,6 @@
+---
+category: Fixes
+authors: [Procoder1234556]
+---
+
+Translate the `(none)` placeholder shown in the budget transfer menu.

--- a/upcoming-release-notes/8154.md
+++ b/upcoming-release-notes/8154.md
@@ -1,5 +1,5 @@
 ---
-category: Fixes
+category: Bugfixes
 authors: [Procoder1234556]
 ---
 


### PR DESCRIPTION
Closes #8134.

This patch updates the payee rule-count path so rules tied only to completed schedules are excluded from both:
- the associated-rules count shown on the Payees page
- the payee-specific rules list used when opening associated rules

Decision log:
- Keep the filter in the server payees layer so the count badge and the rules lookup stay in sync.
- Use schedule completion state from the database rather than trying to infer this in the UI.
- Add a regression test that covers direct rules, active schedule-linked rules, and completed schedule-linked rules.

Verification:
- yarn vitest run packages/loot-core/src/server/payees/app.test.ts
- yarn oxfmt packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts
- yarn oxlint --quiet packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts