### PR TITLE
remove forced waits to speed up some Playwright tests

### DIFF
--- a/packages/desktop-client/e2e/budget.test.ts
+++ b/packages/desktop-client/e2e/budget.test.ts
@@ -43,11 +43,10 @@ test.describe('Budget', () => {
     const currentFundsB = await budgetPage.getBalanceForRow(2);
 
     await budgetPage.transferAllBalance(1, 2);
-    await page.waitForTimeout(1000);
 
-    expect(await budgetPage.getBalanceForRow(2)).toEqual(
-      currentFundsA + currentFundsB,
-    );
+    await expect
+      .poll(() => budgetPage.getBalanceForRow(2))
+      .toEqual(currentFundsA + currentFundsB);
     await expect(page).toMatchThemeScreenshots();
   });
 

--- a/packages/desktop-client/e2e/page-models/budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/budget-page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 import { AccountPage } from './account-page';
@@ -105,33 +106,26 @@ export class BudgetPage {
   async #waitForNewMonthToLoad({
     currentMonth,
     errorMessage,
-    maxAttempts = 3,
   }: {
     currentMonth: string;
     errorMessage: string;
-    maxAttempts: number;
   }) {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const newMonth = await this.getSelectedMonth();
-      if (newMonth !== currentMonth) {
-        return newMonth;
-      }
-      await this.page.waitForTimeout(500);
-    }
+    await expect(this.selectedMonthButton, errorMessage).not.toHaveAttribute(
+      'data-month',
+      currentMonth,
+    );
 
-    throw new Error(errorMessage);
+    return this.getSelectedMonth();
   }
 
-  async goToNextMonth({ maxAttempts = 3 }: { maxAttempts?: number } = {}) {
+  async goToNextMonth() {
     const currentMonth = await this.getSelectedMonth();
 
     await this.nextMonthButton.click();
 
     return await this.#waitForNewMonthToLoad({
       currentMonth,
-      maxAttempts,
-      errorMessage:
-        'Failed to navigate to the next month after maximum attempts.',
+      errorMessage: 'Failed to navigate to the next month.',
     });
   }
 

--- a/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 import { MobileAccountPage } from './mobile-account-page';
@@ -262,33 +263,26 @@ export class MobileBudgetPage {
   async #waitForNewMonthToLoad({
     currentMonth,
     errorMessage,
-    maxAttempts = 3,
   }: {
     currentMonth: string;
     errorMessage: string;
-    maxAttempts: number;
   }) {
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const newMonth = await this.getSelectedMonth();
-      if (newMonth !== currentMonth) {
-        return newMonth;
-      }
-      await this.page.waitForTimeout(500);
-    }
+    await expect(
+      this.heading.locator('[data-month]'),
+      errorMessage,
+    ).not.toHaveAttribute('data-month', currentMonth);
 
-    throw new Error(errorMessage);
+    return this.getSelectedMonth();
   }
 
-  async goToPreviousMonth({ maxAttempts = 3 }: { maxAttempts?: number } = {}) {
+  async goToPreviousMonth() {
     const currentMonth = await this.getSelectedMonth();
 
     await this.previousMonthButton.click();
 
     return await this.#waitForNewMonthToLoad({
       currentMonth,
-      maxAttempts,
-      errorMessage:
-        'Failed to navigate to the previous month after maximum attempts.',
+      errorMessage: 'Failed to navigate to the previous month.',
     });
   }
 
@@ -296,16 +290,14 @@ export class MobileBudgetPage {
     await this.selectedBudgetMonthButton.click();
   }
 
-  async goToNextMonth({ maxAttempts = 3 }: { maxAttempts?: number } = {}) {
+  async goToNextMonth() {
     const currentMonth = await this.getSelectedMonth();
 
     await this.nextMonthButton.click();
 
     return await this.#waitForNewMonthToLoad({
       currentMonth,
-      maxAttempts,
-      errorMessage:
-        'Failed to navigate to the next month after maximum attempts.',
+      errorMessage: 'Failed to navigate to the next month.',
     });
   }
 

--- a/packages/desktop-client/e2e/page-models/mobile-navigation.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-navigation.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 import { MobileAccountPage } from './mobile-account-page';
@@ -91,9 +92,7 @@ export class MobileNavigation {
       },
     });
 
