### PR TITLE
[WIP] Fix split transaction glitch: phantom /bin/zsh.00 row and UI flicker

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -3281,12 +3281,12 @@ export const TransactionTable = forwardRef(
           }
         } else {
           const trans = latestState.current.transactions.find(t => t.id === id);
-          const newId = onSplitProp(id);
           if (!trans) {
             return;
           }
 
           splitsExpandedDispatch({ type: 'open-split', id: trans.id });
+          const newId = onSplitProp(id);
 
           const { tableNavigator } = latestState.current;
           if (trans.amount === null) {

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -338,16 +338,24 @@ export function splitTransaction(
     }
 
     const subtransactions = createSubtransactions?.(trans) || [
-      makeChild(trans),
+      makeChild(trans, { amount: trans.amount ?? 0 }),
     ];
 
     const { error: _error, ...rest } = trans;
+
+    const subtransactionTotal = subtransactions.reduce(
+      (sum, t) => sum + num(t.amount),
+      0,
+    );
 
     return {
       ...rest,
       is_parent: true,
       payee: null,
-      error: num(trans.amount) === 0 ? null : SplitTransactionError(0, trans),
+      error:
+        num(trans.amount) === 0 || subtransactionTotal === num(trans.amount)
+          ? null
+          : SplitTransactionError(subtransactionTotal, trans),
       subtransactions: subtransactions.map(t => ({
         ...t,
         sort_order: t.sort_order || -1,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

Fixes two bugs that occur when converting an existing transaction into a split transaction:

The first child row defaulted to $0.00, leaving a phantom zero-amount entry after conversion
The split rows would flicker (disappear and reappear) during conversion

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

When a user tries to convert an existing transaction into a split transaction, two visual bugs occur that don't happen when creating a split from scratch:
The split rows flash and disappear momentarily before reappearing — a jarring flicker that makes the UI feel broken
After the split is created, a leftover $0.00 entry appears at the bottom that shouldn't be there

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

AI tools: (Claude) was used to identify some of the root cause and write the fix.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

For my testing steps I did:
Go to any account (e.g. Checking)
Click an existing transaction to select it
Click the Category field and choose "Split transaction" from the dropdown
Observe: split rows flicker and a phantom $0.00 entry appears at the bottom

Verifying my fix I did:
Repeat the same steps above
Split rows should appear immediately without flickering
The first split entry should show the full original transaction amount, not the phantom $0.00
Verify that creating a brand new split transaction (on a new transaction row) still works as before

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.12 MB → 13.12 MB (+184 B) | +0.00%
loot-core | 1 | 4.82 MB → 4.82 MB (+185 B) | +0.00%
api | 2 | 3.87 MB → 3.87 MB (+184 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.12 MB → 13.12 MB (+184 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +184 B (+2.15%) | 8.36 kB → 8.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.63 MB (+184 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 735.67 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.24 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 175.04 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.73 kB | 0%
static/js/en-GB.js | 9.19 kB | 0%
static/js/en.js | 197.48 kB | 0%
static/js/es.js | 168.09 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.22 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.93 kB | 0%
static/js/narrow.js | 358.79 kB | 0%
static/js/nb-NO.js | 139.47 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.96 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.73 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 306.06 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+185 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +185 B (+2.96%) | 6.1 kB → 6.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BAXRltic.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BI4lxjlp.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB → 3.87 MB (+184 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +184 B (+3.04%) | 5.9 kB → 6.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB → 3.87 MB (+184 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->