### PR TITLE
[AI] Minify web bundle while keeping original identifiers

### DIFF
--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -308,7 +308,7 @@ export default defineConfig(async ({ mode, command }) => {
     base: '/',
     envPrefix: 'REACT_APP_',
     build: {
-      minify: false,
+      minify: 'oxc',
       target: 'es2022',
       sourcemap: true,
       outDir: mode === 'desktop' ? 'build-electron' : 'build',
@@ -318,6 +318,14 @@ export default defineConfig(async ({ mode, command }) => {
       chunkSizeWarningLimit: 1500,
       rolldownOptions: {
         output: {
+          // Users debug from raw stack traces, so compress and strip
+          // whitespace but never mangle identifiers (overrides the
+          // mangle: true that `minify: 'oxc'` implies).
+          minify: {
+            compress: true,
+            mangle: false,
+            codegen: true,
+          },
           assetFileNames: (assetInfo: PreRenderedAsset) => {
             const info = assetInfo.name?.split('.') ?? [];
             let extType = info[info.length - 1];

--- a/packages/loot-core/vite.config.mts
+++ b/packages/loot-core/vite.config.mts
@@ -38,6 +38,16 @@ export default defineConfig(({ mode }) => {
           warn(warning);
         },
         output: {
+          // Users debug from raw stack traces, so compress and strip
+          // whitespace but never mangle identifiers (overrides the
+          // mangle: true that `minify: 'oxc'` implies).
+          ...(!isDev && {
+            minify: {
+              compress: true,
+              mangle: false,
+              codegen: true,
+            },
+          }),
           chunkFileNames: isDev
             ? '[name].kcab.worker.dev.js'
             : '[id].[name].kcab.worker.[hash].js',
@@ -51,7 +61,7 @@ export default defineConfig(({ mode }) => {
         external: [],
       },
       sourcemap: true,
-      minify: false,
+      minify: isDev ? false : 'oxc',
     },
     define: {
       'process.env': '{}',

--- a/upcoming-release-notes/minify-web-bundle-keep-names.md
+++ b/upcoming-release-notes/minify-web-bundle-keep-names.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Minify the web bundle while keeping original function and variable names so user-reported stack traces stay debuggable


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

I had removed minification entirely because people started sending us obfuscated stack traces that were impossible to debug.

But I think we can bring some parts of minification back..

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 14.14 MB → 13.23 MB (-932.21 kB) | -6.44%
loot-core | 1 | 5.29 MB → 4.86 MB (-433.69 kB) | -8.01%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 14.14 MB → 13.23 MB (-932.21 kB) | -6.44%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/react-dom/cjs/react-dom-client.production.js` | 📉 -238 B (-0.05%) | 441.7 kB → 441.47 kB
`src/components/reports/reports/CustomReport.tsx` | 📉 -59 B (-0.14%) | 42.34 kB → 42.29 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📉 -93 B (-0.21%) | 43.66 kB → 43.57 kB
`node_modules/moment/dist/moment.js` | 📉 -242 B (-0.21%) | 111.68 kB → 111.44 kB
`node_modules/re-resizable/lib/index.js` | 📉 -64 B (-0.24%) | 25.53 kB → 25.47 kB
`node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js` | 📉 -65 B (-0.25%) | 25.34 kB → 25.28 kB
`node_modules/hyperformula/es/interpreter/plugin/StatisticalPlugin.mjs` | 📉 -73 B (-0.33%) | 21.32 kB → 21.25 kB
`node_modules/hyperformula/es/CrudOperations.mjs` | 📉 -73 B (-0.35%) | 20.58 kB → 20.51 kB
`node_modules/fzf/dist/fzf.es.js` | 📉 -85 B (-0.39%) | 21.4 kB → 21.32 kB
`node_modules/recharts/es6/shape/Trapezoid.js` | 📉 -33 B (-0.53%) | 6.11 kB → 6.07 kB
`node_modules/hyperformula/es/interpreter/plugin/StatisticalAggregationPlugin.mjs` | 📉 -73 B (-0.54%) | 13.12 kB → 13.05 kB
`node_modules/recharts/es6/component/Text.js` | 📉 -51 B (-0.66%) | 7.57 kB → 7.52 kB
`node_modules/@react-stately/layout/dist/ListLayout.mjs` | 📉 -141 B (-0.71%) | 19.41 kB → 19.27 kB
`node_modules/pikaday/pikaday.js` | 📉 -203 B (-0.72%) | 27.35 kB → 27.15 kB
`node_modules/react-dnd-html5-backend/dist/HTML5BackendImpl.js` | 📉 -126 B (-0.81%) | 15.14 kB → 15.02 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📉 -73 B (-0.82%) | 8.72 kB → 8.65 kB
`node_modules/hyperformula/es/interpreter/plugin/RadixConversionPlugin.mjs` | 📉 -73 B (-0.82%) | 8.72 kB → 8.65 kB
`node_modules/hyperformula/es/interpreter/plugin/ComplexPlugin.mjs` | 📉 -73 B (-0.83%) | 8.54 kB → 8.47 kB
`node_modules/hyperformula/es/DateTimeHelper.mjs` | 📉 -73 B (-0.86%) | 8.25 kB → 8.18 kB
`node_modules/hyperformula/es/interpreter/plugin/MathPlugin.mjs` | 📉 -73 B (-0.87%) | 8.22 kB → 8.15 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📉 -73 B (-0.88%) | 8.07 kB → 8 kB
`node_modules/recharts/es6/shape/Cross.js` | 📉 -29 B (-0.92%) | 3.09 kB → 3.07 kB
`node_modules/hyperformula/es/interpreter/plugin/MatrixPlugin.mjs` | 📉 -73 B (-0.92%) | 7.77 kB → 7.7 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/parser.js` | 📉 -83 B (-0.95%) | 8.49 kB → 8.41 kB
`node_modules/handlebars/dist/cjs/handlebars/runtime.js` | 📉 -112 B (-0.98%) | 11.12 kB → 11.01 kB
`node_modules/recharts/es6/cartesian/YAxis.js` | 📉 -77 B (-0.99%) | 7.56 kB → 7.48 kB
`node_modules/recharts/es6/chart/Sankey.js` | 📉 -255 B (-1.02%) | 24.52 kB → 24.27 kB
`node_modules/hyperformula/es/interpreter/plugin/RoundingPlugin.mjs` | 📉 -73 B (-1.12%) | 6.36 kB → 6.29 kB
`node_modules/hyperformula/es/parser/Ast.mjs` | 📉 -118 B (-1.15%) | 10 kB → 9.89 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/traits/tree_builder.js` | 📉 -113 B (-1.17%) | 9.45 kB → 9.34 kB
`node_modules/hyperformula/es/interpreter/CriterionFunctionCompute.mjs` | 📉 -73 B (-1.19%) | 6.01 kB → 5.94 kB
`src/components/filters/FiltersMenu.tsx` | 📉 -269 B (-1.20%) | 21.98 kB → 21.71 kB
`node_modules/@react-aria/utils/dist/ShadowTreeWalker.mjs` | 📉 -69 B (-1.21%) | 5.57 kB → 5.5 kB
`node_modules/recharts/es6/cartesian/CartesianGrid.js` | 📉 -157 B (-1.23%) | 12.42 kB → 12.27 kB
`node_modules/date-fns/locale/mn/_lib/formatDistance.js` | 📉 -36 B (-1.28%) | 2.75 kB → 2.71 kB
`node_modules/hyperformula/es/interpreter/Criterion.mjs` | 📉 -73 B (-1.31%) | 5.43 kB → 5.36 kB
`node_modules/hyperformula/es/format/format.mjs` | 📉 -73 B (-1.39%) | 5.13 kB → 5.06 kB
`node_modules/hyperformula/es/ArraySize.mjs` | 📉 -73 B (-1.44%) | 4.94 kB → 4.86 kB
`node_modules/hyperformula/es/interpreter/plugin/SimpleArithmertic.mjs` | 📉 -73 B (-1.48%) | 4.82 kB → 4.75 kB
`node_modules/react/cjs/react.production.js` | 📉 -227 B (-1.48%) | 14.97 kB → 14.75 kB
`node_modules/recharts/es6/cartesian/XAxis.js` | 📉 -107 B (-1.55%) | 6.75 kB → 6.65 kB
`node_modules/hyperformula/es/BuildEngineFactory.mjs` | 📉 -73 B (-1.58%) | 4.51 kB → 4.44 kB
`node_modules/hyperformula/es/interpreter/plugin/RomanPlugin.mjs` | 📉 -73 B (-1.59%) | 4.48 kB → 4.41 kB
`node_modules/hyperformula/es/Serialization.mjs` | 📉 -73 B (-1.62%) | 4.4 kB → 4.33 kB
`node_modules/hyperformula/es/dependencyTransformers/RemoveColumnsTransformer.mjs` | 📉 -73 B (-1.64%) | 4.34 kB → 4.26 kB
`node_modules/hyperformula/es/interpreter/plugin/ArrayPlugin.mjs` | 📉 -73 B (-1.66%) | 4.29 kB → 4.21 kB
`node_modules/@react-aria/collections/dist/Document.mjs` | 📉 -240 B (-1.68%) | 13.98 kB → 13.75 kB
`node_modules/recharts/es6/component/Label.js` | 📉 -190 B (-1.69%) | 10.98 kB → 10.79 kB
`node_modules/recharts/es6/shape/Sector.js` | 📉 -122 B (-1.70%) | 7 kB → 6.88 kB
`node_modules/hyperformula/es/dependencyTransformers/MoveCellsTransformer.mjs` | 📉 -73 B (-1.72%) | 4.15 kB → 4.08 kB
`node_modules/hyperformula/es/dependencyTransformers/RemoveRowsTransformer.mjs` | 📉 -73 B (-1.74%) | 4.09 kB → 4.02 kB
`node_modules/recharts/es6/cartesian/Bar.js` | 📉 -355 B (-1.76%) | 19.73 kB → 19.38 kB
`node_modules/chevrotain/lib_esm/src/parse/grammar/interpreter.js` | 📉 -318 B (-1.93%) | 16.11 kB → 15.8 kB
`node_modules/hyperformula/es/interpreter/plugin/FinancialPlugin.mjs` | 📉 -482 B (-1.97%) | 23.88 kB → 23.41 kB
`node_modules/recharts/es6/cartesian/Area.js` | 📉 -416 B (-1.98%) | 20.53 kB → 20.13 kB
`node_modules/hyperformula/es/dependencyTransformers/Transformer.mjs` | 📉 -73 B (-2.01%) | 3.54 kB → 3.47 kB
`node_modules/hyperformula/es/parser/ParserWithCaching.mjs` | 📉 -243 B (-2.02%) | 11.73 kB → 11.49 kB
`node_modules/hyperformula/es/AbsoluteCellRange.mjs` | 📉 -265 B (-2.02%) | 12.78 kB → 12.52 kB
`node_modules/hyperformula/es/interpreter/FunctionRegistry.mjs` | 📉 -173 B (-2.04%) | 8.28 kB → 8.11 kB
`node_modules/react-resizable/build/Resizable.js` | 📉 -181 B (-2.04%) | 8.66 kB → 8.48 kB
`node_modules/hyperformula/es/interpreter/ArithmeticHelper.mjs` | 📉 -415 B (-2.10%) | 19.28 kB → 18.87 kB
`node_modules/recharts/es6/state/selectors/selectChartOffsetInternal.js` | 📉 -84 B (-2.11%) | 3.88 kB → 3.8 kB
`node_modules/hyperformula/es/ArrayValue.mjs` | 📉 -73 B (-2.24%) | 3.18 kB → 3.11 kB
`node_modules/hyperformula/es/ClipboardOperations.mjs` | 📉 -73 B (-2.35%) | 3.04 kB → 2.97 kB
`node_modules/hyperformula/es/parser/LexerConfig.mjs` | 📉 -128 B (-2.40%) | 5.21 kB → 5.09 kB
`node_modules/hyperformula/es/dependencyTransformers/AddColumnsTransformer.mjs` | 📉 -73 B (-2.44%) | 2.92 kB → 2.85 kB
`node_modules/hyperformula/es/Lookup/AdvancedFind.mjs` | 📉 -73 B (-2.49%) | 2.86 kB → 2.79 kB
`node_modules/scheduler/cjs/scheduler.production.js` | 📉 -231 B (-2.50%) | 9.01 kB → 8.79 kB
`node_modules/react-remove-scroll-bar/dist/es2015/component.js` | 📉 -68 B (-2.53%) | 2.62 kB → 2.55 kB
`node_modules/hyperformula/es/dependencyTransformers/AddRowsTransformer.mjs` | 📉 -73 B (-2.58%) | 2.76 kB → 2.69 kB
`node_modules/hyperformula/es/parser/ColumnAddress.mjs` | 📉 -73 B (-2.59%) | 2.75 kB → 2.68 kB
`node_modules/hyperformula/es/interpreter/binarySearch.mjs` | 📉 -73 B (-2.64%) | 2.7 kB → 2.63 kB
`node_modules/hyperformula/es/i18n/TranslationPackage.mjs` | 📉 -73 B (-2.66%) | 2.68 kB → 2.61 kB
`node_modules/hyperformula/es/interpreter/plugin/AddressPlugin.mjs` | 📉 -73 B (-2.66%) | 2.68 kB → 2.6 kB
`node_modules/recharts/es6/polar/Pie.js` | 📉 -584 B (-2.68%) | 21.32 kB → 20.75 kB
`node_modules/@react-stately/virtualizer/dist/Virtualizer.mjs` | 📉 -203 B (-2.69%) | 7.38 kB → 7.18 kB
`node_modules/@react-spring/animated/dist/react-spring_animated.modern.mjs` | 📉 -203 B (-2.74%) | 7.25 kB → 7.05 kB
`node_modules/recharts/es6/shape/Symbols.js` | 📉 -124 B (-2.74%) | 4.42 kB → 4.3 kB
`node_modules/hyperformula/es/interpreter/Interpreter.mjs` | 📉 -421 B (-2.76%) | 14.89 kB → 14.47 kB
`node_modules/hyperformula/es/format/parser.mjs` | 📉 -73 B (-2.81%) | 2.53 kB → 2.46 kB
`node_modules/hyperformula/es/Span.mjs` | 📉 -73 B (-2.82%) | 2.53 kB → 2.46 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📉 -538 B (-2.83%) | 18.55 kB → 18.02 kB
`node_modules/hyperformula/es/parser/Cache.mjs` | 📉 -73 B (-2.89%) | 2.46 kB → 2.39 kB
`node_modules/hyperformula/es/parser/collectDependencies.mjs` | 📉 -73 B (-2.93%) | 2.43 kB → 2.36 kB
`node_modules/chevrotain/lib_esm/src/scan/lexer.js` | 📉 -738 B (-2.97%) | 24.28 kB → 23.56 kB
`node_modules/@codemirror/lint/dist/index.js` | 📉 -544 B (-2.98%) | 17.83 kB → 17.3 kB
`node_modules/hyperformula/es/parser/RowAddress.mjs` | 📉 -73 B (-2.99%) | 2.38 kB → 2.31 kB
`node_modules/hyperformula/es/Config.mjs` | 📉 -256 B (-3.05%) | 8.21 kB → 7.96 kB
`node_modules/chevrotain/lib_esm/src/utils/utils.js` | 📉 -269 B (-3.12%) | 8.42 kB → 8.16 kB
`node_modules/recharts/es6/state/cartesianAxisSlice.js` | 📉 -139 B (-3.28%) | 4.13 kB → 4 kB
`node_modules/hyperformula/es/error-message.mjs` | 📉 -147 B (-3.37%) | 4.26 kB → 4.12 kB
`node_modules/@react-aria/overlays/dist/useModal.mjs` | 📉 -86 B (-3.40%) | 2.47 kB → 2.39 kB
`node_modules/recharts/es6/shape/Curve.js` | 📉 -166 B (-3.51%) | 4.62 kB → 4.46 kB
`node_modules/hyperformula/es/CellContentParser.mjs` | 📉 -157 B (-3.60%) | 4.26 kB → 4.1 kB
`node_modules/hyperformula/es/interpreter/plugin/DateTimePlugin.mjs` | 📉 -793 B (-3.62%) | 21.39 kB → 20.62 kB
`node_modules/hyperformula/es/ArgumentSanitization.mjs` | 📉 -73 B (-3.66%) | 1.95 kB → 1.87 kB
`node_modules/hyperformula/es/index.mjs` | 📉 -117 B (-3.70%) | 3.09 kB → 2.97 kB
`node_modules/recharts/es6/cartesian/getCartesianPosition.js` | 📉 -229 B (-3.72%) | 6 kB → 5.78 kB
`node_modules/@react-aria/interactions/dist/useFocusVisible.mjs` | 📉 -379 B (-3.80%) | 9.74 kB → 9.37 kB
`node_modules/react-dom/cjs/react-dom.production.js` | 📉 -231 B (-3.89%) | 5.81 kB → 5.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.08 MB → 4.49 MB (-609.92 kB) | -11.72%
static/js/FormulaEditor.js | 962.55 kB → 814.39 kB (-148.16 kB) | -15.39%
static/js/toString.js | 705.18 kB → 638.83 kB (-66.35 kB) | -9.41%
static/js/extends.js | 508.79 kB → 473.99 kB (-34.79 kB) | -6.84%
static/js/ReportRouter.js | 1.27 MB → 1.25 MB (-27.35 kB) | -2.10%
static/js/_baseIsEqual.js | 98.38 kB → 76.76 kB (-21.62 kB) | -21.97%
static/js/index.js | 1.6 MB → 1.58 MB (-15.11 kB) | -0.92%
static/js/TransactionList.js | 85.81 kB → 82.8 kB (-3.01 kB) | -3.51%
static/js/SchedulesTable.js | 206.3 kB → 203.52 kB (-2.78 kB) | -1.35%
static/js/theme.js | 31.88 kB → 31.01 kB (-896 B) | -2.74%
static/js/wide.js | 298.99 kB → 298.17 kB (-843 B) | -0.28%
static/js/narrow.js | 365.05 kB → 364.55 kB (-514 B) | -0.14%
static/js/client.js | 451.37 kB → 450.92 kB (-469 B) | -0.10%
static/js/PayeeRuleCountLabel.js | 7.33 kB → 7.1 kB (-239 B) | -3.18%
static/js/ManageRules.js | 46.63 kB → 46.47 kB (-165 B) | -0.35%
static/js/ScheduleEditForm.js | 146.57 kB → 146.51 kB (-67 B) | -0.04%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 201.71 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.29 MB → 4.86 MB (-433.69 kB) | -8.01%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/pako/lib/zlib/trees.js` | 📉 -23 B (-0.15%) | 15.44 kB → 15.42 kB
`node_modules/sax/lib/sax.js` | 📉 -58 B (-0.16%) | 36.29 kB → 36.23 kB
`node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js` | 📉 -68 B (-0.25%) | 26.09 kB → 26.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -74 B (-0.29%) | 24.87 kB → 24.8 kB
`node_modules/hyperformula/es/interpreter/plugin/StatisticalPlugin.mjs` | 📉 -76 B (-0.34%) | 22.14 kB → 22.07 kB
`node_modules/hyperformula/es/CrudOperations.mjs` | 📉 -76 B (-0.35%) | 20.95 kB → 20.88 kB
`node_modules/@bufbuild/protobuf/dist/esm/to-binary.js` | 📉 -21 B (-0.43%) | 4.78 kB → 4.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -107 B (-0.49%) | 21.28 kB → 21.17 kB
`node_modules/hyperformula/es/interpreter/plugin/StatisticalAggregationPlugin.mjs` | 📉 -76 B (-0.55%) | 13.44 kB → 13.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📉 -225 B (-0.73%) | 30.06 kB → 29.84 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📉 -76 B (-0.81%) | 9.13 kB → 9.06 kB
`node_modules/hyperformula/es/interpreter/plugin/RadixConversionPlugin.mjs` | 📉 -76 B (-0.83%) | 8.96 kB → 8.89 kB
`node_modules/hyperformula/es/interpreter/plugin/ComplexPlugin.mjs` | 📉 -76 B (-0.84%) | 8.8 kB → 8.72 kB
`node_modules/browserify-zlib/lib/binding.js` | 📉 -81 B (-0.84%) | 9.37 kB → 9.29 kB
`node_modules/hyperformula/es/DateTimeHelper.mjs` | 📉 -76 B (-0.87%) | 8.5 kB → 8.42 kB
`node_modules/hyperformula/es/interpreter/plugin/MathPlugin.mjs` | 📉 -76 B (-0.88%) | 8.47 kB → 8.4 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📉 -76 B (-0.90%) | 8.24 kB → 8.16 kB
`node_modules/hyperformula/es/interpreter/plugin/MatrixPlugin.mjs` | 📉 -76 B (-0.93%) | 7.95 kB → 7.87 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/parser.js` | 📉 -86 B (-0.97%) | 8.69 kB → 8.61 kB
`node_modules/handlebars/dist/cjs/handlebars/runtime.js` | 📉 -115 B (-0.99%) | 11.35 kB → 11.24 kB
`node_modules/assert/build/internal/util/comparisons.js` | 📉 -160 B (-1.00%) | 15.61 kB → 15.46 kB
`node_modules/hyperformula/es/interpreter/plugin/RoundingPlugin.mjs` | 📉 -76 B (-1.13%) | 6.55 kB → 6.47 kB
`node_modules/hyperformula/es/parser/Ast.mjs` | 📉 -124 B (-1.18%) | 10.24 kB → 10.12 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/traits/tree_builder.js` | 📉 -118 B (-1.19%) | 9.67 kB → 9.56 kB
`node_modules/absurd-sql/dist/indexeddb-backend.js` | 📉 -289 B (-1.21%) | 23.37 kB → 23.08 kB
`node_modules/hyperformula/es/interpreter/CriterionFunctionCompute.mjs` | 📉 -76 B (-1.21%) | 6.12 kB → 6.05 kB
`node_modules/define-data-property/index.js` | 📉 -29 B (-1.31%) | 2.16 kB → 2.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-filters.ts` | 📉 -105 B (-1.31%) | 7.82 kB → 7.72 kB
`node_modules/date-fns/locale/mn/_lib/formatDistance.js` | 📉 -39 B (-1.33%) | 2.86 kB → 2.82 kB
`node_modules/hyperformula/es/interpreter/Criterion.mjs` | 📉 -76 B (-1.34%) | 5.53 kB → 5.45 kB
`node_modules/hyperformula/es/format/format.mjs` | 📉 -76 B (-1.41%) | 5.28 kB → 5.2 kB
`node_modules/hyperformula/es/ArraySize.mjs` | 📉 -76 B (-1.47%) | 5.05 kB → 4.97 kB
`node_modules/hyperformula/es/interpreter/plugin/SimpleArithmertic.mjs` | 📉 -76 B (-1.48%) | 5.01 kB → 4.93 kB
`node_modules/hyperformula/es/interpreter/plugin/RomanPlugin.mjs` | 📉 -76 B (-1.58%) | 4.69 kB → 4.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📉 -105 B (-1.60%) | 6.42 kB → 6.32 kB
`node_modules/hyperformula/es/BuildEngineFactory.mjs` | 📉 -76 B (-1.62%) | 4.59 kB → 4.52 kB
`node_modules/hyperformula/es/Serialization.mjs` | 📉 -76 B (-1.65%) | 4.5 kB → 4.42 kB
`node_modules/hyperformula/es/dependencyTransformers/RemoveColumnsTransformer.mjs` | 📉 -76 B (-1.68%) | 4.41 kB → 4.34 kB
`node_modules/hyperformula/es/interpreter/plugin/ArrayPlugin.mjs` | 📉 -76 B (-1.69%) | 4.38 kB → 4.31 kB
`node_modules/hyperformula/es/dependencyTransformers/MoveCellsTransformer.mjs` | 📉 -76 B (-1.75%) | 4.25 kB → 4.17 kB
`node_modules/hyperformula/es/dependencyTransformers/RemoveRowsTransformer.mjs` | 📉 -76 B (-1.78%) | 4.16 kB → 4.09 kB
`node_modules/chevrotain/lib_esm/src/parse/grammar/interpreter.js` | 📉 -325 B (-1.92%) | 16.52 kB → 16.2 kB
`node_modules/hyperformula/es/interpreter/plugin/FinancialPlugin.mjs` | 📉 -495 B (-1.96%) | 24.64 kB → 24.16 kB
`node_modules/@bufbuild/protobuf/dist/esm/proto-int64.js` | 📉 -54 B (-1.97%) | 2.68 kB → 2.63 kB
`node_modules/hyperformula/es/AbsoluteCellRange.mjs` | 📉 -273 B (-2.03%) | 13.12 kB → 12.86 kB
`node_modules/hyperformula/es/dependencyTransformers/Transformer.mjs` | 📉 -76 B (-2.05%) | 3.62 kB → 3.54 kB
`node_modules/hyperformula/es/parser/ParserWithCaching.mjs` | 📉 -252 B (-2.05%) | 11.99 kB → 11.75 kB
`node_modules/hyperformula/es/interpreter/FunctionRegistry.mjs` | 📉 -182 B (-2.11%) | 8.44 kB → 8.26 kB
`node_modules/hyperformula/es/interpreter/ArithmeticHelper.mjs` | 📉 -432 B (-2.13%) | 19.78 kB → 19.36 kB
`node_modules/set-function-length/index.js` | 📉 -29 B (-2.21%) | 1.28 kB → 1.25 kB
`node_modules/hyperformula/es/ArrayValue.mjs` | 📉 -76 B (-2.26%) | 3.28 kB → 3.21 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/reflect.js` | 📉 -259 B (-2.29%) | 11.03 kB → 10.78 kB
`node_modules/hyperformula/es/ClipboardOperations.mjs` | 📉 -76 B (-2.39%) | 3.11 kB → 3.03 kB
`node_modules/hyperformula/es/parser/LexerConfig.mjs` | 📉 -134 B (-2.41%) | 5.43 kB → 5.3 kB
`node_modules/hyperformula/es/dependencyTransformers/AddColumnsTransformer.mjs` | 📉 -76 B (-2.49%) | 2.98 kB → 2.9 kB
`node_modules/hyperformula/es/Lookup/AdvancedFind.mjs` | 📉 -76 B (-2.55%) | 2.91 kB → 2.84 kB
`node_modules/hyperformula/es/parser/ColumnAddress.mjs` | 📉 -76 B (-2.63%) | 2.83 kB → 2.75 kB
`node_modules/hyperformula/es/dependencyTransformers/AddRowsTransformer.mjs` | 📉 -76 B (-2.64%) | 2.82 kB → 2.74 kB
`node_modules/hyperformula/es/interpreter/binarySearch.mjs` | 📉 -76 B (-2.70%) | 2.75 kB → 2.68 kB
`node_modules/hyperformula/es/i18n/TranslationPackage.mjs` | 📉 -76 B (-2.70%) | 2.75 kB → 2.67 kB
`node_modules/hyperformula/es/interpreter/plugin/AddressPlugin.mjs` | 📉 -76 B (-2.71%) | 2.74 kB → 2.66 kB
`node_modules/hyperformula/es/interpreter/Interpreter.mjs` | 📉 -437 B (-2.81%) | 15.16 kB → 14.73 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📉 -551 B (-2.82%) | 19.11 kB → 18.57 kB
`home/runner/work/actual/actual/packages/crdt/src/crdt/merkle.ts` | 📉 -59 B (-2.84%) | 2.03 kB → 1.97 kB
`node_modules/hyperformula/es/format/parser.mjs` | 📉 -76 B (-2.84%) | 2.61 kB → 2.54 kB
`node_modules/hyperformula/es/Span.mjs` | 📉 -76 B (-2.85%) | 2.61 kB → 2.53 kB
`node_modules/hyperformula/es/parser/Cache.mjs` | 📉 -76 B (-2.94%) | 2.53 kB → 2.45 kB
`node_modules/chevrotain/lib_esm/src/scan/lexer.js` | 📉 -753 B (-2.97%) | 24.8 kB → 24.06 kB
`node_modules/hyperformula/es/parser/collectDependencies.mjs` | 📉 -76 B (-2.98%) | 2.49 kB → 2.42 kB
`node_modules/hyperformula/es/parser/RowAddress.mjs` | 📉 -76 B (-3.03%) | 2.45 kB → 2.38 kB
`node_modules/is-generator-function/index.js` | 📉 -29 B (-3.08%) | 943 B → 914 B
`node_modules/hyperformula/es/Config.mjs` | 📉 -265 B (-3.09%) | 8.37 kB → 8.12 kB
`node_modules/chevrotain/lib_esm/src/utils/utils.js` | 📉 -288 B (-3.24%) | 8.68 kB → 8.4 kB
`node_modules/vite-plugin-node-polyfills/shims/buffer/dist/index.cjs` | 📉 -1.88 kB (-3.28%) | 57.52 kB → 55.63 kB
`node_modules/vite-plugin-node-polyfills/shims/buffer/dist/index.js` | 📉 -1.88 kB (-3.29%) | 57.37 kB → 55.49 kB
`node_modules/hyperformula/es/error-message.mjs` | 📉 -153 B (-3.44%) | 4.34 kB → 4.19 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📉 -208 B (-3.50%) | 5.8 kB → 5.6 kB
`node_modules/hyperformula/es/CellContentParser.mjs` | 📉 -165 B (-3.68%) | 4.38 kB → 4.22 kB
`node_modules/hyperformula/es/interpreter/plugin/DateTimePlugin.mjs` | 📉 -839 B (-3.72%) | 22.05 kB → 21.23 kB
`node_modules/hyperformula/es/ArgumentSanitization.mjs` | 📉 -76 B (-3.74%) | 1.98 kB → 1.91 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/reflect-check.js` | 📉 -238 B (-3.82%) | 6.08 kB → 5.84 kB
`node_modules/hyperformula/es/index.mjs` | 📉 -123 B (-3.83%) | 3.14 kB → 3.02 kB
`node_modules/dunder-proto/get.js` | 📉 -33 B (-3.92%) | 842 B → 809 B
`node_modules/hyperformula/es/LazilyTransformingAstService.mjs` | 📉 -76 B (-4.11%) | 1.8 kB → 1.73 kB
`node_modules/get-proto/index.js` | 📉 -29 B (-4.17%) | 696 B → 667 B
`node_modules/@rschedule/core/es2015/rules.js` | 📉 -1.25 kB (-4.27%) | 29.4 kB → 28.14 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/traits/gast_recorder.js` | 📉 -464 B (-4.32%) | 10.5 kB → 10.04 kB
`node_modules/hyperformula/es/interpreter/plugin/LookupPlugin.mjs` | 📉 -443 B (-4.32%) | 10.02 kB → 9.59 kB
`node_modules/hyperformula/es/parser/Unparser.mjs` | 📉 -210 B (-4.36%) | 4.71 kB → 4.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📉 -910 B (-4.36%) | 20.37 kB → 19.48 kB
`node_modules/hyperformula/es/interpreter/plugin/BitShiftPlugin.mjs` | 📉 -76 B (-4.74%) | 1.57 kB → 1.49 kB
`node_modules/has-symbols/index.js` | 📉 -29 B (-4.97%) | 583 B → 554 B
`home/runner/work/actual/actual/packages/crdt/src/crdt/timestamp.ts` | 📉 -275 B (-4.98%) | 5.39 kB → 5.12 kB
`node_modules/pako/lib/zlib/deflate.js` | 📉 -1.45 kB (-4.99%) | 29 kB → 27.56 kB
`node_modules/@bufbuild/protobuf/dist/esm/from-binary.js` | 📉 -286 B (-5.07%) | 5.51 kB → 5.23 kB
`node_modules/available-typed-arrays/index.js` | 📉 -29 B (-5.11%) | 568 B → 539 B
`node_modules/hyperformula/es/GraphBuilder.mjs` | 📉 -206 B (-5.13%) | 3.92 kB → 3.72 kB
`node_modules/safe-regex-test/index.js` | 📉 -29 B (-5.29%) | 548 B → 519 B
`node_modules/hyperformula/es/parser/RelativeDependency.mjs` | 📉 -76 B (-5.31%) | 1.4 kB → 1.32 kB
`node_modules/hyperformula/es/interpreter/plugin/TrigonometryPlugin.mjs` | 📉 -284 B (-5.32%) | 5.21 kB → 4.94 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Z0IVOHEd.js | 0 B → 4.86 MB (+4.86 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DjCqYlkp.js | 5.29 MB → 0 B (-5.29 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->