### PR TITLE
[AI] Move budget automations to overflow menus and add category switcher

### DIFF
--- a/packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts
+++ b/packages/desktop-client/e2e/page-models/mobile-category-menu-modal.ts
@@ -8,7 +8,6 @@ export class CategoryMenuModal {
   readonly heading: Locator;
   readonly budgetAmountInput: Locator;
   readonly editNotesButton: Locator;
-  readonly budgetAutomationsButton: Locator;
 
   constructor(locator: Locator) {
     this.locator = locator;
@@ -17,9 +16,6 @@ export class CategoryMenuModal {
     this.heading = locator.getByRole('heading');
     this.budgetAmountInput = locator.getByTestId('amount-input');
     this.editNotesButton = locator.getByRole('button', { name: 'Edit notes' });
-    this.budgetAutomationsButton = locator.getByRole('button', {
-      name: 'Budget automations',
-    });
   }
 
   async close() {
@@ -37,7 +33,10 @@ export class CategoryMenuModal {
   }
 
   async editAutomations() {
-    await this.budgetAutomationsButton.click();
+    await this.locator.getByRole('button', { name: 'Menu' }).click();
+    await this.page
+      .getByRole('menuitem', { name: 'Budget automations' })
+      .click();
 
     return this.page.getByRole('dialog', { name: 'Modal dialog' });
   }

--- a/packages/desktop-client/src/components/NotesButton.tsx
+++ b/packages/desktop-client/src/components/NotesButton.tsx
@@ -22,7 +22,6 @@ type NotesButtonProps = {
   height?: number;
   defaultColor?: string;
   tooltipPosition?: ComponentProps<typeof Tooltip>['placement'];
-  showPlaceholder?: boolean;
   style?: CSSProperties;
 };
 export function NotesButton({
@@ -31,7 +30,6 @@ export function NotesButton({
   height = 12,
   defaultColor = theme.buttonNormalText,
   tooltipPosition = 'bottom start',
-  showPlaceholder = false,
   style,
 }: NotesButtonProps) {
   const { t } = useTranslation();
@@ -75,15 +73,11 @@ export function NotesButton({
               color: defaultColor,
               ...style,
               padding: 4,
-              ...(showPlaceholder && {
-                opacity: hasNotes || isOpen ? 1 : 0.3,
-              }),
               ...(isOpen && { color: theme.buttonNormalText }),
               '&:hover': { opacity: 1 },
             }),
-            !hasNotes && !isOpen && !showPlaceholder ? 'hover-visible' : '',
+            !hasNotes && !isOpen ? 'hover-visible' : '',
           )}
-          data-placeholder={showPlaceholder}
           onPress={() => {
             setIsOpen(true);
           }}

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useRef } from 'react';
+import React, { useContext, useRef } from 'react';
 import type { CSSProperties, Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -15,9 +15,14 @@ import type {
   CategoryGroupEntity,
 } from '@actual-app/core/types/models';
 
+import { MonthsContext } from '#components/budget/MonthsContext';
 import { InputCell } from '#components/table';
 import { useContextMenu } from '#hooks/useContextMenu';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGlobalPref } from '#hooks/useGlobalPref';
+import { useSyncedPref } from '#hooks/useSyncedPref';
+import { pushModal } from '#modals/modalsSlice';
+import { useDispatch } from '#redux';
 
 import { SidebarCategoryButtons } from './SidebarCategoryButtons';
 
@@ -61,8 +66,19 @@ export function SidebarCategory({
   onHideNewCategory,
 }: SidebarCategoryProps) {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const monthsContext = useContext(MonthsContext);
+  const month = monthsContext?.months?.[0];
+  const goalTemplatesEnabled = useFeatureFlag('goalTemplatesEnabled');
+  const goalTemplatesUIEnabled = useFeatureFlag('goalTemplatesUIEnabled');
+  const [budgetType = 'envelope'] = useSyncedPref('budgetType');
   const [categoryExpandedStatePref] = useGlobalPref('categoryExpandedState');
   const categoryExpandedState = categoryExpandedStatePref ?? 0;
+
+  const canEditAutomations =
+    goalTemplatesEnabled &&
+    goalTemplatesUIEnabled &&
+    !(category.is_income && budgetType !== 'tracking');
 
   const temporary = category.id === 'new';
   const { setMenuOpen, menuOpen, handleContextMenu, resetPosition, position } =
@@ -114,6 +130,15 @@ export function SidebarCategory({
             onMenuSelect={type => {
               if (type === 'rename') {
                 onEditName(category.id);
+              } else if (type === 'edit-automations') {
+                dispatch(
+                  pushModal({
+                    modal: {
+                      name: 'category-automations-edit',
+                      options: { categoryId: category.id, month },
+                    },
+                  }),
+                );
               } else if (type === 'delete') {
                 onDelete(category.id);
               } else if (type === 'toggle-visibility') {
@@ -123,6 +148,11 @@ export function SidebarCategory({
             }}
             items={[
               { name: 'rename', text: t('Rename') },
+              canEditAutomations && {
+                name: 'edit-automations',
+                text: t('Budget automations'),
+              },
+              canEditAutomations && Menu.line,
               !categoryGroup?.hidden && {
                 name: 'toggle-visibility',
                 text: category.hidden ? t('Show') : t('Hide'),
@@ -132,11 +162,7 @@ export function SidebarCategory({
           />
         </Popover>
       </View>
-      <SidebarCategoryButtons
-        category={category}
-        dragging={dragging}
-        goalsShown={goalsShown}
-      />
+      <SidebarCategoryButtons category={category} dragging={dragging} />
     </View>
   );
 

--- a/packages/desktop-client/src/components/budget/SidebarCategory.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.tsx
@@ -32,7 +32,6 @@ type SidebarCategoryProps = {
   categoryGroup?: CategoryGroupEntity;
   dragPreview?: boolean;
   dragging?: boolean;
-  goalsShown?: boolean;
   style?: CSSProperties;
   borderColor?: string;
   isLast?: boolean;
@@ -57,7 +56,6 @@ export function SidebarCategory({
   dragPreview,
   dragging,
   editing,
-  goalsShown = false,
   style,
   isLast,
   onEditName,

--- a/packages/desktop-client/src/components/budget/SidebarCategoryButtons.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategoryButtons.tsx
@@ -3,48 +3,31 @@ import { View } from '@actual-app/components/view';
 import type { CategoryEntity } from '@actual-app/core/types/models/category';
 
 import { NotesButton } from '#components/NotesButton';
-import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useNotes } from '#hooks/useNotes';
-
-import { CategoryAutomationButton } from './goals/CategoryAutomationButton';
 
 type SidebarCategoryButtonsProps = {
   category: CategoryEntity;
   dragging: boolean;
-  goalsShown: boolean;
 };
 
 export const SidebarCategoryButtons = ({
   category,
   dragging,
-  goalsShown,
 }: SidebarCategoryButtonsProps) => {
-  const isGoalTemplatesUIEnabled = useFeatureFlag('goalTemplatesUIEnabled');
   const notes = useNotes(category.id) || '';
+
+  if (!notes) {
+    return null;
+  }
 
   return (
     <>
       <View style={{ flex: 1 }} />
-      {!goalsShown && isGoalTemplatesUIEnabled && (
-        <View style={{ flexShrink: 0 }}>
-          <CategoryAutomationButton
-            category={category}
-            style={dragging ? { color: 'currentColor' } : undefined}
-            defaultColor={theme.pageTextLight}
-            showPlaceholder={!!notes}
-          />
-        </View>
-      )}
       <View style={{ flexShrink: 0 }}>
         <NotesButton
           id={category.id}
           style={dragging ? { color: 'currentColor' } : undefined}
           defaultColor={theme.pageTextLight}
-          showPlaceholder={
-            !goalsShown &&
-            isGoalTemplatesUIEnabled &&
-            (!!category.goal_def?.length || !!category.cleanup_def?.length)
-          }
         />
       </View>
     </>

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationCategorySelect.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/AutomationCategorySelect.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Menu } from '@actual-app/components/menu';
+import { Select } from '@actual-app/components/select';
+import type { SelectOption } from '@actual-app/components/select';
+import { theme } from '@actual-app/components/theme';
+
+import { useCategories } from '#hooks/useCategories';
+import { useSyncedPref } from '#hooks/useSyncedPref';
+
+type AutomationCategorySelectProps = {
+  categoryId: string;
+  onCategoryChange: (categoryId: string) => void;
+  style?: CSSProperties;
+};
+
+export function AutomationCategorySelect({
+  categoryId,
+  onCategoryChange,
+  style,
+}: AutomationCategorySelectProps) {
+  const { t } = useTranslation();
+  const { data: categoriesData } = useCategories();
+  const [budgetType = 'envelope'] = useSyncedPref('budgetType');
+
+  const options = useMemo(() => {
+    const result: SelectOption[] = [];
+    for (const group of categoriesData?.grouped ?? []) {
+      const categories = (group.categories ?? []).filter(category => {
+        if (category.is_income && budgetType !== 'tracking') {
+          return false;
+        }
+        return true;
+      });
+      if (categories.length === 0) {
+        continue;
+      }
+      if (result.length > 0) {
+        result.push(Menu.line);
+      }
+      for (const category of categories) {
+        result.push([category.id, category.name]);
+      }
+    }
+    return result;
+  }, [budgetType, categoriesData?.grouped]);
+
+  return (
+    <Select
+      bare
+      value={categoryId}
+      options={options}
+      defaultLabel={t('Select a category')}
+      onChange={onCategoryChange}
+      style={{
+        fontSize: 20,
+        fontWeight: 600,
+        color: theme.pageText,
+        padding: 0,
+        height: 'auto',
+        minHeight: 0,
+        ...style,
+      }}
+      popoverStyle={{ maxHeight: 320, overflowY: 'auto' }}
+    />
+  );
+}

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx
@@ -23,6 +23,7 @@ import { Link } from '#components/common/Link';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 
+import { AutomationCategorySelect } from './AutomationCategorySelect';
 import { AutomationEditorPane } from './AutomationEditorPane';
 import { AutomationListRow } from './AutomationListRow';
 import { BudgetAutomationMigrationWarning } from './BudgetAutomationMigrationWarning';
@@ -107,7 +108,7 @@ function SidebarAddButton({
 
 type BudgetAutomationsBodyProps = {
   categoryId: string;
-  categoryName: string;
+  onCategoryChange: (categoryId: string) => void;
   needsMigration: boolean;
   initialEntries: AutomationEntry[];
   initialCleanup: CleanupTemplate[];
@@ -119,7 +120,7 @@ type BudgetAutomationsBodyProps = {
 
 export function BudgetAutomationsBody({
   categoryId,
-  categoryName,
+  onCategoryChange,
   needsMigration,
   initialEntries,
   initialCleanup,
@@ -188,16 +189,11 @@ export function BudgetAutomationsBody({
           <Text style={{ fontSize: 12, color: theme.pageTextLight }}>
             <Trans>Budget automation</Trans>
           </Text>
-          <Text
-            style={{
-              fontSize: 20,
-              fontWeight: 600,
-              color: theme.pageText,
-              marginTop: 2,
-            }}
-          >
-            {categoryName}
-          </Text>
+          <AutomationCategorySelect
+            categoryId={categoryId}
+            onCategoryChange={onCategoryChange}
+            style={{ marginTop: 2 }}
+          />
         </View>
         <View style={{ textAlign: 'right', flexShrink: 0, minWidth: 220 }}>
           <View

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBodyMobile.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsBodyMobile.tsx
@@ -24,6 +24,7 @@ import { MobileBackButton } from '#components/mobile/MobileBackButton';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 
+import { AutomationCategorySelect } from './AutomationCategorySelect';
 import { AutomationEditorPane } from './AutomationEditorPane';
 import { AutomationListRow } from './AutomationListRow';
 import { BudgetAutomationMigrationWarning } from './BudgetAutomationMigrationWarning';
@@ -86,7 +87,7 @@ function AddButton({
 
 type BudgetAutomationsBodyMobileProps = {
   categoryId: string;
-  categoryName: string;
+  onCategoryChange: (categoryId: string) => void;
   needsMigration: boolean;
   initialEntries: AutomationEntry[];
   initialCleanup: CleanupTemplate[];
@@ -98,7 +99,7 @@ type BudgetAutomationsBodyMobileProps = {
 
 export function BudgetAutomationsBodyMobile({
   categoryId,
-  categoryName,
+  onCategoryChange,
   needsMigration,
   initialEntries,
   initialCleanup,
@@ -297,16 +298,11 @@ export function BudgetAutomationsBodyMobile({
           <Text style={{ fontSize: 11, color: theme.pageTextLight }}>
             <Trans>Budget automation</Trans>
           </Text>
-          <Text
-            style={{
-              fontSize: 18,
-              fontWeight: 600,
-              color: theme.pageText,
-              marginTop: 2,
-            }}
-          >
-            {categoryName}
-          </Text>
+          <AutomationCategorySelect
+            categoryId={categoryId}
+            onCategoryChange={onCategoryChange}
+            style={{ marginTop: 2, fontSize: 18 }}
+          />
         </View>
         <View style={{ textAlign: 'right', flexShrink: 0 }}>
           <Text

--- a/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
+++ b/packages/desktop-client/src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { AnimatedLoading } from '@actual-app/components/icons/AnimatedLoading';
@@ -31,6 +31,7 @@ export function BudgetAutomationsModal({
   month?: string;
 }) {
   const { isNarrowWidth } = useResponsive();
+  const [selectedCategoryId, setSelectedCategoryId] = useState(categoryId);
   const [parsedTemplates, setParsedTemplates] = useState<Template[] | null>(
     null,
   );
@@ -39,11 +40,14 @@ export function BudgetAutomationsModal({
   );
   const effectiveMonth = month ?? currentMonth();
 
-  const onLoaded = (result: Record<string, Template[]>) => {
-    setParsedTemplates(result[categoryId] ?? []);
-  };
+  const onLoaded = useCallback(
+    (result: Record<string, Template[]>) => {
+      setParsedTemplates(result[selectedCategoryId] ?? []);
+    },
+    [selectedCategoryId],
+  );
 
-  const { data: currentCategory } = useCategory(categoryId);
+  const { data: currentCategory } = useCategory(selectedCategoryId);
   // default to 'ui' while the category is still resolving so we don't fire a
   // notes-mode migration on a category that may turn out to be ui-managed
   const needsMigration =
@@ -52,7 +56,7 @@ export function BudgetAutomationsModal({
   const source = needsMigration ? 'notes' : 'ui';
 
   const { loading: templatesLoading } = useBudgetAutomations({
-    categoryId,
+    categoryId: selectedCategoryId,
     source,
     onLoaded,
   });
@@ -64,11 +68,20 @@ export function BudgetAutomationsModal({
   const categories = useBudgetAutomationCategories();
 
   const { loading: cleanupLoading } = useCategoryCleanup({
-    categoryId,
+    categoryId: selectedCategoryId,
     source,
     onLoaded: setParsedCleanup,
   });
   const loading = templatesLoading || cleanupLoading || schedulesLoading;
+
+  const handleCategoryChange = (newCategoryId: string) => {
+    if (newCategoryId === selectedCategoryId) {
+      return;
+    }
+    setSelectedCategoryId(newCategoryId);
+    setParsedTemplates(null);
+    setParsedCleanup(null);
+  };
 
   const hasErrorTemplate =
     parsedTemplates?.some(t => t.type === 'error') ?? false;
@@ -133,8 +146,9 @@ export function BudgetAutomationsModal({
             <UnsupportedDirectivesNotice onClose={() => state.close()} />
           ) : isNarrowWidth ? (
             <BudgetAutomationsBodyMobile
-              categoryId={categoryId}
-              categoryName={currentCategory?.name ?? ''}
+              key={selectedCategoryId}
+              categoryId={selectedCategoryId}
+              onCategoryChange={handleCategoryChange}
               needsMigration={needsMigration}
               initialEntries={initialEntries ?? []}
               initialCleanup={parsedCleanup}
@@ -145,8 +159,9 @@ export function BudgetAutomationsModal({
             />
           ) : (
             <BudgetAutomationsBody
-              categoryId={categoryId}
-              categoryName={currentCategory?.name ?? ''}
+              key={selectedCategoryId}
+              categoryId={selectedCategoryId}
+              onCategoryChange={handleCategoryChange}
               needsMigration={needsMigration}
               initialEntries={initialEntries ?? []}
               initialCleanup={parsedCleanup}

--- a/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
+++ b/packages/desktop-client/src/components/modals/CategoryMenuModal.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import {
-  SvgChartPie,
   SvgDotsHorizontalTriple,
   SvgTrash,
 } from '@actual-app/components/icons/v1';
@@ -101,6 +100,9 @@ export function CategoryMenuModal({
                 categoryGroup={categoryGroup}
                 onDelete={_onDelete}
                 onToggleVisibility={_onToggleVisibility}
+                onEditAutomations={
+                  onEditAutomations ? _onEditAutomations : undefined
+                }
               />
             }
             title={
@@ -158,16 +160,6 @@ export function CategoryMenuModal({
                 />
                 <Trans>Edit notes</Trans>
               </Button>
-              {onEditAutomations && (
-                <Button style={buttonStyle} onPress={_onEditAutomations}>
-                  <SvgChartPie
-                    width={20}
-                    height={20}
-                    style={{ paddingRight: 5 }}
-                  />
-                  <Trans>Budget automations</Trans>
-                </Button>
-              )}
             </View>
           </View>
         </>
@@ -181,6 +173,7 @@ function AdditionalCategoryMenu({
   categoryGroup,
   onDelete,
   onToggleVisibility,
+  onEditAutomations,
 }) {
   const { t } = useTranslation();
   const triggerRef = useRef(null);
@@ -219,6 +212,11 @@ function AdditionalCategoryMenu({
           <Menu
             getItemStyle={getItemStyle}
             items={[
+              onEditAutomations && {
+                name: 'editAutomations',
+                text: t('Budget automations'),
+              },
+              onEditAutomations && Menu.line,
               !categoryGroup?.hidden && {
                 name: 'toggleVisibility',
                 text: category.hidden ? t('Show') : t('Hide'),
@@ -235,7 +233,9 @@ function AdditionalCategoryMenu({
             ]}
             onMenuSelect={itemName => {
               setMenuOpen(false);
-              if (itemName === 'delete') {
+              if (itemName === 'editAutomations') {
+                onEditAutomations();
+              } else if (itemName === 'delete') {
                 onDelete();
               } else if (itemName === 'toggleVisibility') {
                 onToggleVisibility();

--- a/upcoming-release-notes/budget-automations-overflow-menu.md
+++ b/upcoming-release-notes/budget-automations-overflow-menu.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [saahiljaffer]
+---
+
+Move budget automations to overflow menus and add a category switcher in the automations modal


### PR DESCRIPTION
## Description

used cursor, but manually reviewed the PR. I found the UI cluttered with all these placeholder note icons on every category that had an automations so I moved the automation to the category menu and made it easier to switch between categories in the automation modal

## Testing

try using the automation modal and switching categories

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.09 MB → 13.08 MB (-5.51 kB) | -0.04%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.09 MB → 13.08 MB (-5.51 kB) | -0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/BudgetAutomationsModal/AutomationCategorySelect.tsx` | 🆕 +1.95 kB | 0 B → 1.95 kB
`src/components/budget/SidebarCategory.tsx` | 📈 +989 B (+10.82%) | 8.93 kB → 9.89 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📈 +619 B (+10.71%) | 5.64 kB → 6.25 kB
`src/components/modals/CategoryMenuModal.tsx` | 📈 +187 B (+2.20%) | 8.32 kB → 8.5 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBodyMobile.tsx` | 📈 +42 B (+0.20%) | 20.03 kB → 20.07 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBody.tsx` | 📈 +20 B (+0.10%) | 19.38 kB → 19.4 kB
`src/components/NotesButton.tsx` | 📉 -318 B (-6.90%) | 4.5 kB → 4.19 kB
`src/components/budget/SidebarCategoryButtons.tsx` | 📉 -1.02 kB (-47.63%) | 2.14 kB → 1.12 kB
`src/components/budget/goals/CategoryAutomationButton.tsx` | 🔥 -7.95 kB (-100%) | 7.95 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.64 MB (+2.49 kB) | +0.03%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 305.07 kB → 297.07 kB (-8 kB) | -2.62%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.23 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 176.85 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 174.94 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.49 kB | 0%
static/js/es.js | 169.72 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 99.04 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 207.07 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 111.31 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->