### PR TITLE
wire tests up to depot test results analysis

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,6 +86,9 @@ jobs:
   test:
     needs: setup
     runs-on: depot-ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Authenticate to Depot via GitHub OIDC for test reporting
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -96,6 +99,11 @@ jobs:
           download-translations: 'false'
       - name: Test
         run: yarn test
+      - name: Report test results to Depot
+        uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
+        if: ${{ !cancelled() }}
+        with:
+          path: '**/test-results/junit*.xml'
   check-gh-actions:
     runs-on: depot-ubuntu-latest
     permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -103,7 +103,9 @@ jobs:
         uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
         if: ${{ !cancelled() }}
         with:
-          path: '**/test-results/junit*.xml'
+          path: |
+            bin/test-results/junit*.xml
+            packages/*/test-results/junit*.xml
   check-gh-actions:
     runs-on: depot-ubuntu-latest
     permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -101,7 +101,7 @@ jobs:
         run: yarn test
       - name: Report test results to Depot
         uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'push' }}
         with:
           path: |
             bin/test-results/junit*.xml

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -105,7 +105,7 @@ jobs:
     name: Report E2E results to Depot
     needs: functional
     runs-on: depot-ubuntu-latest
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name == 'merge_group' }}
     permissions:
       contents: read
       id-token: write # Authenticate to Depot via GitHub OIDC for test reporting
@@ -157,7 +157,7 @@ jobs:
           overwrite: true
       - name: Report test results to Depot
         uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'merge_group' }}
         with:
           path: packages/desktop-electron/e2e/test-results/junit.xml
 
@@ -233,7 +233,7 @@ jobs:
           pattern: vrt-junit-*
       - name: Report test results to Depot
         uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.event_name == 'merge_group' }}
         with:
           path: vrt-junit
       - name: Merge reports

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -92,10 +92,41 @@ jobs:
           path: packages/desktop-client/test-results/
           retention-days: 30
           overwrite: true
+      - name: Upload E2E JUnit report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: e2e-junit-${{ matrix.shard }}
+          path: packages/desktop-client/test-results/junit.xml
+          retention-days: 1
+          overwrite: true
+
+  report-e2e:
+    name: Report E2E results to Depot
+    needs: functional
+    runs-on: depot-ubuntu-latest
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+      id-token: write # Authenticate to Depot via GitHub OIDC for test reporting
+    steps:
+      - name: Download E2E JUnit reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: e2e-junit
+          pattern: e2e-junit-*
+      - name: Report test results to Depot
+        uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
+        if: ${{ !cancelled() }}
+        with:
+          path: e2e-junit
 
   functional-desktop-app:
     name: Functional Desktop App
     runs-on: depot-ubuntu-latest-4
+    permissions:
+      contents: read
+      id-token: write # Authenticate to Depot via GitHub OIDC for test reporting
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-jammy
     steps:
@@ -124,6 +155,11 @@ jobs:
           path: packages/desktop-electron/e2e/test-results/
           retention-days: 30
           overwrite: true
+      - name: Report test results to Depot
+        uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
+        if: ${{ !cancelled() }}
+        with:
+          path: packages/desktop-electron/e2e/test-results/junit.xml
 
   vrt:
     name: Visual regression (shard ${{ matrix.shard }}/3)
@@ -161,12 +197,23 @@ jobs:
           path: packages/desktop-client/blob-report/
           retention-days: 1
           overwrite: true
+      - name: Upload VRT JUnit report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: vrt-junit-${{ matrix.shard }}
+          path: packages/desktop-client/test-results/junit.xml
+          retention-days: 1
+          overwrite: true
 
   merge-vrt:
     name: Merge VRT Reports
     needs: vrt
     runs-on: depot-ubuntu-latest
     if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+      id-token: write # Authenticate to Depot via GitHub OIDC for test reporting
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -179,6 +226,16 @@ jobs:
           path: packages/desktop-client/all-blob-reports
           pattern: vrt-blob-report-*
           merge-multiple: true
+      - name: Download VRT JUnit reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: vrt-junit
+          pattern: vrt-junit-*
+      - name: Report test results to Depot
+        uses: depot/test-report-action@2ad5779840a9c63e884fa26f11d019768a27a941 # v1.0.1
+        if: ${{ !cancelled() }}
+        with:
+          path: vrt-junit
       - name: Merge reports
         id: merge-reports
         run: yarn workspace @actual-app/web run playwright merge-reports --reporter html ./all-blob-reports

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ build/
 # Lage cache
 .lage/
 
+# Test results (JUnit XML reports, Playwright artifacts)
+**/test-results/
+
 *storybook.log
 storybook-static
 

