### PR TITLE
[AI] Fix CORS proxy GitHub API allowlist prefix bypass

### DIFF
--- a/packages/sync-server/src/app-cors-proxy.js
+++ b/packages/sync-server/src/app-cors-proxy.js
@@ -91,7 +91,8 @@ function isUrlAllowed(targetUrl) {
           targetUrl === repoUrl ||
           targetUrl.startsWith(repoUrl + '/') ||
           (hostname === 'api.github.com' &&
-            url.pathname.startsWith(`/repos/${repoOwner}/${repoName}`)) ||
+            (url.pathname === `/repos/${repoOwner}/${repoName}` ||
+              url.pathname.startsWith(`/repos/${repoOwner}/${repoName}/`))) ||
           (hostname === 'raw.githubusercontent.com' &&
             url.pathname.startsWith(`/${repoOwner}/${repoName}/`)) ||
           (hostname === 'github.com' &&

--- a/packages/sync-server/src/app-cors-proxy.test.js
+++ b/packages/sync-server/src/app-cors-proxy.test.js
@@ -264,6 +264,27 @@ describe('app-cors-proxy', () => {
       expect(res.statusCode).toBe(200);
     });
 
+    it('should allow the exact GitHub API repo URL for allowlisted repos', async () => {
+      const res = await request(app)
+        .get('/')
+        .query({ url: 'https://api.github.com/repos/user/repo1' });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('should block prefix-matched GitHub API repos that are not allowlisted', async () => {
+      const res = await request(app).get('/').query({
+        url: 'https://api.github.com/repos/user/repo1-private/contents/.env',
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.error).toBe('URL not allowed');
+      expect(console.warn).toHaveBeenCalledWith(
+        'Blocked request to unauthorized URL:',
+        'https://api.github.com/repos/user/repo1-private/contents/.env',
+      );
+    });
+
     it('should allow raw.githubusercontent.com URLs for allowlisted repos', async () => {
       const res = await request(app).get('/').query({
         url: 'https://raw.githubusercontent.com/user/repo1/main/file.txt',

--- a/upcoming-release-notes/fix-cors-proxy-github-allowlist-prefix-bypass.md
+++ b/upcoming-release-notes/fix-cors-proxy-github-allowlist-prefix-bypass.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [actual-github-bot]
+---
+
+Fix CORS proxy GitHub API allowlist prefix bypass that could leak private repositories through the server GitHub token (GHSA-m62c-5q34-f3cf)

--- a/upcoming-release-notes/fix-cors-proxy-github-allowlist-prefix-bypass.md
+++ b/upcoming-release-notes/fix-cors-proxy-github-allowlist-prefix-bypass.md
@@ -1,6 +1,6 @@
 ---
 category: Bugfix
-authors: [actual-github-bot]
+authors: [MatissJanis]
 ---
 
-Fix CORS proxy GitHub API allowlist prefix bypass that could leak private repositories through the server GitHub token (GHSA-m62c-5q34-f3cf)
+Fix a CORS proxy security issue that could expose private GitHub repositories.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Fix low severity issue allowing access to private repos that match the allowlisted repo name (extremely unlikely scenario, but since the fix is so simple.. no problem applying it).

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/security/advisories/GHSA-m62c-5q34-f3cf

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
