### PR TITLE
reorganise the SimpleFIN key saving logic

### DIFF
--- a/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/SimpleFinInitialiseModal.tsx
@@ -52,6 +52,10 @@ export const SimpleFinInitialiseModal = ({
       setIsValid(false);
       setError(getSecretsError(error, reason));
     } else {
+      await send('secret-set', {
+        name: 'simplefin_accessKey',
+        value: null,
+      });
       onSuccess();
     }
     setIsLoading(false);

--- a/packages/sync-server/src/app-secrets.js
+++ b/packages/sync-server/src/app-secrets.js
@@ -42,15 +42,7 @@ app.post('/', async (req, res) => {
     return;
   }
 
-  const simplefinTokenChanged =
-    name === SecretName.simplefin_token &&
-    value !== secretsService.get(SecretName.simplefin_token);
-
   secretsService.set(name, value);
-
-  if (simplefinTokenChanged) {
-    secretsService.set(SecretName.simplefin_accessKey, null);
-  }
 
   res.status(200).send({ status: 'ok' });
 });

--- a/packages/sync-server/src/secrets.test.js
+++ b/packages/sync-server/src/secrets.test.js
@@ -101,35 +101,6 @@ describe('secretsService', () => {
       });
     });
 
-    it('clears the cached SimpleFIN access key when the token changes', async () => {
-      secretsService.set(SecretName.simplefin_token, 'old-token');
-      secretsService.set(SecretName.simplefin_accessKey, 'cached-access-key');
-
-      const res = await request(app)
-        .post(`/`)
-        .set('x-actual-token', 'valid-token')
-        .send({ name: SecretName.simplefin_token, value: 'new-token' });
-
-      expect(res.statusCode).toEqual(200);
-      expect(secretsService.get(SecretName.simplefin_token)).toBe('new-token');
-      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
-    });
-
-    it('keeps the SimpleFIN access key when the token is unchanged', async () => {
-      secretsService.set(SecretName.simplefin_token, 'same-token');
-      secretsService.set(SecretName.simplefin_accessKey, 'cached-access-key');
-
-      const res = await request(app)
-        .post(`/`)
-        .set('x-actual-token', 'valid-token')
-        .send({ name: SecretName.simplefin_token, value: 'same-token' });
-
-      expect(res.statusCode).toEqual(200);
-      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
-        'cached-access-key',
-      );
-    });
-
     it('POST returns 400 for unknown secret names', async () => {
       const res = await request(app)
         .post('/')

--- a/upcoming-release-notes/simplefin-secrets-tweak.md
+++ b/upcoming-release-notes/simplefin-secrets-tweak.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Reorganise the SimpleFIN key saving logic


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

https://github.com/actualbudget/actual/pull/8339#discussion_r3493542583

I thought I was being clever making sure they could never diverge, but I can see why we'd prefer not to do it in the secrets handler!

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->
https://github.com/actualbudget/actual/pull/8339#discussion_r3493542583

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.1 MB → 13.12 MB (+25.2 kB) | +0.19%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.1 MB → 13.12 MB (+25.2 kB) | +0.19%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 📈 +19.47 kB (+16.27%) | 119.69 kB → 139.16 kB
`locale/de.json` | 📈 +5.63 kB (+3.25%) | 173.1 kB → 178.73 kB
`src/components/modals/SimpleFinInitialiseModal.tsx` | 📈 +101 B (+2.75%) | 3.59 kB → 3.69 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 119.69 kB → 139.16 kB (+19.47 kB) | +16.27%
static/js/de.js | 173.1 kB → 178.73 kB (+5.63 kB) | +3.25%
static/js/index.js | 7.63 MB → 7.63 MB (+101 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.24 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 175.04 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.48 kB | 0%
static/js/es.js | 168.09 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pt-BR.js | 176.96 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.73 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 306.06 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Xleo7SE_.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->