### PR TITLE
[AI] Fix mobile category delete confirmation

### DIFF
--- a/packages/desktop-client/e2e/budget.mobile.test.ts
+++ b/packages/desktop-client/e2e/budget.mobile.test.ts
@@ -278,13 +278,12 @@ budgetTypes.forEach(budgetType => {
       const budgetPage = await navigation.goToBudgetPage();
 
       const categoryGroupName = await budgetPage.getCategoryGroupNameForRow(0);
-      await budgetPage.openCategoryGroupMenu(categoryGroupName);
+      const categoryGroupMenuModal =
+        await budgetPage.openCategoryGroupMenu(categoryGroupName);
 
-      const categoryMenuModalHeading = page
-        .getByRole('dialog')
-        .getByRole('heading');
-
-      await expect(categoryMenuModalHeading).toHaveText(categoryGroupName);
+      await expect(categoryGroupMenuModal.heading).toHaveText(
+        categoryGroupName,
+      );
       await expect(page).toMatchThemeScreenshots();
     });
 
@@ -296,6 +295,41 @@ budgetTypes.forEach(budgetType => {
 
       await expect(categoryMenuModal.heading).toHaveText(categoryName);
       await expect(page).toMatchThemeScreenshots();
+    });
+
+    test('opens the transfer confirmation when deleting a category group with transactions', async () => {
+      const budgetPage = await navigation.goToBudgetPage();
+
+      const categoryGroupName = await budgetPage.getCategoryGroupNameForRow(0);
+      const categoryGroupMenuModal =
+        await budgetPage.openCategoryGroupMenu(categoryGroupName);
+
+      await categoryGroupMenuModal.delete();
+
+      const confirmDeleteModal = page.getByTestId(
+        'confirm-category-delete-modal',
+      );
+      await expect(confirmDeleteModal.getByRole('heading')).toHaveText(
+        'Confirm Delete',
+      );
+      await expect(confirmDeleteModal).toContainText('Transfer to:');
+    });
+
+    test('opens the transfer confirmation when deleting a category with transactions', async () => {
+      const budgetPage = await navigation.goToBudgetPage();
+
+      const categoryName = await budgetPage.getCategoryNameForRow(0);
+      const categoryMenuModal = await budgetPage.openCategoryMenu(categoryName);
+
+      await categoryMenuModal.delete();
+
+      const confirmDeleteModal = page.getByTestId(
+        'confirm-category-delete-modal',
+      );
+      await expect(confirmDeleteModal.getByRole('heading')).toHaveText(
+        'Confirm Delete',
+      );
+      await expect(confirmDeleteModal).toContainText('Transfer to:');
     });
 
     // Budgeted Cell Tests

--- a/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-budget-page.ts
@@ -4,6 +4,7 @@ import type { Locator, Page } from '@playwright/test';
 import { MobileAccountPage } from './mobile-account-page';
 import { BalanceMenuModal } from './mobile-balance-menu-modal';
 import { BudgetMenuModal } from './mobile-budget-menu-modal';
+import { CategoryGroupMenuModal } from './mobile-category-group-menu-modal';
 import { CategoryMenuModal } from './mobile-category-menu-modal';
 import { EnvelopeBudgetSummaryModal } from './mobile-envelope-budget-summary-modal';
 import { TrackingBudgetSummaryModal } from './mobile-tracking-budget-summary-modal';
