### PR TITLE
[AI] Add api.getPreferences() for reading synced preferences

### DIFF
--- a/packages/api/methods.test.ts
+++ b/packages/api/methods.test.ts
@@ -1110,3 +1110,23 @@ test('Schedules: successfully complete schedules operations', async () => {
     ]),
   );
 });
+
+// apis: getPreferences
+test('Preferences: successfully read synced preferences', async () => {
+  await api.loadBudget(budgetName);
+
+  await api.internal?.send('preferences/save', {
+    id: 'numberFormat',
+    value: '1.234,56',
+  });
+  await api.internal?.send('preferences/save', {
+    id: 'hideFraction',
+    value: 'true',
+  });
+
+  const preferences = await api.getPreferences();
+  expect(preferences).toMatchObject({
+    numberFormat: '1.234,56',
+    hideFraction: 'true',
+  });
+});

--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -16,6 +16,7 @@ import type {
   RuleEntity,
   TransactionEntity,
 } from '@actual-app/core/types/models';
+import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 
 export { q } from './app/query';
 
@@ -358,4 +359,9 @@ export function getIDByName(
 
 export function getServerVersion() {
   return send('api/get-server-version');
+}
+
+/** Read the budget's synced preferences (number format, currency, etc.). */
+export function getPreferences(): Promise<SyncedPrefs> {
+  return send('preferences/get');
 }

--- a/packages/api/models.ts
+++ b/packages/api/models.ts
@@ -1,2 +1,2 @@
 export type * from '@actual-app/core/server/api-models';
-export type { SyncedPrefs } from '@actual-app/core/types/prefs';
+export type { SyncedPrefs as Preferences } from '@actual-app/core/types/prefs';

--- a/packages/api/models.ts
+++ b/packages/api/models.ts
@@ -1,1 +1,2 @@
 export type * from '@actual-app/core/server/api-models';
+export type { SyncedPrefs } from '@actual-app/core/types/prefs';

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -105,7 +105,8 @@ import APIList from './APIList';
 "downloadBudget",
 "batchBudgetUpdates",
 "runQuery",
-"getIDByName"
+"getIDByName",
+"getPreferences"
 ]} />
 
 ## Types of Methods
@@ -842,3 +843,9 @@ get the ID for any Account, Payee, Category or Schedule by providing the corresp
 <Method name="getServerVersion" args={[]} returns="Promise<{error?: string;} | {version: string;}>" />
 
 return error or the current server versions.
+
+#### `getPreferences`
+
+<Method name="getPreferences" args={[]} returns="Promise<SyncedPrefs>" />
+
+Returns the budget's synced preferences — settings that sync across devices, such as the number format (`numberFormat`, `hideFraction`), currency (`defaultCurrencyCode`, `currencySymbolPosition`, `currencySpaceBetweenAmountAndSymbol`), date format (`dateFormat`), and first day of the week (`firstDayOfWeekIdx`). All values are strings (or `undefined` if the preference has never been set). The `SyncedPrefs` type is exported from `@actual-app/api/models`.

--- a/upcoming-release-notes/api-get-preferences.md
+++ b/upcoming-release-notes/api-get-preferences.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+The API can now read a budget's formatting preferences, such as its number and currency format.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Adding synced pref method to the api pkg. 

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Unit test added

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->


---
_Generated by [Claude Code](https://claude.ai/code/session_01KxwSQJiPo5mEk79mA54TWg)_

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB → 3.88 MB (+140 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.29 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+140 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`methods.ts` | 📈 +140 B (+2.41%) | 5.67 kB → 5.8 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+140 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->