### PR TITLE
[WIP] QE Take-Home: E2E test plan and Playwright tests

### DIFF
--- a/.cursor/rules/qe-takehome.mdc
+++ b/.cursor/rules/qe-takehome.mdc
@@ -1,0 +1,167 @@
+---
+alwaysApply: false
+---
+# QE Take-Home — Playwright + pytest E2E Tests
+
+## What this is
+
+End-to-end tests for **Actual Budget** covering **envelope budgeting** and
+**account transactions**. Tests run in the browser against the local dev server
+(`http://localhost:3001`) — no backend API, no sync server, no Docker.
+
+- **Stack:** Python 3.12+, pytest, pytest-playwright, Chromium
+- **App:** Actual Budget started via `yarn start` (from repo root, port 3001)
+
+## Project layout
+
+```
+qe-takehome/
+├── data/constants.py          # all test data (names, amounts, display values)
+├── pages/                     # Page Object Model classes
+│   ├── budget_page.py         # BudgetPage — set budget, read balance/spent, transfer
+│   ├── account_page.py        # AccountPage — add/cancel txn, mark cleared
+│   └── configuration_page.py  # ConfigurationPage — first-run setup
+├── flows/app_flows.py         # shared setup: open_test_budget(), clear_sidebar_hover()
+├── tests/
+│   ├── test_budget.py         # BUD-01 to BUD-04
+│   ├── test_transactions.py   # TXN-01 to TXN-04
+│   └── test_journeys.py       # J-01, J-02
+├── conftest.py                # adds project root to sys.path
+├── pytest.ini                 # testpaths, base_url, browser
+└── TEST_PLAN.md               # test plan and manual findings
+```
+
+## Rules you MUST follow
+
+1. **Page objects in `pages/`, tests in `tests/`, flows in `flows/`.**
+   Never put assertions in page objects. Never put page interactions in test files
+   (use page object methods instead).
+
+2. **All test data in `data/constants.py`.**
+   No hardcoded strings or numbers in test files. Add new constants there and
+   import them.
+
+3. **Locators: `get_by_test_id()` and `get_by_role()` only.**
+   Do not use raw CSS selectors or XPath.
+
+4. **Compare money as integer cents.**
+   Use `to_cents()` and `balance_cents()` from `budget_page.py`.
+   Never compare money as floats.
+
+5. **Every test starts fresh.**
+   Call `open_test_budget(page)` from `flows/app_flows.py` at the top of each
+   test. This navigates to `/` and creates a new test file.
+
+6. **Call `clear_sidebar_hover(page)` before budget interactions.**
+   Sidebar tooltips can block clicks. Move the mouse to `(0, 0)` first.
+
+7. **Type hints on all function signatures.** Docstrings on page object classes
+   and non-obvious helpers.
+
+8. **One page object per page.** Don't mix budget actions into `AccountPage` or
+   vice versa.
+
+## How to run
+
+```bash
+# Terminal 1 — app (repo root)
+yarn start
+
+# Terminal 2 — tests (qe-takehome/)
+source .venv/bin/activate
+pytest -v                              # headless
+pytest -v --headed --slowmo=1000       # watch mode
+```
+
+## Patterns to follow
+
+### Adding a new test
+
+```python
+from playwright.sync_api import Page, expect
+from data.constants import SOME_VALUE
+from flows.app_flows import open_test_budget
+
+def test_my_new_case(page: Page):
+    budget_page = open_test_budget(page)
+    # interact via page objects, then assert
+    expect(some_locator).to_be_visible()
+```
+
+### Adding a new page object
+
+```python
+from playwright.sync_api import Page
+
+class NewPage:
+    def __init__(self, page: Page) -> None:
+        self.page = page
+        # locators via get_by_test_id / get_by_role
+
+    def some_action(self) -> None:
+        pass  # no assertions here
+```
+
+### Adding test data
+
+```python
+# data/constants.py
+NEW_CATEGORY = "Rent"
+NEW_AMOUNT_INPUT = "100"
+NEW_AMOUNT_DISPLAY = "100.00"
+```
+
+## Scope
+
+**In scope:** Budget page, Account/Transactions page (browser-only).
+**Out of scope:** Bank sync, Docker, REST API, Reports, Settings, sync server.
+
+## Do's and Don'ts
+
+### Do
+
+- **Do** use `open_test_budget(page)` to start every test with a clean state.
+- **Do** use `expect()` from Playwright for UI visibility/text checks and plain
+  `assert` for computed numeric comparisons (e.g. money in cents).
+- **Do** wait for elements before interacting — use `wait_for()`, `wait_for_timeout()`,
+  or Playwright's auto-waiting locators.
+- **Do** give test functions descriptive names matching the test plan IDs
+  (e.g. `test_overbudget_warning` for BUD-03).
+- **Do** keep page object methods small and single-purpose — one action per method.
+- **Do** use `parse_money()` and `to_cents()` for reading displayed amounts.
+- **Do** run `pytest -v` (headless) to validate before pushing, and `--headed` to debug.
+- **Do** keep `TEST_PLAN.md` in sync when adding or changing test cases.
+- **Do** add a comment with the test ID at the top of each test
+  (e.g. `# BUD-03: budgeting too much shows an overbudget warning`).
+- **Do** use `press_sequentially()` for typing into filtered/autocomplete fields
+  (e.g. payee, category pickers) — `fill()` skips input events the app relies on.
+
+### Don't
+
+- **Don't** use `page.locator("css=...")` or XPath — always use `get_by_test_id()`
+  or `get_by_role()`.
+- **Don't** hardcode strings like `"Food"` or `"25"` in test files — import from
+  `data/constants.py`.
+- **Don't** put `expect()` or `assert` inside page objects — page objects return
+  values, tests make assertions.
+- **Don't** compare money as floats (`==`). Convert to cents first with `to_cents()`.
+- **Don't** use `time.sleep()` — use Playwright's `wait_for_timeout()` or auto-waiting
+  locators instead.
+- **Don't** share state between tests — each test creates its own budget via
+  `open_test_budget()`. No fixtures that persist across tests.
+- **Don't** use `page.evaluate()` for things Playwright locators can handle natively.
+- **Don't** add new dependencies without updating `requirements.txt`.
+- **Don't** write one giant test that covers multiple features — split into focused
+  unit tests and use journey tests (`test_journeys.py`) for cross-feature flows.
+- **Don't** forget `clear_sidebar_hover(page)` before budget page interactions —
+  tooltip overlays will cause flaky click failures.
+
+## Troubleshooting
+
+| Problem                          | Fix                                                    |
+| -------------------------------- | ------------------------------------------------------ |
+| Tests fail before starting       | Is `yarn start` running on port 3001?                  |
+| Sidebar tooltip blocks a click   | Call `clear_sidebar_hover(page)` first                 |
+| Money comparison is flaky        | Use `balance_cents()` / `to_cents()`, never floats     |
+| Import error on pages/flows/data | `conftest.py` adds project root to `sys.path`          |
+| Playwright not found             | `pip install -r requirements.txt && playwright install chromium` |

