### PR TITLE
[AI] Fix append/prepend notes rules on new transactions

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -72,6 +72,7 @@
     "#components/reports/util": "./src/components/reports/util.ts",
     "#components/schedules": "./src/components/schedules/index.tsx",
     "#components/schedules/schedule-edit-utils": "./src/components/schedules/schedule-edit-utils.ts",
+    "#components/transactions/table/utils": "./src/components/transactions/table/utils.ts",
     "#components/util/accountValidation": "./src/components/util/accountValidation.ts",
     "#components/util/countries": "./src/components/util/countries.ts",
     "#components/util/localeToCountry": "./src/components/util/localeToCountry.ts",

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -81,6 +81,7 @@ import {
 } from '#components/mobile/MobileForms';
 import { getPrettyPayee } from '#components/mobile/utils';
 import { MobilePageHeader, Page } from '#components/Page';
+import { shouldApplyRuleChange } from '#components/transactions/table/utils';
 import { createSingleTimeScheduleFromTransaction } from '#components/transactions/TransactionList';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategories } from '#hooks/useCategories';
@@ -1777,15 +1778,13 @@ function TransactionEditUnconnected({
         if (diff) {
           Object.keys(diff).forEach(key => {
             const field = key as keyof TransactionEntity;
-            // Update "empty" fields in general
+            // Apply rule changes to "empty" fields and append/prepend notes rules
+            // (see shouldApplyRuleChange).
             // Or update all fields if the payee changes (assists location-based entry by
             // applying rules to prefill category, notes, etc. based on the selected payee)
             if (
-              newTransaction[field] == null ||
-              newTransaction[field] === '' ||
-              newTransaction[field] === 0 ||
-              newTransaction[field] === false ||
-              updatedField === 'payee'
+              updatedField === 'payee' ||
+              shouldApplyRuleChange(field, newTransaction[field], diff[field])
             ) {
               (newTransaction as Record<string, unknown>)[field] = diff[field];
             }

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -41,6 +41,7 @@ import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 
+import { shouldApplyRuleChange } from './table/utils';
 import { TransactionTable } from './TransactionsTable';
 import type { TransactionTableProps } from './TransactionsTable';
 // When data changes, there are two ways to update the UI:
@@ -541,10 +542,7 @@ export function TransactionList({
       if (diff) {
         Object.keys(diff).forEach(field => {
           if (
-            newTransaction[field] == null ||
-            newTransaction[field] === '' ||
-            newTransaction[field] === 0 ||
-            newTransaction[field] === false
+            shouldApplyRuleChange(field, newTransaction[field], diff[field])
           ) {
             newTransaction[field] = diff[field];
           }

--- a/packages/desktop-client/src/components/transactions/table/utils.test.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.test.ts
@@ -1,0 +1,65 @@
+import { shouldApplyRuleChange } from './utils';
+
+describe('shouldApplyRuleChange', () => {
+  test('applies rule changes to empty fields', () => {
+    expect(shouldApplyRuleChange('category', null, 'food')).toBe(true);
+    expect(shouldApplyRuleChange('notes', '', 'memo')).toBe(true);
+    expect(shouldApplyRuleChange('cleared', false, true)).toBe(true);
+    expect(shouldApplyRuleChange('amount', 0, 1200)).toBe(true);
+  });
+
+  test('keeps user-entered values for non-empty fields by default', () => {
+    expect(shouldApplyRuleChange('category', 'food', 'home')).toBe(false);
+    expect(shouldApplyRuleChange('notes', 'manual note', 'rule note')).toBe(
+      false,
+    );
+  });
+
+  test('applies append and prepend notes rules', () => {
+    expect(
+      shouldApplyRuleChange('notes', 'Coffee and cake', 'Coffee and cake Tip'),
+    ).toBe(true);
+    expect(
+      shouldApplyRuleChange('notes', 'Coffee and cake', 'Tip Coffee and cake'),
+    ).toBe(true);
+  });
+
+  test('applies appends with no separator between the note and added text', () => {
+    expect(shouldApplyRuleChange('notes', 'Coffee', 'CoffeePAID')).toBe(true);
+  });
+
+  test('applies a combined prepend and append in a single rule run', () => {
+    expect(shouldApplyRuleChange('notes', 'Coffee', 'A Coffee B')).toBe(true);
+  });
+
+  test('is idempotent: does not re-append text already present', () => {
+    // Rules re-run on every keystroke during entry; the second run sees the
+    // already-appended note and must not append again.
+    expect(
+      shouldApplyRuleChange(
+        'notes',
+        'Coffee and cake Tip',
+        'Coffee and cake Tip Tip',
+      ),
+    ).toBe(false);
+    expect(
+      shouldApplyRuleChange(
+        'notes',
+        'Tip Coffee and cake',
+        'Tip Tip Coffee and cake',
+      ),
+    ).toBe(false);
+  });
+
+  test('does not apply when the rule replaces the note entirely', () => {
+    expect(
+      shouldApplyRuleChange('notes', 'manual note', 'completely different'),
+    ).toBe(false);
+  });
+
+  test('only the notes field is allowed to merge', () => {
+    expect(shouldApplyRuleChange('imported_payee', 'Store', 'Store Inc')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/desktop-client/src/components/transactions/table/utils.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.ts
@@ -120,6 +120,55 @@ export function getDisplayValue<T>(obj: T | null | undefined, name: keyof T) {
   return obj ? obj[name] : '';
 }
 
+// Decides whether a rule result should be applied to a field while the user is
+// entering a new transaction. By default rules only fill fields the user left
+// empty, so their manual input isn't overwritten. The exception is the notes
+// field: append/prepend notes rules intentionally preserve the existing note and
+// add text before or after it, so we allow those through. The check stays
+// idempotent — rules are re-run on every keystroke during entry, so we must not
+// re-add text that the previous run already applied.
+export function shouldApplyRuleChange(
+  field: string,
+  currentValue: unknown,
+  nextValue: unknown,
+) {
+  if (
+    currentValue == null ||
+    currentValue === '' ||
+    currentValue === 0 ||
+    currentValue === false
+  ) {
+    return true;
+  }
+
+  if (
+    field !== 'notes' ||
+    typeof currentValue !== 'string' ||
+    typeof nextValue !== 'string' ||
+    nextValue === currentValue
+  ) {
+    return false;
+  }
+
+  // The rule preserved the user's note only if the result still contains it
+  // verbatim. Otherwise treat it as an overwrite and keep the manual note.
+  const index = nextValue.indexOf(currentValue);
+  if (index === -1) {
+    return false;
+  }
+
+  const prepended = nextValue.slice(0, index);
+  const appended = nextValue.slice(index + currentValue.length);
+
+  // If the note already starts/ends with these exact additions, a previous rule
+  // run already applied them — applying again would duplicate the text.
+  const alreadyApplied =
+    (prepended === '' || currentValue.startsWith(prepended)) &&
+    (appended === '' || currentValue.endsWith(appended));
+
+  return !alreadyApplied;
+}
+
 export function makeTemporaryTransactions(
   currentAccountId: AccountEntity['id'] | null | undefined,
   currentCategoryId: CategoryEntity['id'] | null | undefined,

--- a/upcoming-release-notes/fix-append-prepend-notes-rules-new-transaction.md
+++ b/upcoming-release-notes/fix-append-prepend-notes-rules-new-transaction.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MatissJanis]
+---
+
+Fix append and prepend notes rules being ignored when adding a new transaction that already has a note, without duplicating the added text.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

For some reason bots (presumably) really love solving this issue. But all of the solutions were incomplete.

When you add a new transaction that already has a note and a rule is set up to add text to that note, the app re-runs rules repeatedly as you fill in the transaction.. Once for each field you touch and again when you save. The two existing fixes make the rule's text get added, but they don't stop it from being added again on each of those repeats, so a note that should read "Coffee and cake - paid" ends up as "Coffee and cake - paid - paid - paid," with the rule's text duplicated several times.



## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/pull/8003
https://github.com/actualbudget/actual/pull/8296

Fixes #7303


## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

unit tests added and manual verification done

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB → 13.02 MB (+594 B) | +0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB → 13.02 MB (+594 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/table/utils.ts` | 📈 +631 B (+34.59%) | 1.78 kB → 2.4 kB
`package.json` | 📈 +89 B (+0.93%) | 9.39 kB → 9.47 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📉 -63 B (-0.09%) | 71.92 kB → 71.86 kB
`src/components/transactions/TransactionList.tsx` | 📉 -63 B (-0.36%) | 17.32 kB → 17.26 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.63 MB (+594 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 177.24 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CdbreuPy.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->