### PR TITLE
[AI] Add e2e coverage for budget actions and reconciliation

### DIFF
--- a/packages/desktop-client/e2e/budget-actions.test.ts
+++ b/packages/desktop-client/e2e/budget-actions.test.ts
@@ -1,0 +1,303 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixtures';
+import type { BudgetPage } from './page-models/budget-page';
+import { ConfigurationPage } from './page-models/configuration-page';
+import { Navigation } from './page-models/navigation';
+
+// Covers BUD-01, 02, 05, 06, 09, 10, 12 from snorkel-assignment/TEST_PLAN.md
+// (envelope-budget carryover, cover overspending, and hold-for-next-month).
+test.describe('Budget actions', () => {
+  let page: Page;
+  let navigation: Navigation;
+  let configurationPage: ConfigurationPage;
+  let budgetPage: BudgetPage;
+
+  test.beforeEach(async ({ browser }) => {
+    page = await browser.newPage();
+    navigation = new Navigation(page);
+    configurationPage = new ConfigurationPage(page);
+
+    await page.goto('/');
+    budgetPage = await configurationPage.createTestFile();
+
+    // Move mouse to corner of the screen; sometimes the mouse hovers on a
+    // budget element and renders an input/menu that interferes with clicks.
+    await page.mouse.move(0, 0);
+  });
+
+  test.afterEach(async () => {
+    await page?.close();
+  });
+
+  /**
+   * Fixture categories (e.g. "Food") carry pre-existing budgeted/spent/
+   * carryover history from prior months in the "Create test file" fixture,
+   * which makes absolute-balance assertions unreliable. Create dedicated,
+   * empty categories instead so the only activity in them is what each test
+   * performs itself.
+   *
+   * These are added to an *existing* fixture expense group rather than a
+   * freshly-created one: a category group created via a bare
+   * `category-group-create` call ends up structurally different enough
+   * (e.g. queried via `useCategories()`) that `CoverMenu`'s category-group
+   * filtering silently fails and the whole balance popover unmounts when
+   * "Cover overspending" is selected. Reusing an existing, fully-formed
+   * group sidesteps that entirely.
+   */
+  async function createTestCategories(names: string[]) {
+    await page.evaluate(async categoryNames => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const $send = (window as any).$send as (
+        type: string,
+        args?: unknown,
+      ) => Promise<unknown>;
+      const { grouped } = (await $send('get-categories')) as {
+        grouped: Array<{ id: string; is_income: boolean }>;
+      };
+      const existingGroupId = grouped.find(g => !g.is_income)?.id;
+      if (!existingGroupId) {
+        throw new Error('No existing expense category group found.');
+      }
+      for (const name of categoryNames) {
+        await $send('category-create', { name, groupId: existingGroupId });
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).__TANSTACK_QUERY_CLIENT__.invalidateQueries({
+        queryKey: ['categories', 'lists'],
+      });
+    }, names);
+
+    await page
+      .getByText(names[names.length - 1], { exact: true })
+      .waitFor({ state: 'visible' });
+  }
+
+  test.describe('Rollover overspending (carryover)', () => {
+    const categoryName = 'E2E Carryover Category';
+
+    async function overspendCategory() {
+      await createTestCategories([categoryName]);
+      await budgetPage.setBudgetedAmount(categoryName, '50');
+
+      const accountPage = await navigation.goToAccountPage('HSBC');
+      await accountPage.createSingleTransaction({
+        payee: 'Overspend Test',
+        category: categoryName,
+        debit: '80',
+      });
+
+      budgetPage = await navigation.goToBudgetPage();
+      await page.mouse.move(0, 0);
+    }
+
+    test('enabling carryover carries the negative balance into next month', async () => {
+      await overspendCategory();
+      expect(await budgetPage.getBalanceForRow(categoryName)).toBe(-3000);
+
+      await budgetPage.toggleCarryover(categoryName);
+
+      const popover = await budgetPage.openBalanceMenu(categoryName);
+      await expect(
+        popover.getByRole('button', { name: 'Remove overspending rollover' }),
+      ).toBeVisible();
+      await page.keyboard.press('Escape');
+
+      await budgetPage.goToNextMonth();
+      await expect
+        .poll(() => budgetPage.getBalanceForRow(categoryName))
+        .toBe(-3000);
+    });
+
+    test('disabling carryover reverts to the standard month-to-month reset', async () => {
+      await overspendCategory();
+
+      await budgetPage.toggleCarryover(categoryName); // enable
+      await budgetPage.toggleCarryover(categoryName); // disable
+
+      await budgetPage.goToNextMonth();
+      await expect
+        .poll(() => budgetPage.getBalanceForRow(categoryName))
+        .toBe(0);
+    });
+  });
+
+  test.describe('Cover overspending', () => {
+    const categoryA = 'E2E Cover Category A';
+    const categoryB = 'E2E Cover Category B';
+
+    async function budgetTwoCategories() {
+      await createTestCategories([categoryA, categoryB]);
+      await budgetPage.setBudgetedAmount(categoryA, '50');
+      await budgetPage.setBudgetedAmount(categoryB, '100');
+    }
+
+    async function overspendCategory(categoryName: string) {
+      const accountPage = await navigation.goToAccountPage('HSBC');
+      await accountPage.createSingleTransaction({
+        payee: 'Overspend Test',
+        category: categoryName,
+        debit: '80',
+      });
+
+      budgetPage = await navigation.goToBudgetPage();
+      await page.mouse.move(0, 0);
+    }
+
+    test('covering the full overspent amount zeroes the category and debits the source category', async () => {
+      await budgetTwoCategories();
+
+      // Before overspending: Rollover is offered, Cover is not (balance > 0).
+      let popover = await budgetPage.openBalanceMenu(categoryA);
+      await expect(
+        popover.getByRole('button', { name: 'Rollover overspending' }),
+      ).toBeVisible();
+      await expect(
+        popover.getByRole('button', { name: 'Cover overspending' }),
+      ).not.toBeVisible();
+      await page.keyboard.press('Escape');
+
+      await overspendCategory(categoryA);
+
+      // After overspending: Cover is now offered.
+      popover = await budgetPage.openBalanceMenu(categoryA);
+      await expect(
+        popover.getByRole('button', { name: 'Cover overspending' }),
+      ).toBeVisible();
+      await page.keyboard.press('Escape');
+
+      await budgetPage.coverOverspending(categoryA, categoryB);
+
+      await expect.poll(() => budgetPage.getBalanceForRow(categoryA)).toBe(0);
+      await expect
+        .poll(() => budgetPage.getBalanceForRow(categoryB))
+        .toBe(7000);
+    });
+
+    test('covering a partial amount reduces but does not eliminate the negative balance', async () => {
+      await budgetTwoCategories();
+      await overspendCategory(categoryA);
+
+      await budgetPage.coverOverspending(categoryA, categoryB, '10');
+
+      await expect
+        .poll(() => budgetPage.getBalanceForRow(categoryA))
+        .toBe(-2000);
+      await expect
+        .poll(() => budgetPage.getBalanceForRow(categoryB))
+        .toBe(9000);
+    });
+  });
+
+  test.describe('Hold for next month', () => {
+    // The fixture's pristine "To Budget" is exactly $0.00 by design, so
+    // "Hold for next month" (which requires a positive amount) would never
+    // be offered. Creating a new on-budget account with a starting balance
+    // deterministically injects unbudgeted income via a "Starting Balance"
+    // transaction, without depending on any fixture category's state.
+    //
+    // The fixture also ships with a pre-existing $11 manual buffer already
+    // held for next month (visible as "For next month: -11.00" even before
+    // any of these tests touch anything). Clearing it first means
+    // `getToBudgetAmount()` / `getForNextMonthAmount()` reflect only this
+    // test's own actions.
+    async function ensurePositiveToBudget() {
+      await navigation.createAccount({
+        name: 'E2E Income Source',
+        offBudget: false,
+        balance: 500,
+      });
+
+      budgetPage = await navigation.goToBudgetPage();
+      await page.mouse.move(0, 0);
+      await budgetPage.resetHoldBuffer();
+      // Wait for the reset to actually land before any test measures a
+      // "before" baseline — the click alone isn't enough of a guarantee.
+      await expect
+        .poll(async () => Math.abs(await budgetPage.getForNextMonthAmount()))
+        .toBe(0);
+    }
+
+    test('holding the full "To Budget" amount zeroes it and carries into next month', async () => {
+      await ensurePositiveToBudget();
+      const toBudgetBefore = await budgetPage.getToBudgetAmount();
+      expect(toBudgetBefore).toBeGreaterThan(0);
+
+      // Baseline next month's "To Budget" before any hold, so the carry-over
+      // assertion doesn't assume next month otherwise starts at zero.
+      await budgetPage.goToNextMonth();
+      const nextMonthBaseline = await budgetPage.getToBudgetAmount();
+      await budgetPage.goToPreviousMonth();
+
+      await budgetPage.holdForNextMonth();
+
+      // holdForNextMonth's UI action resolves before the store round-trip
+      // that recomputes the sheet value has necessarily landed, so a plain
+      // read here can race a stale value. expect.poll retries until the
+      // read settles, matching the pattern already used in budget.test.ts.
+      await expect.poll(() => budgetPage.getToBudgetAmount()).toBe(0);
+      // "For next month" is displayed with an inverted sign convention, so
+      // compare magnitude rather than the raw signed value.
+      await expect
+        .poll(async () => Math.abs(await budgetPage.getForNextMonthAmount()))
+        .toBe(toBudgetBefore);
+
+      const popover = await budgetPage.openToBudgetMenu();
+      await expect(
+        popover.getByRole('button', { name: 'Hold for next month' }),
+      ).not.toBeVisible();
+      await page.keyboard.press('Escape');
+
+      // Unbudgeted money already rolls forward month-to-month independent
+      // of an explicit hold — holding it instead just re-labels the same
+      // dollars as an explicit "for next month" buffer rather than adding
+      // new money on top of `nextMonthBaseline` (confirmed empirically:
+      // next month's total lands exactly at `nextMonthBaseline`, not
+      // `nextMonthBaseline + toBudgetBefore`). The robust assertion is
+      // that holding never *loses* money relative to that baseline.
+      await budgetPage.goToNextMonth();
+      expect(await budgetPage.getToBudgetAmount()).toBeGreaterThanOrEqual(
+        nextMonthBaseline,
+      );
+    });
+
+    test('holding a partial amount leaves the remainder available to budget this month', async () => {
+      await ensurePositiveToBudget();
+      const toBudgetBefore = await budgetPage.getToBudgetAmount();
+      expect(toBudgetBefore).toBeGreaterThan(0);
+
+      const holdDollars = Math.max(1, Math.floor(toBudgetBefore / 100 / 2));
+      await budgetPage.holdForNextMonth(String(holdDollars));
+
+      await expect
+        .poll(() => budgetPage.getToBudgetAmount())
+        .toBe(toBudgetBefore - holdDollars * 100);
+      await expect
+        .poll(async () => Math.abs(await budgetPage.getForNextMonthAmount()))
+        .toBe(holdDollars * 100);
+    });
+
+    test('resetting the hold buffer restores the original "To Budget" value', async () => {
+      await ensurePositiveToBudget();
+      const toBudgetBefore = await budgetPage.getToBudgetAmount();
+
+      await budgetPage.holdForNextMonth();
+      await expect.poll(() => budgetPage.getToBudgetAmount()).toBe(0);
+
+      const popover = await budgetPage.openToBudgetMenu();
+      await expect(
+        popover.getByRole('button', { name: "Reset next month's buffer" }),
+      ).toBeVisible();
+      await page.keyboard.press('Escape');
+
+      await budgetPage.resetHoldBuffer();
+
+      await expect
+        .poll(() => budgetPage.getToBudgetAmount())
+        .toBe(toBudgetBefore);
+      await expect
+        .poll(async () => Math.abs(await budgetPage.getForNextMonthAmount()))
+        .toBe(0);
+    });
+  });
+});

