### PR TITLE
automation UI: fix various bugs

### DIFF
--- a/packages/desktop-client/src/components/budget/goals/ActiveEditor.tsx
+++ b/packages/desktop-client/src/components/budget/goals/ActiveEditor.tsx
@@ -22,6 +22,7 @@ type ActiveEditorProps = {
   categories: CategoryGroupEntity[];
   hasLimitAutomation: boolean;
   onAddLimitAutomation: () => void;
+  defaultWeeklyStart: string;
 };
 
 export function ActiveEditor({
@@ -31,10 +32,17 @@ export function ActiveEditor({
   categories,
   hasLimitAutomation,
   onAddLimitAutomation,
+  defaultWeeklyStart,
 }: ActiveEditorProps) {
   switch (state.displayType) {
     case 'limit':
-      return <LimitAutomation template={state.template} dispatch={dispatch} />;
+      return (
+        <LimitAutomation
+          template={state.template}
+          dispatch={dispatch}
+          defaultWeeklyStart={defaultWeeklyStart}
+        />
+      );
     case 'refill':
       return (
         <RefillAutomation

--- a/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
+++ b/packages/desktop-client/src/components/budget/goals/CategoryAutomationButton.tsx
@@ -17,6 +17,7 @@ import {
   emptyCleanupConfig,
 } from '#components/budget/goals/cleanupModel';
 import type { CleanupConfig } from '#components/budget/goals/cleanupModel';
+import { displayTemplateTypes } from '#components/budget/goals/constants';
 import { MonthsContext } from '#components/budget/MonthsContext';
 import { migrateTemplatesToAutomations } from '#components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations';
 import { useCategories } from '#hooks/useCategories';
@@ -102,6 +103,11 @@ export function CategoryAutomationButton({
   }
 
   const automations = getAutomationEntries(category.goal_def);
+  const sortedAutomations = [...automations].sort(
+    (a, b) =>
+      displayTemplateTypes.indexOf(a.displayType) -
+      displayTemplateTypes.indexOf(b.displayType),
+  );
   const categoryNameMap: Record<string, string> = {};
   for (const cat of categoriesData?.list ?? []) {
     categoryNameMap[cat.id] = cat.name;
@@ -152,7 +158,7 @@ export function CategoryAutomationButton({
       placement="bottom start"
       content={
         <View style={{ maxWidth: 320, padding: 10, gap: 10 }}>
-          {automations.map(entry => (
+          {sortedAutomations.map(entry => (
             <View key={entry.id} style={{ gap: 4 }}>
               <Text style={{ display: 'block' }}>
                 <TemplateSentence

--- a/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
@@ -89,9 +89,19 @@ export const BySaveAutomation = ({
 
   const committedRepeat = template.repeat ?? 1;
   const [rawRepeat, setRawRepeat] = useState(String(committedRepeat));
+
   useEffect(() => {
     setRawRepeat(String(committedRepeat));
   }, [committedRepeat]);
+
+  const onRepeatChange = (value: string) => {
+    setRawRepeat(value);
+    const parsed = Math.trunc(Number(value));
+    if (value.trim() !== '' && parsed >= 1 && parsed !== committedRepeat) {
+      dispatch(updateTemplate({ type: template.type, repeat: parsed }));
+    }
+  };
+
   const commitRepeat = () => {
     const parsed = Math.max(1, Math.trunc(Number(rawRepeat)) || 1);
     setRawRepeat(String(parsed));
@@ -176,7 +186,7 @@ export const BySaveAutomation = ({
               min={1}
               step={1}
               value={rawRepeat}
-              onChangeValue={setRawRepeat}
+              onChangeValue={onRepeatChange}
               onBlur={commitRepeat}
             />
           </FormField>

--- a/packages/desktop-client/src/components/budget/goals/editor/FixedAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/FixedAutomation.tsx
@@ -47,6 +47,20 @@ export const FixedAutomation = ({
   useEffect(() => {
     setRawPeriodAmount(String(periodAmount));
   }, [periodAmount]);
+
+  const onPeriodAmountChange = (value: string) => {
+    setRawPeriodAmount(value);
+    const parsed = Math.trunc(Number(value));
+    if (value.trim() !== '' && parsed >= 1 && parsed !== periodAmount) {
+      dispatch(
+        updateTemplate({
+          type: 'periodic',
+          period: { period: periodUnit, amount: parsed },
+        }),
+      );
+    }
+  };
+
   const commitPeriodAmount = () => {
     const parsed = Math.max(1, Math.trunc(Number(rawPeriodAmount)) || 1);
     setRawPeriodAmount(String(parsed));
@@ -86,7 +100,7 @@ export const FixedAutomation = ({
           min={1}
           step={1}
           value={rawPeriodAmount}
-          onChangeValue={setRawPeriodAmount}
+          onChangeValue={onPeriodAmountChange}
           onBlur={commitPeriodAmount}
         />
       </FormField>

--- a/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/LimitAutomation.tsx
@@ -5,8 +5,8 @@ import { SpaceBetween } from '@actual-app/components/space-between';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import {
-  currentDate,
   dayFromDate,
+  firstDayOfMonth,
   parseDate,
 } from '@actual-app/core/shared/months';
 import { amountToInteger, integerToAmount } from '@actual-app/core/shared/util';
@@ -27,11 +27,13 @@ import { useFormat } from '#hooks/useFormat';
 type LimitAutomationProps = {
   template: LimitTemplate;
   dispatch: (action: Action) => void;
+  defaultWeeklyStart?: string;
 };
 
 export const LimitAutomation = ({
   template,
   dispatch,
+  defaultWeeklyStart,
 }: LimitAutomationProps) => {
   const { t } = useTranslation();
   const format = useFormat();
@@ -42,8 +44,11 @@ export const LimitAutomation = ({
     template.amount,
     format.currency.decimalPlaces,
   );
-  const start = template.start;
-  const dayOfWeek = start ? getDay(parseDate(start)) : 0;
+  const start =
+    template.start ??
+    defaultWeeklyStart ??
+    dayFromDate(firstDayOfMonth(new Date()));
+  const dayOfWeek = getDay(parseDate(start));
   const hold = template.hold;
 
   const selectButtonClassName = css({
@@ -63,7 +68,7 @@ export const LimitAutomation = ({
           dispatch(
             updateTemplate({
               type: 'limit',
-              start: dayFromDate(setDay(currentDate(), Number(value))),
+              start: dayFromDate(setDay(parseDate(start), Number(value))),
             }),
           )
         }
@@ -100,7 +105,11 @@ export const LimitAutomation = ({
         id="cadence-field"
         value={period}
         onChange={cadence =>
-          dispatch(updateTemplate({ type: 'limit', period: cadence }))
+          dispatch(
+            cadence === 'weekly' && !template.start
+              ? updateTemplate({ type: 'limit', period: cadence, start })
+              : updateTemplate({ type: 'limit', period: cadence }),
+          )
         }
         options={[
           ['daily', t('Day')],

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx
@@ -9,6 +9,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { tokens } from '@actual-app/components/tokens';
 import { View } from '@actual-app/components/view';
+import { dayFromDate, firstDayOfMonth } from '@actual-app/core/shared/months';
 import type {
   CategoryGroupEntity,
   ScheduleEntity,
@@ -69,6 +70,26 @@ const SINGLETON_TYPES: ReadonlySet<DisplayTemplateType> = new Set([
   'remainder',
 ]);
 
+function getDefaultWeeklyStart(entries: AutomationEntry[]): string {
+  const starts: string[] = [];
+
+  for (const { template } of entries) {
+    if (template.type === 'periodic' && template.starting) {
+      starts.push(template.starting);
+    } else if (
+      (template.type === 'by' || template.type === 'spend') &&
+      template.month
+    ) {
+      starts.push(`${template.month}-01`);
+    }
+  }
+
+  const earliest =
+    starts.length > 0 ? starts.reduce((a, b) => (a < b ? a : b)) : null;
+
+  return earliest ?? dayFromDate(firstDayOfMonth(new Date()));
+}
+
 type AutomationEditorPaneProps = {
   entries: AutomationEntry[];
   activeIdx: number;
@@ -97,6 +118,7 @@ export function AutomationEditorPane({
   const activeError = automationErrors[activeIdx];
 
   const state = active ? getInitialState(active.template) : null;
+  const defaultWeeklyStart = getDefaultWeeklyStart(entries);
 
   const dispatch = (action: Parameters<typeof templateReducer>[1]) => {
     setEntries(prev =>
@@ -284,6 +306,7 @@ export function AutomationEditorPane({
                 categories={categories}
                 hasLimitAutomation={hasLimitAutomation}
                 onAddLimitAutomation={onAddLimitAutomation}
+                defaultWeeklyStart={defaultWeeklyStart}
               />
             </View>
           </>
@@ -298,6 +321,7 @@ export function AutomationEditorPane({
             categories={categories}
             hasLimitAutomation={hasLimitAutomation}
             onAddLimitAutomation={onAddLimitAutomation}
+            defaultWeeklyStart={defaultWeeklyStart}
           />
         )}
 

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
@@ -100,7 +100,7 @@ describe('migrateTemplatesToAutomations', () => {
     });
   });
 
-  it('expands `#template 0 up to N` into limit + fixed-zero (not refill)', () => {
+  it('expands `#template 0 up to N` into a standalone limit (no refill, no $0 contribution)', () => {
     const simpleTemplate = {
       type: 'simple',
       directive: 'template',
@@ -115,13 +115,12 @@ describe('migrateTemplatesToAutomations', () => {
 
     const result = migrateTemplatesToAutomations([simpleTemplate]);
 
-    expect(result).toHaveLength(2);
-    expect(result.map(entry => entry.displayType)).toEqual(['limit', 'fixed']);
-    expect(result[1].template).toMatchObject({
-      type: 'periodic',
-      amount: 0,
+    expect(result).toHaveLength(1);
+    expect(result.map(entry => entry.displayType)).toEqual(['limit']);
+    expect(result[0].template).toMatchObject({
+      type: 'limit',
+      amount: 1000,
       directive: 'template',
-      priority: 4,
     });
   });
 

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
@@ -15,7 +15,7 @@ describe('migrateTemplatesToAutomations', () => {
     expect(migrateTemplatesToAutomations([simpleTemplate])).toEqual([]);
   });
 
-  it('drops simple templates whose monthly amount is zero with no limit', () => {
+  it('migrates a standalone `#template 0` (no limit) into a $0 fixed entry', () => {
     const simpleTemplate = {
       type: 'simple',
       directive: 'template',
@@ -23,7 +23,17 @@ describe('migrateTemplatesToAutomations', () => {
       monthly: 0,
     } satisfies Template;
 
-    expect(migrateTemplatesToAutomations([simpleTemplate])).toEqual([]);
+    const result = migrateTemplatesToAutomations([simpleTemplate]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].displayType).toBe('fixed');
+    expect(result[0].template).toMatchObject({
+      type: 'periodic',
+      amount: 0,
+      period: { period: 'month', amount: 1 },
+      directive: 'template',
+      priority: 5,
+    });
   });
 
   it('migrates a goal directive to a long-term goal entry', () => {

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.test.ts
@@ -152,6 +152,98 @@ describe('migrateTemplatesToAutomations', () => {
     });
   });
 
+  it('splits a periodic template with an `up to` limit into fixed + limit entries', () => {
+    // `#template 32.5 repeat every 1 days starting 2025-02-01 up to 2500`: the
+    // fixed editor can't show the inline cap, so the limit must become its own
+    // entry rather than vanishing and re-serialising as a duplicate `up to`.
+    const periodicTemplate = {
+      type: 'periodic',
+      directive: 'template',
+      priority: 2,
+      amount: 32.5,
+      period: { period: 'day', amount: 1 },
+      starting: '2025-02-01',
+      limit: {
+        amount: 2500,
+        hold: false,
+        period: 'monthly',
+      },
+    } satisfies Template;
+
+    const result = migrateTemplatesToAutomations([periodicTemplate]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(entry => entry.displayType)).toEqual(['fixed', 'limit']);
+    expect(result[0].template).toEqual({
+      type: 'periodic',
+      directive: 'template',
+      priority: 2,
+      amount: 32.5,
+      period: { period: 'day', amount: 1 },
+      starting: '2025-02-01',
+    });
+    expect(result[1].template).toEqual({
+      type: 'limit',
+      amount: 2500,
+      hold: false,
+      period: 'monthly',
+      start: undefined,
+      directive: 'template',
+      priority: null,
+    });
+  });
+
+  it('splits a remainder template with an `up to` limit into remainder + limit entries', () => {
+    const remainderTemplate = {
+      type: 'remainder',
+      directive: 'template',
+      priority: null,
+      weight: 2,
+      limit: {
+        amount: 500,
+        hold: true,
+        period: 'monthly',
+      },
+    } satisfies Template;
+
+    const result = migrateTemplatesToAutomations([remainderTemplate]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(entry => entry.displayType)).toEqual([
+      'remainder',
+      'limit',
+    ]);
+    expect(result[0].template).toEqual({
+      type: 'remainder',
+      directive: 'template',
+      priority: null,
+      weight: 2,
+    });
+    expect(result[1].template).toMatchObject({
+      type: 'limit',
+      amount: 500,
+      hold: true,
+      period: 'monthly',
+    });
+  });
+
+  it('leaves a periodic template without a limit as a single fixed entry', () => {
+    const periodicTemplate = {
+      type: 'periodic',
+      directive: 'template',
+      priority: 2,
+      amount: 10,
+      period: { period: 'month', amount: 1 },
+      starting: '2025-02-01',
+    } satisfies Template;
+
+    const result = migrateTemplatesToAutomations([periodicTemplate]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].displayType).toBe('fixed');
+    expect(result[0].template).toEqual(periodicTemplate);
+  });
+
   it('creates a single entry for non-simple templates', () => {
     const scheduleTemplate = {
       type: 'schedule',

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -83,12 +83,17 @@ export function migrateTemplatesToAutomations(
         }
       }
 
-      if (hasMonthly) {
+      const contribution =
+        hasMonthly || (monthly === 0 && template.limit == null)
+          ? monthly
+          : null;
+
+      if (contribution != null) {
         entries.push(
           createAutomationEntry(
             {
               type: 'periodic',
-              amount: monthly,
+              amount: contribution,
               period: { period: 'month', amount: 1 },
               starting: dayFromDate(firstDayOfMonth(new Date())),
               directive: 'template',

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -106,6 +106,31 @@ export function migrateTemplatesToAutomations(
       return;
     }
 
+    if (
+      (template.type === 'periodic' || template.type === 'remainder') &&
+      template.limit
+    ) {
+      const { limit, ...base } = template;
+      entries.push(
+        createAutomationEntry(base, getDisplayTypeFromTemplate(base)),
+      );
+      entries.push(
+        createAutomationEntry(
+          {
+            type: 'limit',
+            amount: limit.amount,
+            hold: limit.hold,
+            period: limit.period,
+            start: limit.start,
+            directive: 'template',
+            priority: null,
+          },
+          'limit',
+        ),
+      );
+      return;
+    }
+
     entries.push(
       createAutomationEntry(template, getDisplayTypeFromTemplate(template)),
     );

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts
@@ -47,8 +47,7 @@ export function migrateTemplatesToAutomations(
   templates.forEach(template => {
     if (template.type === 'simple') {
       const monthly = template.monthly;
-      const hasMonthly =
-        monthly != null && (monthly !== 0 || template.limit != null);
+      const hasMonthly = monthly != null && monthly !== 0;
       const { description } = template;
 
       if (template.limit) {
@@ -70,7 +69,7 @@ export function migrateTemplatesToAutomations(
           ),
         );
 
-        if (!hasMonthly) {
+        if (monthly == null) {
           entries.push(
             createAutomationEntry(
               {

--- a/upcoming-release-notes/budget-automation-feedback.md
+++ b/upcoming-release-notes/budget-automation-feedback.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix various QOL and parsing bugs in the Automation UI


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Assisted by Claude for the tests

Fixes all reported bugs in the automation UI, doesn't add any of the feature requests

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Each commit addresses one of the below for ease of reviewing

https://github.com/actualbudget/actual/issues/7692#issuecomment-4641576734
https://github.com/actualbudget/actual/issues/7692#issuecomment-4643466235 (bugs 1 and 2)
https://github.com/actualbudget/actual/issues/7692#issuecomment-4653661241 (and https://github.com/actualbudget/actual/issues/7692#issuecomment-4660123033)
https://github.com/actualbudget/actual/issues/7692#issuecomment-4668638675

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

All repro instructions in the bug reports linked above.
Tests added where appropriate

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.1 MB → 13.11 MB (+3.18 kB) | +0.02%
loot-core | 1 | 4.9 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.1 MB → 13.11 MB (+3.18 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts` | 📈 +533 B (+27.08%) | 1.92 kB → 2.44 kB
`src/components/budget/goals/editor/FixedAutomation.tsx` | 📈 +596 B (+7.58%) | 7.68 kB → 8.26 kB
`src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx` | 📈 +812 B (+5.67%) | 13.99 kB → 14.78 kB
`src/components/budget/goals/editor/LimitAutomation.tsx` | 📈 +465 B (+4.46%) | 10.18 kB → 10.64 kB
`src/components/budget/goals/editor/BySaveAutomation.tsx` | 📈 +546 B (+4.02%) | 13.27 kB → 13.8 kB
`src/components/budget/goals/ActiveEditor.tsx` | 📈 +109 B (+3.27%) | 3.26 kB → 3.37 kB
`src/components/budget/goals/CategoryAutomationButton.tsx` | 📈 +195 B (+2.46%) | 7.75 kB → 7.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB → 7.61 MB (+2.99 kB) | +0.04%
static/js/wide.js | 298.21 kB → 298.4 kB (+195 B) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.33 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.23 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTfCF_Gu.js | 4.9 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->