--- a/qe-takehome/.gitignore
+++ b/qe-takehome/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+.pytest_cache/
+__pycache__/
+*.pyc

--- a/qe-takehome/README.md
+++ b/qe-takehome/README.md
@@ -1,0 +1,36 @@
+# QE Take Home — Actual Budget E2E Tests
+
+Playwright + pytest (Python). **Author:** Shreya Kumari
+
+**Prerequisites:** Node.js 22+, Yarn, Python 3.12+
+
+## Setup note
+
+Tests run against the local dev app (`yarn start` on port 3001).
+
+Docker is not required for these flows — budget and transactions work in the browser without a sync server. 
+
+## Run
+
+```bash
+# Terminal 1 — repo root
+yarn start
+
+# Terminal 2
+cd qe-takehome
+source .venv/bin/activate
+pip install -r requirements.txt   # first time only
+playwright install chromium       # first time only
+pytest -v
+```
+
+Headed (watch): `pytest -v --headed --slowmo=1000`
+
+## What's in this folder
+
+| File                        | Purpose                                |
+| --------------------------- | -------------------------------------- |
+| `TEST_PLAN.md`              | Test plan, manual findings, 10 cases   |
+| `docs/ai-sessions.md`       | How Cursor was used on this assignment |
+| `tests/`                    | 10 Playwright tests                    |
+| `pages/`, `flows/`, `data/` | Page objects and shared setup          |

