### PR TITLE
Add auto "Hold for next month" action

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -28,6 +28,7 @@
     "./select": "./src/Select.tsx",
     "./space-between": "./src/SpaceBetween.tsx",
     "./styles": "./src/styles.ts",
+    "./tabs": "./src/Tabs.tsx",
     "./text": "./src/Text.tsx",
     "./text-one-line": "./src/TextOneLine.tsx",
     "./theme": "./src/theme.ts",

--- a/packages/component-library/src/Popover.tsx
+++ b/packages/component-library/src/Popover.tsx
@@ -14,24 +14,39 @@ export const Popover = ({
   ...props
 }: PopoverProps) => {
   const ref = useRef<HTMLElement>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { isNonModal, isOpen, onOpenChange } = props;
 
   const handleFocus = useCallback(
     (e: FocusEvent) => {
-      if (!ref.current?.contains(e.relatedTarget as Node)) {
-        props.onOpenChange?.(false);
+      if (ref.current?.contains(e.relatedTarget as Node | null)) {
+        return;
       }
+
+      closeTimeoutRef.current = setTimeout(() => {
+        if (!ref.current?.contains(document.activeElement)) {
+          onOpenChange?.(false);
+        }
+      }, 0);
     },
-    [props],
+    [onOpenChange],
   );
 
   useEffect(() => {
-    if (!props.isNonModal) return;
-    if (props.isOpen) {
+    if (!isNonModal) return;
+    if (isOpen) {
       ref.current?.addEventListener('focusout', handleFocus);
     } else {
       ref.current?.removeEventListener('focusout', handleFocus);
     }
-  }, [handleFocus, props.isNonModal, props.isOpen]);
+
+    return () => {
+      ref.current?.removeEventListener('focusout', handleFocus);
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, [handleFocus, isNonModal, isOpen]);
 
   return (
     <ReactAriaPopover

--- a/packages/component-library/src/Tabs.stories.tsx
+++ b/packages/component-library/src/Tabs.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from './Tabs';
+
+const meta = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultSelectedKey="overview" style={{ width: 580 }}>
+      <TabList aria-label="Report sections">
+        <Tab id="overview">Overview</Tab>
+        <Tab id="analytics">Analytics</Tab>
+        <Tab id="reports">Reports</Tab>
+        <Tab id="settings">Settings</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel id="overview">Overview content</TabPanel>
+        <TabPanel id="analytics">Analytics content</TabPanel>
+        <TabPanel id="reports">Reports content</TabPanel>
+        <TabPanel id="settings">Settings content</TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};
+
+export const Vertical: Story = {
+  render: () => (
+    <Tabs orientation="vertical" defaultSelectedKey="overview">
+      <TabList aria-label="Report sections">
+        <Tab id="overview">Overview</Tab>
+        <Tab id="analytics">Analytics</Tab>
+        <Tab id="reports">Reports</Tab>
+      </TabList>
+      <TabPanels style={{ minWidth: 240 }}>
+        <TabPanel id="overview">Overview content</TabPanel>
+        <TabPanel id="analytics">Analytics content</TabPanel>
+        <TabPanel id="reports">Reports content</TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};

--- a/packages/component-library/src/Tabs.tsx
+++ b/packages/component-library/src/Tabs.tsx
@@ -50,29 +50,21 @@ const defaultTabListClassName = css({
 
 const defaultTabClassName = css({
   display: 'inline-flex',
-  minHeight: 26,
+  minHeight: 24,
   alignItems: 'center',
   justifyContent: 'center',
-  border: 0,
   borderRadius: 5,
-  backgroundColor: 'transparent',
   color: theme.pageTextLight,
   cursor: 'pointer',
-  fontSize: 14,
   fontWeight: 500,
-  lineHeight: 1,
-  margin: 0,
-  outline: 0,
   padding: '4px 10px',
-  whiteSpace: 'nowrap',
-  WebkitAppRegion: 'no-drag',
   transition: 'background-color .15s, box-shadow .15s, color .15s',
   '&[data-pressed]': {
     transform: 'translateY(1px)',
   },
   '&[data-selected]': {
     backgroundColor: theme.buttonPrimaryBackground,
-    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.2)',
     color: theme.buttonPrimaryText,
   },
   '&[data-disabled]': {

--- a/packages/component-library/src/Tabs.tsx
+++ b/packages/component-library/src/Tabs.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import type { ComponentPropsWithRef } from 'react';
+import {
+  Tab as ReactAriaTab,
+  TabList as ReactAriaTabList,
+  TabPanel as ReactAriaTabPanel,
+  TabPanels as ReactAriaTabPanels,
+  Tabs as ReactAriaTabs,
+} from 'react-aria-components';
+import type {
+  TabListProps as ReactAriaTabListProps,
+  TabPanelsProps as ReactAriaTabPanelsProps,
+} from 'react-aria-components';
+
+import { css, cx } from '@emotion/css';
+
+import { theme } from './theme';
+
+export type TabsProps = ComponentPropsWithRef<typeof ReactAriaTabs>;
+export type TabListProps<T> = ReactAriaTabListProps<T>;
+export type TabProps = ComponentPropsWithRef<typeof ReactAriaTab>;
+export type TabPanelsProps<T> = ReactAriaTabPanelsProps<T>;
+export type TabPanelProps = ComponentPropsWithRef<typeof ReactAriaTabPanel>;
+
+const defaultTabsClassName = css({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  '&[data-orientation="vertical"]': {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+});
+
+const defaultTabListClassName = css({
+  display: 'inline-flex',
+  width: 'fit-content',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 2,
+  borderRadius: 8,
+  backgroundColor: theme.pageBackground,
+  padding: 4,
+  color: theme.pillText,
+  '&[data-orientation="vertical"]': {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+  },
+});
+
+const defaultTabClassName = css({
+  display: 'inline-flex',
+  minHeight: 26,
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 0,
+  borderRadius: 5,
+  backgroundColor: 'transparent',
+  color: theme.pageTextLight,
+  cursor: 'pointer',
+  fontSize: 14,
+  fontWeight: 500,
+  lineHeight: 1,
+  margin: 0,
+  outline: 0,
+  padding: '4px 10px',
+  whiteSpace: 'nowrap',
+  WebkitAppRegion: 'no-drag',
+  transition: 'background-color .15s, box-shadow .15s, color .15s',
+  '&[data-pressed]': {
+    transform: 'translateY(1px)',
+  },
+  '&[data-selected]': {
+    backgroundColor: theme.buttonPrimaryBackground,
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12)',
+    color: theme.buttonPrimaryText,
+  },
+  '&[data-disabled]': {
+    cursor: 'default',
+    opacity: 0.75,
+  },
+});
+
+const defaultTabPanelsClassName = css({
+  display: 'flex',
+  flex: 1,
+  minWidth: 0,
+});
+
+const defaultTabPanelClassName = css({
+  flex: 1,
+  minWidth: 0,
+  outline: 0,
+});
+
+export function Tabs({ className, ref, ...props }: TabsProps) {
+  return (
+    <ReactAriaTabs
+      ref={ref}
+      className={
+        typeof className === 'function'
+          ? renderProps => cx(defaultTabsClassName, className(renderProps))
+          : cx(defaultTabsClassName, className)
+      }
+      {...props}
+    />
+  );
+}
+
+export function TabList<T>({ className, ...props }: TabListProps<T>) {
+  return (
+    <ReactAriaTabList
+      className={
+        typeof className === 'function'
+          ? renderProps => cx(defaultTabListClassName, className(renderProps))
+          : cx(defaultTabListClassName, className)
+      }
+      {...props}
+    />
+  );
+}
+
+export function Tab({ className, ref, ...props }: TabProps) {
+  return (
+    <ReactAriaTab
+      ref={ref}
+      className={
+        typeof className === 'function'
+          ? renderProps => cx(defaultTabClassName, className(renderProps))
+          : cx(defaultTabClassName, className)
+      }
+      {...props}
+    />
+  );
+}
+
+export function TabPanels<T>({ className, ...props }: TabPanelsProps<T>) {
+  return (
+    <ReactAriaTabPanels
+      className={cx(defaultTabPanelsClassName, className)}
+      {...props}
+    />
+  );
+}
+
+export function TabPanel({ className, ref, ...props }: TabPanelProps) {
+  return (
+    <ReactAriaTabPanel
+      ref={ref}
+      className={
+        typeof className === 'function'
+          ? renderProps => cx(defaultTabPanelClassName, className(renderProps))
+          : cx(defaultTabPanelClassName, className)
+      }
+      {...props}
+    />
+  );
+}

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -584,6 +584,14 @@ type ApplyBudgetActionPayload =
       args?: never;
     }
   | {
+      type: 'auto-hold';
+      month: string;
+      args: {
+        months: number;
+        allowNegativeToBudget?: boolean;
+      };
+    }
+  | {
       type: 'cover-overspending';
       month: string;
       args: {
@@ -733,6 +741,13 @@ export function useBudgetActions() {
           return null;
         case 'reset-hold':
           await send('budget/reset-hold', { month });
+          return null;
+        case 'auto-hold':
+          await send('budget/auto-hold-for-next-month', {
+            month,
+            months: args.months,
+            allowNegativeToBudget: args.allowNegativeToBudget,
+          });
           return null;
         case 'cover-overspending':
           await send('budget/cover-overspending', {

--- a/packages/desktop-client/src/components/budget/envelope/HoldMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/HoldMenu.tsx
@@ -1,20 +1,77 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Form } from 'react-aria-components';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { InitialFocus } from '@actual-app/components/initial-focus';
+import { Input } from '@actual-app/components/input';
+import {
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@actual-app/components/tabs';
+import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
 import type { IntegerAmount } from '@actual-app/core/shared/util';
 
+import { Checkbox } from '#components/forms';
 import { FinancialInput } from '#components/util/FinancialInput';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useSheetValue } from '#hooks/useSheetValue';
 
 type HoldMenuProps = {
+  month: string;
   onSubmit: (amount: number) => void;
+  onAutoHold: (months: number, allowNegativeToBudget: boolean) => void;
   onClose: () => void;
 };
-export function HoldMenu({ onSubmit, onClose }: HoldMenuProps) {
+
+export function HoldMenu(props: HoldMenuProps) {
+  const { t } = useTranslation();
+  const isAutoHoldEnabled = useFeatureFlag('autoHoldForNextMonth');
+
+  if (!isAutoHoldEnabled) {
+    return (
+      <View style={{ padding: 10 }}>
+        <HoldMenuManual {...props} />
+      </View>
+    );
+  }
+
+  return (
+    <Tabs defaultSelectedKey="auto" style={{ padding: 10 }}>
+      <View
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <TabList aria-label={t('Automatic holding')}>
+          <Tab id="auto">
+            <Trans>Auto</Trans>
+          </Tab>
+          <Tab id="manual">
+            <Trans>Manual</Trans>
+          </Tab>
+        </TabList>
+      </View>
+      <TabPanels>
+        <TabPanel id="auto">
+          <HoldMenuAuto {...props} />
+        </TabPanel>
+        <TabPanel id="manual">
+          <HoldMenuManual {...props} />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}
+
+function HoldMenuManual({ onSubmit, onClose }: HoldMenuProps) {
   const [amount, setAmount] = useState<IntegerAmount | null>(null);
 
   useSheetValue<'envelope-budget', 'to-budget'>('to-budget', ({ value }) => {
@@ -34,7 +91,7 @@ export function HoldMenu({ onSubmit, onClose }: HoldMenuProps) {
         onClose();
       }}
     >
-      <View style={{ padding: 10 }}>
+      <View>
         <View style={{ marginBottom: 5 }}>
           <Trans>Hold this amount:</Trans>
         </View>
@@ -52,6 +109,102 @@ export function HoldMenu({ onSubmit, onClose }: HoldMenuProps) {
           <Button
             type="submit"
             variant="primary"
+            style={{
+              fontSize: 12,
+              paddingTop: 3,
+              paddingBottom: 3,
+            }}
+          >
+            <Trans>Hold</Trans>
+          </Button>
+        </View>
+      </View>
+    </Form>
+  );
+}
+
+function HoldMenuAuto({ month, onAutoHold, onClose }: HoldMenuProps) {
+  const { t } = useTranslation();
+  const [months, setMonths] = useState('1');
+  const [allowNegativeToBudget, setAllowNegativeToBudget] = useState(false);
+  const monthsToInspect = Number(months);
+  const isMonthsValid =
+    months !== '' && Number.isInteger(monthsToInspect) && monthsToInspect >= 0;
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    void send('budget/get-auto-hold-months', { month }).then(
+      defaultMonths => {
+        if (isCurrent) {
+          setMonths(String(Number.isFinite(defaultMonths) ? defaultMonths : 0));
+        }
+      },
+      () => {
+        // ignore errors
+      },
+    );
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [month]);
+
+  return (
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+
+        if (!isMonthsValid) {
+          return;
+        }
+
+        onAutoHold(monthsToInspect, allowNegativeToBudget);
+        onClose();
+      }}
+    >
+      <View>
+        <View style={{ marginBottom: 5 }}>
+          <Trans>Months ahead:</Trans>
+        </View>
+        <InitialFocus>
+          <Input
+            type="number"
+            min={0}
+            step={1}
+            required
+            value={months}
+            aria-label={t('Months ahead')}
+            onChange={e => setMonths(e.currentTarget.value)}
+          />
+        </InitialFocus>
+        {/* oxlint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginTop: 10,
+          }}
+        >
+          <Checkbox
+            checked={allowNegativeToBudget}
+            onChange={() => setAllowNegativeToBudget(value => !value)}
+          />
+          <Text>
+            <Trans>Allow negative "To Budget"</Trans>
+          </Text>
+        </label>
+        <View
+          style={{
+            alignItems: 'flex-end',
+            marginTop: 10,
+          }}
+        >
+          <Button
+            type="submit"
+            variant="primary"
+            isDisabled={!isMonthsValid}
             style={{
               fontSize: 12,
               paddingTop: 3,

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudget.tsx
@@ -61,6 +61,10 @@ export function ToBudget({
     position,
     asContextMenu,
   } = useContextMenu();
+  const closeMenu = useCallback(() => {
+    setMenuStep('actions');
+    setMenuOpen(false);
+  }, [setMenuOpen, setMenuStep]);
 
   return (
     <>
@@ -82,10 +86,7 @@ export function ToBudget({
         triggerRef={triggerRef}
         placement={asContextMenu ? 'bottom start' : 'bottom'}
         isOpen={menuOpen}
-        onOpenChange={() => {
-          setMenuStep('actions');
-          setMenuOpen(false);
-        }}
+        onOpenChange={closeMenu}
         style={{ width: 200, margin: 1 }}
         isNonModal
         {...position}
@@ -98,7 +99,7 @@ export function ToBudget({
               onHoldBuffer={() => setMenuStep('buffer')}
               onResetHoldBuffer={() => {
                 onBudgetAction(month, 'reset-hold');
-                setMenuOpen(false);
+                closeMenu();
               }}
               month={month}
               onBudgetAction={onBudgetAction}
@@ -106,16 +107,23 @@ export function ToBudget({
           )}
           {menuStep === 'buffer' && (
             <HoldMenu
-              onClose={() => setMenuOpen(false)}
+              month={month}
+              onClose={closeMenu}
               onSubmit={amount => {
                 onBudgetAction(month, 'hold', { amount });
+              }}
+              onAutoHold={(months, allowNegativeToBudget) => {
+                onBudgetAction(month, 'auto-hold', {
+                  months,
+                  allowNegativeToBudget,
+                });
               }}
             />
           )}
           {menuStep === 'transfer' && (
             <TransferMenu
               initialAmount={availableValue}
-              onClose={() => setMenuOpen(false)}
+              onClose={closeMenu}
               onSubmit={(amount, categoryId) => {
                 onBudgetAction(month, 'transfer-available', {
                   amount,
@@ -128,7 +136,7 @@ export function ToBudget({
             <CoverMenu
               showToBeBudgeted={false}
               initialAmount={availableValue}
-              onClose={() => setMenuOpen(false)}
+              onClose={closeMenu}
               onSubmit={(amount, categoryId) => {
                 onBudgetAction(month, 'cover-overbudgeted', {
                   category: categoryId,

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
@@ -31,11 +31,24 @@ export function ToBudgetMenu({
   const { t } = useTranslation();
 
   const toBudget = useEnvelopeSheetValue(envelopeBudget.toBudget) ?? 0;
+  const availableFunds =
+    useEnvelopeSheetValue(envelopeBudget.incomeAvailable) ?? 0;
+  const totalBudgeted =
+    useEnvelopeSheetValue(envelopeBudget.totalBudgeted) ?? 0;
+  const budgeted = Math.max(0, -totalBudgeted);
   const forNextMonth = useEnvelopeSheetValue(envelopeBudget.forNextMonth) ?? 0;
   const manualBuffered =
     useEnvelopeSheetValue(envelopeBudget.manualBuffered) ?? 0;
-  const autoBuffered = useEnvelopeSheetValue(envelopeBudget.autoBuffered) ?? 0;
+  const hasSurplus = availableFunds > budgeted;
   const items = [
+    ...(toBudget < 0
+      ? [
+          {
+            name: 'cover',
+            text: t('Cover from a category'),
+          },
+        ]
+      : []),
     ...(toBudget > 0
       ? [
           {
@@ -44,19 +57,11 @@ export function ToBudgetMenu({
           },
         ]
       : []),
-    ...(autoBuffered === 0 && toBudget > 0
+    ...(hasSurplus
       ? [
           {
             name: 'buffer',
             text: t('Hold for next month'),
-          },
-        ]
-      : []),
-    ...(toBudget < 0
-      ? [
-          {
-            name: 'cover',
-            text: t('Cover from a category'),
           },
         ]
       : []),

--- a/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeBudgetSummaryModal.tsx
@@ -120,6 +120,13 @@ export function EnvelopeBudgetSummaryModal({
               void onBudgetAction(month, 'hold', { amount });
               dispatch(collapseModals({ rootModalName: 'hold-buffer' }));
             },
+            onAutoHold: (months, allowNegativeToBudget) => {
+              void onBudgetAction(month, 'auto-hold', {
+                months,
+                allowNegativeToBudget,
+              });
+              dispatch(collapseModals({ rootModalName: 'hold-buffer' }));
+            },
           },
         },
       }),

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -42,10 +42,10 @@ export function HoldBufferModal(props: HoldBufferModalProps) {
     >
       <View style={{ alignItems: 'center' }}>
         <TabList aria-label={t('Automatic holding')}>
-          <Tab id="auto">
+          <Tab id="auto" style={{ minHeight: 30 }}>
             <Trans>Auto</Trans>
           </Tab>
-          <Tab id="manual">
+          <Tab id="manual" style={{ minHeight: 30 }}>
             <Trans>Manual</Trans>
           </Tab>
         </TabList>

--- a/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
+++ b/packages/desktop-client/src/components/modals/HoldBufferModal.tsx
@@ -3,13 +3,25 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { InitialFocus } from '@actual-app/components/initial-focus';
+import { Input } from '@actual-app/components/input';
 import { styles } from '@actual-app/components/styles';
+import {
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@actual-app/components/tabs';
+import { Text } from '@actual-app/components/text';
 import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
 
 import { useEnvelopeSheetValue } from '#components/budget/envelope/EnvelopeBudgetComponents';
 import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
+import { Checkbox } from '#components/forms';
 import { FieldLabel } from '#components/mobile/MobileForms';
 import { AmountInput } from '#components/util/AmountInput';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import type { Modal as ModalType } from '#modals/modalsSlice';
 import { envelopeBudget } from '#spreadsheet/bindings';
@@ -19,8 +31,55 @@ type HoldBufferModalProps = Extract<
   { name: 'hold-buffer' }
 >['options'];
 
-export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
-  const { t } = useTranslation(); // Initialize i18next
+export function HoldBufferModal(props: HoldBufferModalProps) {
+  const { t } = useTranslation();
+  const isAutoHoldEnabled = useFeatureFlag('autoHoldForNextMonth');
+
+  const content = isAutoHoldEnabled ? (
+    <Tabs
+      defaultSelectedKey="auto"
+      style={{ padding: styles.mobileEditingPadding, gap: 20, marginTop: -15 }}
+    >
+      <View style={{ alignItems: 'center' }}>
+        <TabList aria-label={t('Automatic holding')}>
+          <Tab id="auto">
+            <Trans>Auto</Trans>
+          </Tab>
+          <Tab id="manual">
+            <Trans>Manual</Trans>
+          </Tab>
+        </TabList>
+      </View>
+      <TabPanels>
+        <TabPanel id="auto">
+          <HoldBufferModalAuto {...props} />
+        </TabPanel>
+        <TabPanel id="manual">
+          <HoldBufferModalManual {...props} />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  ) : (
+    <HoldBufferModalManual {...props} />
+  );
+
+  return (
+    <Modal name="hold-buffer">
+      {({ state }) => (
+        <>
+          <ModalHeader
+            title={t('Hold for next month')}
+            rightContent={<ModalCloseButton onPress={() => state.close()} />}
+          />
+          {content}
+        </>
+      )}
+    </Modal>
+  );
+}
+
+function HoldBufferModalManual({ onSubmit }: HoldBufferModalProps) {
+  const { t } = useTranslation();
   const [hideFraction] = useSyncedPref('hideFraction');
   const available = useEnvelopeSheetValue(envelopeBudget.toBudget) ?? 0;
   const [amount, setAmount] = useState<number>(0);
@@ -36,56 +95,119 @@ export function HoldBufferModal({ onSubmit }: HoldBufferModalProps) {
   };
 
   return (
-    <Modal name="hold-buffer">
-      {({ state }) => (
-        <>
-          <ModalHeader
-            title={t('Hold for next month')}
-            rightContent={<ModalCloseButton onPress={() => state.close()} />}
-          />
-          <View>
-            <FieldLabel title={t('Hold this amount:')} />{' '}
-            <InitialFocus>
-              <AmountInput
-                value={amount}
-                autoDecimals={String(hideFraction) !== 'true'}
-                zeroSign="+"
-                style={{
-                  marginLeft: styles.mobileEditingPadding,
-                  marginRight: styles.mobileEditingPadding,
-                }}
-                inputStyle={{
-                  height: styles.mobileMinHeight,
-                }}
-                onUpdate={setAmount}
-                onEnter={() => {
-                  _onSubmit(amount);
-                  state.close();
-                }}
-              />
-            </InitialFocus>
-          </View>
-          <View
+    <>
+      <View>
+        <FieldLabel title={t('Hold this amount:')} style={{ marginTop: 0 }} />
+        <InitialFocus>
+          <AmountInput
+            value={amount}
+            autoDecimals={String(hideFraction) !== 'true'}
+            zeroSign="+"
             style={{
-              justifyContent: 'center',
-              alignItems: 'center',
-              paddingTop: 10,
+              marginLeft: styles.mobileEditingPadding,
+              marginRight: styles.mobileEditingPadding,
             }}
-          >
-            <Button
-              variant="primary"
-              style={{
-                height: styles.mobileMinHeight,
-                marginLeft: styles.mobileEditingPadding,
-                marginRight: styles.mobileEditingPadding,
-              }}
-              onPress={() => _onSubmit(amount)}
-            >
-              <Trans>Hold</Trans>
-            </Button>
-          </View>
-        </>
-      )}
-    </Modal>
+            inputStyle={{
+              height: styles.mobileMinHeight,
+            }}
+            onUpdate={setAmount}
+            onEnter={() => _onSubmit(amount)}
+          />
+        </InitialFocus>
+      </View>
+      <View
+        style={{
+          justifyContent: 'center',
+          alignItems: 'center',
+          paddingTop: 10,
+        }}
+      >
+        <Button
+          variant="primary"
+          style={{
+            height: styles.mobileMinHeight,
+            marginLeft: styles.mobileEditingPadding,
+            marginRight: styles.mobileEditingPadding,
+          }}
+          onPress={() => _onSubmit(amount)}
+        >
+          <Trans>Hold</Trans>
+        </Button>
+      </View>
+    </>
+  );
+}
+
+function HoldBufferModalAuto({ month, onAutoHold }: HoldBufferModalProps) {
+  const { t } = useTranslation();
+  const [months, setMonths] = useState('1');
+  const [allowNegativeToBudget, setAllowNegativeToBudget] = useState(false);
+  const monthsToInspect = Number(months);
+  const isMonthsValid =
+    months !== '' && Number.isInteger(monthsToInspect) && monthsToInspect >= 0;
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    void send('budget/get-auto-hold-months', { month }).then(
+      defaultMonths => {
+        if (isCurrent) {
+          setMonths(String(Number.isFinite(defaultMonths) ? defaultMonths : 0));
+        }
+      },
+      () => {
+        // ignore errors
+      },
+    );
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [month]);
+
+  return (
+    <View style={{ gap: 10 }}>
+      <View>
+        <FieldLabel title={t('Months ahead:')} style={{ marginTop: 0 }} />
+        <InitialFocus>
+          <Input
+            type="number"
+            min={0}
+            step={1}
+            required
+            value={months}
+            aria-label={t('Months ahead')}
+            onChange={e => setMonths(e.currentTarget.value)}
+            style={{ height: styles.mobileMinHeight }}
+          />
+        </InitialFocus>
+      </View>
+      {/* oxlint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label style={{ display: 'flex', gap: 8 }}>
+        <Checkbox
+          checked={allowNegativeToBudget}
+          onChange={() => setAllowNegativeToBudget(value => !value)}
+        />
+        <Text>
+          <Trans>Allow negative "To Budget"</Trans>
+        </Text>
+      </label>
+      <View style={{ alignItems: 'center' }}>
+        <Button
+          variant="primary"
+          isDisabled={!isMonthsValid}
+          style={{ height: styles.mobileMinHeight }}
+          onPress={() => {
+            if (!isMonthsValid) {
+              return;
+            }
+
+            onAutoHold(monthsToInspect, allowNegativeToBudget);
+          }}
+        >
+          <Trans>Hold</Trans>
+        </Button>
+      </View>
+    </View>
   );
 }

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -208,6 +208,9 @@ export function ExperimentalFeatures() {
             >
               <Trans>Mobile calculator</Trans>
             </FeatureToggle>
+            <FeatureToggle flag="autoHoldForNextMonth">
+              <Trans>Hold for next month (auto)</Trans>
+            </FeatureToggle>
             <FeatureToggle
               flag="sankeyReport"
               feedbackLink="https://github.com/actualbudget/actual/issues/1919"

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -16,6 +16,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   enableBanking: false,
   sankeyReport: false,
   akahuBankSync: false,
+  autoHoldForNextMonth: false,
   mobileCalculator: false,
 };
 

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -524,6 +524,7 @@ export type Modal =
       options: {
         month: string;
         onSubmit: (amount: number) => void;
+        onAutoHold: (months: number, allowNegativeToBudget: boolean) => void;
       };
     }
   | {

--- a/packages/loot-core/src/server/budget/actions.test.ts
+++ b/packages/loot-core/src/server/budget/actions.test.ts
@@ -5,8 +5,12 @@ import * as db from '#server/db';
 import * as sheet from '#server/sheet';
 
 import {
+  autoHoldForNextMonth,
+  calculateAutoHoldPlan,
   copyUntilYearEnd,
   coverOverbudgeted,
+  getAutoHoldMonthsToInspect,
+  getSheetBoolean,
   getSheetValue,
   set3MonthAvg,
   setBudget,
@@ -14,6 +18,542 @@ import {
   setNMonthAvg,
 } from './actions';
 import * as budget from './base';
+
+describe('calculateAutoHoldPlan', () => {
+  it('sets cumulative hold amounts needed to cover future budgets', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 700,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 700,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 500,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 100,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+  });
+
+  it('prioritizes earlier months when surplus is exhausted', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 500,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 700,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 300,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 500 },
+      { month: '2024-02', amount: 300 },
+      { month: '2024-03', amount: 0 },
+    ]);
+  });
+
+  it('leaves surplus beyond future budgets in the selected month', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 900,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 700,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 500,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 100,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+  });
+
+  it('caps each hold amount so To Budget does not drop below zero', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 700,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 700,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 300,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 100,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 300 },
+      { month: '2024-03', amount: 0 },
+    ]);
+  });
+
+  it('includes overspending in the last inspected month', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 1000,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 1000,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 800,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 400,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 300,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 1000 },
+      { month: '2024-02', amount: 800 },
+      { month: '2024-03', amount: 400 },
+    ]);
+  });
+
+  it('reduces required hold amounts by future income', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 700,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 700,
+          },
+          {
+            month: '2024-02',
+            income: 100,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 500,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 100,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 600 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+  });
+
+  it('can ignore surplus and To Budget capacity limits', () => {
+    expect(
+      calculateAutoHoldPlan({
+        surplus: 100,
+        allowNegativeToBudget: true,
+        months: [
+          {
+            month: '2024-01',
+            income: 0,
+            budgeted: 300,
+            overspent: 0,
+            toBudgetCapacity: 100,
+          },
+          {
+            month: '2024-02',
+            income: 0,
+            budgeted: 200,
+            overspent: 0,
+            toBudgetCapacity: 50,
+          },
+          {
+            month: '2024-03',
+            income: 0,
+            budgeted: 400,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+          {
+            month: '2024-04',
+            income: 0,
+            budgeted: 100,
+            overspent: 0,
+            toBudgetCapacity: 0,
+          },
+        ],
+      }),
+    ).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+  });
+});
+
+describe('autoHoldForNextMonth', () => {
+  beforeEach(global.emptyDatabase());
+  afterEach(global.emptyDatabase());
+
+  it('sets hold amounts for the selected and future months', async () => {
+    await setupAutoHoldDatabase({
+      income: 1000,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 3 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+    expect(await getSheetValue('budget202401', 'buffered')).toBe(700);
+    expect(await getSheetValue('budget202402', 'buffered')).toBe(500);
+    expect(await getSheetValue('budget202403', 'buffered')).toBe(100);
+    expect(await getSheetValue('budget202404', 'buffered')).toBe(0);
+    expect(await getSheetValue('budget202401', 'to-budget')).toBe(0);
+    expect(await getSheetValue('budget202402', 'to-budget')).toBe(0);
+    expect(await getSheetValue('budget202403', 'to-budget')).toBe(0);
+    expect(await getSheetValue('budget202404', 'to-budget')).toBe(0);
+  });
+
+  it('can use the default horizon through the last future budgeted month', async () => {
+    await setupAutoHoldDatabase({
+      income: 1000,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-04': 100,
+      },
+    });
+
+    const months = await getAutoHoldMonthsToInspect({ month: '2024-01' });
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 300 },
+      { month: '2024-02', amount: 100 },
+      { month: '2024-03', amount: 100 },
+    ]);
+    expect(await getSheetValue('budget202401', 'buffered')).toBe(300);
+    expect(await getSheetValue('budget202402', 'buffered')).toBe(100);
+    expect(await getSheetValue('budget202403', 'buffered')).toBe(100);
+    expect(await getSheetValue('budget202404', 'buffered')).toBe(0);
+  });
+
+  it('does not reset income carryover when no plan is produced', async () => {
+    await setupAutoHoldDatabase({
+      income: 1000,
+      budgetedByMonth: {
+        '2024-01': 300,
+      },
+      months: ['2024-01'],
+    });
+    await setCategoryCarryover({
+      startMonth: '2024-01',
+      category: 'income-cat',
+      flag: true,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 1 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([]);
+    expect(await getSheetBoolean('budget202401', 'carryover-income-cat')).toBe(
+      true,
+    );
+  });
+
+  it('does not reset income carryover when the plan only has zero amounts', async () => {
+    await setupAutoHoldDatabase({
+      income: 300,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+      },
+    });
+    await setCategoryCarryover({
+      startMonth: '2024-01',
+      category: 'income-cat',
+      flag: true,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 1 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([]);
+    expect(await getSheetBoolean('budget202401', 'carryover-income-cat')).toBe(
+      true,
+    );
+  });
+
+  it('accounts for overspending when setting future hold amounts', async () => {
+    await setupAutoHoldDatabase({
+      income: 1000,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+      spendingByMonth: {
+        '2024-01': 500,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 3 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 300 },
+      { month: '2024-03', amount: 0 },
+    ]);
+    expect(await getSheetValue('budget202402', 'buffered')).toBe(300);
+    expect(await getSheetValue('budget202402', 'to-budget')).toBe(0);
+  });
+
+  it('covers overspending in the last inspected month', async () => {
+    await setupAutoHoldDatabase({
+      income: 1300,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+      spendingByMonth: {
+        '2024-03': 1200,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 3 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 1000 },
+      { month: '2024-02', amount: 800 },
+      { month: '2024-03', amount: 400 },
+    ]);
+    expect(await getSheetValue('budget202404', 'to-budget')).toBe(0);
+  });
+
+  it('can set holds beyond surplus when negative To Budget is allowed', async () => {
+    await setupAutoHoldDatabase({
+      income: 500,
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({
+      month: '2024-01',
+      months: 3,
+      allowNegativeToBudget: true,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 700 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+    expect(await getSheetValue('budget202401', 'to-budget')).toBe(-500);
+  });
+
+  it('uses future income to reduce current hold amounts', async () => {
+    await setupAutoHoldDatabase({
+      income: 1000,
+      incomeByMonth: {
+        '2024-02': 200,
+      },
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 3 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 500 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+    expect(await getSheetValue('budget202401', 'buffered')).toBe(500);
+    expect(await getSheetValue('budget202402', 'buffered')).toBe(500);
+    expect(await getSheetValue('budget202403', 'buffered')).toBe(100);
+    expect(await getSheetValue('budget202401', 'to-budget')).toBe(200);
+  });
+
+  it('sets future holds from future income when current surplus is zero', async () => {
+    await setupAutoHoldDatabase({
+      income: 300,
+      incomeByMonth: {
+        '2024-02': 700,
+      },
+      budgetedByMonth: {
+        '2024-01': 300,
+        '2024-02': 200,
+        '2024-03': 400,
+        '2024-04': 100,
+      },
+    });
+
+    const plan = await autoHoldForNextMonth({ month: '2024-01', months: 3 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(plan).toEqual([
+      { month: '2024-01', amount: 0 },
+      { month: '2024-02', amount: 500 },
+      { month: '2024-03', amount: 100 },
+    ]);
+    expect(await getSheetValue('budget202401', 'buffered')).toBe(0);
+    expect(await getSheetValue('budget202402', 'buffered')).toBe(500);
+    expect(await getSheetValue('budget202403', 'buffered')).toBe(100);
+  });
+});
 
 describe('copyUntilYearEnd', () => {
   beforeEach(global.emptyDatabase());
@@ -337,6 +877,75 @@ async function setupAverageDatabase() {
     account: 'account1',
     category: 'cat1',
   });
+
+  await sheet.waitOnSpreadsheet();
+}
+
+async function setupAutoHoldDatabase({
+  income,
+  incomeByMonth = {},
+  budgetedByMonth,
+  spendingByMonth = {},
+  months = ['2024-01', '2024-02', '2024-03', '2024-04', '2024-05'],
+}: {
+  income: number;
+  incomeByMonth?: Record<string, number>;
+  budgetedByMonth: Record<string, number>;
+  spendingByMonth?: Record<string, number>;
+  months?: string[];
+}) {
+  await db.insertAccount({ id: 'account1', name: 'Account 1' });
+
+  await db.insertCategoryGroup({
+    id: 'income-group',
+    name: 'Income',
+    is_income: 1,
+  });
+  await db.insertCategory({
+    id: 'income-cat',
+    name: 'Income',
+    cat_group: 'income-group',
+    is_income: 1,
+  });
+  await db.insertCategoryGroup({ id: 'group1', name: 'group1', is_income: 0 });
+  await db.insertCategory({
+    id: 'cat1',
+    name: 'cat1',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+
+  await sheet.loadSpreadsheet(db);
+  await budget.createBudget(months);
+
+  await db.insertTransaction({
+    date: '2024-01-15',
+    amount: income,
+    account: 'account1',
+    category: 'income-cat',
+  });
+
+  for (const [month, amount] of Object.entries(incomeByMonth)) {
+    await db.insertTransaction({
+      date: `${month}-15`,
+      amount,
+      account: 'account1',
+      category: 'income-cat',
+    });
+  }
+
+  for (const [month, amount] of Object.entries(budgetedByMonth)) {
+    await setBudget({ category: 'cat1', month, amount });
+  }
+
+  for (const [month, amount] of Object.entries(spendingByMonth)) {
+    await db.insertTransaction({
+      date: `${month}-15`,
+      amount: -amount,
+      account: 'account1',
+      category: 'cat1',
+    });
+  }
 
   await sheet.waitOnSpreadsheet();
 }

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -64,12 +64,30 @@ function monthFromDbMonth(month: number): string {
   return `${monthString.slice(0, 4)}-${monthString.slice(4)}`;
 }
 
+function getCreatedMonths(): string[] {
+  const { createdMonths } = sheet.get().meta();
+  return [...(createdMonths as Set<string>)].sort();
+}
+
 // TODO: complete list of fields.
 type BudgetData = {
   is_income: 1 | 0;
   hidden: 1 | 0;
   group_hidden: 1 | 0;
   category: string;
+  amount: number;
+};
+
+export type AutoHoldMonth = {
+  month: string;
+  income: number;
+  budgeted: number;
+  overspent: number;
+  toBudgetCapacity: number;
+};
+
+export type AutoHoldPlanItem = {
+  month: string;
   amount: number;
 };
 
@@ -509,6 +527,205 @@ export async function holdForNextMonth({
     return true;
   }
   return false;
+}
+
+async function getDefaultAutoHoldMonths(month: string): Promise<number> {
+  let lastBudgetedMonth: string | null = null;
+
+  for (const futureMonth of getCreatedMonths()) {
+    if (futureMonth <= month) {
+      continue;
+    }
+
+    if (
+      (await getMonthBudgetedExpense(futureMonth)) > 0 ||
+      (await getMonthOverspentAmount(futureMonth)) > 0
+    ) {
+      lastBudgetedMonth = futureMonth;
+    }
+  }
+
+  return lastBudgetedMonth == null
+    ? 0
+    : monthUtils.differenceInCalendarMonths(lastBudgetedMonth, month);
+}
+
+export async function getAutoHoldMonthsToInspect({
+  month,
+}: {
+  month: string;
+}): Promise<number> {
+  return getDefaultAutoHoldMonths(month);
+}
+
+async function getAutoHoldMonths({
+  month,
+  months,
+}: {
+  month: string;
+  months: number;
+}): Promise<AutoHoldMonth[]> {
+  const createdMonths = new Set(getCreatedMonths());
+  const inspectedMonths: AutoHoldMonth[] = [];
+
+  for (let i = 0; i <= months; i++) {
+    const inspectedMonth = monthUtils.addMonths(month, i);
+
+    if (!createdMonths.has(inspectedMonth)) {
+      break;
+    }
+
+    inspectedMonths.push({
+      month: inspectedMonth,
+      income: await getMonthIncomeAmount(inspectedMonth),
+      budgeted: await getMonthBudgetedExpense(inspectedMonth),
+      overspent: await getMonthOverspentAmount(inspectedMonth),
+      toBudgetCapacity: await getMonthToBudgetCapacity(inspectedMonth),
+    });
+  }
+
+  let lastBudgetedIndex = -1;
+  for (let i = inspectedMonths.length - 1; i > 0; i--) {
+    const month = inspectedMonths[i];
+    const monthNeed = month.budgeted + month.overspent;
+    if (monthNeed > 0) {
+      lastBudgetedIndex = i;
+      break;
+    }
+  }
+
+  return lastBudgetedIndex === -1
+    ? inspectedMonths.slice(0, 1)
+    : inspectedMonths.slice(0, lastBudgetedIndex + 1);
+}
+
+export function calculateAutoHoldPlan({
+  surplus,
+  months,
+  allowNegativeToBudget = false,
+}: {
+  surplus: number;
+  months: AutoHoldMonth[];
+  allowNegativeToBudget?: boolean;
+}): AutoHoldPlanItem[] {
+  if (months.length < 2) {
+    return [];
+  }
+
+  const requiredFromPrevious = getAutoHoldRequiredFromPrevious(months);
+  let amountToHold = allowNegativeToBudget
+    ? requiredFromPrevious[1]
+    : Math.min(surplus, requiredFromPrevious[1]);
+
+  return months.slice(0, -1).map(({ month, toBudgetCapacity }, index) => {
+    const amount = Math.max(
+      0,
+      allowNegativeToBudget
+        ? amountToHold
+        : Math.min(
+            amountToHold,
+            requiredFromPrevious[index + 1],
+            toBudgetCapacity,
+          ),
+    );
+
+    const nextMonth = months[index + 1];
+    const nextMonthNeed = nextMonth.budgeted + nextMonth.overspent;
+
+    amountToHold = Math.min(
+      requiredFromPrevious[index + 2] || 0,
+      amount + nextMonth.income - nextMonthNeed,
+    );
+
+    return { month, amount };
+  });
+}
+
+export async function autoHoldForNextMonth({
+  month,
+  months,
+  allowNegativeToBudget = false,
+}: {
+  month: string;
+  months: number;
+  allowNegativeToBudget?: boolean;
+}): Promise<AutoHoldPlanItem[]> {
+  if (!Number.isInteger(months) || months < 0) {
+    return [];
+  }
+
+  if (months === 0) {
+    return [];
+  }
+
+  const surplus = await getMonthToBudgetCapacity(month);
+
+  const plan = calculateAutoHoldPlan({
+    surplus,
+    months: await getAutoHoldMonths({ month, months }),
+    allowNegativeToBudget,
+  });
+
+  if (plan.length === 0) {
+    return plan;
+  }
+
+  if (plan.every(({ amount }) => amount === 0)) {
+    return [];
+  }
+
+  await resetIncomeCarryover({ month });
+
+  await batchMessages(async () => {
+    for (const { month, amount } of plan) {
+      await setBuffer(month, amount);
+    }
+  });
+
+  return plan;
+}
+
+function getAutoHoldRequiredFromPrevious(months: AutoHoldMonth[]): number[] {
+  const requiredFromPrevious = Array(months.length).fill(0);
+
+  for (let i = months.length - 1; i > 0; i--) {
+    const month = months[i];
+    const monthNeed = month.budgeted + month.overspent;
+    requiredFromPrevious[i] =
+      monthNeed + (requiredFromPrevious[i + 1] || 0) - month.income;
+  }
+
+  return requiredFromPrevious;
+}
+
+async function getMonthBudgetedExpense(month: string): Promise<number> {
+  return -safeNumber(
+    await getSheetValue(monthUtils.sheetForMonth(month), 'total-budgeted'),
+  );
+}
+
+async function getMonthIncomeAmount(month: string): Promise<number> {
+  return safeNumber(
+    await getSheetValue(monthUtils.sheetForMonth(month), 'total-income'),
+  );
+}
+
+async function getMonthOverspentAmount(month: string): Promise<number> {
+  return -safeNumber(
+    await getSheetValue(
+      monthUtils.sheetForMonth(month),
+      'last-month-overspent',
+    ),
+  );
+}
+
+async function getMonthToBudgetCapacity(month: string): Promise<number> {
+  const sheetName = monthUtils.sheetForMonth(month);
+  const available = await getSheetValue(sheetName, 'available-funds');
+  const lastOverspent = await getSheetValue(sheetName, 'last-month-overspent');
+  const budgeted = await getMonthBudgetedExpense(month);
+
+  return available + lastOverspent - budgeted;
 }
 
 export async function resetHold({ month }: { month: string }): Promise<void> {

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -37,6 +37,8 @@ export type BudgetHandlers = {
   'budget/apply-single-template': typeof goalActions.applySingleCategoryTemplate;
   'budget/cleanup-goal-template': typeof cleanupActions.cleanupTemplate;
   'budget/hold-for-next-month': typeof actions.holdForNextMonth;
+  'budget/auto-hold-for-next-month': typeof actions.autoHoldForNextMonth;
+  'budget/get-auto-hold-months': typeof actions.getAutoHoldMonthsToInspect;
   'budget/reset-hold': typeof actions.resetHold;
   'budget/cover-overspending': typeof actions.coverOverspending;
   'budget/transfer-available': typeof actions.transferAvailable;
@@ -113,6 +115,11 @@ app.method(
   'budget/hold-for-next-month',
   mutator(undoable(actions.holdForNextMonth)),
 );
+app.method(
+  'budget/auto-hold-for-next-month',
+  mutator(undoable(actions.autoHoldForNextMonth)),
+);
+app.method('budget/get-auto-hold-months', actions.getAutoHoldMonthsToInspect);
 app.method('budget/reset-hold', mutator(undoable(actions.resetHold)));
 app.method(
   'budget/cover-overspending',

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -12,6 +12,7 @@ export type FeatureFlag =
   | 'enableBanking'
   | 'sankeyReport'
   | 'akahuBankSync'
+  | 'autoHoldForNextMonth'
   | 'mobileCalculator';
 
 /**

--- a/upcoming-release-notes/future-auto-hold.md
+++ b/upcoming-release-notes/future-auto-hold.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [tim-smart]
+---
+
+Add "Hold for next month (auto)" action to automatically adjust "For next month" based on budgeted amounts


### PR DESCRIPTION
AI assisted with this PR

## Description

Add "Auto-hold for future months" action to automatically adjust "For next month" based on budgeted amounts

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB → 13.06 MB (+39.12 kB) | +0.29%
loot-core | 1 | 4.82 MB → 4.82 MB (+4.14 kB) | +0.08%
api | 2 | 3.87 MB → 3.87 MB (+4.04 kB) | +0.10%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB → 13.06 MB (+39.12 kB) | +0.29%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/react-aria-components/dist/private/Tabs.mjs` | 🆕 +11.16 kB | 0 B → 11.16 kB
`home/runner/work/actual/actual/packages/component-library/src/Tabs.tsx` | 🆕 +2.74 kB | 0 B → 2.74 kB
`node_modules/react-stately/dist/private/tabs/useTabListState.mjs` | 🆕 +1.97 kB | 0 B → 1.97 kB
`node_modules/react-aria/dist/private/tabs/TabsKeyboardDelegate.mjs` | 🆕 +1.68 kB | 0 B → 1.68 kB
`node_modules/react-aria/dist/private/tabs/useTab.mjs` | 🆕 +1.52 kB | 0 B → 1.52 kB
`node_modules/react-aria/dist/private/tabs/useTabList.mjs` | 🆕 +1.18 kB | 0 B → 1.18 kB
`node_modules/react-stately/dist/private/list/useSingleSelectListState.mjs` | 🆕 +1.04 kB | 0 B → 1.04 kB
`node_modules/react-aria/dist/private/tabs/useTabPanel.mjs` | 🆕 +705 B | 0 B → 705 B
`node_modules/react-aria/dist/private/tabs/utils.mjs` | 🆕 +400 B | 0 B → 400 B
`src/components/modals/HoldBufferModal.tsx` | 📈 +8.12 kB (+296.43%) | 2.74 kB → 10.86 kB
`src/components/budget/envelope/HoldMenu.tsx` | 📈 +7.29 kB (+291.49%) | 2.5 kB → 9.79 kB
`home/runner/work/actual/actual/packages/component-library/src/Popover.tsx` | 📈 +360 B (+33.58%) | 1.05 kB → 1.4 kB
`node_modules/react-aria-components/dist/private/Collection.mjs` | 📈 +173 B (+5.87%) | 2.88 kB → 3.05 kB
`src/hooks/useFeatureFlag.ts` | 📈 +30 B (+4.82%) | 622 B → 652 B
`src/components/modals/EnvelopeBudgetSummaryModal.tsx` | 📈 +225 B (+3.87%) | 5.68 kB → 5.9 kB
`src/components/budget/envelope/budgetsummary/ToBudget.tsx` | 📈 +133 B (+2.32%) | 5.6 kB → 5.73 kB
`src/components/settings/Experimental.tsx` | 📈 +218 B (+1.78%) | 11.93 kB → 12.14 kB
`src/budget/mutations.ts` | 📈 +198 B (+1.48%) | 13.08 kB → 13.27 kB
`src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx` | 📈 +36 B (+0.93%) | 3.79 kB → 3.83 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.67 MB (+39.12 kB) | +0.50%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+4.14 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +3.98 kB (+30.07%) | 13.23 kB → 17.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +167 B (+1.75%) | 9.31 kB → 9.47 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C2xyjSIg.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DHYjs5zD.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+4.04 kB) | +0.10%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +3.88 kB (+30.18%) | 12.87 kB → 16.75 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +165 B (+1.76%) | 9.14 kB → 9.3 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+4.04 kB) | +0.10%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->