### PR TITLE
[WIP] fix(reports): apply correct filters when drilling down from Transfer/Uncategorized bars

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -329,6 +329,7 @@ export function BarGraph({
                     endDate: data.endDate,
                     field: groupBy.toLowerCase(),
                     id: item.id,
+                    uncategorized_id: item.uncategorized_id,
                   })
                 }
                 shape={(props: BarShapeProps) => (

--- a/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/BarGraph.tsx
@@ -313,25 +313,30 @@ export function BarGraph({
                   !['Group', 'Interval'].includes(groupBy) &&
                   setPointer('pointer')
                 }
-                onClick={item =>
-                  ((compact && showTooltip) || !compact) &&
-                  !['Group', 'Interval'].includes(groupBy) &&
-                  showActivity({
-                    navigate,
-                    categories,
-                    accounts,
-                    balanceTypeOp,
-                    filters,
-                    showHiddenCategories,
-                    showOffBudget,
-                    type: 'totals',
-                    startDate: data.startDate,
-                    endDate: data.endDate,
-                    field: groupBy.toLowerCase(),
-                    id: item.id,
-                    uncategorized_id: item.uncategorized_id,
-                  })
-                }
+                onClick={item => {
+                  const groupItem = (data.data ?? []).find(
+                    d => d.id === item.id,
+                  );
+                  return (
+                    ((compact && showTooltip) || !compact) &&
+                    !['Group', 'Interval'].includes(groupBy) &&
+                    showActivity({
+                      navigate,
+                      categories,
+                      accounts,
+                      balanceTypeOp,
+                      filters,
+                      showHiddenCategories,
+                      showOffBudget,
+                      type: 'totals',
+                      startDate: data.startDate,
+                      endDate: data.endDate,
+                      field: groupBy.toLowerCase(),
+                      id: item.id,
+                      uncategorized_id: groupItem?.uncategorized_id,
+                    })
+                  );
+                }}
                 shape={(props: BarShapeProps) => (
                   <Rectangle
                     {...props}

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -31,7 +31,10 @@ const RADIAN = Math.PI / 180;
 
 const canDeviceHover = () => window.matchMedia('(hover: hover)').matches;
 
-type ClickablePieItem = PieSectorDataItem & { id?: string };
+type ClickablePieItem = PieSectorDataItem & {
+  id?: string;
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
+};
 
 // ---------------------------------------------------------------------------
 // Dimension helpers

--- a/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/DonutGraph.tsx
@@ -600,6 +600,7 @@ export function DonutGraph({
                           endDate: data.endDate,
                           field: 'category',
                           id: item.id,
+                          uncategorized_id: item.uncategorized_id,
                         });
                       }
                     }}
@@ -707,6 +708,10 @@ export function DonutGraph({
                             ? 'category'
                             : groupBy.toLowerCase(),
                         id: groupBy === 'Group' ? groupCategoryIds : item.id,
+                        uncategorized_id:
+                          groupBy === 'Group'
+                            ? undefined
+                            : item.uncategorized_id,
                       });
                     }
                   }}

--- a/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/LineGraph.tsx
@@ -190,6 +190,7 @@ export function LineGraph({
     : [];
 
   const onShowActivity = (item, id, payload) => {
+    const legendEntry = data.legend.find(e => e.id === id || e.dataKey === id);
     showActivity({
       navigate,
       categories,
@@ -203,6 +204,7 @@ export function LineGraph({
       endDate: payload.payload.intervalEndDate,
       field: groupBy.toLowerCase(),
       id,
+      uncategorized_id: legendEntry?.uncategorized_id,
       interval,
     });
   };

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -303,6 +303,7 @@ export function StackedBarGraph({
                         endDate: e.payload?.intervalEndDate,
                         field: groupBy.toLowerCase(),
                         id: entry.id,
+                        uncategorized_id: entry.uncategorized_id,
                         interval,
                       })
                     }

--- a/packages/desktop-client/src/components/reports/graphs/showActivity.ts
+++ b/packages/desktop-client/src/components/reports/graphs/showActivity.ts
@@ -24,6 +24,7 @@ type showActivityProps = {
   endDate?: string;
   field?: string;
   id?: string | string[]; // changed: supports array for oneOf
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
   interval?: string;
 };
 
@@ -40,6 +41,7 @@ export function showActivity({
   endDate,
   field,
   id,
+  uncategorized_id,
   interval = 'Day',
 }: showActivityProps) {
   const isOutFlow =
@@ -53,15 +55,31 @@ export function showActivity({
           'FromDate') as 'dayFromDate' | 'monthFromDate' | 'yearFromDate');
   const isDateOp = interval === 'Weekly' || type !== 'time';
 
+  // Pseudo-category drill-downs: `id` is '' for transfer/off_budget/other groups.
+  // Build the correct filter based on uncategorized_id instead of the empty id.
+  const pseudoCategoryFilters =
+    uncategorized_id === 'transfer'
+      ? [{ field: 'transfer', op: 'is', value: true }]
+      : uncategorized_id === 'other'
+        ? [
+            { field: 'category', op: 'is', value: null, type: 'id' },
+            { field: 'transfer', op: 'is', value: false },
+          ]
+        : [];
+
   const filterConditions = [
     ...filters,
-    id && {
-      // changed: use oneOf when id is an array, is when it's a string
-      field,
-      op: Array.isArray(id) ? 'oneOf' : 'is',
-      value: id,
-      type: 'id',
-    },
+    // Skip the generic id-based category filter for pseudo-categories; their
+    // filters are handled by pseudoCategoryFilters above.
+    !uncategorized_id &&
+      id && {
+        // changed: use oneOf when id is an array, is when it's a string
+        field,
+        op: Array.isArray(id) ? 'oneOf' : 'is',
+        value: id,
+        type: 'id',
+      },
+    ...pseudoCategoryFilters,
     {
       field: 'date',
       op: isDateOp ? 'gte' : 'is',

--- a/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/tableGraph/ReportTableRow.tsx
@@ -178,6 +178,7 @@ export const ReportTableRow = memo(
                         endDate: intervalItem.intervalEndDate || '',
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                         interval,
                       })
                     }
@@ -235,6 +236,7 @@ export const ReportTableRow = memo(
                         endDate,
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                       })
                     }
                   />
@@ -285,6 +287,7 @@ export const ReportTableRow = memo(
                         endDate,
                         field: groupBy.toLowerCase(),
                         id: item.id,
+                        uncategorized_id: item.uncategorized_id,
                       })
                     }
                   />