--- a/qe-takehome/README.md
+++ b/qe-takehome/README.md
@@ -8,7 +8,7 @@ Playwright + pytest (Python). **Author:** Shreya Kumari
 
 Tests run against the local dev app (`yarn start` on port 3001).
 
-Docker is not required for these flows — budget and transactions work in the browser without a sync server. 
+Docker is not required for these flows — budget and transactions work in the browser without a sync server.
 
 ## Run
 

--- a/qe-takehome/TEST_PLAN.md
+++ b/qe-takehome/TEST_PLAN.md
@@ -1,0 +1,111 @@
+# Actual Budget — E2E Test Plan
+
+**Author:** Shreya Kumari  
+**Tool:** Playwright + pytest (Python)  
+**App URL:** http://localhost:3001
+
+---
+
+## 1. What I am testing
+
+Actual Budget is a personal finance app. Users budget money by category and track account transactions.
+
+| Feature                | What the user does                                                 |
+| ---------------------- | ------------------------------------------------------------------ |
+| **Envelope Budgeting** | Open Budget page, assign money to categories (Food, Savings, etc.) |
+| **Transactions**       | Open an account, add or cancel transactions, mark cleared          |
+
+**Not testing:** Bank sync, Docker, API calls, Reports, Settings.
+
+All tests run in the **browser only** (no backend API — Actual does not expose one for budget/transactions).
+
+**Approach:** Manual exploration first, then automation. Mix of positive and negative cases, plus 2 cross-feature journeys. Code uses Page Object Model (`pages/`, `flows/`, `data/`).
+
+---
+
+## 2. How to run
+
+See `README.md`.
+
+---
+
+## 3. What I found by clicking manually
+
+| What I tried                            | What happened                                            |
+| --------------------------------------- | -------------------------------------------------------- |
+| Change Food budget → press Escape       | Value stays the same (edit not saved)                    |
+| Change Food budget → click another cell | New value saves                                          |
+| Budget more than available              | Red text: **Overbudgeted** (no popup)                    |
+| Add New → Cancel on account             | Row removed, nothing saved                               |
+| Add Kroger $25 on account               | Row saved, Food **Spent** on Budget went up              |
+| New transaction tick                    | Hollow first; click → green (cleared)                    |
+| Hover account name in sidebar           | Floating panel on all accounts, not only truncated names |
+| Change transaction date and save        | Table re-sorts by date — rows move, payees swap position |
+
+---
+
+## 4. Test cases
+
+### Budget
+
+| ID     | +/- | Test                | Steps                                       | Expected                               | Done |
+| ------ | --- | ------------------- | ------------------------------------------- | -------------------------------------- | ---- |
+| BUD-01 | +   | Budget loads        | Don't use server → View demo                | Budget table + Available funds visible | Yes  |
+| BUD-02 | +   | Assign to Food      | Create test file → Food budget → 50 → Enter | Shows 50.00                            | Yes  |
+| BUD-03 | -   | Overbudget warning  | Budget more than available                  | Red Overbudgeted text                  | Yes  |
+| BUD-04 | +   | Transfer categories | Transfer balance to another category        | Balances update                        | Yes  |
+
+### Transactions
+
+| ID     | +/- | Test               | Steps                            | Expected             | Done |
+| ------ | --- | ------------------ | -------------------------------- | -------------------- | ---- |
+| TXN-01 | +   | Account opens      | Click Ally Savings               | Name + table visible | Yes  |
+| TXN-02 | +   | Add transaction    | Add New → Kroger, 25, Food → Add | Row saved            | Yes  |
+| TXN-03 | -   | Cancel transaction | Add New → Cancel                 | Row gone             | Yes  |
+| TXN-04 | +   | Cleared tick       | Add txn → click hollow tick      | Tick turns green     | Yes  |
+
+### Journeys (full flows)
+
+| ID   | Test                       | Steps                                    | Expected           | Done |
+| ---- | -------------------------- | ---------------------------------------- | ------------------ | ---- |
+| J-01 | Setup and budget           | Create test file → budget Food + Savings | Both amounts saved | Yes  |
+| J-02 | Transaction updates budget | Add Food txn → check Budget Food Spent   | Spent increases    | Yes  |
+
+---
+
+## 5. Project layout
+
+```
+qe-takehome/
+├── data/constants.py      # test data (names, amounts)
+├── pages/                 # page actions (click, fill)
+├── flows/app_flows.py     # common setup steps
+├── tests/                 # test cases only
+├── docs/ai-sessions.md    # how AI was used
+├── conftest.py
+├── TEST_PLAN.md
+└── README.md
+```
+
+---
+
+## 6. Automation status
+
+| File                       | Tests                          | Status    |
+| -------------------------- | ------------------------------ | --------- |
+| tests/test_budget.py       | BUD-01, BUD-02, BUD-03, BUD-04 | 4 passing |
+| tests/test_transactions.py | TXN-01, TXN-02, TXN-03, TXN-04 | 4 passing |
+| tests/test_journeys.py     | J-01, J-02                     | 2 passing |
+
+**Total: 10 tests — all passing**
+
+---
+
+## 7. Observations and suggested improvements
+
+Two items from manual exploration — suggestions, not defects.
+
+| Area            | Observation                                                                   | Suggestion                                                       | Priority |
+| --------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------- |
+| Sidebar tooltip | Hover shows a floating panel for every account, even when the name fits fully | Show tooltip only when truncated, or label it as account details | Low      |
+| Empty payee     | Date-only or $0 transaction with no payee still saves                         | Block or warn before saving rows with no payee and no amount     | Low      |

