### PR TITLE
[AI] Sync `set amount` rule actions when a schedule's amount is edited

### DIFF
--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -810,5 +810,66 @@ describe('schedule app', () => {
         await schedulesApp.stopServices();
       }
     });
+
+    it('keeps a `set amount` action in sync when the amount is edited', async () => {
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            { op: 'is', field: 'account', value: accountId },
+            { op: 'is', field: 'amount', value: -6000 },
+            { op: 'is', field: 'date', value: '2016-12-31' },
+          ],
+        });
+
+        // Some schedules have a rule that also *sets* the amount (e.g. a rule
+        // customized via "Edit as rule"). Posting runs the rule, so the action
+        // value must track the amount condition.
+        const { data: ruleId } = await aqlQuery(
+          q('schedules').filter({ id }).calculate('rule'),
+        );
+        const ruleRow = await db.first<Pick<db.DbRule, 'actions'>>(
+          'SELECT actions FROM rules WHERE id = ?',
+          [ruleId],
+        );
+        await updateRule({
+          id: ruleId,
+          actions: [
+            { op: 'set', field: 'amount', value: -6000 },
+            ...JSON.parse(ruleRow.actions),
+          ],
+        });
+
+        // Edit the amount in the schedule editor (condition only).
+        await updateSchedule({
+          schedule: { id },
+          conditions: [
+            { op: 'is', field: 'account', value: accountId },
+            { op: 'is', field: 'date', value: '2016-12-31' },
+            { op: 'is', field: 'amount', value: -8000 },
+          ],
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions').filter({ schedule: id }).select(['amount']),
+        );
+
+        expect(transactions.map(({ amount }) => amount)).toEqual([-8000]);
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
   });
 });

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -33,7 +33,11 @@ import {
   getStatus,
   recurConfigToRSchedule,
 } from '#shared/schedules';
-import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
+import type {
+  RuleActionEntity,
+  RuleConditionEntity,
+  ScheduleEntity,
+} from '#types/models';
 
 import { findSchedules } from './find-schedules';
 
@@ -119,6 +123,8 @@ export function updateConditions(conditions, newConditions) {
   return updated.concat(added);
 }
 
+// Keep a rule's actions in sync with its (edited) schedule conditions.
+//
 // A schedule's amount lives in the rule's amount *condition*, but a rule can
 // also carry a plain `set amount` *action* (e.g. when customized via "Edit as
 // rule"). Posting a scheduled transaction runs the rule, so a stale action
@@ -130,9 +136,14 @@ export function updateConditions(conditions, newConditions) {
 //     their own value, so they're left untouched.
 //   - `set-split-amount` actions have a different `op` and so are excluded by
 //     the `action.op === 'set'` check below.
-function updateAmountActions(conditions, actions) {
+//
+// Returns `null` when nothing changed, so callers can avoid a redundant write.
+function updateActions(
+  conditions: RuleConditionEntity[],
+  actions: RuleActionEntity[],
+): RuleActionEntity[] | null {
   const { amount: amountCond } = extractScheduleConds(conditions);
-  if (amountCond == null) {
+  if (amountCond === null) {
     return null;
   }
 
@@ -402,10 +413,7 @@ export async function updateSchedule({
       const oldConditions = rule.serialize().conditions;
       const newConditions = updateConditions(oldConditions, conditions);
 
-      const newActions = updateAmountActions(
-        newConditions,
-        rule.serialize().actions,
-      );
+      const newActions = updateActions(newConditions, rule.serialize().actions);
 
       await updateRule({
         id: rule.id,

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -119,6 +119,38 @@ export function updateConditions(conditions, newConditions) {
   return updated.concat(added);
 }
 
+// A schedule's amount lives in the rule's amount *condition*, but a rule can
+// also carry a plain `set amount` *action* (e.g. when customized via "Edit as
+// rule"). Posting a scheduled transaction runs the rule, so a stale action
+// would revert the posted amount to the old value, ignoring the edited
+// amount. Keep such actions in sync with the amount condition. Templated and
+// `set-split-amount` actions compute their own value and are left untouched.
+function updateAmountActions(conditions, actions) {
+  const { amount: amountCond } = extractScheduleConds(conditions);
+  if (amountCond == null) {
+    return null;
+  }
+
+  const amount = getScheduledAmount(amountCond.value);
+
+  let changed = false;
+  const updated = actions.map(action => {
+    if (
+      action.op === 'set' &&
+      action.field === 'amount' &&
+      !action.options?.template &&
+      !action.options?.formula &&
+      action.value !== amount
+    ) {
+      changed = true;
+      return { ...action, value: amount };
+    }
+    return action;
+  });
+
+  return changed ? updated : null;
+}
+
 export async function getRuleForSchedule(id: string | null): Promise<Rule> {
   if (id == null) {
     throw new Error('Schedule not attached to a rule');
@@ -362,7 +394,16 @@ export async function updateSchedule({
       const oldConditions = rule.serialize().conditions;
       const newConditions = updateConditions(oldConditions, conditions);
 
-      await updateRule({ id: rule.id, conditions: newConditions });
+      const newActions = updateAmountActions(
+        newConditions,
+        rule.serialize().actions,
+      );
+
+      await updateRule({
+        id: rule.id,
+        conditions: newConditions,
+        ...(newActions ? { actions: newActions } : {}),
+      });
 
       // Annoyingly, sometimes it has `type` and sometimes it doesn't
       const stripType = ({ type: _type, ...fields }) => fields;

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -123,14 +123,22 @@ export function updateConditions(conditions, newConditions) {
 // also carry a plain `set amount` *action* (e.g. when customized via "Edit as
 // rule"). Posting a scheduled transaction runs the rule, so a stale action
 // would revert the posted amount to the old value, ignoring the edited
-// amount. Keep such actions in sync with the amount condition. Templated and
-// `set-split-amount` actions compute their own value and are left untouched.
+// amount. Keep such actions in sync with the amount condition.
+//
+// Only plain `set amount` actions are rewritten:
+//   - Templated/formula actions (`options.template`/`options.formula`) compute
+//     their own value, so they're left untouched.
+//   - `set-split-amount` actions have a different `op` and so are excluded by
+//     the `action.op === 'set'` check below.
 function updateAmountActions(conditions, actions) {
   const { amount: amountCond } = extractScheduleConds(conditions);
   if (amountCond == null) {
     return null;
   }
 
+  // Mirrors how `_amount` resolves: a deleted/empty amount condition value
+  // yields 0, so the action is synced to 0 too, keeping it consistent with
+  // the amount the schedule actually posts.
   const amount = getScheduledAmount(amountCond.value);
 
   let changed = false;

--- a/upcoming-release-notes/8266.md
+++ b/upcoming-release-notes/8266.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [zannis]
+---
+
+Fixed editing a schedule's amount not updating a `set amount` action on its rule, which caused auto-posted transactions to keep using the old amount.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes the issue where a scheduled payment, created with amount X and after being edited with the 'set amount' to amount Y action, correctly reflects amount Y in the Schedules view but keeps auto-creating transactions with amount X. 

Used Claude Code for the fix.

## Related issue(s)

Fixes #8265. 

## Testing

One new integration test in `app.test.ts`.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB | 0%
loot-core | 1 | 4.82 MB → 4.82 MB (+691 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+672 B) | +0.02%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 177.24 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+691 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +691 B (+4.60%) | 14.67 kB → 15.34 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CdbreuPy.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DHYjs5zD.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+672 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +672 B (+4.57%) | 14.36 kB → 15.02 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+672 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->