-    // Wait for the react-spring animation to complete before taking screenshots.
-    // The animation typically takes a few hundred milliseconds to finish.
-    await this.page.waitForTimeout(500);
+    await expect(this.navbar).not.toHaveAttribute('data-navbar-state', 'open');
   }
 
   async hasNavbarState(...states: string[]) {

--- a/packages/desktop-client/e2e/page-models/schedules-page.ts
+++ b/packages/desktop-client/e2e/page-models/schedules-page.ts
@@ -55,7 +55,6 @@ export class SchedulesPage {
    */
   async postNthSchedule(index: number) {
     await this._performNthAction(index, 'Post transaction today');
-    await this.page.waitForTimeout(1000);
   }
 
   /**
@@ -64,7 +63,6 @@ export class SchedulesPage {
    */
   async completeNthSchedule(index: number) {
     await this._performNthAction(index, 'Complete');
-    await this.page.waitForTimeout(1000);
   }
 
   async _performNthAction(index: number, actionName: string | RegExp) {

--- a/packages/desktop-client/e2e/payees.mobile.test.ts
+++ b/packages/desktop-client/e2e/payees.mobile.test.ts
@@ -86,7 +86,6 @@ test.describe('Mobile Payees', () => {
   test('page handles empty state gracefully', async () => {
     // Search for something that won't match to get empty state
     await payeesPage.searchFor('NonExistentPayee123456789');
-    await page.waitForTimeout(500);
 
     // Check that empty message is shown
     const emptyMessage = page.getByText('No payees found.');

--- a/packages/desktop-client/e2e/rules.mobile.test.ts
+++ b/packages/desktop-client/e2e/rules.mobile.test.ts
@@ -76,7 +76,6 @@ test.describe('Mobile Rules', () => {
   test('page handles empty state gracefully', async () => {
     // Search for something that won't match to get empty state
     await rulesPage.searchFor('NonExistentRule123456789');
-    await page.waitForTimeout(500);
 
     // Check that empty message is shown
     const emptyMessage = page.getByText(/No rules found/);

--- a/packages/desktop-client/e2e/rules.test.ts
+++ b/packages/desktop-client/e2e/rules.test.ts
@@ -71,8 +71,6 @@ test.describe('Rules', () => {
   });
 
   test('creates a split transaction rule and makes sure it is applied when creating a transaction', async () => {
-    rulesPage = await navigation.goToRulesPage();
-
     const editRuleModal = await rulesPage.createNewRule();
     await editRuleModal.fill({
       conditions: [

--- a/packages/desktop-client/e2e/schedules.mobile.test.ts
+++ b/packages/desktop-client/e2e/schedules.mobile.test.ts
@@ -57,7 +57,6 @@ test.describe('Mobile Schedules', () => {
   test('page handles empty state gracefully', async () => {
     // Search for something that won't match to get empty state
     await schedulesPage.searchFor('NonExistentSchedule123456789');
-    await page.waitForTimeout(500);
 
     // Check that empty message is shown
     await expect(schedulesPage.emptyMessage).toBeVisible();
@@ -99,20 +98,20 @@ test.describe('Mobile Schedules', () => {
 
     // Search for a specific schedule
     await schedulesPage.searchFor('Dominion Power');
-    await page.waitForTimeout(500);
 
     // Verify search box has the value
     await expect(schedulesPage.searchBox).toHaveValue('Dominion Power');
-    expect(await schedulesPage.getScheduleCount()).toBe(1);
+    await expect.poll(() => schedulesPage.getScheduleCount()).toBe(1);
 
     await expect(page).toMatchThemeScreenshots();
 
     // Clear search
     await schedulesPage.clearSearch();
-    await page.waitForTimeout(500);
 
     // Verify all schedules are visible again
-    expect(await schedulesPage.getScheduleCount()).toBeGreaterThan(1);
+    await expect
+      .poll(() => schedulesPage.getScheduleCount())
+      .toBeGreaterThan(1);
 
     await expect(page).toMatchThemeScreenshots();
   });

--- a/upcoming-release-notes/test-speeds-1.md
+++ b/upcoming-release-notes/test-speeds-1.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Remove forced waits to speed up some Playwright tests


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Using the depot analytics it looks like some of our tests are pretty slow, I'll tackle it in stages as much as I can to make sure we don't introduce any flakes.

My first stab is to remove as many forced waits as possible in favour of just waiting the length of time actually required.

Locally, this took the whole suite down about 30-40s and I'd expect VRT gains to be even higher.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->


Ran them all locally, hammered the changes quite a few times with single threads, and then again with concurrent runners. None flaked even once

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB | 0%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 176.61 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DHYjs5zD.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->