### PR TITLE
[AI] Fix git-guard false positives on heredoc and multi -m commit messages

### DIFF
--- a/scripts/agent-hooks/git-guard.sh
+++ b/scripts/agent-hooks/git-guard.sh
@@ -105,17 +105,21 @@ case "$cmd" in
     # First line of the remainder tells us the message form. An empty result
     # means no inline message (editor/--amend/-F) — left alone.
     first=$(printf '%s\n' "$rest" | sed -n '1s/^[[:space:]]*//p')
+    msg=''
     case "$first" in
       *'$('*'<<'*)
         # Heredoc via command substitution: -m "$(cat <<'EOF' ... EOF)".
-        # The subject is the first line of the heredoc body, i.e. the line
-        # after the one carrying the flag.
-        msg=$(printf '%s\n' "$rest" | sed -n '2p') ;;
-      *)
-        # Inline string: strip one leading quote, truncate at the next quote
-        # (good enough for a prefix check).
-        msg=$(printf '%s\n' "$first" | sed "s/^['\"]//; s/['\"].*//") ;;
+        # The subject is the first non-blank line of the heredoc body (git's
+        # default cleanup strips leading blank lines).
+        msg=$(printf '%s\n' "$rest" | sed -n '2,$p' |
+          sed -n '/[^[:space:]]/{s/^[[:space:]]*//;p;q;}') ;;
     esac
+    # Inline string: strip one leading quote, truncate at the next quote
+    # (good enough for a prefix check). Also the fallback when the heredoc
+    # pattern matched but no body line followed — e.g. a single-line <<<
+    # here-string — so a statically unknowable message fails closed instead
+    # of slipping past as empty.
+    [ -n "$msg" ] || msg=$(printf '%s\n' "$first" | sed "s/^['\"]//; s/['\"].*//")
     case "$msg" in
       "" | "[AI]"*) ;;
       *) block "Blocked: commit messages must start with '[AI]'. Got: $msg" ;;

--- a/scripts/agent-hooks/git-guard.sh
+++ b/scripts/agent-hooks/git-guard.sh
@@ -86,12 +86,36 @@ esac
 # Commit messages must start with [AI].
 case "$cmd" in
   *"git commit"*)
-    # Extract the message from -m / --message (quoted first, then unquoted).
-    # An empty result means no inline message (editor/--amend) — left alone.
-    msg=$(printf '%s' "$cmd" | sed -n "s/.*-m[[:space:]]*['\"]\\([^'\"]*\\).*/\\1/p")
-    [ -n "$msg" ] || msg=$(printf '%s' "$cmd" | sed -n "s/.*--message[=[:space:]][[:space:]]*['\"]\\([^'\"]*\\).*/\\1/p")
-    [ -n "$msg" ] || msg=$(printf '%s' "$cmd" | sed -n "s/.*-m[[:space:]][[:space:]]*\\([^[:space:]'\"][^[:space:]]*\\).*/\\1/p")
-    [ -n "$msg" ] || msg=$(printf '%s' "$cmd" | sed -n "s/.*--message[=[:space:]][[:space:]]*\\([^[:space:]'\"][^[:space:]]*\\).*/\\1/p")
+    # The [AI] rule applies to the commit subject, which git takes from the
+    # FIRST -m/--message flag (later -m flags become body paragraphs, e.g. a
+    # Co-Authored-By trailer). ${var#pattern} strips the shortest matching
+    # prefix, i.e. finds the first occurrence; when both flag spellings are
+    # present, the longer remainder is the one whose flag came first.
+    rest=''
+    case "$cmd" in
+      *" --message"*)
+        rest=${cmd#*" --message"}
+        rest=${rest#=} ;;
+    esac
+    case "$cmd" in
+      *" -m"*)
+        m_rest=${cmd#*" -m"}
+        [ ${#m_rest} -gt ${#rest} ] && rest=$m_rest ;;
+    esac
+    # First line of the remainder tells us the message form. An empty result
+    # means no inline message (editor/--amend/-F) — left alone.
+    first=$(printf '%s\n' "$rest" | sed -n '1s/^[[:space:]]*//p')
+    case "$first" in
+      *'$('*'<<'*)
+        # Heredoc via command substitution: -m "$(cat <<'EOF' ... EOF)".
+        # The subject is the first line of the heredoc body, i.e. the line
+        # after the one carrying the flag.
+        msg=$(printf '%s\n' "$rest" | sed -n '2p') ;;
+      *)
+        # Inline string: strip one leading quote, truncate at the next quote
+        # (good enough for a prefix check).
+        msg=$(printf '%s\n' "$first" | sed "s/^['\"]//; s/['\"].*//") ;;
+    esac
     case "$msg" in
       "" | "[AI]"*) ;;
       *) block "Blocked: commit messages must start with '[AI]'. Got: $msg" ;;

--- a/upcoming-release-notes/8192.md
+++ b/upcoming-release-notes/8192.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Fix agent git-guard hook false positives on heredoc-style and multi-paragraph commit messages


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Small LLM agent improvement: allow multi-line commit messages

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
