### PR TITLE
[AI] Move typescript-strict-plugin to devDependencies in loot-core

### DIFF
--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -201,7 +201,6 @@
     "memoize-one": "^6.0.0",
     "mitt": "^3.0.1",
     "promise-retry": "^2.0.1",
-    "typescript-strict-plugin": "^2.4.4",
     "ua-parser-js": "^2.0.10",
     "uuid": "^14.0.0",
     "xml2js": "^0.6.2"
@@ -230,6 +229,7 @@
     "stream-browserify": "^3.0.0",
     "timers-browserify": "^2.0.12",
     "ts-node": "^10.9.2",
+    "typescript-strict-plugin": "^2.4.4",
     "util": "^0.12.5",
     "vite": "^8.0.16",
     "vite-plugin-node-polyfills": "^0.28.0",

--- a/upcoming-release-notes/typescript-strict-plugin-devdep.md
+++ b/upcoming-release-notes/typescript-strict-plugin-devdep.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Move `typescript-strict-plugin` to `devDependencies` in `loot-core`


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Tiny fix

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hm1ibCg4H96ww51eDwRBiT)_

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.14 MB | 0%
loot-core | 1 | 4.9 MB | 0%
api | 2 | 3.94 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.14 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.65 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.25 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/_baseIsEqual.js | 76.78 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.39 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 478.18 kB | 0%
static/js/fr.js | 171.39 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.88 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/resize-observer.js | 18.06 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 298.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.9 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Ct366LiD.js | 4.9 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.94 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.94 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->