### PR TITLE
[WIP] Fix completed schedules in payee rule counts

### DIFF
--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,51 @@
+import { loadMappings } from '#server/db/mappings';
+import {
+  createSchedule as createScheduleBase,
+  updateSchedule,
+} from '#server/schedules/app';
+import { insertRule, loadRules } from '#server/transactions/transaction-rules';
+import type { RuleConditionEntity } from '#types/models';
+
+import { app } from './app';
+
+const createSchedule = createScheduleBase as (args: {
+  conditions: RuleConditionEntity[];
+}) => Promise<string>;
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+  await loadRules();
+});
+
+describe('payee app', () => {
+  it('excludes completed schedule rules from payee rule counts', async () => {
+    await insertRule({
+      stage: 'pre',
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: 'payee-1' }],
+      actions: [],
+    });
+
+    await createSchedule({
+      conditions: [
+        { op: 'is', field: 'payee', value: 'payee-1' },
+        { op: 'is', field: 'date', value: '2026-06-01' },
+      ],
+    });
+
+    const completedScheduleId = await createSchedule({
+      conditions: [
+        { op: 'is', field: 'payee', value: 'payee-1' },
+        { op: 'is', field: 'date', value: '2026-06-02' },
+      ],
+    });
+    await updateSchedule({
+      schedule: { id: completedScheduleId, completed: true },
+    });
+
+    const counts = await app.handlers['payees-get-rule-counts']();
+
+    expect(counts['payee-1']).toBe(2);
+  });
+});

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -73,13 +73,27 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
+  const completedScheduleRuleIds = new Set(
+    (
+      await db.all<Pick<db.DbSchedule, 'rule'>>(
+        'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
+      )
+    ).map(schedule => schedule.rule),
+  );
 
-  rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
-    if (payeeCounts[id] == null) {
-      payeeCounts[id] = 0;
-    }
-    payeeCounts[id]++;
-  });
+  rules.iterateIds(
+    rules.getRules().filter(rule => {
+      const id = rule.getId();
+      return id == null || !completedScheduleRuleIds.has(id);
+    }),
+    'payee',
+    (rule, id) => {
+      if (payeeCounts[id] == null) {
+        payeeCounts[id] = 0;
+      }
+      payeeCounts[id]++;
+    },
+  );
 
   return payeeCounts;
 }

--- a/upcoming-release-notes/8190.md
+++ b/upcoming-release-notes/8190.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [xub5210-droid]
+---
+
+Fix the associated rule count on the payees page including rules from completed schedules.


### PR DESCRIPTION
## Description

Exclude rules backing completed schedules from the associated-rule counts shown on the Payees page. Active schedule rules and regular rules continue to be counted.

Added a focused regression test covering a regular rule, an active schedule, and a completed schedule for the same payee.

AI disclosure: Codex assisted with the implementation and test.

## Related issue(s)

Fixes #8134

## Testing

- `yarn workspace @actual-app/core test:node src/server/payees/app.test.ts`
- `yarn workspace @actual-app/core typecheck`
- `oxfmt packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts`
- `oxlint --type-aware --quiet packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts`

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.14 MB | 0%
loot-core | 1 | 5.28 MB → 5.28 MB (+269 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+265 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.14 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.6 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 962.55 kB | 0%
static/js/ManageRules.js | 46.63 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.33 kB | 0%
static/js/ReportRouter.js | 1.27 MB | 0%
static/js/ScheduleEditForm.js | 146.57 kB | 0%
static/js/SchedulesTable.js | 206.3 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 85.81 kB | 0%
static/js/Value.js | 5.08 MB | 0%
static/js/_baseIsEqual.js | 98.38 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 451.37 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.71 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 508.79 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 365.05 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.88 kB | 0%
static/js/toString.js | 705.18 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.88 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.28 MB → 5.28 MB (+269 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +269 B (+4.44%) | 5.92 kB → 6.18 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cj5OLAS9.js | 0 B → 5.28 MB (+5.28 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Co0zOyQO.js | 5.28 MB → 0 B (-5.28 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+265 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +265 B (+4.43%) | 5.84 kB → 6.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+265 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->