--- a/qe-takehome/conftest.py
+++ b/qe-takehome/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Allow imports like: from pages.budget_page import BudgetPage
+sys.path.insert(0, str(Path(__file__).parent))

--- a/qe-takehome/data/constants.py
+++ b/qe-takehome/data/constants.py
@@ -1,0 +1,23 @@
+# Shared test data — keeps amounts and names in one place
+
+BASE_URL = "/"
+
+# Accounts
+ALLY_SAVINGS = "Ally Savings"
+
+# Categories
+FOOD = "Food"
+SAVINGS = "Savings"
+
+# Budget amounts (input = what we type, display = what the UI shows)
+FOOD_BUDGET_INPUT = "50"
+FOOD_BUDGET_DISPLAY = "50.00"
+SAVINGS_BUDGET_INPUT = "30"
+SAVINGS_BUDGET_DISPLAY = "30.00"
+SAVINGS_TRANSFER_BUDGET = "500"
+OVERBUDGET_AMOUNT = "999999"
+
+# Transaction
+PAYEE_KROGER = "Kroger"
+TXN_AMOUNT = "25"          # typed into the debit field
+TXN_AMOUNT_VALUE = 25.0    # used for numeric checks on the budget page

--- a/qe-takehome/docs/ai-sessions.md
+++ b/qe-takehome/docs/ai-sessions.md
@@ -1,0 +1,57 @@
+# AI Sessions — How I Used Cursor
+
+**Author:** Shreya Kumari  
+**Project:** Actual Budget QE Take-Home
+
+---
+
+## Summary
+
+I used Cursor while working on this assignment. I tested the app manually first, wrote the test plan, then built the Playwright tests. When I needed help — setup questions, code drafts, or debugging — I asked Cursor. I always ran the tests and fixed anything that did not match what I saw in the app.
+
+---
+
+## What I worked on
+
+- Explored Budget and Transactions in the browser
+- Picked two features: envelope budgeting and account transactions
+- Wrote `TEST_PLAN.md` with test cases and manual notes
+- Built tests using page objects (`pages/`), shared flows (`flows/`), and test data (`data/`)
+- Ran the full suite with `pytest -v` (headless and headed)
+
+---
+
+## How I used Cursor
+
+| When I needed…              | What happened                                              |
+| --------------------------- | ---------------------------------------------------------- |
+| Help running Actual locally | Got steps for `yarn start` and browser-only E2E testing    |
+| Code for a page or test     | Cursor drafted it; I ran it and fixed selectors if needed  |
+| A failing test fixed        | Cursor helped find the cause; I re-ran until it passed     |
+| A format for docs           | Got a starting layout; I kept only what matched my testing |
+
+---
+
+## Things I changed after AI suggestions
+
+| Suggestion                  | What I kept instead                                 |
+| --------------------------- | --------------------------------------------------- |
+| One big test file           | Split into `pages/`, `flows/`, and `tests/` folders |
+| `expect()` for numbers      | Plain `assert` for money values                     |
+| Transfer from Food with $50 | Budget Savings first — Food had no positive balance |
+| Long documents              | Short, plain English                                |
+
+---
+
+## Example questions I asked
+
+1. How do I run Actual Budget locally for E2E tests?
+2. Can you split my tests into page objects and flows?
+3. Help me automate cancel transaction — I checked it manually already.
+4. Why does the add transaction test fail after clicking Add?
+
+---
+
+## Closing note
+
+Cursor saved time on repetitive code and debugging. The tests and test plan are based on what I clicked through in the app and what passed when I ran pytest locally.

