### PR TITLE
[WIP] fix(payees): exclude completed schedule rules from payee rule counts

### DIFF
--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -80,7 +80,9 @@ async function getPayeeRuleCounts() {
     'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0 AND rule IS NOT NULL',
   );
   const completedRuleIds = new Set(
-    completedScheduleRules.map(s => s.rule).filter((r): r is string => r !== null),
+    completedScheduleRules
+      .map(s => s.rule)
+      .filter((r): r is string => r !== null),
   );
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -76,10 +76,12 @@ async function getPayeeRuleCounts() {
 
   // Exclude rules that belong to completed schedules — those rules exist
   // only to drive the schedule and should not show as user-facing rules.
-  const completedScheduleRules = await db.all<{ rule: string }>(
-    'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
+  const completedScheduleRules = await db.all<{ rule: string | null }>(
+    'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0 AND rule IS NOT NULL',
   );
-  const completedRuleIds = new Set(completedScheduleRules.map(s => s.rule));
+  const completedRuleIds = new Set(
+    completedScheduleRules.map(s => s.rule).filter((r): r is string => r !== null),
+  );
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
     if (completedRuleIds.has(rule.id)) {

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -74,7 +74,17 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
 
+  // Exclude rules that belong to completed schedules — those rules exist
+  // only to drive the schedule and should not show as user-facing rules.
+  const completedScheduleRules = await db.all<{ rule: string }>(
+    'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
+  );
+  const completedRuleIds = new Set(completedScheduleRules.map(s => s.rule));
+
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    if (completedRuleIds.has(rule.id)) {
+      return;
+    }
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }

--- a/upcoming-release-notes/8134.md
+++ b/upcoming-release-notes/8134.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix payee associated rules count incorrectly including rules from completed schedules


### PR DESCRIPTION
## What

Payee rule counts were including rules that belong to completed schedules, inflating the count shown in the Payees list.

## Fix

- Exclude completed schedule rules from the payee rule count query
- Handle the nullable `rule` field in the completed schedules query to avoid crashes when `rule` is null

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 13.23 MB | 0%
loot-core | 1 | 4.86 MB → 4.86 MB (+284 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+281 B) | +0.01%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 13.23 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/ManageRules.js | 46.47 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.51 kB | 0%
static/js/SchedulesTable.js | 203.52 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.49 MB | 0%
static/js/_baseIsEqual.js | 76.76 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 202.14 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 473.99 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 364.55 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.01 kB | 0%
static/js/toString.js | 638.95 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.23 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.86 MB → 4.86 MB (+284 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +284 B (+4.68%) | 5.92 kB → 6.2 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cl3c8PLD.js | 0 B → 4.86 MB (+4.86 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DhLbg59B.js | 4.86 MB → 0 B (-4.86 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+281 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +281 B (+4.70%) | 5.84 kB → 6.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+281 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->