### PR TITLE
Add experimental "Future buffer mode"

### DIFF
--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -46,6 +46,7 @@ import { EnvelopeBudgetSummaryModal } from './modals/EnvelopeBudgetSummaryModal'
 import { EnvelopeIncomeBalanceMenuModal } from './modals/EnvelopeIncomeBalanceMenuModal';
 import { EnvelopeToBudgetMenuModal } from './modals/EnvelopeToBudgetMenuModal';
 import { FixEncryptionKeyModal } from './modals/FixEncryptionKeyModal';
+import { FutureBufferModeModal } from './modals/FutureBufferModeModal';
 import { GoalTemplateModal } from './modals/GoalTemplateModal';
 import { GoCardlessExternalMsgModal } from './modals/GoCardlessExternalMsgModal';
 import { GoCardlessInitialiseModal } from './modals/GoCardlessInitialiseModal';
@@ -335,6 +336,9 @@ export function Modals() {
               <EnvelopeToBudgetMenuModal {...modal.options} />
             </SheetNameProvider>
           );
+
+        case 'future-buffer-mode':
+          return <FutureBufferModeModal key={key} />;
 
         case 'hold-buffer':
           return (

--- a/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/CategoryAutocomplete.tsx
@@ -24,12 +24,12 @@ import type {
 } from '@actual-app/core/types/models';
 import { css, cx } from '@emotion/css';
 
-import { useEnvelopeSheetValue } from '#components/budget/envelope/EnvelopeBudgetComponents';
 import { makeAmountFullStyle } from '#components/budget/util';
 import { FinancialText } from '#components/FinancialText';
 import { useCategories } from '#hooks/useCategories';
 import { useSheetValue } from '#hooks/useSheetValue';
 import { useSyncedPref } from '#hooks/useSyncedPref';
+import type { Binding } from '#spreadsheet';
 import { envelopeBudget, trackingBudget } from '#spreadsheet/bindings';
 
 import { Autocomplete } from './Autocomplete';
@@ -396,17 +396,8 @@ function CategoryItem({
     : {};
   const [budgetType = 'envelope'] = useSyncedPref('budgetType');
 
-  const balanceBinding =
-    budgetType === 'envelope'
-      ? envelopeBudget.catBalance(item.id)
-      : trackingBudget.catBalance(item.id);
-  const balance = useSheetValue<
-    'envelope-budget' | 'tracking-budget',
-    typeof balanceBinding
-  >(balanceBinding);
-
-  const isToBudgetItem = item.id === 'to-budget';
-  const toBudget = useEnvelopeSheetValue(envelopeBudget.toBudget);
+  const balanceBinding = getCategoryBinding(budgetType, item.id);
+  const balance = useSheetValue(balanceBinding);
 
   return (
     <button
@@ -444,33 +435,38 @@ function CategoryItem({
             display: !showBalances ? 'none' : undefined,
             marginLeft: 5,
             flexShrink: 0,
-            ...makeAmountFullStyle((isToBudgetItem ? toBudget : balance) || 0, {
+            ...makeAmountFullStyle(balance || 0, {
               positiveColor: theme.noticeTextMenu,
               negativeColor: theme.errorTextMenu,
             }),
           }}
         >
-          {isToBudgetItem
-            ? toBudget != null && (
-                <>
-                  {' '}
-                  <FinancialText>
-                    {integerToCurrency(toBudget || 0)}
-                  </FinancialText>
-                </>
-              )
-            : balance != null && (
-                <>
-                  {' '}
-                  <FinancialText>
-                    {integerToCurrency(balance || 0)}
-                  </FinancialText>
-                </>
-              )}
+          {balance != null && (
+            <>
+              {' '}
+              <FinancialText>{integerToCurrency(balance || 0)}</FinancialText>
+            </>
+          )}
         </TextOneLine>
       </View>
     </button>
   );
+}
+
+function getCategoryBinding(
+  budgetType: string,
+  categoryId: string,
+  // oxlint-disable-next-line typescript/no-explicit-any
+): Binding<'envelope-budget' | 'tracking-budget', any> {
+  const budget = budgetType === 'envelope' ? envelopeBudget : trackingBudget;
+  switch (categoryId) {
+    case 'to-budget':
+      return envelopeBudget.toBudget;
+    case 'for-next-month':
+      return envelopeBudget.forNextMonth;
+    default:
+      return budget.catBalance(categoryId);
+  }
 }
 
 function defaultRenderCategoryItem(

--- a/packages/desktop-client/src/components/budget/envelope/BalanceMovementMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/BalanceMovementMenu.tsx
@@ -76,6 +76,7 @@ export function BalanceMovementMenu({
         <CoverMenu
           categoryId={categoryId}
           initialAmount={catBalance}
+          showForNextMonth
           onClose={onClose}
           onSubmit={(amount, fromCategoryId) => {
             onBudgetAction(month, 'cover-overspending', {

--- a/packages/desktop-client/src/components/budget/envelope/CoverMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/CoverMenu.tsx
@@ -16,13 +16,16 @@ import type { CategoryEntity } from '@actual-app/core/types/models';
 
 import { CategoryAutocomplete } from '#components/autocomplete/CategoryAutocomplete';
 import {
+  addForNextMonthGroup,
   addToBeBudgetedGroup,
   removeCategoriesFromGroups,
 } from '#components/budget/util';
 import { useCategories } from '#hooks/useCategories';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 
 type CoverMenuProps = {
   showToBeBudgeted?: boolean;
+  showForNextMonth?: boolean;
   initialAmount?: IntegerAmount | null;
   categoryId?: CategoryEntity['id'];
   onSubmit: (amount: IntegerAmount, categoryId: CategoryEntity['id']) => void;
@@ -31,12 +34,14 @@ type CoverMenuProps = {
 
 export function CoverMenu({
   showToBeBudgeted = true,
+  showForNextMonth = false,
   initialAmount = 0,
   categoryId,
   onSubmit,
   onClose,
 }: CoverMenuProps) {
   const { t } = useTranslation();
+  const isFutureBufferModeAvailable = useFeatureFlag('futureBufferMode');
 
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =
     useCategories();
@@ -48,10 +53,20 @@ export function CoverMenu({
     const categoryGroups = showToBeBudgeted
       ? addToBeBudgetedGroup(expenseGroups)
       : expenseGroups;
+    const categoryGroupsWithForNextMonth =
+      showForNextMonth && isFutureBufferModeAvailable
+        ? addForNextMonthGroup(categoryGroups)
+        : categoryGroups;
     return categoryId
-      ? removeCategoriesFromGroups(categoryGroups, categoryId)
-      : categoryGroups;
-  }, [categoryId, showToBeBudgeted, originalCategoryGroups]);
+      ? removeCategoriesFromGroups(categoryGroupsWithForNextMonth, categoryId)
+      : categoryGroupsWithForNextMonth;
+  }, [
+    categoryId,
+    showToBeBudgeted,
+    showForNextMonth,
+    isFutureBufferModeAvailable,
+    originalCategoryGroups,
+  ]);
 
   const _initialAmount = integerToCurrency(Math.abs(initialAmount ?? 0));
   const [amount, setAmount] = useState<string>(_initialAmount);

--- a/packages/desktop-client/src/components/budget/envelope/IncomeMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/IncomeMenu.tsx
@@ -1,8 +1,10 @@
 import { useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
+import type { MenuItem } from '@actual-app/components/menu';
 import type { CategoryEntity } from '@actual-app/core/types/models';
 
+import { useFutureBufferMode } from '#hooks/useFutureBufferMode';
 import { envelopeBudget } from '#spreadsheet/bindings';
 
 import { useEnvelopeSheetValue } from './EnvelopeBudgetComponents';
@@ -23,9 +25,28 @@ export function IncomeMenu({
   onClose,
 }: IncomeMenuProps) {
   const { t } = useTranslation();
+  const { isAutomaticFutureBufferMode } = useFutureBufferMode();
   const carryover = useEnvelopeSheetValue(
     envelopeBudget.catCarryover(categoryId),
   );
+
+  // Hide the manual income auto-hold toggle while future buffer mode is active.
+  const hideAutoHold = isAutomaticFutureBufferMode;
+
+  const items: MenuItem[] = [
+    ...(hideAutoHold
+      ? []
+      : [
+          {
+            name: 'carryover',
+            text: carryover ? t('Disable auto hold') : t('Enable auto hold'),
+          },
+        ]),
+    {
+      name: 'view',
+      text: t('View transactions'),
+    },
+  ];
 
   return (
     <span>
@@ -47,16 +68,7 @@ export function IncomeMenu({
               throw new Error(`Unrecognized menu option: ${String(name)}`);
           }
         }}
-        items={[
-          {
-            name: 'carryover',
-            text: carryover ? t('Disable auto hold') : t('Enable auto hold'),
-          },
-          {
-            name: 'view',
-            text: t('View transactions'),
-          },
-        ]}
+        items={items}
       />
     </span>
   );

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx
@@ -5,6 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Menu } from '@actual-app/components/menu';
 
 import { useEnvelopeSheetValue } from '#components/budget/envelope/EnvelopeBudgetComponents';
+import { useFutureBufferMode } from '#hooks/useFutureBufferMode';
+import { pushModal } from '#modals/modalsSlice';
+import { useDispatch } from '#redux';
 import { envelopeBudget } from '#spreadsheet/bindings';
 
 type ToBudgetMenuProps = Omit<
@@ -29,6 +32,19 @@ export function ToBudgetMenu({
   ...props
 }: ToBudgetMenuProps) {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  const {
+    isFutureBufferModeAvailable,
+    isAutomaticFutureBufferMode,
+    isCurrentOrFutureMonth,
+  } = useFutureBufferMode();
+
+  // While future buffer mode is active, manual hold/reset controls are
+  // hidden for the current and future months because future buffer mode
+  // controls those buffers. They remain available for past months.
+  const hideManualControls =
+    isAutomaticFutureBufferMode && isCurrentOrFutureMonth(month);
 
   const toBudget = useEnvelopeSheetValue(envelopeBudget.toBudget) ?? 0;
   const forNextMonth = useEnvelopeSheetValue(envelopeBudget.forNextMonth) ?? 0;
@@ -44,7 +60,7 @@ export function ToBudgetMenu({
           },
         ]
       : []),
-    ...(autoBuffered === 0 && toBudget > 0
+    ...(!hideManualControls && autoBuffered === 0 && toBudget > 0
       ? [
           {
             name: 'buffer',
@@ -60,7 +76,7 @@ export function ToBudgetMenu({
           },
         ]
       : []),
-    ...(forNextMonth > 0 && manualBuffered === 0
+    ...(!hideManualControls && forNextMonth > 0 && manualBuffered === 0
       ? [
           {
             name: 'disable-auto-buffer',
@@ -68,11 +84,19 @@ export function ToBudgetMenu({
           },
         ]
       : []),
-    ...(forNextMonth > 0 && manualBuffered !== 0
+    ...(!hideManualControls && forNextMonth > 0 && manualBuffered !== 0
       ? [
           {
             name: 'reset-buffer',
             text: t("Reset next month's buffer"),
+          },
+        ]
+      : []),
+    ...(isFutureBufferModeAvailable
+      ? [
+          {
+            name: 'future-buffer-mode',
+            text: t('Change future buffer mode'),
           },
         ]
       : []),
@@ -98,6 +122,15 @@ export function ToBudgetMenu({
             break;
           case 'disable-auto-buffer':
             onBudgetAction?.(month, 'reset-income-carryover', {});
+            break;
+          case 'future-buffer-mode':
+            dispatch(
+              pushModal({
+                modal: {
+                  name: 'future-buffer-mode',
+                },
+              }),
+            );
             break;
           default:
             throw new Error(`Unrecognized menu option: ${name}`);

--- a/packages/desktop-client/src/components/budget/util.ts
+++ b/packages/desktop-client/src/components/budget/util.ts
@@ -38,6 +38,24 @@ export function addToBeBudgetedGroup(groups: CategoryGroupEntity[]) {
   ];
 }
 
+export function addForNextMonthGroup(groups: CategoryGroupEntity[]) {
+  return groups.map(group =>
+    group.id === 'to-budget'
+      ? ({
+          ...group,
+          categories: [
+            ...(group.categories ?? []),
+            {
+              id: 'for-next-month',
+              name: t('For next month'),
+              group: 'to-budget',
+            },
+          ],
+        } as CategoryGroupEntity)
+      : group,
+  );
+}
+
 export function removeCategoriesFromGroups(
   categoryGroups: CategoryGroupEntity[],
   ...categoryIds: CategoryEntity['id'][]

--- a/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/BudgetPage.tsx
@@ -872,6 +872,7 @@ function OverspendingBanner({ month, onBudgetAction, budgetType, ...props }) {
               month,
               amount: amountsByCategoryRef.current.get(category.id),
               categoryId: category.id,
+              showForNextMonth: true,
               onSubmit: (amount, fromCategoryId) => {
                 onBudgetAction(month, 'cover-overspending', {
                   to: category.id,
@@ -887,7 +888,9 @@ function OverspendingBanner({ month, onBudgetAction, budgetType, ...props }) {
                       fromCategoryName:
                         fromCategoryId === 'to-budget'
                           ? t('To Budget')
-                          : categoriesById[fromCategoryId].name,
+                          : fromCategoryId === 'for-next-month'
+                            ? t('For next month')
+                            : categoriesById[fromCategoryId].name,
                     },
                   ),
                 });

--- a/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
+++ b/packages/desktop-client/src/components/mobile/budget/ExpenseCategoryListItem.tsx
@@ -325,6 +325,7 @@ export function ExpenseCategoryListItem({
             month,
             amount: catBalance,
             categoryId: category.id,
+            showForNextMonth: true,
             onSubmit: (amount, fromCategoryId) => {
               onBudgetAction(month, 'cover-overspending', {
                 to: category.id,
@@ -339,7 +340,12 @@ export function ExpenseCategoryListItem({
                   {
                     amount: format(amount, 'financial'),
                     toCategoryName: category.name,
-                    fromCategoryName: categoriesById[fromCategoryId].name,
+                    fromCategoryName:
+                      fromCategoryId === 'to-budget'
+                        ? t('To Budget')
+                        : fromCategoryId === 'for-next-month'
+                          ? t('For next month')
+                          : categoriesById[fromCategoryId].name,
                   },
                 ),
               });

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -8,6 +8,7 @@ import { View } from '@actual-app/components/view';
 import type { IntegerAmount } from '@actual-app/core/shared/util';
 
 import {
+  addForNextMonthGroup,
   addToBeBudgetedGroup,
   removeCategoriesFromGroups,
 } from '#components/budget/util';
@@ -15,6 +16,7 @@ import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
 import { FieldLabel, TapField } from '#components/mobile/MobileForms';
 import { AmountInput } from '#components/util/AmountInput';
 import { useCategories } from '#hooks/useCategories';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useInitialMount } from '#hooks/useInitialMount';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { pushModal } from '#modals/modalsSlice';
@@ -29,9 +31,11 @@ export function CoverModal({
   categoryId,
   month,
   showToBeBudgeted = true,
+  showForNextMonth = false,
   onSubmit,
 }: CoverModalProps) {
   const { t } = useTranslation();
+  const isFutureBufferModeAvailable = useFeatureFlag('futureBufferMode');
   const [hideFraction] = useSyncedPref('hideFraction');
 
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =
@@ -41,14 +45,24 @@ export function CoverModal({
     const categoryGroups = showToBeBudgeted
       ? addToBeBudgetedGroup(expenseGroups)
       : expenseGroups;
+    const categoryGroupsWithForNextMonth =
+      showForNextMonth && isFutureBufferModeAvailable
+        ? addForNextMonthGroup(categoryGroups)
+        : categoryGroups;
     const filteredCategoryGroups = categoryId
-      ? removeCategoriesFromGroups(categoryGroups, categoryId)
-      : categoryGroups;
+      ? removeCategoriesFromGroups(categoryGroupsWithForNextMonth, categoryId)
+      : categoryGroupsWithForNextMonth;
     const filteredCategoryies = filteredCategoryGroups.flatMap(
       g => g.categories || [],
     );
     return [filteredCategoryGroups, filteredCategoryies];
-  }, [categoryId, originalCategoryGroups, showToBeBudgeted]);
+  }, [
+    categoryId,
+    originalCategoryGroups,
+    showToBeBudgeted,
+    showForNextMonth,
+    isFutureBufferModeAvailable,
+  ]);
 
   const [fromCategoryId, setFromCategoryId] = useState<string | null>(null);
   const dispatch = useDispatch();

--- a/packages/desktop-client/src/components/modals/CoverModal.tsx
+++ b/packages/desktop-client/src/components/modals/CoverModal.tsx
@@ -16,7 +16,7 @@ import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
 import { FieldLabel, TapField } from '#components/mobile/MobileForms';
 import { AmountInput } from '#components/util/AmountInput';
 import { useCategories } from '#hooks/useCategories';
-import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useFutureBufferMode } from '#hooks/useFutureBufferMode';
 import { useInitialMount } from '#hooks/useInitialMount';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { pushModal } from '#modals/modalsSlice';
@@ -35,7 +35,7 @@ export function CoverModal({
   onSubmit,
 }: CoverModalProps) {
   const { t } = useTranslation();
-  const isFutureBufferModeAvailable = useFeatureFlag('futureBufferMode');
+  const { isFutureBufferModeAvailable } = useFutureBufferMode();
   const [hideFraction] = useSyncedPref('hideFraction');
 
   const { data: { grouped: originalCategoryGroups } = { grouped: [] } } =

--- a/packages/desktop-client/src/components/modals/EnvelopeIncomeBalanceMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/EnvelopeIncomeBalanceMenuModal.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
+import type { MenuItem } from '@actual-app/components/menu';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
@@ -21,13 +22,14 @@ import {
 } from '#components/common/Modal';
 import { CellValueText } from '#components/spreadsheet/CellValue';
 import { useCategory } from '#hooks/useCategory';
+import { useFutureBufferMode } from '#hooks/useFutureBufferMode';
 import type { Modal as ModalType } from '#modals/modalsSlice';
 import { envelopeBudget } from '#spreadsheet/bindings';
 
-type EnvelopeIncomeBalanceMenuModalProps = Omit<
-  Extract<ModalType, { name: 'envelope-income-balance-menu' }>['options'],
-  'month'
->;
+type EnvelopeIncomeBalanceMenuModalProps = Extract<
+  ModalType,
+  { name: 'envelope-income-balance-menu' }
+>['options'];
 
 export function EnvelopeIncomeBalanceMenuModal({
   categoryId,
@@ -43,10 +45,29 @@ export function EnvelopeIncomeBalanceMenuModal({
 
   const { t } = useTranslation();
   const { data: category } = useCategory(categoryId);
+  const { isAutomaticFutureBufferMode } = useFutureBufferMode();
 
   const carryover = useEnvelopeSheetValue(
     envelopeBudget.catCarryover(categoryId),
   );
+
+  // Hide the manual income auto-hold toggle while future buffer mode is active.
+  const hideAutoHold = isAutomaticFutureBufferMode;
+
+  const items: MenuItem[] = [
+    ...(hideAutoHold
+      ? []
+      : [
+          {
+            name: 'carryover',
+            text: carryover ? t('Disable auto hold') : t('Enable auto hold'),
+          },
+        ]),
+    {
+      name: 'view',
+      text: t('View transactions'),
+    },
+  ];
 
   if (!category) {
     return null;
@@ -120,18 +141,7 @@ export function EnvelopeIncomeBalanceMenuModal({
                   throw new Error(`Unrecognized menu option: ${String(name)}`);
               }
             }}
-            items={[
-              {
-                name: 'carryover',
-                text: carryover
-                  ? t('Disable auto hold')
-                  : t('Enable auto hold'),
-              },
-              {
-                name: 'view',
-                text: t('View transactions'),
-              },
-            ]}
+            items={items}
           />
         </>
       )}

--- a/packages/desktop-client/src/components/modals/FutureBufferModeModal.tsx
+++ b/packages/desktop-client/src/components/modals/FutureBufferModeModal.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Button, ButtonWithLoading } from '@actual-app/components/button';
+import { Paragraph } from '@actual-app/components/paragraph';
+import { styles } from '@actual-app/components/styles';
+import { Text } from '@actual-app/components/text';
+import { View } from '@actual-app/components/view';
+import type { FutureBufferMode } from '@actual-app/core/types/prefs';
+import { css } from '@emotion/css';
+
+import {
+  Modal,
+  ModalButtons,
+  ModalCloseButton,
+  ModalHeader,
+} from '#components/common/Modal';
+import { useFutureBufferMode } from '#hooks/useFutureBufferMode';
+
+export function FutureBufferModeModal() {
+  const { t } = useTranslation();
+  const { futureBufferMode, setFutureBufferMode } = useFutureBufferMode();
+  const [selectedMode, setSelectedMode] =
+    useState<FutureBufferMode>(futureBufferMode);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const onSave = async (close: () => void) => {
+    if (selectedMode === futureBufferMode) {
+      close();
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      await setFutureBufferMode(selectedMode);
+      close();
+    } catch (error) {
+      setIsSaving(false);
+      throw error;
+    }
+  };
+
+  return (
+    <Modal name="future-buffer-mode">
+      {({ state }) => (
+        <>
+          <ModalHeader
+            title={t('Future buffer mode')}
+            rightContent={<ModalCloseButton onPress={() => state.close()} />}
+          />
+          <View style={{ lineHeight: 1.5 }}>
+            <Paragraph>
+              <Trans>
+                Choose how you want to reserve funds for future months.
+              </Trans>
+            </Paragraph>
+            <View style={{ gap: 10 }}>
+              <Button
+                aria-pressed={selectedMode === 'manual'}
+                aria-label={t('Manual mode')}
+                className={buttonStyle}
+                variant={selectedMode === 'manual' ? 'primary' : 'normal'}
+                onPress={() => setSelectedMode('manual')}
+              >
+                <Text style={{ fontWeight: 600 }}>
+                  <Trans>Manual</Trans>
+                </Text>
+                <Text style={{ maxWidth: '50ch' }}>
+                  <Trans>
+                    Manage the funds held for future months yourself. Use "Hold
+                    for next month" from the "To budget" menu when you want to
+                    set money aside.
+                  </Trans>
+                </Text>
+              </Button>
+              <Button
+                aria-pressed={selectedMode === 'automatic'}
+                aria-label={t('Automatic mode')}
+                className={buttonStyle}
+                variant={selectedMode === 'automatic' ? 'primary' : 'normal'}
+                onPress={() => setSelectedMode('automatic')}
+              >
+                <Text style={{ fontWeight: 600 }}>
+                  <Trans>Automatic</Trans>
+                </Text>
+                <Text style={{ maxWidth: '50ch' }}>
+                  <Trans>
+                    Let Actual manage the buffer for you. "To budget" and "For
+                    next month" will automatically update as you budget into the
+                    future.
+                  </Trans>
+                </Text>
+              </Button>
+            </View>
+            <ModalButtons>
+              <ButtonWithLoading
+                variant="primary"
+                isLoading={isSaving}
+                isDisabled={isSaving}
+                style={{ height: styles.mobileMinHeight }}
+                onPress={() => void onSave(() => state.close())}
+              >
+                <Trans>Save</Trans>
+              </ButtonWithLoading>
+            </ModalButtons>
+          </View>
+        </>
+      )}
+    </Modal>
+  );
+}
+const buttonStyle = css({
+  alignItems: 'flex-start',
+  flexDirection: 'column',
+  gap: 5,
+  justifyContent: 'flex-start',
+  padding: 12,
+  textAlign: 'left',
+});

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -208,6 +208,9 @@ export function ExperimentalFeatures() {
             >
               <Trans>Mobile calculator</Trans>
             </FeatureToggle>
+            <FeatureToggle flag="futureBufferMode">
+              <Trans>Future buffer mode</Trans>
+            </FeatureToggle>
             <FeatureToggle
               flag="sankeyReport"
               feedbackLink="https://github.com/actualbudget/actual/issues/1919"

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -16,6 +16,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   enableBanking: false,
   sankeyReport: false,
   akahuBankSync: false,
+  futureBufferMode: false,
   mobileCalculator: false,
 };
 

--- a/packages/desktop-client/src/hooks/useFutureBufferMode.ts
+++ b/packages/desktop-client/src/hooks/useFutureBufferMode.ts
@@ -1,0 +1,55 @@
+import { send } from '@actual-app/core/platform/client/connection';
+import * as monthUtils from '@actual-app/core/shared/months';
+import type { FutureBufferMode } from '@actual-app/core/types/prefs';
+
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useSyncedPref } from '#hooks/useSyncedPref';
+import { mergeSyncedPrefs } from '#prefs/prefsSlice';
+import { useDispatch } from '#redux';
+
+type UseFutureBufferModeResult = {
+  // The selected future buffer mode. Unset preferences default to manual.
+  futureBufferMode: FutureBufferMode;
+  // Whether the future buffer mode setting should be shown (feature flag on + envelope).
+  isFutureBufferModeAvailable: boolean;
+  // Whether automatic future buffer mode is currently active.
+  isAutomaticFutureBufferMode: boolean;
+  // Whether the given month is the current month or a future month.
+  isCurrentOrFutureMonth: (month: string) => boolean;
+  // Persist the future buffer mode preference via the atomic core action.
+  setFutureBufferMode: (mode: FutureBufferMode) => Promise<void>;
+};
+
+export function useFutureBufferMode(): UseFutureBufferModeResult {
+  const featureFlagEnabled = useFeatureFlag('futureBufferMode');
+  const [budgetType = 'envelope'] = useSyncedPref('budgetType');
+  const [futureBufferModePref] = useSyncedPref('futureBufferMode');
+  const dispatch = useDispatch();
+
+  const futureBufferMode: FutureBufferMode =
+    futureBufferModePref === 'automatic' ? 'automatic' : 'manual';
+  const isFutureBufferModeAvailable =
+    featureFlagEnabled && budgetType === 'envelope';
+  const isAutomaticFutureBufferMode =
+    isFutureBufferModeAvailable && futureBufferMode === 'automatic';
+
+  const setFutureBufferMode = async (mode: FutureBufferMode) => {
+    await send('budget/set-future-buffer-mode', { mode });
+    dispatch(
+      mergeSyncedPrefs({
+        futureBufferMode: mode,
+      }),
+    );
+  };
+
+  const isCurrentOrFutureMonth = (month: string) =>
+    month >= monthUtils.currentMonth();
+
+  return {
+    futureBufferMode,
+    isFutureBufferModeAvailable,
+    isAutomaticFutureBufferMode,
+    isCurrentOrFutureMonth,
+    setFutureBufferMode,
+  };
+}

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -484,6 +484,9 @@ export type Modal =
       };
     }
   | {
+      name: 'future-buffer-mode';
+    }
+  | {
       name: 'tracking-balance-menu';
       options: {
         categoryId: CategoryEntity['id'];

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -516,6 +516,7 @@ export type Modal =
         categoryId?: CategoryEntity['id'];
         month: string;
         showToBeBudgeted?: boolean;
+        showForNextMonth?: boolean;
         onSubmit: (
           amount: IntegerAmount,
           fromCategoryId: CategoryEntity['id'],

--- a/packages/loot-core/src/server/app.ts
+++ b/packages/loot-core/src/server/app.ts
@@ -15,7 +15,7 @@ type Events = {
   'load-budget': { id: string };
 };
 
-type UnlistenService = () => void;
+type UnlistenService = () => void | Promise<void>;
 type Service = () => UnlistenService;
 
 class App<Handlers> {
@@ -77,11 +77,11 @@ class App<Handlers> {
   }
 
   async stopServices() {
-    this.unlistenServices.forEach(unlisten => {
-      if (unlisten) {
-        unlisten();
-      }
-    });
+    await Promise.all(
+      this.unlistenServices.map(async unlisten => {
+        await unlisten();
+      }),
+    );
     this.unlistenServices = [];
   }
 }

--- a/packages/loot-core/src/server/budget/actions.test.ts
+++ b/packages/loot-core/src/server/budget/actions.test.ts
@@ -2,18 +2,463 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import * as db from '#server/db';
+import { runHandler } from '#server/mutators';
 import * as sheet from '#server/sheet';
+import { app as transactionsApp } from '#server/transactions/app';
+import { clearUndo, undo } from '#server/undo';
 
 import {
   copyUntilYearEnd,
   coverOverbudgeted,
   getSheetValue,
+  isFutureBufferModeActive,
+  recalculateFutureBuffer,
   set3MonthAvg,
   setBudget,
+  setBuffer,
   setCategoryCarryover,
   setNMonthAvg,
 } from './actions';
+import { app } from './app';
 import * as budget from './base';
+
+describe('future buffer mode', () => {
+  let originalCurrentMonth: string | null;
+
+  beforeEach(async () => {
+    await global.emptyDatabase()();
+    clearUndo();
+    originalCurrentMonth = global.currentMonth;
+    global.currentMonth = '2024-03';
+  });
+
+  afterEach(async () => {
+    global.currentMonth = originalCurrentMonth;
+    clearUndo();
+    await global.emptyDatabase()();
+  });
+
+  it('no-ops when prefs are missing or inactive and when using a tracking budget', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setBuffer('2024-03', 111);
+    await setBuffer('2024-04', 222);
+    await sheet.waitOnSpreadsheet();
+
+    expect(isFutureBufferModeActive()).toBe(false);
+    await recalculateFutureBuffer();
+    expect(await getBuffered('2024-03')).toBe(111);
+    expect(await getBuffered('2024-04')).toBe(222);
+
+    setPreference('flags.futureBufferMode', 'true');
+    setPreference('futureBufferMode', 'manual');
+
+    expect(isFutureBufferModeActive()).toBe(false);
+    await recalculateFutureBuffer();
+    expect(await getBuffered('2024-03')).toBe(111);
+    expect(await getBuffered('2024-04')).toBe(222);
+
+    setPreference('futureBufferMode', 'automatic');
+    setPreference('budgetType', 'tracking');
+
+    expect(isFutureBufferModeActive()).toBe(false);
+    await recalculateFutureBuffer();
+    expect(await getBuffered('2024-03')).toBe(111);
+    expect(await getBuffered('2024-04')).toBe(222);
+  });
+
+  it('persists automatic and recalculates when enabled through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setSingleFutureMonthAmounts();
+    setPreference('flags.futureBufferMode', 'true');
+
+    await runHandler(app.handlers['budget/set-future-buffer-mode'], {
+      mode: 'automatic',
+    });
+
+    expect(getPreference('futureBufferMode')).toBe('automatic');
+    expect(await getBuffered('2024-03')).toBe(42000);
+    expect(await getBuffered('2024-04')).toBe(0);
+  });
+
+  it('persists manual and leaves buffers unchanged when disabled through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setSingleFutureMonthAmounts();
+    setPreference('flags.futureBufferMode', 'true');
+
+    await runHandler(app.handlers['budget/set-future-buffer-mode'], {
+      mode: 'automatic',
+    });
+    const currentBuffer = await getBuffered('2024-03');
+    const futureBuffer = await getBuffered('2024-04');
+
+    await runHandler(app.handlers['budget/set-future-buffer-mode'], {
+      mode: 'manual',
+    });
+
+    expect(getPreference('futureBufferMode')).toBe('manual');
+    expect(await getBuffered('2024-03')).toBe(currentBuffer);
+    expect(await getBuffered('2024-04')).toBe(futureBuffer);
+  });
+
+  it('uses backward-pass math for one future month', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setSingleFutureMonthAmounts();
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/recalculate-future-buffer']);
+
+    expect(await getBuffered('2024-03')).toBe(42000);
+    expect(await getBuffered('2024-04')).toBe(0);
+  });
+
+  it('uses backward-pass math for multiple future months', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04', '2024-05']);
+    await setBudget({ category: 'cat1', month: '2024-04', amount: 60000 });
+    await db.insertTransaction({
+      date: '2024-04-01',
+      amount: 10000,
+      account: 'account1',
+      category: 'income-cat',
+    });
+    await setBudget({ category: 'cat1', month: '2024-05', amount: 30000 });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await recalculateFutureBuffer();
+
+    expect(await getBuffered('2024-03')).toBe(80000);
+    expect(await getBuffered('2024-04')).toBe(30000);
+    expect(await getBuffered('2024-05')).toBe(0);
+  });
+
+  it('can make to-budget negative', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setSingleFutureMonthAmounts();
+    enableFutureBufferModePrefs();
+
+    await recalculateFutureBuffer();
+
+    expect(await getBuffered('2024-03')).toBe(42000);
+    expect(await getSheetValue('budget202403', 'to-budget')).toBe(-42000);
+  });
+
+  it('leaves past buffers and income carryover unchanged while clearing current and future income carryover', async () => {
+    await setupFutureBufferModeDatabase([
+      '2024-02',
+      '2024-03',
+      '2024-04',
+      '2024-05',
+    ]);
+    await setBudget({ category: 'cat1', month: '2024-04', amount: 60000 });
+    await setBudget({ category: 'cat1', month: '2024-05', amount: 30000 });
+    await setBuffer('2024-02', 777);
+    await setBuffer('2024-03', 888);
+    await setBuffer('2024-04', 999);
+    await setBuffer('2024-05', 444);
+    await setCategoryCarryover({
+      startMonth: '2024-02',
+      category: 'income-cat',
+      flag: true,
+    });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await recalculateFutureBuffer();
+
+    expect(await getBuffered('2024-02')).toBe(777);
+    expect(await getCarryover('2024-02', 'income-cat')).toBe(true);
+    expect(await getCarryover('2024-03', 'income-cat')).toBe(false);
+    expect(await getCarryover('2024-04', 'income-cat')).toBe(false);
+    expect(await getCarryover('2024-05', 'income-cat')).toBe(false);
+    expect(await getBuffered('2024-03')).toBe(90000);
+    expect(await getBuffered('2024-04')).toBe(30000);
+    expect(await getBuffered('2024-05')).toBe(0);
+  });
+
+  it('recalculates after a future direct budget edit through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setBuffer('2024-03', 123);
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat1',
+      month: '2024-04',
+      amount: 50000,
+    });
+
+    expect(await getBuffered('2024-03')).toBe(50000);
+    expect(await getBuffered('2024-04')).toBe(0);
+  });
+
+  it('recalculates after current-month budget edits through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await db.insertTransaction({
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat1',
+    });
+    await setBudget({ category: 'cat1', month: '2024-03', amount: 10000 });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+    await recalculateFutureBuffer();
+    expect(await getBuffered('2024-03')).toBe(0);
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat1',
+      month: '2024-03',
+      amount: 0,
+    });
+    expect(await getBuffered('2024-03')).toBe(10000);
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat1',
+      month: '2024-03',
+      amount: 10000,
+    });
+    expect(await getBuffered('2024-03')).toBe(0);
+  });
+
+  it('does not recalculate after past budget edits through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-02', '2024-03', '2024-04']);
+    await setBudget({ category: 'cat1', month: '2024-04', amount: 50000 });
+    await setBuffer('2024-03', 123);
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat2',
+      month: '2024-02',
+      amount: 2000,
+    });
+    expect(await getBuffered('2024-03')).toBe(123);
+  });
+
+  it('recalculates after covering current-month overspending through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await db.insertTransaction({
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat1',
+    });
+    await setBudget({ category: 'cat2', month: '2024-03', amount: 20000 });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+    await recalculateFutureBuffer();
+    expect(await getBuffered('2024-03')).toBe(10000);
+
+    await runHandler(app.handlers['budget/cover-overspending'], {
+      month: '2024-03',
+      to: 'cat1',
+      from: 'cat2',
+      currencyCode: 'USD',
+    });
+
+    expect(await getSheetValue('budget202403', 'leftover-cat1')).toBe(0);
+    expect(await getBuffered('2024-03')).toBe(0);
+  });
+
+  it('recalculates after adding, deleting, and recategorizing current-month transactions through the handler', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await setBudget({ category: 'cat2', month: '2024-03', amount: 20000 });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await runHandler(transactionsApp.handlers['transaction-add'], {
+      id: 'transaction1',
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat1',
+    });
+    expect(await getBuffered('2024-03')).toBe(10000);
+
+    await runHandler(transactionsApp.handlers['transaction-update'], {
+      id: 'transaction1',
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat2',
+    });
+    expect(await getBuffered('2024-03')).toBe(0);
+
+    await runHandler(transactionsApp.handlers['transaction-update'], {
+      id: 'transaction1',
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat1',
+    });
+    expect(await getBuffered('2024-03')).toBe(10000);
+
+    await runHandler(transactionsApp.handlers['transaction-delete'], {
+      id: 'transaction1',
+    });
+    expect(await getBuffered('2024-03')).toBe(0);
+  });
+
+  it('does not recalculate from future handlers for tracking budgets', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    setPreference('flags.futureBufferMode', 'true');
+    setPreference('futureBufferMode', 'automatic');
+    setPreference('budgetType', 'tracking');
+    await setBuffer('2024-03', 123);
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat1',
+      month: '2024-04',
+      amount: 50000,
+    });
+
+    expect(await getBuffered('2024-03')).toBe(123);
+  });
+
+  it('recalculates for copy-until-year-end when it touches a current or future month', async () => {
+    global.currentMonth = '2024-02';
+    await setupFutureBufferModeDatabase(['2024-01', '2024-02', '2024-03']);
+    await setBudget({ category: 'cat1', month: '2024-01', amount: 50000 });
+    await setBuffer('2024-02', 123);
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/copy-until-year-end'], {
+      month: '2024-01',
+      category: 'cat1',
+    });
+
+    expect(await getSheetValue('budget202403', 'budget-cat1')).toBe(50000);
+    expect(await getBuffered('2024-02')).toBe(50000);
+
+    global.currentMonth = '2024-03';
+    await setBuffer('2024-03', 456);
+
+    await runHandler(app.handlers['budget/copy-until-year-end'], {
+      month: '2024-02',
+      category: 'cat1',
+    });
+
+    expect(await getBuffered('2024-03')).toBe(0);
+  });
+
+  it('recalculates after a representative future multi-category budget action', async () => {
+    global.currentMonth = '2024-02';
+    await setupAverageDatabase();
+    await setBuffer('2024-02', 123);
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/set-3month-avg'], {
+      month: '2024-04',
+    });
+
+    expect(await getSheetValue('budget202404', 'budget-cat1')).toBe(600);
+    expect(await getBuffered('2024-02')).toBe(4800);
+    expect(await getBuffered('2024-03')).toBe(1800);
+    expect(await getBuffered('2024-04')).toBe(0);
+  });
+
+  it('recalculates when a new future budget month is created through budget bounds', async () => {
+    await setupFutureBufferModeDatabase(['2024-03']);
+    await setBudget({ category: 'cat1', month: '2024-04', amount: 50000 });
+    await setBuffer('2024-03', 123);
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['get-budget-bounds']);
+
+    expect(await getBuffered('2024-03')).toBe(50000);
+  });
+
+  it('prewarms manual, auto, and selected buffered summary cells', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+
+    const values = await runHandler(app.handlers['envelope-budget-month'], {
+      month: '2024-03',
+    });
+
+    expect(values.map(value => value.name)).toEqual(
+      expect.arrayContaining([
+        'budget202403!buffered',
+        'budget202403!buffered-auto',
+        'budget202403!buffered-selected',
+      ]),
+    );
+  });
+
+  it('prevents direct current and future hold, reset, and income carryover changes while active', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    await db.insertTransaction({
+      date: '2024-03-01',
+      amount: 10000,
+      account: 'account1',
+      category: 'income-cat',
+    });
+    await setBuffer('2024-03', 0);
+    await setBuffer('2024-04', 999);
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    const held = await runHandler(app.handlers['budget/hold-for-next-month'], {
+      month: '2024-03',
+      amount: 5000,
+    });
+    await runHandler(app.handlers['budget/reset-hold'], { month: '2024-04' });
+    expect(await getBuffered('2024-04')).toBe(999);
+
+    await runHandler(app.handlers['budget/set-carryover'], {
+      startMonth: '2024-03',
+      category: 'income-cat',
+      flag: true,
+    });
+
+    expect(held).toBe(false);
+    expect(await getBuffered('2024-03')).toBe(0);
+    expect(await getBuffered('2024-04')).toBe(0);
+    expect(await getCarryover('2024-03', 'income-cat')).toBe(false);
+    expect(await getCarryover('2024-04', 'income-cat')).toBe(false);
+  });
+
+  it('caps past income carryover changes so current and future income carryover remains disabled while active', async () => {
+    await setupFutureBufferModeDatabase(['2024-02', '2024-03', '2024-04']);
+    await setCategoryCarryover({
+      startMonth: '2024-02',
+      category: 'income-cat',
+      flag: true,
+    });
+    await sheet.waitOnSpreadsheet();
+    expect(await getCarryover('2024-03', 'income-cat')).toBe(true);
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/set-carryover'], {
+      startMonth: '2024-02',
+      category: 'income-cat',
+      flag: true,
+    });
+
+    expect(await getCarryover('2024-02', 'income-cat')).toBe(true);
+    expect(await getCarryover('2024-03', 'income-cat')).toBe(false);
+    expect(await getCarryover('2024-04', 'income-cat')).toBe(false);
+  });
+
+  it('undoes a future budget edit and its auto recalculation together', async () => {
+    await setupFutureBufferModeDatabase(['2024-03', '2024-04']);
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['budget/budget-amount'], {
+      category: 'cat1',
+      month: '2024-04',
+      amount: 50000,
+    });
+    expect(await getSheetValue('budget202404', 'budget-cat1')).toBe(50000);
+    expect(await getBuffered('2024-03')).toBe(50000);
+
+    await undo();
+    await sheet.waitOnSpreadsheet();
+
+    expect(await getSheetValue('budget202404', 'budget-cat1')).toBe(0);
+    expect(await getBuffered('2024-03')).toBe(0);
+  });
+});
 
 describe('copyUntilYearEnd', () => {
   beforeEach(global.emptyDatabase());
@@ -279,6 +724,93 @@ async function prepareDatabase() {
     flag: true,
   });
   await sheet.waitOnSpreadsheet();
+}
+
+async function setupFutureBufferModeDatabase(months: string[]) {
+  await db.insertAccount({ id: 'account1', name: 'Account 1' });
+  await db.insertCategoryGroup({
+    id: 'income-group',
+    name: 'Income',
+    is_income: 1,
+  });
+  await db.insertCategory({
+    id: 'income-cat',
+    name: 'Income',
+    cat_group: 'income-group',
+    is_income: 1,
+  });
+  await db.insertCategoryGroup({ id: 'group1', name: 'group1', is_income: 0 });
+  await db.insertCategory({
+    id: 'cat1',
+    name: 'cat1',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+  await db.insertCategory({
+    id: 'cat2',
+    name: 'cat2',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+
+  await sheet.loadSpreadsheet(db);
+  await budget.createBudget(months);
+}
+
+async function setSingleFutureMonthAmounts() {
+  await db.insertTransaction({
+    date: '2024-04-01',
+    amount: 10000,
+    account: 'account1',
+    category: 'income-cat',
+  });
+  await db.insertTransaction({
+    date: '2024-03-15',
+    amount: -2000,
+    account: 'account1',
+    category: 'cat2',
+  });
+  await setBudget({ category: 'cat1', month: '2024-04', amount: 50000 });
+  await sheet.waitOnSpreadsheet();
+}
+
+function setPreference(id: string, value: string) {
+  db.runQuery('INSERT OR REPLACE INTO preferences (id, value) VALUES (?, ?)', [
+    id,
+    value,
+  ]);
+}
+
+function getPreference(id: string) {
+  return db.firstSync<Pick<db.DbPreference, 'value'>>(
+    'SELECT value FROM preferences WHERE id = ?',
+    [id],
+  )?.value;
+}
+
+function enableFutureBufferModePrefs() {
+  setPreference('flags.futureBufferMode', 'true');
+  setPreference('futureBufferMode', 'automatic');
+}
+
+async function getBuffered(month: string) {
+  return (
+    await db.first<Pick<db.DbZeroBudgetMonth, 'buffered'>>(
+      'SELECT buffered FROM zero_budget_months WHERE id = ?',
+      [month],
+    )
+  )?.buffered;
+}
+
+async function getCarryover(month: string, category: string) {
+  return (
+    ((
+      await db.first<Pick<db.DbZeroBudget, 'carryover'>>(
+        'SELECT carryover FROM zero_budgets WHERE month = ? AND category = ?',
+        [parseInt(month.replace('-', '')), category],
+      )
+    )?.carryover ?? 0) === 1
+  );
 }
 
 async function setupAverageDatabase() {

--- a/packages/loot-core/src/server/budget/actions.test.ts
+++ b/packages/loot-core/src/server/budget/actions.test.ts
@@ -10,6 +10,7 @@ import { clearUndo, undo } from '#server/undo';
 import {
   copyUntilYearEnd,
   coverOverbudgeted,
+  getSheetBoolean,
   getSheetValue,
   isFutureBufferModeActive,
   recalculateFutureBuffer,
@@ -367,6 +368,29 @@ describe('future buffer mode', () => {
     await runHandler(app.handlers['get-budget-bounds']);
 
     expect(await getBuffered('2024-03')).toBe(50000);
+  });
+
+  it('uses previous carryover when future months are created for automatic buffers', async () => {
+    await setupFutureBufferModeDatabase(['2024-03']);
+    await db.insertTransaction({
+      date: '2024-03-01',
+      amount: -10000,
+      account: 'account1',
+      category: 'cat1',
+    });
+    await setCategoryCarryover({
+      startMonth: '2024-03',
+      category: 'cat1',
+      flag: true,
+    });
+    await sheet.waitOnSpreadsheet();
+    enableFutureBufferModePrefs();
+
+    await runHandler(app.handlers['get-budget-bounds']);
+
+    expect(await getSheetBoolean('budget202404', 'carryover-cat1')).toBe(true);
+    expect(await getBuffered('2024-03')).toBe(0);
+    expect(await getBuffered('2024-04')).toBe(0);
   });
 
   it('prewarms manual, auto, and selected buffered summary cells', async () => {

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -687,10 +687,18 @@ export async function coverOverspending({
 }): Promise<void> {
   const sheetName = monthUtils.sheetForMonth(month);
   const toBudgeted = await getSheetValue(sheetName, 'budget-' + to);
-  const leftoverFrom = await getSheetValue(
+  let leftoverFrom = await getSheetValue(
     sheetName,
     from === 'to-budget' ? 'to-budget' : 'leftover-' + from,
   );
+
+  if (
+    from === 'to-budget' &&
+    isFutureBufferModeActive() &&
+    isCurrentOrFutureMonth(month)
+  ) {
+    leftoverFrom += await getSheetValue(sheetName, 'buffered-selected');
+  }
 
   // Cover provided amount (can be partial) or full overspending amount.
   const amountToCover = amount
@@ -891,6 +899,11 @@ export async function setCategoryCarryover({
   const months = isFutureBufferActiveForIncome
     ? allMonths.filter(month => month < monthUtils.currentMonth())
     : allMonths;
+  const shouldRecalculateFutureBuffer =
+    isFutureBufferModeActive() &&
+    allMonths.some(month =>
+      isCurrentOrFutureMonth(monthUtils.nextMonth(month)),
+    );
 
   await batchMessages(async () => {
     for (const month of months) {
@@ -898,10 +911,7 @@ export async function setCategoryCarryover({
     }
   });
 
-  if (
-    isFutureBufferActiveForIncome &&
-    allMonths.some(month => isCurrentOrFutureMonth(month))
-  ) {
+  if (shouldRecalculateFutureBuffer) {
     await recalculateFutureBuffer();
   }
 }

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -1,10 +1,13 @@
 // @ts-strict-ignore
 
 import * as asyncStorage from '#platform/server/asyncStorage';
-import { logger } from '#platform/server/log';
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
-import { batchMessages } from '#server/sync';
+import {
+  batchMessages,
+  registerBudgetChangeHook,
+  runBudgetChangeHooks,
+} from '#server/sync';
 import { getCurrency } from '#shared/currencies';
 import { getLocale } from '#shared/locale';
 import * as monthUtils from '#shared/months';
@@ -55,15 +58,6 @@ export function isTrackingBudget(): boolean {
   );
   const val = budgetType ? budgetType.value : 'envelope';
   return val === 'tracking';
-}
-
-function dbMonth(month: string): number {
-  return parseInt(month.replace('-', ''));
-}
-
-function monthFromDbMonth(month: number): string {
-  const monthString = String(month).padStart(6, '0');
-  return `${monthString.slice(0, 4)}-${monthString.slice(4)}`;
 }
 
 // TODO: complete list of fields.
@@ -120,7 +114,7 @@ export function getBudget({
   const table = getBudgetTable();
   const existing = db.firstSync<db.DbZeroBudget | db.DbReflectBudget>(
     `SELECT * FROM ${table} WHERE month = ? AND category = ?`,
-    [dbMonth(month), category],
+    [monthUtils.toDbMonth(month), category],
   );
   return existing ? existing.amount || 0 : 0;
 }
@@ -140,15 +134,15 @@ export function setBudget({
   const existing = db.firstSync<
     Pick<db.DbZeroBudget | db.DbReflectBudget, 'id'>
   >(`SELECT id FROM ${table} WHERE month = ? AND category = ?`, [
-    dbMonth(month),
+    monthUtils.toDbMonth(month),
     category,
   ]);
   if (existing) {
     return db.update(table, { id: existing.id, amount });
   }
   return db.insert(table, {
-    id: `${dbMonth(month)}-${category}`,
-    month: dbMonth(month),
+    id: `${monthUtils.toDbMonth(month)}-${category}`,
+    month: monthUtils.toDbMonth(month),
     category,
     amount,
   });
@@ -159,7 +153,7 @@ export function setGoal({ month, category, goal, long_goal }): Promise<void> {
   const existing = db.firstSync<
     Pick<db.DbZeroBudget | db.DbReflectBudget, 'id'>
   >(`SELECT id FROM ${table} WHERE month = ? AND category = ?`, [
-    dbMonth(month),
+    monthUtils.toDbMonth(month),
     category,
   ]);
   if (existing) {
@@ -170,8 +164,8 @@ export function setGoal({ month, category, goal, long_goal }): Promise<void> {
     });
   }
   return db.insert(table, {
-    id: `${dbMonth(month)}-${category}`,
-    month: dbMonth(month),
+    id: `${monthUtils.toDbMonth(month)}-${category}`,
+    month: monthUtils.toDbMonth(month),
     category,
     goal,
     long_goal,
@@ -234,46 +228,12 @@ export function isFutureBufferModeActive(): boolean {
   );
 }
 
-export function withBudgetChangeHooks<Args extends [unknown], Result>(
-  action: (...args: Args) => Result,
-  getTouchedMonths: (
-    args: Args[0],
-    result: Awaited<Result>,
-  ) => Iterable<string> | Promise<Iterable<string>>,
-) {
-  return async (...args: Args): Promise<Awaited<Result>> => {
-    const result = await action(...args);
-    const touchedMonths = await getTouchedMonths(args[0], result);
-    await runBudgetChangeHooks(touchedMonths);
-    return result;
-  };
-}
-
-export async function runBudgetChangeHooks(
-  months: Iterable<string>,
-): Promise<void> {
-  try {
-    if (isFutureBufferModeActive()) {
-      for (const month of months) {
-        if (isCurrentOrFutureMonth(month)) {
-          await recalculateFutureBuffer();
-          break;
-        }
-      }
-    }
-  } catch (error) {
-    logger.warn('Failed running budget change hooks', error);
-  }
-}
-
 function isCurrentOrFutureMonth(month: string): boolean {
   return month >= monthUtils.currentMonth();
 }
 
-export async function recalculateFutureBuffer(): Promise<void> {
-  if (!isFutureBufferModeActive()) {
-    return;
-  }
+async function recalculateFutureBufferImpl(): Promise<void> {
+  if (!isFutureBufferModeActive()) return;
 
   const currentMonth = monthUtils.currentMonth();
   const { createdMonths = new Set<string>() } = sheet.get().meta();
@@ -296,7 +256,7 @@ export async function recalculateFutureBuffer(): Promise<void> {
           await setCarryover(
             'zero_budgets',
             category.id,
-            dbMonth(month).toString(),
+            monthUtils.toDbMonth(month).toString(),
             false,
           );
         }
@@ -347,6 +307,34 @@ export async function recalculateFutureBuffer(): Promise<void> {
   await sheet.waitOnSpreadsheet();
 }
 
+let isRecalculatingFutureBuffer = false;
+
+export async function recalculateFutureBuffer(): Promise<void> {
+  if (isRecalculatingFutureBuffer) {
+    return;
+  }
+
+  try {
+    isRecalculatingFutureBuffer = true;
+    await recalculateFutureBufferImpl();
+  } finally {
+    isRecalculatingFutureBuffer = false;
+  }
+}
+
+registerBudgetChangeHook(async months => {
+  if (!isFutureBufferModeActive()) {
+    return;
+  }
+
+  for (const month of months) {
+    if (isCurrentOrFutureMonth(month)) {
+      await recalculateFutureBuffer();
+      return;
+    }
+  }
+});
+
 export async function setFutureBufferMode({
   mode,
 }: {
@@ -369,7 +357,7 @@ export async function copyPreviousMonth({
 }: {
   month: string;
 }): Promise<void> {
-  const prevMonth = dbMonth(monthUtils.prevMonth(month));
+  const prevMonth = monthUtils.toDbMonth(monthUtils.prevMonth(month));
   const table = getBudgetTable();
   const budgetData = await getBudgetData(table, prevMonth.toString());
 
@@ -609,7 +597,7 @@ async function getFirstActivityMonth({
   endMonth: string;
 }): Promise<string | null> {
   const table = getBudgetTable();
-  const endDbMonth = dbMonth(endMonth);
+  const endDbMonth = monthUtils.toDbMonth(endMonth);
   const firstActivity = await db.first<{ month: number | null }>(
     `SELECT MIN(month) AS month
        FROM (
@@ -629,7 +617,7 @@ async function getFirstActivityMonth({
 
   return firstActivity?.month == null
     ? null
-    : monthFromDbMonth(firstActivity.month);
+    : monthUtils.fromDbMonth(firstActivity.month);
 }
 
 export async function holdForNextMonth({
@@ -866,18 +854,6 @@ export async function copyUntilYearEnd({
   });
 }
 
-export function getCopyUntilYearEndTouchedMonths({
-  month,
-}: {
-  month: string;
-}): string[] {
-  const yearEnd = monthUtils.getYearEnd(month);
-  const { createdMonths } = sheet.get().meta();
-  return [...(createdMonths as Set<string>)]
-    .filter(m => m > month && m <= yearEnd)
-    .sort();
-}
-
 export async function setCategoryCarryover({
   startMonth,
   category,
@@ -899,20 +875,23 @@ export async function setCategoryCarryover({
   const months = isFutureBufferActiveForIncome
     ? allMonths.filter(month => month < monthUtils.currentMonth())
     : allMonths;
-  const shouldRecalculateFutureBuffer =
-    isFutureBufferModeActive() &&
-    allMonths.some(month =>
-      isCurrentOrFutureMonth(monthUtils.nextMonth(month)),
-    );
+  const skippedMonths = isFutureBufferActiveForIncome
+    ? allMonths.filter(isCurrentOrFutureMonth)
+    : [];
 
   await batchMessages(async () => {
     for (const month of months) {
-      await setCarryover(table, category, dbMonth(month).toString(), flag);
+      await setCarryover(
+        table,
+        category,
+        monthUtils.toDbMonth(month).toString(),
+        flag,
+      );
     }
   });
 
-  if (shouldRecalculateFutureBuffer) {
-    await recalculateFutureBuffer();
+  if (skippedMonths.length > 0) {
+    await runBudgetChangeHooks(skippedMonths);
   }
 }
 
@@ -990,7 +969,12 @@ export async function resetIncomeCarryover({
 
   await batchMessages(async () => {
     for (const category of categories) {
-      await setCarryover(table, category.id, dbMonth(month).toString(), false);
+      await setCarryover(
+        table,
+        category.id,
+        monthUtils.toDbMonth(month).toString(),
+        false,
+      );
     }
   });
 }

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -3,11 +3,11 @@
 import * as asyncStorage from '#platform/server/asyncStorage';
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
+import { batchMessages } from '#server/sync';
 import {
-  batchMessages,
   registerBudgetChangeHook,
   runBudgetChangeHooks,
-} from '#server/sync';
+} from '#server/sync/hooks';
 import { getCurrency } from '#shared/currencies';
 import { getLocale } from '#shared/locale';
 import * as monthUtils from '#shared/months';

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -1,6 +1,7 @@
 // @ts-strict-ignore
 
 import * as asyncStorage from '#platform/server/asyncStorage';
+import { logger } from '#platform/server/log';
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
 import { batchMessages } from '#server/sync';
@@ -10,6 +11,7 @@ import * as monthUtils from '#shared/months';
 import { integerToCurrency, safeNumber } from '#shared/util';
 import type { IntegerAmount } from '#shared/util';
 import type { CategoryEntity } from '#types/models';
+import type { FutureBufferMode } from '#types/prefs';
 
 export async function getSheetValue(
   sheetName: string,
@@ -213,6 +215,153 @@ function setCarryover(
   });
 }
 
+export function isFutureBufferModeActive(): boolean {
+  if (isTrackingBudget()) {
+    return false;
+  }
+
+  const featureFlag = db.firstSync<Pick<db.DbPreference, 'value'>>(
+    'SELECT value FROM preferences WHERE id = ?',
+    ['flags.futureBufferMode'],
+  );
+  const budgetPreference = db.firstSync<Pick<db.DbPreference, 'value'>>(
+    'SELECT value FROM preferences WHERE id = ?',
+    ['futureBufferMode'],
+  );
+
+  return (
+    featureFlag?.value === 'true' && budgetPreference?.value === 'automatic'
+  );
+}
+
+export function withBudgetChangeHooks<Args extends [unknown], Result>(
+  action: (...args: Args) => Result,
+  getTouchedMonths: (
+    args: Args[0],
+    result: Awaited<Result>,
+  ) => Iterable<string> | Promise<Iterable<string>>,
+) {
+  return async (...args: Args): Promise<Awaited<Result>> => {
+    const result = await action(...args);
+    const touchedMonths = await getTouchedMonths(args[0], result);
+    await runBudgetChangeHooks(touchedMonths);
+    return result;
+  };
+}
+
+export async function runBudgetChangeHooks(
+  months: Iterable<string>,
+): Promise<void> {
+  try {
+    if (isFutureBufferModeActive()) {
+      for (const month of months) {
+        if (isCurrentOrFutureMonth(month)) {
+          await recalculateFutureBuffer();
+          break;
+        }
+      }
+    }
+  } catch (error) {
+    logger.warn('Failed running budget change hooks', error);
+  }
+}
+
+function isCurrentOrFutureMonth(month: string): boolean {
+  return month >= monthUtils.currentMonth();
+}
+
+export async function recalculateFutureBuffer(): Promise<void> {
+  if (!isFutureBufferModeActive()) {
+    return;
+  }
+
+  const currentMonth = monthUtils.currentMonth();
+  const { createdMonths = new Set<string>() } = sheet.get().meta();
+  const managedMonths = [...(createdMonths as Set<string>)]
+    .filter(month => month >= currentMonth)
+    .sort();
+
+  if (managedMonths.length === 0) {
+    return;
+  }
+
+  const incomeCategories = await db.all<Pick<db.DbCategory, 'id'>>(
+    'SELECT id FROM categories WHERE tombstone = 0 AND is_income = 1',
+  );
+
+  if (incomeCategories.length > 0) {
+    await batchMessages(async () => {
+      for (const month of managedMonths) {
+        for (const category of incomeCategories) {
+          await setCarryover(
+            'zero_budgets',
+            category.id,
+            dbMonth(month).toString(),
+            false,
+          );
+        }
+      }
+    });
+  }
+
+  await sheet.waitOnSpreadsheet();
+
+  const autoBuffers = new Map<string, number>();
+  let nextMonthAutoBuffer = 0;
+
+  for (let i = managedMonths.length - 1; i >= 0; i--) {
+    const month = managedMonths[i];
+    const nextMonth = managedMonths[i + 1];
+    let autoBuffer = 0;
+
+    if (nextMonth) {
+      const sheetName = monthUtils.sheetForMonth(nextMonth);
+      const totalIncome = await getSheetValue(sheetName, 'total-income');
+      const lastMonthOverspent = await getSheetValue(
+        sheetName,
+        'last-month-overspent',
+      );
+      const totalBudgeted = await getSheetValue(sheetName, 'total-budgeted');
+
+      autoBuffer = Math.round(
+        Math.max(
+          0,
+          safeNumber(
+            -(totalIncome + lastMonthOverspent + totalBudgeted) +
+              nextMonthAutoBuffer,
+          ),
+        ),
+      );
+    }
+
+    autoBuffers.set(month, autoBuffer);
+    nextMonthAutoBuffer = autoBuffer;
+  }
+
+  await batchMessages(async () => {
+    for (const month of managedMonths) {
+      await setBuffer(month, autoBuffers.get(month) ?? 0);
+    }
+  });
+
+  await sheet.waitOnSpreadsheet();
+}
+
+export async function setFutureBufferMode({
+  mode,
+}: {
+  mode: FutureBufferMode;
+}): Promise<void> {
+  await db.update('preferences', {
+    id: 'futureBufferMode',
+    value: mode,
+  });
+
+  if (mode === 'automatic') {
+    await recalculateFutureBuffer();
+  }
+}
+
 // Actions
 
 export async function copyPreviousMonth({
@@ -225,19 +374,19 @@ export async function copyPreviousMonth({
   const budgetData = await getBudgetData(table, prevMonth.toString());
 
   await batchMessages(async () => {
-    budgetData.forEach(prevBudget => {
+    for (const prevBudget of budgetData) {
       if (prevBudget.is_income === 1 && !isTrackingBudget()) {
-        return;
+        continue;
       }
       if (prevBudget.hidden === 1 || prevBudget.group_hidden === 1) {
-        return;
+        continue;
       }
-      void setBudget({
+      await setBudget({
         category: prevBudget.category,
         month,
         amount: prevBudget.amount,
       });
-    });
+    }
   });
 }
 
@@ -254,7 +403,7 @@ export async function copySinglePreviousMonth({
     'budget-' + category,
   );
   await batchMessages(async () => {
-    void setBudget({ category, month, amount: newAmount });
+    await setBudget({ category, month, amount: newAmount });
   });
 }
 
@@ -264,12 +413,12 @@ export async function setZero({ month }: { month: string }): Promise<void> {
   );
 
   await batchMessages(async () => {
-    categories.forEach(cat => {
+    for (const cat of categories) {
       if (cat.is_income === 1 && !isTrackingBudget()) {
-        return;
+        continue;
       }
-      void setBudget({ category: cat.id, month, amount: 0 });
-    });
+      await setBudget({ category: cat.id, month, amount: 0 });
+    }
   });
 }
 
@@ -303,7 +452,7 @@ export async function set3MonthAvg({
         avg *= -1;
       }
 
-      void setBudget({ category: cat.id, month, amount: avg });
+      await setBudget({ category: cat.id, month, amount: avg });
     }
   });
 }
@@ -327,7 +476,7 @@ export async function set12MonthAvg({
       if (cat.is_income === 1 && !isTrackingBudget()) {
         continue;
       }
-      void setNMonthAvg({ month, N: 12, category: cat.id });
+      await setNMonthAvg({ month, N: 12, category: cat.id });
     }
   });
 }
@@ -351,7 +500,7 @@ export async function set6MonthAvg({
       if (cat.is_income === 1 && !isTrackingBudget()) {
         continue;
       }
-      void setNMonthAvg({ month, N: 6, category: cat.id });
+      await setNMonthAvg({ month, N: 6, category: cat.id });
     }
   });
 }
@@ -381,7 +530,7 @@ export async function setNMonthAvg({
       avg *= -1;
     }
 
-    void setBudget({ category, month, amount: avg });
+    await setBudget({ category, month, amount: avg });
   });
 }
 
@@ -490,6 +639,10 @@ export async function holdForNextMonth({
   month: string;
   amount: number;
 }): Promise<boolean> {
+  if (isFutureBufferModeActive() && isCurrentOrFutureMonth(month)) {
+    return false;
+  }
+
   const row = await db.first<Pick<db.DbZeroBudgetMonth, 'buffered'>>(
     'SELECT buffered FROM zero_budget_months WHERE id = ?',
     [month],
@@ -512,6 +665,10 @@ export async function holdForNextMonth({
 }
 
 export async function resetHold({ month }: { month: string }): Promise<void> {
+  if (isFutureBufferModeActive() && isCurrentOrFutureMonth(month)) {
+    return;
+  }
+
   await setBuffer(month, 0);
 }
 
@@ -696,9 +853,21 @@ export async function copyUntilYearEnd({
 
   await batchMessages(async () => {
     for (const futureMonth of futureMonths) {
-      void setBudget({ category, month: futureMonth, amount });
+      await setBudget({ category, month: futureMonth, amount });
     }
   });
+}
+
+export function getCopyUntilYearEndTouchedMonths({
+  month,
+}: {
+  month: string;
+}): string[] {
+  const yearEnd = monthUtils.getYearEnd(month);
+  const { createdMonths } = sheet.get().meta();
+  return [...(createdMonths as Set<string>)]
+    .filter(m => m > month && m <= yearEnd)
+    .sort();
 }
 
 export async function setCategoryCarryover({
@@ -711,13 +880,30 @@ export async function setCategoryCarryover({
   flag: boolean;
 }): Promise<void> {
   const table = getBudgetTable();
-  const months = getAllMonths(startMonth);
+  const categoryFromDb = await db.first<Pick<db.DbViewCategory, 'is_income'>>(
+    'SELECT is_income FROM v_categories WHERE id = ?',
+    [category],
+  );
+  const isIncomeCategory = categoryFromDb?.is_income === 1;
+  const isFutureBufferActiveForIncome =
+    isIncomeCategory && isFutureBufferModeActive();
+  const allMonths = getAllMonths(startMonth);
+  const months = isFutureBufferActiveForIncome
+    ? allMonths.filter(month => month < monthUtils.currentMonth())
+    : allMonths;
 
   await batchMessages(async () => {
     for (const month of months) {
-      void setCarryover(table, category, dbMonth(month).toString(), flag);
+      await setCarryover(table, category, dbMonth(month).toString(), flag);
     }
   });
+
+  if (
+    isFutureBufferActiveForIncome &&
+    allMonths.some(month => isCurrentOrFutureMonth(month))
+  ) {
+    await recalculateFutureBuffer();
+  }
 }
 
 function addNewLine(notes?: string) {

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -8,6 +8,7 @@ import {
   registerBudgetChangeHook,
   runBudgetChangeHooks,
 } from '#server/sync/hooks';
+import { single } from '#shared/async';
 import { getCurrency } from '#shared/currencies';
 import { getLocale } from '#shared/locale';
 import * as monthUtils from '#shared/months';
@@ -232,7 +233,7 @@ function isCurrentOrFutureMonth(month: string): boolean {
   return month >= monthUtils.currentMonth();
 }
 
-async function recalculateFutureBufferImpl(): Promise<void> {
+export const recalculateFutureBuffer = single(async function (): Promise<void> {
   if (!isFutureBufferModeActive()) return;
 
   const currentMonth = monthUtils.currentMonth();
@@ -305,22 +306,7 @@ async function recalculateFutureBufferImpl(): Promise<void> {
   });
 
   await sheet.waitOnSpreadsheet();
-}
-
-let isRecalculatingFutureBuffer = false;
-
-export async function recalculateFutureBuffer(): Promise<void> {
-  if (isRecalculatingFutureBuffer) {
-    return;
-  }
-
-  try {
-    isRecalculatingFutureBuffer = true;
-    await recalculateFutureBufferImpl();
-  } finally {
-    isRecalculatingFutureBuffer = false;
-  }
-}
+});
 
 registerBudgetChangeHook(async months => {
   if (!isFutureBufferModeActive()) {

--- a/packages/loot-core/src/server/budget/actions.ts
+++ b/packages/loot-core/src/server/budget/actions.ts
@@ -669,24 +669,27 @@ export async function coverOverspending({
 }: {
   month: string;
   to: CategoryEntity['id'] | 'to-budget';
-  from: CategoryEntity['id'] | 'to-budget' | 'overbudgeted';
+  from: CategoryEntity['id'] | 'to-budget' | 'overbudgeted' | 'for-next-month';
   amount?: IntegerAmount;
   currencyCode: string;
 }): Promise<void> {
   const sheetName = monthUtils.sheetForMonth(month);
   const toBudgeted = await getSheetValue(sheetName, 'budget-' + to);
-  let leftoverFrom = await getSheetValue(
-    sheetName,
-    from === 'to-budget' ? 'to-budget' : 'leftover-' + from,
-  );
 
-  if (
-    from === 'to-budget' &&
-    isFutureBufferModeActive() &&
-    isCurrentOrFutureMonth(month)
-  ) {
-    leftoverFrom += await getSheetValue(sheetName, 'buffered-selected');
+  let source: string;
+  switch (from) {
+    case 'to-budget':
+      source = 'to-budget';
+      break;
+    case 'for-next-month':
+      source = 'buffered-selected';
+      break;
+    default:
+      source = `leftover-${from}`;
+      break;
   }
+  const isForNextMonthSource = source === 'buffered-selected';
+  const leftoverFrom = await getSheetValue(sheetName, source);
 
   // Cover provided amount (can be partial) or full overspending amount.
   const amountToCover = amount
@@ -702,8 +705,10 @@ export async function coverOverspending({
   const coverableAmount = Math.min(Math.abs(amountToCover), leftoverFrom);
 
   await batchMessages(async () => {
-    // If we are covering it from the to be budgeted amount, ignore this
-    if (from !== 'to-budget') {
+    if (isForNextMonthSource) {
+      const buffered = await getSheetValue(sheetName, source);
+      await setBuffer(month, buffered - coverableAmount);
+    } else if (from !== 'to-budget') {
       const fromBudgeted = await getSheetValue(sheetName, 'budget-' + from);
       await setBudget({
         category: from,
@@ -909,7 +914,7 @@ async function addMovementNotes({
   month: string;
   amount: number;
   to: CategoryEntity['id'] | 'to-budget' | 'overbudgeted';
-  from: CategoryEntity['id'] | 'to-budget';
+  from: CategoryEntity['id'] | 'to-budget' | 'for-next-month';
   currencyCode: string;
 }) {
   const currency = getCurrency(currencyCode);
@@ -934,13 +939,17 @@ async function addMovementNotes({
     locale,
   );
   const categories = await db.getCategories(
-    [from, to].filter(c => c !== 'to-budget' && c !== 'overbudgeted'),
+    [from, to].filter(
+      c => c !== 'to-budget' && c !== 'overbudgeted' && c !== 'for-next-month',
+    ),
   );
 
   const fromCategoryName =
     from === 'to-budget'
       ? 'To Budget'
-      : categories.find(c => c.id === from)?.name;
+      : from === 'for-next-month'
+        ? 'For next month'
+        : categories.find(c => c.id === from)?.name;
 
   const toCategoryName =
     to === 'to-budget'

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -45,6 +45,8 @@ export type BudgetHandlers = {
   'budget/copy-until-year-end': typeof actions.copyUntilYearEnd;
   'budget/set-carryover': typeof actions.setCategoryCarryover;
   'budget/reset-income-carryover': typeof actions.resetIncomeCarryover;
+  'budget/recalculate-future-buffer': typeof actions.recalculateFutureBuffer;
+  'budget/set-future-buffer-mode': typeof actions.setFutureBufferMode;
   'get-categories': typeof getCategories;
   'get-budget-bounds': typeof getBudgetBounds;
   'envelope-budget-month': typeof envelopeBudgetMonth;
@@ -71,43 +73,134 @@ export type BudgetHandlers = {
 
 export const app = createApp<BudgetHandlers>();
 
-app.method('budget/budget-amount', mutator(undoable(actions.setBudget)));
+app.method(
+  'budget/budget-amount',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.setBudget, touchedTargetMonth),
+    ),
+  ),
+);
 app.method(
   'budget/copy-previous-month',
-  mutator(undoable(actions.copyPreviousMonth)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.copyPreviousMonth,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/copy-single-month',
-  mutator(undoable(actions.copySinglePreviousMonth)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.copySinglePreviousMonth,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
-app.method('budget/set-zero', mutator(undoable(actions.setZero)));
-app.method('budget/set-3month-avg', mutator(undoable(actions.set3MonthAvg)));
-app.method('budget/set-6month-avg', mutator(undoable(actions.set6MonthAvg)));
-app.method('budget/set-12month-avg', mutator(undoable(actions.set12MonthAvg)));
-app.method('budget/set-n-month-avg', mutator(undoable(actions.setNMonthAvg)));
+app.method(
+  'budget/set-zero',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.setZero, touchedTargetMonth),
+    ),
+  ),
+);
+app.method(
+  'budget/set-3month-avg',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.set3MonthAvg, touchedTargetMonth),
+    ),
+  ),
+);
+app.method(
+  'budget/set-6month-avg',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.set6MonthAvg, touchedTargetMonth),
+    ),
+  ),
+);
+app.method(
+  'budget/set-12month-avg',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.set12MonthAvg, touchedTargetMonth),
+    ),
+  ),
+);
+app.method(
+  'budget/set-n-month-avg',
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(actions.setNMonthAvg, touchedTargetMonth),
+    ),
+  ),
+);
 app.method(
   'budget/check-templates',
   mutator(undoable(goalActions.runCheckTemplates)),
 );
 app.method(
   'budget/apply-goal-template',
-  mutator(undoable(goalActions.applyTemplate)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        goalActions.applyTemplate,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/apply-multiple-templates',
-  mutator(undoable(goalActions.applyMultipleCategoryTemplates)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        goalActions.applyMultipleCategoryTemplates,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/overwrite-goal-template',
-  mutator(undoable(goalActions.overwriteTemplate)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        goalActions.overwriteTemplate,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/apply-single-template',
-  mutator(undoable(goalActions.applySingleCategoryTemplate)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        goalActions.applySingleCategoryTemplate,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/cleanup-goal-template',
-  mutator(undoable(cleanupActions.cleanupTemplate)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        cleanupActions.cleanupTemplate,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/hold-for-next-month',
@@ -116,23 +209,58 @@ app.method(
 app.method('budget/reset-hold', mutator(undoable(actions.resetHold)));
 app.method(
   'budget/cover-overspending',
-  mutator(undoable(actions.coverOverspending)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.coverOverspending,
+        touchedNextMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/transfer-available',
-  mutator(undoable(actions.transferAvailable)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.transferAvailable,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/cover-overbudgeted',
-  mutator(undoable(actions.coverOverbudgeted)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.coverOverbudgeted,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/transfer-category',
-  mutator(undoable(actions.transferCategory)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.transferCategory,
+        touchedTargetMonth,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/copy-until-year-end',
-  mutator(undoable(actions.copyUntilYearEnd)),
+  mutator(
+    undoable(
+      actions.withBudgetChangeHooks(
+        actions.copyUntilYearEnd,
+        actions.getCopyUntilYearEndTouchedMonths,
+      ),
+    ),
+  ),
 );
 app.method(
   'budget/set-carryover',
@@ -141,6 +269,14 @@ app.method(
 app.method(
   'budget/reset-income-carryover',
   mutator(undoable(actions.resetIncomeCarryover)),
+);
+app.method(
+  'budget/recalculate-future-buffer',
+  mutator(undoable(actions.recalculateFutureBuffer)),
+);
+app.method(
+  'budget/set-future-buffer-mode',
+  mutator(undoable(actions.setFutureBufferMode)),
 );
 app.method('get-categories', getCategories);
 app.method('get-budget-bounds', getBudgetBounds);
@@ -203,7 +339,19 @@ async function getCategories({ hidden }: { hidden?: boolean } = {}) {
 }
 
 async function getBudgetBounds() {
-  return await budget.createAllBudgets();
+  const createdMonthsBefore = new Set<string>(sheet.get().meta().createdMonths);
+  const bounds = await budget.createAllBudgets();
+  const createdMonthsAfter = new Set<string>(sheet.get().meta().createdMonths);
+  const newMonths = [...createdMonthsAfter].filter(
+    month => !createdMonthsBefore.has(month),
+  );
+
+  // `get-budget-bounds` is a load/horizon-extension handler, not a user
+  // budget-edit mutator. Keep this fallback outside undo history while still
+  // refreshing auto-managed buffers when loading creates future months.
+  await actions.runBudgetChangeHooks(newMonths);
+
+  return bounds;
 }
 
 async function envelopeBudgetMonth({ month }: { month: string }) {
@@ -219,6 +367,8 @@ async function envelopeBudgetMonth({ month }: { month: string }) {
     value('available-funds'),
     value('last-month-overspent'),
     value('buffered'),
+    value('buffered-auto'),
+    value('buffered-selected'),
     value('total-budgeted'),
     value('to-budget'),
 
@@ -508,4 +658,12 @@ async function isCategoryTransferRequired({
 
     return value != null && value !== 0;
   });
+}
+
+function touchedTargetMonth({ month }: { month: string }): string[] {
+  return [month];
+}
+
+function touchedNextMonth({ month }: { month: string }): string[] {
+  return [monthUtils.nextMonth(month)];
 }

--- a/packages/loot-core/src/server/budget/app.ts
+++ b/packages/loot-core/src/server/budget/app.ts
@@ -73,134 +73,43 @@ export type BudgetHandlers = {
 
 export const app = createApp<BudgetHandlers>();
 
-app.method(
-  'budget/budget-amount',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.setBudget, touchedTargetMonth),
-    ),
-  ),
-);
+app.method('budget/budget-amount', mutator(undoable(actions.setBudget)));
 app.method(
   'budget/copy-previous-month',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.copyPreviousMonth,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.copyPreviousMonth)),
 );
 app.method(
   'budget/copy-single-month',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.copySinglePreviousMonth,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.copySinglePreviousMonth)),
 );
-app.method(
-  'budget/set-zero',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.setZero, touchedTargetMonth),
-    ),
-  ),
-);
-app.method(
-  'budget/set-3month-avg',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.set3MonthAvg, touchedTargetMonth),
-    ),
-  ),
-);
-app.method(
-  'budget/set-6month-avg',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.set6MonthAvg, touchedTargetMonth),
-    ),
-  ),
-);
-app.method(
-  'budget/set-12month-avg',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.set12MonthAvg, touchedTargetMonth),
-    ),
-  ),
-);
-app.method(
-  'budget/set-n-month-avg',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(actions.setNMonthAvg, touchedTargetMonth),
-    ),
-  ),
-);
+app.method('budget/set-zero', mutator(undoable(actions.setZero)));
+app.method('budget/set-3month-avg', mutator(undoable(actions.set3MonthAvg)));
+app.method('budget/set-6month-avg', mutator(undoable(actions.set6MonthAvg)));
+app.method('budget/set-12month-avg', mutator(undoable(actions.set12MonthAvg)));
+app.method('budget/set-n-month-avg', mutator(undoable(actions.setNMonthAvg)));
 app.method(
   'budget/check-templates',
   mutator(undoable(goalActions.runCheckTemplates)),
 );
 app.method(
   'budget/apply-goal-template',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        goalActions.applyTemplate,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(goalActions.applyTemplate)),
 );
 app.method(
   'budget/apply-multiple-templates',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        goalActions.applyMultipleCategoryTemplates,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(goalActions.applyMultipleCategoryTemplates)),
 );
 app.method(
   'budget/overwrite-goal-template',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        goalActions.overwriteTemplate,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(goalActions.overwriteTemplate)),
 );
 app.method(
   'budget/apply-single-template',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        goalActions.applySingleCategoryTemplate,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(goalActions.applySingleCategoryTemplate)),
 );
 app.method(
   'budget/cleanup-goal-template',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        cleanupActions.cleanupTemplate,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(cleanupActions.cleanupTemplate)),
 );
 app.method(
   'budget/hold-for-next-month',
@@ -209,58 +118,23 @@ app.method(
 app.method('budget/reset-hold', mutator(undoable(actions.resetHold)));
 app.method(
   'budget/cover-overspending',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.coverOverspending,
-        touchedNextMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.coverOverspending)),
 );
 app.method(
   'budget/transfer-available',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.transferAvailable,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.transferAvailable)),
 );
 app.method(
   'budget/cover-overbudgeted',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.coverOverbudgeted,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.coverOverbudgeted)),
 );
 app.method(
   'budget/transfer-category',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.transferCategory,
-        touchedTargetMonth,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.transferCategory)),
 );
 app.method(
   'budget/copy-until-year-end',
-  mutator(
-    undoable(
-      actions.withBudgetChangeHooks(
-        actions.copyUntilYearEnd,
-        actions.getCopyUntilYearEndTouchedMonths,
-      ),
-    ),
-  ),
+  mutator(undoable(actions.copyUntilYearEnd)),
 );
 app.method(
   'budget/set-carryover',
@@ -339,19 +213,7 @@ async function getCategories({ hidden }: { hidden?: boolean } = {}) {
 }
 
 async function getBudgetBounds() {
-  const createdMonthsBefore = new Set<string>(sheet.get().meta().createdMonths);
-  const bounds = await budget.createAllBudgets();
-  const createdMonthsAfter = new Set<string>(sheet.get().meta().createdMonths);
-  const newMonths = [...createdMonthsAfter].filter(
-    month => !createdMonthsBefore.has(month),
-  );
-
-  // `get-budget-bounds` is a load/horizon-extension handler, not a user
-  // budget-edit mutator. Keep this fallback outside undo history while still
-  // refreshing auto-managed buffers when loading creates future months.
-  await actions.runBudgetChangeHooks(newMonths);
-
-  return bounds;
+  return budget.createAllBudgets();
 }
 
 async function envelopeBudgetMonth({ month }: { month: string }) {
@@ -658,12 +520,4 @@ async function isCategoryTransferRequired({
 
     return value != null && value !== 0;
   });
-}
-
-function touchedTargetMonth({ month }: { month: string }): string[] {
-  return [month];
-}
-
-function touchedNextMonth({ month }: { month: string }): string[] {
-  return [monthUtils.nextMonth(month)];
 }

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -177,8 +177,40 @@ function handleBudgetChange(budget) {
   }
 }
 
+const FUTURE_BUFFER_BUDGET_FIELDS = new Set([
+  'amount',
+  'carryover',
+  'goal',
+  'long_goal',
+]);
+
+const FUTURE_BUFFER_TRANSACTION_FIELDS = new Set([
+  'date',
+  'acct',
+  'account',
+  'amount',
+  'category',
+  'tombstone',
+  'isParent',
+  'isChild',
+]);
+
+const FUTURE_BUFFER_CATEGORY_FIELDS = new Set([
+  'is_income',
+  'cat_group',
+  'hidden',
+  'tombstone',
+]);
+
+const FUTURE_BUFFER_CATEGORY_GROUP_FIELDS = new Set([
+  'is_income',
+  'hidden',
+  'tombstone',
+]);
+
 export function triggerBudgetChanges(oldValues, newValues) {
   const { createdMonths = new Set() } = sheet.get().meta();
+  const futureBufferTouchedMonths = new Set<string>();
   const budgetType = getBudgetType();
   sheet.startTransaction();
 
@@ -188,6 +220,14 @@ export function triggerBudgetChanges(oldValues, newValues) {
 
       items.forEach(newValue => {
         const oldValue = old && old.get(newValue.id);
+
+        addFutureBufferTouchedMonths({
+          months: futureBufferTouchedMonths,
+          table,
+          oldValue,
+          newValue,
+          createdMonths,
+        });
 
         if (table === 'zero_budget_months') {
           handleBudgetMonthChange(newValue);
@@ -240,6 +280,146 @@ export function triggerBudgetChanges(oldValues, newValues) {
   } finally {
     sheet.endTransaction();
   }
+
+  return futureBufferTouchedMonths;
+}
+
+function addFutureBufferTouchedMonths({
+  months,
+  table,
+  oldValue,
+  newValue,
+  createdMonths,
+}: {
+  months: Set<string>;
+  table: string;
+  oldValue: unknown;
+  newValue: unknown;
+  createdMonths: Set<string>;
+}) {
+  const changedFields = getChangedFields(oldValue, newValue);
+
+  if (table === 'zero_budget_months') {
+    return;
+  }
+
+  if (table === 'zero_budgets') {
+    if (
+      changedFields.size === 0 ||
+      hasChangedField(changedFields, FUTURE_BUFFER_BUDGET_FIELDS)
+    ) {
+      addBudgetMonths(months, oldValue, newValue);
+
+      if (
+        changedFields.has('carryover') &&
+        (oldValue || isCarryoverEnabled(newValue))
+      ) {
+        addNextBudgetMonths(months, oldValue, newValue);
+      }
+    }
+  } else if (table === 'reflect_budgets') {
+    if (
+      changedFields.size === 0 ||
+      hasChangedField(changedFields, FUTURE_BUFFER_BUDGET_FIELDS)
+    ) {
+      addBudgetMonths(months, oldValue, newValue);
+    }
+  } else if (table === 'transactions') {
+    if (hasChangedField(changedFields, FUTURE_BUFFER_TRANSACTION_FIELDS)) {
+      if (oldValue) {
+        addTransactionMonth(months, oldValue);
+      }
+      addTransactionMonth(months, newValue);
+    }
+  } else if (table === 'accounts') {
+    if (!oldValue || changedFields.has('offbudget')) {
+      addCreatedMonths(months, createdMonths);
+    }
+  } else if (table === 'categories') {
+    if (hasChangedField(changedFields, FUTURE_BUFFER_CATEGORY_FIELDS)) {
+      addCreatedMonths(months, createdMonths);
+    }
+  } else if (table === 'category_groups') {
+    if (hasChangedField(changedFields, FUTURE_BUFFER_CATEGORY_GROUP_FIELDS)) {
+      addCreatedMonths(months, createdMonths);
+    }
+  } else if (table === 'category_mapping') {
+    addCreatedMonths(months, createdMonths);
+  }
+}
+
+function getChangedFields(oldValue: unknown, newValue: unknown): Set<string> {
+  return new Set(Object.keys(getChangedValues(oldValue || {}, newValue) || {}));
+}
+
+function hasChangedField(changedFields: Set<string>, fields: Set<string>) {
+  for (const field of fields) {
+    if (changedFields.has(field)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function addBudgetMonths(
+  months: Set<string>,
+  oldValue: { month?: number } | null | undefined,
+  newValue: { month?: number },
+) {
+  if (oldValue) {
+    addBudgetMonth(months, oldValue);
+  }
+  addBudgetMonth(months, newValue);
+}
+
+function addBudgetMonth(months: Set<string>, budget: { month?: number }) {
+  const month = getBudgetMonth(budget);
+  if (month) {
+    months.add(month);
+  }
+}
+
+function getBudgetMonth(budget: { month?: number }): string | null {
+  if (budget.month) {
+    return monthUtils.fromDbMonth(budget.month);
+  }
+  return null;
+}
+
+function isCarryoverEnabled(budget: { carryover?: number | boolean }): boolean {
+  return budget.carryover === 1 || budget.carryover === true;
+}
+
+function addNextBudgetMonths(
+  months: Set<string>,
+  oldValue: { month?: number } | null | undefined,
+  newValue: { month?: number },
+) {
+  const oldMonth = oldValue ? getBudgetMonth(oldValue) : null;
+  const newMonth = getBudgetMonth(newValue);
+
+  if (oldMonth) {
+    months.add(monthUtils.nextMonth(oldMonth));
+  }
+  if (newMonth) {
+    months.add(monthUtils.nextMonth(newMonth));
+  }
+}
+
+function addTransactionMonth(
+  months: Set<string>,
+  transaction: {
+    date?: number;
+    category?: string;
+  },
+) {
+  if (transaction.date && transaction.category) {
+    months.add(monthUtils.monthFromDate(db.fromDateRepr(transaction.date)));
+  }
+}
+
+function addCreatedMonths(months: Set<string>, createdMonths: Set<string>) {
+  createdMonths.forEach(month => months.add(month));
 }
 
 export async function doTransfer(categoryIds, transferId) {
@@ -396,6 +576,11 @@ export async function createAllBudgets() {
 
   if (newMonths.length > 0) {
     await createBudget(range);
+
+    if (newMonths.some(month => month >= currentMonth)) {
+      const { runBudgetChangeHooks } = await import('#server/sync');
+      await runBudgetChangeHooks(newMonths);
+    }
   }
 
   return { start, end };

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -2,6 +2,7 @@ import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
 import * as sheet from '#server/sheet';
 import { resolveName } from '#server/spreadsheet/util';
+import { runBudgetChangeHooks } from '#server/sync/hooks';
 // @ts-strict-ignore
 import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
@@ -70,7 +71,14 @@ function getSumAmountsByMonth(
   return sums;
 }
 
-export function createCategory(cat, sheetName, prevSheetName, start, end) {
+export function createCategory(
+  cat,
+  sheetName,
+  prevSheetName,
+  start,
+  end,
+  options = {},
+) {
   sheet.get().createDynamic(sheetName, 'sum-amount-' + cat.id, {
     initialValue: 0,
     run: () => {
@@ -90,7 +98,7 @@ export function createCategory(cat, sheetName, prevSheetName, start, end) {
   });
 
   if (getBudgetType() === 'envelope') {
-    envelopeBudget.createCategory(cat, sheetName, prevSheetName);
+    envelopeBudget.createCategory(cat, sheetName, prevSheetName, options);
   } else {
     void trackingBudget.createCategory(cat, sheetName, prevSheetName);
   }
@@ -493,6 +501,8 @@ export async function createBudget(months) {
     return sumAmounts;
   };
   const seededCells: string[] = [];
+  const copyPreviousCarryover =
+    budgetType === 'envelope' && budgetActions.isFutureBufferModeActive();
 
   monthsToCreate.forEach(month => {
     const prevMonth = monthUtils.prevMonth(month);
@@ -513,7 +523,13 @@ export async function createBudget(months) {
           .load(name, getSumAmounts().get(`${dbMonth}-${cat.id}`) || 0);
         seededCells.push(name);
       }
-      createCategory(cat, sheetName, prevSheetName, start, end);
+      createCategory(cat, sheetName, prevSheetName, start, end, {
+        initialCarryover:
+          copyPreviousCarryover &&
+          sheet
+            .get()
+            .getCellValueLoose(prevSheetName, `carryover-${cat.id}`) === true,
+      });
     });
     groups.forEach(group => {
       if (budgetType === 'envelope') {
@@ -578,7 +594,6 @@ export async function createAllBudgets() {
     await createBudget(range);
 
     if (newMonths.some(month => month >= currentMonth)) {
-      const { runBudgetChangeHooks } = await import('#server/sync');
       await runBudgetChangeHooks(newMonths);
     }
   }

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -243,9 +243,10 @@ export function triggerBudgetChanges(oldValues, newValues) {
 }
 
 export async function doTransfer(categoryIds, transferId) {
-  const { createdMonths: months } = sheet.get().meta();
+  const { createdMonths = new Set<string>() } = sheet.get().meta();
+  const months = [...createdMonths];
 
-  [...months].forEach(month => {
+  for (const month of months) {
     const totalValue = categoryIds
       .map(id => {
         return budgetActions.getBudget({ month, category: id });
@@ -257,12 +258,12 @@ export async function doTransfer(categoryIds, transferId) {
       category: transferId,
     });
 
-    void budgetActions.setBudget({
+    await budgetActions.setBudget({
       month,
       category: transferId,
       amount: totalValue + transferValue,
     });
-  });
+  }
 }
 
 export async function createBudget(months) {

--- a/packages/loot-core/src/server/budget/envelope.ts
+++ b/packages/loot-core/src/server/budget/envelope.ts
@@ -30,7 +30,12 @@ function createBlankMonth(categories, sheetName, months) {
   categories.forEach(cat => createBlankCategory(cat, months));
 }
 
-export function createCategory(cat, sheetName, prevSheetName) {
+export function createCategory(
+  cat,
+  sheetName,
+  prevSheetName,
+  { initialCarryover = false } = {},
+) {
   if (!cat.is_income) {
     sheet.get().createStatic(sheetName, `budget-${cat.id}`, 0);
 
@@ -43,7 +48,9 @@ export function createCategory(cat, sheetName, prevSheetName) {
       sheet.get().set(resolveName(sheetName, `budget-${cat.id}`), 0);
     }
 
-    sheet.get().createStatic(sheetName, `carryover-${cat.id}`, false);
+    sheet
+      .get()
+      .createStatic(sheetName, `carryover-${cat.id}`, initialCarryover);
 
     sheet.get().createDynamic(sheetName, `leftover-${cat.id}`, {
       initialValue: 0,

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -186,13 +186,13 @@ type TemplateBudget = {
 
 async function setBudgets(month: string, templateBudget: TemplateBudget[]) {
   await batchMessages(async () => {
-    templateBudget.forEach(element => {
-      void setBudget({
+    for (const element of templateBudget) {
+      await setBudget({
         category: element.category,
         month,
         amount: element.budgeted,
       });
-    });
+    }
   });
 }
 
@@ -204,14 +204,14 @@ type TemplateGoal = {
 
 async function setGoals(month: string, templateGoal: TemplateGoal[]) {
   await batchMessages(async () => {
-    templateGoal.forEach(element => {
-      void setGoal({
+    for (const element of templateGoal) {
+      await setGoal({
         month,
         category: element.category,
         goal: element.goal,
         long_goal: element.longGoal,
       });
-    });
+    }
   });
 }
 

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -543,7 +543,11 @@ function trackJSONPaths() {
     });
   });
 
-  return addSyncListener(onApplySync);
+  const unlisten = addSyncListener(onApplySync);
+  return async () => {
+    unlisten();
+    await pendingScheduleService;
+  };
 }
 
 function onApplySync(oldValues, newValues) {
@@ -558,6 +562,22 @@ function onApplySync(oldValues, newValues) {
 
 // This is the service that move schedules forward automatically and
 // posts transactions
+
+let pendingScheduleService: Promise<void> | null = null;
+
+function runScheduleService(syncSuccess: boolean) {
+  const promise = runMutator(() => advanceSchedulesService(syncSuccess))
+    .catch(error => {
+      logger.log('Error running schedules service', error);
+    })
+    .finally(() => {
+      if (pendingScheduleService === promise) {
+        pendingScheduleService = null;
+      }
+    });
+
+  pendingScheduleService = promise;
+}
 
 async function postTransactionForSchedule({
   id,
@@ -832,7 +852,7 @@ app.events.on('sync', ({ type }) => {
 
     const { lastScheduleRun } = prefs.getPrefs();
     if (lastScheduleRun !== currentDay()) {
-      void runMutator(() => advanceSchedulesService(type === 'success'));
+      runScheduleService(type === 'success');
 
       // Only mark the day as done when sync succeeded, so that
       // schedule auto-posting is retried on subsequent successful syncs

--- a/packages/loot-core/src/server/sync/hooks.ts
+++ b/packages/loot-core/src/server/sync/hooks.ts
@@ -1,0 +1,31 @@
+export type BudgetChangeHook = (
+  months: readonly string[],
+) => Promise<void> | void;
+
+function getBudgetChangeHooks(): Set<BudgetChangeHook> {
+  const store = getBudgetChangeHooks as typeof getBudgetChangeHooks & {
+    hooks?: Set<BudgetChangeHook>;
+  };
+  store.hooks ||= new Set();
+  return store.hooks;
+}
+
+export function registerBudgetChangeHook(hook: BudgetChangeHook): () => void {
+  getBudgetChangeHooks().add(hook);
+  return () => {
+    getBudgetChangeHooks().delete(hook);
+  };
+}
+
+export async function runBudgetChangeHooks(
+  months: Iterable<string>,
+): Promise<void> {
+  const touchedMonths = [...months];
+  if (touchedMonths.length === 0) {
+    return;
+  }
+
+  for (const hook of getBudgetChangeHooks()) {
+    await hook(touchedMonths);
+  }
+}

--- a/packages/loot-core/src/server/sync/hooks.ts
+++ b/packages/loot-core/src/server/sync/hooks.ts
@@ -1,23 +1,19 @@
+import { single } from '#shared/async';
+
 export type BudgetChangeHook = (
   months: readonly string[],
 ) => Promise<void> | void;
 
-function getBudgetChangeHooks(): Set<BudgetChangeHook> {
-  const store = getBudgetChangeHooks as typeof getBudgetChangeHooks & {
-    hooks?: Set<BudgetChangeHook>;
-  };
-  store.hooks ||= new Set();
-  return store.hooks;
-}
+const budgetChangeHooks = new Set<BudgetChangeHook>();
 
 export function registerBudgetChangeHook(hook: BudgetChangeHook): () => void {
-  getBudgetChangeHooks().add(hook);
+  budgetChangeHooks.add(hook);
   return () => {
-    getBudgetChangeHooks().delete(hook);
+    budgetChangeHooks.delete(hook);
   };
 }
 
-export async function runBudgetChangeHooks(
+export const runBudgetChangeHooks = single(async function (
   months: Iterable<string>,
 ): Promise<void> {
   const touchedMonths = [...months];
@@ -25,7 +21,7 @@ export async function runBudgetChangeHooks(
     return;
   }
 
-  for (const hook of getBudgetChangeHooks()) {
+  for (const hook of budgetChangeHooks) {
     await hook(touchedMonths);
   }
-}
+});

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -30,6 +30,7 @@ import { getIn, setIn } from '#shared/util';
 import type { MetadataPrefs } from '#types/prefs';
 
 import * as encoder from './encoder';
+import { runBudgetChangeHooks } from './hooks';
 import { rebuildMerkleHash } from './repair';
 import { isError } from './utils';
 
@@ -457,38 +458,6 @@ export async function applyMessagesWithHooks(
   }
 
   return result?.messages ?? [];
-}
-
-export type BudgetChangeHook = (
-  months: readonly string[],
-) => Promise<void> | void;
-
-function getBudgetChangeHooks(): Set<BudgetChangeHook> {
-  const store = getBudgetChangeHooks as typeof getBudgetChangeHooks & {
-    hooks?: Set<BudgetChangeHook>;
-  };
-  store.hooks ||= new Set();
-  return store.hooks;
-}
-
-export function registerBudgetChangeHook(hook: BudgetChangeHook): () => void {
-  getBudgetChangeHooks().add(hook);
-  return () => {
-    getBudgetChangeHooks().delete(hook);
-  };
-}
-
-export async function runBudgetChangeHooks(
-  months: Iterable<string>,
-): Promise<void> {
-  const touchedMonths = [...months];
-  if (touchedMonths.length === 0) {
-    return;
-  }
-
-  for (const hook of getBudgetChangeHooks()) {
-    await hook(touchedMonths);
-  }
 }
 
 export function receiveMessages(messages: Message[]): Promise<Message[]> {

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -258,7 +258,7 @@ export type Message = {
   value: string | number | null;
 };
 
-export const applyMessages = sequential(async (messages: Message[]) => {
+const applyMessages = sequential(async (messages: Message[]) => {
   if (checkSyncingMode('import')) {
     applyMessagesForImport(messages);
     return undefined;
@@ -398,11 +398,13 @@ export const applyMessages = sequential(async (messages: Message[]) => {
 
   const newData = await fetchData();
 
+  let budgetChangeTouchedMonths: Set<string> | null = null;
+
   // In testing, sometimes the spreadsheet isn't loaded, and that's ok
   if (sheet.get()) {
     // Need to clean up these APIs and make them consistent
     sheet.startTransaction();
-    triggerBudgetChanges(oldData, newData);
+    budgetChangeTouchedMonths = triggerBudgetChanges(oldData, newData);
     sheet.get().triggerDatabaseChanges(oldData, newData);
     sheet.endTransaction();
 
@@ -441,8 +443,53 @@ export const applyMessages = sequential(async (messages: Message[]) => {
     prevData: oldData,
   });
 
-  return messages;
+  return { budgetChangeTouchedMonths, messages } as const;
 });
+
+export async function applyMessagesWithHooks(
+  inputMessages: Message[],
+): Promise<Message[]> {
+  const result = await applyMessages(inputMessages);
+  if (result?.budgetChangeTouchedMonths) {
+    await runBudgetChangeHooks(result.budgetChangeTouchedMonths).catch(
+      errorHandler,
+    );
+  }
+
+  return result?.messages ?? [];
+}
+
+export type BudgetChangeHook = (
+  months: readonly string[],
+) => Promise<void> | void;
+
+function getBudgetChangeHooks(): Set<BudgetChangeHook> {
+  const store = getBudgetChangeHooks as typeof getBudgetChangeHooks & {
+    hooks?: Set<BudgetChangeHook>;
+  };
+  store.hooks ||= new Set();
+  return store.hooks;
+}
+
+export function registerBudgetChangeHook(hook: BudgetChangeHook): () => void {
+  getBudgetChangeHooks().add(hook);
+  return () => {
+    getBudgetChangeHooks().delete(hook);
+  };
+}
+
+export async function runBudgetChangeHooks(
+  months: Iterable<string>,
+): Promise<void> {
+  const touchedMonths = [...months];
+  if (touchedMonths.length === 0) {
+    return;
+  }
+
+  for (const hook of getBudgetChangeHooks()) {
+    await hook(touchedMonths);
+  }
+}
 
 export function receiveMessages(messages: Message[]): Promise<Message[]> {
   try {
@@ -456,7 +503,7 @@ export function receiveMessages(messages: Message[]): Promise<Message[]> {
     throw e;
   }
 
-  return runMutator(() => applyMessages(messages));
+  return runMutator(() => applyMessagesWithHooks(messages));
 }
 
 async function errorHandler(e: Error) {
@@ -487,7 +534,7 @@ async function errorHandler(e: Error) {
 
 async function _sendMessages(messages: Message[]): Promise<void> {
   try {
-    await applyMessages(messages);
+    await applyMessagesWithHooks(messages);
   } catch (e) {
     void errorHandler(e);
     throw e;

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -451,6 +451,7 @@ export async function applyMessagesWithHooks(
   inputMessages: Message[],
 ): Promise<Message[]> {
   const result = await applyMessages(inputMessages);
+
   if (result?.budgetChangeTouchedMonths) {
     await runBudgetChangeHooks(result.budgetChangeTouchedMonths).catch(
       errorHandler,

--- a/packages/loot-core/src/server/sync/migrate.ts
+++ b/packages/loot-core/src/server/sync/migrate.ts
@@ -1,7 +1,7 @@
 // @ts-strict-ignore
 import { Timestamp } from '@actual-app/crdt';
 
-import { addSyncListener, applyMessages } from './index';
+import { addSyncListener, applyMessagesWithHooks } from './index';
 import type { Message } from './index';
 
 function migrateParentIds(_oldValues, newValues) {
@@ -28,7 +28,7 @@ function migrateParentIds(_oldValues, newValues) {
       });
 
       if (toApply.length > 0) {
-        void applyMessages(toApply);
+        void applyMessagesWithHooks(toApply);
       }
     }
   });

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -9,7 +9,12 @@ import * as mockSyncServer from '#server/tests/mockSyncServer';
 import * as encoder from './encoder';
 import { isError } from './utils';
 
-import { applyMessages, fullSync, sendMessages, setSyncingMode } from './index';
+import {
+  applyMessagesWithHooks,
+  fullSync,
+  sendMessages,
+  setSyncingMode,
+} from './index';
 
 beforeEach(() => {
   mockSyncServer.reset();
@@ -68,7 +73,7 @@ describe('Sync', () => {
 
     global.stepForwardInTime(Date.parse('2018-11-13T13:20:00.000Z'));
 
-    await applyMessages([
+    await applyMessagesWithHooks([
       global.stepForwardInTime() || {
         dataset: 'transactions',
         row: 'foo',
@@ -135,7 +140,7 @@ describe('Sync', () => {
       ),
     );
 
-    await applyMessages([
+    await applyMessagesWithHooks([
       global.stepForwardInTime(Date.parse('1970-01-03T10:17:37.000Z')) || {
         dataset: 'transactions',
         row: 'foo',
@@ -250,13 +255,13 @@ describe('Sync projections', () => {
     const messages = mockSyncServer.getMessages();
 
     // Apply all but the last message (which deletes the category)
-    await applyMessages(messages.slice(0, -1));
+    await applyMessagesWithHooks(messages.slice(0, -1));
     expect((await db.getCategories()).length).toBe(1);
     expectCellToExist('budget201701', 'sum-amount-' + fooId);
 
     // Apply the last message and make sure it deleted the appropriate
     // budget cells
-    await applyMessages([messages[messages.length - 1]]);
+    await applyMessagesWithHooks([messages[messages.length - 1]]);
     expect((await db.getCategories()).length).toBe(0);
     expectCellNotToExist('budget201701', 'sum-amount-' + fooId, true);
   });
@@ -304,14 +309,14 @@ describe('Sync projections', () => {
     const secondMessages = messages.filter(m => m.column === 'tombstone');
 
     // Apply all the good messages
-    await applyMessages(firstMessages);
+    await applyMessagesWithHooks(firstMessages);
     expect((await db.getCategories()).length).toBe(1);
     expect((await db.getCategoriesGrouped()).length).toBe(1);
     expectCellToExist('budget201701', 'sum-amount-' + fooId);
     expectCellToExist('budget201701', 'group-sum-amount-' + groupId);
 
     // Apply the messages that deletes it
-    await applyMessages(secondMessages);
+    await applyMessagesWithHooks(secondMessages);
     expect((await db.getCategories()).length).toBe(0);
     expect((await db.getCategoriesGrouped()).length).toBe(0);
     expectCellNotToExist('budget201701', 'sum-amount-' + fooId, true);
@@ -338,12 +343,12 @@ describe('Sync projections', () => {
     const secondMessages = messages.slice(-2);
 
     // Apply all the good messages
-    await applyMessages(firstMessages);
+    await applyMessagesWithHooks(firstMessages);
     const [cat] = await db.getCategories();
     expect(cat.cat_group).toBe('group1');
     expectCellToExist('budget201701', 'group-sum-amount-' + groupId);
 
     // Apply the messages that deletes it
-    await applyMessages(secondMessages);
+    await applyMessagesWithHooks(secondMessages);
   });
 });

--- a/packages/loot-core/src/server/transactions/index.ts
+++ b/packages/loot-core/src/server/transactions/index.ts
@@ -1,9 +1,11 @@
 // @ts-strict-ignore
 
 import * as connection from '#platform/server/connection';
+import { runBudgetChangeHooks } from '#server/budget/actions';
 import * as db from '#server/db';
 import { incrFetch, whereIn } from '#server/db/util';
 import { batchMessages } from '#server/sync';
+import * as monthUtils from '#shared/months';
 import type { Diff } from '#shared/util';
 import type { PayeeEntity, TransactionEntity } from '#types/models';
 
@@ -37,6 +39,20 @@ async function getTransactionsByIds(
   );
 }
 
+function getBudgetTouchedMonths(
+  transactions: TransactionEntity[],
+): Set<string> {
+  const months = new Set<string>();
+
+  for (const transaction of transactions) {
+    if (!transaction.is_parent && transaction.date && transaction.category) {
+      months.add(monthUtils.monthFromDate(transaction.date));
+    }
+  }
+
+  return months;
+}
+
 export async function batchUpdateTransactions({
   added,
   deleted,
@@ -55,6 +71,8 @@ export async function batchUpdateTransactions({
   const deletedIds = deleted
     ? await idsWithChildren(deleted.map(d => d.id))
     : [];
+  const oldUpdated = await getTransactionsByIds(updatedIds);
+  const oldDeleted = await getTransactionsByIds(deletedIds);
 
   const oldPayees = new Set<PayeeEntity['id']>();
   const accounts = await db.all<db.DbAccount>(
@@ -128,6 +146,13 @@ export async function batchUpdateTransactions({
   const allAdded = await getTransactionsByIds(addedIds);
   const allUpdated = await getTransactionsByIds(updatedIds);
   const allDeleted = await getTransactionsByIds(deletedIds);
+  const touchedBudgetMonths = getBudgetTouchedMonths([
+    ...oldUpdated,
+    ...oldDeleted,
+    ...allAdded,
+    ...allUpdated,
+    ...allDeleted,
+  ]);
 
   // Post-processing phase: first do any updates to transfers.
   // Transfers update the transactions and we need to return updates
@@ -184,6 +209,8 @@ export async function batchUpdateTransactions({
       }
     }
   }
+
+  await runBudgetChangeHooks(touchedBudgetMonths);
 
   return {
     added: resultAdded,

--- a/packages/loot-core/src/server/transactions/index.ts
+++ b/packages/loot-core/src/server/transactions/index.ts
@@ -1,11 +1,9 @@
 // @ts-strict-ignore
 
 import * as connection from '#platform/server/connection';
-import { runBudgetChangeHooks } from '#server/budget/actions';
 import * as db from '#server/db';
 import { incrFetch, whereIn } from '#server/db/util';
 import { batchMessages } from '#server/sync';
-import * as monthUtils from '#shared/months';
 import type { Diff } from '#shared/util';
 import type { PayeeEntity, TransactionEntity } from '#types/models';
 
@@ -39,20 +37,6 @@ async function getTransactionsByIds(
   );
 }
 
-function getBudgetTouchedMonths(
-  transactions: TransactionEntity[],
-): Set<string> {
-  const months = new Set<string>();
-
-  for (const transaction of transactions) {
-    if (!transaction.is_parent && transaction.date && transaction.category) {
-      months.add(monthUtils.monthFromDate(transaction.date));
-    }
-  }
-
-  return months;
-}
-
 export async function batchUpdateTransactions({
   added,
   deleted,
@@ -71,8 +55,6 @@ export async function batchUpdateTransactions({
   const deletedIds = deleted
     ? await idsWithChildren(deleted.map(d => d.id))
     : [];
-  const oldUpdated = await getTransactionsByIds(updatedIds);
-  const oldDeleted = await getTransactionsByIds(deletedIds);
 
   const oldPayees = new Set<PayeeEntity['id']>();
   const accounts = await db.all<db.DbAccount>(
@@ -146,13 +128,6 @@ export async function batchUpdateTransactions({
   const allAdded = await getTransactionsByIds(addedIds);
   const allUpdated = await getTransactionsByIds(updatedIds);
   const allDeleted = await getTransactionsByIds(deletedIds);
-  const touchedBudgetMonths = getBudgetTouchedMonths([
-    ...oldUpdated,
-    ...oldDeleted,
-    ...allAdded,
-    ...allUpdated,
-    ...allDeleted,
-  ]);
 
   // Post-processing phase: first do any updates to transfers.
   // Transfers update the transactions and we need to return updates
@@ -209,8 +184,6 @@ export async function batchUpdateTransactions({
       }
     }
   }
-
-  await runBudgetChangeHooks(touchedBudgetMonths);
 
   return {
     added: resultAdded,

--- a/packages/loot-core/src/shared/async.ts
+++ b/packages/loot-core/src/shared/async.ts
@@ -74,3 +74,22 @@ export function once<T extends AnyFunction>(
     return promise;
   };
 }
+
+/**
+ * Ensures that the function is only called one at a time.
+ * While the function is running, overlapping calls will return immediately.
+ */
+export function single<T extends AnyFunction>(
+  fn: T,
+): (...args: Parameters<T>) => Promise<void> {
+  let running = false;
+  return (...args: Parameters<T>) => {
+    if (!running) {
+      running = true;
+      return fn(...args).finally(() => {
+        running = false;
+      });
+    }
+    return Promise.resolve();
+  };
+}

--- a/packages/loot-core/src/shared/months.ts
+++ b/packages/loot-core/src/shared/months.ts
@@ -90,6 +90,15 @@ export function monthFromDate(date: DateLike): string {
   return d.format(_parse(date), 'yyyy-MM');
 }
 
+export function toDbMonth(month: DateLike): number {
+  return parseInt(d.format(_parse(month), 'yyyyMM'));
+}
+
+export function fromDbMonth(month: number): string {
+  const monthString = String(month).padStart(6, '0');
+  return `${monthString.slice(0, 4)}-${monthString.slice(4)}`;
+}
+
 export function isValidYearMonth(value: string): boolean {
   const match = /^(\d{4})-(\d{2})$/.exec(value);
   if (!match) return false;

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -12,7 +12,10 @@ export type FeatureFlag =
   | 'enableBanking'
   | 'sankeyReport'
   | 'akahuBankSync'
+  | 'futureBufferMode'
   | 'mobileCalculator';
+
+export type FutureBufferMode = 'manual' | 'automatic';
 
 /**
  * Cross-device preferences. These sync across devices when they are changed.
@@ -29,6 +32,7 @@ export type SyncedPrefs = Partial<
     | 'currencySymbolPosition'
     | 'currencySpaceBetweenAmountAndSymbol'
     | 'defaultCurrencyCode'
+    | 'futureBufferMode'
     | `show-account-${string}-net-worth-chart`
     | `side-nav.show-balance-history-${string}`
     | `show-balances-${string}`

--- a/upcoming-release-notes/future-buffer-mode.md
+++ b/upcoming-release-notes/future-buffer-mode.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [tim-smart]
+---
+
+Add experimental Future buffer mode, for configuring how future budgeting works


### PR DESCRIPTION
Demo:

https://github.com/user-attachments/assets/a655abf2-a019-4072-a002-c4a68e16fb12


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.12 MB (+9.05 kB) | +0.07%
loot-core | 1 | 4.82 MB → 4.83 MB (+9.09 kB) | +0.18%
api | 2 | 3.87 MB → 3.88 MB (+9.02 kB) | +0.23%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.12 MB (+9.05 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/FutureBufferModeModal.tsx` | 🆕 +4.24 kB | 0 B → 4.24 kB
`src/hooks/useFutureBufferMode.ts` | 🆕 +974 B | 0 B → 974 B
`src/components/budget/envelope/budgetsummary/ToBudgetMenu.tsx` | 📈 +1.14 kB (+30.05%) | 3.79 kB → 4.93 kB
`src/components/modals/EnvelopeIncomeBalanceMenuModal.tsx` | 📈 +615 B (+16.83%) | 3.57 kB → 4.17 kB
`src/components/budget/envelope/CoverMenu.tsx` | 📈 +470 B (+9.37%) | 4.9 kB → 5.36 kB
`src/components/modals/CoverModal.tsx` | 📈 +461 B (+7.79%) | 5.78 kB → 6.23 kB
`src/components/budget/util.ts` | 📈 +254 B (+7.69%) | 3.22 kB → 3.47 kB
`src/components/budget/envelope/IncomeMenu.tsx` | 📈 +125 B (+5.92%) | 2.06 kB → 2.18 kB
`src/hooks/useFeatureFlag.ts` | 📈 +26 B (+4.18%) | 622 B → 648 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +292 B (+2.81%) | 10.14 kB → 10.42 kB
`src/components/settings/Experimental.tsx` | 📈 +206 B (+1.69%) | 11.93 kB → 12.13 kB
`src/components/budget/envelope/BalanceMovementMenu.tsx` | 📈 +27 B (+0.92%) | 2.86 kB → 2.89 kB
`src/components/Modals.tsx` | 📈 +116 B (+0.87%) | 12.97 kB → 13.08 kB
`src/components/mobile/budget/ExpenseCategoryListItem.tsx` | 📈 +139 B (+0.87%) | 15.69 kB → 15.82 kB
`node_modules/d3-interpolate/src/value.js` | 📈 +4 B (+0.71%) | 562 B → 566 B
`node_modules/d3-color/src/define.js` | 📈 +2 B (+0.51%) | 392 B → 394 B
`node_modules/d3-interpolate/src/string.js` | 📈 +4 B (+0.39%) | 1.01 kB → 1.01 kB
`node_modules/d3-scale/src/continuous.js` | 📈 +8 B (+0.28%) | 2.79 kB → 2.79 kB
`node_modules/d3-format/src/formatSpecifier.js` | 📈 +4 B (+0.26%) | 1.53 kB → 1.53 kB
`src/components/mobile/budget/BudgetPage.tsx` | 📈 +88 B (+0.23%) | 36.92 kB → 37 kB
`node_modules/d3-scale/src/time.js` | 📈 +4 B (+0.20%) | 1.93 kB → 1.94 kB
`node_modules/victory-vendor/es/d3-scale.js` | 📈 +2 B (+0.19%) | 1.05 kB → 1.05 kB
`locale/en.json` | 📈 +324 B (+0.16%) | 200.96 kB → 201.27 kB
`node_modules/d3-format/src/locale.js` | 📈 +6 B (+0.14%) | 4.07 kB → 4.08 kB
`node_modules/d3-path/src/path.js` | 📈 +4 B (+0.12%) | 3.15 kB → 3.15 kB
`node_modules/d3-color/src/color.js` | 📈 +12 B (+0.12%) | 9.71 kB → 9.72 kB
`src/notes/linkParser.ts` | 📈 +4 B (+0.10%) | 3.82 kB → 3.82 kB
`node_modules/d3-scale/src/band.js` | 📈 +2 B (+0.08%) | 2.31 kB → 2.31 kB
`node_modules/moment/dist/moment.js` | 📈 +92 B (+0.08%) | 111.62 kB → 111.71 kB
`src/components/budget/goals/editor/ScheduleAutomation.tsx` | 📈 +2 B (+0.06%) | 3.02 kB → 3.02 kB
`src/components/budget/envelope/EnvelopeBudgetComponents.tsx` | 📉 -4 B (-0.01%) | 29.39 kB → 29.39 kB
`node_modules/micromark-extension-gfm-autolink-literal/lib/syntax.js` | 📉 -6 B (-0.07%) | 8.69 kB → 8.69 kB
`node_modules/unified/lib/index.js` | 📉 -6 B (-0.07%) | 7.84 kB → 7.84 kB
`node_modules/react-markdown/lib/index.js` | 📉 -4 B (-0.08%) | 5.07 kB → 5.07 kB
`node_modules/vfile/lib/minpath.browser.js` | 📉 -4 B (-0.08%) | 4.75 kB → 4.75 kB
`node_modules/mdast-util-from-markdown/lib/index.js` | 📉 -18 B (-0.10%) | 17.94 kB → 17.92 kB
`node_modules/unist-util-visit-parents/lib/index.js` | 📉 -2 B (-0.10%) | 1.86 kB → 1.86 kB
`node_modules/mdast-util-to-markdown/lib/handle/code.js` | 📉 -4 B (-0.31%) | 1.28 kB → 1.27 kB
`node_modules/is-plain-obj/index.js` | 📉 -2 B (-0.52%) | 387 B → 385 B
`node_modules/mdast-util-to-string/lib/index.js` | 📉 -6 B (-0.56%) | 1.05 kB → 1.04 kB
`node_modules/property-information/lib/util/types.js` | 📉 -4 B (-0.58%) | 688 B → 684 B
`node_modules/@ungap/structured-clone/esm/serialize.js` | 📉 -24 B (-0.73%) | 3.19 kB → 3.17 kB
`node_modules/property-information/lib/html.js` | 📉 -50 B (-0.81%) | 6.06 kB → 6.01 kB
`node_modules/property-information/lib/svg.js` | 📉 -106 B (-0.81%) | 12.75 kB → 12.65 kB
`src/hooks/useLocale.ts` | 📉 -2 B (-0.84%) | 237 B → 235 B
`node_modules/is-absolute-url/index.js` | 📉 -4 B (-1.04%) | 385 B → 381 B
`src/undo/index.ts` | 📉 -6 B (-1.08%) | 557 B → 551 B
`node_modules/hast-util-whitespace/lib/index.js` | 📉 -4 B (-1.29%) | 309 B → 305 B
`src/components/autocomplete/CategoryAutocomplete.tsx` | 📉 -220 B (-1.44%) | 14.9 kB → 14.68 kB
`node_modules/property-information/lib/aria.js` | 📉 -24 B (-1.59%) | 1.48 kB → 1.45 kB
`node_modules/unist-util-visit-parents/lib/color.js` | 📉 -2 B (-1.74%) | 115 B → 113 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/locale.ts` | 📉 -16 B (-3.62%) | 442 B → 426 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.64 MB (+8.51 kB) | +0.11%
static/js/en.js | 200.96 kB → 201.27 kB (+324 B) | +0.16%
static/js/narrow.js | 358.73 kB → 358.95 kB (+227 B) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.83 MB (+9.09 kB) | +0.18%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/hooks.ts` | 🆕 +458 B | 0 B → 458 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +3.8 kB (+44.50%) | 8.54 kB → 12.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +3.31 kB (+25.05%) | 13.23 kB → 16.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/async.ts` | 📈 +220 B (+21.70%) | 1014 B → 1.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +237 B (+4.34%) | 5.33 kB → 5.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +393 B (+2.72%) | 14.13 kB → 14.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +432 B (+2.71%) | 15.56 kB → 15.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +237 B (+2.49%) | 9.31 kB → 9.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/migrate.ts` | 📈 +9 B (+1.07%) | 844 B → 853 B
`home/runner/work/actual/actual/packages/loot-core/src/server/app.ts` | 📈 +13 B (+0.91%) | 1.4 kB → 1.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/envelope.ts` | 📈 +46 B (+0.49%) | 9.12 kB → 9.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📉 -19 B (-0.26%) | 7.24 kB → 7.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D45q0Gc7.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C80Ll9xl.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.88 MB (+9.02 kB) | +0.23%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/hooks.ts` | 🆕 +446 B | 0 B → 446 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +3.71 kB (+44.41%) | 8.36 kB → 12.07 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/async.ts` | 📈 +349 B (+35.98%) | 970 B → 1.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +3.25 kB (+25.24%) | 12.87 kB → 16.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +230 B (+4.37%) | 5.14 kB → 5.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +384 B (+2.74%) | 13.68 kB → 14.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +419 B (+2.69%) | 15.24 kB → 15.64 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +233 B (+2.49%) | 9.14 kB → 9.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/migrate.ts` | 📈 +9 B (+1.11%) | 813 B → 822 B
`home/runner/work/actual/actual/packages/loot-core/src/server/app.ts` | 📈 +13 B (+1.04%) | 1.22 kB → 1.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/envelope.ts` | 📈 +46 B (+0.50%) | 8.9 kB → 8.95 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📉 -15 B (-0.21%) | 7.07 kB → 7.05 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.88 MB (+9.02 kB) | +0.23%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->