### PR TITLE
[WIP] Add open-banking.io as a bank sync provider

### DIFF
--- a/packages/desktop-client/src/accounts/mutations.ts
+++ b/packages/desktop-client/src/accounts/mutations.ts
@@ -8,6 +8,7 @@ import type {
   SyncServerAkahuAccount,
   SyncServerEnableBankingAccount,
   SyncServerGoCardlessAccount,
+  SyncServerOpenBankingIoAccount,
   SyncServerPluggyAiAccount,
   SyncServerSimpleFinAccount,
   TransactionEntity,
@@ -494,6 +495,48 @@ export function useLinkAccountPluggyAiMutation() {
         dispatch,
         t(
           'There was an error linking the account to PluggyAI. Please try again.',
+        ),
+        error,
+      );
+    },
+  });
+}
+
+type LinkAccountOpenBankingIoPayload = LinkAccountBasePayload & {
+  externalAccount: SyncServerOpenBankingIoAccount;
+};
+
+export function useLinkAccountOpenBankingIoMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({
+      externalAccount,
+      upgradingId,
+      offBudget,
+      startingDate,
+      startingBalance,
+    }: LinkAccountOpenBankingIoPayload) => {
+      await send('openbankingio-accounts-link', {
+        externalAccount,
+        upgradingId,
+        offBudget,
+        startingDate,
+        startingBalance,
+      });
+    },
+    onSuccess: () => {
+      invalidateQueries(queryClient);
+      invalidateQueries(queryClient, payeeQueries.lists());
+    },
+    onError: error => {
+      console.error('Error linking account to open-banking.io:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t(
+          'There was an error linking the account to open-banking.io. Please try again.',
         ),
         error,
       );

--- a/packages/desktop-client/src/components/Modals.tsx
+++ b/packages/desktop-client/src/components/Modals.tsx
@@ -66,6 +66,7 @@ import { MergeUnusedPayeesModal } from './modals/MergeUnusedPayeesModal';
 import { NewCategoryGroupModal } from './modals/NewCategoryGroupModal';
 import { NewCategoryModal } from './modals/NewCategoryModal';
 import { NotesModal } from './modals/NotesModal';
+import { OpenBankingIoInitialiseModal } from './modals/OpenBankingIoInitialiseModal';
 import { OpenIDEnableModal } from './modals/OpenIDEnableModal';
 import { OutOfSyncMigrationsModal } from './modals/OutOfSyncMigrationsModal';
 import { PasswordEnableModal } from './modals/PasswordEnableModal';
