### PR TITLE
[AI] Clarify nYNAB export alternatives

### DIFF
--- a/packages/docs/docs/community-repos.md
+++ b/packages/docs/docs/community-repos.md
@@ -30,8 +30,10 @@ tracking, loyalty card paybacks, prepaid cards, etc.
 
 ## Budget Migration
 
-Actual currently has official support for migrating budgets from YNAB4 and nYNAB. The following are available for migrating from other budget apps.
+Actual currently has official support for migrating budgets from YNAB4 and nYNAB. The following are available for migrating from YNAB or other budget apps.
 
+- **YNAB Export** - https://github.com/StephenBrown2/ynab-export
+  - _A terminal tool that exports nYNAB budget data as JSON for import into Actual._
 - **MoneyMoney** - https://github.com/NikxDa/actual-moneymoney
 - **Quicken on Mac** - https://github.com/slimslickner/quicken-mac-to-actual-budget
 

--- a/packages/docs/docs/migration/nynab.md
+++ b/packages/docs/docs/migration/nynab.md
@@ -3,19 +3,19 @@ import TabItem from '@theme/TabItem';
 
 # Migrating from nYNAB
 
-To export your budget from YNAB, choose one of the methods below. **Option A** is the easiest for most users. If that tool is unavailable, **Options B, C, and D** provide alternatives.
+To export your budget from YNAB, choose one of the methods below. The third-party web tool is the easiest when it works, but it may be unavailable if YNAB restricts access to it. The alternative methods use your own YNAB API token and do not depend on the web tool.
 
 ## Third-Party Web Tool
 
-This is the easiest method available. Visit [https://json-exporter-for-ynab.netlify.app](https://json-exporter-for-ynab.netlify.app), which guides you through authorizing your YNAB account and downloading your budget as a JSON file.
+Visit [https://json-exporter-for-ynab.netlify.app](https://json-exporter-for-ynab.netlify.app), which guides you through authorizing your YNAB account and downloading your budget as a JSON file.
 
 :::note
-This tool is maintained by the community, not the Actual Budget team.
+This tool is maintained by the community, not the Actual Budget team. It may occasionally be unavailable or show an authorization restriction from YNAB. If that happens, use one of the alternative export methods below.
 :::
 
 Once you have the JSON file, skip ahead to [Import the JSON File](#import-the-json-file).
 
-If the json-exporter tool above does not work for any reason (it appears to be blocked by YNAB occasionally), you may try one of the following options.
+If the json-exporter tool above does not work for any reason, use one of the following options.
 
 ## Alternative Export Methods
 

--- a/upcoming-release-notes/nynab-export-docs.md
+++ b/upcoming-release-notes/nynab-export-docs.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [archit-goyal]
+---
+
+Clarify nYNAB export options when the third-party web exporter is unavailable.


### PR DESCRIPTION
## Description

Closes actualbudget/actual#6833.

This updates the nYNAB migration docs to clarify that the community web exporter may be unavailable when YNAB restricts authorization, and points users to the API-token based alternatives instead. It also adds `StephenBrown2/ynab-export` to the community migration tools list as a terminal-based option for exporting nYNAB data.

Issue #6833 reports that the current third-party web exporter can show an authorization restriction and no longer work for some users. The existing docs already mention that the web tool can be blocked occasionally, but the fallback path is easy to miss and the linked community tools page did not list the requested exporter.

This PR was prepared with AI assistance from Codex and human-reviewed before submission.

## Related issue(s)

Closes actualbudget/actual#6833.

## Testing

- `git diff --check`
- `node .yarn/releases/yarn-4.13.0.cjs workspace docs build`

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
