### PR TITLE
Always show stacked bar graph tooltip label on hover

### DIFF
--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -89,6 +89,12 @@ const CustomTooltip = ({
       );
   }, [payload]);
 
+  const maxTooltipItems = 5;
+
+  const allLabelsShowing =
+    items.length <= maxTooltipItems ||
+    (items.length === maxTooltipItems + 1 && tooltip === items.at(-1).name);
+
   if (active && items.length) {
     return (
       <div
@@ -112,7 +118,7 @@ const CustomTooltip = ({
               const isHovered = tooltip === pay.name;
               return (
                 pay.value !== 0 &&
-                (compact ? i < 5 || isHovered : true) && (
+                (compact ? i < maxTooltipItems || isHovered : true) && (
                   <AlignedText
                     key={pay.name}
                     left={displayName}
@@ -129,7 +135,7 @@ const CustomTooltip = ({
                 )
               );
             })}
-            {payload.length > 5 && compact && '...'}
+            {compact && !allLabelsShowing && '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -109,9 +109,10 @@ const CustomTooltip = ({
           <div style={{ lineHeight: 1.4 }}>
             {items.map((pay, i) => {
               const displayName = dataKeyToName.get(pay.name) ?? pay.name;
+              const isHovered = tooltip === pay.name;
               return (
                 pay.value !== 0 &&
-                (compact ? i < 5 : true) && (
+                (compact ? i < 5 || isHovered : true) && (
                   <AlignedText
                     key={pay.name}
                     left={displayName}
@@ -122,8 +123,7 @@ const CustomTooltip = ({
                     }
                     style={{
                       color: pay.color,
-                      textDecoration:
-                        tooltip === pay.name ? 'underline' : 'inherit',
+                      textDecoration: isHovered ? 'underline' : 'inherit',
                     }}
                   />
                 )

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -92,12 +92,14 @@ const CustomTooltip = ({
   const maxTooltipItems = 5;
 
   const visibleItems = useMemo(() => {
-    if (!compact || items.length <= maxTooltipItems) return items;
-    const hoveredIndex = items.findIndex(p => tooltip === p.name);
+    const nonZero = items.filter(p => p.value !== 0);
+    if (!compact || nonZero.length <= maxTooltipItems) return nonZero;
+
+    const hoveredIndex = nonZero.findIndex(p => tooltip === p.name);
     if (hoveredIndex >= maxTooltipItems) {
-      return [...items.slice(0, maxTooltipItems - 1), items[hoveredIndex]];
+      return [...nonZero.slice(0, maxTooltipItems - 1), nonZero[hoveredIndex]];
     }
-    return items.slice(0, maxTooltipItems);
+    return nonZero.slice(0, maxTooltipItems);
   }, [compact, items, tooltip]);
 
   if (active && items.length) {
@@ -120,26 +122,24 @@ const CustomTooltip = ({
           <div style={{ lineHeight: 1.4 }}>
             {visibleItems.map(pay => {
               const displayName = dataKeyToName.get(pay.name) ?? pay.name;
-              const isHovered = tooltip === pay.name;
               return (
-                pay.value !== 0 && (
-                  <AlignedText
-                    key={pay.name}
-                    left={displayName}
-                    right={
-                      <FinancialText>
-                        {format(pay.value, 'financial')}
-                      </FinancialText>
-                    }
-                    style={{
-                      color: pay.color,
-                      textDecoration: isHovered ? 'underline' : 'inherit',
-                    }}
-                  />
-                )
+                <AlignedText
+                  key={pay.name}
+                  left={displayName}
+                  right={
+                    <FinancialText>
+                      {format(pay.value, 'financial')}
+                    </FinancialText>
+                  }
+                  style={{
+                    color: pay.color,
+                    textDecoration:
+                      tooltip === pay.name ? 'underline' : 'inherit',
+                  }}
+                />
               );
             })}
-            {compact && items.length > maxTooltipItems && '...'}
+            {compact && items.length > visibleItems.length && '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/StackedBarGraph.tsx
@@ -91,9 +91,14 @@ const CustomTooltip = ({
 
   const maxTooltipItems = 5;
 
-  const allLabelsShowing =
-    items.length <= maxTooltipItems ||
-    (items.length === maxTooltipItems + 1 && tooltip === items.at(-1).name);
+  const visibleItems = useMemo(() => {
+    if (!compact || items.length <= maxTooltipItems) return items;
+    const hoveredIndex = items.findIndex(p => tooltip === p.name);
+    if (hoveredIndex >= maxTooltipItems) {
+      return [...items.slice(0, maxTooltipItems - 1), items[hoveredIndex]];
+    }
+    return items.slice(0, maxTooltipItems);
+  }, [compact, items, tooltip]);
 
   if (active && items.length) {
     return (
@@ -113,12 +118,11 @@ const CustomTooltip = ({
             <strong>{label}</strong>
           </div>
           <div style={{ lineHeight: 1.4 }}>
-            {items.map((pay, i) => {
+            {visibleItems.map(pay => {
               const displayName = dataKeyToName.get(pay.name) ?? pay.name;
               const isHovered = tooltip === pay.name;
               return (
-                pay.value !== 0 &&
-                (compact ? i < maxTooltipItems || isHovered : true) && (
+                pay.value !== 0 && (
                   <AlignedText
                     key={pay.name}
                     left={displayName}
@@ -135,7 +139,7 @@ const CustomTooltip = ({
                 )
               );
             })}
-            {compact && !allLabelsShowing && '...'}
+            {compact && items.length > maxTooltipItems && '...'}
             <AlignedText
               left={t('Total')}
               right={

--- a/upcoming-release-notes/fix-stacked-bar-tooltip.md
+++ b/upcoming-release-notes/fix-stacked-bar-tooltip.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [dsmaugy]
+---
+
+Shows label name of hovered stacked bar chart group even if the label would have been hidden in compact mode


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Allows you to always see the stacked bar chart label even if that label would have been hidden by the tooltip when the chart is in `compact` mode.

### Example
**Mouse is hovering over "Entertainment"**
<img width="582" height="225" alt="image" src="https://github.com/user-attachments/assets/c4726ff6-20f2-49c5-b6b5-ce2a3306bdd5" />



**Mouse is hovering over "Gifts". Gifts replaces the last element in the list (entertainment)**
<img width="570" height="213" alt="image" src="https://github.com/user-attachments/assets/03fa6d59-3026-4b04-aa07-f249291c1896" />


I would like for there to be a "show all" feature in the tooltip when the chart is in compact mode, but I figured this change would be a nice starting spot and not too controversial.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

- Spin up dev instance
- Generate test data
- Create "New Custom Report"
- Make sure custom report is set to "Time" mode that is split by "Category"
- Go back to reports dashboard page and try hovering over the category bars

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.1 MB → 13.1 MB (+710 B) | +0.01%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.1 MB → 13.1 MB (+710 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/graphs/StackedBarGraph.tsx` | 📈 +569 B (+5.65%) | 9.84 kB → 10.4 kB
`locale/es.json` | 📈 +139 B (+0.08%) | 167.95 kB → 168.09 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +2 B (+0.01%) | 27.58 kB → 27.59 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.23 MB → 1.24 MB (+571 B) | +0.04%
static/js/es.js | 167.95 kB → 168.09 kB (+139 B) | +0.08%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 175.04 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 173.1 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.48 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 119.69 kB | 0%
static/js/pt-BR.js | 176.96 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.73 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 306.06 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Xleo7SE_.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->