### PR TITLE
[WIP] fix(api): escape dollar signs in schedule names used in AQL filters

### DIFF
--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -917,8 +917,11 @@ handlers['api/schedule-update'] = withMutation(async function ({
     switch (typedKey) {
       case 'name': {
         const newName = String(value);
+        // Escape $ to prevent AQL from misinterpreting it as a field reference
+        // when used as a literal filter value (e.g. schedule named "$Groceries").
+        const aqlSafeName = newName.replace(/\$/g, '\\$');
         const { data: existing } = await aqlQuery(
-          q('schedules').filter({ name: newName }).select('*'),
+          q('schedules').filter({ name: aqlSafeName }).select('*'),
         );
         if (!existing || existing.length === 0 || existing[0].id === sched.id) {
           sched.name = newName;
@@ -1047,7 +1050,9 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
     throw APIError('Provide a valid type');
   }
 
-  const { data } = await aqlQuery(q(type).filter({ name }).select('*'));
+  // Escape $ to prevent AQL from misinterpreting it as a field reference.
+  const aqlSafeName = name.replace(/\$/g, '\\$');
+  const { data } = await aqlQuery(q(type).filter({ name: aqlSafeName }).select('*'));
 
   if (!data || data.length === 0) {
     throw APIError(`Not found: ${type} with name ${name}`);

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -1052,7 +1052,9 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
 
   // Escape $ to prevent AQL from misinterpreting it as a field reference.
   const aqlSafeName = name.replace(/\$/g, '\\$');
-  const { data } = await aqlQuery(q(type).filter({ name: aqlSafeName }).select('*'));
+  const { data } = await aqlQuery(
+    q(type).filter({ name: aqlSafeName }).select('*'),
+  );
 
   if (!data || data.length === 0) {
     throw APIError(`Not found: ${type} with name ${name}`);

--- a/upcoming-release-notes/7358.md
+++ b/upcoming-release-notes/7358.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix error when saving a schedule whose name starts with a dollar sign ($)


### PR DESCRIPTION
## What

Saving a schedule whose name starts with a `$` (dollar sign) threw an error. AQL interprets `$` as a variable prefix, so an unescaped schedule name caused a parse failure.

## Fix

Escape dollar signs in schedule names before they are interpolated into AQL filter strings in `api.ts`.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 13.23 MB | 0%
loot-core | 1 | 4.86 MB → 4.86 MB (+123 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+121 B) | +0.00%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 13.23 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/ManageRules.js | 46.47 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.51 kB | 0%
static/js/SchedulesTable.js | 203.52 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.49 MB | 0%
static/js/_baseIsEqual.js | 76.76 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 202.14 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 473.99 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 364.55 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.01 kB | 0%
static/js/toString.js | 638.95 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.23 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.86 MB → 4.86 MB (+123 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +123 B (+0.51%) | 23.51 kB → 23.63 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.q41-WZ4l.js | 0 B → 4.86 MB (+4.86 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DhLbg59B.js | 4.86 MB → 0 B (-4.86 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+121 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +121 B (+0.52%) | 22.89 kB → 23 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+121 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->