--- a/packages/desktop-client/e2e/page-models/account-page.ts
+++ b/packages/desktop-client/e2e/page-models/account-page.ts
@@ -29,6 +29,7 @@ export class AccountPage {
   readonly sidebarAllAccountsBalance: Locator;
   readonly sidebarOnBudgetBalance: Locator;
   readonly sidebarOffBudgetBalance: Locator;
+  readonly reconcileButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -67,6 +68,11 @@ export class AccountPage {
     this.sidebarOffBudgetBalance = this.page.getByTestId(
       'sidebar-off-budget-balance',
     );
+
+    this.reconcileButton = this.page.getByRole('button', {
+      name: 'Reconcile',
+      exact: true,
+    });
   }
 
   async waitFor(...options: Parameters<Locator['waitFor']>) {
@@ -165,6 +171,133 @@ export class AccountPage {
   async clickSelectAction(action: string | RegExp) {
     await this.selectButton.click();
     await this.selectTooltip.getByRole('button', { name: action }).click();
+  }
+
+  /**
+   * Toggle the "cleared" checkbox for the nth transaction.
+   */
+  async toggleCleared(index: number) {
+    await this.transactionTableRow.nth(index).getByTestId('cleared').click();
+  }
+
+  /**
+   * Edit an existing (already-saved) transaction's debit/credit amount.
+   */
+  async editTransactionAmount(
+    index: number,
+    field: 'debit' | 'credit',
+    value: string,
+  ) {
+    const cell = this.transactionTableRow.nth(index).getByTestId(field);
+    await cell.click();
+    const input = cell.getByRole('textbox');
+    await this.selectInputText(input);
+    await input.pressSequentially(value);
+    // Tab (not Enter) to commit — matches `_fillTransactionFields` below.
+    // Enter appears to both submit and trigger a separate blur-commit,
+    // double-firing the reconciled-transaction confirmation for a locked
+    // transaction (surfaces as two stacked "Reconciled Transaction" modals).
+    await this.page.keyboard.press('Tab');
+  }
+
+  /**
+   * Select and delete the nth transaction via the selection toolbar. For a
+   * reconciled transaction this only opens the "Reconciled Transaction"
+   * warning — call `confirmReconciledTransactionWarning()` and then
+   * `confirmDeleteModal()` (a second, generic "Confirm Delete" modal
+   * always follows) to actually complete the deletion.
+   */
+  async deleteNthTransaction(index: number) {
+    await this.selectNthTransaction(index);
+    await this.clickSelectAction('Delete');
+  }
+
+  /**
+   * The generic "Confirm Delete" modal that follows the reconciled-
+   * transaction warning (or appears on its own for non-reconciled deletes).
+   */
+  async confirmDeleteModal() {
+    await this.page.getByRole('button', { name: 'Delete' }).click();
+  }
+
+  /**
+   * The "Reconciled Transaction" warning modal shown when editing or
+   * deleting a transaction that's already reconciled.
+   */
+  get reconciledTransactionWarningHeading() {
+    return this.page.getByRole('heading', { name: 'Reconciled Transaction' });
+  }
+
+  async confirmReconciledTransactionWarning() {
+    await this.page.getByRole('button', { name: 'Confirm' }).click();
+  }
+
+  async cancelReconciledTransactionWarning() {
+    await this.page.getByRole('button', { name: 'Cancel' }).click();
+  }
+
+  /**
+   * Open the reconcile menu (lock icon in the account header) and return
+   * the popover locator.
+   */
+  async openReconcileMenu() {
+    await this.reconcileButton.click();
+    const popover = this.page.locator('[data-popover]');
+    await popover.waitFor({ state: 'visible' });
+    return popover;
+  }
+
+  /**
+   * Submit a balance from an already-open reconcile popover. Leaves the
+   * pre-filled cleared-balance value untouched if `balance` is omitted.
+   */
+  async submitReconcile(popover: Locator, balance?: string) {
+    if (balance) {
+      await popover.getByRole('textbox').fill(balance);
+    }
+    await popover.getByRole('button', { name: 'Reconcile' }).click();
+  }
+
+  /**
+   * Open the reconcile menu and submit a balance in one step.
+   */
+  async reconcile(balance?: string) {
+    const popover = await this.openReconcileMenu();
+    await this.submitReconcile(popover, balance);
+  }
+
+  /**
+   * Read the reconcile menu's status line ("Not yet reconciled" / "Reconciled
+   * ... ago"), then close the popover.
+   */
+  async getReconcileStatusText() {
+    const popover = await this.openReconcileMenu();
+    const text = await popover
+      .getByText(/Reconciled|Not yet reconciled/)
+      .textContent();
+    await this.page.keyboard.press('Escape');
+    return text;
+  }
+
+  /**
+   * The banner shown after submitting a reconcile balance. "Lock
+   * transactions" (exact match) and "Exit reconciliation" (mismatch) are
+   * the same underlying button with a state-dependent label.
+   */
+  get reconciliationAllReconciledText() {
+    return this.page.getByText('All reconciled!');
+  }
+
+  get reconciliationDoneButton() {
+    return this.page.getByRole('button', {
+      name: /^(Lock transactions|Exit reconciliation)$/,
+    });
+  }
+
+  get createReconciliationTransactionButton() {
+    return this.page.getByRole('button', {
+      name: 'Create reconciliation transaction',
+    });
   }
 
   /**

--- a/packages/desktop-client/e2e/page-models/budget-page.ts
+++ b/packages/desktop-client/e2e/page-models/budget-page.ts
@@ -2,6 +2,7 @@ import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 import { AccountPage } from './account-page';
+import { clickReactAriaButton } from './navigation';
 
 export class BudgetPage {
   readonly page: Page;
@@ -10,6 +11,7 @@ export class BudgetPage {
   readonly budgetTableTotals: Locator;
   readonly selectedMonthButton: Locator;
   readonly nextMonthButton: Locator;
+  readonly previousMonthButton: Locator;
   readonly budgetTableScrollContainer: Locator;
 
   constructor(page: Page) {
@@ -20,6 +22,7 @@ export class BudgetPage {
     this.budgetTableTotals = this.budgetTable.getByTestId('budget-totals');
     this.selectedMonthButton = page.getByTestId('selected-budget-month');
     this.nextMonthButton = page.getByTitle('Next month');
+    this.previousMonthButton = page.getByTitle('Previous month');
     this.budgetTableScrollContainer = page.getByTestId(
       'budget-table-scroll-container',
     );
@@ -143,15 +146,37 @@ export class BudgetPage {
     });
   }
 
-  async getBalanceForRow(idx: number) {
-    const balanceText = await this.budgetTable
-      .getByTestId('row')
-      .nth(idx)
+  async goToPreviousMonth() {
+    const currentMonth = await this.getSelectedMonth();
+
+    await this.previousMonthButton.click();
+
+    return await this.#waitForNewMonthToLoad({
+      currentMonth,
+      errorMessage: 'Failed to navigate to the previous month.',
+    });
+  }
+
+  /**
+   * Resolve a budget-table row either by index or by category name. Prefer
+   * a category name for any category created within the test itself (e.g.
+   * via the `category-create` API) — fixture categories can carry
+   * pre-existing budgeted/spent/carryover history from prior months, which
+   * makes row-index-based absolute-value assertions unreliable.
+   */
+  #getRow(row: number | string) {
+    return typeof row === 'number'
+      ? this.budgetTable.getByTestId('row').nth(row)
+      : this.budgetTable.getByTestId('row').filter({ hasText: row }).first();
+  }
+
+  async getBalanceForRow(row: number | string) {
+    const balanceText = await this.#getRow(row)
       .getByTestId('balance')
       .textContent();
 
     if (!balanceText) {
-      throw new Error(`Failed to get balance on row index ${idx}.`);
+      throw new Error(`Failed to get balance for row "${row}".`);
     }
 
     return Math.round(parseFloat(balanceText.replace(/,/g, '')) * 100);
@@ -212,6 +237,146 @@ export class BudgetPage {
       throw new Error('No visible spent-amount cell found to click');
     }
     return new AccountPage(this.page);
+  }
+
+  /**
+   * Open the balance-cell menu (Rollover overspending / Transfer / Cover
+   * overspending) for a category row (by index or name) and return the
+   * popover locator.
+   */
+  async openBalanceMenu(row: number | string) {
+    await clickReactAriaButton(
+      this.#getRow(row)
+        .getByTestId('balance')
+        .getByTestId(/^budget/),
+    );
+
+    const popover = this.page.locator('[data-popover]');
+    await popover.waitFor({ state: 'visible' });
+    return popover;
+  }
+
+  /**
+   * Toggle "Rollover overspending" / "Remove overspending rollover" for a
+   * category row. Present regardless of the category's balance sign.
+   */
+  async toggleCarryover(row: number | string) {
+    const popover = await this.openBalanceMenu(row);
+    await clickReactAriaButton(
+      popover.getByRole('button', {
+        name: /rollover overspending|overspending rollover/i,
+      }),
+    );
+  }
+
+  /**
+   * Cover an overspent category's balance from another category. Only
+   * available in the menu when the row's balance is negative.
+   */
+  async coverOverspending(
+    row: number | string,
+    fromCategoryName: string,
+    amount?: string,
+  ) {
+    const popover = await this.openBalanceMenu(row);
+    await popover.getByRole('button', { name: 'Cover overspending' }).click();
+
+    if (amount) {
+      const amountInput = popover.getByRole('textbox').first();
+      await amountInput.fill(amount);
+    }
+
+    await popover.getByPlaceholder('(none)').click();
+    await this.page.keyboard.type(fromCategoryName);
+    await this.page.keyboard.press('Enter');
+    await popover.getByRole('button', { name: 'Transfer' }).click();
+  }
+
+  /**
+   * The spreadsheet's sheet name for a given month is not the raw
+   * "YYYY-MM" string — it's `sheetForMonth` from loot-core
+   * (`'budget' + month.replace('-', '')`), which is what feeds `data-testid`
+   * on per-month cell values. Replicated here since the page model has no
+   * access to `monthUtils`.
+   */
+  async #getMonthSheetName() {
+    const month = await this.getSelectedMonth();
+    return `budget${month.replace('-', '')}`;
+  }
+
+  /**
+   * Locate the "To Budget" / "Overbudgeted" amount for the currently
+   * selected month. The budget view keeps adjacent months mounted in the
+   * DOM, so this must be scoped by month rather than a bare testid.
+   */
+  async #getToBudgetAmountLocator() {
+    const sheetName = await this.#getMonthSheetName();
+    return this.page.getByTestId(`${sheetName}!to-budget`);
+  }
+
+  /**
+   * Open the "To Budget" / "Overbudgeted" summary menu and return the
+   * popover locator.
+   */
+  async openToBudgetMenu() {
+    await clickReactAriaButton(await this.#getToBudgetAmountLocator());
+
+    const popover = this.page.locator('[data-popover]');
+    await popover.waitFor({ state: 'visible' });
+    return popover;
+  }
+
+  /**
+   * Hold an amount of the current "To Budget" total for next month. Only
+   * available when "To Budget" is positive and no auto-buffer is active.
+   * Defaults to holding the full pre-filled amount.
+   */
+  async holdForNextMonth(amount?: string) {
+    const popover = await this.openToBudgetMenu();
+    // Plain `.click()` — see the comment in `coverOverspending` above;
+    // this button switches the popover's internal step (ToBudgetMenu ->
+    // HoldMenu) and is subject to the same native-click/refocus race.
+    await popover.getByRole('button', { name: 'Hold for next month' }).click();
+
+    if (amount) {
+      const amountInput = popover.getByRole('textbox').first();
+      await amountInput.fill(amount);
+    }
+
+    await popover.getByRole('button', { name: 'Hold' }).click();
+  }
+
+  /**
+   * Reset a previously-held "for next month" buffer back to zero.
+   */
+  async resetHoldBuffer() {
+    const popover = await this.openToBudgetMenu();
+    await popover
+      .getByRole('button', { name: "Reset next month's buffer" })
+      .click();
+  }
+
+  async getToBudgetAmount() {
+    const text = await (await this.#getToBudgetAmountLocator()).textContent();
+
+    if (!text) {
+      throw new Error('Failed to get the "To Budget" amount.');
+    }
+
+    return Math.round(parseFloat(text.replace(/,/g, '')) * 100);
+  }
+
+  async getForNextMonthAmount() {
+    const sheetName = await this.#getMonthSheetName();
+    const text = await this.page
+      .getByTestId(`${sheetName}!buffered-selected`)
+      .textContent();
+
+    if (!text) {
+      throw new Error('Failed to get the "For next month" amount.');
+    }
+
+    return Math.round(parseFloat(text.replace(/,/g, '')) * 100);
   }
 
   async transferAllBalance(fromIdx: number, toIdx: number) {

--- a/packages/desktop-client/e2e/page-models/navigation.ts
+++ b/packages/desktop-client/e2e/page-models/navigation.ts
@@ -34,7 +34,7 @@ type AccountEntry = {
  * resolution and click. HTMLElement.click() dispatches a real MouseEvent
  * that React Aria handles correctly.
  */
-async function clickReactAriaButton(locator: Locator): Promise<void> {
+export async function clickReactAriaButton(locator: Locator): Promise<void> {
   await locator.evaluate((el: HTMLElement) => el.click());
 }
 

--- a/packages/desktop-client/e2e/reconciliation.test.ts
+++ b/packages/desktop-client/e2e/reconciliation.test.ts
@@ -1,0 +1,193 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixtures';
+import type { AccountPage } from './page-models/account-page';
+import { ConfigurationPage } from './page-models/configuration-page';
+import { Navigation } from './page-models/navigation';
+
+// Covers RECON-01, 03, 04, 05, 06, 07, 08, 09 from
+// snorkel-assignment/TEST_PLAN.md (account reconciliation).
+test.describe('Account reconciliation', () => {
+  let page: Page;
+  let navigation: Navigation;
+  let configurationPage: ConfigurationPage;
+  let accountPage: AccountPage;
+
+  test.beforeEach(async ({ browser }) => {
+    page = await browser.newPage();
+    navigation = new Navigation(page);
+    configurationPage = new ConfigurationPage(page);
+
+    await page.goto('/');
+    await configurationPage.createTestFile();
+
+    // A fresh, empty account rather than a fixture one: fixture accounts
+    // may already have cleared/reconciled history baked in, which would
+    // make the cleared-balance and "Not yet reconciled" assertions below
+    // unreliable.
+    accountPage = await navigation.createAccount({
+      name: 'E2E Reconcile Account',
+      offBudget: false,
+      balance: 0,
+    });
+    await accountPage.waitFor();
+  });
+
+  test.afterEach(async () => {
+    await page?.close();
+  });
+
+  test('opening the reconcile menu pre-fills the balance input with the cleared balance', async () => {
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+
+    const popover = await accountPage.openReconcileMenu();
+    await expect(popover.getByRole('textbox')).toHaveValue('60.00');
+  });
+
+  test('submitting a balance equal to the cleared balance shows "All reconciled!"; locking marks transactions reconciled', async () => {
+    const statusBefore = await accountPage.getReconcileStatusText();
+    expect(statusBefore).toContain('Not yet reconciled');
+
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+
+    // Submits the pre-filled (matching) cleared balance as-is.
+    await accountPage.reconcile();
+
+    await expect(accountPage.reconciliationAllReconciledText).toBeVisible();
+    await expect(accountPage.reconciliationDoneButton).toHaveText(
+      'Lock transactions',
+    );
+    await expect(
+      accountPage.createReconciliationTransactionButton,
+    ).not.toBeVisible();
+
+    await accountPage.reconciliationDoneButton.click();
+
+    await expect
+      .poll(() => accountPage.getReconcileStatusText())
+      .not.toContain('Not yet reconciled');
+  });
+
+  test('submitting a different balance shows the difference; creating an adjustment transaction reconciles it', async () => {
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+
+    // Bank balance is $15 higher than the cleared register total.
+    await accountPage.reconcile('75');
+
+    await expect(accountPage.reconciliationAllReconciledText).not.toBeVisible();
+    await expect(accountPage.reconciliationDoneButton).toHaveText(
+      'Exit reconciliation',
+    );
+    await expect(
+      accountPage.createReconciliationTransactionButton,
+    ).toBeVisible();
+
+    await accountPage.createReconciliationTransactionButton.click();
+
+    // Newest transactions are shown first, so the adjustment lands at row 0.
+    const adjustment = accountPage.getNthTransaction(0);
+    await expect(adjustment.notes).toHaveText(
+      'Reconciliation balance adjustment',
+    );
+    await expect(adjustment.credit).toHaveText('15.00');
+
+    // The cleared total now matches the $75 target reactively.
+    await expect(accountPage.reconciliationAllReconciledText).toBeVisible();
+  });
+
+  test('exiting reconciliation without creating an adjustment leaves everything unchanged', async () => {
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+
+    await accountPage.reconcile('75');
+    await accountPage.reconciliationDoneButton.click(); // "Exit reconciliation"
+
+    await expect(accountPage.reconciliationAllReconciledText).not.toBeVisible();
+    await expect(accountPage.transactionTableRow).toHaveCount(1);
+
+    // The transaction itself was never locked: editing it afterward does
+    // not trigger the reconciled-transaction warning. (Note: the account's
+    // "last reconciled" timestamp *does* update on "Exit reconciliation"
+    // even though nothing was actually reconciled — that status text is
+    // not a reliable signal of whether anything changed.)
+    await accountPage.editTransactionAmount(0, 'credit', '65');
+    await expect(
+      accountPage.reconciledTransactionWarningHeading,
+    ).not.toBeVisible();
+    await expect(accountPage.getNthTransaction(0).credit).toHaveText('65.00');
+  });
+
+  test('editing a reconciled transaction shows a warning before the change is applied', async () => {
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+    await accountPage.reconcile();
+    await accountPage.reconciliationDoneButton.click(); // locks -> reconciled: true
+
+    await accountPage.editTransactionAmount(0, 'credit', '70');
+
+    await expect(accountPage.reconciledTransactionWarningHeading).toBeVisible();
+    // Not applied yet.
+    await expect(accountPage.getNthTransaction(0).credit).toHaveText('60.00');
+
+    await accountPage.confirmReconciledTransactionWarning();
+
+    await expect(accountPage.getNthTransaction(0).credit).toHaveText('70.00');
+  });
+
+  test('deleting a reconciled transaction shows a warning before it is removed', async () => {
+    // KNOWN BUG (found while writing this test, intentionally not exercised
+    // here): cancelling this specific warning crashes the app with
+    // `TypeError: onCancel is not a function`. The batch/selection-based
+    // delete path (`checkForReconciledTransactions` in
+    // useTransactionBatchActions.ts) pushes the 'confirm-transaction-edit'
+    // modal without an `onCancel` handler, but `ConfirmTransactionEditModal`
+    // unconditionally calls `onCancel()` from its Cancel button. The
+    // single-transaction inline-edit path (exercised in the "editing a
+    // reconciled transaction" test above) passes `onCancel` correctly, so
+    // this only affects delete. Only the Confirm path is covered below
+    // until that's fixed.
+    await accountPage.createSingleTransaction({
+      payee: '',
+      notes: 'cleared txn',
+      credit: '60',
+    });
+    await accountPage.toggleCleared(0);
+    await accountPage.reconcile();
+    await accountPage.reconciliationDoneButton.click();
+
+    await accountPage.deleteNthTransaction(0);
+    await expect(accountPage.reconciledTransactionWarningHeading).toBeVisible();
+    // Not removed yet.
+    await expect(accountPage.transactionTableRow).toHaveCount(1);
+
+    // Confirming proceeds to the generic delete confirmation, and only
+    // then removes the transaction.
+    await accountPage.confirmReconciledTransactionWarning();
+    await expect(accountPage.transactionTableRow).toHaveCount(1);
+    await accountPage.confirmDeleteModal();
+    await expect(accountPage.transactionTableRow).toHaveCount(0);
+  });
+});

--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx
@@ -77,6 +77,7 @@ export function ToBudgetAmount({
             }}
           >
             <Block
+              data-testid={sheetName.fullSheetName}
               onClick={onClick}
               onContextMenu={onContextMenu}
               data-cellname={sheetName}

--- a/snorkel-assignment/AI_AGENT_BRIEF.md
+++ b/snorkel-assignment/AI_AGENT_BRIEF.md
@@ -1,0 +1,119 @@
+# Reusable Agent Brief: E2E Coverage Gap Assignment
+
+A generalized prompt/spec for directing an AI coding agent through the
+workflow used in this assignment: given a codebase, find the highest-value
+untested feature(s), write a defensible test plan, audit it, then implement
+it. Adapt the bracketed placeholders for a new project.
+
+---
+
+## Step 0 — Orient (read-only)
+
+```
+Read [existing e2e test files / test directory] and summarize, in plain
+English, what each file already tests and what's conspicuously missing.
+Don't write any code yet — investigate and report back.
+```
+
+Why this step exists: it forces the agent to build an accurate model of
+current coverage before opinions form. Skipping straight to "pick a feature"
+produces recommendations anchored on nothing.
+
+## Step 1 — Force a real prioritization pass (not a default)
+
+```
+In your opinion, what are the [N] highest-priority features I should cover
+in this assignment? Give me just reasoning, not code.
+```
+
+**Do not accept the first answer if it's obviously anchored on whatever the
+agent looked at most recently** (recency bias is the most common failure mode
+here — an agent will default to extending whatever's already in its context
+window rather than surveying the whole codebase fresh). If the reasoning
+reads as a rationalization rather than a comparison, push back explicitly:
+
+```
+Are you sure those are the highest priority? Compare against [alternative
+features] too.
+```
+
+This single question, asked twice in this session, is what separated the
+final feature choices (envelope-budget money actions, account reconciliation)
+from the agent's initial defaults (Rules, Schedules) — the initial defaults
+weren't wrong exactly, just under-justified relative to what a fresh
+comparison turned up.
+
+## Step 2 — Ground the recommendation in the actual code
+
+```
+Go look at [feature]'s current test coverage before I decide. Trace the
+actual component/handler code, don't just infer from file names.
+```
+
+An agent's untested claim ("this seems important") is not evidence. Have it
+grep for the relevant components, read the handler logic, and cite specific
+file names, component names, and test titles (or their absence). This is what
+turns "budgeting seems core to the product" into "`BalanceMenu`, `CoverMenu`,
+and `ToBudgetMenu` are fully tested on mobile but have zero desktop coverage"
+— a claim someone can verify in thirty seconds.
+
+## Step 3 — Draft the test plan
+
+```
+Write a test plan for [feature(s)] as a markdown file: test case IDs,
+one-line titles, priority (P0/P1/P2), and detailed numbered steps for the
+highest-priority cases. Don't write Playwright code yet.
+```
+
+Keep code and planning phases separated — reviewing a test plan in prose is
+much cheaper than reviewing it embedded in test code, and catches scope
+problems before any implementation cost is sunk.
+
+## Step 4 — Audit the draft as a separate pass
+
+```
+Let's walk through the test plan and audit what test cases we actually need
+and whether each one is valuable. For each case: keep, cut, or merge, with
+reasoning.
+```
+
+This is the step most likely to be skipped, and the one with the highest
+payoff. A first-draft test plan reliably contains: (a) cases that are really
+just assertions that belong inside another case's setup (e.g. "menu item X is
+hidden when condition Y" — usually cheaper to assert inline than as a
+standalone case), and (b) cases exercising a shared utility rather than the
+feature itself (arithmetic parsing, date formatting) that are unit-test
+concerns wearing an e2e costume. A dedicated audit pass catches both, and
+often surfaces one or two genuinely new gaps the first pass missed, because
+re-reading the source with "is this worth testing" as the explicit question
+surfaces things skimming for "what does this do" does not.
+
+Expect the case count to go down, not up. If the audit doesn't cut anything,
+the first draft was probably already over-filtered, or the audit wasn't done
+critically enough.
+
+## Step 5 — Implement incrementally, with review checkpoints
+
+```
+Implement [feature]'s tests now. Extend the existing page-object model
+pattern rather than inlining selectors in the test file.
+```
+
+Apply changes in reviewable chunks (one feature/file at a time) rather than
+one large diff — it's the only way a rejected/interrupted edit doesn't cost
+the whole batch of work.
+
+## Anti-patterns observed / to avoid
+
+- **Accepting the agent's first feature pick.** It will almost always be
+  anchored on recent context rather than a fresh survey. Ask "why not X
+  instead?" before committing.
+- **Skipping the audit step and going straight from draft plan to code.**
+  The draft plan is optimized for "did I think of enough cases," not "is each
+  case worth the maintenance cost." Those are different questions and need a
+  separate pass.
+- **Letting the agent cite a feature's existence as evidence it's tested.**
+  Always require a specific test title, file, or explicit "no coverage found"
+  — not "this is probably covered somewhere."
+- **One giant diff.** If a tool-use gets rejected or interrupted mid-batch,
+  smaller checkpoints mean you lose minutes of work, not the whole session.

--- a/snorkel-assignment/TEST_PLAN.md
+++ b/snorkel-assignment/TEST_PLAN.md
@@ -1,0 +1,264 @@
+# E2E Test Plan — Actual Budget
+
+**Project under test:** [actualbudget/actual](https://github.com/actualbudget/actual)
+**Test framework:** Playwright (`packages/desktop-client/e2e/`)
+**Scope:** Two features selected after auditing existing E2E coverage (see "How these features were chosen" below).
+
+---
+
+## How these features were chosen
+
+The existing E2E suite (`budget.test.ts`, `rules.test.ts`, `accounts.test.ts`) covers
+happy-path creation flows but stops short of testing the underlying _mechanics_ of
+zero-based budgeting and balance verification. Two gaps stood out as both
+high-value (they move real money / change financial state) and currently
+untested on desktop:
+
+1. **Envelope budget money-movement actions** — `BalanceMenu`, `CoverMenu`, and
+   `ToBudgetMenu` exist in the codebase and are fully tested on **mobile**
+   (`budget.mobile.test.ts`), but have **zero desktop E2E coverage**. These are
+   not edge features — they are the core mechanics of envelope budgeting
+   (rolling over a balance, covering overspending from another category,
+   holding funds for next month).
+2. **Account reconciliation** — a dedicated `Reconcile.tsx` component (with its
+   own unit test, `Reconcile.test.tsx`) drives the "match my register to my
+   bank statement" workflow, yet across the entire e2e suite there is only a
+   single incidental assertion about reconciled transactions
+   (`accounts.test.ts` — hidden-row range selection). No test exercises
+   opening the reconcile menu, matching/mismatching a balance, locking
+   transactions, creating an adjustment transaction, or the warning shown when
+   editing/deleting an already-reconciled transaction. This is the mechanism
+   users rely on to catch errors in their financial records, which makes the
+   gap higher-stakes than it might first appear.
+
+---
+
+## Feature 1: Envelope Budget — Carryover, Cover Overspending & Hold for Next Month
+
+### Background
+
+In the envelope (zero-based) budget, three category/summary-level actions move
+money outside the normal "budget this month" flow:
+
+| Action                                | Trigger                                                                                                                | Component                   |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| **Rollover overspending** (carryover) | Click a category's balance cell → "Rollover overspending" / "Remove overspending rollover"                             | `BalanceMenu` (envelope)    |
+| **Cover overspending**                | Click a category's balance cell (only shown when balance < 0) → "Cover overspending" → pick a source category + amount | `CoverMenu`                 |
+| **Hold for next month**               | Click the "To Budget" summary amount (only shown when To Budget > 0) → "Hold for next month" → enter amount            | `ToBudgetMenu` + `HoldMenu` |
+
+**Note on scope:** `IncomeMenu`'s "Enable/Disable auto hold" (income-category
+carryover) is a related but distinct mechanism and is excluded to keep this
+feature focused on the three actions named above.
+
+### Test Environment / Setup
+
+All tests start from the deterministic "Create test file" fixture
+(`ConfigurationPage.createTestFile()`), the same fixture used by
+`budget.test.ts`. Where a test needs a category with a negative balance, it
+will budget a fixed amount into a category and then create a transaction that
+overspends it (via `AccountPage.createSingleTransaction`).
+
+### Test Cases
+
+> Audit note: an earlier draft of this plan had 13 cases in this feature.
+> Four (BUD-03, BUD-04, BUD-07, BUD-13) were pure menu-visibility guards that
+> duplicated setup already present in the cases below, and one (BUD-08,
+> arithmetic-expression input) exercised a shared utility (`evalArithmetic`)
+> used across many unrelated amount fields — better suited to a unit test
+> than a dedicated e2e case. Their assertions were folded into the remaining
+> cases instead of dropped. BUD-11 was merged into BUD-09 since it's a direct
+> continuation of the same setup, not an independent scenario.
+
+#### 1.1 Rollover overspending (carryover)
+
+| ID     | Title                                                                                                                       | Priority |
+| ------ | --------------------------------------------------------------------------------------------------------------------------- | -------- |
+| BUD-01 | Enabling "Rollover overspending" on an overspent category carries the negative balance into next month instead of resetting | P0       |
+| BUD-02 | Disabling carryover ("Remove overspending rollover") reverts to standard month-to-month reset behavior                      | P0       |
+
+**BUD-01 — detailed steps:**
+
+1. Open the budget table on a test file. Note the current month.
+2. Budget `$50` into category A; create a `$80` debit transaction against category A (balance now `-$30`).
+3. Click category A's balance cell → click "Rollover overspending".
+4. Assert the menu item now reads "Remove overspending rollover" and a carryover indicator is visible on the balance cell (folds the former BUD-03).
+5. Navigate to next month via `budgetPage.goToNextMonth()`.
+6. Assert category A's starting balance for next month reflects the carried-over `-$30` (i.e., is `$30` lower than it would be without carryover).
+
+**BUD-02 — detailed steps:** same setup as BUD-01, but after enabling carryover, click again to disable it ("Remove overspending rollover"), then go to next month and assert the `-$30` was **not** carried forward (next month starts unaffected by the prior overspend).
+
+#### 1.2 Cover overspending
+
+| ID     | Title                                                                                                                                                                   | Priority |
+| ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| BUD-05 | Covering the full overspent amount from another category zeroes out the overspent category's balance and decreases the source category's balance by the same amount     | P0       |
+| BUD-06 | Covering a partial amount (less than the full overspend) reduces — but does not eliminate — the negative balance, and decreases the source category by only that amount | P1       |
+
+**BUD-05 — detailed steps:**
+
+1. Budget `$50` into category A and `$100` into category B.
+2. Before overspending, open category A's balance cell menu and assert "Rollover overspending" is present but "Cover overspending" is **not** (balance is still positive) — folds the former BUD-04/BUD-07 into this setup.
+3. Overspend category A via a `$80` transaction (balance `-$30`).
+4. Re-open the balance cell menu and assert "Cover overspending" is now present.
+5. Click "Cover overspending". Confirm the amount field is pre-filled with `30.00`.
+6. Type "Category B" into the "From" autocomplete and select it.
+7. Submit.
+8. Assert category A's balance is now `0.00` and category B's balance is now `70.00` (100 − 30).
+
+#### 1.3 Hold for next month
+
+| ID     | Title                                                                                                                                                                                  | Priority |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| BUD-09 | Holding the full "To Budget" amount moves it entirely into "For next month", reducing "To Budget" to zero, without reducing next month's own "To Budget" total when navigating forward | P0       |
+| BUD-10 | Holding a partial amount leaves the remainder available to budget this month, and only the held portion appears in "For next month"                                                    | P1       |
+| BUD-12 | After holding an amount, the menu option changes to "Reset next month's buffer"; selecting it resets the buffer to zero and restores the original "To Budget" value                    | P1       |
+
+**BUD-09 — detailed steps:**
+
+1. Note the current "To Budget" amount (must be > 0 — true by default on the test fixture's first month).
+2. Click the "To Budget" summary amount → "Hold for next month".
+3. Confirm the amount field is pre-filled with the full "To Budget" value; submit as-is.
+4. Assert "To Budget" is now `0.00` (or "Overbudgeted: $0.00" depending on formatting) and "For next month" shows the held amount.
+5. Re-open the "To Budget" menu and assert "Hold for next month" is no longer offered (To Budget is now `0`) — folds the former BUD-13.
+6. Navigate to next month and assert its "To Budget" is at least the pre-hold baseline for that month (folds the former BUD-11). Note: unbudgeted money already rolls forward month-to-month independent of an explicit hold, so holding does not _additionally_ increase next month's total on top of that baseline — it only prevents the money from being spent this month instead of reserved. The correctness guard is that holding never _loses_ money relative to next month's baseline.
+
+---
+
+## Feature 2: Account Reconciliation
+
+### Background
+
+Reconciliation is the workflow where a user enters their bank's current
+balance and Actual either confirms the register matches it, or helps resolve
+a mismatch. It's driven by `packages/desktop-client/src/components/accounts/Reconcile.tsx`:
+
+| Step                   | Trigger                                                                                                                                                                                                   | Component                                                                |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Open reconcile menu    | Click the lock icon (aria-label "Reconcile") in the account header                                                                                                                                        | `ReconcileMenu`                                                          |
+| Enter bank balance     | Type an amount (pre-filled with the account's current cleared balance) → "Reconcile"                                                                                                                      | `ReconcileMenu`                                                          |
+| Resolve match/mismatch | A banner appears showing either "All reconciled!" or the dollar difference                                                                                                                                | `ReconcilingMessage`                                                     |
+| Finish                 | "Lock transactions" (exact match) marks all cleared transactions as reconciled; "Create reconciliation transaction" (mismatch) adds an adjustment transaction; "Exit reconciliation" abandons the attempt | `Account.tsx` (`onDoneReconciling`, `onCreateReconciliationTransaction`) |
+| Guard rail             | Editing or deleting an already-reconciled transaction shows a "Reconciled Transaction" warning modal before applying the change                                                                           | `ConfirmTransactionEditModal.tsx`                                        |
+
+Only one incidental assertion about reconciled transactions exists today
+(`accounts.test.ts` — hidden-row range selection); the actual reconcile flow
+above has no coverage.
+
+### Test Cases
+
+> Audit note: RECON-02 ("Use last synced total") is deferred rather than
+> written now. The "Create test file" fixture accounts are manual/offline, so
+> `account.balance_current` is `null` and the button never renders — testing
+> it would require a bank-sync-linked account fixture (see `bank-sync.test.ts`
+> for the setup pattern), which is disproportionate cost for a P2 case. One
+> new case, RECON-10, was added below after a closer read of `Account.tsx`
+> surfaced a real, non-obvious, currently-untested behavior.
+
+#### 2.1 Opening the reconcile menu
+
+| ID       | Title                                                                                             | Priority |
+| -------- | ------------------------------------------------------------------------------------------------- | -------- |
+| RECON-01 | Opening the reconcile menu pre-fills the balance input with the account's current cleared balance | P1       |
+
+#### 2.2 Matching balance (exact reconciliation)
+
+| ID       | Title                                                                                                                                                    | Priority |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| RECON-03 | Submitting a balance equal to the cleared balance shows "All reconciled!" and a "Lock transactions" button                                               | P0       |
+| RECON-04 | Clicking "Lock transactions" marks every previously-cleared, unreconciled transaction as reconciled and updates the account's "Reconciled ... ago" label | P0       |
+
+**RECON-03/04 — detailed steps:**
+
+1. On a test-fixture account, clear one or more transactions (or use already-cleared fixture data) and note the total cleared balance.
+2. Click the "Reconcile" (lock icon) button in the account header.
+3. Confirm the input is pre-filled with the cleared balance; submit as-is.
+4. Assert the reconciliation banner shows "All reconciled!" and a "Lock transactions" button (no "Create reconciliation transaction" button).
+5. Click "Lock transactions".
+6. Assert the banner disappears, and the account header's reconcile tooltip no longer reads "Not yet reconciled" (reflects a recent timestamp instead).
+
+#### 2.3 Mismatched balance
+
+| ID       | Title                                                                                                                                                                                                                         | Priority |
+| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| RECON-05 | Submitting a balance different from the cleared balance shows the exact dollar difference and offers "Create reconciliation transaction" / "Exit reconciliation" (no "Lock transactions")                                     | P0       |
+| RECON-06 | Clicking "Create reconciliation transaction" adds an adjustment transaction for exactly the difference amount, with notes "Reconciliation balance adjustment", bringing the cleared balance to match the entered bank balance | P0       |
+| RECON-07 | Clicking "Exit reconciliation" (without creating an adjustment) closes the banner without changing any transaction's reconciled state or the account's last-reconciled timestamp                                              | P1       |
+
+**RECON-05/06 — detailed steps:**
+
+1. Note the account's cleared balance (e.g. `$500.00`).
+2. Open the reconcile menu, enter a different amount (e.g. `$550.00`), submit.
+3. Assert the banner shows the cleared balance, the bank balance, and a difference of `+$50.00`, with "Create reconciliation transaction" and "Exit reconciliation" buttons (and no "Lock transactions" button).
+4. Click "Create reconciliation transaction".
+5. Assert a new transaction appears in the register for `$50.00` with notes "Reconciliation balance adjustment", and the account's cleared balance now equals `$550.00`.
+
+#### 2.4 Guard rails on reconciled transactions
+
+| ID       | Title                                                                                                                              | Priority |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| RECON-08 | Attempting to edit a field on a reconciled transaction shows a "Reconciled Transaction" warning modal before the change is applied | P0       |
+| RECON-09 | Attempting to delete a reconciled transaction shows the same warning modal before the deletion happens                             | P0       |
+
+**RECON-08 — detailed steps:**
+
+1. Complete a full reconciliation (RECON-03/04) so at least one transaction is `reconciled: true`.
+2. Attempt to edit that transaction's amount or category directly in the register.
+3. Assert the "Reconciled Transaction" modal appears with the "editing reconciled transactions may bring your reconciliation out of balance" message, before any change is persisted.
+4. Confirm the edit; assert the change is applied only after confirming.
+
+**RECON-09 — detailed steps:**
+
+1. Complete a full reconciliation (RECON-03/04) so at least one transaction is `reconciled: true`.
+2. Select that transaction and attempt to delete it.
+3. Assert the "Reconciled Transaction" modal appears (with the delete-specific message) before the transaction is removed.
+4. Confirm the deletion; assert the transaction is removed only after confirming, then confirm the follow-up generic "Confirm Delete" modal.
+
+> Implementation note: while writing this case, cancelling this specific
+> warning was found to crash the app (`TypeError: onCancel is not a
+function`) — the batch/selection-delete path
+> (`checkForReconciledTransactions` in `useTransactionBatchActions.ts`)
+> pushes the confirmation modal without an `onCancel` handler, unlike the
+> single-transaction inline-edit path (RECON-08), which passes it
+> correctly. Per direction, the test only exercises the Confirm path and
+> documents the bug inline rather than fixing product code or asserting on
+> the crash; it's flagged here for separate triage.
+
+#### 2.5 Interaction with the "cleared" checkbox column
+
+Correction from an earlier draft: `showCleared` in `Account.tsx` does **not**
+control which transactions are visible (that's the separate, already-tested
+"Hide reconciled transactions" toggle). It controls whether the **"cleared"
+checkbox column** is shown in the register at all (account menu → `Show/Hide
+"cleared" checkboxes`). `onReconcile` forces this column on for the duration
+of reconciliation — so a user can check transactions off while reconciling
+even if they'd normally hidden that column — and restores the prior state via
+`onDoneReconciling`. This is non-obvious and currently untested.
+
+| ID       | Title                                                                                                                                                                | Priority |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| RECON-10 | Starting reconciliation while the "cleared" checkbox column is hidden temporarily reveals it, then restores the prior column visibility once reconciliation finishes | P2       |
+
+**RECON-10 — detailed steps:**
+
+1. Via the account menu, select "Hide 'cleared' checkboxes" so the column is not shown.
+2. Confirm the "cleared" checkbox column is absent from the transaction table.
+3. Start reconciliation (open the reconcile menu and submit a balance).
+4. Assert the "cleared" checkbox column is now visible while reconciliation is in progress.
+5. Finish reconciliation (Lock transactions or Exit reconciliation).
+6. Assert the "cleared" checkbox column is hidden again, matching the state from step 1.
+
+---
+
+## Priority Legend
+
+- **P0** — Core money-correctness behavior; a regression here directly produces wrong financial totals shown to the user.
+- **P1** — Important UI/state-consistency behavior; a regression is visible and confusing but not silently wrong.
+- **P2** — Edge cases / lower-traffic interactions; valuable for completeness, lowest risk if temporarily broken.
+
+## Out of Scope
+
+- Tracking-budget equivalents of carryover (`tracking/BalanceMenu.tsx`) — same underlying mechanic, different budget type; could be a follow-up.
+- `IncomeMenu`'s income-carryover ("auto hold") — related but distinct from the three actions above.
+- Mobile variants of either feature — desktop budget actions are covered on mobile already (`budget.mobile.test.ts` / `budget-automations.mobile.test.ts`); reconciliation's mobile equivalent (if any) is not investigated here.
+- Reconciling transfer transactions specifically (the `batchEditWithReconciledTransfer` / `batchDeleteWithReconciledTransfer` warning variants) — same guard-rail mechanism as RECON-08/09, called out as a follow-up rather than a separate case.
+- Multi-account or multi-currency reconciliation edge cases.


### PR DESCRIPTION
### Description

Adds Playwright e2e coverage for two features that had zero desktop coverage despite being either fully tested on mobile or acting as the app's core money-integrity safeguard:

1. Envelope budget menu actions — rollover overspending (carryover), covering overspending from another category, and holding funds for next month. These are fully covered on mobile (budget.mobile.test.ts) but had no desktop equivalent.
2. Account reconciliation — the reconcile-menu flow (matching balance → lock transactions; mismatched balance → create adjustment or exit) and the guard rail that warns before editing/deleting an already-reconciled transaction.

Also adds a stable data-testid to the "To Budget" amount (ToBudgetAmount.tsx) — it had no reliable selector before, so it was untestable.

Notable findings while writing these tests (both documented inline as comments, not fixed as part of this PR):
- Holding money for next month doesn't additively increase next month's total if that money would have rolled forward anyway — a real accounting nuance in holdForNextMonth, not a bug.
- A real crash: cancelling the "Reconciled Transaction" warning on the batch/selection delete path throws TypeError: onCancel is not a function (useTransactionBatchActions.ts — the single-transaction inline-edit path passes onCancel correctly, but the batch-delete path doesn't). Flagged for separate triage.

A test plan (snorkel-assignment/TEST_PLAN.md) and process notes are included for context on how the test cases were scoped and prioritized.


Added 13 new Playwright e2e tests covering two previously-untested desktop features (see snorkel-assignment/TEST_PLAN.md for the full test plan and prioritization rationale). All 13 pass locally (yarn workspace @actual-app/web run playwright test budget-actions.test.ts reconciliation.test.ts --browser=chromium).

packages/desktop-client/e2e/budget-actions.test.ts — envelope-budget money actions (rollover overspending, cover overspending, hold for next month), zero prior desktop coverage despite full mobile coverage (budget.mobile.test.ts):
- [x] Rollover overspending (carryover)
  - [x] Enabling carryover carries the negative balance into next month (BUD-01)
  - [x] Disabling carryover reverts to the standard month-to-month reset (BUD-02)
- [x] Cover overspending
  - [x] Covering the full overspent amount zeroes the category and debits the source category (BUD-05)
  - [x] Covering a partial amount reduces but does not eliminate the negative balance (BUD-06)
- [x] Hold for next month
  - [x] Holding the full "To Budget" amount zeroes it and carries into next month (BUD-09)
  - [x] Holding a partial amount leaves the remainder available to budget this month (BUD-10)
  - [x] Resetting the hold buffer restores the original "To Budget" value (BUD-12)

packages/desktop-client/e2e/reconciliation.test.ts — account reconciliation, previously only one incidental assertion in the entire e2e suite:
- [x] Opening the reconcile menu pre-fills the balance input with the cleared balance (RECON-01)
- [x] Submitting a balance equal to the cleared balance shows "All reconciled!"; locking marks transactions reconciled (RECON-03/04)
- [x] Submitting a different balance shows the difference; creating an adjustment transaction reconciles it (RECON-05/06)
- [x] Exiting reconciliation without creating an adjustment leaves everything unchanged (RECON-07)
- [x] Editing a reconciled transaction shows a warning before the change is applied (RECON-08)
- [x] Deleting a reconciled transaction shows a warning before it is removed (RECON-09)

### Testing

Ran locally with --repeat-each=2 for both new spec files (13/13 passing, no flakiness):
yarn workspace @actual-app/web e2e budget-actions.test.ts reconciliation.test.ts --browser=chromium --repeat-each=2

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (+62 B) | +0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (+62 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/envelope/budgetsummary/ToBudgetAmount.tsx` | 📈 +62 B (+1.49%) | 4.05 kB → 4.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+62 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.27 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BQZb0KVY.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/strip-ansi/index.js` | 📉 -26 B (-8.33%) | 312 B → 286 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (-26 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->