### PR TITLE
[AI] 🐛 Exclude completed schedule rules from payee rule counts

### DIFF
--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -35,7 +35,7 @@ export function ManagePayeesWithData({
   useEffect(() => {
     const unlisten = listen('sync-event', async event => {
       if (event.type === 'applied') {
-        if (event.tables.includes('rules')) {
+        if (event.tables.includes('rules') || event.tables.includes('schedules')) {
           await refetchRuleCounts();
         }
       }

--- a/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayeesWithData.tsx
@@ -35,7 +35,10 @@ export function ManagePayeesWithData({
   useEffect(() => {
     const unlisten = listen('sync-event', async event => {
       if (event.type === 'applied') {
-        if (event.tables.includes('rules') || event.tables.includes('schedules')) {
+        if (
+          event.tables.includes('rules') ||
+          event.tables.includes('schedules')
+        ) {
           await refetchRuleCounts();
         }
       }

--- a/packages/desktop-client/src/components/rules/ScheduleValue.tsx
+++ b/packages/desktop-client/src/components/rules/ScheduleValue.tsx
@@ -13,7 +13,7 @@ import { describeSchedule } from '#util/schedule';
 import { Value } from './Value';
 
 type ScheduleValueProps = {
-  value: ScheduleEntity;
+  value: ScheduleEntity['id'];
 };
 
 export function ScheduleValue({ value }: ScheduleValueProps) {

--- a/packages/desktop-client/src/components/rules/ScheduleValue.tsx
+++ b/packages/desktop-client/src/components/rules/ScheduleValue.tsx
@@ -30,16 +30,10 @@ export function ScheduleValue({ value }: ScheduleValueProps) {
     );
   }
 
-  return (
-    <Value
-      value={value}
-      field="rule"
-      data={schedules}
-      // TODO: this manual type coercion does not make much sense -
-      // should we instead do `schedule._payee.id`?
-      describe={schedule =>
-        describeSchedule(schedule, byId[schedule._payee as unknown as string])
-      }
-    />
-  );
+  const schedule = schedules.find(item => item.id === value);
+  const display = schedule
+    ? describeSchedule(schedule, byId[schedule._payee])
+    : t('(deleted)');
+
+  return <Value value={display} field="notes" valueIsRaw />;
 }

--- a/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
+++ b/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
@@ -1,5 +1,6 @@
 import { extractScheduleConds } from '@actual-app/core/shared/schedules';
 import type {
+  RuleConditionEntity,
   RuleConditionOp,
   ScheduleEntity,
 } from '@actual-app/core/types/models';
@@ -10,7 +11,7 @@ import type { ScheduleFormFields } from './ScheduleEditForm';
 export function updateScheduleConditions(
   schedule: Partial<ScheduleEntity>,
   fields: ScheduleFormFields,
-): { error?: string; conditions?: unknown[] } {
+): { error?: string; conditions?: RuleConditionEntity[] } {
   const conds = extractScheduleConds(schedule._conditions);
 
   const updateCond = (
@@ -53,6 +54,6 @@ export function updateScheduleConditions(
         field: 'amount',
         value: fields.amount,
       },
-    ].filter(val => !!val),
+    ].filter((val): val is RuleConditionEntity => val != null),
   };
 }

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 import { app } from '#server/payees/app';

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,3 +1,4 @@
+// @ts-strict-ignore
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
 import { app } from '#server/payees/app';

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -7,7 +7,6 @@ import {
   loadRules,
   resetState,
 } from '#server/transactions/transaction-rules';
-import type { RuleConditionEntity } from '#types/models';
 
 beforeEach(async () => {
   await global.emptyDatabase()();
@@ -36,7 +35,7 @@ describe('payees app', () => {
           { op: 'is', field: 'payee', value: completedPayeeId },
           { op: 'is', field: 'date', value: '2020-12-20' },
         ],
-      } as { conditions: RuleConditionEntity[] });
+      });
       await updateSchedule({
         schedule: { id: scheduleId, completed: true },
       });

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -35,8 +35,8 @@ describe('payees app', () => {
         conditions: [
           { op: 'is', field: 'payee', value: completedPayeeId },
           { op: 'is', field: 'date', value: '2020-12-20' },
-        ] satisfies RuleConditionEntity[],
-      });
+        ],
+      } as { conditions: RuleConditionEntity[] });
       await updateSchedule({
         schedule: { id: scheduleId, completed: true },
       });

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -7,6 +7,7 @@ import {
   loadRules,
   resetState,
 } from '#server/transactions/transaction-rules';
+import type { RuleConditionEntity } from '#types/models';
 
 beforeEach(async () => {
   await global.emptyDatabase()();
@@ -34,7 +35,7 @@ describe('payees app', () => {
         conditions: [
           { op: 'is', field: 'payee', value: completedPayeeId },
           { op: 'is', field: 'date', value: '2020-12-20' },
-        ],
+        ] satisfies RuleConditionEntity[],
       });
       await updateSchedule({
         schedule: { id: scheduleId, completed: true },

--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,49 @@
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import { app } from '#server/payees/app';
+import { createSchedule, updateSchedule } from '#server/schedules/app';
+import {
+  insertRule,
+  loadRules,
+  resetState,
+} from '#server/transactions/transaction-rules';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  resetState();
+  await loadMappings();
+  await loadRules();
+});
+
+describe('payees app', () => {
+  describe('payees-get-rule-counts', () => {
+    it('counts payee rules but excludes rules linked to completed schedules', async () => {
+      const activePayeeId = await db.insertPayee({ name: 'Active Payee' });
+      const completedPayeeId = await db.insertPayee({
+        name: 'Completed Payee',
+      });
+
+      await insertRule({
+        stage: 'pre',
+        conditionsOp: 'and',
+        conditions: [{ op: 'is', field: 'payee', value: activePayeeId }],
+        actions: [{ op: 'set', field: 'category', value: null }],
+      });
+
+      const scheduleId = await createSchedule({
+        conditions: [
+          { op: 'is', field: 'payee', value: completedPayeeId },
+          { op: 'is', field: 'date', value: '2020-12-20' },
+        ],
+      });
+      await updateSchedule({
+        schedule: { id: scheduleId, completed: true },
+      });
+
+      const counts = await app.handlers['payees-get-rule-counts']();
+
+      expect(counts[activePayeeId]).toBe(1);
+      expect(counts[completedPayeeId]).toBeUndefined();
+    });
+  });
+});

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -74,7 +74,21 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
 
+  const completedScheduleRules = new Set(
+    (
+      await db.all<Pick<db.DbSchedule, 'rule'>>(
+        'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
+      )
+    )
+      .map(row => row.rule)
+      .filter((rule): rule is string => !!rule),
+  );
+
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    if (completedScheduleRules.has(rule.id)) {
+      return;
+    }
+
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -85,7 +85,8 @@ async function getPayeeRuleCounts() {
   );
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
-    if (completedScheduleRules.has(rule.id)) {
+    const ruleId = rule.getId();
+    if (ruleId != null && completedScheduleRules.has(ruleId)) {
       return;
     }
 

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -2,6 +2,7 @@ import { createApp } from '#server/app';
 import * as db from '#server/db';
 import { payeeModel } from '#server/models';
 import { mutator } from '#server/mutators';
+import { getCompletedScheduleRuleIds } from '#server/schedules/app';
 import { batchMessages } from '#server/sync';
 import * as rules from '#server/transactions/transaction-rules';
 import { undoable } from '#server/undo';
@@ -73,20 +74,10 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
-
-  const completedScheduleRules = new Set(
-    (
-      await db.all<Pick<db.DbSchedule, 'rule'>>(
-        'SELECT rule FROM schedules WHERE completed = 1 AND tombstone = 0',
-      )
-    )
-      .map(row => row.rule)
-      .filter((rule): rule is string => !!rule),
-  );
+  const completedScheduleRules = new Set(await getCompletedScheduleRuleIds());
 
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
-    const ruleId = rule.getId();
-    if (ruleId != null && completedScheduleRules.has(ruleId)) {
+    if (rule.id && completedScheduleRules.has(rule.id)) {
       return;
     }
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -259,6 +259,9 @@ function normalizeScheduleName(name) {
 export async function createSchedule({
   schedule = null,
   conditions = [],
+}: {
+  schedule?: Partial<ScheduleEntity> | null;
+  conditions?: RuleConditionEntity[];
 } = {}): Promise<ScheduleEntity['id']> {
   const scheduleId = schedule?.id || uuidv4();
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -259,9 +259,6 @@ function normalizeScheduleName(name) {
 export async function createSchedule({
   schedule = null,
   conditions = [],
-}: {
-  schedule?: Partial<ScheduleEntity> | null;
-  conditions?: RuleConditionEntity[];
 } = {}): Promise<ScheduleEntity['id']> {
   const scheduleId = schedule?.id || uuidv4();
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -259,6 +259,9 @@ function normalizeScheduleName(name) {
 export async function createSchedule({
   schedule = null,
   conditions = [],
+}: {
+  schedule?: Partial<ScheduleEntity> | null;
+  conditions?: RuleConditionEntity[];
 } = {}): Promise<ScheduleEntity['id']> {
   const scheduleId = schedule?.id || uuidv4();
 
@@ -532,6 +535,16 @@ async function getSchedule(id: string): Promise<ScheduleEntity | null> {
   } = await aqlQuery(q('schedules').filter({ id }).select('*'));
 
   return schedule ?? null;
+}
+
+export async function getCompletedScheduleRuleIds(): Promise<string[]> {
+  const { data } = await aqlQuery(
+    q('schedules').filter({ completed: true }).select(['rule']),
+  );
+
+  return data
+    .map(schedule => schedule.rule)
+    .filter((rule): rule is string => !!rule);
 }
 
 async function hasTransactionForSchedule(

--- a/packages/loot-core/src/types/models/rule.ts
+++ b/packages/loot-core/src/types/models/rule.ts
@@ -162,7 +162,7 @@ export type SetSplitAmountRuleActionEntity = {
 
 export type LinkScheduleRuleActionEntity = {
   op: 'link-schedule';
-  value: ScheduleEntity;
+  value: ScheduleEntity['id'];
 };
 
 export type PrependNoteRuleActionEntity = {

--- a/upcoming-release-notes/fix-payee-rule-count.md
+++ b/upcoming-release-notes/fix-payee-rule-count.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Juulz]
+---
+
+Fix Payee page. Rule counts no longer count rules associated with complete schedules.

--- a/upcoming-release-notes/fix-payee-rule-count.md
+++ b/upcoming-release-notes/fix-payee-rule-count.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfix
+category: Bugfixes
 authors: [Juulz]
 ---
 

--- a/upcoming-release-notes/fix-payee-rule-count.md
+++ b/upcoming-release-notes/fix-payee-rule-count.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [Juulz]
 ---
 
-Fix Payee page. Rule counts no longer count rules associated with complete schedules.
+Fix Payee page. Rule counts no longer include rules associated with completed schedules.


### PR DESCRIPTION
## Description

Fix ended up not a whole lot different than the other 4 that tried it. LOL

Cursor/Claude DID note that the sync event listener should check when a schedule changes in case it gets completed and that was added. 

I asked Cursor if a new test was important here and why. She said that it was moderately important, but not a dealbreaker, just in case of a refactor later that misses the current disconnect between the rule count and the associated active rules. This made sense so I had her write a small test.  If it's not really needed, I'll be happy to take it out.

AIs are like boats, they are all feminine. 

## Related issue(s)

Fixes #8134 

## Testing

I tested with an import of my budget and checked the payees that I knew had incorrect rule counts. All checked were now correct and the one with every rule completed now shows "Create rule".

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB → 13.02 MB (+485 B) | +0.00%
loot-core | 1 | 4.82 MB → 4.82 MB (+362 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+360 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB → 13.02 MB (+485 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/rules/ScheduleValue.tsx` | 📈 +441 B (+22.84%) | 1.89 kB → 2.32 kB
`src/components/payees/ManagePayeesWithData.tsx` | 📈 +38 B (+1.29%) | 2.88 kB → 2.91 kB
`src/components/schedules/schedule-edit-utils.ts` | 📈 +6 B (+0.67%) | 896 B → 902 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.63 MB (+447 B) | +0.01%
static/js/wide.js | 305.04 kB → 305.07 kB (+38 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 177.24 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+362 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +142 B (+2.34%) | 5.92 kB → 6.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +220 B (+1.40%) | 15.34 kB → 15.56 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.RjHyOlEX.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CdbreuPy.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+360 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +140 B (+2.34%) | 5.84 kB → 5.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +220 B (+1.43%) | 15.02 kB → 15.24 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+360 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->