### PR TITLE
[AI] Show git revision next to client version for edge builds

### DIFF
--- a/packages/desktop-client/src/components/ServerContext.tsx
+++ b/packages/desktop-client/src/components/ServerContext.tsx
@@ -25,6 +25,7 @@ type LoginMethod = {
 type ServerContextValue = {
   url: string | null;
   version: string;
+  revision: string;
   multiuserEnabled: boolean;
   availableLoginMethods: LoginMethod[];
   setURL: (
@@ -39,6 +40,7 @@ type ServerContextValue = {
 const ServerContext = createContext<ServerContextValue>({
   url: null,
   version: '',
+  revision: '',
   multiuserEnabled: false,
   availableLoginMethods: [],
   setURL: () => Promise.reject(new Error('ServerContext not initialized')),
@@ -54,6 +56,7 @@ const ServerContext = createContext<ServerContextValue>({
 
 export const useServerURL = () => useContext(ServerContext).url;
 export const useServerVersion = () => useContext(ServerContext).version;
+export const useServerRevision = () => useContext(ServerContext).revision;
 export const useSetServerURL = () => useContext(ServerContext).setURL;
 export const useMultiuserEnabled = () => {
   const { multiuserEnabled } = useContext(ServerContext);
@@ -73,15 +76,18 @@ export const useLoginMethod = () => {
 export const useAvailableLoginMethods = () =>
   useContext(ServerContext).availableLoginMethods;
 
-async function getServerVersion() {
+async function getServerVersion(): Promise<{
+  version: string;
+  revision: string;
+}> {
   if (Platform.isPlaywright) {
-    return '99.9.9';
+    return { version: '99.9.9', revision: '' };
   }
   const result = await send('get-server-version');
   if ('version' in result) {
-    return result.version;
+    return { version: result.version, revision: result.revision ?? '' };
   }
-  return '';
+  return { version: '', revision: '' };
 }
 
 export const useRefreshLoginMethods = () =>
@@ -97,6 +103,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
   const dispatch = useDispatch();
   const [serverURL, setServerURL] = useState('');
   const [version, setVersion] = useState('');
+  const [revision, setRevision] = useState('');
   const [multiuserEnabled, setMultiuserEnabled] = useState(false);
   const [availableLoginMethods, setAvailableLoginMethods] = useState<
     LoginMethod[]
@@ -109,15 +116,18 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         return;
       }
       setServerURL(serverURL);
-      setVersion(await getServerVersion());
+      const { version, revision } = await getServerVersion();
+      setVersion(version);
+      setRevision(revision);
     }
     void run();
   }, []);
 
   useOnVisible(
     async () => {
-      const version = await getServerVersion();
+      const { version, revision } = await getServerVersion();
       setVersion(version);
+      setRevision(revision);
     },
     {
       isEnabled: !!serverURL,
@@ -166,7 +176,9 @@ export function ServerProvider({ children }: { children: ReactNode }) {
       if (!error) {
         const serverURL = await send('get-server-url');
         setServerURL(serverURL!);
-        setVersion(await getServerVersion());
+        const { version, revision } = await getServerVersion();
+        setVersion(version);
+        setRevision(revision);
       }
       return { error };
     },
@@ -181,6 +193,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
         availableLoginMethods,
         setURL,
         version: version ? `v${version}` : 'N/A',
+        revision,
         refreshLoginMethods,
         setMultiuserEnabled,
         setLoginMethods: setAvailableLoginMethods,

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -42,6 +42,7 @@ import { AdvancedToggle, Setting } from './UI';
 
 function About() {
   const version = useServerVersion();
+  const gitRevision = import.meta.env.REACT_APP_GIT_REVISION;
   const versionInfo = useSelector(state => state.app.versionInfo);
   const [notifyWhenUpdateIsAvailable, setNotifyWhenUpdateIsAvailablePref] =
     useGlobalPref('notifyWhenUpdateIsAvailable', () => {
@@ -77,6 +78,7 @@ function About() {
           <Trans>
             Client version: {{ version: `v${window.Actual?.ACTUAL_VERSION}` }}
           </Trans>
+          {gitRevision ? ` (${gitRevision})` : ''}
         </Text>
         <Text>
           <Trans>Server version: {{ version }}</Trans>

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -43,7 +43,7 @@ import { AdvancedToggle, Setting } from './UI';
 function About() {
   const version = useServerVersion();
   const serverRevision = useServerRevision();
-  const gitRevision = import.meta.env.REACT_APP_GIT_REVISION;
+  const clientRevision = import.meta.env.REACT_APP_GIT_REVISION;
   const versionInfo = useSelector(state => state.app.versionInfo);
   const [notifyWhenUpdateIsAvailable, setNotifyWhenUpdateIsAvailablePref] =
     useGlobalPref('notifyWhenUpdateIsAvailable', () => {
@@ -79,7 +79,7 @@ function About() {
           <Trans>
             Client version: {{ version: `v${window.Actual?.ACTUAL_VERSION}` }}
           </Trans>
-          {gitRevision ? ` (${gitRevision})` : ''}
+          {clientRevision ? ` (${clientRevision})` : ''}
         </Text>
         <Text>
           <Trans>Server version: {{ version }}</Trans>

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -19,7 +19,7 @@ import { Link } from '#components/common/Link';
 import { Checkbox, FormField, FormLabel } from '#components/forms';
 import { MOBILE_NAV_HEIGHT } from '#components/mobile/MobileNavTabs';
 import { Page } from '#components/Page';
-import { useServerVersion } from '#components/ServerContext';
+import { useServerRevision, useServerVersion } from '#components/ServerContext';
 import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useMetadataPref } from '#hooks/useMetadataPref';
@@ -42,6 +42,7 @@ import { AdvancedToggle, Setting } from './UI';
 
 function About() {
   const version = useServerVersion();
+  const serverRevision = useServerRevision();
   const gitRevision = import.meta.env.REACT_APP_GIT_REVISION;
   const versionInfo = useSelector(state => state.app.versionInfo);
   const [notifyWhenUpdateIsAvailable, setNotifyWhenUpdateIsAvailablePref] =
@@ -82,6 +83,7 @@ function About() {
         </Text>
         <Text>
           <Trans>Server version: {{ version }}</Trans>
+          {serverRevision ? ` (${serverRevision})` : ''}
         </Text>
 
         {notifyWhenUpdateIsAvailable && versionInfo?.isOutdated ? (

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { createReadStream } from 'node:fs';
 import { cp, mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises';
@@ -93,6 +93,29 @@ const pluginsServiceDistDir = path.resolve(
 const serviceWorkerDir = path.resolve(__dirname, 'service-worker');
 
 const WORKER_FILENAME_RE = /^kcab\.worker\.(.+)\.js$/;
+
+// Resolve a short git revision so builds (most importantly the `edge`/nightly
+// build, where the package.json version is identical across many commits) can
+// surface a unique identifier in the About settings. Prefers an explicit env
+// var, then the CI-provided commit SHA, then the local git checkout. Never
+// throws — an unavailable revision just yields an empty string.
+function resolveGitRevision(): string {
+  if (process.env.REACT_APP_GIT_REVISION) {
+    return process.env.REACT_APP_GIT_REVISION;
+  }
+  if (process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA.slice(0, 7);
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
 
 async function extractWorkerHash(): Promise<string> {
   const files = await readdir(lootCoreOutDir);
@@ -247,6 +270,10 @@ export default defineConfig(async ({ mode, command }) => {
     process.env.REACT_APP_REVIEW_ID = process.env.REVIEW_ID;
     process.env.REACT_APP_BRANCH = process.env.BRANCH;
   }
+
+  // Expose the build's git revision to the client (via the REACT_APP_ env
+  // prefix) so the About page can show a unique identifier for edge builds.
+  process.env.REACT_APP_GIT_REVISION = resolveGitRevision();
 
   // Electron packaging (--mode=desktop) bundles loot-core directly, so skip
   // all browser-only staging there.

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -77,16 +77,18 @@ handlers['get-server-version'] = async function () {
   }
 
   let version;
+  let revision;
   try {
     const res = await get(getServer().BASE_SERVER + '/info');
 
     const info = JSON.parse(res);
     version = info.build.version;
+    revision = info.build.revision;
   } catch {
     return { error: 'network-failure' };
   }
 
-  return { version };
+  return { version, revision };
 };
 
 handlers['get-server-url'] = async function () {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -286,6 +286,8 @@ export type ApiHandlers = {
     name: string;
   }) => Promise<string>;
   'api/get-server-version': () => Promise<
-    { error: 'no-server' } | { error: 'network-failure' } | { version: string }
+    | { error: 'no-server' }
+    | { error: 'network-failure' }
+    | { version: string; revision?: string }
   >;
 };

--- a/packages/loot-core/src/types/server-handlers.ts
+++ b/packages/loot-core/src/types/server-handlers.ts
@@ -13,7 +13,9 @@ export type ServerHandlers = {
   query: (query: QueryState) => Promise<{ data: any; dependencies: string[] }>;
 
   'get-server-version': () => Promise<
-    { error: 'no-server' } | { error: 'network-failure' } | { version: string }
+    | { error: 'no-server' }
+    | { error: 'network-failure' }
+    | { version: string; revision?: string }
   >;
 
   'get-server-url': () => Promise<string | null>;

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -20,6 +20,11 @@ import * as simpleFinApp from './app-simplefin/app-simplefin';
 import * as syncApp from './app-sync';
 import { config } from './load-config';
 
+// Replaced at build time by Vite's `define` (see vite.config.mts). Declared
+// here so it typechecks; guarded with `typeof` at the use site so it is safe
+// when the bundle runs without the define applied.
+declare const __GIT_REVISION__: string;
+
 const app = express();
 
 process.on('unhandledRejection', reason => {
@@ -113,6 +118,9 @@ app.get('/info', (_req, res) => {
       name: packageJson?.name,
       description: packageJson?.description,
       version: packageJson?.version,
+      // Injected at build time (see vite.config.mts). Empty when built
+      // outside a git checkout / CI.
+      revision: typeof __GIT_REVISION__ !== 'undefined' ? __GIT_REVISION__ : '',
     },
   });
 });

--- a/packages/sync-server/vite.config.mts
+++ b/packages/sync-server/vite.config.mts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
@@ -7,6 +8,28 @@ import type { Plugin } from 'vite';
 const pkg = JSON.parse(
   readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'),
 );
+
+// Resolve a short git revision at build time so the /info endpoint can report a
+// unique identifier for nightly/edge images (where the package.json version is
+// the same across many commits). Prefers an explicit env var, then the
+// CI-provided commit SHA, then the local git checkout. Never throws.
+function resolveGitRevision(): string {
+  if (process.env.ACTUAL_GIT_REVISION) {
+    return process.env.ACTUAL_GIT_REVISION;
+  }
+  if (process.env.GITHUB_SHA) {
+    return process.env.GITHUB_SHA.slice(0, 7);
+  }
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
 
 const shebangPlugin = (entryFile: string): Plugin => ({
   name: 'sync-server-shebang',
@@ -67,6 +90,7 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __GIT_REVISION__: JSON.stringify(resolveGitRevision()),
   },
   assetsInclude: ['**/*.sql'],
   plugins: [shebangPlugin('bin/actual-server.js')],

--- a/upcoming-release-notes/2939.md
+++ b/upcoming-release-notes/2939.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Show the build's git revision next to the client version on the About settings page, giving edge/nightly builds a unique identifier instead of an ambiguous release number.

--- a/upcoming-release-notes/2939.md
+++ b/upcoming-release-notes/2939.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [MatissJanis]
----
-
-Show the build's git revision next to the client version on the About settings page, giving edge/nightly builds a unique identifier instead of an ambiguous release number.

--- a/upcoming-release-notes/matissjanis-edge-build-git-revision.md
+++ b/upcoming-release-notes/matissjanis-edge-build-git-revision.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [MatissJanis]
 ---
 
-Show the build's git revision next to the client version on the About page.
+Show the build's git revision next to the client and server versions on the About page.

--- a/upcoming-release-notes/matissjanis-edge-build-git-revision.md
+++ b/upcoming-release-notes/matissjanis-edge-build-git-revision.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Show the build's git revision next to the client version on the About page.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vmiz6P8eKQ58gkksKSAQZd)_

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (+792 B) | +0.01%
loot-core | 1 | 4.9 MB → 4.9 MB (+91 B) | +0.00%
api | 2 | 3.94 MB → 3.94 MB (+85 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (+792 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/ServerContext.tsx` | 📈 +636 B (+11.09%) | 5.6 kB → 6.22 kB
`src/components/settings/index.tsx` | 📈 +156 B (+1.41%) | 10.78 kB → 10.94 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB → 7.61 MB (+792 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.39 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.23 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.4 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB → 4.9 MB (+91 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +91 B (+1.91%) | 4.64 kB → 4.73 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cvw1iwWi.js | 0 B → 4.9 MB (+4.9 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTfCF_Gu.js | 4.9 MB → 0 B (-4.9 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+85 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +85 B (+2.41%) | 3.45 kB → 3.53 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+85 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->