### PR TITLE
[WIP] [AI] fix: open Enable Banking authorization in a new browser tab instead of a constrained popup

### DIFF
--- a/packages/desktop-client/src/enablebanking.test.ts
+++ b/packages/desktop-client/src/enablebanking.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { authorizeBank } from './enablebanking';
+
+const { sendCatch } = vi.hoisted(() => ({ sendCatch: vi.fn() }));
+
+vi.mock('@actual-app/core/platform/client/connection', () => ({
+  sendCatch: (...args: unknown[]) => sendCatch(...args),
+}));
+
+vi.mock('#modals/modalsSlice', () => ({
+  pushModal: (modal: unknown) => ({ type: 'modals/pushModal', payload: modal }),
+}));
+
+type MoveExternalResult = {
+  error?: string;
+  message?: string;
+  data?: { accounts: unknown[] };
+};
+
+type MoveExternalArgs = {
+  aspspId: string;
+  country: string;
+  maxConsentValidity: number;
+  psuType?: string;
+  onStateReady?: (state: string) => void;
+};
+
+type CapturedOptions = {
+  onMoveExternal: (args: MoveExternalArgs) => Promise<MoveExternalResult>;
+};
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) =>
+      store.has(key) ? (store.get(key) ?? null) : null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+const moveArgs: MoveExternalArgs = {
+  aspspId: 'test-bank',
+  country: 'ES',
+  maxConsentValidity: 90,
+  psuType: 'personal',
+};
+
+function captureOnMoveExternal(): CapturedOptions['onMoveExternal'] {
+  const dispatch = vi.fn();
+  // _authorize dispatches the modal synchronously before awaiting anything, so
+  // the captured options are available immediately.
+  void authorizeBank(dispatch as never);
+
+  const action = dispatch.mock.calls[0][0] as {
+    payload: { modal: { options: CapturedOptions } };
+  };
+  return action.payload.modal.options.onMoveExternal;
+}
+
+describe('enablebanking authorizeBank', () => {
+  beforeEach(() => {
+    sendCatch.mockReset();
+    vi.stubGlobal('localStorage', createMemoryStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('opens the authorization URL in a new tab (not a constrained popup) and polls', async () => {
+    sendCatch.mockImplementation(async (name: string) => {
+      if (name === 'enablebanking-start-auth') {
+        return {
+          data: {
+            data: { url: 'https://bank.example/auth', state: 'state-123' },
+          },
+        };
+      }
+      if (name === 'enablebanking-poll-auth') {
+        return { data: { data: { accounts: [] } } };
+      }
+      return {};
+    });
+
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue({} as ReturnType<typeof window.open>);
+
+    const onMoveExternal = captureOnMoveExternal();
+    const result = await onMoveExternal(moveArgs);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith('https://bank.example/auth', '_blank');
+    // No third windowFeatures argument: the constrained-popup string is gone.
+    expect(openSpy.mock.calls[0]).toHaveLength(2);
+    expect(sendCatch).toHaveBeenCalledWith('enablebanking-poll-auth', {
+      state: 'state-123',
+    });
+    expect(result).toEqual({ data: { accounts: [] } });
+
+    openSpy.mockRestore();
+  });
+
+  it('still polls when window.open returns null (Electron denies the child window but opens the URL externally)', async () => {
+    sendCatch.mockImplementation(async (name: string) => {
+      if (name === 'enablebanking-start-auth') {
+        return {
+          data: {
+            data: { url: 'https://bank.example/auth', state: 'state-123' },
+          },
+        };
+      }
+      if (name === 'enablebanking-poll-auth') {
+        return { data: { data: { accounts: [] } } };
+      }
+      return {};
+    });
+
+    // In the Electron desktop app the window-open handler returns
+    // { action: 'deny' } (opening the URL in the system browser instead), so
+    // window.open resolves to null even though the page opened. The flow must
+    // not treat that as a failure.
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    const onMoveExternal = captureOnMoveExternal();
+    const result = await onMoveExternal(moveArgs);
+
+    expect(openSpy).toHaveBeenCalledWith('https://bank.example/auth', '_blank');
+    expect(sendCatch).toHaveBeenCalledWith('enablebanking-poll-auth', {
+      state: 'state-123',
+    });
+    expect(result).toEqual({ data: { accounts: [] } });
+
+    openSpy.mockRestore();
+  });
+
+  it('returns a missing-auth error before opening a tab when the URL or state is absent', async () => {
+    sendCatch.mockImplementation(async (name: string) => {
+      if (name === 'enablebanking-start-auth') {
+        return { data: { data: {} } };
+      }
+      return {};
+    });
+
+    const openSpy = vi.spyOn(window, 'open');
+
+    const onMoveExternal = captureOnMoveExternal();
+    const result = await onMoveExternal(moveArgs);
+
+    expect(result.error).toBe('unknown');
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(sendCatch).not.toHaveBeenCalledWith(
+      'enablebanking-poll-auth',
+      expect.anything(),
+    );
+
+    openSpy.mockRestore();
+  });
+
+  it('short-circuits when starting auth fails, without opening a tab', async () => {
+    sendCatch.mockImplementation(async (name: string) => {
+      if (name === 'enablebanking-start-auth') {
+        return { error: { message: 'network down' } };
+      }
+      return {};
+    });
+
+    const openSpy = vi.spyOn(window, 'open');
+
+    const onMoveExternal = captureOnMoveExternal();
+    const result = await onMoveExternal(moveArgs);
+
+    expect(result).toEqual({ error: 'unknown', message: 'network down' });
+    expect(openSpy).not.toHaveBeenCalled();
+
+    openSpy.mockRestore();
+  });
+});

--- a/packages/desktop-client/src/enablebanking.ts
+++ b/packages/desktop-client/src/enablebanking.ts
@@ -69,11 +69,18 @@ function _authorize(
 
             localStorage.setItem('enablebanking_auth_state', state);
             onStateReady?.(state);
-            window.open(
-              authUrl,
-              'enablebanking-auth',
-              'width=600,height=700,popup=yes',
-            );
+
+            // Open the bank authorization page in a normal browser tab rather
+            // than a constrained popup window. Some providers detect the small
+            // popup and fall back to a broken mobile/app-link path instead of
+            // the desktop QR-code flow, so authorization never completes.
+            //
+            // The return value is intentionally not inspected: in the Electron
+            // desktop app, window.open is denied by the window-open handler
+            // (which opens the URL in the system browser instead) and returns
+            // null even on success, so it can't be used to detect a blocked
+            // tab. Polling below drives the rest of the flow either way.
+            window.open(authUrl, '_blank');
 
             try {
               const pollResp = await sendCatch('enablebanking-poll-auth', {

--- a/upcoming-release-notes/8326.md
+++ b/upcoming-release-notes/8326.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [mvanhorn]
+---
+
+Fix bank linking with Enable Banking by opening the bank authorization page in a normal browser tab instead of a small popup window, so providers that only show a QR code on desktop can complete the connection.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Fixes #8326

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (-46 B) | -0.00%
loot-core | 1 | 4.82 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (-46 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/enablebanking.ts` | 📉 -46 B (-2.05%) | 2.19 kB → 2.15 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (-46 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->