@@ -160,6 +161,12 @@ export class MobileBudgetPage {
     const categoryGroupButton =
       await this.#getButtonForCategoryGroup(categoryGroupName);
     await categoryGroupButton.click();
+
+    return new CategoryGroupMenuModal(
+      this.page.getByRole('dialog', {
+        name: 'Modal dialog',
+      }),
+    );
   }
 
   async getCategoryNameForRow(idx: number) {

--- a/packages/desktop-client/e2e/page-models/mobile-category-group-menu-modal.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-category-group-menu-modal.ts
@@ -1,0 +1,24 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class CategoryGroupMenuModal {
+  readonly page: Page;
+  readonly locator: Locator;
+  readonly heading: Locator;
+  readonly menuButton: Locator;
+
+  constructor(locator: Locator) {
+    this.locator = locator;
+    this.page = locator.page();
+
+    this.heading = locator.getByRole('heading');
+    this.menuButton = this.heading.getByRole('button', { name: 'Menu' });
+  }
+
+  async delete() {
+    await this.menuButton.click();
+    await this.page
+      .locator('[data-popover]')
+      .getByRole('button', { name: 'Delete' })
+      .click();
+  }
+}

--- a/packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts
@@ -6,6 +6,7 @@ export class CategoryMenuModal {
   readonly page: Page;
   readonly locator: Locator;
   readonly heading: Locator;
+  readonly menuButton: Locator;
   readonly budgetAmountInput: Locator;
   readonly editNotesButton: Locator;
   readonly budgetAutomationsButton: Locator;
@@ -15,6 +16,7 @@ export class CategoryMenuModal {
     this.page = locator.page();
 
     this.heading = locator.getByRole('heading');
+    this.menuButton = this.heading.getByRole('button', { name: 'Menu' });
     this.budgetAmountInput = locator.getByTestId('amount-input');
     this.editNotesButton = locator.getByRole('button', { name: 'Edit notes' });
     this.budgetAutomationsButton = locator.getByRole('button', {
@@ -40,5 +42,13 @@ export class CategoryMenuModal {
     await this.budgetAutomationsButton.click();
 
     return this.page.getByRole('dialog', { name: 'Modal dialog' });
+  }
+
+  async delete() {
+    await this.menuButton.click();
+    await this.page
+      .locator('[data-popover]')
+      .getByRole('button', { name: 'Delete' })
+      .click();
   }
 }

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -237,14 +237,8 @@ export function BudgetPage() {
 
   const onDeleteGroup = useCallback(
     groupId => {
-      deleteCategoryGroup.mutate(
-        { id: groupId },
-        {
-          onSettled: () => {
-            dispatch(collapseModals({ rootModalName: 'category-group-menu' }));
-          },
-        },
-      );
+      dispatch(collapseModals({ rootModalName: 'category-group-menu' }));
+      deleteCategoryGroup.mutate({ id: groupId });
     },
     [deleteCategoryGroup, dispatch],
   );
@@ -270,14 +264,8 @@ export function BudgetPage() {
 
   const onDeleteCategory = useCallback(
     categoryId => {
-      deleteCategory.mutate(
-        { id: categoryId },
-        {
-          onSettled: () => {
-            dispatch(collapseModals({ rootModalName: 'category-menu' }));
-          },
-        },
-      );
+      dispatch(collapseModals({ rootModalName: 'category-menu' }));
+      deleteCategory.mutate({ id: categoryId });
     },
     [deleteCategory, dispatch],
   );

--- a/upcoming-release-notes/fix-mobile-category-delete-confirmation.md
+++ b/upcoming-release-notes/fix-mobile-category-delete-confirmation.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [edwei06]
+---
+
+Fix deleting categories and category groups with transactions on mobile


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes a mobile regression where deleting a category or category group with transactions appeared to do nothing.

When the delete mutation needs to reassign existing transactions and balances, it opens the `confirm-category-delete` modal. On mobile, the category/category group menu previously passed an `onSettled` callback that called `collapseModals(...)` after the mutation, which also collapsed the newly opened confirmation modal. As a result, users did not see the `Confirm Delete` / `Transfer to:` flow.

This changes the flow to close the current category/category group menu before running the delete mutation. If the mutation determines that reassignment is required, the confirmation modal remains active and visible.

This PR also adds mobile Playwright regression coverage for both category and category group deletion paths, and adds a release note.

The code and tests in this PR were assisted by OpenAI Codex. I have reviewed the changes and test results.

## Related issue(s)

Fixes #8230

## Testing

- Ran `corepack yarn install --immutable`.
- Ran `corepack yarn oxfmt --check packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx packages/desktop-client/e2e/budget.mobile.test.ts packages/desktop-client/e2e/page-models/mobile-budget-page.ts packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts packages/desktop-client/e2e/page-models/mobile-category-group-menu-modal.ts upcoming-release-notes/fix-mobile-category-delete-confirmation.md`.
- Ran `corepack yarn workspace @actual-app/web run typecheck`.
- Ran `corepack yarn oxlint --type-aware --quiet packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx packages/desktop-client/e2e/budget.mobile.test.ts packages/desktop-client/e2e/page-models/mobile-budget-page.ts packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts packages/desktop-client/e2e/page-models/mobile-category-group-menu-modal.ts`.
- Ran `BASE_REF=master node packages/ci-actions/bin/release-notes-check.mjs`.
- Ran `corepack yarn workspace @actual-app/web run playwright test e2e/budget.mobile.test.ts --browser=chromium --grep "transfer confirmation"`; 4 tests passed.
- GitHub Actions are passing, including lint, typecheck, test, functional e2e, visual regression tests, and Electron builds for Linux, macOS, and Windows.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 13.02 MB → 13.02 MB (-60 B) | -0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 13.02 MB → 13.02 MB (-60 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/budget/BudgetPage.tsx` | 📉 -60 B (-0.16%) | 36.97 kB → 36.92 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/narrow.js | 358.79 kB → 358.73 kB (-60 B) | -0.02%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 179.71 kB | 0%
static/js/da.js | 100.19 kB | 0%
static/js/de.js | 177.24 kB | 0%
static/js/en-GB.js | 9.25 kB | 0%
static/js/en.js | 200.55 kB | 0%
static/js/es.js | 171.82 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 173.26 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 158.13 kB | 0%
static/js/nb-NO.js | 141.55 kB | 0%
static/js/nl.js | 119.14 kB | 0%
static/js/pt-BR.js | 181.5 kB | 0%
static/js/th.js | 173.33 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 209.97 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.07 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 113.26 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.RjHyOlEX.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->