### PR TITLE
update release process docs to reflect branch protection

### DIFF
--- a/packages/docs/docs/contributing/releasing.md
+++ b/packages/docs/docs/contributing/releasing.md
@@ -29,14 +29,14 @@ For example:
 
 There are two branches involved in every release:
 
-- `release`: the single long-lived branch where release tags live. This is the branch we actually base the release on, and where commits are cherry-picked to if we want them included.
+- `release`: the single long-lived branch where release tags live. This is the branch we actually base the release on. Commits are added by opening pull requests against `release` that cherry-pick the commits we want included.
 - `release-notes/X.Y.Z`: the branch that is used for the release PR. It holds the generated docs pages. It is deleted once a version ships.
 
-Splitting them avoids merge conflicts between cherry-picks on the release branch and the version-bump/docs commits that need to be merged back to `master`.
+Splitting them avoids merge conflicts between the cherry-pick PRs merged into the release branch and the version-bump/docs commits that need to be merged back to `master`.
 
 Monthly cuts run automatically at 17:00 UTC on the 25th of each month. To cut a release manually (monthly or patch), run the [Cut release workflow](https://github.com/actualbudget/actual/actions/workflows/cut-release-branch.yml).
 
-Changes that need to be included in the release after the cut has been made should be cherry-picked onto `release`. Each cherry-pick triggers regeneration of the release notes on `release-notes/X.Y.Z`. Human edits to frontmatter (release highlights, author, etc.) on `release-notes/X.Y.Z` are preserved across regenerations as long as they are above the autogen marker.
+Changes that need to be included in the release after the cut has been made should be added by opening a pull request against `release` that cherry-picks the commit. Each merged PR triggers regeneration of the release notes on `release-notes/X.Y.Z`. Human edits to frontmatter (release highlights, author, etc.) on `release-notes/X.Y.Z` are preserved across regenerations as long as they are above the autogen marker.
 
 ## Release process
 
@@ -77,7 +77,7 @@ Finally, a draft GitHub release should be automatically created; confirm [on the
 
 ## Cutting a patch release
 
-Patch releases (e.g. `26.6.1`) ship a small, targeted set of fixes on top of the latest release. Because `release` is a single long-lived branch, a patch is just a version bump and cherry-picks on top of the previous release, with no new branch to create.
+Patch releases (e.g. `26.6.1`) ship a small, targeted set of fixes on top of the latest release. Because `release` is a single long-lived branch, a patch is just a version bump and a few cherry-pick PRs on top of the previous release, with no new branch to create.
 
 ### Cut the patch
 
@@ -86,6 +86,6 @@ Run the [Cut release workflow](https://github.com/actualbudget/actual/actions/wo
 - `version`: the patch version (e.g. `26.6.1`).
 - `release-date`: when the patch is expected to ship (optional).
 
-This creates `release-notes/26.6.1`. It's worth noting that the release branch after a prior releases have no `upcoming-release-notes/*.md` files in them, so the initial release-notes run generates an empty blog, content will fill in once changes are cherry-picked in to the `release` branch.
+This creates `release-notes/26.6.1`. It's worth noting that the release branch after a prior releases have no `upcoming-release-notes/*.md` files in them, so the initial release-notes run generates an empty blog, content will fill in once cherry-pick PRs are merged into the `release` branch.
 
-The rest of the release process remains the same as a major release. Cherry-pick the appropriate changes into the `release` branch. Follow the steps to get the `release-notes/X.Y.Z` branch ready, then follow the merging and tagging steps outlined above.
+The rest of the release process remains the same as a major release. Open pull requests against the `release` branch that cherry-pick the appropriate changes. Follow the steps to get the `release-notes/X.Y.Z` branch ready, then follow the merging and tagging steps outlined above.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

With branch protection enabled, we need to open PRs to cherry pick changes into `release`. Updated the docs to reflect that

## Related issue(s)

None

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

None

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above) (n/a)
- [ ] No obvious regressions in affected areas (n/a)
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
