### PR TITLE
[AI] Allow previously linked bank-sync accounts to be selected again when reconnecting the same provider

### DIFF
--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
@@ -4,7 +4,10 @@ import type {
 } from '@actual-app/core/types/models';
 import { describe, expect, it } from 'vitest';
 
-import { computeInitialLinkState } from './SelectLinkedAccountsModal';
+import {
+  computeInitialLinkState,
+  getSelectableAccountOptions,
+} from './SelectLinkedAccountsModal';
 
 function makeLocalAccount(
   overrides: Partial<AccountEntity> & { id: string },
@@ -35,6 +38,16 @@ function makeLocalAccount(
 function makeExternalAccount(accountId: string): SyncServerSimpleFinAccount {
   return { account_id: accountId, name: accountId, balance: 0 };
 }
+
+const addOnBudgetAccountOption = {
+  id: 'new-on',
+  name: 'Create new account',
+};
+
+const addOffBudgetAccountOption = {
+  id: 'new-off',
+  name: 'Create new account (off budget)',
+};
 
 describe('computeInitialLinkState', () => {
   it('preselects the upgrading account when there is exactly one unmatched external account', () => {
@@ -95,5 +108,53 @@ describe('computeInitialLinkState', () => {
     );
 
     expect(initiallyChosenAccounts).toEqual({ 'ext-1': 'local-1' });
+  });
+});
+
+describe('getSelectableAccountOptions', () => {
+  it('allows relinking stale accounts from the same sync provider', () => {
+    const staleSimpleFinAccount = makeLocalAccount({
+      id: 'actual-account-stale-simplefin',
+      name: 'Hilton Honors Aspire',
+      account_id: 'old-simplefin-id',
+      account_sync_source: 'simpleFin',
+    });
+    const selectedVisibleSimpleFinAccount = makeLocalAccount({
+      id: 'actual-account-visible-simplefin',
+      name: 'Business Gold Card',
+      account_id: 'visible-simplefin-id',
+      account_sync_source: 'simpleFin',
+    });
+    const goCardlessAccount = makeLocalAccount({
+      id: 'actual-account-gocardless',
+      name: 'Checking',
+      account_id: 'gocardless-id',
+      account_sync_source: 'goCardless',
+    });
+    const manualAccount = makeLocalAccount({
+      id: 'actual-account-manual',
+      name: 'Manual Card',
+    });
+
+    const options = getSelectableAccountOptions({
+      localAccounts: [
+        staleSimpleFinAccount,
+        selectedVisibleSimpleFinAccount,
+        goCardlessAccount,
+        manualAccount,
+      ],
+      selectedLocalAccountIds: new Set([selectedVisibleSimpleFinAccount.id]),
+      chosenAccount: undefined,
+      syncSource: 'simpleFin',
+      addOnBudgetAccountOption,
+      addOffBudgetAccountOption,
+    });
+
+    expect(options.map(option => option.name)).toEqual([
+      'Hilton Honors Aspire',
+      'Manual Card',
+      'Create new account',
+      'Create new account (off budget)',
+    ]);
   });
 });

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
@@ -59,6 +59,43 @@ function useAddBudgetAccountOptions() {
   return { addOnBudgetAccountOption, addOffBudgetAccountOption };
 }
 
+type AddBudgetAccountOption = {
+  id: string;
+  name: string;
+};
+
+export function getSelectableAccountOptions({
+  localAccounts,
+  selectedLocalAccountIds,
+  chosenAccount,
+  syncSource,
+  addOnBudgetAccountOption,
+  addOffBudgetAccountOption,
+}: {
+  localAccounts: AccountEntity[];
+  selectedLocalAccountIds: ReadonlySet<string>;
+  chosenAccount: { id: string; name: string } | undefined;
+  syncSource: NonNullable<AccountEntity['account_sync_source']>;
+  addOnBudgetAccountOption: AddBudgetAccountOption;
+  addOffBudgetAccountOption: AddBudgetAccountOption;
+}): AutocompleteItem[] {
+  const options: AutocompleteItem[] = localAccounts.filter(account => {
+    const isCurrentSelection = account.id === chosenAccount?.id;
+
+    // Keep the current row's selection visible. Otherwise, offer only accounts
+    // that are unselected and either manual or linked to this provider.
+    return (
+      isCurrentSelection ||
+      (!selectedLocalAccountIds.has(account.id) &&
+        (account.account_sync_source == null ||
+          account.account_sync_source === syncSource))
+    );
+  });
+
+  options.push(addOnBudgetAccountOption, addOffBudgetAccountOption);
+  return options;
+}
+
 /**
  * Helper to determine if the chosen account option represents creating a new account.
  */
@@ -364,8 +401,20 @@ export function SelectLinkedAccountsModal({
     dispatch(closeModal());
   }
 
-  const unlinkedAccounts = localAccounts.filter(
-    account => !Object.values(chosenAccounts).includes(account.id),
+  // Only reserve accounts chosen by visible rows; stale provider links should
+  // stay selectable so users can relink them after reconnecting.
+  const currentExternalAccountIds = new Set(
+    propsWithSortedExternalAccounts.externalAccounts.map(
+      account => account.account_id,
+    ),
+  );
+
+  const selectedLocalAccountIds = new Set(
+    Object.entries(chosenAccounts)
+      .filter(([externalAccountId]) =>
+        currentExternalAccountIds.has(externalAccountId),
+      )
+      .map(([, localAccountId]) => localAccountId),
   );
 
   function onSetLinkedAccount(
@@ -504,7 +553,9 @@ export function SelectLinkedAccountsModal({
                   key={account.account_id}
                   externalAccount={account}
                   chosenAccount={getChosenAccount(account.account_id)}
-                  unlinkedAccounts={unlinkedAccounts}
+                  localAccounts={localAccounts}
+                  selectedLocalAccountIds={selectedLocalAccountIds}
+                  syncSource={syncSource}
                   onSetLinkedAccount={onSetLinkedAccount}
                   customStartingDate={getCustomStartingDate(account.account_id)}
                   onSetCustomStartingDate={setCustomStartingDate}
@@ -544,7 +595,9 @@ export function SelectLinkedAccountsModal({
                       key={item.id}
                       externalAccount={item}
                       chosenAccount={chosenAccount}
-                      unlinkedAccounts={unlinkedAccounts}
+                      localAccounts={localAccounts}
+                      selectedLocalAccountIds={selectedLocalAccountIds}
+                      syncSource={syncSource}
                       onSetLinkedAccount={onSetLinkedAccount}
                       customStartingDate={getCustomStartingDate(
                         item.account_id,
@@ -609,30 +662,14 @@ type StartingBalanceInfo = {
 type SharedAccountRowProps = {
   externalAccount: ExternalAccount;
   chosenAccount: { id: string; name: string } | undefined;
-  unlinkedAccounts: AccountEntity[];
+  localAccounts: AccountEntity[];
+  selectedLocalAccountIds: ReadonlySet<string>;
+  syncSource: SelectLinkedAccountsModalProps['syncSource'];
   onSetLinkedAccount: (
     externalAccount: ExternalAccount,
     localAccountId: string | null | undefined,
   ) => void;
 };
-
-function getAvailableAccountOptions(
-  unlinkedAccounts: AccountEntity[],
-  chosenAccount: { id: string; name: string } | undefined,
-  addOnBudgetAccountOption: { id: string; name: string },
-  addOffBudgetAccountOption: { id: string; name: string },
-): AutocompleteItem[] {
-  const options: AutocompleteItem[] = [...unlinkedAccounts];
-  if (
-    chosenAccount &&
-    chosenAccount.id !== addOnBudgetAccountOption.id &&
-    chosenAccount.id !== addOffBudgetAccountOption.id
-  ) {
-    options.push(chosenAccount);
-  }
-  options.push(addOnBudgetAccountOption, addOffBudgetAccountOption);
-  return options;
-}
 
 type TableRowProps = SharedAccountRowProps & {
   customStartingDate: StartingBalanceInfo;
@@ -677,7 +714,9 @@ function useStartingBalanceInfo(accountId: string | undefined) {
 function TableRow({
   externalAccount,
   chosenAccount,
-  unlinkedAccounts,
+  localAccounts,
+  selectedLocalAccountIds,
+  syncSource,
   onSetLinkedAccount,
   customStartingDate,
   onSetCustomStartingDate,
@@ -693,12 +732,14 @@ function TableRow({
     showStartingOptions ? undefined : chosenAccount?.id,
   );
 
-  const availableAccountOptions = getAvailableAccountOptions(
-    unlinkedAccounts,
+  const availableAccountOptions = getSelectableAccountOptions({
+    localAccounts,
+    selectedLocalAccountIds,
     chosenAccount,
+    syncSource,
     addOnBudgetAccountOption,
     addOffBudgetAccountOption,
-  );
+  });
 
   return (
     <Row style={{ backgroundColor: theme.tableBackground }}>
@@ -973,7 +1014,9 @@ type AccountCardProps = SharedAccountRowProps & {
 function AccountCard({
   externalAccount,
   chosenAccount,
-  unlinkedAccounts,
+  localAccounts,
+  selectedLocalAccountIds,
+  syncSource,
   onSetLinkedAccount,
   customStartingDate,
   onSetCustomStartingDate,
@@ -985,12 +1028,14 @@ function AccountCard({
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const { t } = useTranslation();
 
-  const availableAccountOptions = getAvailableAccountOptions(
-    unlinkedAccounts,
+  const availableAccountOptions = getSelectableAccountOptions({
+    localAccounts,
+    selectedLocalAccountIds,
     chosenAccount,
+    syncSource,
     addOnBudgetAccountOption,
     addOffBudgetAccountOption,
-  );
+  });
 
   // Only show starting date options for new accounts being created
   const shouldShowStartingOptions = isNewAccountOption(

--- a/upcoming-release-notes/fix-bank-sync-relink-stale-accounts.md
+++ b/upcoming-release-notes/fix-bank-sync-relink-stale-accounts.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [mooons]
+---
+
+Allow previously linked bank-sync accounts to be selected again when reconnecting the same provider.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

When adding a newly opened AmEx card through SimpleFIN, the new card did not appear in Actual’s link-account flow until the AmEx connection was disconnected and reconnected in SimpleFIN.

After reconnecting AmEx, SimpleFIN returned the new card. However, Actual treated existing Actual accounts linked to the previous AmEx connection as unavailable in the "Link account" selector. This prevented users from relinking those existing accounts and pushed them toward creating duplicate accounts.

<img width="684" height="516" alt="1" src="https://github.com/user-attachments/assets/e1465391-e947-480d-ba40-44b88078d72e" />

This PR updates the selector logic to only reserve local accounts selected by external accounts present in the current link flow. Previously linked accounts from the same sync provider can now be selected again for relinking after reconnecting the provider, while accounts already chosen for visible rows remain unavailable to prevent duplicate selections.

A significant part of this change was drafted with OpenAI Codex (GPT-5.5 xhigh).

## Related issue(s)

n/a (I can file one if it is required)

## Testing

- Ran the focused Vitest test for the new selector helper:
  `node .yarn/releases/yarn-4.13.0.cjs workspace @actual-app/web test src/components/modals/selectLinkedAccounts.test.ts`
- Ran full typecheck:
  `node .yarn/releases/yarn-4.13.0.cjs typecheck`
- Ran formatter check on touched files:
  `node_modules/.bin/oxfmt --check ...`
- Ran oxlint on touched TypeScript files:
  `node_modules/.bin/oxlint --type-aware --quiet ...`
- Deployed and tested in my own Actual instance that it works as I expected. Existing accounts are selectable and they sync just fine.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+808 B) | +0.01%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+808 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +808 B (+2.09%) | 37.68 kB → 38.47 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB → 1.55 MB (+808 B) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 68.85 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.3 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 208.88 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 166.78 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 269.73 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->