### PR TITLE
[WIP] Added new theme "YNAB Dark - Blurple" and renamed existing theme "You Need A Dark Mode" -> "YNAB Dark - Cyan"

### DIFF
--- a/packages/desktop-client/src/data/customThemeCatalog.json
+++ b/packages/desktop-client/src/data/customThemeCatalog.json
@@ -185,11 +185,11 @@
     "name": "YNAB Dark - Blurple",
     "repo": "distantvapor/ynab-dark-blurple",
     "colors": [
-      "#14172e", 
-      "#2c3edd", 
-      "#0f122c", 
-      "#6040dd", 
-      "#94d53f", 
+      "#14172e",
+      "#2c3edd",
+      "#0f122c",
+      "#6040dd",
+      "#94d53f",
       "#994de6"
     ],
     "mode": "dark"

--- a/packages/desktop-client/src/data/customThemeCatalog.json
+++ b/packages/desktop-client/src/data/customThemeCatalog.json
@@ -169,8 +169,8 @@
     "mode": "dark"
   },
   {
-    "name": "You Need A Dark Mode",
-    "repo": "distantvapor/you-need-a-dark-mode",
+    "name": "YNAB Dark - Cyan",
+    "repo": "distantvapor/ynab-dark-cyan",
     "colors": [
       "#121212",
       "#1E1E1E",
@@ -178,6 +178,19 @@
       "#006A84",
       "#D4D4D4",
       "#333333"
+    ],
+    "mode": "dark"
+  },
+  {
+    "name": "YNAB Dark - Blurple",
+    "repo": "distantvapor/ynab-dark-blurple",
+    "colors": [
+      "#14172e", 
+      "#2c3edd", 
+      "#0f122c", 
+      "#6040dd", 
+      "#94d53f", 
+      "#994de6"
     ],
     "mode": "dark"
   },


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?--> 
Pull request adds new theme to customThemeCatalog.json including YNAB Dark - Blurple. This theme will be most familiar to migrating YNAB users as it is inspired directly by YNAB's current "blurple" theming. Additionally, renamed "You Need A Dark Mode" to "YNAB Dark - Cyan" and pointed to renamed cloned repo. This updated name maintains convention consistency and represents the older style YNAB dark color scheme spanning from early 2020 -> late 2023. 

Although two existing YNAB inspired custom themes have been contributed, YNA Theme Dark does not represent current or past color conventions utilized in the YNAB webapp or mobile app. This newly contributed theme should be incredibly familiar to migrated users. "YNA Theme - Light" obviously represents a non-dark mode theme and is not redundant to these contributions.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy --> Moderate AI usage for referencing colors and identifying minimally documented CSS variables (Claude Sonnet 4.6 via Github Copilot).

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 --> N/A

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? --> Tested via custom theme insertion in app on both web and mobile view.

## Checklist

- [ ] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.29 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BQZb0KVY.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (-26 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/strip-ansi/index.js` | 📉 -26 B (-8.33%) | 312 B → 286 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (-26 B) | -0.00%

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->