### PR TITLE
[AI] Fix API password login with OpenID configured

### DIFF
--- a/packages/api/index.test.ts
+++ b/packages/api/index.test.ts
@@ -1,0 +1,25 @@
+import { init as initLootCore } from '@actual-app/core/server/main';
+import { describe, expect, it, vi } from 'vitest';
+
+import * as api from './index';
+
+vi.mock('@actual-app/core/server/main', () => ({
+  init: vi.fn(async () => ({
+    send: vi.fn(),
+  })),
+}));
+
+describe('init', () => {
+  it('passes explicit password login method when initializing remote API with a password', async () => {
+    await api.init({
+      serverURL: 'https://actual.example.com',
+      password: 'test-password',
+    });
+
+    expect(initLootCore).toHaveBeenCalledWith({
+      serverURL: 'https://actual.example.com',
+      password: 'test-password',
+      loginMethod: 'password',
+    });
+  });
+});

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -12,7 +12,12 @@ export let internal: typeof lib | null = null;
 export async function init(config: InitConfig = {}) {
   validateNodeVersion();
 
-  internal = await initLootCore(config);
+  const initConfig =
+    'password' in config && config.password
+      ? { ...config, loginMethod: 'password' as const }
+      : config;
+
+  internal = await initLootCore(initConfig);
   return internal;
 }
 

--- a/packages/loot-core/src/server/main.ts
+++ b/packages/loot-core/src/server/main.ts
@@ -237,6 +237,7 @@ type ServerInitConfig = BaseInitConfig & {
 
 type PasswordAuthConfig = ServerInitConfig & {
   password: string;
+  loginMethod?: 'password';
   sessionToken?: never;
 };
 

--- a/upcoming-release-notes/api-password-login-openid.md
+++ b/upcoming-release-notes/api-password-login-openid.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [maxpetrusenkoagent]
+---
+
+Fix Node.js API password authentication when OpenID is also configured.


### PR DESCRIPTION
<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.9 MB | 0%
api | 2 | 3.94 MB → 3.94 MB (+88 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.61 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.39 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.18 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Ct366LiD.js | 4.9 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB → 3.94 MB (+88 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`index.ts` | 📈 +88 B (+22.68%) | 388 B → 476 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB → 3.94 MB (+88 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->