### PR TITLE
[AI] Fix payee rule counts for completed schedules

### DIFF
--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,63 @@
+// @ts-strict-ignore
+import { loadMappings } from '#server/db/mappings';
+import { app as rulesApp } from '#server/rules/app';
+import { createSchedule, updateSchedule } from '#server/schedules/app';
+import { loadRules } from '#server/transactions/transaction-rules';
+
+import { app as payeesApp } from './app';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+  await loadRules();
+});
+
+describe('payee app', () => {
+  it('excludes completed schedule rules from payee rule counts', async () => {
+    const payeeId = await payeesApp.handlers['payee-create']({
+      name: 'Quarterly taxes',
+    });
+
+    await rulesApp.handlers['rule-add']({
+      stage: 'pre',
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'manual rule' }],
+    });
+
+    await createSchedule({
+      schedule: {
+        name: 'Active estimate',
+        completed: false,
+      },
+      conditions: [
+        { op: 'is', field: 'payee', value: payeeId },
+        { op: 'is', field: 'date', value: '2026-06-01' },
+      ],
+    });
+
+    const completedScheduleId = await createSchedule({
+      schedule: {
+        name: 'Completed estimate',
+        completed: false,
+      },
+      conditions: [
+        { op: 'is', field: 'payee', value: payeeId },
+        { op: 'is', field: 'date', value: '2026-06-01' },
+      ],
+    });
+
+    await updateSchedule({
+      schedule: {
+        id: completedScheduleId,
+        completed: true,
+      },
+    });
+
+    await loadRules();
+
+    expect(await payeesApp.handlers['payees-get-rule-counts']()).toEqual({
+      [payeeId]: 2,
+    });
+  });
+});

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -47,6 +47,10 @@ describe('payee app', () => {
       ],
     });
 
+    expect(await payeesApp.handlers['payees-get-rule-counts']()).toEqual({
+      [payeeId]: 3,
+    });
+
     await updateSchedule({
       schedule: {
         id: completedScheduleId,

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -73,8 +73,19 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
+  const completedScheduleRules = new Set(
+    (
+      await db.all<Pick<db.DbSchedule, 'rule'>>(
+        'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
+      )
+    ).map(schedule => schedule.rule),
+  );
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    if (rule.id != null && completedScheduleRules.has(rule.id)) {
+      return;
+    }
+
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }

--- a/upcoming-release-notes/payee-rule-count-completed-schedules.md
+++ b/upcoming-release-notes/payee-rule-count-completed-schedules.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [pupuking723]
 ---
 
-Fix payee rule counts including rules from completed schedules.
+Fix payee rule counts to exclude rules from completed schedules.

--- a/upcoming-release-notes/payee-rule-count-completed-schedules.md
+++ b/upcoming-release-notes/payee-rule-count-completed-schedules.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [pupuking723]
+---
+
+Fix payee rule counts including rules from completed schedules.


### PR DESCRIPTION
## Description

修复 payee 列表中的 associated rules 计数会包含已完成 schedule 关联规则的问题。

当前规则管理界面会隐藏已完成 schedule 关联的规则，但 payee 计数仍然把这些规则算进去，导致用户看到有规则数量，点进去却看不到对应规则。本次改动让 `payees-get-rule-counts` 与规则列表的过滤逻辑保持一致：已完成 schedule 关联的规则不再计入 payee rule count。

我使用 Codex 作为代码辅助工具，但已逐行检查本次 diff，并在本地运行了目标测试、格式检查和 lint。

## Related issue(s)

Fixes #8134

## Testing

- `yarn workspace @actual-app/core test:node src/server/payees/app.test.ts`
- `yarn exec oxfmt --check packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts upcoming-release-notes/payee-rule-count-completed-schedules.md`
- `yarn exec oxlint --type-aware --quiet packages/loot-core/src/server/payees/app.ts packages/loot-core/src/server/payees/app.test.ts`
- `git diff --check`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 13.23 MB | 0%
loot-core | 1 | 4.86 MB → 4.86 MB (+227 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+225 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 13.23 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/ManageRules.js | 46.47 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.51 kB | 0%
static/js/SchedulesTable.js | 203.52 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.49 MB | 0%
static/js/_baseIsEqual.js | 76.76 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 202.14 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 473.99 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 364.55 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.01 kB | 0%
static/js/toString.js | 638.95 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.23 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.86 MB → 4.86 MB (+227 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +227 B (+3.74%) | 5.92 kB → 6.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cgkuvfxt.js | 0 B → 4.86 MB (+4.86 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DhLbg59B.js | 4.86 MB → 0 B (-4.86 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+225 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +225 B (+3.76%) | 5.84 kB → 6.06 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+225 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->