### PR TITLE
[WIP] [AI] Fix payee rule count excluding schedule-owned rules

### DIFF
--- a/packages/loot-core/src/server/payees/app.test.ts
+++ b/packages/loot-core/src/server/payees/app.test.ts
@@ -1,0 +1,99 @@
+// @ts-strict-ignore
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import {
+  insertRule,
+  loadRules,
+  resetState,
+} from '#server/transactions/transaction-rules';
+
+import { getPayeeRuleCountsForTest } from './app';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  resetState();
+  await loadMappings();
+  await loadRules();
+});
+
+describe('getPayeeRuleCounts', () => {
+  test('counts only standalone rules, not schedule-owned rules', async () => {
+    const payeeId = 'payee-1';
+
+    // Insert a standalone rule for the payee
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'test' }],
+    });
+
+    // Insert a schedule-owned rule for the same payee
+    const scheduleRuleId = await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'schedule rule' }],
+    });
+
+    // Link that rule to a completed schedule
+    await db.insertWithUUID('schedules', {
+      rule: scheduleRuleId,
+      active: 0,
+      completed: 1,
+      posts_transaction: 0,
+      tombstone: 0,
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    // Should be 1 (standalone only), not 2
+    expect(counts[payeeId]).toBe(1);
+  });
+
+  test('counts standalone rules correctly when no schedules exist', async () => {
+    const payeeId = 'payee-2';
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'rule 1' }],
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'rule 2' }],
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    expect(counts[payeeId]).toBe(2);
+  });
+
+  test('excludes active schedule rules too, not just completed', async () => {
+    const payeeId = 'payee-3';
+
+    const scheduleRuleId = await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: payeeId }],
+      actions: [{ op: 'set', field: 'notes', value: 'active schedule rule' }],
+    });
+
+    // Active (not completed) schedule
+    await db.insertWithUUID('schedules', {
+      rule: scheduleRuleId,
+      active: 1,
+      completed: 0,
+      posts_transaction: 0,
+      tombstone: 0,
+    });
+
+    const counts = await getPayeeRuleCountsForTest();
+
+    expect(counts[payeeId]).toBeUndefined();
+  });
+});

