### PR TITLE
give a useful error when a budget automation references a schedule that no longer exists

### DIFF
--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -525,6 +525,37 @@ describe('runSchedule', () => {
     expect(result.to_budget).toBe(0);
   });
 
+  it('records an error instead of throwing when the schedule cannot be found', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        scheduleId: 'missing-id',
+        name: 'Gone',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    vi.mocked(db.first).mockResolvedValue(null);
+    vi.mocked(isTrackingBudget).mockReturnValue(false);
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toContainEqual(
+      expect.stringMatching(/Schedule Gone could not be found/),
+    );
+    expect(result.to_budget).toBe(0);
+  });
+
   it('contributes target/interval per month for a fully-funded bi-monthly schedule', async () => {
     // Every-2-months from 2024-03-15: interval 2 keeps it out of the
     // pay-month-of fast path. With balance == target the engine takes

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -551,7 +551,7 @@ describe('runSchedule', () => {
     );
 
     expect(result.errors).toContainEqual(
-      expect.stringMatching(/Schedule Gone could not be found/),
+      expect.stringMatching(/Schedule "Gone" could not be found/),
     );
     expect(result.to_budget).toBe(0);
   });

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -55,7 +55,7 @@ async function createScheduleList(
     );
     if (!schedule) {
       errors.push(
-        `Schedule ${template.name ?? template.scheduleId ?? ''} could not be found.`,
+        `Schedule "${template.name ?? template.scheduleId ?? ''}" could not be found.`,
       );
       continue;
     }

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -45,16 +45,21 @@ async function createScheduleList(
     // Prefer scheduleId so renames don't break the lookup; fall back to name
     // for notes-source templates (and legacy ui-source data) that only carry
     // the name.
-    const {
-      id: sid,
-      name: scheduleName,
-      completed,
-    } = await db.first<Pick<db.DbSchedule, 'id' | 'name' | 'completed'>>(
+    const schedule = await db.first<
+      Pick<db.DbSchedule, 'id' | 'name' | 'completed'>
+    >(
       template.scheduleId
         ? 'SELECT id, name, completed FROM schedules WHERE id = ? AND tombstone = 0'
         : 'SELECT id, name, completed FROM schedules WHERE TRIM(name) = ? AND tombstone = 0',
       [template.scheduleId ?? template.name],
     );
+    if (!schedule) {
+      errors.push(
+        `Schedule ${template.name ?? template.scheduleId ?? ''} could not be found.`,
+      );
+      continue;
+    }
+    const { id: sid, name: scheduleName, completed } = schedule;
     const rule = await getRuleForSchedule(sid);
     const conditions = rule.serialize().conditions;
     const { date: dateConditions, amount: amountCondition } =

--- a/upcoming-release-notes/schedule-automation-missing-schedule.md
+++ b/upcoming-release-notes/schedule-automation-missing-schedule.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Give a useful error when a budget automation references a schedule that no longer exists


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

This (I believe) should sort https://github.com/actualbudget/actual/issues/7692#issuecomment-4749494824

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/7692#issuecomment-4749494824

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

New test to verify

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 | 12.99 MB | 0%
loot-core | 1 | 4.82 MB → 4.82 MB (+166 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+161 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 | 12.99 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 176.85 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 174.94 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.38 kB | 0%
static/js/es.js | 169.72 kB | 0%
static/js/extends.js | 435.39 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 207.07 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.07 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 111.31 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+166 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +166 B (+1.89%) | 8.58 kB → 8.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.RTcGiyZK.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+161 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +161 B (+1.87%) | 8.41 kB → 8.57 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+161 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->