### PR TITLE
[WIP][AI] Formula on schedules

### DIFF
--- a/packages/desktop-client/src/components/formula/FormulaEditor.tsx
+++ b/packages/desktop-client/src/components/formula/FormulaEditor.tsx
@@ -8,8 +8,7 @@ import { autocompleteTabAcceptHighest } from '#components/codemirror/autocomplet
 import { useTheme } from '#style/theme';
 
 import { excelFormulaExtension } from './codeMirror-excelLanguage';
-
-type FormulaMode = 'transaction' | 'query';
+import type { FormulaMode } from './formulaCatalog';
 
 type FormulaEditorProps = {
   value: string;

--- a/packages/desktop-client/src/components/formula/codeMirror-excelLanguage.tsx
+++ b/packages/desktop-client/src/components/formula/codeMirror-excelLanguage.tsx
@@ -30,6 +30,7 @@ import {
   getFunctionCompletions,
   getNamedVariableCompletions,
   getRuleFieldCompletions,
+  getScheduleFieldCompletions,
   sortFormulaCompletions,
 } from './formulaCatalog';
 import type { FormulaMode } from './formulaCatalog';
@@ -169,6 +170,8 @@ export function excelFormulaAutocomplete(
 
         if (mode === 'transaction') {
           suggestions.push(...getRuleFieldCompletions());
+        } else if (mode === 'schedule') {
+          suggestions.push(...getScheduleFieldCompletions());
         }
 
         return {
@@ -215,9 +218,13 @@ export function excelFormulaHover(mode: FormulaMode): Extension {
       } satisfies Tooltip;
     }
 
-    // Transaction fields
-    if (mode === 'transaction') {
-      const field = getRuleFieldCompletions().find(f => f.label === w);
+    // Transaction/schedule fields
+    if (mode === 'transaction' || mode === 'schedule') {
+      const fields =
+        mode === 'transaction'
+          ? getRuleFieldCompletions()
+          : getScheduleFieldCompletions();
+      const field = fields.find(f => f.label === w);
       if (field) {
         return {
           pos: word.from,

--- a/packages/desktop-client/src/components/formula/formulaCatalog.ts
+++ b/packages/desktop-client/src/components/formula/formulaCatalog.ts
@@ -1,7 +1,7 @@
 import type { Completion } from '@codemirror/autocomplete';
 import { t } from 'i18next';
 
-export type FormulaMode = 'query' | 'transaction';
+export type FormulaMode = 'query' | 'transaction' | 'schedule';
 
 export type FormulaFunctionCategory =
   | 'math'
@@ -1112,6 +1112,7 @@ export function getFormulaFunctionsByMode(): Record<FormulaMode, string[]> {
   const functionsByMode: Record<FormulaMode, string[]> = {
     query: [],
     transaction: [],
+    schedule: [],
   };
 
   for (const [name, func] of Object.entries(getFormulaFunctionCatalog())) {

--- a/packages/desktop-client/src/components/formula/formulaCatalog.ts
+++ b/packages/desktop-client/src/components/formula/formulaCatalog.ts
@@ -77,6 +77,10 @@ function getRuleFieldCompletionSection(): string {
   return `💰 ${t('Transaction Fields')}`;
 }
 
+function getScheduleFieldCompletionSection(): string {
+  return `💰 ${t('Schedule Fields')}`;
+}
+
 function getFormulaCompletionSectionOrder(): Record<string, number> {
   const categoryConfig = getFormulaFunctionCategoryConfig();
 
@@ -89,6 +93,7 @@ function getFormulaCompletionSectionOrder(): Record<string, number> {
     [categoryConfig.date.section]: categoryConfig.date.order,
     [categoryConfig.other.section]: categoryConfig.other.order,
     [getRuleFieldCompletionSection()]: 6,
+    [getScheduleFieldCompletionSection()]: 6,
   };
 }
 
@@ -1128,9 +1133,13 @@ export function getFormulaFunctionsForMode(
   mode: FormulaMode,
 ): Record<string, FormulaFunctionDef> {
   const catalog = getFormulaFunctionCatalog();
+  // Schedule formulas expose the same functions as transaction formulas.
+  const lookupMode = mode === 'schedule' ? 'transaction' : mode;
 
   return Object.fromEntries(
-    Object.entries(catalog).filter(([, func]) => func.modes.includes(mode)),
+    Object.entries(catalog).filter(([, func]) =>
+      func.modes.includes(lookupMode),
+    ),
   );
 }
 
@@ -1140,8 +1149,10 @@ export function getFormulaFunctionByName(
 ): FormulaFunctionDef | undefined {
   const upperName = name.toUpperCase();
   const func = getFormulaFunctionCatalog()[upperName];
+  // Schedule formulas expose the same functions as transaction formulas.
+  const lookupMode = mode === 'schedule' ? 'transaction' : mode;
 
-  if (!func || (mode && !func.modes.includes(mode))) {
+  if (!func || (lookupMode && !func.modes.includes(lookupMode))) {
     return undefined;
   }
 
@@ -1303,6 +1314,22 @@ export function getRuleFieldCompletions(): Completion[] {
       boost: 5,
       info: t(
         'The amount of the parent transaction in cents in split transactions.\n\nExample: =(parent_amount / 100) * .05',
+      ),
+    },
+  ];
+}
+
+// Schedule formulas are evaluated with only the occurrence date available
+// (see getScheduledAmount in loot-core), so `date` is the only field variable.
+export function getScheduleFieldCompletions(): Completion[] {
+  return [
+    {
+      label: 'date',
+      type: 'variable',
+      section: getScheduleFieldCompletionSection(),
+      boost: 5,
+      info: t(
+        'The date of the schedule occurrence in YYYY-MM-DD format. Use with date functions.\n\nExample: =IF(MONTH(date) = 1, 150, 100)',
       ),
     },
   ];

--- a/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
@@ -12,7 +12,9 @@ import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
+import { evaluateFormula } from '@actual-app/core/shared/formulas/evaluate';
 import * as monthUtils from '@actual-app/core/shared/months';
+import { amountToInteger } from '@actual-app/core/shared/util';
 import type {
   RecurConfig,
   ScheduleEntity,
@@ -29,6 +31,8 @@ import { SimpleTransactionsTable } from '#components/transactions/SimpleTransact
 import { AmountInput, BetweenAmountInput } from '#components/util/AmountInput';
 import { GenericInput } from '#components/util/GenericInput';
 import { useDateFormat } from '#hooks/useDateFormat';
+import { useFeatureFlag } from '#hooks/useFeatureFlag';
+import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { SelectedProvider } from '#hooks/useSelected';
 import type { Actions } from '#hooks/useSelected';
@@ -36,7 +40,7 @@ import type { Actions } from '#hooks/useSelected';
 export type ScheduleFormFields = {
   payee: null | string;
   account: null | string;
-  amount: null | number | { num1: number; num2: number };
+  amount: null | number | { num1: number; num2: number } | string;
   amountOp: null | string;
   date: null | string | RecurConfig;
   posts_transaction: boolean;
@@ -53,12 +57,12 @@ export type ScheduleEditFormDispatch =
   | {
       type: 'set-field';
       field: 'amountOp';
-      value: 'is' | 'isbetween' | 'isapprox';
+      value: 'is' | 'isbetween' | 'isapprox' | 'formula';
     }
   | {
       type: 'set-field';
       field: 'amount';
-      value: number | { num1: number; num2: number };
+      value: number | { num1: number; num2: number } | string;
     }
   | {
       type: 'set-field';
@@ -119,6 +123,30 @@ export function ScheduleEditForm({
   const { t } = useTranslation();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const { isNarrowWidth } = useResponsive();
+  const format = useFormat();
+  const formulaModeEnabled = useFeatureFlag('formulaMode');
+  // Make sure that we don't hide the formula if formulaMode has been disabled after the schedule was created
+  const showFormulaOp = formulaModeEnabled || fields.amountOp === 'formula';
+
+  const previewDate =
+    upcomingDates?.[0] ?? schedule?.next_date ?? monthUtils.currentDay();
+  const formulaPreview = (() => {
+    if (fields.amountOp !== 'formula') return null;
+    if (typeof fields.amount !== 'string' || !fields.amount.startsWith('=')) {
+      return null;
+    }
+    try {
+      const result = evaluateFormula(fields.amount, { date: previewDate });
+      if (typeof result !== 'number') {
+        return { error: t('Formula did not evaluate to a number') };
+      }
+      return {
+        value: amountToInteger(Math.round(result * 100) / 100),
+      };
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : String(e) };
+    }
+  })();
 
   return (
     <>
@@ -185,8 +213,14 @@ export function ScheduleEditForm({
                 style={{ margin: 0, flex: 1 }}
               />
               <OpSelect
-                ops={['isapprox', 'is', 'isbetween']}
-                value={fields.amountOp as 'isapprox' | 'is' | 'isbetween'}
+                ops={
+                  showFormulaOp
+                    ? ['isapprox', 'is', 'isbetween', 'formula']
+                    : ['isapprox', 'is', 'isbetween']
+                }
+                value={
+                  fields.amountOp as 'isapprox' | 'is' | 'isbetween' | 'formula'
+                }
                 formatOp={op => {
                   switch (op) {
                     case 'is':
@@ -195,6 +229,8 @@ export function ScheduleEditForm({
                       return t('is approximately');
                     case 'isbetween':
                       return t('is between');
+                    case 'formula':
+                      return t('is formula');
                     default:
                       throw new Error('Invalid op for select: ' + op);
                   }
@@ -225,6 +261,47 @@ export function ScheduleEditForm({
                   })
                 }
               />
+            ) : fields.amountOp === 'formula' ? (
+              <>
+                <Input
+                  id="amount-field"
+                  value={typeof fields.amount === 'string' ? fields.amount : ''}
+                  onChangeValue={value =>
+                    dispatch({
+                      type: 'set-field',
+                      field: 'amount',
+                      value,
+                    })
+                  }
+                />
+                {formulaPreview && (
+                  <Text
+                    style={{
+                      fontSize: 12,
+                      marginTop: 3,
+                      color:
+                        'error' in formulaPreview
+                          ? theme.errorText
+                          : theme.pageTextLight,
+                    }}
+                  >
+                    {'error' in formulaPreview ? (
+                      formulaPreview.error
+                    ) : (
+                      <Trans>
+                        Evaluates to{' '}
+                        {{
+                          amount: format(formulaPreview.value, 'financial'),
+                        }}{' '}
+                        for{' '}
+                        {{
+                          date: monthUtils.format(previewDate, dateFormat),
+                        }}
+                      </Trans>
+                    )}
+                  </Text>
+                )}
+              </>
             ) : (
               <AmountInput
                 id="amount-field"

--- a/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
@@ -141,7 +141,7 @@ export function ScheduleEditForm({
         return { error: t('Formula did not evaluate to a number') };
       }
       return {
-        value: amountToInteger(Math.round(result * 100) / 100),
+        value: amountToInteger(result, format.currency.decimalPlaces),
       };
     } catch (e) {
       return { error: e instanceof Error ? e.message : String(e) };

--- a/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditForm.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -12,7 +12,10 @@ import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
-import { evaluateFormula } from '@actual-app/core/shared/formulas/evaluate';
+import {
+  evaluateFormula,
+  FormulaEvaluationError,
+} from '@actual-app/core/shared/formulas/evaluate';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { amountToInteger } from '@actual-app/core/shared/util';
 import type {
@@ -36,6 +39,12 @@ import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { SelectedProvider } from '#hooks/useSelected';
 import type { Actions } from '#hooks/useSelected';
+
+const FormulaEditor = lazy(() =>
+  import('#components/formula/FormulaEditor').then(module => ({
+    default: module.FormulaEditor,
+  })),
+);
 
 export type ScheduleFormFields = {
   payee: null | string;
@@ -135,6 +144,10 @@ export function ScheduleEditForm({
     if (typeof fields.amount !== 'string' || !fields.amount.startsWith('=')) {
       return null;
     }
+    // Nothing entered yet (e.g. the seeded `=`) — don't show anything.
+    if (fields.amount.replace(/^=/, '').trim() === '') {
+      return null;
+    }
     try {
       const result = evaluateFormula(fields.amount, { date: previewDate });
       if (typeof result !== 'number') {
@@ -144,6 +157,15 @@ export function ScheduleEditForm({
         value: amountToInteger(result, format.currency.decimalPlaces),
       };
     } catch (e) {
+      // An incomplete/invalid formula (still typing) surfaces as a HyperFormula
+      // parse error — show a calm hint instead of the raw parser dump. Genuine
+      // evaluation errors (#DIV/0!, #NAME?, …) keep showing as errors.
+      if (
+        e instanceof FormulaEvaluationError &&
+        e.formulaErrorType === 'ERROR'
+      ) {
+        return { error: t('Not a valid formula'), soft: true };
+      }
       return { error: e instanceof Error ? e.message : String(e) };
     }
   })();
@@ -171,6 +193,7 @@ export function ScheduleEditForm({
             marginTop: 20,
             display: isNarrowWidth ? 'grid' : 'flex',
             gridTemplateColumns: '1fr 1fr',
+            alignItems: 'flex-start',
           }}
         >
           <FormField style={{ flex: 1 }}>
@@ -209,7 +232,9 @@ export function ScheduleEditForm({
             <SpaceBetween style={{ marginBottom: 3, alignItems: 'center' }}>
               <FormLabel
                 title={t('Amount')}
-                htmlFor="amount-field"
+                htmlFor={
+                  fields.amountOp === 'formula' ? undefined : 'amount-field'
+                }
                 style={{ margin: 0, flex: 1 }}
               />
               <OpSelect
@@ -263,24 +288,40 @@ export function ScheduleEditForm({
               />
             ) : fields.amountOp === 'formula' ? (
               <>
-                <Input
-                  id="amount-field"
-                  value={typeof fields.amount === 'string' ? fields.amount : ''}
-                  onChangeValue={value =>
-                    dispatch({
-                      type: 'set-field',
-                      field: 'amount',
-                      value,
-                    })
-                  }
-                />
+                <View
+                  style={{
+                    flex: 1,
+                    border: `1px solid ${theme.formInputBorder}`,
+                    borderRadius: 4,
+                    overflow: 'visible',
+                    backgroundColor: theme.tableBackground,
+                  }}
+                >
+                  <Suspense fallback={<div style={{ height: 32 }} />}>
+                    <FormulaEditor
+                      value={
+                        typeof fields.amount === 'string' ? fields.amount : ''
+                      }
+                      onChange={value =>
+                        dispatch({
+                          type: 'set-field',
+                          field: 'amount',
+                          value: value.replace(/[\r\n]+/g, ' '),
+                        })
+                      }
+                      mode="schedule"
+                      singleLine
+                      showLineNumbers={false}
+                    />
+                  </Suspense>
+                </View>
                 {formulaPreview && (
                   <Text
                     style={{
                       fontSize: 12,
                       marginTop: 3,
                       color:
-                        'error' in formulaPreview
+                        'error' in formulaPreview && !('soft' in formulaPreview)
                           ? theme.errorText
                           : theme.pageTextLight,
                     }}
@@ -628,7 +669,10 @@ export function ScheduleEditForm({
           <SimpleTransactionsTable
             renderEmpty={
               <NoTransactionsMessage
-                error={error}
+                // A formula amount never affects the match search, so a
+                // formula validation error is not a search failure — it
+                // already shows next to the save button.
+                error={fields.amountOp === 'formula' ? null : error}
                 transactionsMode={transactionsMode}
               />
             }

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -82,7 +82,7 @@ export function ScheduleAmountCell({
     cellText = t('Approximately {{currencyAmount}}', {
       currencyAmount,
     });
-  } else if (isBetween && typeof amount != 'number') {
+  } else if (isBetween && typeof amount === 'object' && amount != null) {
     cellText = t('{{currency1}} to {{currency2}}', {
       currency1: format(Math.abs(amount.num1 || 0), 'financial'),
       currency2: format(Math.abs(amount.num2 || 0), 'financial'),

--- a/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
+++ b/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
@@ -42,6 +42,15 @@ export function updateScheduleConditions(
     return { error: t('A valid amount is required'), conditions: [] };
   }
 
+  if (fields.amountOp === 'formula') {
+    if (typeof fields.amount !== 'string' || !fields.amount.startsWith('=')) {
+      return {
+        error: t('Formula must start with ='),
+        conditions: [],
+      };
+    }
+  }
+
   return {
     conditions: [
       updateCond(conds.payee, 'is', 'payee', fields.payee),

--- a/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
+++ b/packages/desktop-client/src/components/schedules/schedule-edit-utils.ts
@@ -11,6 +11,7 @@ import type { ScheduleFormFields } from './ScheduleEditForm';
 export function updateScheduleConditions(
   schedule: Partial<ScheduleEntity>,
   fields: ScheduleFormFields,
+  { excludeFormulaAmount = false }: { excludeFormulaAmount?: boolean } = {},
 ): { error?: string; conditions?: RuleConditionEntity[] } {
   const conds = extractScheduleConds(schedule._conditions);
 
@@ -42,8 +43,15 @@ export function updateScheduleConditions(
     return { error: t('A valid amount is required'), conditions: [] };
   }
 
-  if (fields.amountOp === 'formula') {
-    if (typeof fields.amount !== 'string' || !fields.amount.startsWith('=')) {
+  const isFormula = fields.amountOp === 'formula';
+
+  // A formula amount can never be evaluated by the DB layer (see
+  // `conditionsToAQL`), so it's irrelevant to the transaction match search.
+  // Skip validating and including it there — an incomplete formula should not
+  // break the match preview, which still matches on payee/account/date.
+  if (isFormula && !excludeFormulaAmount) {
+    const formula = typeof fields.amount === 'string' ? fields.amount : '';
+    if (!formula.startsWith('=') || formula.replace(/^=/, '').trim() === '') {
       return {
         error: t('Formula must start with ='),
         conditions: [],
@@ -57,12 +65,15 @@ export function updateScheduleConditions(
       updateCond(conds.account, 'is', 'account', fields.account),
       updateCond(conds.date, 'isapprox', 'date', fields.date),
       // We don't use `updateCond` for amount because we want to
-      // overwrite it completely
-      {
-        op: (fields.amountOp || 'isapprox') as RuleConditionOp,
-        field: 'amount',
-        value: fields.amount,
-      },
+      // overwrite it completely. Omit a formula amount from the match search
+      // since it can't be applied at the DB layer anyway.
+      isFormula && excludeFormulaAmount
+        ? null
+        : {
+            op: (fields.amountOp || 'isapprox') as RuleConditionOp,
+            field: 'amount',
+            value: fields.amount,
+          },
     ].filter((val): val is RuleConditionEntity => val != null),
   };
 }

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -194,7 +194,10 @@ export function ExperimentalFeatures() {
               flag="formulaMode"
               feedbackLink="https://github.com/actualbudget/actual/issues/5949"
             >
-              <Trans>Excel formula mode (Formula cards & Rule formulas)</Trans>
+              <Trans>
+                Excel formula mode (Formula cards, Rule formulas & Schedule
+                amounts)
+              </Trans>
             </FeatureToggle>
             <FeatureToggle
               flag="currency"

--- a/packages/desktop-client/src/hooks/useScheduleEdit.ts
+++ b/packages/desktop-client/src/hooks/useScheduleEdit.ts
@@ -42,12 +42,12 @@ type ScheduleEditAction =
   | {
       type: 'set-field';
       field: 'amountOp';
-      value: 'is' | 'isbetween' | 'isapprox';
+      value: 'is' | 'isbetween' | 'isapprox' | 'formula';
     }
   | {
       type: 'set-field';
       field: 'amount';
-      value: number | { num1: number; num2: number };
+      value: number | { num1: number; num2: number } | string;
     }
   | {
       type: 'set-field';
@@ -130,13 +130,22 @@ function createScheduleEditReducer(useGetScheduledAmount: boolean = false) {
         };
 
         // If we are changing the amount operator either to or
-        // away from the `isbetween` operator, the amount value is
+        // away from the `isbetween` or `formula` operator, the amount value is
         // different and we need to convert it
         if (
           action.field === 'amountOp' &&
           action.value !== state.fields.amountOp
         ) {
-          if (action.value === 'isbetween') {
+          if (action.value === 'formula') {
+            //  Let's clear all when switch to/from formula
+            fields.amount =
+              typeof state.fields.amount === 'string'
+                ? state.fields.amount
+                : '=';
+          } else if (state.fields.amountOp === 'formula') {
+            fields.amount =
+              action.value === 'isbetween' ? { num1: 0, num2: 0 } : 0;
+          } else if (action.value === 'isbetween') {
             // We need a range if switching to `isbetween`
             if (useGetScheduledAmount) {
               const num = getScheduledAmount(state.fields.amount);
@@ -156,7 +165,12 @@ function createScheduleEditReducer(useGetScheduledAmount: boolean = false) {
               fields.amount =
                 typeof state.fields.amount === 'number'
                   ? state.fields.amount
-                  : state.fields.amount?.num1;
+                  : (
+                      state.fields.amount as
+                        | { num1: number; num2: number }
+                        | null
+                        | undefined
+                    )?.num1;
             }
           }
         }

--- a/packages/desktop-client/src/hooks/useScheduleEdit.ts
+++ b/packages/desktop-client/src/hooks/useScheduleEdit.ts
@@ -376,12 +376,18 @@ export function useScheduleEdit({
     let unsubscribe: (() => void) | undefined;
 
     if (state.schedule && state.transactionsMode === 'matched') {
-      const updated = updateScheduleConditions(state.schedule, state.fields);
+      const updated = updateScheduleConditions(state.schedule, state.fields, {
+        excludeFormulaAmount: true,
+      });
 
       if ('error' in updated) {
         dispatch({ type: 'form-error', error: updated.error });
         return;
       }
+
+      // Clear any stale validation error (e.g. from a previous invalid formula)
+      // now that we have a searchable set of conditions.
+      dispatch({ type: 'form-error', error: null });
 
       // *Extremely* gross hack because the rules are not mapped to
       // public names automatically. We really should be doing that

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -2,7 +2,7 @@ import * as db from '#server/db';
 import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
 import type { Currency } from '#shared/currencies';
-import type { CategoryEntity } from '#types/models';
+import type { CategoryEntity, RuleConditionEntity } from '#types/models';
 
 import { isTrackingBudget } from './actions';
 import { runSchedule } from './schedule-template';
@@ -31,20 +31,41 @@ const defaultCategory = { id: '1', name: 'Test Category' } as CategoryEntity;
 type RuleSpec = {
   id?: string;
   start: string;
-  amount: number | string;
-  amountOp?: 'is' | 'isapprox' | 'isbetween' | 'formula';
   frequency: 'monthly' | 'yearly' | 'weekly' | 'daily';
   interval?: number;
-};
+} & (
+  | { amountOp?: 'is' | 'isapprox'; amount: number }
+  | { amountOp: 'isbetween'; amount: { num1: number; num2: number } }
+  | { amountOp: 'formula'; amount: string }
+);
 
-function makeRule({
-  id = 'r',
-  start,
-  amount,
-  amountOp = 'is',
-  frequency,
-  interval = 1,
-}: RuleSpec): Rule {
+function makeAmountCondition(spec: RuleSpec): RuleConditionEntity {
+  if (spec.amountOp === 'formula') {
+    return {
+      op: 'formula',
+      field: 'amount',
+      value: spec.amount,
+      type: 'string',
+    };
+  }
+  if (spec.amountOp === 'isbetween') {
+    return {
+      op: 'isbetween',
+      field: 'amount',
+      value: spec.amount,
+      type: 'number',
+    };
+  }
+  return {
+    op: spec.amountOp ?? 'is',
+    field: 'amount',
+    value: spec.amount,
+    type: 'number',
+  };
+}
+
+function makeRule(spec: RuleSpec): Rule {
+  const { id = 'r', start, frequency, interval = 1 } = spec;
   return new Rule({
     id,
     stage: 'pre',
@@ -66,12 +87,7 @@ function makeRule({
         },
         type: 'date',
       },
-      {
-        op: amountOp,
-        field: 'amount',
-        value: amount,
-        type: amountOp === 'formula' ? 'string' : 'number',
-      },
+      makeAmountCondition(spec),
     ],
     actions: [],
   });

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -31,7 +31,8 @@ const defaultCategory = { id: '1', name: 'Test Category' } as CategoryEntity;
 type RuleSpec = {
   id?: string;
   start: string;
-  amount: number;
+  amount: number | string;
+  amountOp?: 'is' | 'isapprox' | 'isbetween' | 'formula';
   frequency: 'monthly' | 'yearly' | 'weekly' | 'daily';
   interval?: number;
 };
@@ -40,6 +41,7 @@ function makeRule({
   id = 'r',
   start,
   amount,
+  amountOp = 'is',
   frequency,
   interval = 1,
 }: RuleSpec): Rule {
@@ -64,7 +66,12 @@ function makeRule({
         },
         type: 'date',
       },
-      { op: 'is', field: 'amount', value: amount, type: 'number' },
+      {
+        op: amountOp,
+        field: 'amount',
+        value: amount,
+        type: amountOp === 'formula' ? 'string' : 'number',
+      },
     ],
     actions: [],
   });
@@ -688,5 +695,130 @@ describe('runSchedule', () => {
       defaultCurrency,
     );
     expect(result.to_budget).toBe(0);
+  });
+
+  it('budgets a constant-formula expense schedule for the same amount as a static one', async () => {
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'FormulaSchedule',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+
+    mockSingleSchedule({
+      start: '2024-08-01',
+      amount: '=-100',
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.to_budget).toBe(10000);
+  });
+
+  it('reevaluates a monthly formula schedule against each budget month independently', async () => {
+    const daysOfMonthFormula =
+      '=-DATEDIF(EOMONTH(date,-1) ,EOMONTH(date,0), "D")';
+
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'daysOfMonth',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+
+    // June run
+    mockSingleSchedule({
+      start: '2026-06-15',
+      amount: daysOfMonthFormula,
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+    const june = await runSchedule(
+      template_lines,
+      '2026-06',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    // July run
+    mockSingleSchedule({
+      start: '2026-06-15',
+      amount: daysOfMonthFormula,
+      amountOp: 'formula',
+      frequency: 'monthly',
+    });
+    const july = await runSchedule(
+      template_lines,
+      '2026-07',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(june.errors).toHaveLength(0);
+    expect(july.errors).toHaveLength(0);
+
+    expect(Math.abs(june.to_budget)).toBe(3000);
+    expect(Math.abs(july.to_budget)).toBe(3100);
+  });
+
+  it('budgets a date-dependent formula expense schedule per occurrence', async () => {
+    //Set a daily schedule where we spend the $DAY amount of dollars. 1+2+3+5+..+31 for august
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'DailyFormula',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2024-08-01',
+      amount: '=-DAY(date)',
+      amountOp: 'formula',
+      frequency: 'daily',
+    });
+
+    const result = await runSchedule(
+      template_lines,
+      '2024-08-01',
+      0,
+      0,
+      0,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    // Sum of 1..31 = 496 dollars → 49600 cents
+    expect(result.to_budget).toBe(49600);
   });
 });

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -73,6 +73,7 @@ async function createScheduleList(
     const computeScheduleAmount = (date: string | null): number => {
       let value = getScheduledAmount(amountCondition.value, false, {
         date: date ?? undefined,
+        decimalPlaces: currency.decimalPlaces,
       });
       if (template.adjustment !== undefined && template.adjustmentType) {
         switch (template.adjustmentType) {

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -105,30 +105,15 @@ async function createScheduleList(
     // schedule rules.
     const formulaStrings = collectFormulasFromActions(rule.actions);
 
-    // Use the schedule's next occurrence date so "balance as of this moment"
-    // matches the scheduled date; id/sort_order are unset so we don't exclude a
-    // non-existent transaction from the balance query.
-    const scheduleRuleContext: TransactionEntity = {
-      amount: scheduleAmount,
-      category: category.id,
-      subtransactions: [],
-      ...(next_date_string ? { date: next_date_string } : {}),
-      id: null,
-      sort_order: null,
-    } as TransactionEntity;
-
-    const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
-      scheduleRuleContext,
-      accountsMap,
-      formulaStrings,
-    );
-
     const sign = category.is_income ? 1 : -1;
 
-    const computeOccurrenceTarget = (
+    // Use each occurrence's date so "balance as of this moment" matches that
+    // scheduled date; id/sort_order are unset so we don't exclude a
+    // non-existent transaction from the balance query.
+    const computeOccurrenceTarget = async (
       date: string | null,
       amount: number,
-    ): number => {
+    ): Promise<number> => {
       const occurrenceContext: TransactionEntity = {
         amount,
         category: category.id,
@@ -137,6 +122,11 @@ async function createScheduleList(
         id: null,
         sort_order: null,
       } as TransactionEntity;
+      const balanceOfPrefetched = await prefetchBalanceOfForTransaction(
+        occurrenceContext,
+        accountsMap,
+        formulaStrings,
+      );
       const { amount: postRuleAmount, subtransactions } = rule.execActions({
         ...occurrenceContext,
         _balanceOfPrefetched: balanceOfPrefetched,
@@ -152,7 +142,10 @@ async function createScheduleList(
       );
     };
 
-    const target = computeOccurrenceTarget(next_date_string, scheduleAmount);
+    const target = await computeOccurrenceTarget(
+      next_date_string,
+      scheduleAmount,
+    );
 
     const target_interval = dateConditions.value.interval
       ? dateConditions.value.interval
@@ -205,7 +198,7 @@ async function createScheduleList(
             : nextBaseDate;
           while (nextDate < nextMonth) {
             const occurrenceTarget = isFormulaAmount
-              ? computeOccurrenceTarget(
+              ? await computeOccurrenceTarget(
                   nextDate,
                   computeScheduleAmount(nextDate),
                 )

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -10,6 +10,7 @@ import {
   extractScheduleConds,
   getDateWithSkippedWeekend,
   getNextDate,
+  getScheduledAmount,
 } from '#shared/schedules';
 import { amountToInteger } from '#shared/util';
 import type { CategoryEntity, TransactionEntity } from '#types/models';
@@ -59,37 +60,43 @@ async function createScheduleList(
     const conditions = rule.serialize().conditions;
     const { date: dateConditions, amount: amountCondition } =
       extractScheduleConds(conditions);
-    let scheduleAmount =
-      amountCondition.op === 'isbetween'
-        ? Math.round(amountCondition.value.num1 + amountCondition.value.num2) /
-          2
-        : amountCondition.value;
-    // Apply adjustment percentage if specified
-    if (template.adjustment !== undefined && template.adjustmentType) {
-      switch (template.adjustmentType) {
-        case 'percent': {
-          const adjustmentFactor = 1 + template.adjustment / 100;
-          scheduleAmount = scheduleAmount * adjustmentFactor;
-          break;
-        }
-        case 'fixed': {
-          const sign = scheduleAmount < 0 ? -1 : 1;
-          scheduleAmount +=
-            sign * amountToInteger(template.adjustment, currency.decimalPlaces);
-          break;
-        }
-
-        default:
-        //no valid adjustment was found
-      }
-    }
-
-    scheduleAmount = Math.round(scheduleAmount);
 
     const next_date_string = getNextDate(
       dateConditions,
       monthUtils._parse(current_month),
     );
+
+    const isFormulaAmount =
+      amountCondition.op === 'formula' &&
+      typeof amountCondition.value === 'string';
+
+    const computeScheduleAmount = (date: string | null): number => {
+      let value = getScheduledAmount(amountCondition.value, false, {
+        date: date ?? undefined,
+      });
+      if (template.adjustment !== undefined && template.adjustmentType) {
+        switch (template.adjustmentType) {
+          case 'percent': {
+            const adjustmentFactor = 1 + template.adjustment / 100;
+            value = value * adjustmentFactor;
+            break;
+          }
+          case 'fixed': {
+            const sign = value < 0 ? -1 : 1;
+            value +=
+              sign *
+              amountToInteger(template.adjustment, currency.decimalPlaces);
+            break;
+          }
+
+          default:
+          //no valid adjustment was found
+        }
+      }
+      return Math.round(value);
+    };
+
+    const scheduleAmount = computeScheduleAmount(next_date_string);
 
     // Schedule templates call rule.execActions() on the rule attached to each
     // schedule, so we prefetch balances and pass _balanceOfPrefetched here too.
@@ -115,21 +122,36 @@ async function createScheduleList(
       formulaStrings,
     );
 
-    const { amount: postRuleAmount, subtransactions } = rule.execActions({
-      ...scheduleRuleContext,
-      _balanceOfPrefetched: balanceOfPrefetched,
-    });
-    const categorySubtransactions = subtransactions?.filter(
-      t => t.category === category.id,
-    );
-
-    // Unless the current category is relevant to the schedule, target the post-rule amount.
     const sign = category.is_income ? 1 : -1;
-    const target =
-      sign *
-      (categorySubtransactions?.length
-        ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
-        : (postRuleAmount ?? scheduleAmount));
+
+    const computeOccurrenceTarget = (
+      date: string | null,
+      amount: number,
+    ): number => {
+      const occurrenceContext: TransactionEntity = {
+        amount,
+        category: category.id,
+        subtransactions: [],
+        ...(date ? { date } : {}),
+        id: null,
+        sort_order: null,
+      } as TransactionEntity;
+      const { amount: postRuleAmount, subtransactions } = rule.execActions({
+        ...occurrenceContext,
+        _balanceOfPrefetched: balanceOfPrefetched,
+      });
+      const categorySubtransactions = subtransactions?.filter(
+        t => t.category === category.id,
+      );
+      return (
+        sign *
+        (categorySubtransactions?.length
+          ? categorySubtransactions.reduce((acc, t) => acc + t.amount, 0)
+          : (postRuleAmount ?? amount))
+      );
+    };
+
+    const target = computeOccurrenceTarget(next_date_string, scheduleAmount);
 
     const target_interval = dateConditions.value.interval
       ? dateConditions.value.interval
@@ -181,7 +203,13 @@ async function createScheduleList(
               )
             : nextBaseDate;
           while (nextDate < nextMonth) {
-            monthlyTarget += -target;
+            const occurrenceTarget = isFormulaAmount
+              ? computeOccurrenceTarget(
+                  nextDate,
+                  computeScheduleAmount(nextDate),
+                )
+              : target;
+            monthlyTarget += -occurrenceTarget;
             const currentDate = nextBaseDate;
             const oneDayLater = monthUtils.addDays(nextBaseDate, 1);
             nextBaseDate = getNextDate(

--- a/packages/loot-core/src/server/rules/action.ts
+++ b/packages/loot-core/src/server/rules/action.ts
@@ -1,28 +1,15 @@
 // @ts-strict-ignore
 import * as dateFns from 'date-fns';
 import * as Handlebars from 'handlebars';
-import { HyperFormula } from 'hyperformula';
-import enUS from 'hyperformula/i18n/languages/enUS';
 
 import { logger } from '#platform/server/log';
 import type { TransactionForRules } from '#server/transactions/transaction-rules';
-import {
-  CustomFunctionsPlugin,
-  customFunctionsTranslations,
-} from '#shared/formulas/customFunctions';
+import { evaluateFormula } from '#shared/formulas/evaluate';
 import { currentDay, format, parseDate } from '#shared/months';
 import { FIELD_TYPES } from '#shared/rules';
 import { amountToInteger } from '#shared/util';
 
 import { assert } from './rule-utils';
-
-if (!HyperFormula.getRegisteredLanguagesCodes().includes('enUS')) {
-  HyperFormula.registerLanguage('enUS', enUS);
-}
-HyperFormula.registerFunctionPlugin(
-  CustomFunctionsPlugin,
-  customFunctionsTranslations,
-);
 
 const ACTION_OPS = [
   'set',
@@ -295,66 +282,18 @@ export class Action {
     formula: string,
     transaction: Partial<TransactionForRules>,
   ): unknown {
-    let hfInstance: ReturnType<typeof HyperFormula.buildEmpty> | null = null;
-
-    if (!formula || !formula.startsWith('=')) {
-      throw new Error('Formula must start with =');
-    }
+    const { _balanceOfPrefetched, ...rest } = transaction;
+    const namedExpressions = {
+      ...rest,
+      today: currentDay(),
+      account_name: transaction._account_name || '',
+      category_name: transaction._category_name || '',
+    };
 
     try {
-      hfInstance = HyperFormula.buildEmpty({
-        licenseKey: 'gpl-v3',
-        language: 'enUS',
-        dateFormats: ['DD/MM/YYYY', 'YYYY-MM-DD', 'YYYY/MM/DD'],
-        context: {
-          balanceOfPrefetch: transaction['_balanceOfPrefetched'] ?? new Map(),
-        },
+      const cellValue = evaluateFormula(formula, namedExpressions, {
+        balanceOfPrefetch: _balanceOfPrefetched ?? new Map(),
       });
-
-      const sheetName = hfInstance.addSheet('Sheet1');
-      const sheetId = hfInstance.getSheetId(sheetName);
-
-      if (sheetId === undefined) {
-        throw new Error('Failed to create sheet');
-      }
-
-      const fieldValues: Partial<TransactionForRules> & {
-        today: string;
-        account_name: string;
-        category_name: string;
-      } = {
-        ...transaction,
-        today: currentDay(),
-        account_name: transaction._account_name || '',
-        category_name: transaction._category_name || '',
-      };
-
-      for (const key of Object.keys(fieldValues)) {
-        if (key === '_balanceOfPrefetched') {
-          continue;
-        }
-        let cellValue: string | number | boolean;
-        if (
-          fieldValues[key] === undefined ||
-          fieldValues[key] === null ||
-          typeof fieldValues[key] === 'object'
-        ) {
-          cellValue = '';
-        } else {
-          cellValue = fieldValues[key];
-        }
-        hfInstance.addNamedExpression(key, cellValue);
-      }
-      hfInstance.setCellContents({ sheet: sheetId, col: 0, row: 0 }, [
-        [formula],
-      ]);
-
-      const cellAddress = { sheet: sheetId, col: 0, row: 0 };
-      const cellValue = hfInstance.getCellValue(cellAddress);
-
-      if (cellValue && typeof cellValue === 'object' && 'type' in cellValue) {
-        throw new Error(`Formula error: ${cellValue.message}`);
-      }
 
       if (typeof cellValue === 'number') {
         return amountToInteger(Math.round(cellValue * 100) / 100);
@@ -364,12 +303,6 @@ export class Action {
     } catch (err) {
       logger.error('Formula execution error:', err);
       throw err;
-    } finally {
-      try {
-        hfInstance?.destroy();
-      } catch (err) {
-        logger.error('Error destroying HyperFormula instance:', err);
-      }
     }
   }
 

--- a/packages/loot-core/src/server/rules/condition.ts
+++ b/packages/loot-core/src/server/rules/condition.ts
@@ -2,8 +2,10 @@
 import * as dateFns from 'date-fns';
 
 import { logger } from '#platform/server/log';
+import { evaluateFormula } from '#shared/formulas/evaluate';
 import {
   addDays,
+  currentDay,
   isAfter,
   isBefore,
   monthFromDate,
@@ -18,6 +20,7 @@ import {
   sortNumbers,
 } from '#shared/rules';
 import { extractTagsForFilter } from '#shared/tags';
+import { amountToInteger } from '#shared/util';
 
 import {
   assert,
@@ -142,9 +145,18 @@ export const CONDITION_TYPES = {
     },
   },
   number: {
-    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte'],
+    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte', 'formula'],
     nullable: false,
     parse(op, value, fieldName) {
+      if (op === 'formula') {
+        assert(
+          typeof value === 'string' && value.startsWith('='),
+          'number-format',
+          `Formula value must be a string starting with "=" (field: ${fieldName})`,
+        );
+        return { type: 'formula', value };
+      }
+
       const parsed =
         typeof value === 'number'
           ? { type: 'literal', value }
@@ -320,6 +332,25 @@ export class Condition {
           return fieldValue === number;
         }
         return fieldValue === this.value;
+
+      case 'formula': {
+        try {
+          const result = evaluateFormula(this.value.value, {
+            date: object.date ?? currentDay(),
+          });
+          if (typeof result !== 'number') {
+            return false;
+          }
+          const number = amountToInteger(Math.round(result * 100) / 100);
+          const threshold = getApproxNumberThreshold(number);
+          return (
+            fieldValue >= number - threshold && fieldValue <= number + threshold
+          );
+        } catch (err) {
+          logger.warn('Formula condition evaluation error:', err);
+          return false;
+        }
+      }
 
       case 'isNot':
         return fieldValue !== this.value;

--- a/packages/loot-core/src/server/rules/rule-utils.ts
+++ b/packages/loot-core/src/server/rules/rule-utils.ts
@@ -33,6 +33,7 @@ const OP_SCORES: Record<RuleConditionEntity['op'], number> = {
   hasAnyTag: 0,
   onBudget: 0,
   offBudget: 0,
+  formula: 0,
 };
 
 function computeScore(rule: Rule): number {

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -147,6 +147,31 @@ function updateActions(
     return null;
   }
 
+  // For formula schedules, mirror the formula into any plain `set amount`
+  // action so the rule re-evaluates against each transaction's own date
+  // instead of carrying a stale numeric snapshot.
+  if (amountCond.op === 'formula' && typeof amountCond.value === 'string') {
+    const formula = amountCond.value;
+    let changed = false;
+    const updated = actions.map(action => {
+      if (
+        action.op === 'set' &&
+        action.field === 'amount' &&
+        !action.options?.template &&
+        action.options?.formula !== formula
+      ) {
+        changed = true;
+        return {
+          ...action,
+          value: 0,
+          options: { ...action.options, formula },
+        };
+      }
+      return action;
+    });
+    return changed ? updated : null;
+  }
+
   // Mirrors how `_amount` resolves: a deleted/empty amount condition value
   // yields 0, so the action is synced to 0 too, keeping it consistent with
   // the amount the schedule actually posts.
@@ -572,11 +597,12 @@ async function postTransactionForSchedule({
     return;
   }
 
+  const postingDate = today ? currentDay() : schedule.next_date;
   const transaction = {
     payee: schedule._payee,
     account: schedule._account,
-    amount: getScheduledAmount(schedule._amount),
-    date: today ? currentDay() : schedule.next_date,
+    amount: getScheduledAmount(schedule._amount, false, { date: postingDate }),
+    date: postingDate,
     schedule: schedule.id,
     cleared: false,
   };

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -131,9 +131,14 @@ export function updateConditions(conditions, newConditions) {
 // would revert the posted amount to the old value, ignoring the edited
 // amount. Keep such actions in sync with the amount condition.
 //
-// Only plain `set amount` actions are rewritten:
-//   - Templated/formula actions (`options.template`/`options.formula`) compute
-//     their own value, so they're left untouched.
+// `set amount` actions are rewritten as follows:
+//   - When the amount condition is a formula, the action mirrors that formula
+//     (via `options.formula`) so the rule re-evaluates per transaction.
+//   - When the amount condition is *not* a formula, any leftover
+//     `options.formula` is cleared so a previously-formula schedule cannot
+//     keep applying the stale formula via the action.
+//   - Templated actions (`options.template`) compute their own value, so
+//     they're left untouched.
 //   - `set-split-amount` actions have a different `op` and so are excluded by
 //     the `action.op === 'set'` check below.
 //
@@ -180,16 +185,29 @@ function updateActions(
   let changed = false;
   const updated = actions.map(action => {
     if (
-      action.op === 'set' &&
-      action.field === 'amount' &&
-      !action.options?.template &&
-      !action.options?.formula &&
-      action.value !== amount
+      action.op !== 'set' ||
+      action.field !== 'amount' ||
+      action.options?.template
     ) {
-      changed = true;
+      return action;
+    }
+
+    const hasStaleFormula = action.options?.formula != null;
+    if (!hasStaleFormula && action.value === amount) {
+      return action;
+    }
+
+    changed = true;
+    if (!hasStaleFormula) {
       return { ...action, value: amount };
     }
-    return action;
+
+    const { formula: _drop, ...rest } = action.options!;
+    return {
+      ...action,
+      value: amount,
+      options: Object.keys(rest).length > 0 ? rest : undefined,
+    };
   });
 
   return changed ? updated : null;

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -748,6 +748,17 @@ describe('Transaction rules', () => {
       },
     ]);
   });
+
+  test('formula amount condition is skipped at the AQL layer', async () => {
+    // SQLite can't evaluate formulas, so omit it from the query
+
+    const { filters, errors } = conditionsToAQL([
+      { field: 'amount', op: 'formula', value: '=DAY(date) * 100' },
+      { field: 'notes', op: 'is', value: 'rent' },
+    ]);
+    expect(errors).toEqual([]);
+    expect(filters).toEqual([{ notes: { $transform: '$lower', $eq: 'rent' } }]);
+  });
 });
 
 describe('Learning categories', () => {

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -687,12 +687,20 @@ export function conditionsToAQL(
       case 'offBudget':
         return { 'account.offbudget': true };
 
+      case 'formula':
+        // Formula amounts can only be evaluated in JS (HyperFormula); SQLite
+        // can't run them per row. Skip this condition at the DB layer — the
+        // remaining conditions (payee/account/date) still narrow the match
+        // candidate set, and the rule engine's in-memory `Condition.eval`
+        // handles the exact match when the rule actually fires.
+        return null;
+
       default:
         throw new Error('Unhandled operator: ' + op);
     }
   };
 
-  const filters = conditions.map(mapConditionToActualQL);
+  const filters = conditions.map(mapConditionToActualQL).filter(f => f != null);
   return { filters, errors };
 }
 

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -677,10 +677,15 @@ export function conditionsToAQL(
         return apply(field, '$eq', true);
       case 'false':
         return apply(field, '$eq', false);
-      case 'and':
-        return {
-          $and: getValue(value).map(subExpr => mapConditionToActualQL(subExpr)),
-        };
+      case 'and': {
+        const subFilters = getValue(value)
+          .map(subExpr => mapConditionToActualQL(subExpr))
+          .filter(f => f != null);
+        if (subFilters.length === 0) {
+          return null;
+        }
+        return { $and: subFilters };
+      }
 
       case 'onBudget':
         return { 'account.offbudget': false };

--- a/packages/loot-core/src/shared/formulas/evaluate.ts
+++ b/packages/loot-core/src/shared/formulas/evaluate.ts
@@ -1,0 +1,97 @@
+import { HyperFormula } from 'hyperformula';
+import enUS from 'hyperformula/i18n/languages/enUS';
+
+import { logger } from '#platform/server/log';
+import {
+  CustomFunctionsPlugin,
+  customFunctionsTranslations,
+} from '#shared/formulas/customFunctions';
+
+export type FormulaCellValue = number | string | boolean | null;
+
+type EvaluateOptions = {
+  balanceOfPrefetch?: Map<string, number>;
+};
+
+let bootstrapped = false;
+
+function bootstrap() {
+  if (bootstrapped) return;
+  if (!HyperFormula.getRegisteredLanguagesCodes().includes('enUS')) {
+    HyperFormula.registerLanguage('enUS', enUS);
+  }
+  if (!HyperFormula.getRegisteredFunctionNames('enUS').includes('BALANCE_OF')) {
+    HyperFormula.registerFunctionPlugin(
+      CustomFunctionsPlugin,
+      customFunctionsTranslations,
+    );
+  }
+  bootstrapped = true;
+}
+
+export function evaluateFormula(
+  formula: string,
+  namedExpressions: Record<string, unknown>,
+  options: EvaluateOptions = {},
+): FormulaCellValue {
+  if (!formula || !formula.startsWith('=')) {
+    throw new Error('Formula must start with =');
+  }
+
+  bootstrap();
+
+  let hfInstance: ReturnType<typeof HyperFormula.buildEmpty> | null = null;
+
+  try {
+    hfInstance = HyperFormula.buildEmpty({
+      licenseKey: 'gpl-v3',
+      language: 'enUS',
+      dateFormats: ['DD/MM/YYYY', 'YYYY-MM-DD', 'YYYY/MM/DD'],
+      context: {
+        balanceOfPrefetch: options.balanceOfPrefetch ?? new Map(),
+      },
+    });
+
+    const sheetName = hfInstance.addSheet('Sheet1');
+    const sheetId = hfInstance.getSheetId(sheetName);
+
+    if (sheetId === undefined) {
+      throw new Error('Failed to create sheet');
+    }
+
+    for (const [name, raw] of Object.entries(namedExpressions)) {
+      let value: string | number | boolean;
+      if (
+        typeof raw === 'string' ||
+        typeof raw === 'number' ||
+        typeof raw === 'boolean'
+      ) {
+        value = raw;
+      } else {
+        value = '';
+      }
+      hfInstance.addNamedExpression(name, value);
+    }
+
+    hfInstance.setCellContents({ sheet: sheetId, col: 0, row: 0 }, [[formula]]);
+
+    const cellValue = hfInstance.getCellValue({
+      sheet: sheetId,
+      col: 0,
+      row: 0,
+    });
+
+    if (cellValue && typeof cellValue === 'object' && 'type' in cellValue) {
+      const error = cellValue as { type: string; message?: string };
+      throw new Error(`Formula error: ${error.message ?? error.type}`);
+    }
+
+    return cellValue as FormulaCellValue;
+  } finally {
+    try {
+      hfInstance?.destroy();
+    } catch (err) {
+      logger.error('Error destroying HyperFormula instance:', err);
+    }
+  }
+}

--- a/packages/loot-core/src/shared/formulas/evaluate.ts
+++ b/packages/loot-core/src/shared/formulas/evaluate.ts
@@ -9,6 +9,19 @@ import {
 
 export type FormulaCellValue = number | string | boolean | null;
 
+// Carries the underlying HyperFormula error type (e.g. 'ERROR' for parse/syntax
+// failures, 'DIV_BY_ZERO', 'NAME', … for evaluation failures) so callers can
+// distinguish an incomplete/invalid formula from a genuine evaluation error.
+export class FormulaEvaluationError extends Error {
+  formulaErrorType: string;
+
+  constructor(formulaErrorType: string, message: string) {
+    super(message);
+    this.name = 'FormulaEvaluationError';
+    this.formulaErrorType = formulaErrorType;
+  }
+}
+
 type EvaluateOptions = {
   balanceOfPrefetch?: Map<string, number>;
 };
@@ -83,7 +96,10 @@ export function evaluateFormula(
 
     if (cellValue && typeof cellValue === 'object' && 'type' in cellValue) {
       const error = cellValue as { type: string; message?: string };
-      throw new Error(`Formula error: ${error.message ?? error.type}`);
+      throw new FormulaEvaluationError(
+        error.type,
+        `Formula error: ${error.message ?? error.type}`,
+      );
     }
 
     return cellValue as FormulaCellValue;

--- a/packages/loot-core/src/shared/rules.ts
+++ b/packages/loot-core/src/shared/rules.ts
@@ -41,7 +41,7 @@ const TYPE_INFO = {
     nullable: true,
   },
   number: {
-    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte'],
+    ops: ['is', 'isapprox', 'isbetween', 'gt', 'gte', 'lt', 'lte', 'formula'],
     nullable: false,
   },
   boolean: {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -6,6 +6,7 @@ import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
   getNextDate,
+  getScheduledAmount,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
   getUpcomingDays,
@@ -461,6 +462,50 @@ describe('schedules', () => {
 
       const result = getNextDate(dateCond, new Date(2017, 0, 1));
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getScheduledAmount', () => {
+    it('returns the integer amount unchanged for static schedules', () => {
+      expect(getScheduledAmount(12345)).toBe(12345);
+    });
+
+    it('inverts the sign when requested', () => {
+      expect(getScheduledAmount(12345, true)).toBe(-12345);
+    });
+
+    it('averages and rounds an isbetween amount', () => {
+      expect(getScheduledAmount({ num1: 100, num2: 201 })).toBe(151);
+    });
+
+    it('evaluates a constant formula', () => {
+      // =100 dollars -> 10000 cents
+      expect(getScheduledAmount('=100', false, { date: '2024-03-15' })).toBe(
+        10000,
+      );
+    });
+
+    it('evaluates a date-dependent formula with the supplied date', () => {
+      // DAY(date) on 2024-03-15 -> 15; 15 * 100 = 1500 dollars -> 150000 cents
+      const day15 = getScheduledAmount('=DAY(date) * 100', false, {
+        date: '2024-03-15',
+      });
+      const day28 = getScheduledAmount('=DAY(date) * 100', false, {
+        date: '2024-03-28',
+      });
+      expect(day15).toBe(150000);
+      expect(day28).toBe(280000);
+      expect(day28).not.toBe(day15);
+    });
+
+    it('returns 0 when the formula is malformed', () => {
+      expect(
+        getScheduledAmount('=NOT_A_FUNCTION()', false, { date: '2024-03-15' }),
+      ).toBe(0);
+    });
+
+    it('returns 0 when the formula does not start with =', () => {
+      expect(getScheduledAmount('100', false, { date: '2024-03-15' })).toBe(0);
     });
   });
 });

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -289,7 +289,7 @@ export function getDateWithSkippedWeekend(
 export function getScheduledAmount(
   amount: number | { num1: number; num2: number } | string,
   inverse: boolean = false,
-  context: { date?: string } = {},
+  context: { date?: string; decimalPlaces?: number } = {},
 ): number {
   // this check is temporary, and required at the moment as a schedule rule
   // allows the amount condition to be deleted which causes a crash
@@ -303,7 +303,7 @@ export function getScheduledAmount(
       });
       const num =
         typeof result === 'number'
-          ? amountToInteger(Math.round(result * 100) / 100)
+          ? amountToInteger(result, context.decimalPlaces ?? 2)
           : 0;
       return inverse ? -num : num;
     } catch (err) {

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -2,11 +2,14 @@
 import type { IRuleOptions } from '@rschedule/core';
 import * as d from 'date-fns';
 
+import { logger } from '#platform/server/log';
 import { Condition } from '#server/rules';
 import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 
+import { evaluateFormula } from './formulas/evaluate';
 import * as monthUtils from './months';
 import { q } from './query';
+import { amountToInteger } from './util';
 
 export function getStatus(
   nextDate: string,
@@ -220,7 +223,8 @@ export function extractScheduleConds(conditions) {
         cond =>
           (cond.op === 'is' ||
             cond.op === 'isapprox' ||
-            cond.op === 'isbetween') &&
+            cond.op === 'isbetween' ||
+            cond.op === 'formula') &&
           cond.field === 'amount',
       ) || null,
     date:
@@ -283,12 +287,33 @@ export function getDateWithSkippedWeekend(
 }
 
 export function getScheduledAmount(
-  amount: number | { num1: number; num2: number },
+  amount: number | { num1: number; num2: number } | string,
   inverse: boolean = false,
+  context: { date?: string } = {},
 ): number {
   // this check is temporary, and required at the moment as a schedule rule
   // allows the amount condition to be deleted which causes a crash
   if (amount == null) return 0;
+
+  if (typeof amount === 'string') {
+    // Formula-based amount: evaluate against the occurrence date
+    try {
+      const result = evaluateFormula(amount, {
+        date: context.date ?? monthUtils.currentDay(),
+      });
+      const num =
+        typeof result === 'number'
+          ? amountToInteger(Math.round(result * 100) / 100)
+          : 0;
+      return inverse ? -num : num;
+    } catch (err) {
+      logger.warn(
+        `getScheduledAmount: formula evaluation failed for ${JSON.stringify(amount)}:`,
+        err,
+      );
+      return 0;
+    }
+  }
 
   if (typeof amount === 'number') {
     return inverse ? -amount : amount;

--- a/packages/loot-core/src/types/models/rule.ts
+++ b/packages/loot-core/src/types/models/rule.ts
@@ -41,7 +41,9 @@ type BaseConditionEntity<
     ? Array<FieldValueTypes[Field]>
     : Op extends 'isbetween'
       ? { num1: number; num2: number }
-      : FieldValueTypes[Field];
+      : Op extends 'formula'
+        ? string
+        : FieldValueTypes[Field];
   options?: {
     inflow?: boolean;
     outflow?: boolean;
@@ -89,7 +91,7 @@ export type RuleConditionEntity =
     >
   | BaseConditionEntity<
       'amount',
-      'is' | 'isapprox' | 'isbetween' | 'gt' | 'gte' | 'lt' | 'lte'
+      'is' | 'isapprox' | 'isbetween' | 'gt' | 'gte' | 'lt' | 'lte' | 'formula'
     >
   | BaseConditionEntity<
       'date',

--- a/packages/loot-core/src/types/models/schedule.ts
+++ b/packages/loot-core/src/types/models/schedule.ts
@@ -33,7 +33,7 @@ export type ScheduleEntity = {
   // underlying rule
   _payee: PayeeEntity['id'];
   _account: AccountEntity['id'];
-  _amount: number | { num1: number; num2: number };
+  _amount: number | { num1: number; num2: number } | string;
   _amountOp: string;
   _date: RecurConfig | string;
   _conditions: RuleConditionEntity[];

--- a/upcoming-release-notes/formula-on-schedules.md
+++ b/upcoming-release-notes/formula-on-schedules.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [zyberzero]
 ---
 
-Add formula supportn to a schedules amount, for date dependant calculations.
+Add formula support to a schedules amount, for date dependant calculations.

--- a/upcoming-release-notes/formula-on-schedules.md
+++ b/upcoming-release-notes/formula-on-schedules.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [zyberzero]
+---
+
+Add formula supportn to a schedules amount, for date dependant calculations.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds the option to add formula to a schedules amount. The use case is this: I pay for something upfront for the next month, but the thing costs me like 50 currency for _each_ Friday in the upcoming month.   By combining this with the formula `=-50*(INT((EOMONTH(date,1) - (EOMONTH(date,0)+1) - MOD(5 - WEEKDAY(EOMONTH(date,0)+1, 2) + 7, 7)) / 7) + 1)` for a schedule gives me that, and then I can use a budget automation to save for that schedule. 

I used Claude to help me write the meat of the code - my tTS is a bit rusty and my React even more so. I've gone through every line though, and persuaded myself that I know what exactly everything is doing.

I'm setting this as a WIP as there are a few paint points, one is discoverability. I've added a tooltip like so:
<img width="687" height="238" alt="image" src="https://github.com/user-attachments/assets/716b893e-f51c-479a-9bbe-394d03a46ded" />
but it moves the input boxes around. Before I continue down that path - are there any other ideas how to show it?

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

In addition to the automated tests, I:
* Enabled formulas and goal templates 
* Created a schedule with the above formula
* Verified that it for the next occurrence showed the correct amount
* Created a goal template in the budget for that schedule
* Applied that schedule for the month of June and month of July, verified that I got the intended values (250 for June as there are five Fridays in July,  and 200 for the budget of July as there are four Fridays in August

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.17 MB → 13.18 MB (+8.71 kB) | +0.06%
loot-core | 1 | 4.83 MB → 4.83 MB (+3.31 kB) | +0.07%
api | 2 | 3.88 MB → 3.88 MB (+3.19 kB) | +0.08%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.17 MB → 13.18 MB (+8.71 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.05 kB | 0 B → 2.05 kB
`src/components/schedules/schedule-edit-utils.ts` | 📈 +403 B (+44.68%) | 902 B → 1.27 kB
`src/components/schedules/ScheduleEditForm.tsx` | 📈 +4.27 kB (+15.94%) | 26.75 kB → 31.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +730 B (+8.47%) | 8.42 kB → 9.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +423 B (+6.00%) | 6.88 kB → 7.3 kB
`src/hooks/useScheduleEdit.ts` | 📈 +361 B (+5.42%) | 6.5 kB → 6.85 kB
`src/components/formula/formulaCatalog.ts` | 📈 +578 B (+1.48%) | 38.08 kB → 38.65 kB
`src/components/formula/codeMirror-excelLanguage.tsx` | 📈 +166 B (+0.98%) | 16.49 kB → 16.65 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +14 B (+0.31%) | 4.47 kB → 4.49 kB
`src/components/rules/FormulaActionEditor.tsx` | 📈 +4 B (+0.21%) | 1.82 kB → 1.83 kB
`src/components/settings/Experimental.tsx` | 📈 +18 B (+0.15%) | 11.93 kB → 11.95 kB
`src/components/schedules/SchedulesTable.tsx` | 📈 +19 B (+0.10%) | 17.98 kB → 18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 🔥 -269 B (-100%) | 269 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+7.98 kB) | +0.10%
static/js/FormulaEditor.js | 730.27 kB → 730.99 kB (+744 B) | +0.10%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.74 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+3.31 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.15 kB | 0 B → 2.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +748 B (+8.21%) | 8.89 kB → 9.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +431 B (+7.34%) | 5.73 kB → 6.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +833 B (+5.23%) | 15.56 kB → 16.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +428 B (+4.87%) | 8.58 kB → 9 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +179 B (+0.81%) | 21.54 kB → 21.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +15 B (+0.69%) | 2.13 kB → 2.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +14 B (+0.29%) | 4.66 kB → 4.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -1.43 kB (-17.70%) | 8.06 kB → 6.63 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BTg7k8xl.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.LNjMCuqC.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+3.19 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/evaluate.ts` | 🆕 +2.06 kB | 0 B → 2.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +730 B (+8.48%) | 8.41 kB → 9.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +423 B (+6.50%) | 6.36 kB → 6.77 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +807 B (+5.17%) | 15.24 kB → 16.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +416 B (+4.83%) | 8.41 kB → 8.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +174 B (+0.81%) | 21.11 kB → 21.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +14 B (+0.67%) | 2.03 kB → 2.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +13 B (+0.28%) | 4.49 kB → 4.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -1.39 kB (-18.26%) | 7.6 kB → 6.21 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+3.19 kB) | +0.08%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->