### PR TITLE
move publish jobs back to github runners

### DIFF
--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -50,6 +50,8 @@ jobs:
   publish:
     needs: check-version
     if: needs.check-version.outputs.should-publish == 'true'
+    # must use GitHub hosted runners as NPM will not allow publishing from
+    # self-hosted
     runs-on: ubuntu-latest
     name: Publish @actual-app/crdt to npm
     permissions:

--- a/.github/workflows/publish-crdt.yml
+++ b/.github/workflows/publish-crdt.yml
@@ -50,7 +50,7 @@ jobs:
   publish:
     needs: check-version
     if: needs.check-version.outputs.should-publish == 'true'
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     name: Publish @actual-app/crdt to npm
     permissions:
       contents: read

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -90,6 +90,8 @@ jobs:
             packages/cli/@actual-app/cli.tgz
 
   publish:
+    # must use GitHub hosted runners as NPM will not allow publishing from
+    # self-hosted
     runs-on: ubuntu-latest
     name: Publish npm packages
     needs: build-and-pack

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -90,7 +90,7 @@ jobs:
             packages/cli/@actual-app/cli.tgz
 
   publish:
-    runs-on: depot-ubuntu-latest
+    runs-on: ubuntu-latest
     name: Publish npm packages
     needs: build-and-pack
     environment: release

--- a/upcoming-release-notes/github-runners-publish.md
+++ b/upcoming-release-notes/github-runners-publish.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Move publish jobs back to github runners

--- a/upcoming-release-notes/github-runners-publish.md
+++ b/upcoming-release-notes/github-runners-publish.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [matt-fidd]
 ---
 
-Move publish jobs back to github runners
+Move publish jobs back to GitHub runners


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
https://github.com/actualbudget/actual/actions/runs/27728980741/job/82031795503

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
