### PR TITLE
Fix append notes rule merge for new transactions

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -41,6 +41,7 @@ import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 
+import { shouldApplyRuleChange } from './table/utils';
 import { TransactionTable } from './TransactionsTable';
 import type { TransactionTableProps } from './TransactionsTable';
 // When data changes, there are two ways to update the UI:
@@ -541,10 +542,7 @@ export function TransactionList({
       if (diff) {
         Object.keys(diff).forEach(field => {
           if (
-            newTransaction[field] == null ||
-            newTransaction[field] === '' ||
-            newTransaction[field] === 0 ||
-            newTransaction[field] === false
+            shouldApplyRuleChange(field, newTransaction[field], diff[field])
           ) {
             newTransaction[field] = diff[field];
           }

--- a/packages/desktop-client/src/components/transactions/table/utils.test.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.test.ts
@@ -1,0 +1,25 @@
+import { shouldApplyRuleChange } from './utils';
+
+describe('shouldApplyRuleChange', () => {
+  test('allows rule changes for empty fields', () => {
+    expect(shouldApplyRuleChange('category', null, 'food')).toBe(true);
+    expect(shouldApplyRuleChange('notes', '', 'memo')).toBe(true);
+    expect(shouldApplyRuleChange('cleared', false, true)).toBe(true);
+  });
+
+  test('keeps user-entered field values by default', () => {
+    expect(shouldApplyRuleChange('category', 'food', 'home')).toBe(false);
+    expect(shouldApplyRuleChange('notes', 'manual note', 'rule note')).toBe(
+      false,
+    );
+  });
+
+  test('allows note prepend and append rule changes', () => {
+    expect(
+      shouldApplyRuleChange('notes', 'manual note', 'rule: manual note'),
+    ).toBe(true);
+    expect(
+      shouldApplyRuleChange('notes', 'manual note', 'manual note rule'),
+    ).toBe(true);
+  });
+});

--- a/packages/desktop-client/src/components/transactions/table/utils.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.ts
@@ -120,6 +120,34 @@ export function getDisplayValue<T>(obj: T | null | undefined, name: keyof T) {
   return obj ? obj[name] : '';
 }
 
+export function shouldApplyRuleChange(
+  field: string,
+  currentValue: unknown,
+  nextValue: unknown,
+) {
+  if (
+    currentValue == null ||
+    currentValue === '' ||
+    currentValue === 0 ||
+    currentValue === false
+  ) {
+    return true;
+  }
+
+  if (
+    field === 'notes' &&
+    typeof currentValue === 'string' &&
+    typeof nextValue === 'string'
+  ) {
+    return (
+      nextValue !== currentValue &&
+      (nextValue.startsWith(currentValue) || nextValue.endsWith(currentValue))
+    );
+  }
+
+  return false;
+}
+
 export function makeTemporaryTransactions(
   currentAccountId: AccountEntity['id'] | null | undefined,
   currentCategoryId: CategoryEntity['id'] | null | undefined,

--- a/upcoming-release-notes/fix-append-notes-rule-merge.md
+++ b/upcoming-release-notes/fix-append-notes-rule-merge.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ydnd]
+---
+
+Fix append and prepend notes rules when creating a new transaction


### PR DESCRIPTION
Fixes actualbudget/actual#7303.

When creating a new transaction, rule changes are only applied to fields that are still empty so user-entered values are not overwritten.

This caused append/prepend notes rule actions to be ignored when the notes field already had a value, even though those actions intentionally preserve the existing note and add text before or after it.

This PR keeps the existing non-overwrite behavior for normal rule changes, but allows notes changes when the rule result preserves the original note as a prefix or suffix.

Tested:
- `yarn workspace @actual-app/web test src/components/transactions/table/utils.test.ts`
- `yarn exec oxfmt --check packages/desktop-client/src/components/transactions/TransactionList.tsx packages/desktop-client/src/components/transactions/table/utils.ts packages/desktop-client/src/components/transactions/table/utils.test.ts`
- `yarn workspace @actual-app/web typecheck`

AI disclosure: I used AI assistance to help identify the code path and prepare the change, and I reviewed and tested the final patch.

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB → 13.02 MB (+334 B) | +0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB → 13.02 MB (+334 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/table/utils.ts` | 📈 +397 B (+21.77%) | 1.78 kB → 2.17 kB
`src/components/transactions/TransactionList.tsx` | 📉 -63 B (-0.36%) | 17.32 kB → 17.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.63 MB (+334 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 177.24 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DHYjs5zD.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed