### PR TITLE
[AI] Fix transfer payee sorting by account

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -90,6 +90,7 @@ import { updateNewTransactions } from '#transactions/transactionsSlice';
 
 import { AccountEmptyMessage } from './AccountEmptyMessage';
 import { AccountHeader } from './Header';
+import { getTransactionSortExpressions, getTransactionSortField } from './sort';
 
 type ConditionEntity = Partial<RuleConditionEntity> | TransactionFilterEntity;
 
@@ -183,27 +184,6 @@ function AllTransactions({
     return children(transactions, balances);
   }
   return children(allTransactions, allBalances);
-}
-
-function getField(field?: string) {
-  if (!field) {
-    return 'date';
-  }
-
-  switch (field) {
-    case 'account':
-      return 'account.name';
-    case 'payee':
-      return 'payee.name';
-    case 'category':
-      return 'category.name';
-    case 'payment':
-      return 'amount';
-    case 'deposit':
-      return 'amount';
-    default:
-      return field;
-  }
 }
 
 type AccountInternalProps = {
@@ -1599,11 +1579,14 @@ class AccountInternal extends PureComponent<
   ) => {
     const filterConditions = this.state.filterConditions;
     const isFiltered = filterConditions.length > 0;
-    const sortField = getField(!field ? this.state.sort?.field : field);
-    const sortAscDesc = !ascDesc ? this.state.sort?.ascDesc : ascDesc;
-    const sortPrevField = getField(
-      !prevField ? this.state.sort?.prevField : prevField,
+    const sortField = getTransactionSortField(
+      !field ? this.state.sort?.field : field,
     );
+    const sortAscDesc = !ascDesc ? this.state.sort?.ascDesc : ascDesc;
+    const prevSortField = !prevField ? this.state.sort?.prevField : prevField;
+    const sortPrevField = prevSortField
+      ? getTransactionSortField(prevSortField)
+      : undefined;
     const sortPrevAscDesc = !prevField
       ? this.state.sort?.prevAscDesc
       : prevAscDesc;
@@ -1613,15 +1596,9 @@ class AccountInternal extends PureComponent<
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
     ) {
-      if (sortField === 'cleared') {
-        that.currentQuery = that.currentQuery.orderBy({
-          reconciled: sortAscDesc,
-        });
-      }
-
-      that.currentQuery = that.currentQuery.orderBy({
-        [sortField]: sortAscDesc,
-      });
+      that.currentQuery = that.currentQuery.orderBy(
+        getTransactionSortExpressions(sortField, sortAscDesc),
+      );
     };
 
     const sortRootQuery = function (
@@ -1629,39 +1606,24 @@ class AccountInternal extends PureComponent<
       sortField: string,
       sortAscDesc?: 'asc' | 'desc',
     ) {
-      if (sortField === 'cleared') {
-        that.currentQuery = that.rootQuery.orderBy({
-          reconciled: sortAscDesc,
-        });
-        that.currentQuery = that.currentQuery.orderBy({
-          cleared: sortAscDesc,
-        });
-      } else {
-        that.currentQuery = that.rootQuery.orderBy({
-          [sortField]: sortAscDesc,
-        });
-      }
+      that.currentQuery = that.rootQuery.orderBy(
+        getTransactionSortExpressions(sortField, sortAscDesc),
+      );
     };
 
     // sort by previously used sort field, if any
     const maybeSortByPreviousField = function (
       that: AccountInternal,
-      sortPrevField: string,
+      sortPrevField?: string,
       sortPrevAscDesc?: 'asc' | 'desc',
     ) {
       if (!sortPrevField) {
         return;
       }
 
-      if (sortPrevField === 'cleared') {
-        that.currentQuery = that.currentQuery.orderBy({
-          reconciled: sortPrevAscDesc,
-        });
-      }
-
-      that.currentQuery = that.currentQuery.orderBy({
-        [sortPrevField]: sortPrevAscDesc,
-      });
+      that.currentQuery = that.currentQuery.orderBy(
+        getTransactionSortExpressions(sortPrevField, sortPrevAscDesc),
+      );
     };
 
     switch (true) {

--- a/packages/desktop-client/src/components/accounts/sort.test.ts
+++ b/packages/desktop-client/src/components/accounts/sort.test.ts
@@ -1,0 +1,29 @@
+import { getTransactionSortExpressions, getTransactionSortField } from './sort';
+
+describe('getTransactionSortField', () => {
+  test('maps transaction table columns to query fields', () => {
+    expect(getTransactionSortField()).toBe('date');
+    expect(getTransactionSortField('account')).toBe('account.name');
+    expect(getTransactionSortField('payee')).toBe('payee.name');
+    expect(getTransactionSortField('category')).toBe('category.name');
+    expect(getTransactionSortField('payment')).toBe('amount');
+    expect(getTransactionSortField('deposit')).toBe('amount');
+    expect(getTransactionSortField('notes')).toBe('notes');
+  });
+});
+
+describe('getTransactionSortExpressions', () => {
+  test('sorts transfer payees by their account names', () => {
+    expect(getTransactionSortExpressions('payee', 'asc')).toEqual([
+      { 'payee.name': 'asc' },
+      { 'payee.transfer_acct.name': 'asc' },
+    ]);
+  });
+
+  test('keeps the reconciled tiebreaker for cleared sorting', () => {
+    expect(getTransactionSortExpressions('cleared', 'desc')).toEqual([
+      { reconciled: 'desc' },
+      { cleared: 'desc' },
+    ]);
+  });
+});

--- a/packages/desktop-client/src/components/accounts/sort.ts
+++ b/packages/desktop-client/src/components/accounts/sort.ts
@@ -1,0 +1,42 @@
+type SortDirection = 'asc' | 'desc' | undefined;
+
+export type TransactionSortExpression = Record<string, SortDirection>;
+
+export function getTransactionSortField(field?: string) {
+  if (!field) {
+    return 'date';
+  }
+
+  switch (field) {
+    case 'account':
+      return 'account.name';
+    case 'payee':
+      return 'payee.name';
+    case 'category':
+      return 'category.name';
+    case 'payment':
+    case 'deposit':
+      return 'amount';
+    default:
+      return field;
+  }
+}
+
+export function getTransactionSortExpressions(
+  field?: string,
+  direction?: SortDirection,
+): TransactionSortExpression[] {
+  const sortField = getTransactionSortField(field);
+
+  switch (sortField) {
+    case 'cleared':
+      return [{ reconciled: direction }, { cleared: direction }];
+    case 'payee.name':
+      return [
+        { 'payee.name': direction },
+        { 'payee.transfer_acct.name': direction },
+      ];
+    default:
+      return [{ [sortField]: direction }];
+  }
+}

--- a/upcoming-release-notes/fix-transfer-payee-sort.md
+++ b/upcoming-release-notes/fix-transfer-payee-sort.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [ydnd]
+---
+
+Sort transfers by their destination account when sorting transactions by payee.


### PR DESCRIPTION
## Description

Fix sorting by Payee for transfer transactions.

Transfer rows display their counterparty account from `payee.transfer_acct.name`, but the account transaction sort only ordered by `payee.name`. This caused transfers to be grouped together without sorting by the destination account.

This PR extracts the transaction sort mapping into a small helper and adds `payee.transfer_acct.name` as a secondary sort key for payee sorting, while preserving the existing cleared/reconciled sort behavior.

AI disclosure: I used Codex to help prepare this change and reviewed the diff.

## Related issue(s)

Fixes #3041

## Testing

- `corepack yarn workspace @actual-app/web test src/components/accounts/sort.test.ts`
- `corepack yarn exec oxfmt --check packages/desktop-client/src/components/accounts/Account.tsx packages/desktop-client/src/components/accounts/sort.ts packages/desktop-client/src/components/accounts/sort.test.ts upcoming-release-notes/fix-transfer-payee-sort.md`
- `corepack yarn exec oxlint --type-aware --quiet packages/desktop-client/src/components/accounts/Account.tsx packages/desktop-client/src/components/accounts/sort.ts packages/desktop-client/src/components/accounts/sort.test.ts`
- `corepack yarn workspace @actual-app/web typecheck`
- `corepack yarn typecheck`

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 → 29 | 12.99 MB → 13.09 MB (+99.42 kB) | +0.75%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 → 29 | 12.99 MB → 13.09 MB (+99.42 kB) | +0.75%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 🆕 +99.04 kB | 0 B → 99.04 kB
`src/components/accounts/sort.ts` | 🆕 +712 B | 0 B → 712 B
`src/languages.ts` | 📈 +99 B (+6.58%) | 1.47 kB → 1.57 kB
`locale/en.json` | 📈 +121 B (+0.06%) | 197.38 kB → 197.49 kB
`src/components/accounts/Account.tsx` | 📉 -544 B (-1.20%) | 44.27 kB → 43.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 0 B → 99.04 kB (+99.04 kB) | -

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 305.07 kB → 305.24 kB (+168 B) | +0.05%
static/js/en.js | 197.38 kB → 197.49 kB (+121 B) | +0.06%
static/js/extends.js | 435.39 kB → 435.48 kB (+99 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 176.85 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 174.94 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/es.js | 169.72 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 207.07 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 111.31 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->