### PR TITLE
make SimpleFIN token 'forbidden' check more flexible

### DIFF
--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -42,7 +42,15 @@ app.post('/', async (req, res) => {
     return;
   }
 
+  const simplefinTokenChanged =
+    name === SecretName.simplefin_token &&
+    value !== secretsService.get(SecretName.simplefin_token);
+
   secretsService.set(name, value);
+
+  if (simplefinTokenChanged) {
+    secretsService.set(SecretName.simplefin_accessKey, null);
+  }
 
   res.status(200).send({ status: 'ok' });
 });

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -20,7 +20,7 @@ app.post(
   '/status',
   handleError(async (req, res) => {
     const token = secretsService.get(SecretName.simplefin_token);
-    const configured = token != null && token !== 'Forbidden';
+    const configured = token != null && !isForbidden(token);
 
     res.send({
       status: 'ok',
@@ -37,16 +37,16 @@ app.post(
     let accessKey = secretsService.get(SecretName.simplefin_accessKey);
 
     try {
-      if (accessKey == null || accessKey === 'Forbidden') {
+      if (accessKey == null || isForbidden(accessKey)) {
         const token = secretsService.get(SecretName.simplefin_token);
-        if (token == null || token === 'Forbidden') {
+        if (token == null || isForbidden(token)) {
           throw new Error('No token');
         } else {
           accessKey = await getAccessKey(token);
-          secretsService.set(SecretName.simplefin_accessKey, accessKey);
-          if (accessKey == null || accessKey === 'Forbidden') {
+          if (accessKey == null || isForbidden(accessKey)) {
             throw new Error('No access key');
           }
+          secretsService.set(SecretName.simplefin_accessKey, accessKey);
         }
       }
     } catch {
@@ -77,7 +77,7 @@ app.post(
 
     const accessKey = secretsService.get(SecretName.simplefin_accessKey);
 
-    if (accessKey == null || accessKey === 'Forbidden') {
+    if (accessKey == null || isForbidden(accessKey)) {
       invalidToken(res);
       return;
     }
@@ -104,7 +104,7 @@ app.post(
         new Date(earliestStartDate),
       );
     } catch (e) {
-      if (e.message === 'Forbidden') {
+      if (isForbidden(e.message)) {
         invalidToken(res);
       } else {
         serverDown(e, res);
@@ -335,6 +335,10 @@ async function getAccessKey(base64Token) {
     });
     req.end();
   });
+}
+
+function isForbidden(value) {
+  return typeof value === 'string' && value.startsWith('Forbidden');
 }
 
 async function getTransactions(accessKey, accounts, startDate, endDate) {

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -1,5 +1,3 @@
-import https from 'https';
-
 import express from 'express';
 
 import { handleError } from '#app-gocardless/util/handle-error';
@@ -319,22 +317,10 @@ async function getAccessKey(base64Token) {
   // private addresses are allowed here; cloud metadata and other always-blocked
   // ranges are still rejected.
   await assertUrlAllowed(token, { allowPrivateNetwork: true });
-  const options = {
-    method: 'POST',
-    port: 443,
-    headers: { 'Content-Length': 0 },
-  };
-  return new Promise((resolve, reject) => {
-    const req = https.request(new URL(token), options, res => {
-      res.on('data', d => {
-        resolve(d.toString());
-      });
-    });
-    req.on('error', e => {
-      reject(e);
-    });
-    req.end();
-  });
+
+  // don't auto-follow redirects for SSRF safety
+  const response = await fetch(token, { method: 'POST', redirect: 'manual' });
+  return (await response.text()).trim();
 }
 
 function isForbidden(value) {

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -35,13 +35,13 @@ app.post(
     let accessKey = secretsService.get(SecretName.simplefin_accessKey);
 
     try {
-      if (accessKey == null || isForbidden(accessKey)) {
+      if (isInvalidAccessKey(accessKey)) {
         const token = secretsService.get(SecretName.simplefin_token);
         if (token == null || isForbidden(token)) {
           throw new Error('No token');
         } else {
           accessKey = await getAccessKey(token);
-          if (accessKey == null || isForbidden(accessKey)) {
+          if (isInvalidAccessKey(accessKey)) {
             throw new Error('No access key');
           }
           secretsService.set(SecretName.simplefin_accessKey, accessKey);
@@ -75,7 +75,7 @@ app.post(
 
     const accessKey = secretsService.get(SecretName.simplefin_accessKey);
 
-    if (accessKey == null || isForbidden(accessKey)) {
+    if (isInvalidAccessKey(accessKey)) {
       invalidToken(res);
       return;
     }
@@ -325,6 +325,14 @@ async function getAccessKey(base64Token) {
 
 function isForbidden(value) {
   return typeof value === 'string' && value.startsWith('Forbidden');
+}
+
+function isInvalidAccessKey(accessKey) {
+  return (
+    typeof accessKey !== 'string' ||
+    accessKey.trim() === '' ||
+    isForbidden(accessKey)
+  );
 }
 
 async function getTransactions(accessKey, accounts, startDate, endDate) {

--- a/packages/sync-server/src/app-simplefin/app-simplefin.test.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.test.js
@@ -93,12 +93,40 @@ describe('app-simplefin', () => {
       expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
     });
 
+    it('treats a blank claim response as invalid and does not persist it', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({ claim: okResponse('   \n') });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
     it('re-claims when a stale Forbidden access key is cached', async () => {
       secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
       secretsService.set(
         SecretName.simplefin_accessKey,
         'Forbidden (was it already claimed?)',
       );
+      mockFetch({
+        claim: okResponse(VALID_ACCESS_KEY),
+        accounts: okResponse(
+          JSON.stringify({ accounts: [{ id: 'account-1' }] }),
+        ),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.accounts).toEqual([{ id: 'account-1' }]);
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
+        VALID_ACCESS_KEY,
+      );
+    });
+
+    it('re-claims when a stale empty access key is cached', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      secretsService.set(SecretName.simplefin_accessKey, '');
       mockFetch({
         claim: okResponse(VALID_ACCESS_KEY),
         accounts: okResponse(

--- a/packages/sync-server/src/app-simplefin/app-simplefin.test.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.test.js
@@ -1,0 +1,117 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SecretName, secretsService } from '#services/secrets-service';
+
+import { handlers as app } from './app-simplefin';
+
+vi.mock('#util/ssrf', () => ({
+  assertUrlAllowed: vi.fn().mockResolvedValue(undefined),
+}));
+
+const VALID_ACCESS_KEY = 'https://user:pass@bridge.example.com/simplefin';
+const SETUP_TOKEN = Buffer.from(
+  'https://bridge.example.com/claim/abc',
+).toString('base64');
+
+const okResponse = body => ({
+  status: 200,
+  headers: { get: () => null },
+  text: () => Promise.resolve(body),
+});
+
+// The claim is a POST to the bridge; listing accounts is a GET. Route the mock
+// by method so a test can stub one or both.
+function mockFetch({ claim, accounts }) {
+  global.fetch = vi
+    .fn()
+    .mockImplementation((url, options) =>
+      Promise.resolve(options?.method === 'POST' ? claim : accounts),
+    );
+}
+
+const post = path =>
+  request(app).post(path).set('x-actual-token', 'valid-token');
+
+describe('app-simplefin', () => {
+  beforeEach(() => {
+    secretsService.set(SecretName.simplefin_token, null);
+    secretsService.set(SecretName.simplefin_accessKey, null);
+    vi.spyOn(console, 'log').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('/status', () => {
+    it('reports configured when a real token is stored', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+
+      const res = await post('/status');
+
+      expect(res.body.data.configured).toBe(true);
+    });
+
+    it('reports not configured when the stored token is a Forbidden message', async () => {
+      secretsService.set(
+        SecretName.simplefin_token,
+        'Forbidden (was it already claimed?)',
+      );
+
+      const res = await post('/status');
+
+      expect(res.body.data.configured).toBe(false);
+    });
+  });
+
+  describe('/accounts', () => {
+    it('claims the token, trims the access key and returns accounts', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({
+        claim: okResponse(`${VALID_ACCESS_KEY}\n`),
+        accounts: okResponse(
+          JSON.stringify({ accounts: [{ id: 'account-1' }] }),
+        ),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.accounts).toEqual([{ id: 'account-1' }]);
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
+        VALID_ACCESS_KEY,
+      );
+    });
+
+    it('treats a "Forbidden (was it already claimed?)" claim response as invalid and does not persist it', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({ claim: okResponse('Forbidden (was it already claimed?)') });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('re-claims when a stale Forbidden access key is cached', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      secretsService.set(
+        SecretName.simplefin_accessKey,
+        'Forbidden (was it already claimed?)',
+      );
+      mockFetch({
+        claim: okResponse(VALID_ACCESS_KEY),
+        accounts: okResponse(
+          JSON.stringify({ accounts: [{ id: 'account-1' }] }),
+        ),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.accounts).toEqual([{ id: 'account-1' }]);
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
+        VALID_ACCESS_KEY,
+      );
+    });
+  });
+});

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -101,6 +101,35 @@ describe('secretsService', () => {
       });
     });
 
+    it('clears the cached SimpleFIN access key when the token changes', async () => {
+      secretsService.set(SecretName.simplefin_token, 'old-token');
+      secretsService.set(SecretName.simplefin_accessKey, 'cached-access-key');
+
+      const res = await request(app)
+        .post(`/`)
+        .set('x-actual-token', 'valid-token')
+        .send({ name: SecretName.simplefin_token, value: 'new-token' });
+
+      expect(res.statusCode).toEqual(200);
+      expect(secretsService.get(SecretName.simplefin_token)).toBe('new-token');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('keeps the SimpleFIN access key when the token is unchanged', async () => {
+      secretsService.set(SecretName.simplefin_token, 'same-token');
+      secretsService.set(SecretName.simplefin_accessKey, 'cached-access-key');
+
+      const res = await request(app)
+        .post(`/`)
+        .set('x-actual-token', 'valid-token')
+        .send({ name: SecretName.simplefin_token, value: 'same-token' });
+
+      expect(res.statusCode).toEqual(200);
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
+        'cached-access-key',
+      );
+    });
+
     it('POST returns 400 for unknown secret names', async () => {
       const res = await request(app)
         .post('/')

--- a/upcoming-release-notes/fix-simplefin-token-claim.md
+++ b/upcoming-release-notes/fix-simplefin-token-claim.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix SimpleFIN token claiming failing with "Invalid access key" in some cases

--- a/upcoming-release-notes/fix-simplefin-token-claim.md
+++ b/upcoming-release-notes/fix-simplefin-token-claim.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [matt-fidd]
 ---
 
-Fix SimpleFIN token claiming failing with "Invalid access key" in some cases
+Fix some SimpleFIN setup tokens failing to claim and link accounts


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Looks like SimpleFIN have changed their API response for Forbidden tokens so we were missing the branch. Thanks goes to @craw-fish in https://github.com/actualbudget/actual/issues/7422#issuecomment-4810015371 for a lot of the debugging.

Claude added the tests, checked by me.

I'd like to include this in 26.7 unless there are any objections.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes #7422
Fixes #6329
Fixes #4295

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Unable to test with a real SimpleFIN token because I'm not in the US, but linking with the test token works and I've had Claude add some new tests

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
