### PR TITLE
[AI] Fix Sankey chart IncomePayee other bucket grouping

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -748,6 +748,36 @@ describe('sankey-spreadsheet', () => {
   });
 
   describe('addHiddenNodes via buildSankeyData', () => {
+    it('groups low-value payees into a single payee Other bucket', () => {
+      const graph: Graph = new Map();
+
+      addNode(graph, 'payee1', GraphLayers.IncomePayee, 'Payee 1');
+      addNode(graph, 'payee2', GraphLayers.IncomePayee, 'Payee 2');
+      addNode(graph, 'income1', GraphLayers.IncomeCategory, 'Income Cat 1');
+      addNode(graph, 'income2', GraphLayers.IncomeCategory, 'Income Cat 2');
+      addNode(graph, 'account', GraphLayers.Account, 'Account');
+
+      addValueToLink(graph, 'payee1', 'income1', 300);
+      addValueToLink(graph, 'payee2', 'income2', 200);
+      addValueToLink(graph, 'income1', 'account', 300);
+      addValueToLink(graph, 'income2', 'account', 200);
+
+      const sankeyData = buildSankeyData(
+        graph,
+        1,
+        [],
+        'global',
+        GraphLayers.IncomePayee,
+        GraphLayers.Account,
+      );
+
+      const payeeOtherKeys = sankeyData.nodes
+        .map(node => node.key)
+        .filter(key => key === 'payee__OTHER_BUCKET');
+
+      expect(payeeOtherKeys).toHaveLength(1);
+    });
+
     it('adds one hidden child layer for category groups without children', () => {
       const graph: Graph = new Map();
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -748,7 +748,7 @@ describe('sankey-spreadsheet', () => {
   });
 
   describe('addHiddenNodes via buildSankeyData', () => {
-    it('groups low-value payees into a single payee Other bucket', () => {
+    it('groups low-value payees into a single Other bucket in per-group mode', () => {
       const graph: Graph = new Map();
 
       addNode(graph, 'payee1', GraphLayers.IncomePayee, 'Payee 1');
@@ -766,7 +766,7 @@ describe('sankey-spreadsheet', () => {
         graph,
         1,
         [],
-        'global',
+        'per-group',
         GraphLayers.IncomePayee,
         GraphLayers.Account,
       );

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -985,13 +985,6 @@ function moveToOther(
         const categoryGroupKey = categoryGroupResult[0];
         otherKey = categoryGroupKey + SpecialNodeKeys.OtherSuffix;
       }
-    } else if (nodeData.type === GraphLayers.IncomePayee) {
-      const incomeCategoryKey = Array.from(
-        graph.get(key)?.to.keys() ?? [],
-      ).find(k => graph.get(k)?.type === GraphLayers.IncomeCategory);
-      if (incomeCategoryKey) {
-        otherKey = incomeCategoryKey + SpecialNodeKeys.OtherSuffix;
-      }
     }
   }
 

--- a/upcoming-release-notes/fix-sankey-income-payee-grouping.md
+++ b/upcoming-release-notes/fix-sankey-income-payee-grouping.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [sriranganathan]
+---
+
+Fix Sankey report income payee grouping so low-value income payees collapse into the correct Other bucket


### PR DESCRIPTION
## Description

- Fix Sankey chart `IncomePayee` grouping, so low-value payees are collapsed into the correct payee “Other” bucket, instead of being grouped incorrectly. 
- Add a regression test covering `buildSankeyData` and `IncomePayee` other-bucket behavior.

## Related issue(s)

N/A

## Testing
- Ran tests locally
- Verified from local instance

Before: 
<img width="1417" height="526" alt="Before" src="https://github.com/user-attachments/assets/6017c135-afe0-44e2-ac3d-80ed7b23e228" />

After: 
<img width="1424" height="499" alt="after" src="https://github.com/user-attachments/assets/3e234f0b-d9fd-4737-b502-4fcbd25d154e" />


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (-281 B) | -0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (-281 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📉 -281 B (-0.93%) | 29.44 kB → 29.16 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.22 MB → 1.22 MB (-281 B) | -0.02%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.29 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BQZb0KVY.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->