### PR TITLE
📈 Usage Progressbar in budget page

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetProgress.test.ts
+++ b/packages/desktop-client/src/components/budget/BudgetProgress.test.ts
@@ -3,10 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { getUsageProgress } from './BudgetProgress';
 
 describe('getUsageProgress', () => {
-  it('skips usage when there is no budget', () => {
-    expect(getUsageProgress(0, -25)).toBeNull();
-  });
-
   it('maps normal spending to ten dashes', () => {
     expect(getUsageProgress(100, -50)).toEqual({
       percent: 0.5,

--- a/packages/desktop-client/src/components/budget/BudgetProgress.test.ts
+++ b/packages/desktop-client/src/components/budget/BudgetProgress.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getUsageProgress } from './BudgetProgress';
+
+describe('getUsageProgress', () => {
+  it('skips usage when there is no budget', () => {
+    expect(getUsageProgress(0, -25)).toBeNull();
+  });
+
+  it('maps normal spending to ten dashes', () => {
+    expect(getUsageProgress(100, -50)).toEqual({
+      percent: 0.5,
+      normalFilled: 5,
+      overflowLines: [],
+    });
+  });
+
+  it('adds overflow rows for overspending', () => {
+    expect(getUsageProgress(100, -225)).toEqual({
+      percent: 2.25,
+      normalFilled: 10,
+      overflowLines: [10, 3],
+    });
+  });
+});

--- a/packages/desktop-client/src/components/budget/BudgetProgress.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetProgress.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from 'react';
+
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+
+type UsageProgress = {
+  percent: number;
+  normalFilled: number;
+  overflowLines: number[];
+};
+
+const DASH_COUNT = 10;
+const MAX_OVERFLOW_LINES = 3;
+
+export function getUsageProgress(
+  budgeted: number,
+  spent: number,
+): UsageProgress | null {
+  const budgetAmount = Math.max(0, budgeted);
+  const spentAmount = Math.max(0, -spent);
+
+  if (budgetAmount <= 0) {
+    return null;
+  }
+
+  const percent = spentAmount / budgetAmount;
+  const overflowPercent = Math.max(percent - 1, 0);
+  const overflowLines = Array.from(
+    { length: Math.min(Math.ceil(overflowPercent), MAX_OVERFLOW_LINES) },
+    (_, index) =>
+      Math.min(Math.ceil((overflowPercent - index) * DASH_COUNT), DASH_COUNT),
+  );
+
+  return {
+    percent,
+    normalFilled: Math.min(Math.ceil(percent * DASH_COUNT), DASH_COUNT),
+    overflowLines,
+  };
+}
+
+export function UsageProgressDashes({
+  budgeted,
+  spent,
+}: {
+  budgeted: number;
+  spent: number;
+}) {
+  const progress = getUsageProgress(budgeted, spent);
+
+  if (!progress) {
+    return null;
+  }
+
+  const isOverflowing = progress.overflowLines.length > 0;
+  const dashHeight = isOverflowing ? 5 : 14;
+  const percentLabel = `${Math.round(progress.percent * 100)}%`;
+
+  function renderDashes(filled: number, color: string, height: number) {
+    return Array.from({ length: DASH_COUNT }, (_, index) => (
+      <View
+        key={index}
+        data-testid="usage-dash"
+        style={{
+          width: 3,
+          height,
+          borderRadius: 1,
+          backgroundColor: index < filled ? color : theme.tableBorder,
+          opacity: index < filled ? 1 : 0.35,
+        }}
+      />
+    ));
+  }
+
+  return (
+    <View
+      aria-label={percentLabel}
+      title={percentLabel}
+      style={{
+        gap: isOverflowing ? 2 : 0,
+        justifyContent: 'center',
+        alignItems: 'flex-end',
+      }}
+    >
+      <View style={{ flexDirection: 'row', gap: 3 }}>
+        {renderDashes(
+          progress.normalFilled,
+          theme.budgetNumberPositive,
+          dashHeight,
+        )}
+      </View>
+      {progress.overflowLines.map((filled, index) => (
+        <View key={index} style={{ flexDirection: 'row', gap: 3 }}>
+          {renderDashes(filled, theme.budgetNumberNegative, 5)}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+export function UsageCell({
+  progress,
+  balance,
+  balanceVisible = false,
+}: {
+  progress: ReactNode;
+  balance: ReactNode;
+  balanceVisible?: boolean;
+}) {
+  return (
+    <View
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr',
+        alignItems: 'center',
+        width: '100%',
+        minWidth: 0,
+        ':hover .usage-progress, :focus-within .usage-progress': {
+          opacity: 0,
+        },
+        ':hover .usage-balance, :focus-within .usage-balance': {
+          opacity: 1,
+        },
+      }}
+    >
+      <View
+        className="usage-progress"
+        style={{
+          gridArea: '1 / 1',
+          alignItems: 'flex-end',
+          opacity: balanceVisible ? 0 : 1,
+          transition: 'opacity .12s ease',
+        }}
+      >
+        {progress}
+      </View>
+      <View
+        className="usage-balance"
+        style={{
+          gridArea: '1 / 1',
+          alignItems: 'flex-end',
+          opacity: balanceVisible ? 1 : 0,
+          transition: 'opacity .12s ease',
+        }}
+      >
+        {balance}
+      </View>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/budget/BudgetProgress.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetProgress.tsx
@@ -20,7 +20,11 @@ export function getUsageProgress(
   const spentAmount = Math.max(0, -spent);
 
   if (budgetAmount <= 0) {
-    return null;
+    return {
+      percent: 0,
+      normalFilled: 0,
+      overflowLines: [],
+    };
   }
 
   const percent = spentAmount / budgetAmount;
@@ -65,7 +69,7 @@ export function UsageProgressDashes({
           height,
           borderRadius: 1,
           backgroundColor: index < filled ? color : theme.tableBorder,
-          opacity: index < filled ? 1 : 0.35,
+          opacity: index < filled ? 0.55 : 0.35,
         }}
       />
     ));
@@ -84,7 +88,7 @@ export function UsageProgressDashes({
       <View style={{ flexDirection: 'row', gap: 3 }}>
         {renderDashes(
           progress.normalFilled,
-          theme.budgetNumberPositive,
+          theme.buttonPrimaryBackground,
           dashHeight,
         )}
       </View>

--- a/packages/desktop-client/src/components/budget/BudgetTotals.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTotals.tsx
@@ -15,6 +15,7 @@ import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 
 import { useGlobalPref } from '#hooks/useGlobalPref';
+import { useLocalPref } from '#hooks/useLocalPref';
 
 import { RenderMonths } from './RenderMonths';
 import { getScrollbarWidth } from './util';
@@ -35,6 +36,9 @@ export const BudgetTotals = memo(function BudgetTotals({
   const { t } = useTranslation();
   const [categoryExpandedStatePref, setCategoryExpandedStatePref] =
     useGlobalPref('categoryExpandedState');
+  const [showProgressBars, setShowProgressBars] = useLocalPref(
+    'budget.showProgressBars',
+  );
   const categoryExpandedState = categoryExpandedStatePref ?? 0;
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef(null);
@@ -155,6 +159,8 @@ export const BudgetTotals = memo(function BudgetTotals({
             onMenuSelect={type => {
               if (type === 'toggle-visibility') {
                 toggleHiddenCategories();
+              } else if (type === 'toggle-progress-bars') {
+                setShowProgressBars(!showProgressBars);
               } else if (type === 'expandAllCategories') {
                 expandAllCategories();
               } else if (type === 'collapseAllCategories') {
@@ -166,6 +172,12 @@ export const BudgetTotals = memo(function BudgetTotals({
               {
                 name: 'toggle-visibility',
                 text: t('Toggle hidden categories'),
+              },
+              {
+                name: 'toggle-progress-bars',
+                text: showProgressBars
+                  ? t('Hide progress bars')
+                  : t('Show progress bars'),
               },
               {
                 name: 'expandAllCategories',

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -172,9 +172,6 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
   group,
 }: CategoryGroupMonthProps) {
   const { id } = group;
-  const [showProgressBars] = useLocalPref('budget.showProgressBars');
-  const budgeted = useEnvelopeSheetValue(envelopeBudget.groupBudgeted(id)) ?? 0;
-  const spent = useEnvelopeSheetValue(envelopeBudget.groupSumAmount(id)) ?? 0;
 
   return (
     <View
@@ -206,45 +203,20 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
           type: 'financial',
         }}
       />
-      {showProgressBars ? (
-        <Field
-          name="usage"
-          width="flex"
-          truncate={false}
-          style={{
-            fontWeight: 600,
-            paddingRight: styles.monthRightPadding,
-            ...styles.tnum,
-          }}
-        >
-          <UsageCell
-            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
-            balance={
-              <EnvelopeCellValue
-                binding={envelopeBudget.groupBalance(id)}
-                type="financial"
-              >
-                {props => <CellValueText {...props} />}
-              </EnvelopeCellValue>
-            }
-          />
-        </Field>
-      ) : (
-        <EnvelopeSheetCell
-          name="balance"
-          width="flex"
-          textAlign="right"
-          style={{
-            fontWeight: 600,
-            paddingRight: styles.monthRightPadding,
-            ...styles.tnum,
-          }}
-          valueProps={{
-            binding: envelopeBudget.groupBalance(id),
-            type: 'financial',
-          }}
-        />
-      )}
+      <EnvelopeSheetCell
+        name="balance"
+        width="flex"
+        textAlign="right"
+        style={{
+          fontWeight: 600,
+          paddingRight: styles.monthRightPadding,
+          ...styles.tnum,
+        }}
+        valueProps={{
+          binding: envelopeBudget.groupBalance(id),
+          type: 'financial',
+        }}
+      />
     </View>
   );
 });

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -17,6 +17,10 @@ import * as monthUtils from '@actual-app/core/shared/months';
 import { css } from '@emotion/css';
 
 import { BalanceWithCarryover } from '#components/budget/BalanceWithCarryover';
+import {
+  UsageCell,
+  UsageProgressDashes,
+} from '#components/budget/BudgetProgress';
 import { makeAmountGrey } from '#components/budget/util';
 import { NotesButton } from '#components/NotesButton';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
@@ -25,6 +29,7 @@ import type { SheetCellProps } from '#components/table';
 import { useCategoryScheduleGoalTemplateIndicator } from '#hooks/useCategoryScheduleGoalTemplateIndicator';
 import { useContextMenu } from '#hooks/useContextMenu';
 import { useFormat } from '#hooks/useFormat';
+import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
 import { useSheetName } from '#hooks/useSheetName';
 import { useSheetValue } from '#hooks/useSheetValue';
@@ -75,6 +80,10 @@ const cellStyle: CSSProperties = {
 };
 
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted = useEnvelopeSheetValue(envelopeBudget.totalBudgeted) ?? 0;
+  const spent = useEnvelopeSheetValue(envelopeBudget.totalSpent) ?? 0;
+
   return (
     <View
       style={{
@@ -109,14 +118,33 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
       </View>
       <View style={headerLabelStyle}>
         <Text style={{ color: theme.tableHeaderText }}>
-          <Trans>Balance</Trans>
+          {showProgressBars ? <Trans>Usage</Trans> : <Trans>Balance</Trans>}
         </Text>
-        <EnvelopeCellValue
-          binding={envelopeBudget.totalBalance}
-          type="financial"
-        >
-          {props => <CellValueText {...props} style={cellStyle} />}
-        </EnvelopeCellValue>
+        {showProgressBars ? (
+          <UsageCell
+            progress={
+              <UsageProgressDashes
+                budgeted={Math.abs(budgeted)}
+                spent={spent}
+              />
+            }
+            balance={
+              <EnvelopeCellValue
+                binding={envelopeBudget.totalBalance}
+                type="financial"
+              >
+                {props => <CellValueText {...props} style={cellStyle} />}
+              </EnvelopeCellValue>
+            }
+          />
+        ) : (
+          <EnvelopeCellValue
+            binding={envelopeBudget.totalBalance}
+            type="financial"
+          >
+            {props => <CellValueText {...props} style={cellStyle} />}
+          </EnvelopeCellValue>
+        )}
       </View>
     </View>
   );
@@ -144,6 +172,9 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
   group,
 }: CategoryGroupMonthProps) {
   const { id } = group;
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted = useEnvelopeSheetValue(envelopeBudget.groupBudgeted(id)) ?? 0;
+  const spent = useEnvelopeSheetValue(envelopeBudget.groupSumAmount(id)) ?? 0;
 
   return (
     <View
@@ -175,20 +206,45 @@ export const ExpenseGroupMonth = memo(function ExpenseGroupMonth({
           type: 'financial',
         }}
       />
-      <EnvelopeSheetCell
-        name="balance"
-        width="flex"
-        textAlign="right"
-        style={{
-          fontWeight: 600,
-          paddingRight: styles.monthRightPadding,
-          ...styles.tnum,
-        }}
-        valueProps={{
-          binding: envelopeBudget.groupBalance(id),
-          type: 'financial',
-        }}
-      />
+      {showProgressBars ? (
+        <Field
+          name="usage"
+          width="flex"
+          truncate={false}
+          style={{
+            fontWeight: 600,
+            paddingRight: styles.monthRightPadding,
+            ...styles.tnum,
+          }}
+        >
+          <UsageCell
+            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
+            balance={
+              <EnvelopeCellValue
+                binding={envelopeBudget.groupBalance(id)}
+                type="financial"
+              >
+                {props => <CellValueText {...props} />}
+              </EnvelopeCellValue>
+            }
+          />
+        </Field>
+      ) : (
+        <EnvelopeSheetCell
+          name="balance"
+          width="flex"
+          textAlign="right"
+          style={{
+            fontWeight: 600,
+            paddingRight: styles.monthRightPadding,
+            ...styles.tnum,
+          }}
+          valueProps={{
+            binding: envelopeBudget.groupBalance(id),
+            type: 'financial',
+          }}
+        />
+      )}
     </View>
   );
 });
@@ -203,6 +259,11 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
 }: CategoryMonthProps) {
   const { t } = useTranslation();
   const format = useFormat();
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted =
+    useEnvelopeSheetValue(envelopeBudget.catBudgeted(category.id)) ?? 0;
+  const spent =
+    useEnvelopeSheetValue(envelopeBudget.catSumAmount(category.id)) ?? 0;
 
   const budgetMenuTriggerRef = useRef(null);
   const balanceMenuTriggerRef = useRef(null);
@@ -471,41 +532,82 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
       </Field>
       <Field
         ref={balanceMenuTriggerRef}
-        name="balance"
+        name={showProgressBars ? 'usage' : 'balance'}
         width="flex"
+        truncate={!showProgressBars}
         style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
       >
-        <Button
-          variant="bare"
-          onPress={() => {
-            resetBalancePosition(-6, -4);
-            setBalanceMenuOpen(true);
-          }}
-          onContextMenu={e => {
-            handleBalanceContextMenu(e);
-            // We need to calculate differently from the hook due to being aligned to the right
-            const rect = e.currentTarget.getBoundingClientRect();
-            resetBalancePosition(
-              e.clientX - rect.right + 200 - 8,
-              e.clientY - rect.bottom - 8,
-            );
-          }}
-          style={{
-            justifyContent: 'flex-end',
-            background: 'transparent',
-            width: '100%',
-            padding: 0,
-          }}
-        >
-          <BalanceWithCarryover
-            carryover={envelopeBudget.catCarryover(category.id)}
-            balance={envelopeBudget.catBalance(category.id)}
-            goal={envelopeBudget.catGoal(category.id)}
-            budgeted={envelopeBudget.catBudgeted(category.id)}
-            longGoal={envelopeBudget.catLongGoal(category.id)}
-            tooltipDisabled={balanceMenuOpen}
+        {showProgressBars ? (
+          <UsageCell
+            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
+            balanceVisible={balanceMenuOpen}
+            balance={
+              <Button
+                variant="bare"
+                onPress={() => {
+                  resetBalancePosition(-6, -4);
+                  setBalanceMenuOpen(true);
+                }}
+                onContextMenu={e => {
+                  handleBalanceContextMenu(e);
+                  // We need to calculate differently from the hook due to being aligned to the right
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  resetBalancePosition(
+                    e.clientX - rect.right + 200 - 8,
+                    e.clientY - rect.bottom - 8,
+                  );
+                }}
+                style={{
+                  justifyContent: 'flex-end',
+                  background: 'transparent',
+                  width: '100%',
+                  padding: 0,
+                }}
+              >
+                <BalanceWithCarryover
+                  carryover={envelopeBudget.catCarryover(category.id)}
+                  balance={envelopeBudget.catBalance(category.id)}
+                  goal={envelopeBudget.catGoal(category.id)}
+                  budgeted={envelopeBudget.catBudgeted(category.id)}
+                  longGoal={envelopeBudget.catLongGoal(category.id)}
+                  tooltipDisabled={balanceMenuOpen}
+                />
+              </Button>
+            }
           />
-        </Button>
+        ) : (
+          <Button
+            variant="bare"
+            onPress={() => {
+              resetBalancePosition(-6, -4);
+              setBalanceMenuOpen(true);
+            }}
+            onContextMenu={e => {
+              handleBalanceContextMenu(e);
+              // We need to calculate differently from the hook due to being aligned to the right
+              const rect = e.currentTarget.getBoundingClientRect();
+              resetBalancePosition(
+                e.clientX - rect.right + 200 - 8,
+                e.clientY - rect.bottom - 8,
+              );
+            }}
+            style={{
+              justifyContent: 'flex-end',
+              background: 'transparent',
+              width: '100%',
+              padding: 0,
+            }}
+          >
+            <BalanceWithCarryover
+              carryover={envelopeBudget.catCarryover(category.id)}
+              balance={envelopeBudget.catBalance(category.id)}
+              goal={envelopeBudget.catGoal(category.id)}
+              budgeted={envelopeBudget.catBudgeted(category.id)}
+              longGoal={envelopeBudget.catLongGoal(category.id)}
+              tooltipDisabled={balanceMenuOpen}
+            />
+          </Button>
+        )}
 
         <Popover
           triggerRef={balanceMenuTriggerRef}

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -80,10 +80,6 @@ const cellStyle: CSSProperties = {
 };
 
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
-  const [showProgressBars] = useLocalPref('budget.showProgressBars');
-  const budgeted = useEnvelopeSheetValue(envelopeBudget.totalBudgeted) ?? 0;
-  const spent = useEnvelopeSheetValue(envelopeBudget.totalSpent) ?? 0;
-
   return (
     <View
       style={{
@@ -118,33 +114,14 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
       </View>
       <View style={headerLabelStyle}>
         <Text style={{ color: theme.tableHeaderText }}>
-          {showProgressBars ? <Trans>Usage</Trans> : <Trans>Balance</Trans>}
+          <Trans>Balance</Trans>
         </Text>
-        {showProgressBars ? (
-          <UsageCell
-            progress={
-              <UsageProgressDashes
-                budgeted={Math.abs(budgeted)}
-                spent={spent}
-              />
-            }
-            balance={
-              <EnvelopeCellValue
-                binding={envelopeBudget.totalBalance}
-                type="financial"
-              >
-                {props => <CellValueText {...props} style={cellStyle} />}
-              </EnvelopeCellValue>
-            }
-          />
-        ) : (
-          <EnvelopeCellValue
-            binding={envelopeBudget.totalBalance}
-            type="financial"
-          >
-            {props => <CellValueText {...props} style={cellStyle} />}
-          </EnvelopeCellValue>
-        )}
+        <EnvelopeCellValue
+          binding={envelopeBudget.totalBalance}
+          type="financial"
+        >
+          {props => <CellValueText {...props} style={cellStyle} />}
+        </EnvelopeCellValue>
       </View>
     </View>
   );

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -73,11 +73,6 @@ const cellStyle: CSSProperties = {
 };
 
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
-  const [showProgressBars] = useLocalPref('budget.showProgressBars');
-  const budgeted =
-    useTrackingSheetValue(trackingBudget.totalBudgetedExpense) ?? 0;
-  const spent = useTrackingSheetValue(trackingBudget.totalSpent) ?? 0;
-
   return (
     <View
       style={{
@@ -109,28 +104,14 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
       </View>
       <View style={headerLabelStyle}>
         <Text style={{ color: theme.tableHeaderText }}>
-          {showProgressBars ? <Trans>Usage</Trans> : <Trans>Balance</Trans>}
+          <Trans>Balance</Trans>
         </Text>
-        {showProgressBars ? (
-          <UsageCell
-            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
-            balance={
-              <TrackingCellValue
-                binding={trackingBudget.totalLeftover}
-                type="financial"
-              >
-                {props => <CellValueText {...props} style={cellStyle} />}
-              </TrackingCellValue>
-            }
-          />
-        ) : (
-          <TrackingCellValue
-            binding={trackingBudget.totalLeftover}
-            type="financial"
-          >
-            {props => <CellValueText {...props} style={cellStyle} />}
-          </TrackingCellValue>
-        )}
+        <TrackingCellValue
+          binding={trackingBudget.totalLeftover}
+          type="financial"
+        >
+          {props => <CellValueText {...props} style={cellStyle} />}
+        </TrackingCellValue>
       </View>
     </View>
   );

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -19,6 +19,10 @@ import { css } from '@emotion/css';
 import { t } from 'i18next';
 
 import { BalanceWithCarryover } from '#components/budget/BalanceWithCarryover';
+import {
+  UsageCell,
+  UsageProgressDashes,
+} from '#components/budget/BudgetProgress';
 import { makeAmountGrey } from '#components/budget/util';
 import { NotesButton } from '#components/NotesButton';
 import { CellValue, CellValueText } from '#components/spreadsheet/CellValue';
@@ -26,6 +30,7 @@ import { Field, SheetCell } from '#components/table';
 import type { SheetCellProps } from '#components/table';
 import { useCategoryScheduleGoalTemplateIndicator } from '#hooks/useCategoryScheduleGoalTemplateIndicator';
 import { useFormat } from '#hooks/useFormat';
+import { useLocalPref } from '#hooks/useLocalPref';
 import { useNavigate } from '#hooks/useNavigate';
 import { useSheetValue } from '#hooks/useSheetValue';
 import { useUndo } from '#hooks/useUndo';
@@ -68,6 +73,11 @@ const cellStyle: CSSProperties = {
 };
 
 export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted =
+    useTrackingSheetValue(trackingBudget.totalBudgetedExpense) ?? 0;
+  const spent = useTrackingSheetValue(trackingBudget.totalSpent) ?? 0;
+
   return (
     <View
       style={{
@@ -99,14 +109,28 @@ export const BudgetTotalsMonth = memo(function BudgetTotalsMonth() {
       </View>
       <View style={headerLabelStyle}>
         <Text style={{ color: theme.tableHeaderText }}>
-          <Trans>Balance</Trans>
+          {showProgressBars ? <Trans>Usage</Trans> : <Trans>Balance</Trans>}
         </Text>
-        <TrackingCellValue
-          binding={trackingBudget.totalLeftover}
-          type="financial"
-        >
-          {props => <CellValueText {...props} style={cellStyle} />}
-        </TrackingCellValue>
+        {showProgressBars ? (
+          <UsageCell
+            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
+            balance={
+              <TrackingCellValue
+                binding={trackingBudget.totalLeftover}
+                type="financial"
+              >
+                {props => <CellValueText {...props} style={cellStyle} />}
+              </TrackingCellValue>
+            }
+          />
+        ) : (
+          <TrackingCellValue
+            binding={trackingBudget.totalLeftover}
+            type="financial"
+          >
+            {props => <CellValueText {...props} style={cellStyle} />}
+          </TrackingCellValue>
+        )}
       </View>
     </View>
   );
@@ -140,6 +164,9 @@ export const GroupMonth = memo(function GroupMonth({
   group,
 }: CategoryGroupMonthProps) {
   const { id } = group;
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted = useTrackingSheetValue(trackingBudget.groupBudgeted(id)) ?? 0;
+  const spent = useTrackingSheetValue(trackingBudget.groupSumAmount(id)) ?? 0;
 
   return (
     <View
@@ -171,7 +198,31 @@ export const GroupMonth = memo(function GroupMonth({
           type: 'financial',
         }}
       />
-      {!group.is_income && (
+      {!group.is_income && showProgressBars && (
+        <Field
+          name="usage"
+          width="flex"
+          truncate={false}
+          style={{
+            fontWeight: 600,
+            paddingRight: styles.monthRightPadding,
+            ...styles.tnum,
+          }}
+        >
+          <UsageCell
+            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
+            balance={
+              <TrackingCellValue
+                binding={trackingBudget.groupBalance(id)}
+                type="financial"
+              >
+                {props => <CellValueText {...props} />}
+              </TrackingCellValue>
+            }
+          />
+        </Field>
+      )}
+      {!group.is_income && !showProgressBars && (
         <TrackingSheetCell
           name="balance"
           width="flex"
@@ -202,6 +253,11 @@ export const CategoryMonth = memo(function CategoryMonth({
   const [menuOpen, setMenuOpen] = useState(false);
   const triggerRef = useRef(null);
   const format = useFormat();
+  const [showProgressBars] = useLocalPref('budget.showProgressBars');
+  const budgeted =
+    useTrackingSheetValue(trackingBudget.catBudgeted(category.id)) ?? 0;
+  const spent =
+    useTrackingSheetValue(trackingBudget.catSumAmount(category.id)) ?? 0;
 
   const [balanceMenuOpen, setBalanceMenuOpen] = useState(false);
   const triggerBalanceMenuRef = useRef(null);
@@ -459,30 +515,62 @@ export const CategoryMonth = memo(function CategoryMonth({
 
       {!category.is_income && (
         <Field
-          name="balance"
+          name={showProgressBars ? 'usage' : 'balance'}
           width="flex"
+          truncate={!showProgressBars}
           style={{ paddingRight: styles.monthRightPadding, textAlign: 'right' }}
         >
-          <Button
-            variant="bare"
-            ref={triggerBalanceMenuRef}
-            onPress={() => !category.is_income && setBalanceMenuOpen(true)}
-            style={{
-              justifyContent: 'flex-end',
-              background: 'transparent',
-              width: '100%',
-              padding: 0,
-            }}
-          >
-            <BalanceWithCarryover
-              isDisabled={category.is_income}
-              carryover={trackingBudget.catCarryover(category.id)}
-              balance={trackingBudget.catBalance(category.id)}
-              goal={trackingBudget.catGoal(category.id)}
-              budgeted={trackingBudget.catBudgeted(category.id)}
-              longGoal={trackingBudget.catLongGoal(category.id)}
+          {showProgressBars ? (
+            <UsageCell
+              progress={
+                <UsageProgressDashes budgeted={budgeted} spent={spent} />
+              }
+              balanceVisible={balanceMenuOpen}
+              balance={
+                <Button
+                  variant="bare"
+                  ref={triggerBalanceMenuRef}
+                  onPress={() => setBalanceMenuOpen(true)}
+                  style={{
+                    justifyContent: 'flex-end',
+                    background: 'transparent',
+                    width: '100%',
+                    padding: 0,
+                  }}
+                >
+                  <BalanceWithCarryover
+                    isDisabled={category.is_income}
+                    carryover={trackingBudget.catCarryover(category.id)}
+                    balance={trackingBudget.catBalance(category.id)}
+                    goal={trackingBudget.catGoal(category.id)}
+                    budgeted={trackingBudget.catBudgeted(category.id)}
+                    longGoal={trackingBudget.catLongGoal(category.id)}
+                  />
+                </Button>
+              }
             />
-          </Button>
+          ) : (
+            <Button
+              variant="bare"
+              ref={triggerBalanceMenuRef}
+              onPress={() => setBalanceMenuOpen(true)}
+              style={{
+                justifyContent: 'flex-end',
+                background: 'transparent',
+                width: '100%',
+                padding: 0,
+              }}
+            >
+              <BalanceWithCarryover
+                isDisabled={category.is_income}
+                carryover={trackingBudget.catCarryover(category.id)}
+                balance={trackingBudget.catBalance(category.id)}
+                goal={trackingBudget.catGoal(category.id)}
+                budgeted={trackingBudget.catBudgeted(category.id)}
+                longGoal={trackingBudget.catLongGoal(category.id)}
+              />
+            </Button>
+          )}
 
           <Popover
             triggerRef={triggerBalanceMenuRef}

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -164,9 +164,6 @@ export const GroupMonth = memo(function GroupMonth({
   group,
 }: CategoryGroupMonthProps) {
   const { id } = group;
-  const [showProgressBars] = useLocalPref('budget.showProgressBars');
-  const budgeted = useTrackingSheetValue(trackingBudget.groupBudgeted(id)) ?? 0;
-  const spent = useTrackingSheetValue(trackingBudget.groupSumAmount(id)) ?? 0;
 
   return (
     <View
@@ -198,31 +195,7 @@ export const GroupMonth = memo(function GroupMonth({
           type: 'financial',
         }}
       />
-      {!group.is_income && showProgressBars && (
-        <Field
-          name="usage"
-          width="flex"
-          truncate={false}
-          style={{
-            fontWeight: 600,
-            paddingRight: styles.monthRightPadding,
-            ...styles.tnum,
-          }}
-        >
-          <UsageCell
-            progress={<UsageProgressDashes budgeted={budgeted} spent={spent} />}
-            balance={
-              <TrackingCellValue
-                binding={trackingBudget.groupBalance(id)}
-                type="financial"
-              >
-                {props => <CellValueText {...props} />}
-              </TrackingCellValue>
-            }
-          />
-        </Field>
-      )}
-      {!group.is_income && !showProgressBars && (
+      {!group.is_income && (
         <TrackingSheetCell
           name="balance"
           width="flex"

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -89,6 +89,7 @@ export type LocalPrefs = Partial<{
   'budget.collapsed': string[];
   'budget.summaryCollapsed': boolean;
   'budget.showHiddenCategories': boolean;
+  'budget.showProgressBars': boolean;
   'budget.startMonth': string;
   'flags.updateNotificationShownForVersion': string;
   'schedules.showCompleted': boolean;

--- a/upcoming-release-notes/usage-progressbar.md
+++ b/upcoming-release-notes/usage-progressbar.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [lelemm, tbuist]
 ---
 
-Add optional usage progress bars that hide balances until hovered in the budget page.
+Add optional usage progress bars that hide balances until hovered or focused in the budget page.

--- a/upcoming-release-notes/usage-progressbar.md
+++ b/upcoming-release-notes/usage-progressbar.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [lelemm, tbuist]
+---
+
+Add optional usage progress bars that hide balances until hovered in the budget page.


### PR DESCRIPTION
Instead of showing balance, shows a visual progress bar. This help us folks that are more visual =p
This was inspired by an old PR from [tbuist](https://github.com/tbuist/actual) https://github.com/actualbudget/actual/pull/4371
Envelope:
<img width="741" height="901" alt="image" src="https://github.com/user-attachments/assets/c7454b08-6beb-44c4-a64f-1a8ed1ffb30c" />
Tracking:
<img width="768" height="888" alt="image" src="https://github.com/user-attachments/assets/c5ab5043-408b-4a2a-a3e7-cf7fb52d23f5" />

when hovering:

<img width="342" height="356" alt="image" src="https://github.com/user-attachments/assets/2efa9ccb-66f6-4d2d-81c6-056cef9926a9" />

togglable at:

<img width="274" height="237" alt="image" src="https://github.com/user-attachments/assets/667a7ff4-7241-4df2-a8d8-e956aef7947c" />

disabled by default

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.12 MB → 13.13 MB (+7.21 kB) | +0.05%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.87 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.12 MB → 13.13 MB (+7.21 kB) | +0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/BudgetProgress.tsx` | 🆕 +4.66 kB | 0 B → 4.66 kB
`src/components/budget/BudgetTotals.tsx` | 📈 +696 B (+9.21%) | 7.38 kB → 8.06 kB
`src/components/budget/tracking/TrackingBudgetComponents.tsx` | 📈 +1.33 kB (+6.91%) | 19.18 kB → 20.51 kB
`src/components/budget/envelope/EnvelopeBudgetComponents.tsx` | 📈 +550 B (+1.89%) | 28.47 kB → 29.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.64 MB (+6.53 kB) | +0.08%
static/js/wide.js | 306.06 kB → 306.74 kB (+696 B) | +0.22%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.24 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 200.96 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.48 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BI4lxjlp.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.87 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.87 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->