### PR TITLE
[WIP] feat(titlebar): add persistent degraded environment indicator

### DIFF
--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -6,7 +6,6 @@ import { Route, Routes, useLocation } from 'react-router';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SvgArrowLeft } from '@actual-app/components/icons/v1';
-import { Tooltip } from '@actual-app/components/tooltip';
 import {
   SvgAlertTriangle,
   SvgNavigationMenu,
@@ -18,6 +17,7 @@ import { styles } from '@actual-app/components/styles';
 import type { CSSProperties } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
 import { isDevelopmentEnvironment } from '@actual-app/core/shared/environment';

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -6,6 +6,7 @@ import { Route, Routes, useLocation } from 'react-router';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SvgArrowLeft } from '@actual-app/components/icons/v1';
+import { Tooltip } from '@actual-app/components/tooltip';
 import {
   SvgAlertTriangle,
   SvgNavigationMenu,
@@ -250,6 +251,45 @@ function ServerSyncButton({ style, isMobile = false }: ServerSyncButtonProps) {
   );
 }
 
+function DegradedEnvIndicator() {
+  const { t } = useTranslation();
+  const isDegraded =
+    typeof SharedArrayBuffer === 'undefined' &&
+    !!localStorage.getItem('SharedArrayBufferOverride');
+
+  if (!isDegraded) {
+    return null;
+  }
+
+  return (
+    <Tooltip
+      content={
+        <Trans>
+          Actual is running in a degraded state. Your server may not be using
+          HTTPS or may be missing required security headers. Data loss or sync
+          issues may occur. See{' '}
+          <a
+            href="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            the troubleshooting docs
+          </a>{' '}
+          for more information.
+        </Trans>
+      }
+    >
+      <Button
+        variant="bare"
+        aria-label={t('Degraded environment warning')}
+        style={{ color: theme.warningText }}
+      >
+        <SvgAlertTriangle style={{ width: 14, height: 14 }} />
+      </Button>
+    </Tooltip>
+  );
+}
+
 function BudgetTitlebar() {
   const [maxMonths, setMaxMonthsPref] = useGlobalPref('maxMonths');
 
@@ -342,6 +382,7 @@ export function Titlebar({ style }: TitlebarProps) {
       <SpaceBetween gap={10}>
         <UncategorizedButton />
         {isDevelopmentEnvironment() && !isTestEnv && <ThemeSelector />}
+        <DegradedEnvIndicator />
         <PrivacyButton />
         {serverURL ? <ServerSyncButton /> : null}
         <LoggedInUser />

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -268,13 +268,12 @@ function DegradedEnvIndicator() {
           Actual is running in a degraded state. Your server may not be using
           HTTPS or may be missing required security headers. Data loss or sync
           issues may occur. See{' '}
-          <a
-            href="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
-            target="_blank"
-            rel="noopener noreferrer"
+          <Link
+            variant="external"
+            to="https://actualbudget.org/docs/troubleshooting/shared-array-buffer"
           >
             the troubleshooting docs
-          </a>{' '}
+          </Link>{' '}
           for more information.
         </Trans>
       }

--- a/upcoming-release-notes/7747.md
+++ b/upcoming-release-notes/7747.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [okxint]
+---
+
+Show a persistent warning indicator in the titlebar when Actual is running in a degraded environment (HTTPS or security header misconfiguration)


### PR DESCRIPTION
## What

When `SharedArrayBuffer` is unavailable and the user has bypassed the warning (`SharedArrayBufferOverride` in localStorage), there was no ongoing indication that the environment is degraded. Users could forget they dismissed the warning and wonder why certain features behave unexpectedly.

## Fix

Adds a warning icon to the titlebar that persists for the session whenever the degraded-environment condition is active. The icon has a tooltip explaining the server may not be using HTTPS or is missing required security headers.

Also uses the `Link` component instead of a raw `<a>` tag in `DegradedEnvIndicator` for consistency with the rest of the codebase.

Closes #7747

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 | 13.23 MB → 13.24 MB (+1.64 kB) | +0.01%
loot-core | 1 | 4.86 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 7.97 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 | 13.23 MB → 13.24 MB (+1.64 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/Titlebar.tsx` | 📈 +1.64 kB (+13.68%) | 12.01 kB → 13.66 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB → 1.59 MB (+1.64 kB) | +0.10%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 814.39 kB | 0%
static/js/ManageRules.js | 46.47 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/ScheduleEditForm.js | 146.51 kB | 0%
static/js/SchedulesTable.js | 203.52 kB | 0%
static/js/TransactionEdit.js | 90.63 kB | 0%
static/js/TransactionList.js | 82.8 kB | 0%
static/js/Value.js | 4.49 MB | 0%
static/js/_baseIsEqual.js | 76.76 kB | 0%
static/js/ca.js | 185.63 kB | 0%
static/js/client.js | 450.92 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 182.38 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 202.14 kB | 0%
static/js/es.js | 177.58 kB | 0%
static/js/extends.js | 473.99 kB | 0%
static/js/fr.js | 177.35 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 163.93 kB | 0%
static/js/narrow.js | 364.55 kB | 0%
static/js/nb-NO.js | 147.07 kB | 0%
static/js/nl.js | 119.71 kB | 0%
static/js/pt-BR.js | 187.34 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.01 kB | 0%
static/js/toString.js | 638.95 kB | 0%
static/js/uk.js | 216.7 kB | 0%
static/js/useFormatList.js | 2.52 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.23 kB | 0%
static/js/workbox-window.prod.es5.js | 7.33 kB | 0%
static/js/zh-Hans.js | 116.44 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.86 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DhLbg59B.js | 4.86 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->