--- a/bin/vitest.config.mts
+++ b/bin/vitest.config.mts
@@ -6,7 +6,13 @@ export default defineConfig({
     include: ['__tests__/**/*.test.ts'],
     environment: 'node',
     reporters: process.env.CI
-      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'bin' }]]
+      ? [
+          'default',
+          [
+            'junit',
+            { outputFile: './test-results/junit.xml', suiteName: 'bin' },
+          ],
+        ]
       : ['default'],
   },
 });

--- a/bin/vitest.config.mts
+++ b/bin/vitest.config.mts
@@ -5,5 +5,8 @@ export default defineConfig({
     globals: true,
     include: ['__tests__/**/*.test.ts'],
     environment: 'node',
+    reporters: process.env.CI
+      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'bin' }]]
+      : ['default'],
   },
 });

--- a/packages/api/vite.config.mts
+++ b/packages/api/vite.config.mts
@@ -96,5 +96,11 @@ export default defineConfig({
       return type === 'stderr';
     },
     maxWorkers: 2,
+    reporters: process.env.CI
+      ? [
+          'default',
+          ['junit', { outputFile: './test-results/junit.xml', suiteName: 'api' }],
+        ]
+      : ['default'],
   },
 });

--- a/packages/api/vite.config.mts
+++ b/packages/api/vite.config.mts
@@ -99,7 +99,10 @@ export default defineConfig({
     reporters: process.env.CI
       ? [
           'default',
-          ['junit', { outputFile: './test-results/junit.xml', suiteName: 'api' }],
+          [
+            'junit',
+            { outputFile: './test-results/junit.xml', suiteName: 'api' },
+          ],
         ]
       : ['default'],
   },

--- a/packages/ci-actions/vitest.config.mts
+++ b/packages/ci-actions/vitest.config.mts
@@ -7,5 +7,8 @@ export default defineConfig({
     environment: 'node',
     maxWorkers: 1,
     isolate: false,
+    reporters: process.env.CI
+      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'ci-actions' }]]
+      : ['default'],
   },
 });

--- a/packages/ci-actions/vitest.config.mts
+++ b/packages/ci-actions/vitest.config.mts
@@ -8,7 +8,13 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
     reporters: process.env.CI
-      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'ci-actions' }]]
+      ? [
+          'default',
+          [
+            'junit',
+            { outputFile: './test-results/junit.xml', suiteName: 'ci-actions' },
+          ],
+        ]
       : ['default'],
   },
 });

--- a/packages/component-library/vitest.web.config.ts
+++ b/packages/component-library/vitest.web.config.ts
@@ -8,6 +8,18 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.web.test.(js|jsx|ts|tsx)'],
     maxWorkers: 2,
+    reporters: process.env.CI
+      ? [
+          'default',
+          [
+            'junit',
+            {
+              outputFile: './test-results/junit-web.xml',
+              suiteName: 'component-library (web)',
+            },
+          ],
+        ]
+      : ['default'],
   },
   plugins: [react(), peggyLoader()],
 });

--- a/packages/crdt/vitest.config.mts
+++ b/packages/crdt/vitest.config.mts
@@ -7,5 +7,8 @@ export default defineConfig({
     environment: 'node',
     maxWorkers: 1,
     isolate: false,
+    reporters: process.env.CI
+      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'crdt' }]]
+      : ['default'],
   },
 });

--- a/packages/crdt/vitest.config.mts
+++ b/packages/crdt/vitest.config.mts
@@ -8,7 +8,13 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
     reporters: process.env.CI
-      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'crdt' }]]
+      ? [
+          'default',
+          [
+            'junit',
+            { outputFile: './test-results/junit.xml', suiteName: 'crdt' },
+          ],
+        ]
       : ['default'],
   },
 });

--- a/packages/desktop-client/playwright.config.ts
+++ b/packages/desktop-client/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: process.env.CI ? 4 : undefined,
   testDir: 'e2e/',
   reporter: process.env.CI
