### PR TITLE
[AI] api: remove grouped option from api/categories-get

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -220,7 +220,7 @@ export function deleteCategoryGroup(
 }
 
 export function getCategories(options: { hidden?: boolean } = {}) {
-  return send('api/categories-get', { grouped: false, ...options });
+  return send('api/categories-get', options);
 }
 
 export function createCategory(category: Omit<APICategoryEntity, 'id'>) {

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -649,14 +649,11 @@ handlers['api/account-balance'] = withMutation(async function ({
 });
 
 handlers['api/categories-get'] = async function ({
-  grouped,
   hidden,
-}: { grouped?: boolean; hidden?: boolean } = {}) {
+}: { hidden?: boolean } = {}) {
   checkFileOpen();
   const result = await handlers['get-categories']({ hidden });
-  return grouped
-    ? result.grouped.map(group => categoryGroupModel.toExternal(group))
-    : result.list.map(category => categoryModel.toExternal(category));
+  return result.list.map(category => categoryModel.toExternal(category));
 };
 
 handlers['api/category-groups-get'] = async function ({

--- a/packages/loot-core/src/server/importers/ynab4.ts
+++ b/packages/loot-core/src/server/importers/ynab4.ts
@@ -133,9 +133,7 @@ async function importTransactions(
   data: YNAB4.YFull,
   entityIdMap: Map<string, string>,
 ) {
-  const categories = await send('api/categories-get', {
-    grouped: false,
-  });
+  const categories = await send('api/categories-get');
   const incomeCategoryId: string = categories.find(
     cat => cat.name === 'Income',
   ).id;

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -291,9 +291,7 @@ async function importCategories(
   // Hidden categories are put in its own group by YNAB,
   // so it's already handled.
 
-  const categories = await send('api/categories-get', {
-    grouped: false,
-  });
+  const categories = await send('api/categories-get');
   const incomeCatId = findIdByName(categories, 'Income');
   const ynabIncomeCategories = ['To be Budgeted', 'Inflow: Ready to Assign'];
 
@@ -572,9 +570,7 @@ async function importTransactions(
   flagNameConflicts: Set<string>,
 ) {
   const payees = await send('api/payees-get');
-  const categories = await send('api/categories-get', {
-    grouped: false,
-  });
+  const categories = await send('api/categories-get');
   const incomeCatId = findIdByName(categories, 'Income');
   const startingBalanceCatId = findIdByName(categories, 'Starting Balances'); //better way to do it?
 

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -165,9 +165,8 @@ export type ApiHandlers = {
   }) => Promise<number>;
 
   'api/categories-get': (arg: {
-    grouped?: boolean;
     hidden?: boolean;
-  }) => Promise<Array<APICategoryGroupEntity | APICategoryEntity>>;
+  }) => Promise<APICategoryEntity[]>;
 
   'api/category-groups-get': (arg?: {
     hidden?: boolean;

--- a/upcoming-release-notes/simplify-categories-get-api.md
+++ b/upcoming-release-notes/simplify-categories-get-api.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Simplify the getCategories API to always return a flat list of categories.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

The `grouped: true` option was never used. It was originally introduced wayyy back when Actual was open sourced. 

Since nothing is using it.. lets drop the logic to simplify the types, etc.

## Related issue(s)

N/A

## Testing

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.82 MB → 4.82 MB (-172 B) | -0.00%
api | 2 | 3.88 MB → 3.88 MB (-199 B) | -0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (-172 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -40 B (-0.16%) | 24.76 kB → 24.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📉 -20 B (-0.21%) | 9.4 kB → 9.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📉 -112 B (-0.47%) | 23.51 kB → 23.4 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dnkhqvb8.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (-199 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -40 B (-0.16%) | 24.15 kB → 24.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📉 -20 B (-0.21%) | 9.18 kB → 9.16 kB
`methods.ts` | 📉 -28 B (-0.47%) | 5.8 kB → 5.77 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📉 -111 B (-0.47%) | 22.88 kB → 22.78 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (-199 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->