### PR TITLE
fix flaky vrt by increasing timeout

### DIFF
--- a/packages/desktop-client/e2e/schedules.test.ts
+++ b/packages/desktop-client/e2e/schedules.test.ts
@@ -31,8 +31,6 @@ test.describe('Schedules', () => {
   });
 
   test('creates a new schedule, posts the transaction and later completes it', async () => {
-    test.setTimeout(40000);
-
     const scheduleEditModal = await schedulesPage.addNewSchedule();
     await scheduleEditModal.fill({
       payee: 'Home Depot',
@@ -88,8 +86,6 @@ test.describe('Schedules', () => {
   });
 
   test('creates two new schedules, posts both transactions and later completes one', async () => {
-    test.setTimeout(40000);
-
     // Adding two schedules with the same payee and account and amount, mimicking two different subscriptions
     let scheduleEditModal = await schedulesPage.addNewSchedule();
     await scheduleEditModal.fill({

--- a/upcoming-release-notes/fix-flaky-schedules-vrt-timeout.md
+++ b/upcoming-release-notes/fix-flaky-schedules-vrt-timeout.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix flaky schedules VRT test by increasing the timeout


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

There's a VRT test that's failed twice in the last two days on a timeout, it appears to have a custom one from before we increased the global timeout, so I've just upped it to match the rest. The fact the e2e passed but vrt didn't means this is probably the issue.

https://depot.dev/orgs/czn39jgkd3/github-actions/jobs/83035227628/test-results
https://depot.dev/orgs/czn39jgkd3/github-actions/jobs/82759722406/test-results

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 28 → 29 | 12.99 MB → 13.09 MB (+99.25 kB) | +0.75%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
28 → 29 | 12.99 MB → 13.09 MB (+99.25 kB) | +0.75%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 🆕 +99.04 kB | 0 B → 99.04 kB
`src/languages.ts` | 📈 +99 B (+6.58%) | 1.47 kB → 1.57 kB
`locale/en.json` | 📈 +121 B (+0.06%) | 197.38 kB → 197.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 0 B → 99.04 kB (+99.04 kB) | -

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 197.38 kB → 197.49 kB (+121 B) | +0.06%
static/js/extends.js | 435.39 kB → 435.48 kB (+99 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 176.85 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 174.94 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/es.js | 169.72 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 207.07 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 305.07 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 111.31 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->