### PR TITLE
[AI] Migrate remaining CI workflows to Depot action runners

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -127,7 +127,7 @@ jobs:
 
   vrt:
     name: Visual regression (shard ${{ matrix.shard }}/3)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: build-web
     strategy:
       fail-fast: false
@@ -165,7 +165,7 @@ jobs:
   merge-vrt:
     name: Merge VRT Reports
     needs: vrt
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/e2e-vrt-comment.yml
+++ b/.github/workflows/e2e-vrt-comment.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   comment:
     name: Post VRT Comment
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Download VRT metadata

--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-22.04
             runner: depot-ubuntu-22.04-4
           - os: windows-2022
-            runner: windows-2022
+            runner: depot-windows-2022
           - os: macos-latest
             runner: depot-macos-latest
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/electron-pr.yml
+++ b/.github/workflows/electron-pr.yml
@@ -35,7 +35,7 @@ jobs:
           - os: ubuntu-22.04
             runner: depot-ubuntu-22.04-4
           - os: windows-2022
-            runner: windows-2022
+            runner: depot-windows-2022
           - os: macos-latest
             runner: depot-macos-latest
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/publish-microsoft-store.yml
+++ b/.github/workflows/publish-microsoft-store.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   publish-microsoft-store:
-    runs-on: windows-latest
+    runs-on: depot-windows-2022
     environment: release
     steps:
       - name: Resolve version

--- a/.github/workflows/publish-nightly-electron.yml
+++ b/.github/workflows/publish-nightly-electron.yml
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-22.04
             runner: depot-ubuntu-22.04-4
           - os: windows-latest
-            runner: windows-latest
+            runner: depot-windows-2022
           - os: macos-latest
             runner: depot-macos-latest
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/vrt-update-apply.yml
+++ b/.github/workflows/vrt-update-apply.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   apply-vrt-updates:
     name: Apply VRT Updates
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     environment: pr-automation
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   add-reaction:
     name: Add 👀 Reaction
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     # Only run on PR comments containing /update-vrt
     if: >
       github.event.issue.pull_request &&
@@ -38,7 +38,7 @@ jobs:
 
   get-pr:
     name: Resolve PR details
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     if: >
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/update-vrt')
@@ -63,7 +63,7 @@ jobs:
 
   build-web:
     name: Build web bundle
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: get-pr
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -97,7 +97,7 @@ jobs:
 
   browser-vrt:
     name: Browser VRT (shard ${{ matrix.shard }}/3)
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: [get-pr, build-web]
     strategy:
       fail-fast: false
@@ -167,7 +167,7 @@ jobs:
 
   desktop-vrt:
     name: Desktop VRT
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: get-pr
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy
@@ -233,7 +233,7 @@ jobs:
 
   merge-patch:
     name: Merge VRT Patches
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     needs: [get-pr, browser-vrt, desktop-vrt]
     if: ${{ !cancelled() && needs.get-pr.result == 'success' }}
     steps:

--- a/upcoming-release-notes/migrate-workflows-to-depot-runners.md
+++ b/upcoming-release-notes/migrate-workflows-to-depot-runners.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Migrate remaining CI workflows to depot action runners


### PR DESCRIPTION
## Description

Switching the remaining jobs to use depot action runners. We will now have them all in the same place. Some of these might be slightly slower.. but at least it will give us data in depot so we can start optimizing them.

Also: the work @matt-fidd did on VRT stability improvements has unlocked moving VRTs to depot 🎉 

## Related issue(s)

N/A

## Testing

CI should pass

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

https://claude.ai/code/session_013dQEH47R5kTkPCvhC2cpoB