--- a/qe-takehome/flows/app_flows.py
+++ b/qe-takehome/flows/app_flows.py
@@ -1,0 +1,19 @@
+"""Shared steps used at the start of many tests."""
+
+from playwright.sync_api import Page
+
+from data.constants import BASE_URL
+from pages.budget_page import BudgetPage
+from pages.configuration_page import ConfigurationPage
+
+
+def clear_sidebar_hover(page: Page) -> None:
+    """Move mouse to corner so sidebar tooltips do not block clicks."""
+    page.mouse.move(0, 0)
+
+
+def open_test_budget(page: Page) -> BudgetPage:
+    """Go to app and open a fresh test budget with sample data."""
+    page.goto(BASE_URL)
+    setup_page = ConfigurationPage(page)
+    return setup_page.create_test_file()

--- a/qe-takehome/pages/account_page.py
+++ b/qe-takehome/pages/account_page.py
@@ -1,0 +1,54 @@
+"""Account page — add transactions and mark them cleared."""
+
+from playwright.sync_api import Page
+
+
+class AccountPage:
+    def __init__(self, page: Page) -> None:
+        self.page = page
+        self.name = page.get_by_test_id("account-name")
+        self.balance = page.get_by_test_id("account-balance")
+        self.table = page.get_by_test_id("transaction-table")
+        self.new_row = page.get_by_test_id("new-transaction")
+
+    def open(self, account_name: str) -> None:
+        self.page.get_by_role("link", name=account_name).click()
+        self.table.wait_for()
+
+    def add_new(self) -> None:
+        self.page.get_by_role("button", name="Add New").click()
+
+    def fill(self, payee: str, debit: str, category: str) -> None:
+        row = self.new_row.get_by_test_id("row")
+
+        payee_cell = row.get_by_test_id("payee")
+        payee_cell.click()
+        payee_cell.get_by_role("textbox").press_sequentially(payee)
+        self.page.keyboard.press("Tab")
+
+        debit_cell = row.get_by_test_id("debit")
+        debit_cell.click()
+        debit_cell.get_by_role("textbox").press_sequentially(debit)
+        self.page.keyboard.press("Tab")
+
+        category_cell = row.get_by_test_id("category")
+        category_cell.click()
+        category_cell.get_by_role("textbox").press_sequentially(category)
+        self.page.keyboard.press("Tab")
+
+    def cancel(self) -> None:
+        self.page.get_by_role("button", name="Cancel").click()
+
+    def save(self) -> None:
+        self.page.get_by_test_id("add-button").click()
+        # App keeps an empty new row open until Cancel is clicked
+        self.page.get_by_role("button", name="Cancel").click()
+
+    def add(self, payee: str, debit: str, category: str) -> None:
+        self.add_new()
+        self.fill(payee, debit, category)
+        self.save()
+
+    def mark_cleared(self, payee: str) -> None:
+        row = self.table.get_by_test_id("row").filter(has_text=payee).first
+        row.get_by_test_id("cleared").click()

