### PR TITLE
Resolve payee name during rule evaluation

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -220,6 +220,42 @@ describe('Transaction rules', () => {
     expect(transaction.category).toBe(null);
   });
 
+  test('payee rules match after a staged formula sets payee name', async () => {
+    await loadRules();
+
+    await db.insertPayee({ id: 'amazon_id', name: 'Amazon' });
+
+    await insertRule({
+      stage: 'pre',
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'imported_payee', value: 'AMZN MKTP' }],
+      actions: [
+        {
+          op: 'set',
+          field: 'payee_name',
+          value: null,
+          options: { formula: '="Amazon"' },
+        },
+      ],
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: 'amazon_id' }],
+      actions: [{ op: 'set', field: 'category', value: 'shopping' }],
+    });
+
+    const transaction = await runRules({
+      imported_payee: 'AMZN MKTP',
+      payee: null,
+      category: null,
+    });
+
+    expect(transaction.payee).toBe('amazon_id');
+    expect(transaction.category).toBe('shopping');
+  });
+
   test('loadRules loads all the rules', async () => {
     await loadRules();
     await insertRule({

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -370,16 +370,19 @@ export async function runRules(
         // bypass condition checking to run the rule even if the transaction date falls outside of the schedule's date range.
         const changes = rules[i].execActions(finalTrans);
         finalTrans = Object.assign({}, finalTrans, changes);
+        await resolvePayeeNameForRules(finalTrans);
       } else if (RuleIdsLinkedToSchedules.includes(rules[i].id)) {
         // skip all other rules that are linked to other schedules.
         continue;
       } else {
         // if a rule is not linked to a schedule, run it.
         finalTrans = rules[i].apply(finalTrans);
+        await resolvePayeeNameForRules(finalTrans);
       }
     } else {
       // if there is no scheduleRuleID then just run all rules.
       finalTrans = rules[i].apply(finalTrans);
+      await resolvePayeeNameForRules(finalTrans);
     }
   }
 
@@ -1098,23 +1101,30 @@ export async function prepareTransactionForRules(
   return r;
 }
 
+async function resolvePayeeNameForRules(
+  trans: TransactionEntity | TransactionForRules,
+): Promise<void> {
+  if (!('payee_name' in trans) || trans.payee !== 'new') {
+    return;
+  }
+
+  if (trans.payee_name) {
+    let payee_id = (await getPayeeByName(trans.payee_name))?.id;
+    payee_id ??= await insertPayee({
+      name: trans.payee_name,
+    });
+
+    trans.payee = payee_id;
+  } else {
+    trans.payee = null;
+  }
+}
+
 export async function finalizeTransactionForRules(
   trans: TransactionEntity | TransactionForRules,
 ): Promise<TransactionEntity> {
   if ('payee_name' in trans) {
-    if (trans.payee === 'new') {
-      if (trans.payee_name) {
-        let payeeId = (await getPayeeByName(trans.payee_name))?.id;
-        payeeId ??= await insertPayee({
-          name: trans.payee_name,
-        });
-
-        trans.payee = payeeId;
-      } else {
-        trans.payee = null;
-      }
-    }
-
+    await resolvePayeeNameForRules(trans);
     delete trans.payee_name;
   }
 

--- a/upcoming-release-notes/resolve-payee-name-eagerly.md
+++ b/upcoming-release-notes/resolve-payee-name-eagerly.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [julienvincent]
+---
+
+When a rule action sets payee_name, resolve it to the actual payee ID immediately during rule execution instead of waiting until finalization.


### PR DESCRIPTION
# Description

I took a stab at fixing #8359 as it seemed like a pretty straight forward change to make. Please read the original issue for full context on the problem this is trying to solve.

---

When a rule action sets payee_name, resolve it to the actual payee ID immediately during rule execution instead of waiting until finalization.

This allows later staged rules to match on the resolved payee. Previously, payee_name actions temporarily set payee to "new", and the real payee ID was only resolved in finalizeTransactionForRules after rule matching had completed.

# Testing

I tested this by running the test suite and by running the app with `yarn start:desktop` wherein I re-created the rules from my main Budget file and ran a test transaction import. It now does what I expect.

# AI Usage Disclosure

I used AI for the initial analysis and to propose an approach for the fix, but wrote the implementation presented here myself.

# Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

Fixes #8359

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.1 MB → 13.12 MB (+25.1 kB) | +0.19%
loot-core | 1 | 4.82 MB → 4.82 MB (+291 B) | +0.01%
api | 2 | 3.87 MB → 3.87 MB (+279 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.1 MB → 13.12 MB (+25.1 kB) | +0.19%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 📈 +19.47 kB (+16.27%) | 119.69 kB → 139.16 kB
`locale/de.json` | 📈 +5.63 kB (+3.25%) | 173.1 kB → 178.73 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 119.69 kB → 139.16 kB (+19.47 kB) | +16.27%
static/js/de.js | 173.1 kB → 178.73 kB (+5.63 kB) | +3.25%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.24 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 175.04 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.48 kB | 0%
static/js/es.js | 168.09 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 176.96 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.73 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 306.06 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+291 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +291 B (+1.34%) | 21.25 kB → 21.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BI4lxjlp.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Xleo7SE_.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+279 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +279 B (+1.31%) | 20.83 kB → 21.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+279 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->