### PR TITLE
[AI] resolve release-note PR links from base branch history

### DIFF
--- a/packages/ci-actions/bin/release-notes-generate.mjs
+++ b/packages/ci-actions/bin/release-notes-generate.mjs
@@ -22,6 +22,8 @@ if (!releaseBranch || !notesBranch || !version) {
   );
 }
 
+const baseBranch = 'master';
+
 const apiResult = await fetch('https://api.github.com/graphql', {
   method: 'POST',
   headers: {
@@ -94,10 +96,9 @@ const AUTOGEN_MARKER = '<!-- release-notes:auto-generated -->';
 
 await group('Prepare branch', async () => {
   // recover deleted release note files from previous generation commits
-  const baseRef = 'master';
-  await exec(`git fetch origin ${baseRef}`, { stdio: 'inherit' });
+  await exec(`git fetch origin ${baseBranch}`, { stdio: 'inherit' });
   const { stdout: mergeBase } = await exec(
-    `git merge-base HEAD origin/${baseRef}`,
+    `git merge-base HEAD origin/${baseBranch}`,
   );
   const base = mergeBase.trim();
   const { stdout: genLog } = await exec(
@@ -133,6 +134,7 @@ const { notesByCategory, files } = await parseReleaseNotes(
   'upcoming-release-notes',
   owner,
   repo,
+  `origin/${baseBranch}`,
 );
 const categorizedNotes = formatNotes(notesByCategory);
 

--- a/packages/ci-actions/src/release-notes/util.mjs
+++ b/packages/ci-actions/src/release-notes/util.mjs
@@ -21,7 +21,7 @@ export const categoryOrder = [
   'Maintenance',
 ];
 
-export async function parseReleaseNotes(dir, owner, repo) {
+export async function parseReleaseNotes(dir, owner, repo, historyRef) {
   const files = (await fs.readdir(dir)).filter(
     f => f.endsWith('.md') && f !== 'README.md',
   );
@@ -32,7 +32,7 @@ export async function parseReleaseNotes(dir, owner, repo) {
       data.authors.map(a => `@${a}`),
       { finalWord: '&' },
     );
-    const number = await resolvePrNumber(dir, name);
+    const number = await resolvePrNumber(dir, name, historyRef);
     const prefix = number
       ? `[#${number}](https://github.com/${owner}/${repo}/pull/${number}) `
       : '';
@@ -57,7 +57,7 @@ export async function parseReleaseNotes(dir, owner, repo) {
   return { notesByCategory, files };
 }
 
-async function resolvePrNumber(dir, name) {
+async function resolvePrNumber(dir, name, historyRef = 'HEAD') {
   const basename = name.replace(/\.md$/, '');
   if (/^\d+$/.test(basename)) {
     return basename;
@@ -70,6 +70,7 @@ async function resolvePrNumber(dir, name) {
       '-1',
       '--diff-filter=A',
       '--format=%s',
+      historyRef,
       '--',
       join(dir, name),
     ]);

--- a/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
+++ b/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [matt-fidd]
 ---
 
-Fix release note generation script to resolve links in cherry picked changes
+Fix release note generation script to resolve links in cherry-picked changes

--- a/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
+++ b/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Resolve PR links when generating release notes from the base branch history, so notes added to the release branch after it was cut still get linked

--- a/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
+++ b/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [matt-fidd]
 ---
 
-Resolve PR links when generating release notes from the base branch history, so notes added to the release branch after it was cut still get linked
+Fix release note generation script to resolve links in cherry picked changes


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Our release notes from cherry picked commits are being generated without links, this should fix it.

Eg. https://github.com/actualbudget/actual/pull/8332/changes/03697a188d12c51eee41011c5e07ad82154529f3

My first AI-driven PR, very odd! Don't think I'll do it much, but it was good to set off and see it work out what the problem was. Obviously checked it all over before I pushed.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