-    ? [['blob'], ['list']]
+    ? [['blob'], ['list'], ['junit', { outputFile: 'test-results/junit.xml' }]]
     : [['html', { open: 'never' }]],
   use: {
     userAgent: 'playwright',

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -407,6 +407,12 @@ export default defineConfig(async ({ mode, command }) => {
         return type === 'stderr';
       },
       maxWorkers: 2,
+      reporters: process.env.CI
+        ? [
+            'default',
+            ['junit', { outputFile: './test-results/junit.xml', suiteName: 'desktop-client' }],
+          ]
+        : ['default'],
     },
   };
 });

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -410,7 +410,13 @@ export default defineConfig(async ({ mode, command }) => {
       reporters: process.env.CI
         ? [
             'default',
-            ['junit', { outputFile: './test-results/junit.xml', suiteName: 'desktop-client' }],
+            [
+              'junit',
+              {
+                outputFile: './test-results/junit.xml',
+                suiteName: 'desktop-client',
+              },
+            ],
           ]
         : ['default'],
     },

--- a/packages/desktop-electron/playwright.config.ts
+++ b/packages/desktop-electron/playwright.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   timeout: 60000, // 60 seconds
   retries: 1,
   testDir: 'e2e/',
-  reporter: undefined,
+  reporter: process.env.CI
+    ? [['list'], ['junit', { outputFile: 'e2e/test-results/junit.xml' }]]
+    : undefined,
   outputDir: 'e2e/test-results/',
   snapshotPathTemplate:
     '{testDir}/__screenshots__/{testFilePath}/{arg}-{platform}{ext}',

--- a/packages/eslint-plugin-actual/vitest.config.mts
+++ b/packages/eslint-plugin-actual/vitest.config.mts
@@ -7,5 +7,8 @@ export default defineConfig({
     environment: 'node',
     maxWorkers: 1,
     isolate: false,
+    reporters: process.env.CI
+      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'eslint-plugin-actual' }]]
+      : ['default'],
   },
 });

--- a/packages/eslint-plugin-actual/vitest.config.mts
+++ b/packages/eslint-plugin-actual/vitest.config.mts
@@ -8,7 +8,16 @@ export default defineConfig({
     maxWorkers: 1,
     isolate: false,
     reporters: process.env.CI
-      ? ['default', ['junit', { outputFile: './test-results/junit.xml', suiteName: 'eslint-plugin-actual' }]]
+      ? [
+          'default',
+          [
+            'junit',
+            {
+              outputFile: './test-results/junit.xml',
+              suiteName: 'eslint-plugin-actual',
+            },
+          ],
+        ]
       : ['default'],
   },
 });

--- a/packages/loot-core/vitest.config.ts
+++ b/packages/loot-core/vitest.config.ts
@@ -15,6 +15,18 @@ export default defineConfig({
       return type === 'stderr';
     },
     maxWorkers: 2,
+    reporters: process.env.CI
+      ? [
+          'default',
+          [
+            'junit',
+            {
+              outputFile: './test-results/junit-node.xml',
+              suiteName: 'loot-core (node)',
+            },
+          ],
+        ]
+      : ['default'],
   },
   ssr: {
     resolve: { conditions: ['electron', 'module', 'node', 'development'] },

--- a/packages/loot-core/vitest.web.config.ts
+++ b/packages/loot-core/vitest.web.config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
       'src/platform/server/fs/index.test.ts',
     ],
     maxWorkers: 2,
+    reporters: process.env.CI
+      ? [
+          'default',
+          [
+            'junit',
+            {
+              outputFile: './test-results/junit-web.xml',
+              suiteName: 'loot-core (web)',
+            },
+          ],
+        ]
+      : ['default'],
   },
   plugins: [peggyLoader()],
 });

--- a/packages/sync-server/vitest.config.ts
+++ b/packages/sync-server/vitest.config.ts
@@ -10,5 +10,17 @@ export default {
     // All test files share account.sqlite. Running files in parallel races on
     // the auth table's PRIMARY KEY (e.g. UNIQUE constraint failed: auth.method).
     fileParallelism: false,
+    reporters: process.env.CI
+      ? [
+          'default',
+          [
+            'junit',
+            {
+              outputFile: './test-results/junit.xml',
+              suiteName: 'sync-server',
+            },
+          ],
+        ]
+      : ['default'],
   },
 };

--- a/upcoming-release-notes/depot-test-results.md
+++ b/upcoming-release-notes/depot-test-results.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Report Vitest and Playwright test results to Depot for CI test observability.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Let's see! [depot.dev/docs/github-actions/observability/github-actions-test-results](https://depot.dev/docs/github-actions/observability/github-actions-test-results)

Scoped to only runs on master, IMO PR runs are too volatile and I don't want to pollute the data. We don't run e2e/vrt on master push, only merge_group so it'll have to do, even though it's less stable than master it's only for information.

No need for a CRDT bump here

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.14 MB | 0%
loot-core | 1 | 4.9 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.14 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.65 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.39 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.18 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Ct366LiD.js | 4.9 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->