### PR TITLE
docs: add Zenith managed-hosting option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Want to say thanks? Click the ⭐ at the top of the page.
 
 ## Installation
 
-There are four ways to deploy Actual:
+There are five ways to deploy Actual:
 
+1. Managed hosting [with Zenith](https://zenith.hosting/host/actual-budget?ref=gh): storage, backups and updates handled for you, and a share of revenue goes back to Actual Budget.
 1. One-click deployment [via PikaPods](https://www.pikapods.com/pods?run=actual) (~1.40 $/month) - recommended for non-technical users
 1. Managed hosting [via Fly.io](https://actualbudget.org/docs/install/fly) (~1.50 $/month)
 1. Self-hosted by using [a Docker image](https://actualbudget.org/docs/install/docker)

--- a/upcoming-release-notes/zenith-hosting-badge.md
+++ b/upcoming-release-notes/zenith-hosting-badge.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [odpay]
+---
+
+Add Zenith as a managed-hosting option in the installation docs.


### PR DESCRIPTION
## Description

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Actual Budget to our marketplace, so this PR adds a small managed-hosting entry in the Installation options (links to https://zenith.hosting/host/actual-budget?ref=gh).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

AI usage: No LLMs were involved.

## Related issue(s)

n/a

## Testing

docs-only change, reviewed the rendered markdown link locally.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
