### PR TITLE
🍒 release <- 8335

### DIFF
--- a/packages/loot-core/migrations/1780606215001_add_performance_indexes.sql
+++ b/packages/loot-core/migrations/1780606215001_add_performance_indexes.sql
@@ -1,0 +1,6 @@
+BEGIN TRANSACTION;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_acct_tombstone ON transactions(acct, tombstone);
+CREATE INDEX IF NOT EXISTS idx_transactions_schedule ON transactions(schedule);
+
+COMMIT;

--- a/upcoming-release-notes/wip-ai-add-performance-indexes-for-transactions-table.md
+++ b/upcoming-release-notes/wip-ai-add-performance-indexes-for-transactions-table.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [alecbakholdin]
+---
+
+Add performance indices for transactions table


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Cherry picks https://github.com/actualbudget/actual/pull/8335 into release

This is a good idea because:
- otherwise nightly users won't be able to move to the stable tag when it release
- very low risk, large reward in terms of speed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 → 29 | 14.02 MB → 13.1 MB (-942.86 kB) | -6.57%
loot-core | 1 | 5.34 MB → 4.82 MB (-534.61 kB) | -9.77%
api | 2 | 3.96 MB → 3.87 MB (-95.64 kB) | -2.36%
cli | 1 | 7.97 MB → 8.02 MB (+52.78 kB) | +0.65%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 → 29 | 14.02 MB → 13.1 MB (-942.86 kB) | -6.57%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 🆕 +119.69 kB | 0 B → 119.69 kB
`node_modules/react-router/dist/development/chunk-6CSD65Y2.mjs` | 🆕 +89.09 kB | 0 B → 89.09 kB
`node_modules/react-aria/dist/private/focus/FocusScope.mjs` | 🆕 +24.17 kB | 0 B → 24.17 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBodyMobile.tsx` | 🆕 +20.03 kB | 0 B → 20.03 kB
`node_modules/react-stately/dist/private/color/Color.mjs` | 🆕 +19.91 kB | 0 B → 19.91 kB
`node_modules/react-stately/dist/private/layout/ListLayout.mjs` | 🆕 +19.83 kB | 0 B → 19.83 kB
`node_modules/react-aria/dist/private/overlays/calculatePosition.mjs` | 🆕 +17.64 kB | 0 B → 17.64 kB
`node_modules/react-aria/dist/private/interactions/usePress.mjs` | 🆕 +17.05 kB | 0 B → 17.05 kB
`node_modules/react-aria/dist/private/dnd/useDroppableCollection.mjs` | 🆕 +16.61 kB | 0 B → 16.61 kB
`node_modules/react-aria-components/dist/private/GridList.mjs` | 🆕 +16.27 kB | 0 B → 16.27 kB
`node_modules/react-aria/dist/private/dnd/DragManager.mjs` | 🆕 +15.69 kB | 0 B → 15.69 kB
`node_modules/react-aria-components/dist/private/ListBox.mjs` | 🆕 +14.96 kB | 0 B → 14.96 kB
`src/components/common/CalculatorButtons.tsx` | 🆕 +14.08 kB | 0 B → 14.08 kB
`node_modules/react-aria/dist/private/selection/useSelectableCollection.mjs` | 🆕 +12.19 kB | 0 B → 12.19 kB
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +11.15 kB | 0 B → 11.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.01 kB | 0 B → 11.01 kB
`node_modules/react-aria/dist/private/collections/Document.mjs` | 🆕 +10.25 kB | 0 B → 10.25 kB
`node_modules/@internationalized/number/dist/private/NumberParser.mjs` | 🆕 +10.24 kB | 0 B → 10.24 kB
`node_modules/react-aria/dist/private/dnd/useDrop.mjs` | 🆕 +9.42 kB | 0 B → 9.42 kB
`node_modules/react-aria/dist/private/numberfield/useNumberField.mjs` | 🆕 +9.39 kB | 0 B → 9.39 kB
`node_modules/react-aria/dist/private/interactions/useFocusVisible.mjs` | 🆕 +9.37 kB | 0 B → 9.37 kB
`node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js` | 🆕 +9.28 kB | 0 B → 9.28 kB
`node_modules/react-aria/dist/private/intl/dnd/ru-RU.mjs` | 🆕 +9.28 kB | 0 B → 9.28 kB
`node_modules/react-aria/dist/private/intl/dnd/el-GR.mjs` | 🆕 +9.04 kB | 0 B → 9.04 kB
`node_modules/react-aria/dist/private/intl/dnd/uk-UA.mjs` | 🆕 +9.02 kB | 0 B → 9.02 kB
`node_modules/react-aria/dist/private/gridlist/useGridListItem.mjs` | 🆕 +8.82 kB | 0 B → 8.82 kB
`node_modules/react-stately/dist/private/selection/SelectionManager.mjs` | 🆕 +8.79 kB | 0 B → 8.79 kB
`node_modules/react-aria/dist/private/intl/dnd/bg-BG.mjs` | 🆕 +8.3 kB | 0 B → 8.3 kB
`node_modules/react-aria/dist/private/dnd/useDrag.mjs` | 🆕 +7.94 kB | 0 B → 7.94 kB
`node_modules/react-aria/dist/private/selection/useSelectableItem.mjs` | 🆕 +7.72 kB | 0 B → 7.72 kB
`node_modules/react-stately/dist/private/virtualizer/Virtualizer.mjs` | 🆕 +7.45 kB | 0 B → 7.45 kB
`node_modules/react-aria/dist/private/virtualizer/ScrollView.mjs` | 🆕 +7.31 kB | 0 B → 7.31 kB
`node_modules/react-aria/dist/private/selection/ListKeyboardDelegate.mjs` | 🆕 +7.26 kB | 0 B → 7.26 kB
`node_modules/react-aria/dist/private/dnd/utils.mjs` | 🆕 +7.07 kB | 0 B → 7.07 kB
`node_modules/react-stately/dist/private/numberfield/useNumberFieldState.mjs` | 🆕 +7.07 kB | 0 B → 7.07 kB
`node_modules/react-aria/dist/private/collections/CollectionBuilder.mjs` | 🆕 +7.06 kB | 0 B → 7.06 kB
`node_modules/react-aria/dist/private/collections/BaseCollection.mjs` | 🆕 +7.04 kB | 0 B → 7.04 kB
`node_modules/react-aria/dist/private/dnd/DropTargetKeyboardNavigation.mjs` | 🆕 +6.58 kB | 0 B → 6.58 kB
`node_modules/react-aria/dist/private/spinbutton/useSpinButton.mjs` | 🆕 +6.31 kB | 0 B → 6.31 kB
`node_modules/react-aria/dist/private/overlays/ariaHideOutside.mjs` | 🆕 +6.24 kB | 0 B → 6.24 kB
`node_modules/react-aria/dist/private/overlays/usePreventScroll.mjs` | 🆕 +6.16 kB | 0 B → 6.16 kB
`node_modules/react-aria/dist/private/intl/dnd/ja-JP.mjs` | 🆕 +6.11 kB | 0 B → 6.11 kB
`src/components/modals/BudgetAutomationsModal/useBudgetAutomationsEditor.ts` | 🆕 +6.1 kB | 0 B → 6.1 kB
`src/components/mobile/transactions/CalculatorAmountInput.tsx` | 🆕 +6.04 kB | 0 B → 6.04 kB
`node_modules/react-aria-components/dist/private/Popover.mjs` | 🆕 +6.04 kB | 0 B → 6.04 kB
`node_modules/react-aria/dist/private/intl/dnd/he-IL.mjs` | 🆕 +6.04 kB | 0 B → 6.04 kB
`node_modules/react-aria-components/dist/private/Modal.mjs` | 🆕 +5.89 kB | 0 B → 5.89 kB
`node_modules/react-stately/dist/private/collections/CollectionBuilder.mjs` | 🆕 +5.75 kB | 0 B → 5.75 kB
`node_modules/react-aria/dist/private/utils/scrollIntoView.mjs` | 🆕 +5.72 kB | 0 B → 5.72 kB
`node_modules/react-aria/dist/private/intl/dnd/ar-AE.mjs` | 🆕 +5.72 kB | 0 B → 5.72 kB
`src/components/mobile/transactions/CalculatorKeyboard.tsx` | 🆕 +5.69 kB | 0 B → 5.69 kB
`node_modules/react-aria/dist/private/overlays/useOverlayPosition.mjs` | 🆕 +5.67 kB | 0 B → 5.67 kB
`src/util/error.ts` | 🆕 +5.51 kB | 0 B → 5.51 kB
`node_modules/react-stately/dist/private/form/useFormValidationState.mjs` | 🆕 +5.32 kB | 0 B → 5.32 kB
`node_modules/react-aria/dist/private/utils/shadowdom/ShadowTreeWalker.mjs` | 🆕 +5.13 kB | 0 B → 5.13 kB
`node_modules/react-aria/dist/private/intl/dnd/ko-KR.mjs` | 🆕 +5.09 kB | 0 B → 5.09 kB
`node_modules/react-aria-components/dist/private/utils.mjs` | 🆕 +5.06 kB | 0 B → 5.06 kB
`node_modules/@internationalized/number/dist/private/NumberFormatter.mjs` | 🆕 +4.8 kB | 0 B → 4.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/browser-preload/worker-bridge.ts` | 🆕 +4.65 kB | 0 B → 4.65 kB
`node_modules/react-stately/dist/private/dnd/useDroppableCollectionState.mjs` | 🆕 +4.61 kB | 0 B → 4.61 kB
`src/components/modals/AkahuInitialiseModal.tsx` | 🆕 +4.58 kB | 0 B → 4.58 kB
`node_modules/react-aria-components/dist/private/Virtualizer.mjs` | 🆕 +4.44 kB | 0 B → 4.44 kB
`src/components/autocomplete/TagMultiAutocomplete.tsx` | 🆕 +4.41 kB | 0 B → 4.41 kB
`node_modules/react-aria-components/dist/private/ColorField.mjs` | 🆕 +4.32 kB | 0 B → 4.32 kB
`src/components/mobile/transactions/AmountInput.tsx` | 🆕 +4.25 kB | 0 B → 4.25 kB
`node_modules/react-aria/dist/private/dnd/ListDropTargetDelegate.mjs` | 🆕 +4.25 kB | 0 B → 4.25 kB
`node_modules/react-aria/dist/private/interactions/utils.mjs` | 🆕 +4.21 kB | 0 B → 4.21 kB
`src/util/schedule.ts` | 🆕 +4.19 kB | 0 B → 4.19 kB
`node_modules/react-aria/dist/private/intl/dnd/zh-TW.mjs` | 🆕 +4.15 kB | 0 B → 4.15 kB
`node_modules/es-toolkit/dist/predicate/isEqualWith.mjs` | 🆕 +3.9 kB | 0 B → 3.9 kB
`node_modules/react-aria/dist/private/interactions/useHover.mjs` | 🆕 +3.87 kB | 0 B → 3.87 kB
`node_modules/react-aria-components/dist/private/Tooltip.mjs` | 🆕 +3.74 kB | 0 B → 3.74 kB
`node_modules/react-stately/dist/private/color/useColorFieldState.mjs` | 🆕 +3.7 kB | 0 B → 3.7 kB
`node_modules/react-aria/dist/private/intl/dnd/cs-CZ.mjs` | 🆕 +3.66 kB | 0 B → 3.66 kB
`node_modules/react-stately/dist/private/tooltip/useTooltipTriggerState.mjs` | 🆕 +3.66 kB | 0 B → 3.66 kB
`node_modules/react-aria/dist/private/intl/dnd/zh-CN.mjs` | 🆕 +3.64 kB | 0 B → 3.64 kB
`node_modules/react-aria/dist/private/intl/dnd/tr-TR.mjs` | 🆕 +3.5 kB | 0 B → 3.5 kB
`node_modules/hyperformula/es/interpreter/plugin/PercentilePlugin.mjs` | 🆕 +3.47 kB | 0 B → 3.47 kB
`src/components/mobile/transactions/SplitAmountInput.tsx` | 🆕 +3.47 kB | 0 B → 3.47 kB
`node_modules/react-aria/dist/private/intl/dnd/pl-PL.mjs` | 🆕 +3.44 kB | 0 B → 3.44 kB
`node_modules/react-aria/dist/private/intl/dnd/sk-SK.mjs` | 🆕 +3.43 kB | 0 B → 3.43 kB
`node_modules/react-aria-components/dist/private/Button.mjs` | 🆕 +3.43 kB | 0 B → 3.43 kB
`src/components/tags/SelectedTagsButton.tsx` | 🆕 +3.42 kB | 0 B → 3.42 kB
`node_modules/react-aria/dist/private/intl/dnd/lt-LT.mjs` | 🆕 +3.4 kB | 0 B → 3.4 kB
`node_modules/react-stately/dist/private/intl/color/uk-UA.mjs` | 🆕 +3.39 kB | 0 B → 3.39 kB
`node_modules/react-aria/dist/private/textfield/useFormattedTextField.mjs` | 🆕 +3.37 kB | 0 B → 3.37 kB
`node_modules/react-aria/dist/private/intl/dnd/hu-HU.mjs` | 🆕 +3.31 kB | 0 B → 3.31 kB
`node_modules/react-stately/dist/private/intl/color/ru-RU.mjs` | 🆕 +3.29 kB | 0 B → 3.29 kB
`node_modules/react-aria/dist/private/grid/useGridSelectionAnnouncement.mjs` | 🆕 +3.24 kB | 0 B → 3.24 kB
`node_modules/hyperformula/es/interpreter/plugin/SequencePlugin.mjs` | 🆕 +3.22 kB | 0 B → 3.22 kB
`node_modules/react-aria/dist/private/intl/dnd/lv-LV.mjs` | 🆕 +3.21 kB | 0 B → 3.21 kB
`node_modules/react-aria/dist/private/intl/dnd/ro-RO.mjs` | 🆕 +3.19 kB | 0 B → 3.19 kB
`node_modules/react-aria/dist/private/intl/dnd/fr-FR.mjs` | 🆕 +3.18 kB | 0 B → 3.18 kB
`node_modules/react-aria/dist/private/intl/dnd/hr-HR.mjs` | 🆕 +3.14 kB | 0 B → 3.14 kB
`src/util/rule.ts` | 🆕 +3.11 kB | 0 B → 3.11 kB
`node_modules/react-aria/dist/private/utils/openLink.mjs` | 🆕 +3.1 kB | 0 B → 3.1 kB
`node_modules/react-aria/dist/private/intl/dnd/sr-SP.mjs` | 🆕 +3.1 kB | 0 B → 3.1 kB
`node_modules/react-aria/dist/private/intl/dnd/de-DE.mjs` | 🆕 +3.09 kB | 0 B → 3.09 kB
`node_modules/react-aria/dist/private/form/useFormValidation.mjs` | 🆕 +3.09 kB | 0 B → 3.09 kB
`node_modules/react-aria/dist/private/intl/dnd/sl-SI.mjs` | 🆕 +3.05 kB | 0 B → 3.05 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 0 B → 119.69 kB (+119.69 kB) | -
static/js/AppliedFilters.js | 0 B → 36.47 kB (+36.47 kB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.07 MB → 0 B (-5.07 MB) | -100%
static/js/toString.js | 705.14 kB → 0 B (-705.14 kB) | -100%
static/js/client.js | 451.37 kB → 0 B (-451.37 kB) | -100%
static/js/SchedulesTable.js | 202.7 kB → 0 B (-202.7 kB) | -100%
static/js/ScheduleEditForm.js | 146.45 kB → 0 B (-146.45 kB) | -100%
static/js/_baseIsEqual.js | 98.02 kB → 0 B (-98.02 kB) | -100%
static/js/TransactionEdit.js | 89.65 kB → 0 B (-89.65 kB) | -100%
static/js/ManageRules.js | 46.98 kB → 0 B (-46.98 kB) | -100%
static/js/resize-observer.js | 18.06 kB → 0 B (-18.06 kB) | -100%
static/js/useFormatList.js | 2.52 kB → 0 B (-2.52 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.54 MB → 7.63 MB (+6.09 MB) | +395.01%
static/js/nl.js | 106.24 kB → 116.97 kB (+10.73 kB) | +10.10%
static/js/wide.js | 296.1 kB → 305.07 kB (+8.97 kB) | +3.03%
static/js/de.js | 170.79 kB → 173.1 kB (+2.31 kB) | +1.35%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/FormulaEditor.js | 962.55 kB → 735.67 kB (-226.89 kB) | -23.57%
static/js/extends.js | 500.57 kB → 435.48 kB (-65.08 kB) | -13.00%
static/js/ReportRouter.js | 1.26 MB → 1.23 MB (-25.83 kB) | -2.01%
static/js/ca.js | 186.78 kB → 175.04 kB (-11.74 kB) | -6.28%
static/js/pt-BR.js | 188.46 kB → 176.96 kB (-11.5 kB) | -6.10%
static/js/es.js | 178.71 kB → 168.09 kB (-10.63 kB) | -5.95%
static/js/it.js | 165.02 kB → 155.93 kB (-9.09 kB) | -5.51%
static/js/nb-NO.js | 148.08 kB → 139.47 kB (-8.61 kB) | -5.81%
static/js/fr.js | 178.61 kB → 170.22 kB (-8.39 kB) | -4.70%
static/js/zh-Hans.js | 116.92 kB → 109.86 kB (-7.06 kB) | -6.04%
static/js/narrow.js | 364.2 kB → 358.79 kB (-5.41 kB) | -1.48%
static/js/th.js | 174.48 kB → 170 kB (-4.48 kB) | -2.57%
static/js/da.js | 101.17 kB → 98.1 kB (-3.08 kB) | -3.04%
static/js/uk.js | 207.49 kB → 204.73 kB (-2.75 kB) | -1.33%
static/js/theme.js | 31.77 kB → 31.02 kB (-763 B) | -2.35%
static/js/en.js | 198.13 kB → 197.48 kB (-662 B) | -0.33%
static/js/TransactionList.js | 85.81 kB → 85.19 kB (-634 B) | -0.72%
static/js/PayeeRuleCountLabel.js | 7.33 kB → 7.1 kB (-239 B) | -3.18%
static/js/workbox-window.prod.es5.js | 7.33 kB → 7.21 kB (-117 B) | -1.56%
static/js/en-GB.js | 9.25 kB → 9.19 kB (-67 B) | -0.71%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 4.82 MB (-534.61 kB) | -9.77%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +11.43 kB | 0 B → 11.43 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.36 kB | 0 B → 11.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/customFunctionsPreferences.ts` | 🆕 +4.36 kB | 0 B → 4.36 kB
`node_modules/hyperformula/es/interpreter/plugin/PercentilePlugin.mjs` | 🆕 +3.56 kB | 0 B → 3.56 kB
`node_modules/hyperformula/es/interpreter/plugin/SequencePlugin.mjs` | 🆕 +3.29 kB | 0 B → 3.29 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatchWith.mjs` | 🆕 +3.21 kB | 0 B → 3.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-tracking-budget.ts` | 🆕 +1.82 kB | 0 B → 1.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/bootstrap.ts` | 🆕 +648 B | 0 B → 648 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/sort-categories.ts` | 🆕 +577 B | 0 B → 577 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/memoize.ts` | 🆕 +548 B | 0 B → 548 B
`@oxc-project+runtime@0.133.0/helpers/esm/toPrimitive.js` | 🆕 +418 B | 0 B → 418 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 🆕 +416 B | 0 B → 416 B
`@oxc-project+runtime@0.133.0/helpers/esm/typeof.js` | 🆕 +409 B | 0 B → 409 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/environment.browser.ts` | 🆕 +309 B | 0 B → 309 B
`@oxc-project+runtime@0.133.0/helpers/esm/assertClassBrand.js` | 🆕 +288 B | 0 B → 288 B
`@oxc-project+runtime@0.133.0/helpers/esm/defineProperty.js` | 🆕 +282 B | 0 B → 282 B
`@oxc-project+runtime@0.133.0/helpers/esm/checkPrivateRedeclaration.js` | 🆕 +246 B | 0 B → 246 B
`node_modules/es-toolkit/dist/_internal/isEqualsSameValueZero.mjs` | 🆕 +217 B | 0 B → 217 B
`node_modules/es-toolkit/dist/compat/predicate/isObject.mjs` | 🆕 +206 B | 0 B → 206 B
`node_modules/es-toolkit/dist/predicate/isPrimitive.mjs` | 🆕 +202 B | 0 B → 202 B
`@oxc-project+runtime@0.133.0/helpers/esm/toPropertyKey.js` | 🆕 +197 B | 0 B → 197 B
`@oxc-project+runtime@0.133.0/helpers/esm/classPrivateFieldInitSpec.js` | 🆕 +195 B | 0 B → 195 B
`@oxc-project+runtime@0.133.0/helpers/esm/classPrivateMethodInitSpec.js` | 🆕 +191 B | 0 B → 191 B
`@oxc-project+runtime@0.133.0/helpers/esm/classPrivateFieldSet2.js` | 🆕 +185 B | 0 B → 185 B
`node_modules/es-toolkit/dist/compat/predicate/isMatch.mjs` | 🆕 +178 B | 0 B → 178 B
`@oxc-project+runtime@0.133.0/helpers/esm/classPrivateFieldGet2.js` | 🆕 +176 B | 0 B → 176 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/app.ts` | 🆕 +169 B | 0 B → 169 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +644 B (+34.87%) | 1.8 kB → 2.43 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +129 B (+31.01%) | 416 B → 545 B
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +744 B (+30.27%) | 2.4 kB → 3.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +3.1 kB (+24.88%) | 12.46 kB → 15.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +632 B (+24.18%) | 2.55 kB → 3.17 kB
`node_modules/hyperformula/es/LazilyTransformingAstService.mjs` | 📈 +426 B (+23.05%) | 1.8 kB → 2.22 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +1.43 kB (+20.15%) | 7.11 kB → 8.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +1.42 kB (+11.97%) | 11.82 kB → 13.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.13 kB (+11.65%) | 26.9 kB → 30.04 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📈 +1.57 kB (+8.22%) | 19.11 kB → 20.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +662 B (+7.84%) | 8.25 kB → 8.89 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +422 B (+6.56%) | 6.29 kB → 6.7 kB
`node_modules/hyperformula/es/interpreter/plugin/index.mjs` | 📈 +124 B (+6.44%) | 1.88 kB → 2 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +351 B (+6.36%) | 5.39 kB → 5.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +296 B (+5.75%) | 5.03 kB → 5.32 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📈 +418 B (+4.47%) | 9.13 kB → 9.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +1.06 kB (+4.45%) | 23.74 kB → 24.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +42 B (+4.36%) | 963 B → 1005 B
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +242 B (+3.88%) | 6.08 kB → 6.32 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +277 B (+3.26%) | 8.31 kB → 8.58 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +142 B (+2.34%) | 5.92 kB → 6.06 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📈 +178 B (+2.11%) | 8.24 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +78 B (+1.72%) | 4.42 kB → 4.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +84 B (+1.56%) | 5.25 kB → 5.33 kB
`node_modules/des.js/lib/des/ede.js` | 📈 +22 B (+1.44%) | 1.49 kB → 1.51 kB
`node_modules/des.js/lib/des/cbc.js` | 📈 +22 B (+1.42%) | 1.51 kB → 1.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +30 B (+1.41%) | 2.08 kB → 2.11 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +30 B (+1.39%) | 2.1 kB → 2.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +267 B (+1.24%) | 20.95 kB → 21.21 kB
`node_modules/date-fns/locale/zh-TW/_lib/match.js` | 📈 +34 B (+1.15%) | 2.88 kB → 2.91 kB
`node_modules/date-fns/locale/zh-HK/_lib/match.js` | 📈 +34 B (+1.13%) | 2.93 kB → 2.96 kB
`node_modules/date-fns/locale/zh-CN/_lib/match.js` | 📈 +34 B (+1.13%) | 2.93 kB → 2.96 kB
`node_modules/lru-cache/dist/esm/browser/index.min.js` | 📈 +414 B (+1.04%) | 38.7 kB → 39.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +36 B (+0.96%) | 3.64 kB → 3.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +59 B (+0.95%) | 6.05 kB → 6.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +18 B (+0.94%) | 1.87 kB → 1.88 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +85 B (+0.85%) | 9.76 kB → 9.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +66 B (+0.81%) | 8 kB → 8.06 kB
`rolldown/runtime.js` | 📈 +13 B (+0.79%) | 1.6 kB → 1.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +170 B (+0.79%) | 21.09 kB → 21.25 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +70 B (+0.74%) | 9.24 kB → 9.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/spreadsheet.ts` | 📈 +63 B (+0.71%) | 8.68 kB → 8.74 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/traits/recognizer_engine.js` | 📈 +107 B (+0.53%) | 19.79 kB → 19.9 kB
`node_modules/handlebars/dist/cjs/handlebars/compiler/whitespace-control.js` | 📈 +26 B (+0.51%) | 4.96 kB → 4.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +57 B (+0.51%) | 10.99 kB → 11.04 kB
`node_modules/hyperformula/es/Config.mjs` | 📈 +41 B (+0.48%) | 8.37 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +30 B (+0.39%) | 7.44 kB → 7.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +16 B (+0.34%) | 4.64 kB → 4.66 kB
`node_modules/date-fns/locale/de/_lib/match.js` | 📈 +8 B (+0.25%) | 3.07 kB → 3.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +17 B (+0.23%) | 7.13 kB → 7.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/index.ts` | 📈 +17 B (+0.21%) | 7.93 kB → 7.95 kB
`node_modules/readable-stream/lib/_stream_writable.js` | 📈 +26 B (+0.19%) | 13.14 kB → 13.17 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +43 B (+0.17%) | 24.71 kB → 24.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +6 B (+0.13%) | 4.64 kB → 4.64 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +20 B (+0.08%) | 23.49 kB → 23.51 kB
`node_modules/bn.js/lib/bn.js` | 📈 +25 B (+0.03%) | 76.48 kB → 76.51 kB
`node_modules/assert/build/assert.js` | 📉 -2 B (-0.01%) | 16.43 kB → 16.43 kB
`node_modules/assert/build/internal/assert/assertion_error.js` | 📉 -4 B (-0.02%) | 17.33 kB → 17.33 kB
`node_modules/readable-stream/lib/internal/streams/buffer_list.js` | 📉 -2 B (-0.03%) | 6.59 kB → 6.59 kB
`node_modules/readable-stream/errors-browser.js` | 📉 -2 B (-0.05%) | 3.74 kB → 3.73 kB
`node_modules/object-keys/implementation.js` | 📉 -2 B (-0.06%) | 3.16 kB → 3.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -6 B (-0.07%) | 8.49 kB → 8.49 kB
`node_modules/pako/lib/zlib/trees.js` | 📉 -23 B (-0.15%) | 15.44 kB → 15.42 kB
`node_modules/sax/lib/sax.js` | 📉 -58 B (-0.16%) | 36.29 kB → 36.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/budget-name.ts` | 📉 -2 B (-0.17%) | 1.15 kB → 1.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/unicodeLike.ts` | 📉 -2 B (-0.19%) | 1 kB → 1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/undo.ts` | 📉 -10 B (-0.20%) | 4.84 kB → 4.83 kB
`node_modules/object-keys/index.js` | 📉 -2 B (-0.24%) | 840 B → 838 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/backups.ts` | 📉 -12 B (-0.25%) | 4.75 kB → 4.74 kB
`node_modules/handlebars/dist/cjs/handlebars/compiler/javascript-compiler.js` | 📉 -68 B (-0.25%) | 26.09 kB → 26.02 kB
`node_modules/hyperformula/es/interpreter/plugin/StatisticalPlugin.mjs` | 📉 -76 B (-0.34%) | 22.14 kB → 22.07 kB
`node_modules/hyperformula/es/CrudOperations.mjs` | 📉 -76 B (-0.35%) | 20.95 kB → 20.88 kB
`node_modules/object-keys/isArguments.js` | 📉 -2 B (-0.36%) | 556 B → 554 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BGKt0ne7.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C_UHYSJL.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.87 MB (-95.64 kB) | -2.36%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +15.79 kB | 0 B → 15.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.08 kB | 0 B → 11.08 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatchWith.mjs` | 🆕 +6.09 kB | 0 B → 6.09 kB
`node_modules/hyperformula/es/interpreter/plugin/PercentilePlugin.mjs` | 🆕 +6.03 kB | 0 B → 6.03 kB
`node_modules/hyperformula/es/interpreter/plugin/SequencePlugin.mjs` | 🆕 +5.08 kB | 0 B → 5.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/customFunctionsPreferences.ts` | 🆕 +4.28 kB | 0 B → 4.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-tracking-budget.ts` | 🆕 +1.78 kB | 0 B → 1.78 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/retry.ts` | 🆕 +1.13 kB | 0 B → 1.13 kB
`node_modules/es-toolkit/dist/compat/predicate/isObject.mjs` | 🆕 +1 kB | 0 B → 1 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatch.mjs` | 🆕 +1023 B | 0 B → 1023 B
`node_modules/es-toolkit/dist/predicate/isPrimitive.mjs` | 🆕 +861 B | 0 B → 861 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/memoize.ts` | 🆕 +778 B | 0 B → 778 B
`node_modules/es-toolkit/dist/_internal/isEqualsSameValueZero.mjs` | 🆕 +606 B | 0 B → 606 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/bootstrap.ts` | 🆕 +605 B | 0 B → 605 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/sort-categories.ts` | 🆕 +569 B | 0 B → 569 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 🆕 +403 B | 0 B → 403 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/connection/index.api.ts` | 🆕 +326 B | 0 B → 326 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/app.ts` | 🆕 +167 B | 0 B → 167 B
`node_modules/hyperformula/es/DependencyGraph/index.mjs` | 🆕 +157 B | 0 B → 157 B
`node_modules/hyperformula/es/statistics/index.mjs` | 🆕 +152 B | 0 B → 152 B
`node_modules/hyperformula/es/parser/index.mjs` | 🆕 +148 B | 0 B → 148 B
`node_modules/hyperformula/es/LazilyTransformingAstService.mjs` | 📈 +2.79 kB (+158.80%) | 1.75 kB → 4.54 kB
`node_modules/date-fns/addDays.js` | 📈 +1.21 kB (+105.70%) | 1.15 kB → 2.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts` | 📈 +1.17 kB (+103.11%) | 1.13 kB → 2.29 kB
`node_modules/hyperformula/es/Lookup/ColumnBinarySearch.mjs` | 📈 +392 B (+53.85%) | 728 B → 1.09 kB
`node_modules/adm-zip/adm-zip.js` | 📈 +8.73 kB (+50.47%) | 17.29 kB → 26.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +617 B (+34.30%) | 1.76 kB → 2.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +725 B (+30.21%) | 2.34 kB → 3.05 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📈 +4.92 kB (+26.53%) | 18.55 kB → 23.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +3.04 kB (+24.94%) | 12.19 kB → 15.24 kB
`node_modules/hyperformula/es/i18n/languages/enUS.mjs` | 📈 +59 B (+24.38%) | 242 B → 301 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +626 B (+24.25%) | 2.52 kB → 3.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.1 kB (+20.86%) | 5.26 kB → 6.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +1.41 kB (+20.26%) | 6.95 kB → 8.36 kB
`node_modules/hyperformula/es/interpreter/plugin/TextPlugin.mjs` | 📈 +2.2 kB (+20.12%) | 10.95 kB → 13.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.27 kB (+12.46%) | 26.23 kB → 29.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +1.37 kB (+11.96%) | 11.49 kB → 12.87 kB
`node_modules/adm-zip/zipFile.js` | 📈 +1.03 kB (+11.68%) | 8.81 kB → 9.84 kB
`node_modules/hyperformula/es/interpreter/plugin/index.mjs` | 📈 +194 B (+10.32%) | 1.84 kB → 2.03 kB
`node_modules/hyperformula/es/Emitter.mjs` | 📈 +73 B (+10.25%) | 712 B → 785 B
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +649 B (+8.16%) | 7.77 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +398 B (+6.55%) | 5.94 kB → 6.33 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📈 +479 B (+5.80%) | 8.07 kB → 8.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +285 B (+5.65%) | 4.93 kB → 5.2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +341 B (+5.60%) | 5.95 kB → 6.28 kB
`node_modules/hyperformula/es/interpreter/plugin/FunctionPlugin.mjs` | 📈 +684 B (+5.48%) | 12.2 kB → 12.86 kB
`node_modules/hyperformula/es/parser/parser-consts.mjs` | 📈 +73 B (+5.44%) | 1.31 kB → 1.38 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📈 +474 B (+5.31%) | 8.72 kB → 9.19 kB
`node_modules/handlebars/dist/cjs/handlebars/base.js` | 📈 +153 B (+5.04%) | 2.97 kB → 3.12 kB
`node_modules/date-fns/locale/ca/_lib/localize.js` | 📈 +324 B (+4.86%) | 6.52 kB → 6.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +1.1 kB (+4.72%) | 23.21 kB → 24.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +41 B (+4.41%) | 929 B → 970 B
`node_modules/hyperformula/es/Config.mjs` | 📈 +303 B (+3.61%) | 8.21 kB → 8.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +273 B (+3.27%) | 8.14 kB → 8.41 kB
`node_modules/hyperformula/es/helpers/licenseKeyValidator.mjs` | 📈 +58 B (+2.68%) | 2.11 kB → 2.17 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +140 B (+2.34%) | 5.84 kB → 5.98 kB
`node_modules/hyperformula/es/interpreter/plugin/AddressPlugin.mjs` | 📈 +50 B (+1.82%) | 2.68 kB → 2.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +79 B (+1.81%) | 4.27 kB → 4.34 kB
`node_modules/hyperformula/es/error-message.mjs` | 📈 +75 B (+1.72%) | 4.26 kB → 4.34 kB
`node_modules/lru-cache/dist/esm/index.min.js` | 📈 +397 B (+1.69%) | 22.99 kB → 23.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +31 B (+1.55%) | 1.95 kB → 1.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +29 B (+1.42%) | 2 kB → 2.03 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +272 B (+1.29%) | 20.57 kB → 20.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +18 B (+1.26%) | 1.4 kB → 1.41 kB
`node_modules/date-fns/locale/zh-TW/_lib/match.js` | 📈 +34 B (+1.20%) | 2.76 kB → 2.8 kB
`node_modules/date-fns/locale/zh-HK/_lib/match.js` | 📈 +34 B (+1.18%) | 2.81 kB → 2.85 kB
`node_modules/date-fns/locale/zh-CN/_lib/match.js` | 📈 +34 B (+1.18%) | 2.81 kB → 2.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +60 B (+1.15%) | 5.08 kB → 5.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +235 B (+1.15%) | 19.95 kB → 20.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +57 B (+0.95%) | 5.85 kB → 5.9 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +34 B (+0.93%) | 3.55 kB → 3.59 kB
`rolldown/runtime.js` | 📈 +13 B (+0.90%) | 1.41 kB → 1.42 kB
`node_modules/hyperformula/es/Operations.mjs` | 📈 +299 B (+0.89%) | 32.72 kB → 33.01 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +83 B (+0.86%) | 9.47 kB → 9.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +64 B (+0.83%) | 7.54 kB → 7.6 kB
`node_modules/hyperformula/es/BuildEngineFactory.mjs` | 📈 +38 B (+0.82%) | 4.51 kB → 4.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +69 B (+0.74%) | 9.07 kB → 9.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/spreadsheet.ts` | 📈 +60 B (+0.73%) | 8.01 kB → 8.07 kB
`node_modules/hyperformula/es/parser/ParserWithCaching.mjs` | 📈 +73 B (+0.61%) | 11.73 kB → 11.8 kB
`node_modules/chevrotain/lib_esm/src/parse/parser/traits/recognizer_engine.js` | 📈 +104 B (+0.52%) | 19.37 kB → 19.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +55 B (+0.51%) | 10.63 kB → 10.68 kB
`node_modules/handlebars/dist/cjs/handlebars/compiler/whitespace-control.js` | 📈 +25 B (+0.50%) | 4.85 kB → 4.88 kB
`node_modules/hyperformula/es/HyperFormula.mjs` | 📈 +691 B (+0.45%) | 150.22 kB → 150.89 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +28 B (+0.38%) | 7.29 kB → 7.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📈 +15 B (+0.33%) | 4.47 kB → 4.49 kB
`node_modules/hyperformula/es/parser/FormulaParser.mjs` | 📈 +73 B (+0.28%) | 25.43 kB → 25.5 kB
`node_modules/date-fns/locale/de/_lib/match.js` | 📈 +8 B (+0.26%) | 2.95 kB → 2.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +17 B (+0.24%) | 6.95 kB → 6.96 kB
`node_modules/chevrotain/lib_esm/src/parse/grammar/interpreter.js` | 📈 +29 B (+0.18%) | 16.11 kB → 16.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +42 B (+0.17%) | 24.11 kB → 24.15 kB
`node_modules/hyperformula/es/interpreter/plugin/FinancialPlugin.mjs` | 📈 +34 B (+0.14%) | 23.88 kB → 23.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +19 B (+0.08%) | 22.87 kB → 22.88 kB
`node_modules/chevrotain/lib_esm/src/utils/utils.js` | 📈 +6 B (+0.07%) | 8.38 kB → 8.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +12 B (+0.06%) | 19.9 kB → 19.91 kB
`node_modules/@bufbuild/protobuf/dist/esm/wkt/gen/google/protobuf/descriptor_pb.js` | 📉 -4 B (-0.01%) | 56.86 kB → 56.85 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/util.ts` | 📉 -4 B (-0.06%) | 6.22 kB → 6.22 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📉 -6 B (-0.06%) | 9.19 kB → 9.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -6 B (-0.07%) | 8.24 kB → 8.23 kB
`node_modules/@bufbuild/protobuf/dist/esm/proto-int64.js` | 📉 -2 B (-0.07%) | 2.62 kB → 2.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/budget-name.ts` | 📉 -2 B (-0.17%) | 1.12 kB → 1.12 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.87 MB (-95.64 kB) | -2.36%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB → 8.02 MB (+52.78 kB) | +0.65%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/cosmiconfig/dist/merge.js` | 📈 +87 B (+6.72%) | 1.26 kB → 1.35 kB
`node_modules/cosmiconfig/dist/util.js` | 📈 +125 B (+4.40%) | 2.77 kB → 2.89 kB
`node_modules/cosmiconfig/dist/Explorer.js` | 📈 +112 B (+2.04%) | 5.37 kB → 5.48 kB
`node_modules/cosmiconfig/dist/ExplorerSync.js` | 📈 +112 B (+2.01%) | 5.45 kB → 5.56 kB
`node_modules/js-yaml/lib/type/timestamp.js` | 📈 +32 B (+1.65%) | 1.89 kB → 1.93 kB
`src/config.ts` | 📈 +40 B (+1.11%) | 3.52 kB → 3.56 kB
`rolldown/runtime.js` | 📈 +13 B (+1.11%) | 1.15 kB → 1.16 kB
`node_modules/js-yaml/lib/type/float.js` | 📈 +16 B (+0.77%) | 2.03 kB → 2.04 kB
`node_modules/typescript/lib/typescript.js` | 📈 +58.81 kB (+0.77%) | 7.48 MB → 7.53 MB
`node_modules/@babel/code-frame/lib/index.js` | 📈 +32 B (+0.48%) | 6.51 kB → 6.54 kB
`node_modules/graceful-fs/graceful-fs.js` | 📈 +48 B (+0.46%) | 10.29 kB → 10.34 kB
`node_modules/proper-lockfile/lib/lockfile.js` | 📈 +4 B (+0.06%) | 6.56 kB → 6.56 kB
`node_modules/emoji-regex/index.js` | 📉 -26 B (-0.25%) | 10.17 kB → 10.15 kB
`node_modules/cosmiconfig/dist/ExplorerBase.js` | 📉 -34 B (-0.81%) | 4.08 kB → 4.05 kB
`node_modules/cosmiconfig/dist/defaults.js` | 📉 -70 B (-2.35%) | 2.91 kB → 2.85 kB
`node_modules/is-fullwidth-code-point/index.js` | 📉 -26 B (-2.36%) | 1.08 kB → 1.05 kB
`node_modules/commander/lib/command.js` | 📉 -2.31 kB (-3.29%) | 70.2 kB → 67.89 kB
`node_modules/commander/lib/help.js` | 📉 -891 B (-5.23%) | 16.64 kB → 15.77 kB
`node_modules/commander/lib/option.js` | 📉 -473 B (-5.28%) | 8.75 kB → 8.29 kB
`node_modules/commander/lib/suggestSimilar.js` | 📉 -176 B (-8.35%) | 2.06 kB → 1.89 kB
`node_modules/commander/lib/argument.js` | 📉 -325 B (-10.46%) | 3.04 kB → 2.72 kB
`node_modules/commander/lib/error.js` | 📉 -200 B (-16.50%) | 1.18 kB → 1012 B
`node_modules/cosmiconfig/dist/index.js` | 📉 -1.06 kB (-18.17%) | 5.84 kB → 4.78 kB
`node_modules/commander/index.js` | 📉 -794 B (-89.62%) | 886 B → 92 B
`node_modules/commander/esm.mjs` | 🔥 -331 B (-100%) | 331 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB → 8.02 MB (+52.78 kB) | +0.65%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->