--- a/packages/loot-core/src/server/payees/app.ts
+++ b/packages/loot-core/src/server/payees/app.ts
@@ -74,7 +74,13 @@ async function getOrphanedPayees(): Promise<Array<Pick<PayeeEntity, 'id'>>> {
 async function getPayeeRuleCounts() {
   const payeeCounts: Record<PayeeEntity['id'], number> = {};
 
+  const scheduleRuleIds = new Set(await rules.getAllRuleIdsFromSchedules(''));
+
   rules.iterateIds(rules.getRules(), 'payee', (rule, id) => {
+    const ruleId = rule.getId();
+    if (ruleId != null && scheduleRuleIds.has(ruleId)) {
+      return;
+    }
     if (payeeCounts[id] == null) {
       payeeCounts[id] = 0;
     }
@@ -83,6 +89,8 @@ async function getPayeeRuleCounts() {
 
   return payeeCounts;
 }
+
+export { getPayeeRuleCounts as getPayeeRuleCountsForTest };
 
 async function mergePayees({
   targetId,


### PR DESCRIPTION
Fixes #8134

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.1 MB (-10.36 kB) | -0.08%
loot-core | 1 | 4.82 MB → 4.9 MB (+81.13 kB) | +1.64%
api | 2 | 3.88 MB → 3.94 MB (+62.72 kB) | +1.58%
cli | 1 | 8.02 MB → 8.02 MB (+26 B) | +0.00%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.1 MB (-10.36 kB) | -0.08%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/ua-parser-js/src/main/ua-parser.mjs` | 🆕 +42.3 kB | 0 B → 42.3 kB
`src/components/formula/queryModeFunctions.ts` | 🆕 +18.72 kB | 0 B → 18.72 kB
`src/components/formula/transactionModeFunctions.ts` | 🆕 +15.31 kB | 0 B → 15.31 kB
`src/components/transactions/TransactionMenu.tsx` | 🆕 +8.32 kB | 0 B → 8.32 kB
`node_modules/@juggle/resize-observer/lib/algorithms/calculateBoxSize.js` | 🆕 +3.91 kB | 0 B → 3.91 kB
`node_modules/retry/lib/retry_operation.js` | 🆕 +3.46 kB | 0 B → 3.46 kB
`node_modules/lodash/debounce.js` | 🆕 +2.8 kB | 0 B → 2.8 kB
`node_modules/@juggle/resize-observer/lib/utils/scheduler.js` | 🆕 +2.32 kB | 0 B → 2.32 kB
`node_modules/lodash/_equalByTag.js` | 🆕 +2.15 kB | 0 B → 2.15 kB
`node_modules/retry/lib/retry.js` | 🆕 +2.1 kB | 0 B → 2.1 kB
`node_modules/lodash/_baseIsEqualDeep.js` | 🆕 +2.03 kB | 0 B → 2.03 kB
`node_modules/lodash/_baseIsTypedArray.js` | 🆕 +1.91 kB | 0 B → 1.91 kB
`node_modules/lodash/_equalObjects.js` | 🆕 +1.85 kB | 0 B → 1.85 kB
`node_modules/@juggle/resize-observer/lib/ResizeObserverController.js` | 🆕 +1.81 kB | 0 B → 1.81 kB
`node_modules/lodash/_equalArrays.js` | 🆕 +1.72 kB | 0 B → 1.72 kB
`node_modules/@juggle/resize-observer/lib/ResizeObserver.js` | 🆕 +1.5 kB | 0 B → 1.5 kB
`node_modules/lodash/_getTag.js` | 🆕 +1.46 kB | 0 B → 1.46 kB
`node_modules/lodash/_baseIsMatch.js` | 🆕 +1.17 kB | 0 B → 1.17 kB
`node_modules/promise-retry/index.js` | 🆕 +1.14 kB | 0 B → 1.14 kB
`node_modules/memoize-one/dist/memoize-one.esm.js` | 🆕 +1.09 kB | 0 B → 1.09 kB
`node_modules/lodash/_arrayLikeKeys.js` | 🆕 +1.08 kB | 0 B → 1.08 kB
`node_modules/@juggle/resize-observer/lib/utils/element.js` | 🆕 +1.01 kB | 0 B → 1.01 kB
`node_modules/@juggle/resize-observer/lib/algorithms/broadcastActiveObservations.js` | 🆕 +995 B | 0 B → 995 B
`node_modules/lodash/toNumber.js` | 🆕 +963 B | 0 B → 963 B
`node_modules/lodash/_baseIsNative.js` | 🆕 +923 B | 0 B → 923 B
`node_modules/lodash/_baseMatchesProperty.js` | 🆕 +906 B | 0 B → 906 B
`node_modules/err-code/index.js` | 🆕 +893 B | 0 B → 893 B
`node_modules/@juggle/resize-observer/lib/ResizeObservation.js` | 🆕 +868 B | 0 B → 868 B
`node_modules/lodash/_hasPath.js` | 🆕 +856 B | 0 B → 856 B
`node_modules/lodash/_ListCache.js` | 🆕 +821 B | 0 B → 821 B
`node_modules/lodash/memoize.js` | 🆕 +810 B | 0 B → 810 B
`node_modules/lodash/_MapCache.js` | 🆕 +797 B | 0 B → 797 B
`node_modules/@juggle/resize-observer/lib/DOMRectReadOnly.js` | 🆕 +797 B | 0 B → 797 B
`node_modules/lodash/_baseToString.js` | 🆕 +774 B | 0 B → 774 B
`node_modules/lodash/_getRawTag.js` | 🆕 +768 B | 0 B → 768 B
`node_modules/lodash/_nodeUtil.js` | 🆕 +745 B | 0 B → 745 B
`node_modules/lodash/_Hash.js` | 🆕 +701 B | 0 B → 701 B
`node_modules/lodash/_stringToPath.js` | 🆕 +688 B | 0 B → 688 B
`node_modules/lodash/_createBaseEach.js` | 🆕 +685 B | 0 B → 685 B
`node_modules/lodash/_stackSet.js` | 🆕 +674 B | 0 B → 674 B
`node_modules/lodash/_Stack.js` | 🆕 +659 B | 0 B → 659 B
`node_modules/lodash/_createAggregator.js` | 🆕 +655 B | 0 B → 655 B
`node_modules/lodash/isArguments.js` | 🆕 +652 B | 0 B → 652 B
`node_modules/lodash/_isKey.js` | 🆕 +649 B | 0 B → 649 B
`node_modules/lodash/_baseIteratee.js` | 🆕 +638 B | 0 B → 638 B
`src/components/reports/useDashboardWidgetCopyMenu.ts` | 🆕 +636 B | 0 B → 636 B
`node_modules/lodash/_getSymbols.js` | 🆕 +634 B | 0 B → 634 B
`node_modules/lodash/_baseGetTag.js` | 🆕 +626 B | 0 B → 626 B
`node_modules/lodash/_baseMatches.js` | 🆕 +620 B | 0 B → 620 B
`node_modules/@juggle/resize-observer/lib/utils/queueMicroTask.js` | 🆕 +593 B | 0 B → 593 B
`node_modules/lodash/_baseIsEqual.js` | 🆕 +587 B | 0 B → 587 B
`node_modules/lodash/isBuffer.js` | 🆕 +576 B | 0 B → 576 B
`node_modules/lodash/isFunction.js` | 🆕 +572 B | 0 B → 572 B
`node_modules/lodash/_SetCache.js` | 🆕 +571 B | 0 B → 571 B
`node_modules/lodash/_hashGet.js` | 🆕 +547 B | 0 B → 547 B
`node_modules/@juggle/resize-observer/lib/algorithms/gatherActiveObservationsAtDepth.js` | 🆕 +546 B | 0 B → 546 B
`node_modules/lodash/_baseKeys.js` | 🆕 +544 B | 0 B → 544 B
`node_modules/lodash/_createBaseFor.js` | 🆕 +537 B | 0 B → 537 B
`node_modules/lodash/_getMatchData.js` | 🆕 +524 B | 0 B → 524 B
`node_modules/lodash/_listCacheDelete.js` | 🆕 +515 B | 0 B → 515 B
`node_modules/lodash/_isIndex.js` | 🆕 +503 B | 0 B → 503 B
`node_modules/@juggle/resize-observer/lib/ResizeObserverEntry.js` | 🆕 +502 B | 0 B → 502 B
`node_modules/lodash/_baseAssignValue.js` | 🆕 +489 B | 0 B → 489 B
`node_modules/lodash/_baseGet.js` | 🆕 +477 B | 0 B → 477 B
`node_modules/@juggle/resize-observer/lib/algorithms/deliverResizeLoopError.js` | 🆕 +476 B | 0 B → 476 B
`node_modules/lodash/_arrayAggregator.js` | 🆕 +463 B | 0 B → 463 B
`node_modules/lodash/_isMasked.js` | 🆕 +462 B | 0 B → 462 B
`node_modules/lodash/_arrayFilter.js` | 🆕 +461 B | 0 B → 461 B
`node_modules/lodash/_hashSet.js` | 🆕 +455 B | 0 B → 455 B
`node_modules/lodash/_memoizeCapped.js` | 🆕 +452 B | 0 B → 452 B
`node_modules/lodash/_castPath.js` | 🆕 +452 B | 0 B → 452 B
`node_modules/lodash/isTypedArray.js` | 🆕 +448 B | 0 B → 448 B
`node_modules/lodash/_baseAggregator.js` | 🆕 +447 B | 0 B → 447 B
`node_modules/lodash/_listCacheSet.js` | 🆕 +442 B | 0 B → 442 B
`node_modules/lodash/_mapCacheClear.js` | 🆕 +429 B | 0 B → 429 B
`node_modules/lodash/_baseGetAllKeys.js` | 🆕 +429 B | 0 B → 429 B
`node_modules/@juggle/resize-observer/lib/ResizeObserverBoxOptions.js` | 🆕 +429 B | 0 B → 429 B
`node_modules/lodash/_matchesStrictComparable.js` | 🆕 +428 B | 0 B → 428 B
`node_modules/lodash/property.js` | 🆕 +421 B | 0 B → 421 B
`node_modules/lodash/isSymbol.js` | 🆕 +414 B | 0 B → 414 B
`node_modules/lodash/_toKey.js` | 🆕 +412 B | 0 B → 412 B
`node_modules/lodash/_baseIsArguments.js` | 🆕 +411 B | 0 B → 411 B
`node_modules/lodash/_hashHas.js` | 🆕 +405 B | 0 B → 405 B
`node_modules/lodash/_toSource.js` | 🆕 +403 B | 0 B → 403 B
`node_modules/lodash/_arrayMap.js` | 🆕 +397 B | 0 B → 397 B
`node_modules/lodash/_mapCacheSet.js` | 🆕 +397 B | 0 B → 397 B
`node_modules/lodash/_defineProperty.js` | 🆕 +384 B | 0 B → 384 B
`node_modules/lodash/_baseTrim.js` | 🆕 +381 B | 0 B → 381 B
`node_modules/@juggle/resize-observer/lib/ResizeObserverDetail.js` | 🆕 +380 B | 0 B → 380 B
`node_modules/lodash/_arraySome.js` | 🆕 +379 B | 0 B → 379 B
`node_modules/lodash/keys.js` | 🆕 +376 B | 0 B → 376 B
`node_modules/lodash/_getNative.js` | 🆕 +375 B | 0 B → 375 B
`node_modules/lodash/_isPrototype.js` | 🆕 +375 B | 0 B → 375 B
`node_modules/lodash/_getAllKeys.js` | 🆕 +372 B | 0 B → 372 B
`node_modules/@juggle/resize-observer/lib/utils/process.js` | 🆕 +371 B | 0 B → 371 B
`node_modules/lodash/_listCacheGet.js` | 🆕 +370 B | 0 B → 370 B
`node_modules/lodash/_getMapData.js` | 🆕 +368 B | 0 B → 368 B
`node_modules/lodash/_mapCacheDelete.js` | 🆕 +368 B | 0 B → 368 B
`node_modules/lodash/_trimmedEndIndex.js` | 🆕 +366 B | 0 B → 366 B
`node_modules/lodash/_isKeyable.js` | 🆕 +364 B | 0 B → 364 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/_baseIsEqual.js | 0 B → 76.78 kB (+76.78 kB) | -
static/js/resize-observer.js | 0 B → 18.06 kB (+18.06 kB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/pl.js | 139.16 kB → 0 B (-139.16 kB) | -100%
static/js/AppliedFilters.js | 36.47 kB → 0 B (-36.47 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/extends.js | 435.59 kB → 478.23 kB (+42.64 kB) | +9.79%
static/js/ReportRouter.js | 1.22 MB → 1.25 MB (+25.85 kB) | +2.07%
static/js/FormulaEditor.js | 730.27 kB → 735.67 kB (+5.4 kB) | +0.74%
static/js/uk.js | 204.6 kB → 209.97 kB (+5.37 kB) | +2.63%
static/js/ca.js | 174.64 kB → 179.71 kB (+5.07 kB) | +2.90%
static/js/pt-BR.js | 176.56 kB → 181.5 kB (+4.95 kB) | +2.80%
static/js/es.js | 167.69 kB → 171.82 kB (+4.13 kB) | +2.47%
static/js/zh-Hans.js | 109.57 kB → 113.26 kB (+3.69 kB) | +3.37%
static/js/th.js | 170 kB → 173.33 kB (+3.33 kB) | +1.96%
static/js/it.js | 155.52 kB → 158.13 kB (+2.62 kB) | +1.68%
static/js/nl.js | 116.92 kB → 119.14 kB (+2.22 kB) | +1.90%
static/js/nb-NO.js | 139.35 kB → 141.55 kB (+2.21 kB) | +1.58%
static/js/da.js | 98.1 kB → 100.19 kB (+2.1 kB) | +2.14%
static/js/fr.js | 169.79 kB → 171.39 kB (+1.6 kB) | +0.94%
static/js/narrow.js | 358.73 kB → 358.88 kB (+147 B) | +0.04%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.61 MB (-26.52 kB) | -0.34%
static/js/wide.js | 304.69 kB → 298.21 kB (-6.48 kB) | -2.13%
static/js/de.js | 181.66 kB → 176.61 kB (-5.05 kB) | -2.78%
static/js/en-GB.js | 11.1 kB → 9.25 kB (-1.85 kB) | -16.63%
static/js/en.js | 201.31 kB → 200.33 kB (-1004 B) | -0.49%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.9 MB (+81.13 kB) | +1.64%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/ua-parser-js/src/main/ua-parser.mjs` | 🆕 +44.21 kB | 0 B → 44.21 kB
`node_modules/lodash/_equalByTag.js` | 🆕 +2.19 kB | 0 B → 2.19 kB
`node_modules/lodash/_baseIsEqualDeep.js` | 🆕 +2.07 kB | 0 B → 2.07 kB
`node_modules/lodash/_baseIsTypedArray.js` | 🆕 +1.92 kB | 0 B → 1.92 kB
`node_modules/lodash/_equalObjects.js` | 🆕 +1.89 kB | 0 B → 1.89 kB
`node_modules/lodash/_equalArrays.js` | 🆕 +1.75 kB | 0 B → 1.75 kB
`node_modules/lodash/_getTag.js` | 🆕 +1.47 kB | 0 B → 1.47 kB
`node_modules/lodash/_baseIsMatch.js` | 🆕 +1.2 kB | 0 B → 1.2 kB
`node_modules/memoize-one/dist/memoize-one.esm.js` | 🆕 +1.12 kB | 0 B → 1.12 kB
`node_modules/lodash/_arrayLikeKeys.js` | 🆕 +1.09 kB | 0 B → 1.09 kB
`node_modules/lodash/_baseIsNative.js` | 🆕 +937 B | 0 B → 937 B
`node_modules/lodash/_ListCache.js` | 🆕 +838 B | 0 B → 838 B
`node_modules/lodash/_MapCache.js` | 🆕 +814 B | 0 B → 814 B
`node_modules/lodash/_getRawTag.js` | 🆕 +787 B | 0 B → 787 B
`node_modules/lodash/_nodeUtil.js` | 🆕 +759 B | 0 B → 759 B
`node_modules/lodash/_Hash.js` | 🆕 +718 B | 0 B → 718 B
`node_modules/lodash/_stackSet.js` | 🆕 +694 B | 0 B → 694 B
`node_modules/lodash/_Stack.js` | 🆕 +672 B | 0 B → 672 B
`node_modules/lodash/isArguments.js` | 🆕 +664 B | 0 B → 664 B
`node_modules/lodash/_getSymbols.js` | 🆕 +647 B | 0 B → 647 B
`node_modules/lodash/_baseGetTag.js` | 🆕 +636 B | 0 B → 636 B
`node_modules/lodash/_baseIsEqual.js` | 🆕 +596 B | 0 B → 596 B
`node_modules/lodash/isBuffer.js` | 🆕 +584 B | 0 B → 584 B
`node_modules/lodash/isFunction.js` | 🆕 +582 B | 0 B → 582 B
`node_modules/lodash/_SetCache.js` | 🆕 +582 B | 0 B → 582 B
`node_modules/lodash/_hashGet.js` | 🆕 +561 B | 0 B → 561 B
`node_modules/lodash/_baseKeys.js` | 🆕 +555 B | 0 B → 555 B
`node_modules/lodash/_getMatchData.js` | 🆕 +540 B | 0 B → 540 B
`node_modules/lodash/_listCacheDelete.js` | 🆕 +528 B | 0 B → 528 B
`node_modules/lodash/_isIndex.js` | 🆕 +513 B | 0 B → 513 B
`node_modules/lodash/_isMasked.js` | 🆕 +473 B | 0 B → 473 B
`node_modules/lodash/_arrayFilter.js` | 🆕 +472 B | 0 B → 472 B
`node_modules/lodash/_hashSet.js` | 🆕 +466 B | 0 B → 466 B
`node_modules/lodash/_listCacheSet.js` | 🆕 +454 B | 0 B → 454 B
`node_modules/lodash/isTypedArray.js` | 🆕 +454 B | 0 B → 454 B
`node_modules/lodash/_mapCacheClear.js` | 🆕 +441 B | 0 B → 441 B
`node_modules/lodash/_baseGetAllKeys.js` | 🆕 +437 B | 0 B → 437 B
`node_modules/lodash/_baseIsArguments.js` | 🆕 +419 B | 0 B → 419 B
`node_modules/lodash/_toSource.js` | 🆕 +418 B | 0 B → 418 B
`node_modules/lodash/_hashHas.js` | 🆕 +414 B | 0 B → 414 B
`node_modules/lodash/_mapCacheSet.js` | 🆕 +407 B | 0 B → 407 B
`node_modules/lodash/_arraySome.js` | 🆕 +387 B | 0 B → 387 B
`node_modules/lodash/_getNative.js` | 🆕 +383 B | 0 B → 383 B
`node_modules/lodash/_isPrototype.js` | 🆕 +383 B | 0 B → 383 B
`node_modules/lodash/keys.js` | 🆕 +383 B | 0 B → 383 B
`node_modules/lodash/_getAllKeys.js` | 🆕 +379 B | 0 B → 379 B
`node_modules/lodash/_listCacheGet.js` | 🆕 +378 B | 0 B → 378 B
`node_modules/lodash/isMatch.js` | 🆕 +378 B | 0 B → 378 B
`node_modules/lodash/_mapCacheDelete.js` | 🆕 +377 B | 0 B → 377 B
`node_modules/lodash/_getMapData.js` | 🆕 +376 B | 0 B → 376 B
`node_modules/lodash/_isKeyable.js` | 🆕 +371 B | 0 B → 371 B
`node_modules/lodash/_arrayPush.js` | 🆕 +371 B | 0 B → 371 B
`node_modules/lodash/_assocIndexOf.js` | 🆕 +365 B | 0 B → 365 B
`node_modules/lodash/isArrayLike.js` | 🆕 +364 B | 0 B → 364 B
`node_modules/lodash/_mapToArray.js` | 🆕 +359 B | 0 B → 359 B
`node_modules/lodash/_root.js` | 🆕 +356 B | 0 B → 356 B
`node_modules/lodash/_setToArray.js` | 🆕 +347 B | 0 B → 347 B
`node_modules/lodash/isLength.js` | 🆕 +347 B | 0 B → 347 B
`node_modules/lodash/_setCacheAdd.js` | 🆕 +334 B | 0 B → 334 B
`node_modules/lodash/_objectToString.js` | 🆕 +333 B | 0 B → 333 B
`node_modules/lodash/_isStrictComparable.js` | 🆕 +333 B | 0 B → 333 B
`node_modules/lodash/_hashClear.js` | 🆕 +331 B | 0 B → 331 B
`node_modules/lodash/_baseTimes.js` | 🆕 +331 B | 0 B → 331 B
`node_modules/lodash/_hashDelete.js` | 🆕 +325 B | 0 B → 325 B
`node_modules/lodash/_stackDelete.js` | 🆕 +322 B | 0 B → 322 B
`node_modules/lodash/_listCacheHas.js` | 🆕 +318 B | 0 B → 318 B
`node_modules/lodash/_stackClear.js` | 🆕 +306 B | 0 B → 306 B
`node_modules/lodash/isObject.js` | 🆕 +304 B | 0 B → 304 B
`node_modules/lodash/_mapCacheGet.js` | 🆕 +303 B | 0 B → 303 B
`node_modules/lodash/_mapCacheHas.js` | 🆕 +303 B | 0 B → 303 B
`node_modules/lodash/_freeGlobal.js` | 🆕 +293 B | 0 B → 293 B
`node_modules/lodash/_overArg.js` | 🆕 +280 B | 0 B → 280 B
`node_modules/lodash/isObjectLike.js` | 🆕 +276 B | 0 B → 276 B
`node_modules/lodash/_baseUnary.js` | 🆕 +270 B | 0 B → 270 B
`node_modules/lodash/_listCacheClear.js` | 🆕 +269 B | 0 B → 269 B
`node_modules/lodash/_getValue.js` | 🆕 +264 B | 0 B → 264 B
`node_modules/lodash/_setCacheHas.js` | 🆕 +257 B | 0 B → 257 B
`node_modules/lodash/eq.js` | 🆕 +255 B | 0 B → 255 B
`node_modules/lodash/_nativeCreate.js` | 🆕 +249 B | 0 B → 249 B
`node_modules/lodash/_DataView.js` | 🆕 +244 B | 0 B → 244 B
`node_modules/lodash/_nativeKeys.js` | 🆕 +242 B | 0 B → 242 B
`node_modules/lodash/_stackGet.js` | 🆕 +241 B | 0 B → 241 B
`node_modules/lodash/_stackHas.js` | 🆕 +241 B | 0 B → 241 B
`node_modules/lodash/_coreJsData.js` | 🆕 +240 B | 0 B → 240 B
`node_modules/lodash/_cacheHas.js` | 🆕 +240 B | 0 B → 240 B
`node_modules/lodash/_Promise.js` | 🆕 +239 B | 0 B → 239 B
`node_modules/lodash/_WeakMap.js` | 🆕 +239 B | 0 B → 239 B
`node_modules/lodash/_Uint8Array.js` | 🆕 +229 B | 0 B → 229 B
`node_modules/lodash/stubFalse.js` | 🆕 +223 B | 0 B → 223 B
`node_modules/lodash/stubArray.js` | 🆕 +220 B | 0 B → 220 B
`node_modules/lodash/_Map.js` | 🆕 +219 B | 0 B → 219 B
`node_modules/lodash/_Set.js` | 🆕 +219 B | 0 B → 219 B
`node_modules/lodash/_Symbol.js` | 🆕 +209 B | 0 B → 209 B
`node_modules/lodash/isArray.js` | 🆕 +202 B | 0 B → 202 B
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +65 B (+1.73%) | 3.68 kB → 3.74 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +25 B (+0.40%) | 6.06 kB → 6.08 kB
`node_modules/object-keys/isArguments.js` | 📈 +2 B (+0.36%) | 554 B → 556 B
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +20 B (+0.26%) | 7.47 kB → 7.49 kB
`node_modules/object-keys/index.js` | 📈 +2 B (+0.24%) | 838 B → 840 B
`node_modules/object-keys/implementation.js` | 📈 +2 B (+0.06%) | 3.16 kB → 3.16 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CNM-CrN5.js | 0 B → 4.9 MB (+4.9 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.94 MB (+62.72 kB) | +1.58%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/retry/lib/retry_operation.js` | 🆕 +3.46 kB | 0 B → 3.46 kB
`node_modules/lodash/_equalByTag.js` | 🆕 +3.11 kB | 0 B → 3.11 kB
`node_modules/lodash/_baseIsEqualDeep.js` | 🆕 +2.87 kB | 0 B → 2.87 kB
`node_modules/lodash/_equalObjects.js` | 🆕 +2.55 kB | 0 B → 2.55 kB
`node_modules/lodash/_equalArrays.js` | 🆕 +2.37 kB | 0 B → 2.37 kB
`node_modules/lodash/_baseIsTypedArray.js` | 🆕 +2.23 kB | 0 B → 2.23 kB
`node_modules/retry/lib/retry.js` | 🆕 +2.1 kB | 0 B → 2.1 kB
`node_modules/lodash/_getTag.js` | 🆕 +1.69 kB | 0 B → 1.69 kB
`node_modules/lodash/_baseIsMatch.js` | 🆕 +1.67 kB | 0 B → 1.67 kB
`node_modules/lodash/_baseIsNative.js` | 🆕 +1.48 kB | 0 B → 1.48 kB
`node_modules/lodash/_arrayLikeKeys.js` | 🆕 +1.4 kB | 0 B → 1.4 kB
`node_modules/lodash/_getRawTag.js` | 🆕 +1.21 kB | 0 B → 1.21 kB
`node_modules/lodash/isMatch.js` | 🆕 +1.18 kB | 0 B → 1.18 kB
`node_modules/lodash/isArguments.js` | 🆕 +1.14 kB | 0 B → 1.14 kB
`node_modules/promise-retry/index.js` | 🆕 +1.14 kB | 0 B → 1.14 kB
`node_modules/lodash/_baseIsEqual.js` | 🆕 +1.11 kB | 0 B → 1.11 kB
`node_modules/memoize-one/dist/memoize-one.esm.js` | 🆕 +1.09 kB | 0 B → 1.09 kB
`node_modules/lodash/isBuffer.js` | 🆕 +1022 B | 0 B → 1022 B
`node_modules/lodash/keys.js` | 🆕 +1005 B | 0 B → 1005 B
`node_modules/lodash/_stackSet.js` | 🆕 +973 B | 0 B → 973 B
`node_modules/lodash/isArrayLike.js` | 🆕 +972 B | 0 B → 972 B
`node_modules/lodash/isFunction.js` | 🆕 +956 B | 0 B → 956 B
`node_modules/lodash/_ListCache.js` | 🆕 +952 B | 0 B → 952 B
`node_modules/lodash/_MapCache.js` | 🆕 +951 B | 0 B → 951 B
`node_modules/lodash/isLength.js` | 🆕 +945 B | 0 B → 945 B
`node_modules/lodash/eq.js` | 🆕 +931 B | 0 B → 931 B
`node_modules/lodash/_nodeUtil.js` | 🆕 +924 B | 0 B → 924 B
`node_modules/lodash/_baseGetTag.js` | 🆕 +899 B | 0 B → 899 B
`node_modules/err-code/index.js` | 🆕 +893 B | 0 B → 893 B
`node_modules/lodash/_baseGetAllKeys.js` | 🆕 +889 B | 0 B → 889 B
`node_modules/lodash/_isIndex.js` | 🆕 +884 B | 0 B → 884 B
`node_modules/lodash/isObject.js` | 🆕 +879 B | 0 B → 879 B
`node_modules/lodash/_getSymbols.js` | 🆕 +853 B | 0 B → 853 B
`node_modules/lodash/_hashGet.js` | 🆕 +833 B | 0 B → 833 B
`node_modules/lodash/_Hash.js` | 🆕 +825 B | 0 B → 825 B
`node_modules/lodash/_Stack.js` | 🆕 +815 B | 0 B → 815 B
`node_modules/lodash/_baseKeys.js` | 🆕 +805 B | 0 B → 805 B
`node_modules/lodash/isTypedArray.js` | 🆕 +798 B | 0 B → 798 B
`node_modules/lodash/_listCacheDelete.js` | 🆕 +797 B | 0 B → 797 B
`node_modules/lodash/isObjectLike.js` | 🆕 +768 B | 0 B → 768 B
`node_modules/lodash/_arrayFilter.js` | 🆕 +751 B | 0 B → 751 B
`node_modules/lodash/_hashSet.js` | 🆕 +737 B | 0 B → 737 B
`node_modules/lodash/_SetCache.js` | 🆕 +719 B | 0 B → 719 B
`node_modules/lodash/_getMatchData.js` | 🆕 +718 B | 0 B → 718 B
`node_modules/lodash/_arraySome.js` | 🆕 +713 B | 0 B → 713 B
`node_modules/lodash/_isMasked.js` | 🆕 +705 B | 0 B → 705 B
`node_modules/lodash/_hashHas.js` | 🆕 +689 B | 0 B → 689 B
`node_modules/lodash/_listCacheSet.js` | 🆕 +687 B | 0 B → 687 B
`node_modules/lodash/_objectToString.js` | 🆕 +650 B | 0 B → 650 B
`node_modules/lodash/_baseIsArguments.js` | 🆕 +641 B | 0 B → 641 B
`node_modules/lodash/_baseTimes.js` | 🆕 +637 B | 0 B → 637 B
`node_modules/lodash/_mapCacheSet.js` | 🆕 +633 B | 0 B → 633 B
`node_modules/lodash/isArray.js` | 🆕 +631 B | 0 B → 631 B
`node_modules/lodash/_toSource.js` | 🆕 +623 B | 0 B → 623 B
`node_modules/lodash/_getNative.js` | 🆕 +620 B | 0 B → 620 B
`node_modules/lodash/_assocIndexOf.js` | 🆕 +616 B | 0 B → 616 B
`node_modules/lodash/_isPrototype.js` | 🆕 +613 B | 0 B → 613 B
`node_modules/lodash/_mapCacheDelete.js` | 🆕 +607 B | 0 B → 607 B
`node_modules/lodash/_hashDelete.js` | 🆕 +597 B | 0 B → 597 B
`node_modules/lodash/_getAllKeys.js` | 🆕 +590 B | 0 B → 590 B
`node_modules/lodash/_setCacheAdd.js` | 🆕 +579 B | 0 B → 579 B
`node_modules/lodash/_isStrictComparable.js` | 🆕 +579 B | 0 B → 579 B
`node_modules/lodash/_isKeyable.js` | 🆕 +566 B | 0 B → 566 B
`node_modules/lodash/_arrayPush.js` | 🆕 +564 B | 0 B → 564 B
`node_modules/lodash/_listCacheGet.js` | 🆕 +563 B | 0 B → 563 B
`node_modules/lodash/_listCacheHas.js` | 🆕 +556 B | 0 B → 556 B
`node_modules/lodash/_stackDelete.js` | 🆕 +552 B | 0 B → 552 B
`node_modules/lodash/_getMapData.js` | 🆕 +541 B | 0 B → 541 B
`node_modules/lodash/stubArray.js` | 🆕 +538 B | 0 B → 538 B
`node_modules/lodash/_mapCacheClear.js` | 🆕 +537 B | 0 B → 537 B
`node_modules/lodash/_mapCacheHas.js` | 🆕 +533 B | 0 B → 533 B
`node_modules/lodash/_overArg.js` | 🆕 +527 B | 0 B → 527 B
`node_modules/lodash/_mapToArray.js` | 🆕 +507 B | 0 B → 507 B
`node_modules/lodash/_setToArray.js` | 🆕 +489 B | 0 B → 489 B
`node_modules/lodash/_cacheHas.js` | 🆕 +485 B | 0 B → 485 B
`node_modules/lodash/_mapCacheGet.js` | 🆕 +481 B | 0 B → 481 B
`node_modules/lodash/_baseUnary.js` | 🆕 +481 B | 0 B → 481 B
`node_modules/lodash/_stackHas.js` | 🆕 +471 B | 0 B → 471 B
`node_modules/lodash/_setCacheHas.js` | 🆕 +471 B | 0 B → 471 B
`node_modules/lodash/_getValue.js` | 🆕 +470 B | 0 B → 470 B
`node_modules/lodash/_root.js` | 🆕 +437 B | 0 B → 437 B
`node_modules/lodash/_hashClear.js` | 🆕 +428 B | 0 B → 428 B
`node_modules/lodash/stubFalse.js` | 🆕 +428 B | 0 B → 428 B
`node_modules/lodash/_stackGet.js` | 🆕 +419 B | 0 B → 419 B
`node_modules/lodash/_stackClear.js` | 🆕 +405 B | 0 B → 405 B
`node_modules/lodash/_listCacheClear.js` | 🆕 +378 B | 0 B → 378 B
`node_modules/lodash/_freeGlobal.js` | 🆕 +324 B | 0 B → 324 B
`node_modules/lodash/_coreJsData.js` | 🆕 +287 B | 0 B → 287 B
`node_modules/lodash/_Uint8Array.js` | 🆕 +260 B | 0 B → 260 B
`node_modules/lodash/_nativeCreate.js` | 🆕 +245 B | 0 B → 245 B
`node_modules/lodash/_Symbol.js` | 🆕 +240 B | 0 B → 240 B
`node_modules/lodash/_DataView.js` | 🆕 +240 B | 0 B → 240 B
`node_modules/lodash/_nativeKeys.js` | 🆕 +238 B | 0 B → 238 B
`node_modules/lodash/_Promise.js` | 🆕 +235 B | 0 B → 235 B
`node_modules/lodash/_WeakMap.js` | 🆕 +235 B | 0 B → 235 B
`node_modules/lodash/_Map.js` | 🆕 +215 B | 0 B → 215 B
`node_modules/lodash/_Set.js` | 🆕 +215 B | 0 B → 215 B
`node_modules/retry/index.js` | 🆕 +173 B | 0 B → 173 B
`utils.ts` | 📈 +86 B (+51.50%) | 167 B → 253 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/log/index.ts` | 📈 +77 B (+12.62%) | 610 B → 687 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.94 MB (+62.72 kB) | +1.58%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+26 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/strip-ansi/index.js` | 📈 +26 B (+9.09%) | 286 B → 312 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+26 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->