@@ -195,6 +196,9 @@ export function Modals() {
 
         case 'enablebanking-init':
           return <EnableBankingInitialiseModal key={key} {...modal.options} />;
+
+        case 'openbankingio-init':
+          return <OpenBankingIoInitialiseModal key={key} {...modal.options} />;
 
         case 'enablebanking-external-msg':
           return <EnableBankingExternalMsgModal key={key} {...modal.options} />;

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
@@ -16,6 +16,7 @@ export const BUILT_IN_BANK_SYNC_PROVIDERS = [
 
 const SYNC_PROVIDER_KEYS = [
   ...BUILT_IN_BANK_SYNC_PROVIDERS,
+  'openBankingIo',
   'enableBanking',
   'akahu',
   'unlinked',
@@ -34,6 +35,7 @@ export function getSyncSourceReadable(
     goCardless: 'GoCardless',
     simpleFin: 'SimpleFIN',
     pluggyai: 'Pluggy.ai',
+    openBankingIo: 'open-banking.io',
     enableBanking: 'Enable Banking',
     akahu: 'Akahu',
     unlinked: translate('Unlinked'),

--- a/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
+++ b/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
@@ -6,6 +6,7 @@ import type {
   AccountEntity,
   BankSyncProviders,
 } from '@actual-app/core/types/models';
+import type { SyncServerOpenBankingIoAccount } from '@actual-app/core/types/models/openbankingio';
 import type { SyncServerSimpleFinAccount } from '@actual-app/core/types/models/simplefin';
 
 import { useAuth } from '#auth/AuthProvider';
@@ -17,6 +18,7 @@ import { useAkahuStatus } from '#hooks/useAkahuStatus';
 import { useEnableBankingStatus } from '#hooks/useEnableBankingStatus';
 import { useFeatureFlag } from '#hooks/useFeatureFlag';
 import { useGoCardlessStatus } from '#hooks/useGoCardlessStatus';
+import { useOpenBankingIoStatus } from '#hooks/useOpenBankingIoStatus';
 import { usePluggyAiStatus } from '#hooks/usePluggyAiStatus';
 import { useSimpleFinStatus } from '#hooks/useSimpleFinStatus';
 import { useSyncServerStatus } from '#hooks/useSyncServerStatus';
@@ -107,6 +109,8 @@ export function useBuiltInBankSyncProviders({
   const [isPluggyAiSetupComplete, setIsPluggyAiSetupComplete] = useState<
     boolean | null
   >(null);
+  const [isOpenBankingIoSetupComplete, setIsOpenBankingIoSetupComplete] =
+    useState<boolean | null>(null);
   const [isEnableBankingSetupComplete, setIsEnableBankingSetupComplete] =
     useState<boolean | null>(null);
   const [isAkahuSetupComplete, setIsAkahuSetupComplete] = useState<
@@ -114,13 +118,18 @@ export function useBuiltInBankSyncProviders({
   >(null);
   const [loadingSimpleFinAccounts, setLoadingSimpleFinAccounts] =
     useState(false);
+  const [loadingOpenBankingIoAccounts, setLoadingOpenBankingIoAccounts] =
+    useState(false);
   const [loadingAkahuAccounts, setLoadingAkahuAccounts] = useState(false);
 
   const enableBankingEnabled = useFeatureFlag('enableBanking');
   const akahuEnabled = useFeatureFlag('akahuBankSync');
+  const openBankingIoEnabled = useFeatureFlag('openBankingIo');
   const { configuredGoCardless } = useGoCardlessStatus();
   const { configuredSimpleFin } = useSimpleFinStatus();
   const { configuredPluggyAi } = usePluggyAiStatus();
+  const { configuredOpenBankingIo } =
+    useOpenBankingIoStatus(openBankingIoEnabled);
   const { configuredAkahu } = useAkahuStatus(akahuEnabled);
   const { configuredEnableBanking, isLoading: isEnableBankingLoading } =
     useEnableBankingStatus(enableBankingEnabled);
@@ -136,6 +145,10 @@ export function useBuiltInBankSyncProviders({
   useEffect(() => {
     setIsPluggyAiSetupComplete(configuredPluggyAi);
   }, [configuredPluggyAi]);
+
+  useEffect(() => {
+    setIsOpenBankingIoSetupComplete(configuredOpenBankingIo);
+  }, [configuredOpenBankingIo]);
 
   useEffect(() => {
     setIsEnableBankingSetupComplete(configuredEnableBanking);
@@ -178,6 +191,19 @@ export function useBuiltInBankSyncProviders({
           name: 'pluggyai-init',
           options: {
             onSuccess: () => setIsPluggyAiSetupComplete(true),
+          },
+        },
+      }),
+    );
+  }, [dispatch]);
+
+  const onOpenBankingIoInit = useCallback(() => {
+    dispatch(
+      pushModal({
+        modal: {
+          name: 'openbankingio-init',
+          options: {
+            onSuccess: () => setIsOpenBankingIoSetupComplete(true),
           },
         },
       }),
@@ -301,6 +327,21 @@ export function useBuiltInBankSyncProviders({
     }
   }, [notifyResetFailure]);
 
+  const onOpenBankingIoReset = useCallback(async () => {
+    try {
+      await ensureSuccessResponse(
+        await send('secret-set', {
+          name: 'openbankingio_credentials',
+          value: null,
+        }),
+        'Failed to clear open-banking.io credentials',
+      );
+      setIsOpenBankingIoSetupComplete(false);
+    } catch (error) {
+      notifyResetFailure('open-banking.io', error);
+    }
+  }, [notifyResetFailure]);
+
   const onEnableBankingReset = useCallback(async () => {
     try {
       await ensureSuccessResponse(
@@ -414,6 +455,55 @@ export function useBuiltInBankSyncProviders({
     isSimpleFinSetupComplete,
     loadingSimpleFinAccounts,
     onSimpleFinInit,
+    upgradingAccountId,
+  ]);
+
+  const onConnectOpenBankingIo = useCallback(async () => {
+    if (!isOpenBankingIoSetupComplete) {
+      onOpenBankingIoInit();
+      return;
+    }
+
+    if (loadingOpenBankingIoAccounts) {
+      return;
+    }
+
+    setLoadingOpenBankingIoAccounts(true);
+
+    try {
+      const results = await send('openbankingio-accounts');
+      if (results.error_code) {
+        throw new Error(results.reason);
+      }
+      if ('error' in results && results.error) {
+        throw new Error(results.reason || results.error);
+      }
+
+      const externalAccounts: SyncServerOpenBankingIoAccount[] =
+        results.accounts ?? [];
+
+      dispatch(
+        pushModal({
+          modal: {
+            name: 'select-linked-accounts',
+            options: {
+              externalAccounts,
+              syncSource: 'openBankingIo',
+              upgradingAccountId,
+            },
+          },
+        }),
+      );
+    } catch {
+      onOpenBankingIoInit();
+    } finally {
+      setLoadingOpenBankingIoAccounts(false);
+    }
+  }, [
+    dispatch,
+    isOpenBankingIoSetupComplete,
+    loadingOpenBankingIoAccounts,
+    onOpenBankingIoInit,
     upgradingAccountId,
   ]);
 
@@ -596,6 +686,7 @@ export function useBuiltInBankSyncProviders({
     goCardless: Boolean(isGoCardlessSetupComplete),
     simpleFin: Boolean(isSimpleFinSetupComplete),
     pluggyai: Boolean(isPluggyAiSetupComplete),
+    openBankingIo: Boolean(isOpenBankingIoSetupComplete),
     enableBanking: Boolean(isEnableBankingSetupComplete),
     akahu: Boolean(isAkahuSetupComplete),
   } satisfies Record<BankSyncProviders, boolean>;
@@ -680,23 +771,43 @@ export function useBuiltInBankSyncProviders({
       });
     }
 
+    if (openBankingIoEnabled) {
+      baseProviders.push({
+        id: 'openBankingIo',
+        displayName: 'open-banking.io',
+        description: t(
+          'Link a European or UK bank account via open-banking.io, an affordable certificate-free alternative for PSD2-supported banks.',
+        ),
+        isConfigured: configuredProviders.openBankingIo,
+        canConfigure: canConfigureProviders,
+        isLoading: loadingOpenBankingIoAccounts,
+        onConfigure: onOpenBankingIoInit,
+        onLink: onConnectOpenBankingIo,
+        onReset: onOpenBankingIoReset,
+      });
+    }
+
     return baseProviders;
   }, [
     canConfigureProviders,
     configuredProviders.enableBanking,
     configuredProviders.goCardless,
     configuredProviders.pluggyai,
+    configuredProviders.openBankingIo,
     configuredProviders.simpleFin,
     configuredProviders.akahu,
     enableBankingEnabled,
     akahuEnabled,
+    openBankingIoEnabled,
     isEnableBankingLoading,
     loadingSimpleFinAccounts,
+    loadingOpenBankingIoAccounts,
     loadingAkahuAccounts,
     onConnectAkahu,
     onConnectEnableBanking,
     onConnectGoCardless,
     onConnectPluggyAi,
+    onConnectOpenBankingIo,
     onConnectSimpleFin,
     onAkahuInit,
     onAkahuReset,
@@ -706,6 +817,8 @@ export function useBuiltInBankSyncProviders({
     onGoCardlessReset,
     onPluggyAiInit,
     onPluggyAiReset,
+    onOpenBankingIoInit,
+    onOpenBankingIoReset,
     onSimpleFinInit,
     onSimpleFinReset,
     t,

--- a/packages/desktop-client/src/components/modals/OpenBankingIoInitialiseModal.tsx
+++ b/packages/desktop-client/src/components/modals/OpenBankingIoInitialiseModal.tsx
@@ -1,0 +1,152 @@
+// @ts-strict-ignore
+import React, { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { ButtonWithLoading } from '@actual-app/components/button';
+import { Text } from '@actual-app/components/text';
+import { theme } from '@actual-app/components/theme';
+import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
+import { css } from '@emotion/css';
+
+import { Error } from '#components/alerts';
+import { Link } from '#components/common/Link';
+import {
+  Modal,
+  ModalButtons,
+  ModalCloseButton,
+  ModalHeader,
+} from '#components/common/Modal';
+import { FormField, FormLabel } from '#components/forms';
+import type { Modal as ModalType } from '#modals/modalsSlice';
+import { getSecretsError } from '#util/error';
+
+type OpenBankingIoInitialiseModalProps = Extract<
+  ModalType,
+  { name: 'openbankingio-init' }
+>['options'];
+
+export const OpenBankingIoInitialiseModal = ({
+  onSuccess,
+}: OpenBankingIoInitialiseModalProps) => {
+  const { t } = useTranslation();
+  const [credentials, setCredentials] = useState('');
+  const [isValid, setIsValid] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(
+    t('It is required to provide the credentials.'),
+  );
+
+  const onSubmit = async (close: () => void) => {
+    if (!credentials) {
+      setIsValid(false);
+      setError(t('It is required to provide the credentials.'));
+      return;
+    }
+
+    try {
+      JSON.parse(credentials);
+    } catch {
+      setIsValid(false);
+      setError(t('The credentials must be valid JSON.'));
+      return;
+    }
+
+    setIsLoading(true);
+
+    const { error, reason } =
+      (await send('secret-set', {
+        name: 'openbankingio_credentials',
+        value: credentials,
+      })) || {};
+
+    if (error) {
+      setIsValid(false);
+      setError(getSecretsError(error, reason));
+      setIsLoading(false);
+      // Keep the modal open so the user can correct the credentials rather
+      // than closing silently on a failed save.
+      return;
+    }
+
+    onSuccess();
+    setIsLoading(false);
+    close();
+  };
+
+  return (
+    <Modal name="openbankingio-init" containerProps={{ style: { width: 300 } }}>
+      {({ state }) => (
+        <>
+          <ModalHeader
+            title={t('Set-up open-banking.io')}
+            rightContent={<ModalCloseButton onPress={() => state.close()} />}
+          />
+          <View style={{ display: 'flex', gap: 10 }}>
+            <Text>
+              <Trans>
+                In order to enable bank sync via open-banking.io (only for
+                European banks), you will need to create an account and download
+                your credentials. This can be done by creating an account with{' '}
+                <Link
+                  variant="external"
+                  to="https://open-banking.io/"
+                  linkColor="purple"
+                >
+                  open-banking.io
+                </Link>
+                .
+              </Trans>
+            </Text>
+
+            <FormField>
+              <FormLabel
+                title={t('Credentials (credentials.json):')}
+                htmlFor="credentials-field"
+              />
+              <textarea
+                id="credentials-field"
+                aria-label={t('Credentials (credentials.json)')}
+                className={css({
+                  width: '100%',
+                  minHeight: 120,
+                  resize: 'vertical',
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  lineHeight: 1.4,
+                  padding: '8px 10px',
+                  borderRadius: 4,
+                  border: `1px solid ${theme.formInputBorder}`,
+                  backgroundColor: theme.tableBackground,
+                  color: theme.tableText,
+                  '::placeholder': { color: theme.pageTextLight },
+                })}
+                value={credentials}
+                onChange={e => {
+                  setCredentials(e.target.value);
+                  setIsValid(true);
+                }}
+                placeholder={t('Paste the contents of credentials.json here')}
+              />
+            </FormField>
+
+            {!isValid && <Error>{error}</Error>}
+          </View>
+
+          <ModalButtons>
+            <ButtonWithLoading
+              variant="primary"
+              autoFocus
+              isLoading={isLoading}
+              onPress={() => {
+                void onSubmit(() => state.close());
+              }}
+            >
+              <Trans>Save and continue</Trans>
+            </ButtonWithLoading>
+          </ModalButtons>
+        </>
+      )}
+    </Modal>
+  );
+};

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
@@ -16,6 +16,7 @@ import type {
   SyncServerAkahuAccount,
   SyncServerEnableBankingAccount,
   SyncServerGoCardlessAccount,
+  SyncServerOpenBankingIoAccount,
   SyncServerPluggyAiAccount,
   SyncServerSimpleFinAccount,
 } from '@actual-app/core/types/models';
@@ -25,6 +26,7 @@ import {
   useLinkAccountAkahuMutation,
   useLinkAccountEnableBankingMutation,
   useLinkAccountMutation,
+  useLinkAccountOpenBankingIoMutation,
   useLinkAccountPluggyAiMutation,
   useLinkAccountSimpleFinMutation,
   useUnlinkAccountMutation,
@@ -94,6 +96,12 @@ export type SelectLinkedAccountsModalProps =
     }
   | {
       requisitionId?: undefined;
+      externalAccounts: SyncServerOpenBankingIoAccount[];
+      syncSource: 'openBankingIo';
+      upgradingAccountId?: string;
+    }
+  | {
+      requisitionId?: undefined;
       externalAccounts: SyncServerEnableBankingAccount[];
       syncSource: 'enableBanking';
       upgradingAccountId?: string;
@@ -130,6 +138,12 @@ export function SelectLinkedAccountsModal({
           return {
             syncSource: 'pluggyai',
             externalAccounts: toSort as SyncServerPluggyAiAccount[],
+            upgradingAccountId,
+          };
+        case 'openBankingIo':
+          return {
+            syncSource: 'openBankingIo',
+            externalAccounts: toSort as SyncServerOpenBankingIoAccount[],
             upgradingAccountId,
           };
         case 'akahu':
@@ -220,6 +234,7 @@ export function SelectLinkedAccountsModal({
   const unlinkAccount = useUnlinkAccountMutation();
   const linkAccountSimpleFin = useLinkAccountSimpleFinMutation();
   const linkAccountPluggyAi = useLinkAccountPluggyAiMutation();
+  const linkAccountOpenBankingIo = useLinkAccountOpenBankingIoMutation();
   const linkAccountAkahu = useLinkAccountAkahuMutation();
   const linkAccountEnableBanking = useLinkAccountEnableBankingMutation();
 
@@ -274,6 +289,23 @@ export function SelectLinkedAccountsModal({
           });
         } else if (propsWithSortedExternalAccounts.syncSource === 'pluggyai') {
           linkAccountPluggyAi.mutate({
+            externalAccount:
+              propsWithSortedExternalAccounts.externalAccounts[
+                externalAccountIndex
+              ],
+            upgradingId:
+              chosenLocalAccountId !== addOnBudgetAccountOption.id &&
+              chosenLocalAccountId !== addOffBudgetAccountOption.id
+                ? chosenLocalAccountId
+                : undefined,
+            offBudget,
+            startingDate,
+            startingBalance,
+          });
+        } else if (
+          propsWithSortedExternalAccounts.syncSource === 'openBankingIo'
+        ) {
+          linkAccountOpenBankingIo.mutate({
             externalAccount:
               propsWithSortedExternalAccounts.externalAccounts[
                 externalAccountIndex
@@ -576,6 +608,7 @@ type ExternalAccount =
   | SyncServerGoCardlessAccount
   | SyncServerSimpleFinAccount
   | SyncServerPluggyAiAccount
+  | SyncServerOpenBankingIoAccount
   | SyncServerAkahuAccount
   | SyncServerEnableBankingAccount;
 

--- a/packages/desktop-client/src/components/settings/Experimental.tsx
+++ b/packages/desktop-client/src/components/settings/Experimental.tsx
@@ -245,6 +245,12 @@ export function ExperimentalFeatures() {
               <Trans>Enable Banking sync (EU banks)</Trans>
             </FeatureToggle>
             <FeatureToggle
+              flag="openBankingIo"
+              feedbackLink="https://github.com/actualbudget/actual/issues/8394"
+            >
+              <Trans>open-banking.io sync (EU/UK banks)</Trans>
+            </FeatureToggle>
+            <FeatureToggle
               flag="akahuBankSync"
               feedbackLink="https://github.com/actualbudget/actual/issues/8020"
             >

--- a/packages/desktop-client/src/hooks/useFeatureFlag.ts
+++ b/packages/desktop-client/src/hooks/useFeatureFlag.ts
@@ -14,6 +14,7 @@ const DEFAULT_FEATURE_FLAG_STATE: Record<FeatureFlag, boolean> = {
   budgetAnalysisReport: false,
   payeeLocations: false,
   enableBanking: false,
+  openBankingIo: false,
   sankeyReport: false,
   akahuBankSync: false,
   mobileCalculator: false,

--- a/packages/desktop-client/src/hooks/useOpenBankingIoStatus.ts
+++ b/packages/desktop-client/src/hooks/useOpenBankingIoStatus.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+import { send } from '@actual-app/core/platform/client/connection';
+
+import { useSyncServerStatus } from './useSyncServerStatus';
+
+export function useOpenBankingIoStatus(enabled = true) {
+  const [configuredOpenBankingIo, setConfiguredOpenBankingIo] = useState<
+    boolean | null
+  >(null);
+  const [isLoading, setIsLoading] = useState(enabled);
+  const status = useSyncServerStatus();
+
+  useEffect(() => {
+    if (!enabled) {
+      setIsLoading(false);
+      return;
+    }
+
+    async function fetch() {
+      setIsLoading(true);
+      try {
+        const results = await send('openbankingio-status');
+        setConfiguredOpenBankingIo(results.configured || false);
+      } catch {
+        setConfiguredOpenBankingIo(false);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    if (status === 'online') {
+      void fetch();
+    } else {
+      setIsLoading(false);
+    }
+  }, [status, enabled]);
+
+  return {
+    configuredOpenBankingIo,
+    isLoading,
+  };
+}

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -142,6 +142,12 @@ export type Modal =
       };
     }
   | {
+      name: 'openbankingio-init';
+      options: {
+        onSuccess: () => void;
+      };
+    }
+  | {
       name: 'enablebanking-external-msg';
       options: {
         onMoveExternal: (arg: {

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -173,6 +173,7 @@ const sidebars = {
               items: [
                 'advanced/bank-sync/akahu',
                 'advanced/bank-sync/enable-banking',
+                'advanced/bank-sync/openbankingio',
                 'advanced/bank-sync/gocardless',
                 'advanced/bank-sync/simplefin',
                 'advanced/bank-sync/pluggyai',

--- a/packages/docs/docs/advanced/bank-sync/openbankingio.md
+++ b/packages/docs/docs/advanced/bank-sync/openbankingio.md
@@ -1,0 +1,17 @@
+# open-banking.io Setup
+
+<ExperimentalFeatureWarning issueId="8394" />
+
+:::warning
+All functionality described here may not be available in the latest stable release. See [Experimental Features](../../experimental/index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
+:::
+
+[open-banking.io](https://open-banking.io) provides bank-sync coverage across the EEA and the UK, with support for 2,600+ banks. It is **zero-knowledge**: the credential bundle is decrypted on your own Actual sync-server, and the service never sees your plaintext account data.
+
+To set up open-banking.io, start by creating and signing in to your account: https://open-banking.io
+
+Register your application and link the accounts you want, then export your credentials bundle. This downloads a `credentials.json` file that contains everything your sync-server needs to connect.
+
+Go to **More → Bank Sync**, choose **Set up open-banking.io**, and paste the full contents of your `credentials.json` bundle. The credentials are stored on your server, so you only need to enter them once.
+
+Now go to an Actual Budget account and select **Link account → open-banking.io**. Select the account you want to connect and follow the prompts to link it.

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -32,6 +32,7 @@ import type {
   SyncServerAkahuAccount,
   SyncServerEnableBankingAccount,
   SyncServerGoCardlessAccount,
+  SyncServerOpenBankingIoAccount,
   SyncServerPluggyAiAccount,
   SyncServerSimpleFinAccount,
   TransactionEntity,
@@ -59,6 +60,7 @@ export type AccountHandlers = {
   'pluggyai-accounts-link': typeof linkPluggyAiAccount;
   'akahu-accounts-link': typeof linkAkahuAccount;
   'enablebanking-accounts-link': typeof linkEnableBankingAccount;
+  'openbankingio-accounts-link': typeof linkOpenBankingIoAccount;
   'account-create': typeof createAccount;
   'account-close': typeof closeAccount;
   'account-reopen': typeof reopenAccount;
@@ -71,6 +73,7 @@ export type AccountHandlers = {
   'simplefin-status': typeof simpleFinStatus;
   'pluggyai-status': typeof pluggyAiStatus;
   'akahu-status': typeof akahuStatus;
+  'openbankingio-status': typeof openBankingIoStatus;
   'enablebanking-status': typeof enableBankingStatus;
   'enablebanking-aspsps': typeof enableBankingAspsps;
   'enablebanking-start-auth': typeof enableBankingStartAuth;
@@ -81,6 +84,7 @@ export type AccountHandlers = {
   'simplefin-accounts': typeof simpleFinAccounts;
   'pluggyai-accounts': typeof pluggyAiAccounts;
   'akahu-accounts': typeof akahuAccounts;
+  'openbankingio-accounts': typeof openBankingIoAccounts;
   'gocardless-get-banks': typeof getGoCardlessBanks;
   'gocardless-create-web-token': typeof createGoCardlessWebToken;
   'accounts-bank-sync': typeof accountsBankSync;
@@ -543,6 +547,83 @@ async function linkEnableBankingAccount({
   return 'ok';
 }
 
+async function linkOpenBankingIoAccount({
+  externalAccount,
+  upgradingId,
+  offBudget = false,
+  startingDate,
+  startingBalance,
+}: LinkAccountBaseParams & {
+  externalAccount: SyncServerOpenBankingIoAccount;
+}) {
+  let id;
+
+  const institution = {
+    // Persist a null name when the provider doesn't report an institution, so
+    // the desktop-client can render a localized fallback instead of baking an
+    // English string into shared bank data.
+    name: externalAccount.institution ?? null,
+  };
+
+  const bank = await link.findOrCreateBank(
+    institution,
+    externalAccount.account_id,
+  );
+
+  if (upgradingId) {
+    const accRow = await db.first<db.DbAccount>(
+      'SELECT * FROM accounts WHERE id = ?',
+      [upgradingId],
+    );
+
+    if (!accRow) {
+      throw new Error(`Account with ID ${upgradingId} not found.`);
+    }
+
+    id = accRow.id;
+    await db.update('accounts', {
+      id,
+      account_id: externalAccount.account_id,
+      bank: bank.id,
+      account_sync_source: 'openBankingIo',
+    });
+  } else {
+    id = uuidv4();
+    await db.insertWithUUID('accounts', {
+      id,
+      account_id: externalAccount.account_id,
+      name: externalAccount.name,
+      official_name: externalAccount.name,
+      bank: bank.id,
+      offbudget: offBudget ? 1 : 0,
+      account_sync_source: 'openBankingIo',
+    });
+    await db.insertPayee({
+      name: '',
+      transfer_acct: id,
+    });
+  }
+
+  const syncRes = await bankSync.syncAccount(
+    undefined,
+    undefined,
+    id,
+    externalAccount.account_id,
+    bank.bank_id,
+    startingDate,
+    startingBalance,
+  );
+
+  await handleSyncResponse(syncRes, id);
+
+  connection.send('sync-event', {
+    type: 'success',
+    tables: ['transactions', 'accounts'],
+  });
+
+  return 'ok';
+}
+
 async function createAccount({
   name,
   balance = 0,
@@ -930,6 +1011,53 @@ async function akahuStatus() {
       'X-ACTUAL-TOKEN': userToken,
     },
   );
+}
+
+async function openBankingIoStatus() {
+  const userToken = await asyncStorage.getItem('user-token');
+
+  if (!userToken) {
+    return { error: 'unauthorized' };
+  }
+
+  const serverConfig = getServer();
+  if (!serverConfig) {
+    throw new Error('Failed to get server config.');
+  }
+
+  return post(
+    serverConfig.OPENBANKINGIO_SERVER + '/status',
+    {},
+    {
+      'X-ACTUAL-TOKEN': userToken,
+    },
+  );
+}
+
+async function openBankingIoAccounts() {
+  const userToken = await asyncStorage.getItem('user-token');
+
+  if (!userToken) {
+    return { error: 'unauthorized' };
+  }
+
+  const serverConfig = getServer();
+  if (!serverConfig) {
+    throw new Error('Failed to get server config.');
+  }
+
+  try {
+    return await post(
+      serverConfig.OPENBANKINGIO_SERVER + '/accounts',
+      {},
+      {
+        'X-ACTUAL-TOKEN': userToken,
+      },
+      60000,
+    );
+  } catch {
+    return { error_code: 'TIMED_OUT' };
+  }
 }
 
 async function simpleFinAccounts() {
@@ -1740,6 +1868,7 @@ app.method('simplefin-accounts-link', linkSimpleFinAccount);
 app.method('pluggyai-accounts-link', linkPluggyAiAccount);
 app.method('akahu-accounts-link', linkAkahuAccount);
 app.method('enablebanking-accounts-link', linkEnableBankingAccount);
+app.method('openbankingio-accounts-link', linkOpenBankingIoAccount);
 app.method('account-create', mutator(undoable(createAccount)));
 app.method('account-close', mutator(closeAccount));
 app.method('account-reopen', mutator(undoable(reopenAccount)));
@@ -1752,6 +1881,7 @@ app.method('gocardless-status', goCardlessStatus);
 app.method('simplefin-status', simpleFinStatus);
 app.method('pluggyai-status', pluggyAiStatus);
 app.method('akahu-status', akahuStatus);
+app.method('openbankingio-status', openBankingIoStatus);
 app.method('enablebanking-status', enableBankingStatus);
 app.method('enablebanking-aspsps', enableBankingAspsps);
 app.method('enablebanking-start-auth', enableBankingStartAuth);
@@ -1762,6 +1892,7 @@ app.method('enablebanking-configure', enableBankingConfigure);
 app.method('simplefin-accounts', simpleFinAccounts);
 app.method('pluggyai-accounts', pluggyAiAccounts);
 app.method('akahu-accounts', akahuAccounts);
+app.method('openbankingio-accounts', openBankingIoAccounts);
 app.method('gocardless-get-banks', getGoCardlessBanks);
 app.method('gocardless-create-web-token', createGoCardlessWebToken);
 app.method('accounts-bank-sync', accountsBankSync);

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -391,6 +391,44 @@ async function downloadEnableBankingTransactions(
   };
 }
 
+async function downloadOpenBankingIoTransactions(
+  acctId: string,
+  since: string,
+) {
+  const userToken = await asyncStorage.getItem('user-token');
+  if (!userToken) return;
+
+  logger.log('Pulling transactions from open-banking.io');
+
+  const res = await post(
+    getServer().OPENBANKINGIO_SERVER + '/transactions',
+    {
+      accountId: acctId,
+      startDate: since,
+    },
+    {
+      'X-ACTUAL-TOKEN': userToken,
+    },
+    60000,
+  );
+
+  if (res.error_code) {
+    throw BankSyncError(res.error_type, res.error_code);
+  }
+
+  const {
+    transactions: { all },
+    balances,
+    startingBalance,
+  } = res;
+
+  return {
+    transactions: all,
+    accountBalance: balances,
+    startingBalance,
+  };
+}
+
 async function resolvePayee(trans, payeeName, payeesToCreate) {
   if (trans.payee == null && payeeName) {
     // First check our registry of new payees (to avoid a db access)
@@ -1074,7 +1112,10 @@ async function processBankSyncDownload(
         currentBalance,
       );
       balanceToUse = Math.round(previousBalance);
-    } else if (acctRow.account_sync_source === 'enableBanking') {
+    } else if (
+      acctRow.account_sync_source === 'enableBanking' ||
+      acctRow.account_sync_source === 'openBankingIo'
+    ) {
       const importPending = await aqlQuery(
         q('preferences')
           .filter({ id: `sync-import-pending-${id}` })
@@ -1196,6 +1237,8 @@ export async function syncAccount(
     );
   } else if (acctRow.account_sync_source === 'enableBanking') {
     download = await downloadEnableBankingTransactions(acctId, syncStartDate);
+  } else if (acctRow.account_sync_source === 'openBankingIo') {
+    download = await downloadOpenBankingIoTransactions(acctId, syncStartDate);
   } else {
     throw new Error(
       `Unrecognized bank-sync provider: ${acctRow.account_sync_source}`,

--- a/packages/loot-core/src/server/server-config.ts
+++ b/packages/loot-core/src/server/server-config.ts
@@ -10,6 +10,7 @@ type ServerConfig = {
   PLUGGYAI_SERVER: string;
   AKAHU_SERVER: string;
   ENABLEBANKING_SERVER: string;
+  OPENBANKINGIO_SERVER: string;
 };
 
 let config: ServerConfig | null = null;
@@ -49,6 +50,7 @@ export function getServer(url?: string): ServerConfig | null {
         PLUGGYAI_SERVER: joinURL(url, '/pluggyai'),
         AKAHU_SERVER: joinURL(url, '/akahu'),
         ENABLEBANKING_SERVER: joinURL(url, '/enablebanking'),
+        OPENBANKINGIO_SERVER: joinURL(url, '/openbankingio'),
       };
     } catch (error) {
       logger.warn(

--- a/packages/loot-core/src/types/models/bank-sync.ts
+++ b/packages/loot-core/src/types/models/bank-sync.ts
@@ -26,6 +26,7 @@ export const SYNC_PROVIDERS = [
   'pluggyai',
   'enableBanking',
   'akahu',
+  'openBankingIo',
 ] as const;
 
 export type BankSyncProviders = (typeof SYNC_PROVIDERS)[number];

--- a/packages/loot-core/src/types/models/index.ts
+++ b/packages/loot-core/src/types/models/index.ts
@@ -11,6 +11,7 @@ export type * from './gocardless';
 export type * from './import-transaction';
 export type * from './nearby-payee';
 export type * from './note';
+export type * from './openbankingio';
 export type * from './openid';
 export type * from './payee';
 export type * from './payee-location';

--- a/packages/loot-core/src/types/models/openbankingio.ts
+++ b/packages/loot-core/src/types/models/openbankingio.ts
@@ -1,0 +1,7 @@
+// Normalized type for client-side account selection (matches SimpleFIN/PluggyAI pattern)
+export type SyncServerOpenBankingIoAccount = {
+  account_id: string;
+  name: string;
+  institution: string;
+  balance: number;
+};

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -10,6 +10,7 @@ export type FeatureFlag =
   | 'budgetAnalysisReport'
   | 'payeeLocations'
   | 'enableBanking'
+  | 'openBankingIo'
   | 'sankeyReport'
   | 'akahuBankSync'
   | 'mobileCalculator';

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@actual-app/crdt": "workspace:*",
     "@actual-app/web": "workspace:*",
+    "@open-banking-io/client": "^0.2.0",
     "akahu": "^2.5.1",
     "argon2": "^0.44.0",
     "bcrypt": "^6.0.0",

--- a/packages/sync-server/src/app-openbankingio/app-openbankingio.js
+++ b/packages/sync-server/src/app-openbankingio/app-openbankingio.js
@@ -1,0 +1,144 @@
+import createDebug from 'debug';
+import express from 'express';
+
+import { handleError } from '#app-gocardless/util/handle-error';
+import {
+  requestLoggerMiddleware,
+  validateSessionMiddleware,
+} from '#util/middlewares';
+
+import {
+  isImportableTransaction,
+  normalizeAccount,
+  normalizeBalance,
+  normalizeTransaction,
+  openBankingIoService,
+} from './services/openbankingio-service';
+
+const debug = createDebug('actual:openbankingio:app');
+
+const app = express();
+export { app as handlers };
+app.use(requestLoggerMiddleware);
+app.use(express.json());
+app.use(validateSessionMiddleware);
+
+app.post(
+  '/status',
+  handleError(async (req, res) => {
+    const configured = openBankingIoService.isConfigured();
+
+    res.send({
+      status: 'ok',
+      data: {
+        configured,
+      },
+    });
+  }),
+);
+
+app.post(
+  '/accounts',
+  handleError(async (req, res) => {
+    const accounts = await openBankingIoService.getAccounts();
+
+    res.send({
+      status: 'ok',
+      data: {
+        accounts: accounts.map(normalizeAccount),
+      },
+    });
+  }),
+);
+
+app.post(
+  '/transactions',
+  handleError(async (req, res) => {
+    const { accountId, startDate } = req.body || {};
+
+    if (!accountId || !startDate) {
+      res.send({
+        status: 'ok',
+        data: {
+          error_code: 'INVALID_INPUT',
+          error_type: 'Missing accountId or startDate',
+        },
+      });
+      return;
+    }
+
+    const dateFrom =
+      typeof startDate === 'string'
+        ? startDate
+        : new Date(startDate).toISOString().split('T')[0];
+
+    // Balances (and the starting balance) come from the account listing; the
+    // SDK returns them inline per account.
+    const accounts = await openBankingIoService.getAccounts();
+    const account = accounts.find(a => a.id === accountId);
+
+    let balances = [];
+    // Null (not 0) when the account is missing from the listing, so loot-core
+    // skips the balance update rather than zeroing the displayed balance.
+    let startingBalance = null;
+    if (account) {
+      balances = (account.balances || []).map(bal =>
+        normalizeBalance(bal, account.currency),
+      );
+
+      // Prefer the interim booked balance ('ITBD'), falling back to the first
+      // balance if it is not present.
+      const preferredBalance =
+        balances.find(b => b.balanceType === 'ITBD') ?? balances[0];
+      if (preferredBalance) {
+        startingBalance = preferredBalance.balanceAmount.amount;
+      }
+    }
+
+    const rawTransactions = await openBankingIoService.getAllTransactions(
+      accountId,
+      dateFrom,
+    );
+
+    const all = [];
+    const booked = [];
+    const pending = [];
+
+    for (const tx of rawTransactions) {
+      const normalized = normalizeTransaction(tx);
+
+      // Drop records Actual's client can't insert (empty/non-ISO date or
+      // non-numeric amount) — one of them would otherwise abort the entire
+      // account sync. Pending transactions that carry a date are unaffected.
+      if (!isImportableTransaction(normalized)) {
+        debug(
+          'Skipping unimportable transaction id=%s date=%s amount=%s',
+          normalized.transactionId,
+          normalized.date,
+          normalized.transactionAmount.amount,
+        );
+        continue;
+      }
+
+      all.push(normalized);
+      if (normalized.booked) {
+        booked.push(normalized);
+      } else {
+        pending.push(normalized);
+      }
+    }
+
+    res.send({
+      status: 'ok',
+      data: {
+        transactions: {
+          all,
+          booked,
+          pending,
+        },
+        balances,
+        startingBalance,
+      },
+    });
+  }),
+);

--- a/packages/sync-server/src/app-openbankingio/app-openbankingio.test.js
+++ b/packages/sync-server/src/app-openbankingio/app-openbankingio.test.js
@@ -1,0 +1,211 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SecretName, secretsService } from '#services/secrets-service';
+
+import {
+  mockAccount,
+  mockDebitTransaction,
+  mockPendingTransaction,
+  mockPendingTransactionNoDate,
+} from './services/tests/fixtures';
+
+// The SDK is not installed in this environment (and would require live
+// credentials anyway), so stub it. The factory prevents Vitest from resolving
+// the real module.
+const { mockGetAccounts, mockGetTransactions, mockFromBundle } = vi.hoisted(
+  () => ({
+    mockGetAccounts: vi.fn(),
+    mockGetTransactions: vi.fn(),
+    mockFromBundle: vi.fn(),
+  }),
+);
+
+vi.mock('@open-banking-io/client', () => ({
+  OpenBankingClient: {
+    fromBundle: mockFromBundle,
+  },
+}));
+
+const VALID_CREDS = JSON.stringify({
+  bundle: 'abc',
+  keys: [],
+  apiBaseUrl: 'https://api.open-banking.io',
+});
+
+const post = path =>
+  request(app).post(path).set('x-actual-token', 'valid-token');
+
+const ids = txns => txns.map(t => t.transactionId);
+
+// Import after the mock is registered.
+const { handlers: app } = await import('./app-openbankingio');
+
+describe('app-openbankingio', () => {
+  beforeEach(() => {
+    mockFromBundle.mockReturnValue({
+      getAccounts: mockGetAccounts,
+      getTransactions: mockGetTransactions,
+    });
+    secretsService.set(SecretName.openbankingio_credentials, null);
+    vi.spyOn(console, 'log').mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  describe('/status', () => {
+    it('reports configured when credentials are stored', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+
+      const res = await post('/status');
+
+      expect(res.body.data.configured).toBe(true);
+    });
+
+    it('reports not configured when no credentials are stored', async () => {
+      const res = await post('/status');
+
+      expect(res.body.data.configured).toBe(false);
+    });
+  });
+
+  describe('/accounts', () => {
+    it('returns normalized accounts', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+      mockGetAccounts.mockResolvedValue([mockAccount]);
+
+      const res = await post('/accounts');
+
+      expect(res.body.status).toBe('ok');
+      expect(res.body.data.accounts).toEqual([
+        {
+          account_id: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+          name: 'Current Account',
+          institution: 'Nordea',
+          balance: 123456,
+        },
+      ]);
+    });
+
+    it('surfaces SDK errors through handleError as INTERNAL_ERROR', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+      mockGetAccounts.mockRejectedValue(new Error('decrypt failed'));
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INTERNAL_ERROR');
+      expect(res.body.data.error_type).toBe('decrypt failed');
+    });
+
+    it('rejects an apiBaseUrl outside the open-banking.io domain (SSRF guard)', async () => {
+      secretsService.set(
+        SecretName.openbankingio_credentials,
+        JSON.stringify({
+          bundle: 'abc',
+          keys: [],
+          apiBaseUrl: 'http://169.254.169.254/latest/meta-data/',
+        }),
+      );
+
+      const res = await post('/accounts');
+
+      // The SDK is never reached once the URL is rejected.
+      expect(mockGetAccounts).not.toHaveBeenCalled();
+      expect(res.body.data.error_code).toBe('INTERNAL_ERROR');
+    });
+  });
+
+  describe('/transactions', () => {
+    it('returns INVALID_INPUT when accountId or startDate is missing', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+
+      const res = await post('/transactions').send({ accountId: 'acc-1' });
+
+      expect(res.body.data.error_code).toBe('INVALID_INPUT');
+    });
+
+    it('returns balances, startingBalance from ITBD, and bucketed transactions', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+      mockGetAccounts.mockResolvedValue([mockAccount]);
+      mockGetTransactions.mockResolvedValue({
+        items: [mockDebitTransaction, mockPendingTransaction],
+        total: 2,
+      });
+
+      const res = await post('/transactions').send({
+        accountId: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+        startDate: '2026-03-01',
+      });
+
+      expect(res.body.status).toBe('ok');
+      expect(res.body.data.startingBalance).toBe(123456);
+      expect(res.body.data.balances[0].balanceType).toBe('ITBD');
+      expect(res.body.data.balances[0].balanceAmount).toEqual({
+        amount: 123456,
+        currency: 'EUR',
+      });
+
+      const { all, booked, pending } = res.body.data.transactions;
+      expect(ids(all)).toEqual(['ref-002', 'tx-003']);
+      expect(ids(booked)).toEqual(['ref-002']);
+      expect(ids(pending)).toEqual(['tx-003']);
+    });
+
+    it('skips a date-less pending transaction that would abort the sync', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+      mockGetAccounts.mockResolvedValue([mockAccount]);
+      mockGetTransactions.mockResolvedValue({
+        items: [
+          mockDebitTransaction,
+          mockPendingTransaction,
+          mockPendingTransactionNoDate,
+        ],
+        total: 3,
+      });
+
+      const res = await post('/transactions').send({
+        accountId: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+        startDate: '2026-03-01',
+      });
+
+      const { all } = res.body.data.transactions;
+      expect(ids(all)).toEqual(['ref-002', 'tx-003']);
+      expect(ids(all)).not.toContain('tx-no-date');
+    });
+
+    it('keeps paginating while pages are full and stops on a short page (no reliance on total)', async () => {
+      secretsService.set(SecretName.openbankingio_credentials, VALID_CREDS);
+      mockGetAccounts.mockResolvedValue([mockAccount]);
+      // A full page (=== the page limit) means "there may be more". Note: no
+      // `total` field is returned, proving pagination doesn't depend on it.
+      const fullPage = Array.from({ length: 500 }, (_, i) => ({
+        ...mockDebitTransaction,
+        id: `p1-${i}`,
+      }));
+      mockGetTransactions
+        .mockResolvedValueOnce({ items: fullPage })
+        .mockResolvedValueOnce({ items: [mockPendingTransaction] });
+
+      const res = await post('/transactions').send({
+        accountId: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+        startDate: '2026-03-01',
+      });
+
+      expect(mockGetTransactions).toHaveBeenCalledTimes(2);
+      expect(mockGetTransactions).toHaveBeenNthCalledWith(
+        1,
+        '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+        { from: '2026-03-01', limit: 500, offset: 0 },
+      );
+      expect(mockGetTransactions).toHaveBeenNthCalledWith(
+        2,
+        '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+        { from: '2026-03-01', limit: 500, offset: 500 },
+      );
+      expect(res.body.data.transactions.all).toHaveLength(501);
+    });
+  });
+});

--- a/packages/sync-server/src/app-openbankingio/services/openbankingio-service.js
+++ b/packages/sync-server/src/app-openbankingio/services/openbankingio-service.js
@@ -1,0 +1,274 @@
+import { OpenBankingClient } from '@open-banking-io/client';
+import createDebug from 'debug';
+
+import { SecretName, secretsService } from '#services/secrets-service';
+
+const debug = createDebug('actual:openbankingio:service');
+
+const TRANSACTIONS_PAGE_LIMIT = 500;
+
+// open-banking.io is a hosted API, so its base URL always lives on the
+// open-banking.io domain. The credentials bundle carries its own `apiBaseUrl`,
+// but that value is user-controlled — pin it to open-banking.io (https only) so
+// a tampered bundle can't point the SDK at an internal/metadata host (SSRF).
+function assertOpenBankingIoUrl(apiBaseUrl) {
+  let url;
+  try {
+    url = new URL(apiBaseUrl);
+  } catch {
+    throw new Error(`Invalid open-banking.io apiBaseUrl: ${apiBaseUrl}`);
+  }
+
+  const host = url.hostname.toLowerCase();
+  const allowed =
+    url.protocol === 'https:' &&
+    (host === 'open-banking.io' || host.endsWith('.open-banking.io'));
+
+  if (!allowed) {
+    throw new Error(
+      `Refusing to use apiBaseUrl outside open-banking.io: ${apiBaseUrl}`,
+    );
+  }
+}
+
+// --- Helper functions ---
+
+function getCredentials() {
+  const credsJson = secretsService.get(SecretName.openbankingio_credentials);
+
+  if (!credsJson) {
+    throw new Error('open-banking.io is not configured');
+  }
+
+  return credsJson;
+}
+
+// The open-banking.io SDK decrypts the credentials bundle and holds the
+// per-institution keys required to fetch + decrypt account data.
+function getClient() {
+  const bundle = JSON.parse(getCredentials());
+
+  if (typeof bundle?.apiBaseUrl === 'string' && bundle.apiBaseUrl) {
+    assertOpenBankingIoUrl(bundle.apiBaseUrl);
+  }
+
+  return OpenBankingClient.fromBundle(bundle);
+}
+
+// --- Normalization functions ---
+
+// SEPA / ISO 20022 structured remittance prefixes (e.g. `EREF+invoice-42`).
+// They are metadata for clearing systems, not user-facing text, so we strip
+// them from the front of each remittance line. The list is an allowlist of
+// known prefixes rather than a catch-all `[A-Z]{3,}\+` so we don't accidentally
+// strip merchant tokens like `BMW+` or `USB+` that legitimately start a
+// description.
+const SEPA_PREFIX_RE =
+  /^(?:EREF|KREF|MREF|CRED|DBTR|CDTR|SVWZ|SVCL|PURP|RTRN|REJT|REFE|SDVA|INDA|NTAV|ULTC|ULTD|ULTB|ABWA|ABWE|IBAN|BIC|COAM|OAMT|REMI|SQTP|ROC)\+/;
+
+function stripSepaPrefix(s) {
+  return s.replace(SEPA_PREFIX_RE, '').trim();
+}
+
+function cleanRemittanceArray(arr) {
+  return arr.map(stripSepaPrefix).filter(Boolean);
+}
+
+// The SDK may return remittance information as a single string or an array of
+// lines; normalize to an array so downstream handling matches Enable Banking.
+function toRemittanceArray(remittanceInformation) {
+  if (Array.isArray(remittanceInformation)) {
+    return remittanceInformation.filter(s => typeof s === 'string');
+  }
+  if (typeof remittanceInformation === 'string' && remittanceInformation) {
+    return [remittanceInformation];
+  }
+  return [];
+}
+
+export function normalizeTransaction(tx) {
+  const transactionId = tx.id || '';
+  const bookingDate =
+    tx.bookingDate || tx.valueDate || tx.transactionDate || '';
+  const valueDate = tx.valueDate;
+
+  let payeeName = '';
+  if (tx.creditDebitIndicator === 'CRDT' && tx.debtorName) {
+    payeeName = tx.debtorName;
+  } else if (tx.creditDebitIndicator === 'DBIT' && tx.creditorName) {
+    payeeName = tx.creditorName;
+  } else if (tx.creditorName) {
+    payeeName = tx.creditorName;
+  } else if (tx.debtorName) {
+    payeeName = tx.debtorName;
+  } else {
+    const cleanedFallback = cleanRemittanceArray(
+      toRemittanceArray(tx.remittanceInformation),
+    );
+    if (cleanedFallback.length > 0) {
+      payeeName = cleanedFallback[0];
+    }
+  }
+
+  const cleanedAll = cleanRemittanceArray(
+    toRemittanceArray(tx.remittanceInformation),
+  );
+  const remittanceInformationUnstructured =
+    cleanedAll.length > 0 ? cleanedAll.join(' ') : undefined;
+
+  // Normalize amount based on credit/debit indicator. The SDK returns an
+  // unsigned magnitude (decimal string), so strip any stray sign and apply the
+  // correct one: DBIT is money out (negative), CRDT is money in (positive).
+  const trimmedAmount = String(tx.amount ?? '').trim();
+  let signedAmount;
+  if (tx.creditDebitIndicator === 'DBIT') {
+    signedAmount = '-' + trimmedAmount.replace(/^[+-]/, '');
+  } else if (tx.creditDebitIndicator === 'CRDT') {
+    signedAmount = trimmedAmount.replace(/^[+-]/, '');
+  } else {
+    // Unknown/absent direction: we can't tell whether this is money in or out.
+    // Keep the raw magnitude here, but `isImportableTransaction` drops the
+    // record so we never import a guessed sign (a wrong sign silently corrupts
+    // the balance).
+    signedAmount = trimmedAmount;
+  }
+
+  // Return an explicit, clean shape — do NOT spread `...tx`. The SDK's raw
+  // transaction carries a top-level unsigned `amount` magnitude; leaking it
+  // would shadow loot-core's fallback to the signed `transactionAmount.amount`
+  // (sync.ts: `if (!trans.amount) trans.amount = trans.transactionAmount.amount`),
+  // making every transaction import as a positive deposit. (Enable Banking can
+  // safely spread its raw tx because it uses `transaction_amount`, not `amount`.)
+  return {
+    transactionId,
+    date: bookingDate,
+    bookingDate,
+    valueDate,
+    transactionAmount: {
+      amount: signedAmount,
+      currency: tx.currency,
+    },
+    payeeName,
+    notes: remittanceInformationUnstructured ?? tx.note,
+    remittanceInformationUnstructured,
+    // Kept so `isImportableTransaction` can drop records with no clear
+    // credit/debit direction (rather than importing a guessed sign).
+    creditDebitIndicator: tx.creditDebitIndicator,
+    // open-banking.io passes the Berlin Group status through unchanged
+    // ('BOOK' booked, 'PDNG' pending), exactly like Enable Banking.
+    booked: tx.status !== 'PDNG',
+  };
+}
+
+const IMPORTABLE_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// Actual's client imports a transaction by inserting it into a local SQLite
+// database: the `date` column is a required integer derived from an ISO date,
+// and the amount must be numeric. A record with an empty / non-ISO date or a
+// non-numeric amount makes that insert throw, which aborts the whole account
+// sync, so callers skip such records instead of failing the entire import.
+export function isImportableTransaction(tx) {
+  // Trim and reject empty amounts explicitly: Number('') is 0 (finite), so an
+  // empty/whitespace amount would otherwise slip through as a zero transaction.
+  const amount = tx.transactionAmount.amount.trim();
+  // Require a known credit/debit direction — without it we can't sign the
+  // amount, and importing an unsigned magnitude would flip outgoing payments
+  // into positive deposits.
+  const hasDirection =
+    tx.creditDebitIndicator === 'CRDT' || tx.creditDebitIndicator === 'DBIT';
+  return (
+    hasDirection &&
+    IMPORTABLE_DATE_REGEX.test(tx.date) &&
+    amount !== '' &&
+    Number.isFinite(Number(amount))
+  );
+}
+
+// Balances arrive without a currency of their own, so the account currency is
+// threaded through. Amounts are integer cents to match the bank-sync wire
+// format Actual expects.
+export function normalizeBalance(bal, currency) {
+  const amount = Math.round(parseFloat(bal.amount) * 100);
+  return {
+    balanceAmount: {
+      amount,
+      currency,
+    },
+    balanceType: bal.type,
+    referenceDate: bal.referenceDate,
+  };
+}
+
+// The interim booked balance ('ITBD') is the closing balance Actual uses as the
+// starting balance; fall back to the first available balance if absent.
+function getStartingBalanceCents(balances, currency) {
+  const source = balances || [];
+  const preferred = source.find(b => b.type === 'ITBD') ?? source[0];
+  return preferred
+    ? normalizeBalance(preferred, currency).balanceAmount.amount
+    : 0;
+}
+
+export function normalizeAccount(account) {
+  return {
+    account_id: account.id,
+    name:
+      account.displayName ||
+      account.accountName ||
+      account.ownerName ||
+      account.iban ||
+      account.id,
+    institution: account.aspspName || 'Unknown',
+    balance: getStartingBalanceCents(account.balances, account.currency),
+  };
+}
+
+// --- Service ---
+
+export const openBankingIoService = {
+  isConfigured() {
+    return !!secretsService.get(SecretName.openbankingio_credentials);
+  },
+
+  async getAccounts() {
+    const client = getClient();
+    return client.getAccounts();
+  },
+
+  async getAllTransactions(accountId, startDate) {
+    const client = getClient();
+
+    const allTransactions = [];
+    let offset = 0;
+    const maxIterations = 100;
+    let iteration = 0;
+
+    // Page until the API returns a non-full page. We deliberately don't rely on
+    // `page.total`: if the API omits it, trusting it would stop after the first
+    // page and silently truncate history. A short (or empty) page is the last.
+    while (iteration < maxIterations) {
+      const page = await client.getTransactions(accountId, {
+        from: startDate,
+        limit: TRANSACTIONS_PAGE_LIMIT,
+        offset,
+      });
+
+      const items = page.items || [];
+      allTransactions.push(...items);
+      offset += items.length;
+      iteration++;
+
+      if (items.length < TRANSACTIONS_PAGE_LIMIT) {
+        break;
+      }
+    }
+
+    debug(
+      'Fetched %d transactions for account %s',
+      allTransactions.length,
+      accountId,
+    );
+
+    return allTransactions;
+  },
+};

--- a/packages/sync-server/src/app-openbankingio/services/tests/fixtures.js
+++ b/packages/sync-server/src/app-openbankingio/services/tests/fixtures.js
@@ -1,0 +1,109 @@
+// Fixtures mirror the shapes returned by the @open-banking-io/client SDK.
+
+export const mockCreditTransaction = {
+  id: 'ref-001',
+  amount: '100.50',
+  currency: 'EUR',
+  creditDebitIndicator: 'CRDT',
+  status: 'BOOK',
+  bookingDate: '2026-03-01',
+  valueDate: '2026-03-01',
+  transactionDate: '2026-03-01',
+  creditorName: 'Salary Inc',
+  debtorName: 'My Employer',
+  remittanceInformation: ['Monthly salary', 'March 2026'],
+  note: 'salary note',
+};
+
+export const mockDebitTransaction = {
+  id: 'ref-002',
+  amount: '25.99',
+  currency: 'EUR',
+  creditDebitIndicator: 'DBIT',
+  status: 'BOOK',
+  bookingDate: '2026-03-02',
+  valueDate: '2026-03-02',
+  transactionDate: '2026-03-02',
+  creditorName: 'Grocery Store',
+  debtorName: 'My Account',
+  remittanceInformation: ['Groceries purchase'],
+};
+
+export const mockPendingTransaction = {
+  id: 'tx-003',
+  amount: '10.00',
+  currency: 'EUR',
+  status: 'PDNG',
+  creditDebitIndicator: 'DBIT',
+  valueDate: '2026-03-03',
+  transactionDate: '2026-03-03',
+  remittanceInformation: ['Card payment'],
+};
+
+export const mockTransactionNoPayee = {
+  id: 'ref-004',
+  amount: '5.00',
+  currency: 'EUR',
+  creditDebitIndicator: 'CRDT',
+  status: 'BOOK',
+  bookingDate: '2026-03-04',
+  remittanceInformation: ['Transfer from savings'],
+};
+
+export const mockTransactionMinimal = {
+  amount: '1.23',
+  currency: 'EUR',
+  status: 'BOOK',
+};
+
+// A pending transaction with no booking/value/transaction date. Some ASPSPs
+// return these; normalizeTransaction maps it to date: '', which Actual's client
+// cannot insert.
+export const mockPendingTransactionNoDate = {
+  id: 'tx-no-date',
+  amount: '7.50',
+  currency: 'EUR',
+  creditDebitIndicator: 'DBIT',
+  status: 'PDNG',
+  remittanceInformation: ['Card payment, not yet booked'],
+};
+
+export const mockBalance = {
+  type: 'ITBD',
+  amount: '1234.56',
+};
+
+export const mockNegativeBalance = {
+  type: 'XPCD',
+  amount: '-50.75',
+};
+
+export const mockAccount = {
+  id: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+  displayName: 'Current Account',
+  accountName: 'Checking',
+  ownerName: 'Jane Doe',
+  iban: 'FI0455231152453547',
+  aspspName: 'Nordea',
+  currency: 'EUR',
+  balances: [
+    { type: 'ITBD', amount: '1234.56' },
+    { type: 'XPCD', amount: '1200.00' },
+  ],
+};
+
+export const mockAccountNoDisplayName = {
+  id: '12345678-1234-1234-1234-123456789abc',
+  accountName: 'Savings',
+  ownerName: 'Jane Doe',
+  iban: 'FI9876543210000001',
+  aspspName: 'OP',
+  currency: 'EUR',
+  balances: [{ type: 'ITBD', amount: '500.00' }],
+};
+
+export const mockAccountMinimal = {
+  id: 'aaaabbbb-cccc-dddd-eeee-ffff00001111',
+  currency: 'EUR',
+  balances: [],
+};

--- a/packages/sync-server/src/app-openbankingio/services/tests/normalization.spec.js
+++ b/packages/sync-server/src/app-openbankingio/services/tests/normalization.spec.js
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The service statically imports the SDK; stub it so the module resolves
+// without the (uninstalled) package. These tests exercise pure normalization
+// helpers only, so the client is never invoked.
+vi.mock('@open-banking-io/client', () => ({
+  OpenBankingClient: { fromBundle: vi.fn() },
+}));
+
+const {
+  isImportableTransaction,
+  normalizeAccount,
+  normalizeBalance,
+  normalizeTransaction,
+} = await import('../openbankingio-service');
+
+const {
+  mockAccount,
+  mockAccountMinimal,
+  mockAccountNoDisplayName,
+  mockBalance,
+  mockCreditTransaction,
+  mockDebitTransaction,
+  mockNegativeBalance,
+  mockPendingTransaction,
+  mockPendingTransactionNoDate,
+  mockTransactionMinimal,
+  mockTransactionNoPayee,
+} = await import('./fixtures');
+
+describe('normalizeTransaction', () => {
+  it('should use debtor name for CRDT transactions', () => {
+    const result = normalizeTransaction(mockCreditTransaction);
+    expect(result.payeeName).toBe('My Employer');
+    expect(result.booked).toBe(true);
+    expect(result.transactionId).toBe('ref-001');
+    expect(result.bookingDate).toBe('2026-03-01');
+    expect(result.valueDate).toBe('2026-03-01');
+    expect(result.transactionAmount).toEqual({
+      amount: '100.50',
+      currency: 'EUR',
+    });
+  });
+
+  it('should use creditor name for DBIT transactions and sign the amount negative', () => {
+    const result = normalizeTransaction(mockDebitTransaction);
+    expect(result.payeeName).toBe('Grocery Store');
+    expect(result.booked).toBe(true);
+    expect(result.transactionId).toBe('ref-002');
+    // magnitude was unsigned '25.99' -> DBIT makes it negative
+    expect(result.transactionAmount.amount).toBe('-25.99');
+  });
+
+  it('should sign CRDT magnitude positive', () => {
+    const result = normalizeTransaction(mockCreditTransaction);
+    expect(result.transactionAmount.amount).toBe('100.50');
+  });
+
+  it('should mark pending transactions as not booked', () => {
+    const result = normalizeTransaction(mockPendingTransaction);
+    expect(result.booked).toBe(false);
+    expect(result.transactionId).toBe('tx-003');
+    // DBIT indicator still applies to pending
+    expect(result.transactionAmount.amount).toBe('-10.00');
+  });
+
+  it('treats the Berlin Group status verbatim: only PDNG is unbooked', () => {
+    // The SDK forwards the raw Berlin Group status ('BOOK'/'PDNG'). Guard
+    // against regressing to a lowercase compare, which marks pending booked.
+    expect(
+      normalizeTransaction({ ...mockDebitTransaction, status: 'PDNG' }).booked,
+    ).toBe(false);
+    expect(
+      normalizeTransaction({ ...mockDebitTransaction, status: 'BOOK' }).booked,
+    ).toBe(true);
+    // Anything that isn't PDNG (incl. a missing status) is treated as booked.
+    expect(
+      normalizeTransaction({ ...mockDebitTransaction, status: undefined })
+        .booked,
+    ).toBe(true);
+  });
+
+  it('does not leak the SDK unsigned `amount`, so loot-core sees the signed value', () => {
+    // loot-core does `if (!trans.amount) trans.amount = trans.transactionAmount.amount`
+    // then decides payment/deposit via `trans.amount <= 0`. If we leaked the raw
+    // unsigned magnitude as `amount`, every DBIT would import as a positive deposit.
+    const debit = normalizeTransaction(mockDebitTransaction);
+    expect(debit.amount).toBeUndefined();
+    const asLootCoreSeesIt = debit.amount ?? debit.transactionAmount.amount;
+    expect(Number(asLootCoreSeesIt)).toBeLessThan(0); // DBIT → payment
+
+    const credit = normalizeTransaction(mockCreditTransaction);
+    expect(credit.amount).toBeUndefined();
+    expect(
+      Number(credit.amount ?? credit.transactionAmount.amount),
+    ).toBeGreaterThan(0); // CRDT → deposit
+  });
+
+  it('should fall back to remittanceInformation for payee when no creditor/debtor', () => {
+    const result = normalizeTransaction(mockTransactionNoPayee);
+    // No creditor/debtor names -> first cleaned remittance line is the payee
+    expect(result.payeeName).toBe('Transfer from savings');
+  });
+
+  it('should join remittanceInformation with a space', () => {
+    const result = normalizeTransaction(mockCreditTransaction);
+    expect(result.remittanceInformationUnstructured).toBe(
+      'Monthly salary March 2026',
+    );
+  });
+
+  it('should handle minimal transaction with empty payee/id/date', () => {
+    const result = normalizeTransaction(mockTransactionMinimal);
+    expect(result.payeeName).toBe('');
+    expect(result.transactionId).toBe('');
+    expect(result.bookingDate).toBe('');
+    expect(result.booked).toBe(true);
+  });
+
+  it('should fall back bookingDate to valueDate then transactionDate', () => {
+    const noBookingDate = { ...mockCreditTransaction, bookingDate: undefined };
+    expect(normalizeTransaction(noBookingDate).bookingDate).toBe('2026-03-01');
+
+    const noBookingOrValueDate = {
+      ...mockCreditTransaction,
+      bookingDate: undefined,
+      valueDate: undefined,
+      transactionDate: '2026-02-28',
+    };
+    expect(normalizeTransaction(noBookingOrValueDate).bookingDate).toBe(
+      '2026-02-28',
+    );
+  });
+
+  it('should strip existing sign from the magnitude before applying indicator', () => {
+    const result = normalizeTransaction({
+      ...mockDebitTransaction,
+      amount: '-25.99',
+    });
+    expect(result.transactionAmount.amount).toBe('-25.99');
+  });
+
+  it('should fall back notes to the SDK note field when remittance is empty', () => {
+    const result = normalizeTransaction({
+      ...mockCreditTransaction,
+      remittanceInformation: undefined,
+      note: 'a plain note',
+    });
+    expect(result.remittanceInformationUnstructured).toBeUndefined();
+    expect(result.notes).toBe('a plain note');
+  });
+});
+
+describe('isImportableTransaction', () => {
+  it('accepts a normal booked transaction (ISO date + numeric amount)', () => {
+    expect(
+      isImportableTransaction(normalizeTransaction(mockCreditTransaction)),
+    ).toBe(true);
+  });
+
+  it('accepts a pending transaction that carries a date (no regression)', () => {
+    expect(
+      isImportableTransaction(normalizeTransaction(mockPendingTransaction)),
+    ).toBe(true);
+  });
+
+  it('rejects a pending transaction with no date (the case that aborts the sync)', () => {
+    const normalized = normalizeTransaction(mockPendingTransactionNoDate);
+    expect(normalized.date).toBe('');
+    expect(normalized.booked).toBe(false);
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects a transaction with no clear credit/debit direction', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      creditDebitIndicator: undefined,
+    });
+    // date + amount are fine; only the missing direction should drop it.
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects a non-ISO date', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      bookingDate: '03/01/2026',
+      valueDate: undefined,
+      transactionDate: undefined,
+    });
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects a non-numeric amount', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      amount: 'n/a',
+    });
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+
+  it('rejects an empty amount (Number("") would coerce to 0)', () => {
+    const normalized = normalizeTransaction({
+      ...mockCreditTransaction,
+      amount: '',
+    });
+    expect(normalized.transactionAmount.amount).toBe('');
+    expect(isImportableTransaction(normalized)).toBe(false);
+  });
+});
+
+describe('SEPA prefix stripping', () => {
+  it('strips EREF+ from a single line and from the payee fallback', () => {
+    const tx = {
+      id: 'tx-prefix-1',
+      amount: '10.00',
+      currency: 'EUR',
+      creditDebitIndicator: 'CRDT',
+      status: 'BOOK',
+      bookingDate: '2026-04-01',
+      remittanceInformation: ['EREF+invoice-42', 'thanks'],
+    };
+    const out = normalizeTransaction(tx);
+    expect(out.payeeName).toBe('invoice-42');
+    expect(out.remittanceInformationUnstructured).toBe('invoice-42 thanks');
+  });
+
+  it('accepts a remittanceInformation string (not just an array)', () => {
+    const tx = {
+      id: 'tx-prefix-str',
+      amount: '10.00',
+      currency: 'EUR',
+      creditDebitIndicator: 'CRDT',
+      status: 'BOOK',
+      bookingDate: '2026-04-01',
+      remittanceInformation: 'EREF+invoice-99',
+    };
+    const out = normalizeTransaction(tx);
+    expect(out.remittanceInformationUnstructured).toBe('invoice-99');
+    expect(out.payeeName).toBe('invoice-99');
+  });
+
+  it('preserves merchant tokens that look like prefixes but are not on the allowlist', () => {
+    const tx = {
+      id: 'tx-prefix-4',
+      amount: '99.00',
+      currency: 'EUR',
+      creditDebitIndicator: 'DBIT',
+      status: 'BOOK',
+      bookingDate: '2026-04-04',
+      remittanceInformation: [
+        'BMW+ Service Vertrag',
+        'USB+HDMI Kabel',
+        'COVID+ Test Apotheke',
+      ],
+    };
+    const out = normalizeTransaction(tx);
+    expect(out.remittanceInformationUnstructured).toBe(
+      'BMW+ Service Vertrag USB+HDMI Kabel COVID+ Test Apotheke',
+    );
+    expect(out.payeeName).toBe('BMW+ Service Vertrag');
+  });
+});
+
+describe('normalizeBalance', () => {
+  it('should convert string amount to integer cents using the account currency', () => {
+    const result = normalizeBalance(mockBalance, 'EUR');
+    expect(result.balanceAmount.amount).toBe(123456);
+    expect(result.balanceAmount.currency).toBe('EUR');
+    expect(result.balanceType).toBe('ITBD');
+  });
+
+  it('should handle negative amounts', () => {
+    const result = normalizeBalance(mockNegativeBalance, 'EUR');
+    expect(result.balanceAmount.amount).toBe(-5075);
+    expect(result.balanceType).toBe('XPCD');
+  });
+
+  it('should handle whole numbers', () => {
+    const result = normalizeBalance({ type: 'ITBD', amount: '100' }, 'USD');
+    expect(result.balanceAmount.amount).toBe(10000);
+    expect(result.balanceAmount.currency).toBe('USD');
+  });
+});
+
+describe('normalizeAccount', () => {
+  it('maps id, prefers displayName, aspspName, and ITBD balance (cents)', () => {
+    const result = normalizeAccount(mockAccount);
+    expect(result).toEqual({
+      account_id: '07cc67f4-45d6-494b-adac-09b5cbc7e2b5',
+      name: 'Current Account',
+      institution: 'Nordea',
+      balance: 123456,
+    });
+  });
+
+  it('falls back name to accountName when displayName is missing', () => {
+    const result = normalizeAccount(mockAccountNoDisplayName);
+    expect(result.name).toBe('Savings');
+    expect(result.balance).toBe(50000);
+  });
+
+  it('falls back to id for name, Unknown for institution, and 0 balance when minimal', () => {
+    const result = normalizeAccount(mockAccountMinimal);
+    expect(result.name).toBe('aaaabbbb-cccc-dddd-eeee-ffff00001111');
+    expect(result.institution).toBe('Unknown');
+    expect(result.balance).toBe(0);
+  });
+});

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -13,6 +13,7 @@ import * as akahuApp from './app-akahu/app-akahu.js';
 import * as corsApp from './app-cors-proxy';
 import * as enableBankingApp from './app-enablebanking/app-enablebanking';
 import * as goCardlessApp from './app-gocardless/app-gocardless';
+import * as openBankingIoApp from './app-openbankingio/app-openbankingio';
 import * as openidApp from './app-openid';
 import * as pluggai from './app-pluggyai/app-pluggyai';
 import * as secretApp from './app-secrets';
@@ -63,6 +64,7 @@ app.use('/simplefin', simpleFinApp.handlers);
 app.use('/pluggyai', pluggai.handlers);
 app.use('/akahu', akahuApp.handlers);
 app.use('/enablebanking', enableBankingApp.handlers);
+app.use('/openbankingio', openBankingIoApp.handlers);
 app.use('/secret', secretApp.handlers);
 
 if (config.get('corsProxy.enabled')) {

--- a/packages/sync-server/src/services/secrets-service.js
+++ b/packages/sync-server/src/services/secrets-service.js
@@ -19,6 +19,7 @@ export const SecretName = {
   akahu_appToken: 'akahu_appToken',
   enablebanking_applicationId: 'enablebanking_applicationId',
   enablebanking_secretKey: 'enablebanking_secretKey',
+  openbankingio_credentials: 'openbankingio_credentials',
 };
 
 class SecretsDb {

--- a/upcoming-release-notes/8395.md
+++ b/upcoming-release-notes/8395.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [nicolaj-hartmann]
+---
+
+Add open-banking.io as an (experimental) bank sync provider for EU/UK banks.

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,6 +168,7 @@ __metadata:
   dependencies:
     "@actual-app/crdt": "workspace:*"
     "@actual-app/web": "workspace:*"
+    "@open-banking-io/client": "npm:^0.2.0"
     "@types/bcrypt": "npm:^6.0.0"
     "@types/better-sqlite3": "npm:^7.6.13"
     "@types/convict": "npm:^6"
@@ -5537,6 +5538,13 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": "npm:^27.0.0"
   checksum: 10/03d5cfc29556a9b53eae8beb1bf15c0b704dc722db2c51b53f093f3c3ee6c1d8e20b682be8117a3a17034b458be7746d1b22aaefb959ceb5152ad7589b39e2c9
+  languageName: node
+  linkType: hard
+
+"@open-banking-io/client@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@open-banking-io/client@npm:0.2.0"
+  checksum: 10/199abf7df1d93d3a31dc5c1b7fd681106182b0d133237eb53df275d27e21fc0df42c735377db4a195bc95414b523ba14221d98f5e3462907a105a6eb0ca70e57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Adds open-banking.io as a bank sync provider for EU/UK banks. It works like the existing SimpleFIN and Enable Banking providers: you paste an exported `credentials.json` into the settings (no OAuth redirect), and the sync-server fetches and normalizes transactions before handing them to the client. Decryption happens on the sync-server via `@open-banking-io/client`, so nothing decrypted leaves your own server.

It's behind a new `openBankingIo` experimental flag (off by default), with a settings toggle and a docs page. No migration needed since it reuses the existing `account_sync_source` column. The changes are in the usual three places: the sync-server (`/openbankingio` routes + service), loot-core (types, sync dispatch, handlers), and the desktop client (paste-credentials modal, status hook, link flow).

Disclosure: I maintain open-banking.io — happy to hand over the provider files or set up staging access if that makes reviewing/maintaining easier. The first draft was written with Claude, then reviewed, edited and tested by me (per the [AI usage policy](https://actualbudget.org/docs/contributing/ai-usage-policy)).

## Related issue(s)

Relates to #8394.

## Testing

Unit tests: `yarn workspace @actual-app/sync-server vitest run src/app-openbankingio` (36 tests — normalization, the booked/pending mapping, an SSRF check on the bundle URL, pagination, and the routes). Typecheck, oxlint and oxfmt are clean.

I also tested it end to end against a live open-banking.io staging account, running the sync-server and web app locally:

- Linked an account and 267 real transactions imported with the right payees and dates.
- Debits show as payments and credits as deposits.
- A newly linked account's balance matches what the bank reports.
- Re-syncing the same account doesn't create duplicate transactions.
- Pending transactions import as uncleared. Staging doesn't return any pending transactions right now, so I forced one into the response to check that path; the server-side mapping is also covered by a unit test.

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.12 MB (+10.18 kB) | +0.08%
loot-core | 1 | 4.82 MB → 4.83 MB (+3 kB) | +0.06%
api | 2 | 3.88 MB → 3.88 MB (+2.92 kB) | +0.07%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.12 MB (+10.18 kB) | +0.08%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/OpenBankingIoInitialiseModal.tsx` | 🆕 +4.56 kB | 0 B → 4.56 kB
`src/hooks/useOpenBankingIoStatus.ts` | 🆕 +804 B | 0 B → 804 B
`src/components/banksync/useBuiltInBankSyncProviders.ts` | 📈 +2.67 kB (+18.73%) | 14.23 kB → 16.89 kB
`src/accounts/mutations.ts` | 📈 +781 B (+5.39%) | 14.14 kB → 14.91 kB
`src/hooks/useFeatureFlag.ts` | 📈 +23 B (+3.70%) | 622 B → 645 B
`src/components/banksync/bankSyncUtils.ts` | 📈 +54 B (+3.47%) | 1.52 kB → 1.57 kB
`src/components/settings/Experimental.tsx` | 📈 +292 B (+2.39%) | 11.93 kB → 12.21 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +926 B (+2.08%) | 43.51 kB → 44.41 kB
`src/components/Modals.tsx` | 📈 +141 B (+1.06%) | 12.97 kB → 13.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.63 MB → 7.64 MB (+9.41 kB) | +0.12%
static/js/extends.js | 435.59 kB → 436.35 kB (+781 B) | +0.18%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.27 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.83 MB (+3 kB) | +0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +2.18 kB (+7.24%) | 30.04 kB → 32.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +58 B (+5.77%) | 1005 B → 1.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +784 B (+3.09%) | 24.8 kB → 25.57 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BE9dMo95.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BQZb0KVY.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+2.92 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +2.12 kB (+7.18%) | 29.5 kB → 31.61 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +57 B (+5.88%) | 970 B → 1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +767 B (+3.08%) | 24.31 kB → 25.06 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+2.92 kB) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->