### PR TITLE
[AI] Add writing-release-notes skill

### DIFF
--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: writing-release-notes
+description: Use whenever adding, writing, drafting, or fixing a release note in the Actual Budget repo — the changelog entry that ships with a code change, living as a Markdown file in `upcoming-release-notes/`. Trigger for asks like "add a release note", "write the changelog entry", "add the release note for this PR/change", "create the upcoming release note", or any time finishing a user-facing change in this repo where a release note is the natural next step. These notes are published for humans to read, so they must be short, plain-language, and free of technical detail — writing them like a commit message or with implementation jargon produces entries that get flagged and rewritten in review.
+---
+
+# Writing Release Notes for actualbudget/actual
+
+Release notes are the user-facing changelog. Each code change adds one Markdown file to `upcoming-release-notes/`; these get collected into the published changelog at the next release. The authoritative source is the **Writing Good Release Notes** section of `packages/docs/docs/contributing/index.md` — read it if anything below is unclear.
+
+## The file
+
+Create `upcoming-release-notes/<slug>.md`, where `<slug>` is a **short, descriptive kebab-case slug** naming the change (e.g. `add-payee-autocomplete.md`, `fix-mobile-category-delete.md`). Do **not** use a PR number — the PR link is resolved automatically at release time. (Numeric filenames like `1234.md` still work, but a slug is preferred.)
+
+```markdown
+---
+category: Features
+authors: [YourGitHubUsername]
+---
+
+Add payee autocomplete to the transaction entry form
+```
+
+- **`category`** — exactly one of: `Features` (new feature), `Enhancements` (improvement to an existing feature), `Bugfix` (bug fix), `Maintenance` (internal change with no user-visible effect).
+- **`authors`** — array of the GitHub username(s) who did the work.
+
+## Writing the entry
+
+The body is the changelog line. It is read by everyday users, not developers.
+
+- **One sentence.** Short and clear. No paragraphs, no bullet lists, no long prose.
+- **Plain language, no technical detail.** Describe what changed for the user, not how it was built. Avoid file names, function names, internal component names, and implementation jargon. (Exception: `Maintenance` entries may be technical, since they are for internal changes.)
+- **Phrase it as a command** — start with a present-tense verb: "Add …", "Fix …", "Show …" — not "Added …" or "Adds …".
+- Generally match the PR title, but reword it if that reads more clearly to a user.
+
+Good: `Fix incorrect balance when reconciling an account with future transactions`
+Too technical: `Fix off-by-one in reconcileTransactions() when txn.date > today`

--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: writing-release-notes
-description: Use whenever adding, writing, drafting, or fixing a release note in the Actual Budget repo — the changelog entry that ships with a code change, living as a Markdown file in `upcoming-release-notes/`. Trigger for asks like "add a release note", "write the changelog entry", "add the release note for this PR/change", "create the upcoming release note", or any time finishing a user-facing change in this repo where a release note is the natural next step. These notes are published for humans to read, so they must be short, plain-language, and free of technical detail — writing them like a commit message or with implementation jargon produces entries that get flagged and rewritten in review.
+description: Use whenever adding, writing, drafting, or fixing a release note in the Actual Budget repo. This is the changelog entry that ships with a code change, living as a Markdown file in `upcoming-release-notes/`. Trigger for asks like "add a release note", "write the changelog entry", "add the release note for this PR/change", "create the upcoming release note", or any time finishing a user-facing change in this repo where a release note is the natural next step. These notes are published for humans to read, so they must be short, plain-language, and free of technical detail. Writing them like a commit message or with implementation jargon produces entries that get flagged and rewritten in review.
 ---
 
 # Writing Release Notes for actualbudget/actual
 
-Release notes are the user-facing changelog. Each code change adds one Markdown file to `upcoming-release-notes/`; these get collected into the published changelog at the next release. The authoritative source is the **Writing Good Release Notes** section of `packages/docs/docs/contributing/index.md` — read it if anything below is unclear.
+Release notes are the user-facing changelog. Each code change adds one Markdown file to `upcoming-release-notes/`, and these get collected into the published changelog at the next release. The authoritative source is the **Writing Good Release Notes** section of `packages/docs/docs/contributing/index.md`. Read it if anything below is unclear.
 
 ## The file
 
-Create `upcoming-release-notes/<slug>.md`, where `<slug>` is a **short, descriptive kebab-case slug** naming the change (e.g. `add-payee-autocomplete.md`, `fix-mobile-category-delete.md`). Do **not** use a PR number — the PR link is resolved automatically at release time. (Numeric filenames like `1234.md` still work, but a slug is preferred.)
+Create `upcoming-release-notes/<slug>.md`, where `<slug>` is a **short, descriptive kebab-case slug** naming the change (e.g. `add-payee-autocomplete.md`, `fix-mobile-category-delete.md`). Do **not** use a PR number, since the PR link is resolved automatically at release time. (Numeric filenames like `1234.md` still work, but a slug is preferred.)
 
 ```markdown
 ---
@@ -20,8 +20,8 @@ authors: [YourGitHubUsername]
 Add payee autocomplete to the transaction entry form
 ```
 
-- **`category`** — exactly one of: `Features` (new feature), `Enhancements` (improvement to an existing feature), `Bugfix` (bug fix), `Maintenance` (internal change with no user-visible effect).
-- **`authors`** — array of the GitHub username(s) who did the work.
+- **`category`**: exactly one of `Features` (new feature), `Enhancements` (improvement to an existing feature), `Bugfix` (bug fix), or `Maintenance` (internal change with no user-visible effect).
+- **`authors`**: array of the GitHub username(s) who did the work.
 
 ## Writing the entry
 
@@ -29,7 +29,7 @@ The body is the changelog line. It is read by everyday users, not developers.
 
 - **One sentence.** Short and clear. No paragraphs, no bullet lists, no long prose.
 - **Plain language, no technical detail.** Describe what changed for the user, not how it was built. Avoid file names, function names, internal component names, and implementation jargon. (Exception: `Maintenance` entries may be technical, since they are for internal changes.)
-- **Phrase it as a command** — start with a present-tense verb: "Add …", "Fix …", "Show …" — not "Added …" or "Adds …".
+- **Phrase it as a command.** Start with a present-tense verb: "Add …", "Fix …", "Show …", not "Added …" or "Adds …".
 - Generally match the PR title, but reword it if that reads more clearly to a user.
 
 Good: `Fix incorrect balance when reconciling an account with future transactions`

--- a/upcoming-release-notes/add-release-notes-skill.md
+++ b/upcoming-release-notes/add-release-notes-skill.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add a Claude skill for writing release notes


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adding a claude skill for writing good release notes.

I noticed that the release notes claude writes for me are.. not always great.

Hopefully this will improve the situation.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

---
_Generated by [Claude Code](https://claude.ai/code/session_015pA2AZaXmt8ebDNNYEdBDA)_