@@ -334,6 +337,7 @@ export const ReportTableRow = memo(
                 endDate,
                 field: groupBy.toLowerCase(),
                 id: item.id,
+                uncategorized_id: item.uncategorized_id,
               })
             }
             width="flex"

--- a/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/calculateLegend.ts
@@ -66,12 +66,20 @@ export function calculateLegend(
   }
 
   const legend: LegendEntity[] = chooseData.map((item, index) => {
-    return {
+    const entry: LegendEntity = {
       id: item.id || '',
       name: item.name || '',
       color: getColor(item.data, index),
       dataKey: item.id || item.name || '', // Use id for unique data lookup
     };
+    const uncategorized_id =
+      groupBy !== 'Interval' &&
+      'uncategorized_id' in item.data &&
+      item.data.uncategorized_id;
+    if (uncategorized_id) {
+      entry.uncategorized_id = uncategorized_id;
+    }
+    return entry;
   });
   return legend;
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/recalculate.ts
@@ -115,5 +115,8 @@ export function recalculate({
     totalTotals,
     totalBudgeted: totalTotals,
     intervalData,
+    ...(item.uncategorized_id !== undefined && {
+      uncategorized_id: item.uncategorized_id,
+    }),
   };
 }

--- a/packages/loot-core/src/types/models/reports.ts
+++ b/packages/loot-core/src/types/models/reports.ts
@@ -90,6 +90,8 @@ export type LegendEntity = {
   id: string | null;
   color: string;
   dataKey: string; // Uses id for unique data lookup when categories have same name
+  /** Populated for pseudo-categories (transfer, off_budget, other) that share id: '' */
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
 };
 
 export type IntervalEntity = {
@@ -117,6 +119,8 @@ export type GroupedEntity = {
   netDebts: number;
   totalBudgeted: number;
   categories?: GroupedEntity[];
+  /** Populated for pseudo-categories (transfer, off_budget, other) that share id: '' */
+  uncategorized_id?: 'off_budget' | 'transfer' | 'other' | 'all';
 };
 
 export type Interval = {

--- a/upcoming-release-notes/7999.md
+++ b/upcoming-release-notes/7999.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [okxint]
+---
+
+Fix drill-down from Custom Report bar chart not applying Transfer/Uncategorized filters when clicking on pseudo-category rows


### PR DESCRIPTION
## What

Clicking a Transfer, Off-budget, or Uncategorized bar in a Custom Report chart opened the transaction drill-down with no category filter applied — showing all transactions for the period instead of the relevant subset.

These are pseudo-categories with `id: ''`, which is falsy, so `showActivity` silently skipped the filter.

## Fix

Thread an `uncategorized_id` value (`transfer | off_budget | other`) from `UncategorizedEntity` through `GroupedEntity` → `LegendEntity` → `showActivity`. In `showActivity`, pseudo-categories now receive the correct filters:

- `transfer`: `{ field: 'transfer', op: 'is', value: true }`
- `other`: `{ field: 'category', op: 'is', value: null }` + transfer is false

Also fixes TypeScript type errors in `BarGraph` and `DonutGraph` for `uncategorized_id`.

Fixes #7999