### PR TITLE
improve CI yarn cache to make the fetch step quicker

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: 22
-        package-manager-cache: ${{ inputs.cache }}
+        package-manager-cache: false
     - name: Install yarn
       run: npm install -g yarn
       shell: bash
@@ -38,6 +38,15 @@ runs:
       with:
         path: ${{ format('{0}/**/node_modules', inputs.working-directory) }}
         key: yarn-v1-${{ runner.os }}-${{ steps.get-node.outputs.version }}-${{ hashFiles(format('{0}/**/yarn.lock', inputs.working-directory)) }}
+    - name: Cache Yarn download cache
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      if: ${{ inputs.cache == 'true' && steps.cache.outputs.cache-hit != 'true' }}
+      with:
+        path: ${{ format('{0}/.yarn/cache', inputs.working-directory) }}
+        key: yarn-dl-${{ runner.os }}-${{ steps.get-node.outputs.version }}-${{ hashFiles(format('{0}/**/yarn.lock', inputs.working-directory)) }}
+        restore-keys: |
+          yarn-dl-${{ runner.os }}-${{ steps.get-node.outputs.version }}-
+          yarn-dl-${{ runner.os }}-
     - name: Ensure Lage cache directory exists
       run: mkdir -p "$WORKING_DIRECTORY/.lage"
       shell: bash

--- a/upcoming-release-notes/ci-yarn-download-cache.md
+++ b/upcoming-release-notes/ci-yarn-download-cache.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Improve CI yarn cache to make the fetch step quicker


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Claude assisted

The old cache method meant that if that exact build hadn't run, the cache was never used. After this change, if it can't find a complete match it will find the most recent platform run and restore that. Then `yarn` will come along and update the gaps. In my estimation it should save about 20-40s on every CI job that runs `yarn install --immutable` in a PR with dependency changes, but we'll see.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

I haven't, it's hard to test the cache, but it's not very risky and easy to rollback

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