--- a/qe-takehome/pages/budget_page.py
+++ b/qe-takehome/pages/budget_page.py
@@ -1,0 +1,97 @@
+"""Budget page — assign amounts, read balances, transfer between categories."""
+
+import re
+import time
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def parse_money(text: str) -> float:
+    """Turn displayed money text (e.g. '1,234.56') into a float."""
+    text = text.replace("\u2212", "-").strip()
+    amounts = re.findall(r"-?\d[\d,]*\.\d{2}", text)
+    if amounts:
+        return float(amounts[-1].replace(",", ""))
+    fallback = re.search(r"-?[\d,.]+", text)
+    if not fallback:
+        return 0.0
+    return float(fallback.group().replace(",", ""))
+
+
+def to_cents(amount: float) -> int:
+    """Compare money as integer cents — avoids float rounding bugs."""
+    return round(amount * 100)
+
+
+class BudgetPage:
+    def __init__(self, page: Page) -> None:
+        self.page = page
+        self.summary = page.get_by_test_id("budget-summary")
+        self.table = page.get_by_test_id("budget-table")
+
+    def wait_for(self, timeout: int = 10_000) -> None:
+        self.table.wait_for(timeout=timeout)
+
+    def category_row(self, category_name: str) -> Locator:
+        return self.table.get_by_test_id("row").filter(
+            has=self.page.get_by_text(category_name, exact=True)
+        ).first
+
+    def balance_cell(self, category_name: str) -> Locator:
+        return self.category_row(category_name).get_by_test_id("balance").get_by_test_id(
+            re.compile(r"^budget")
+        )
+
+    def set_budget(self, category_name: str, amount: str) -> None:
+        budget_cell = self.category_row(category_name).get_by_test_id("budget").first
+        budget_cell.click()
+        input_field = budget_cell.locator("input")
+        input_field.wait_for(state="visible")
+        input_field.fill(amount)
+        input_field.press("Enter")
+        expect(input_field).not_to_be_visible()
+
+    def balance(self, category_name: str) -> float:
+        return parse_money(self.balance_cell(category_name).inner_text())
+
+    def balance_cents(self, category_name: str) -> int:
+        return to_cents(self.balance(category_name))
+
+    def spent(self, category_name: str) -> float:
+        spent_text = self.category_row(category_name).get_by_test_id(
+            "category-month-spent"
+        ).inner_text()
+        return parse_money(spent_text)
+
+    def transfer_balance(self, from_category: str, to_category: str) -> float:
+        """Move all balance from one category to another. Returns amount moved."""
+        amount_moved = self.balance(from_category)
+
+        self.balance_cell(from_category).click()
+        self.page.get_by_role("button", name="Transfer to another category").click()
+
+        category_picker = self.page.get_by_placeholder("(none)")
+        category_picker.click()
+        category_picker.press_sequentially(to_category)
+        self.page.keyboard.press("Enter")
+
+        transfer_button = self.page.get_by_role("button", name="Transfer")
+        expect(transfer_button).to_be_enabled(timeout=5_000)
+        transfer_button.click()
+
+        # Wait for source to empty, then give the UI time to update the target row
+        expect(self.balance_cell(from_category)).to_have_text("0.00", timeout=10_000)
+        self.page.wait_for_timeout(1_000)
+
+        return amount_moved
+
+    def wait_for_balance_cents(
+        self, category_name: str, expected_cents: int, timeout: int = 10_000
+    ) -> None:
+        """Poll until a category balance matches the expected cents value."""
+        deadline = time.time() + timeout / 1000
+        while time.time() < deadline:
+            if self.balance_cents(category_name) == expected_cents:
+                return
+            self.page.wait_for_timeout(100)
+        assert self.balance_cents(category_name) == expected_cents

--- a/qe-takehome/pages/configuration_page.py
+++ b/qe-takehome/pages/configuration_page.py
@@ -1,0 +1,28 @@
+"""First-run setup — server choice and creating a budget file."""
+
+from playwright.sync_api import Page
+
+from pages.budget_page import BudgetPage
+
+
+class ConfigurationPage:
+    def __init__(self, page: Page) -> None:
+        self.page = page
+        self.heading = page.get_by_role("heading")
+
+    def click_no_server(self) -> None:
+        self.page.get_by_role("button", name="Don't use a server").click()
+
+    def create_demo_file(self) -> BudgetPage:
+        """View demo — sample budget via the welcome screen."""
+        self.page.get_by_role("button", name="View demo").click()
+        budget_page = BudgetPage(self.page)
+        budget_page.wait_for()
+        return budget_page
+
+    def create_test_file(self) -> BudgetPage:
+        """Create test file — sample budget in one click (used by most tests)."""
+        self.page.get_by_role("button", name="Create test file").click()
+        budget_page = BudgetPage(self.page)
+        budget_page.wait_for()
+        return budget_page

--- a/qe-takehome/pytest.ini
+++ b/qe-takehome/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+base_url = http://localhost:3001
+addopts = --browser chromium

