### PR TITLE
[AI] Fix running balance text selection

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -118,6 +118,46 @@ test.describe('Accounts', () => {
     await expect(accountPage.selectButton).toHaveText('2 transactions');
   });
 
+  test('running balance text can be selected', async () => {
+    accountPage = await navigation.createAccount({
+      name: 'Selectable Balance',
+      offBudget: false,
+      balance: 0,
+    });
+    await accountPage.waitFor();
+
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'selectable-balance-one',
+      debit: '10.00',
+    });
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'selectable-balance-two',
+      debit: '20.00',
+    });
+
+    await accountPage.accountMenuButton.click();
+    await page.getByRole('button', { name: 'Show running balance' }).click();
+
+    const balanceCell = accountPage.getNthTransaction(0).balance;
+    await expect(balanceCell).toContainText('-30.00');
+
+    const box = await balanceCell.boundingBox();
+    if (!box) {
+      throw new Error('Failed to get running balance cell bounds.');
+    }
+
+    await page.mouse.move(box.x + box.width - 8, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 8, box.y + box.height / 2);
+    await page.mouse.up();
+
+    await expect
+      .poll(() => page.evaluate(() => window.getSelection()?.toString() ?? ''))
+      .toContain('-30.00');
+  });
+
   test.describe('On Budget Accounts', () => {
     // Reset filters
     test.afterEach(async () => {

--- a/packages/desktop-client/e2e/page-models/account-page.ts
+++ b/packages/desktop-client/e2e/page-models/account-page.ts
@@ -159,6 +159,7 @@ export class AccountPage {
       category: row.getByTestId('category'),
       debit: row.getByTestId('debit'),
       credit: row.getByTestId('credit'),
+      balance: row.getByTestId('balance'),
     };
   }
 

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -1192,6 +1192,26 @@ const Transaction = memo(function Transaction({
   const amountStyle = hideFraction ? { letterSpacing: -0.5 } : null;
 
   const runningBalance = !isTemporaryId(id) ? balance : balance + amount;
+  const [isSelectingRunningBalance, setIsSelectingRunningBalance] =
+    useState(false);
+
+  useEffect(() => {
+    if (!isSelectingRunningBalance) {
+      return;
+    }
+
+    const resetSelectionDragGuard = () => setIsSelectingRunningBalance(false);
+
+    window.addEventListener('pointerup', resetSelectionDragGuard);
+    window.addEventListener('mouseup', resetSelectionDragGuard);
+    window.addEventListener('blur', resetSelectionDragGuard);
+
+    return () => {
+      window.removeEventListener('pointerup', resetSelectionDragGuard);
+      window.removeEventListener('mouseup', resetSelectionDragGuard);
+      window.removeEventListener('blur', resetSelectionDragGuard);
+    };
+  }, [isSelectingRunningBalance]);
 
   // Ok this entire logic is a dirty, dirty hack.. but let me explain.
   // Problem: the split-error Popover (which has the buttons to distribute/add split)
@@ -1232,6 +1252,7 @@ const Transaction = memo(function Transaction({
   // instead of moving the caret or selecting text (see GH #7567).
   const allowRowDrag =
     canDrag &&
+    !isSelectingRunningBalance &&
     !isPreview &&
     !isOnlyTransactionOnDate &&
     (!editing || focusedField === 'select' || focusedField === 'cleared');
@@ -1872,6 +1893,12 @@ const Transaction = memo(function Transaction({
             style={{ ...styles.tnum, ...amountStyle }}
             width={103}
             textAlign="right"
+            onPointerDown={e => {
+              e.stopPropagation();
+              setIsSelectingRunningBalance(true);
+            }}
+            onMouseDown={e => e.stopPropagation()}
+            onDragStart={e => e.stopPropagation()}
             privacyFilter
           />
         )}

--- a/upcoming-release-notes/fix-running-balance-selection.md
+++ b/upcoming-release-notes/fix-running-balance-selection.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [edwei06]
+---
+
+Fix selecting running balance text in Firefox


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes Firefox text selection for the running balance column on the account page.

When transaction rows are draggable, dragging across the running balance cell can start the row-level drag behavior instead of selecting the balance text. This makes the running balance numbers partially or completely unselectable in Firefox. This PR temporarily disables row dragging when the pointer interaction starts inside the running balance cell, and stops the balance cell's pointer, mouse, and drag events from bubbling into the row drag handler.

This change also adds Playwright regression coverage to verify that running balance text can be selected after enabling the running balance column, and includes a release note.

The code and tests in this PR were assisted by OpenAI Codex. I have reviewed the changes and test results.

## Related issue(s)

Fixes #7833

## Testing

Local test environment:

- Windows 11 Pro 10.0.26100, 64-bit.
- Node.js v24.15.0, Yarn 4.13.0, Playwright 1.59.1.
- Playwright-managed Firefox and Chromium browsers, run from the repository root on the local Windows machine.

Commands run:

- Ran `corepack yarn oxfmt --check packages/desktop-client/src/components/transactions/TransactionsTable.tsx packages/desktop-client/e2e/accounts.test.ts packages/desktop-client/e2e/page-models/account-page.ts upcoming-release-notes/fix-running-balance-selection.md`.
- Ran `corepack yarn workspace @actual-app/web run typecheck`.
- Ran `corepack yarn oxlint --type-aware --quiet packages/desktop-client/src/components/transactions/TransactionsTable.tsx packages/desktop-client/e2e/accounts.test.ts packages/desktop-client/e2e/page-models/account-page.ts`.
- Ran `BASE_REF=master node packages/ci-actions/bin/release-notes-check.mjs`.
- Ran `corepack yarn workspace @actual-app/web run playwright test e2e/accounts.test.ts --browser=firefox --grep "running balance text can be selected"`; 1 test passed.
- Ran `corepack yarn workspace @actual-app/web run playwright test e2e/accounts.test.ts --browser=chromium --grep "running balance text can be selected"`; 1 test passed.

GitHub Actions also passed on the latest commit, including lint, typecheck, tests, functional/VRT shards, and Electron builds for Linux, macOS, and Windows.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
