### PR TITLE
recognise EUA expired GoCardless responses

### DIFF
--- a/packages/sync-server/src/app-gocardless/app-gocardless.ts
+++ b/packages/sync-server/src/app-gocardless/app-gocardless.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   AccountNotLinkedToRequisition,
+  EndUserAgreementExpiredError,
   GenericGoCardlessError,
   GoCardlessClientError,
   RateLimitError,
@@ -274,6 +275,7 @@ app.post(
 
       switch (true) {
         case error instanceof RequisitionNotLinked:
+        case error instanceof EndUserAgreementExpiredError:
           sendErrorResponse({
             error_type: 'ITEM_ERROR',
             error_code: 'ITEM_LOGIN_REQUIRED',

--- a/packages/sync-server/src/app-gocardless/errors.ts
+++ b/packages/sync-server/src/app-gocardless/errors.ts
@@ -51,6 +51,12 @@ export class InvalidGoCardlessTokenError extends GoCardlessClientError {
   }
 }
 
+export class EndUserAgreementExpiredError extends GoCardlessClientError {
+  constructor(response: unknown) {
+    super('End User Agreement (EUA) has expired', response);
+  }
+}
+
 export class AccessDeniedError extends GoCardlessClientError {
   constructor(response: unknown) {
     super('IP address access denied', response);

--- a/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
+++ b/packages/sync-server/src/app-gocardless/services/gocardless-service.ts
@@ -5,6 +5,7 @@ import type { IBank } from '#app-gocardless/banks/bank.interface';
 import {
   AccessDeniedError,
   AccountNotLinkedToRequisition,
+  EndUserAgreementExpiredError,
   GenericGoCardlessError,
   InvalidGoCardlessTokenError,
   InvalidInputDataError,
@@ -59,6 +60,22 @@ const getGocardlessClient = (): GoCardlessApi => {
   return client;
 };
 
+const isEuaExpiredError = (error: unknown): boolean => {
+  if (!(error instanceof GoCardlessApiError)) {
+    return false;
+  }
+
+  const data: unknown = error.response.data;
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const { summary } = data as Record<string, unknown>;
+  return (
+    typeof summary === 'string' && /end user agreement.*expired/i.test(summary)
+  );
+};
+
 export const handleGoCardlessError = (error: unknown): never => {
   const status =
     error instanceof GoCardlessApiError ? error.response.status : undefined;
@@ -67,6 +84,9 @@ export const handleGoCardlessError = (error: unknown): never => {
     case 400:
       throw new InvalidInputDataError(error);
     case 401:
+      if (isEuaExpiredError(error)) {
+        throw new EndUserAgreementExpiredError(error);
+      }
       throw new InvalidGoCardlessTokenError(error);
     case 403:
       throw new AccessDeniedError(error);

--- a/packages/sync-server/src/app-gocardless/services/tests/gocardless-service.spec.ts
+++ b/packages/sync-server/src/app-gocardless/services/tests/gocardless-service.spec.ts
@@ -3,6 +3,7 @@ import type { MockInstance } from 'vitest';
 import {
   AccessDeniedError,
   AccountNotLinkedToRequisition,
+  EndUserAgreementExpiredError,
   GenericGoCardlessError,
   InvalidGoCardlessTokenError,
   InvalidInputDataError,
@@ -564,6 +565,33 @@ describe('#handleGoCardlessError', () => {
 
   it('throws InvalidGoCardlessTokenError for status code 401', () => {
     expect(() => handleGoCardlessError(apiError(401))).toThrow(
+      InvalidGoCardlessTokenError,
+    );
+  });
+
+  it('throws EndUserAgreementExpiredError for status code 401 with an expired EUA', () => {
+    const error = apiError(401);
+    error.response.data = {
+      summary:
+        'End User Agreement (EUA) 76c790ff-274b-46cc-8c5e-1aefb2bee25f has expired',
+      detail:
+        'EUA was valid for 90 days and it expired at 2026-06-30 15:57:27.203016+00:00. The end user must connect the account once more with new EUA and Requisition',
+      status_code: 401,
+    };
+
+    expect(() => handleGoCardlessError(error)).toThrow(
+      EndUserAgreementExpiredError,
+    );
+  });
+
+  it('throws InvalidGoCardlessTokenError for status code 401 with an unrelated body', () => {
+    const error = apiError(401);
+    error.response.data = {
+      summary: 'Authentication credentials were not provided.',
+      status_code: 401,
+    };
+
+    expect(() => handleGoCardlessError(error)).toThrow(
       InvalidGoCardlessTokenError,
     );
   });

--- a/upcoming-release-notes/gocardless-eua-expired-reauth.md
+++ b/upcoming-release-notes/gocardless-eua-expired-reauth.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Recognise GoCardless responses advising that the EUA has expired as relink requests


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Found in my own budget

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Actual pointed me to relink instead of the generic error after this patch

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