--- a/qe-takehome/requirements.txt
+++ b/qe-takehome/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=8.0
+pytest-playwright>=0.5.0
+playwright>=1.49.0

--- a/qe-takehome/tests/test_budget.py
+++ b/qe-takehome/tests/test_budget.py
@@ -1,0 +1,64 @@
+from playwright.sync_api import Page, expect
+
+from data.constants import (
+    FOOD,
+    FOOD_BUDGET_DISPLAY,
+    FOOD_BUDGET_INPUT,
+    OVERBUDGET_AMOUNT,
+    SAVINGS,
+    SAVINGS_TRANSFER_BUDGET,
+)
+from flows.app_flows import clear_sidebar_hover, open_test_budget
+from pages.budget_page import to_cents
+from pages.configuration_page import ConfigurationPage
+
+
+def test_budget_loads_with_demo_data(page: Page):
+    # BUD-01: welcome flow loads demo budget with sample data
+    page.goto("/")
+    setup_page = ConfigurationPage(page)
+
+    expect(setup_page.heading).to_have_text("Where's the server?")
+    setup_page.click_no_server()
+    expect(page.get_by_text("Let's get started!")).to_be_visible()
+
+    budget_page = setup_page.create_demo_file()
+    expect(budget_page.table).to_be_visible(timeout=30_000)
+    expect(budget_page.summary.get_by_text("Available funds").first).to_be_visible()
+
+
+def test_assign_budget_to_food(page: Page):
+    # BUD-02: type a budget amount and confirm it saves
+    budget_page = open_test_budget(page)
+    clear_sidebar_hover(page)
+
+    budget_page.set_budget(FOOD, FOOD_BUDGET_INPUT)
+    expect(budget_page.category_row(FOOD).get_by_test_id("budget")).to_have_text(
+        FOOD_BUDGET_DISPLAY
+    )
+
+
+def test_overbudget_warning(page: Page):
+    # BUD-03: budgeting too much shows an overbudget warning
+    budget_page = open_test_budget(page)
+    clear_sidebar_hover(page)
+
+    budget_page.set_budget(FOOD, OVERBUDGET_AMOUNT)
+    expect(budget_page.summary.get_by_text("Overbudgeted").first).to_be_visible()
+
+
+def test_transfer_between_categories(page: Page):
+    # BUD-04: move savings balance into food
+    budget_page = open_test_budget(page)
+    clear_sidebar_hover(page)
+
+    food_balance_before_cents = budget_page.balance_cents(FOOD)
+    budget_page.set_budget(SAVINGS, SAVINGS_TRANSFER_BUDGET)
+    expect(budget_page.balance_cell(SAVINGS)).not_to_have_text("0.00")
+
+    amount_moved = budget_page.transfer_balance(SAVINGS, FOOD)
+    expected_food_cents = food_balance_before_cents + to_cents(amount_moved)
+    budget_page.wait_for_balance_cents(FOOD, expected_food_cents)
+
+    assert budget_page.balance_cents(SAVINGS) == 0
+    assert budget_page.balance_cents(FOOD) == expected_food_cents

--- a/qe-takehome/tests/test_journeys.py
+++ b/qe-takehome/tests/test_journeys.py
@@ -1,0 +1,52 @@
+from playwright.sync_api import Page, expect
+
+from data.constants import (
+    ALLY_SAVINGS,
+    FOOD,
+    FOOD_BUDGET_DISPLAY,
+    FOOD_BUDGET_INPUT,
+    PAYEE_KROGER,
+    SAVINGS,
+    SAVINGS_BUDGET_DISPLAY,
+    SAVINGS_BUDGET_INPUT,
+    TXN_AMOUNT,
+    TXN_AMOUNT_VALUE,
+)
+from flows.app_flows import clear_sidebar_hover, open_test_budget
+from pages.account_page import AccountPage
+from pages.budget_page import BudgetPage
+
+
+def test_setup_and_budget(page: Page):
+    # J-01: budget two categories in one session
+    budget_page = open_test_budget(page)
+    clear_sidebar_hover(page)
+
+    budget_page.set_budget(FOOD, FOOD_BUDGET_INPUT)
+    budget_page.set_budget(SAVINGS, SAVINGS_BUDGET_INPUT)
+
+    expect(budget_page.category_row(FOOD).get_by_test_id("budget")).to_have_text(
+        FOOD_BUDGET_DISPLAY
+    )
+    expect(budget_page.category_row(SAVINGS).get_by_test_id("budget")).to_have_text(
+        SAVINGS_BUDGET_DISPLAY
+    )
+
+
+def test_transaction_updates_food_spent(page: Page):
+    # J-02: a food transaction on an account updates food spent on the budget page
+    budget_page = open_test_budget(page)
+    clear_sidebar_hover(page)
+
+    food_spent_before = budget_page.spent(FOOD)
+
+    page.get_by_role("link", name=ALLY_SAVINGS).click()
+    account_page = AccountPage(page)
+    account_page.add(PAYEE_KROGER, TXN_AMOUNT, FOOD)
+
+    page.goto("/budget")
+    budget_page = BudgetPage(page)
+    budget_page.wait_for()
+
+    food_spent_after = budget_page.spent(FOOD)
+    assert food_spent_after == food_spent_before - TXN_AMOUNT_VALUE

