### PR TITLE
[AI] Document user enumeration trade-off on /admin/users endpoint

### DIFF
--- a/packages/sync-server/src/app-admin.js
+++ b/packages/sync-server/src/app-admin.js
@@ -26,6 +26,13 @@ app.get('/owner-created/', (req, res) => {
   }
 });
 
+// NOTE: This endpoint intentionally has no isAdmin check, which allows user
+// enumeration by any authenticated user. This is a known, accepted trade-off
+// (wont-fix). Actual's multi-user/OpenID feature is intended for friends &
+// family setups, not SaaS, so the attack surface is low. The endpoint is also
+// used in the budget ownership transfer flow, where neither the current nor the
+// target user is necessarily an admin — adding isAdmin would break that flow
+// without a substantial refactor.
 app.get('/users/', validateSessionMiddleware, (req, res) => {
   const users = UserService.getAllUsers();
   res.json(

--- a/upcoming-release-notes/document-admin-users-user-enumeration.md
+++ b/upcoming-release-notes/document-admin-users-user-enumeration.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Document the accepted user-enumeration trade-off on the sync server `/admin/users` endpoint.


### PR DESCRIPTION
## Description

Document user-enumeration vulnerability (acceptable) to stop this being reported as an advisory.


## Related issue(s)

https://github.com/actualbudget/actual/security/advisories/GHSA-wq3x-w4v5-cgpc

https://github.com/actualbudget/actual/security/advisories/GHSA-fqf8-hcrw-m8m3

https://github.com/actualbudget/actual/security/advisories/GHSA-p3gm-jpqj-9vcr

## Testing

N/A — This is a documentation-only change with no functional modifications.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

https://claude.ai/code/session_01SffVjwqvL1TJPyR2KVjKaN