### PR TITLE
Bank Sync Provider per budget file [2/3] - Sync server - Pluggy.ai use per-budget credentials when available

### DIFF
--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -14,7 +14,8 @@ import {
 } from '#server/errors';
 import { app as mainApp } from '#server/main-app';
 import { mutator } from '#server/mutators';
-import { get, post } from '#server/post';
+import { del, get, post } from '#server/post';
+import { getPrefs } from '#server/prefs';
 import { getServer } from '#server/server-config';
 import { batchMessages } from '#server/sync';
 import { undoable, withUndo } from '#server/undo';
@@ -711,9 +712,11 @@ async function moveAccount({
 async function setSecret({
   name,
   value,
+  perBudgetFile = false,
 }: {
   name: string;
   value: string | null;
+  perBudgetFile?: boolean;
 }) {
   const userToken = await asyncStorage.getItem('user-token');
 
@@ -726,16 +729,28 @@ async function setSecret({
     throw new Error('Failed to get server config.');
   }
 
+  const fileId = perBudgetFile ? getPrefs()?.cloudFileId : null;
+  const headers = {
+    'X-ACTUAL-TOKEN': userToken,
+    ...(fileId ? { 'X-Actual-File-Id': fileId } : {}),
+  };
+
   try {
+    if (value === null) {
+      return await del(
+        serverConfig.BASE_SERVER + '/secret/' + name,
+        {},
+        headers,
+      );
+    }
+
     return await post(
       serverConfig.BASE_SERVER + '/secret',
       {
         name,
         value,
       },
-      {
-        'X-ACTUAL-TOKEN': userToken,
-      },
+      headers,
     );
   } catch (error) {
     return {

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -15,7 +15,6 @@ import {
 import { app as mainApp } from '#server/main-app';
 import { mutator } from '#server/mutators';
 import { del, get, post } from '#server/post';
-import { getPrefs } from '#server/prefs';
 import { getServer } from '#server/server-config';
 import { batchMessages } from '#server/sync';
 import { undoable, withUndo } from '#server/undo';
@@ -712,11 +711,11 @@ async function moveAccount({
 async function setSecret({
   name,
   value,
-  perBudgetFile = false,
+  fileId = null,
 }: {
   name: string;
   value: string | null;
-  perBudgetFile?: boolean;
+  fileId?: string | null;
 }) {
   const userToken = await asyncStorage.getItem('user-token');
 
@@ -729,7 +728,6 @@ async function setSecret({
     throw new Error('Failed to get server config.');
   }
 
-  const fileId = perBudgetFile ? getPrefs()?.cloudFileId : null;
   const headers = {
     'X-ACTUAL-TOKEN': userToken,
     ...(fileId ? { 'X-Actual-File-Id': fileId } : {}),

--- a/packages/sync-server/src/app-pluggyai/app-pluggyai.js
+++ b/packages/sync-server/src/app-pluggyai/app-pluggyai.js
@@ -6,6 +6,7 @@ import {
   requestLoggerMiddleware,
   validateSessionMiddleware,
 } from '#util/middlewares';
+import { isValidFileId } from '#util/paths';
 
 import { pluggyaiService } from './pluggyai-service';
 
@@ -18,13 +19,23 @@ app.use(validateSessionMiddleware);
 app.post(
   '/status',
   handleError(async (req, res) => {
-    const clientId = secretsService.get(SecretName.pluggyai_clientId);
-    const configured = clientId != null;
+    const fileId = req.get('X-Actual-File-Id');
+    if (fileId != null && !isValidFileId(fileId)) {
+      res.status(400).send({
+        status: 'error',
+        reason: 'invalid-file-id',
+        details: 'invalid fileId',
+      });
+      return;
+    }
+
+    const source = pluggyaiService.getCredentialSource(fileId);
 
     res.send({
       status: 'ok',
       data: {
-        configured,
+        configured: source != null,
+        source,
       },
     });
   }),
@@ -33,16 +44,39 @@ app.post(
 app.post(
   '/accounts',
   handleError(async (req, res) => {
+    const fileId = req.get('X-Actual-File-Id');
+    if (fileId != null && !isValidFileId(fileId)) {
+      res.status(400).send({
+        status: 'error',
+        reason: 'invalid-file-id',
+        details: 'invalid fileId',
+      });
+      return;
+    }
+
     try {
-      const itemIds = secretsService
-        .get(SecretName.pluggyai_itemIds)
+      const source = pluggyaiService.getCredentialSource(fileId);
+      if (source == null) {
+        res.status(400).send({
+          status: 'error',
+          reason: 'not-configured',
+          details: 'Pluggy credentials are not configured',
+        });
+        return;
+      }
+
+      const credentialFileId = source === 'per-budget-file' ? fileId : null;
+      const itemIds = (
+        secretsService.get(SecretName.pluggyai_itemIds, credentialFileId) ?? ''
+      )
         .split(',')
-        .map(item => item.trim());
+        .map(item => item.trim())
+        .filter(Boolean);
 
       let accounts = [];
 
       for (const item of itemIds) {
-        const partial = await pluggyaiService.getAccountsByItemId(item);
+        const partial = await pluggyaiService.getAccountsByItemId(item, fileId);
         accounts = accounts.concat(partial.results);
       }
 
@@ -67,14 +101,24 @@ app.post(
   '/transactions',
   handleError(async (req, res) => {
     const { accountId, startDate } = req.body || {};
+    const fileId = req.get('X-Actual-File-Id');
+    if (fileId != null && !isValidFileId(fileId)) {
+      res.status(400).send({
+        status: 'error',
+        reason: 'invalid-file-id',
+        details: 'invalid fileId',
+      });
+      return;
+    }
 
     try {
       const transactions = await pluggyaiService.getTransactionsByAccountId(
         accountId,
         startDate,
+        fileId,
       );
 
-      const account = await pluggyaiService.getAccountById(accountId);
+      const account = await pluggyaiService.getAccountById(accountId, fileId);
 
       let startingBalance = parseInt(
         Math.round(account.balance * 100).toString(),

--- a/packages/sync-server/src/app-pluggyai/app-pluggyai.js
+++ b/packages/sync-server/src/app-pluggyai/app-pluggyai.js
@@ -1,5 +1,6 @@
 import express from 'express';
 
+import { isAdmin } from '#account-db';
 import { handleError } from '#app-gocardless/util/handle-error';
 import { SecretName, secretsService } from '#services/secrets-service';
 import {
@@ -7,6 +8,7 @@ import {
   validateSessionMiddleware,
 } from '#util/middlewares';
 import { isValidFileId } from '#util/paths';
+import * as UserService from '#services/user-service';
 
 import { pluggyaiService } from './pluggyai-service';
 
@@ -15,6 +17,10 @@ export { app as handlers };
 app.use(requestLoggerMiddleware);
 app.use(express.json());
 app.use(validateSessionMiddleware);
+
+function canAccessFile(fileId, userId) {
+  return isAdmin(userId) || UserService.countUserAccess(fileId, userId) > 0;
+}
 
 app.post(
   '/status',
@@ -25,6 +31,15 @@ app.post(
         status: 'error',
         reason: 'invalid-file-id',
         details: 'invalid fileId',
+      });
+      return;
+    }
+
+    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
+      res.status(403).send({
+        status: 'error',
+        reason: 'file-access-denied',
+        details: "You don't have permissions over this file",
       });
       return;
     }
@@ -50,6 +65,15 @@ app.post(
         status: 'error',
         reason: 'invalid-file-id',
         details: 'invalid fileId',
+      });
+      return;
+    }
+
+    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
+      res.status(403).send({
+        status: 'error',
+        reason: 'file-access-denied',
+        details: "You don't have permissions over this file",
       });
       return;
     }
@@ -111,7 +135,26 @@ app.post(
       return;
     }
 
+    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
+      res.status(403).send({
+        status: 'error',
+        reason: 'file-access-denied',
+        details: "You don't have permissions over this file",
+      });
+      return;
+    }
+
     try {
+      const source = pluggyaiService.getCredentialSource(fileId);
+      if (source == null) {
+        res.status(400).send({
+          status: 'error',
+          reason: 'not-configured',
+          details: 'Pluggy credentials are not configured',
+        });
+        return;
+      }
+
       const transactions = await pluggyaiService.getTransactionsByAccountId(
         accountId,
         startDate,

--- a/packages/sync-server/src/app-pluggyai/app-pluggyai.js
+++ b/packages/sync-server/src/app-pluggyai/app-pluggyai.js
@@ -3,12 +3,12 @@ import express from 'express';
 import { isAdmin } from '#account-db';
 import { handleError } from '#app-gocardless/util/handle-error';
 import { SecretName, secretsService } from '#services/secrets-service';
+import * as UserService from '#services/user-service';
 import {
   requestLoggerMiddleware,
   validateSessionMiddleware,
 } from '#util/middlewares';
 import { isValidFileId } from '#util/paths';
-import * as UserService from '#services/user-service';
 
 import { pluggyaiService } from './pluggyai-service';
 

--- a/packages/sync-server/src/app-pluggyai/app-pluggyai.js
+++ b/packages/sync-server/src/app-pluggyai/app-pluggyai.js
@@ -26,22 +26,24 @@ app.post(
   '/status',
   handleError(async (req, res) => {
     const fileId = req.get('X-Actual-File-Id');
-    if (fileId != null && !isValidFileId(fileId)) {
-      res.status(400).send({
-        status: 'error',
-        reason: 'invalid-file-id',
-        details: 'invalid fileId',
-      });
-      return;
-    }
+    if (!!fileId) {
+      if (!isValidFileId(fileId)) {
+        res.status(400).send({
+          status: 'error',
+          reason: 'invalid-file-id',
+          details: 'invalid fileId',
+        });
+        return;
+      }
 
-    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
-      res.status(403).send({
-        status: 'error',
-        reason: 'file-access-denied',
-        details: "You don't have permissions over this file",
-      });
-      return;
+      if (!canAccessFile(fileId, res.locals.user_id)) {
+        res.status(403).send({
+          status: 'error',
+          reason: 'file-access-denied',
+          details: "You don't have permissions over this file",
+        });
+        return;
+      }
     }
 
     const source = pluggyaiService.getCredentialSource(fileId);
@@ -49,7 +51,7 @@ app.post(
     res.send({
       status: 'ok',
       data: {
-        configured: source != null,
+        configured: !!source,
         source,
       },
     });
@@ -60,27 +62,29 @@ app.post(
   '/accounts',
   handleError(async (req, res) => {
     const fileId = req.get('X-Actual-File-Id');
-    if (fileId != null && !isValidFileId(fileId)) {
-      res.status(400).send({
-        status: 'error',
-        reason: 'invalid-file-id',
-        details: 'invalid fileId',
-      });
-      return;
-    }
+    if (!!fileId) {
+      if (!isValidFileId(fileId)) {
+        res.status(400).send({
+          status: 'error',
+          reason: 'invalid-file-id',
+          details: 'invalid fileId',
+        });
+        return;
+      }
 
-    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
-      res.status(403).send({
-        status: 'error',
-        reason: 'file-access-denied',
-        details: "You don't have permissions over this file",
-      });
-      return;
+      if (!canAccessFile(fileId, res.locals.user_id)) {
+        res.status(403).send({
+          status: 'error',
+          reason: 'file-access-denied',
+          details: "You don't have permissions over this file",
+        });
+        return;
+      }
     }
 
     try {
       const source = pluggyaiService.getCredentialSource(fileId);
-      if (source == null) {
+      if (!source) {
         res.status(400).send({
           status: 'error',
           reason: 'not-configured',
@@ -126,27 +130,29 @@ app.post(
   handleError(async (req, res) => {
     const { accountId, startDate } = req.body || {};
     const fileId = req.get('X-Actual-File-Id');
-    if (fileId != null && !isValidFileId(fileId)) {
-      res.status(400).send({
-        status: 'error',
-        reason: 'invalid-file-id',
-        details: 'invalid fileId',
-      });
-      return;
-    }
+    if (!!fileId) {
+      if (!isValidFileId(fileId)) {
+        res.status(400).send({
+          status: 'error',
+          reason: 'invalid-file-id',
+          details: 'invalid fileId',
+        });
+        return;
+      }
 
-    if (fileId != null && !canAccessFile(fileId, res.locals.user_id)) {
-      res.status(403).send({
-        status: 'error',
-        reason: 'file-access-denied',
-        details: "You don't have permissions over this file",
-      });
-      return;
+      if (!canAccessFile(fileId, res.locals.user_id)) {
+        res.status(403).send({
+          status: 'error',
+          reason: 'file-access-denied',
+          details: "You don't have permissions over this file",
+        });
+        return;
+      }
     }
 
     try {
       const source = pluggyaiService.getCredentialSource(fileId);
-      if (source == null) {
+      if (!source) {
         res.status(400).send({
           status: 'error',
           reason: 'not-configured',

--- a/packages/sync-server/src/app-pluggyai/pluggyai-service.js
+++ b/packages/sync-server/src/app-pluggyai/pluggyai-service.js
@@ -2,34 +2,55 @@ import { PluggyClient } from 'pluggy-sdk';
 
 import { SecretName, secretsService } from '#services/secrets-service';
 
-let pluggyClient = null;
+function hasCredentials(fileId = null) {
+  return !!(
+    secretsService.get(SecretName.pluggyai_clientId, fileId) &&
+    secretsService.get(SecretName.pluggyai_clientSecret, fileId) &&
+    secretsService.get(SecretName.pluggyai_itemIds, fileId)
+  );
+}
 
-function getPluggyClient() {
-  if (!pluggyClient) {
-    const clientId = secretsService.get(SecretName.pluggyai_clientId);
-    const clientSecret = secretsService.get(SecretName.pluggyai_clientSecret);
-
-    pluggyClient = new PluggyClient({
-      clientId,
-      clientSecret,
-    });
+function getCredentialSource(fileId) {
+  if (fileId != null && hasCredentials(fileId)) {
+    return 'per-budget-file';
   }
 
-  return pluggyClient;
+  if (hasCredentials()) {
+    return 'global';
+  }
+
+  return null;
+}
+
+function getPluggyClient(fileId) {
+  const credentialSource = getCredentialSource(fileId);
+  if (credentialSource == null) {
+    throw new Error('Pluggy credentials are not configured');
+  }
+
+  const credentialFileId =
+    credentialSource === 'per-budget-file' ? fileId : null;
+  const credentials = {
+    clientId: secretsService.get(
+      SecretName.pluggyai_clientId,
+      credentialFileId,
+    ),
+    clientSecret: secretsService.get(
+      SecretName.pluggyai_clientSecret,
+      credentialFileId,
+    ),
+  };
+  return new PluggyClient(credentials);
 }
 
 export const pluggyaiService = {
-  isConfigured: () => {
-    return !!(
-      secretsService.get(SecretName.pluggyai_clientId) &&
-      secretsService.get(SecretName.pluggyai_clientSecret) &&
-      secretsService.get(SecretName.pluggyai_itemIds)
-    );
-  },
+  isConfigured: fileId => getCredentialSource(fileId) != null,
 
-  getAccountsByItemId: async itemId => {
+  getCredentialSource,
+
+  getAccountsByItemId: async (itemId, fileId) => {
     try {
-      const client = getPluggyClient();
+      const client = getPluggyClient(fileId);
       const { results, total, ...rest } = await client.fetchAccounts(itemId);
       return {
         results,
@@ -43,9 +64,9 @@ export const pluggyaiService = {
       throw error;
     }
   },
-  getAccountById: async accountId => {
+  getAccountById: async (accountId, fileId) => {
     try {
-      const client = getPluggyClient();
+      const client = getPluggyClient(fileId);
       const account = await client.fetchAccount(accountId);
       return {
         ...account,
@@ -58,11 +79,11 @@ export const pluggyaiService = {
     }
   },
 
-  getTransactionsByAccountId: async (accountId, startDate) => {
+  getTransactionsByAccountId: async (accountId, startDate, fileId) => {
     try {
-      const client = getPluggyClient();
+      const client = getPluggyClient(fileId);
 
-      const account = await pluggyaiService.getAccountById(accountId);
+      const account = await pluggyaiService.getAccountById(accountId, fileId);
 
       // the sandbox data doesn't move the dates automatically so the
       // transactions are often older than 90 days. The owner on one of the

--- a/packages/sync-server/src/app-pluggyai/pluggyai-service.js
+++ b/packages/sync-server/src/app-pluggyai/pluggyai-service.js
@@ -13,7 +13,7 @@ function hasCredentials(fileId = null) {
 }
 
 function getCredentialSource(fileId) {
-  if (fileId != null && hasCredentials(fileId)) {
+  if (!!fileId && hasCredentials(fileId)) {
     return 'per-budget-file';
   }
 
@@ -47,7 +47,7 @@ function getCredentialsCacheEntry(credentialFileId) {
 
 function getPluggyClient(fileId) {
   const credentialSource = getCredentialSource(fileId);
-  if (credentialSource == null) {
+  if (!credentialSource) {
     throw new Error('Pluggy credentials are not configured');
   }
 

--- a/packages/sync-server/src/app-pluggyai/pluggyai-service.js
+++ b/packages/sync-server/src/app-pluggyai/pluggyai-service.js
@@ -2,6 +2,8 @@ import { PluggyClient } from 'pluggy-sdk';
 
 import { SecretName, secretsService } from '#services/secrets-service';
 
+const pluggyClients = new Map();
+
 function hasCredentials(fileId = null) {
   return !!(
     secretsService.get(SecretName.pluggyai_clientId, fileId) &&
@@ -22,6 +24,27 @@ function getCredentialSource(fileId) {
   return null;
 }
 
+function getCredentialsCacheEntry(credentialFileId) {
+  const clientId = secretsService.get(
+    SecretName.pluggyai_clientId,
+    credentialFileId,
+  );
+  const clientSecret = secretsService.get(
+    SecretName.pluggyai_clientSecret,
+    credentialFileId,
+  );
+
+  return {
+    cacheKey: JSON.stringify({
+      fileId: credentialFileId,
+      [SecretName.pluggyai_clientId]: clientId,
+      [SecretName.pluggyai_clientSecret]: clientSecret,
+    }),
+    clientId,
+    clientSecret,
+  };
+}
+
 function getPluggyClient(fileId) {
   const credentialSource = getCredentialSource(fileId);
   if (credentialSource == null) {
@@ -30,17 +53,18 @@ function getPluggyClient(fileId) {
 
   const credentialFileId =
     credentialSource === 'per-budget-file' ? fileId : null;
-  const credentials = {
-    clientId: secretsService.get(
-      SecretName.pluggyai_clientId,
-      credentialFileId,
-    ),
-    clientSecret: secretsService.get(
-      SecretName.pluggyai_clientSecret,
-      credentialFileId,
-    ),
-  };
-  return new PluggyClient(credentials);
+  const { cacheKey, clientId, clientSecret } =
+    getCredentialsCacheEntry(credentialFileId);
+  let pluggyClient = pluggyClients.get(cacheKey);
+  if (!pluggyClient) {
+    pluggyClient = new PluggyClient({
+      clientId,
+      clientSecret,
+    });
+    pluggyClients.set(cacheKey, pluggyClient);
+  }
+
+  return pluggyClient;
 }
 
 export const pluggyaiService = {

--- a/upcoming-release-notes/pluggy-per-budget-credentials.md
+++ b/upcoming-release-notes/pluggy-per-budget-credentials.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [lelemm]
+---
+
+Use per-budget-file credentials for Pluggy.ai bank sync.


### PR DESCRIPTION
This updates the Pluggy.ai sync-server integration to choose credentials based on the active budget file.
Note: This just prepares pluggy for being able to use budget files, next PR will be the one that does the wiring

I will rebase this once the first PR is completed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.82 MB → 4.82 MB (+199 B) | +0.00%
api | 2 | 3.88 MB → 3.88 MB (+194 B) | +0.00%
cli | 1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.29 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+199 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +199 B (+0.65%) | 30.04 kB → 30.23 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BQZb0KVY.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+194 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +194 B (+0.64%) | 29.5 kB → 29.68 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+194 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/strip-ansi/index.js` | 📉 -26 B (-8.33%) | 312 B → 286 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (-26 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->