--- a/qe-takehome/tests/test_transactions.py
+++ b/qe-takehome/tests/test_transactions.py
@@ -1,0 +1,67 @@
+from playwright.sync_api import Page, expect
+
+from data.constants import ALLY_SAVINGS, FOOD, PAYEE_KROGER, TXN_AMOUNT
+from flows.app_flows import open_test_budget
+from pages.account_page import AccountPage
+
+
+def test_account_page_loads(page: Page):
+    # TXN-01: open an account from the sidebar
+    open_test_budget(page)
+
+    account_page = AccountPage(page)
+    account_page.open(ALLY_SAVINGS)
+
+    expect(account_page.name).to_have_text(ALLY_SAVINGS)
+    expect(account_page.table).to_be_visible()
+
+
+def test_cancel_new_transaction(page: Page):
+    # TXN-03: cancel removes the draft row without saving
+    open_test_budget(page)
+
+    account_page = AccountPage(page)
+    account_page.open(ALLY_SAVINGS)
+
+    account_page.add_new()
+    expect(account_page.new_row).to_be_visible()
+
+    account_page.cancel()
+    expect(account_page.new_row).not_to_be_visible()
+
+
+def test_add_food_transaction(page: Page):
+    # TXN-02: add a transaction and confirm payee appears in the table
+    open_test_budget(page)
+
+    account_page = AccountPage(page)
+    account_page.open(ALLY_SAVINGS)
+
+    account_page.add_new()
+    account_page.fill(PAYEE_KROGER, TXN_AMOUNT, FOOD)
+    account_page.save()
+
+    expect(account_page.new_row).not_to_be_visible()
+    expect(
+        account_page.table.get_by_test_id("row").first.get_by_test_id("payee")
+    ).to_have_text(PAYEE_KROGER)
+
+
+def test_mark_transaction_cleared(page: Page):
+    # TXN-04: cleared tick changes from hollow to filled
+    open_test_budget(page)
+
+    account_page = AccountPage(page)
+    account_page.open(ALLY_SAVINGS)
+
+    account_page.add_new()
+    account_page.fill(PAYEE_KROGER, TXN_AMOUNT, FOOD)
+    account_page.save()
+
+    row = account_page.table.get_by_test_id("row").filter(has_text=PAYEE_KROGER).first
+    cleared_icon = row.get_by_test_id("cleared").locator("path")
+    icon_shape_before = cleared_icon.get_attribute("d")
+
+    account_page.mark_cleared(PAYEE_KROGER)
+
+    expect(cleared_icon).not_to_have_attribute("d", icon_shape_before or "")


### PR DESCRIPTION
## Description

QE take-home submission (Shreya Kumari).

This PR adds a self-contained `qe-takehome/` folder with:

- **Test plan** (`TEST_PLAN.md`) — scope, manual exploration notes, 10 test cases (BUD / TXN / J)
- **Playwright + pytest tests** — envelope budgeting and account transactions (browser-only E2E)
- **AI usage docs** — `docs/ai-sessions.md` (how Cursor was used) and `.cursor/rules/qe-takehome.mdc` (Cursor rules for this work)

**Features tested:** Budget (assign amounts, overbudget warning, transfer) and Transactions (add, cancel, cleared tick), plus 2 cross-feature journeys.