### PR TITLE
[WIP] [AI] Fix payee rule count to exclude schedule-owned rules

### DIFF
--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,99 @@
+// @ts-strict-ignore
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import {
+  insertRule,
+  loadRules,
+  resetState,
+} from '#server/transactions/transaction-rules';
+
+import { getPayeeRuleCountsForTest } from './app';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  resetState();
+  await loadMappings();
+  await loadRules();
+});
+
+describe('getPayeeRuleCounts', () => {
+  test('counts only standalone rules, not schedule-owned rules', async () => {
+    const payeeId = 'payee-1';
+
+    // Insert a standalone rule for the payee
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'test' }],
+    });
+
+    // Insert a schedule-owned rule for the same payee
+    const scheduleRuleId = await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'schedule rule' }],
+    });
+
+    // Link that rule to a completed schedule
+    await db.insertWithUUID('schedules', {
+      rule: scheduleRuleId,
+      active: 0,
+      completed: 1,
+      posts_transaction: 0,
+      tombstone: 0,
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    // Should be 1 (standalone only), not 2
+    expect(counts[payeeId]).toBe(1);
+  });
+
+  test('counts standalone rules correctly when no schedules exist', async () => {
+    const payeeId = 'payee-2';
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'rule 1' }],
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'rule 2' }],
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    expect(counts[payeeId]).toBe(2);
+  });
+
+  test('excludes active schedule rules too, not just completed', async () => {
+    const payeeId = 'payee-3';
+
+    const scheduleRuleId = await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'active schedule rule' }],
+    });
+
+    // Active (not completed) schedule
+    await db.insertWithUUID('schedules', {
+      rule: scheduleRuleId,
+      active: 1,
+      completed: 0,
+      posts_transaction: 0,
+      tombstone: 0,
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    expect(counts[payeeId]).toBeUndefined();
+  });
+});

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -74,7 +74,13 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
 
+  const scheduleRuleIds = new Set(await rules.getAllRuleIdsFromSchedules(''));
+
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    const ruleId = rule.getId();
+    if (ruleId != null && scheduleRuleIds.has(ruleId)) {
+      return;
+    }
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }
@@ -83,6 +89,8 @@ async function getPayeeRuleCounts() {
 
   return payeeCounts;
 }
+
+export { getPayeeRuleCounts as getPayeeRuleCountsForTest };
 
 async function mergePayees({
   targetId,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.1 MB | 0%
loot-core | 1 | 4.9 MB → 4.9 MB (+167 B) | +0.00%
api | 2 | 3.94 MB → 3.94 MB (+164 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.1 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.33 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.23 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB → 4.9 MB (+167 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +167 B (+2.75%) | 5.92 kB → 6.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CNM-CrN5.js | 0 B → 4.9 MB (+4.9 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTfCF_Gu.js | 4.9 MB → 0 B (-4.9 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+164 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +164 B (+2.74%) | 5.84 kB → 6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+164 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->