### PR TITLE
:electron:  Fix desktop app workflow for windows builds

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - windows-latest
+          - windows-2022
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -36,12 +36,6 @@ jobs:
           persist-credentials: false
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
-      - if: ${{ startsWith(matrix.os, 'windows') }}
-        name: Configure Visual Studio for node-gyp
-        # windows-latest uses windows-2025 where node-gyp cannot auto-detect
-        # the VS 2022 installation. Setting GYP_MSVS_VERSION explicitly is required
-        # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
-        run: echo "GYP_MSVS_VERSION=2022" >> "$GITHUB_ENV"
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -36,6 +36,12 @@ jobs:
           persist-credentials: false
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        name: Configure Visual Studio for node-gyp
+        # windows-latest uses windows-2025 where node-gyp cannot auto-detect
+        # the VS 2022 installation. Setting msvs_version explicitly is required
+        # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
+        run: npm config set msvs_version 2022
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -39,9 +39,9 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'windows') }}
         name: Configure Visual Studio for node-gyp
         # windows-latest uses windows-2025 where node-gyp cannot auto-detect
-        # the VS 2022 installation. Setting msvs_version explicitly is required
+        # the VS 2022 installation. Setting GYP_MSVS_VERSION explicitly is required
         # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
-        run: npm config set msvs_version 2022
+        run: echo "GYP_MSVS_VERSION=2022" >> "$GITHUB_ENV"
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -42,6 +42,12 @@ jobs:
           persist-credentials: false
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        name: Configure Visual Studio for node-gyp
+        # windows-latest uses windows-2025 where node-gyp cannot auto-detect
+        # the VS 2022 installation. Setting msvs_version explicitly is required
+        # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
+        run: npm config set msvs_version 2022
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -45,9 +45,9 @@ jobs:
       - if: ${{ startsWith(matrix.os, 'windows') }}
         name: Configure Visual Studio for node-gyp
         # windows-latest uses windows-2025 where node-gyp cannot auto-detect
-        # the VS 2022 installation. Setting msvs_version explicitly is required
+        # the VS 2022 installation. Setting GYP_MSVS_VERSION explicitly is required
         # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
-        run: npm config set msvs_version 2022
+        run: echo "GYP_MSVS_VERSION=2022" >> "$GITHUB_ENV"
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - windows-latest
+          - windows-2022
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,12 +42,6 @@ jobs:
           persist-credentials: false
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: pip.exe install setuptools
-      - if: ${{ startsWith(matrix.os, 'windows') }}
-        name: Configure Visual Studio for node-gyp
-        # windows-latest uses windows-2025 where node-gyp cannot auto-detect
-        # the VS 2022 installation. Setting GYP_MSVS_VERSION explicitly is required
-        # for @electron/rebuild to compile native modules (bcrypt, better-sqlite3).
-        run: echo "GYP_MSVS_VERSION=2022" >> "$GITHUB_ENV"
       - if: ${{ ! startsWith(matrix.os, 'windows') }}
         run: |
           mkdir .venv

--- a/upcoming-release-notes/8211.md
+++ b/upcoming-release-notes/8211.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Update desktop app publish workflow to work with the new GitHub runners

--- a/upcoming-release-notes/8211.md
+++ b/upcoming-release-notes/8211.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MikesGlitch]
 ---
 
-Update desktop app publish workflow to work with the new GitHub runners
+Pinning desktop app workflows to the 2022 GitHub runners


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

windows-latest on GitHub Actions recently switched to windows-2025. This broke the windows electron builds.

Pinning us to 2022 to fix the issue, we can try the upgrade at a later time. 


<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
