### PR TITLE
[WIP] Show a clear error when GoCardless credentials are missing after restore

### DIFF
--- a/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
+++ b/packages/desktop-client/src/components/accounts/AccountSyncCheck.tsx
@@ -47,6 +47,11 @@ function useErrorMessage() {
       case 'RATE_LIMIT_EXCEEDED':
         return t('Rate limit exceeded for this item. Please try again later.');
 
+      case 'GOCARDLESS_NOT_CONFIGURED':
+        return t(
+          'Your GoCardless credentials are missing. Please re-enter them to restore bank sync.',
+        );
+
       case 'TIMED_OUT':
         return t('The request timed out. Please try again later.');
 

--- a/packages/sync-server/src/app-gocardless/app-gocardless.ts
+++ b/packages/sync-server/src/app-gocardless/app-gocardless.ts
@@ -192,6 +192,19 @@ app.post(
     const requisitionId = sanitizeId<GoCardlessRequisitionId>(rawRequisitionId);
     const accountId = sanitizeId<GoCardlessAccountId>(rawAccountId);
 
+    // Is GoCardless configured?
+    if (!goCardlessService.isConfigured()) {
+      // Stop here and send a clear, specific error
+      return res.send({
+        status: 'ok',
+        data: {
+          error_type: 'GOCARDLESS_NOT_CONFIGURED',
+          error_code: 'GOCARDLESS_NOT_CONFIGURED',
+          reason: 'GoCardless credentials are missing',
+        },
+      });
+    }
+
     try {
       if (includeBalance) {
         const {

--- a/packages/sync-server/src/app-gocardless/tests/transactions.spec.ts
+++ b/packages/sync-server/src/app-gocardless/tests/transactions.spec.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Mock external dependencies before importing the app (mirrors the
+// app-enablebanking transactions test).
+
+// Return falsy secrets so the *real* isConfigured() resolves to `false` — this
+// reproduces the "GoCardless credentials missing after a backup restore" state
+// from issue #4742 without faking our own code.
+vi.mock('../../services/secrets-service', () => ({
+  SecretName: {
+    gocardless_secretId: 'gocardless_secretId',
+    gocardless_secretKey: 'gocardless_secretKey',
+  },
+  secretsService: {
+    get: vi.fn(() => null),
+    set: vi.fn(),
+  },
+}));
+
+// Bypass the session guard so requests actually reach the route handler.
+vi.mock('../../util/middlewares', () => ({
+  requestLoggerMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+  validateSessionMiddleware: (_req: unknown, _res: unknown, next: () => void) =>
+    next(),
+}));
+
+const { handlers } = await import('../app-gocardless');
+
+const app = express();
+app.use(express.json());
+app.use('/', handlers);
+
+describe('POST /transactions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns GOCARDLESS_NOT_CONFIGURED when credentials are missing', async () => {
+    const res = await request(app)
+      .post('/transactions')
+      // IDs must be sanitizeId-safe (alphanumeric/_/-) so the request reaches
+      // the configuration guard instead of failing validation first.
+      .send({ requisitionId: 'req-1', accountId: 'acc-1' });
+
+    // The HTTP envelope is always "ok"; the real error lives inside `data`.
+    expect(res.body.status).toBe('ok');
+    expect(res.body.data.error_type).toBe('GOCARDLESS_NOT_CONFIGURED');
+    expect(res.body.data.error_code).toBe('GOCARDLESS_NOT_CONFIGURED');
+  });
+});

--- a/upcoming-release-notes/gocardless-missing-credentials-error.md
+++ b/upcoming-release-notes/gocardless-missing-credentials-error.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [birajlamichhane75]
+---
+
+Show a clear error when GoCardless credentials are missing after restoring a backup


### PR DESCRIPTION
## Description

When a user restores a budget backup, the GoCardless Secret ID and Secret Key are not included in the export. If they then try to sync their bank account, the app shows a generic "An internal error occurred" message with no way to fix it. The user has no idea their credentials are missing or what to do next.

The root cause is that the `/transactions` endpoint never checked whether credentials existed before trying to contact GoCardless. A missing-credentials error fell through to `UNKNOWN` and the frontend had no specific handler for it, so it showed the generic fallback message.

This PR adds an `isConfigured()` guard at the start of the `/transactions` handler that returns a specific `GOCARDLESS_NOT_CONFIGURED` error code when credentials are missing, and adds a matching case in `AccountSyncCheck.tsx` so the user sees a clear message instead of the generic error.

AI disclosure: I wrote the implementation myself with Claude Code as a guide for navigating the codebase. The unit test and release note were drafted by Claude Code and reviewed by me.

## Related issue(s)

Fixes #4742

## Testing

Reproduced the bug locally by injecting a GoCardless-linked account using the browser console with no credentials on the sync server. Before the fix, clicking Bank Sync showed "An internal error occurred" with only an "Unlink account" button and no recovery path. After the fix, the user sees a specific message explaining that GoCardless credentials are missing.

Added a unit test in `transactions.spec.ts` that confirms the `/transactions` endpoint returns `GOCARDLESS_NOT_CONFIGURED` when `isConfigured()` is false. Ran `yarn typecheck` and `yarn lint:fix` - both passed.

## Checklist
- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (+135 B) | +0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (+135 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/AccountSyncCheck.tsx` | 📈 +135 B (+1.80%) | 7.32 kB → 7.45 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+135 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.96 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 178.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.29 kB | 0%
static/js/es.js | 168.01 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 170.14 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.85 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.4 kB | 0%
static/js/nl.js | 116.97 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.89 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.65 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.86 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->