### PR TITLE
[WIP] [AI] Make budget template notifications translatable

### DIFF
--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -683,6 +683,36 @@ type ApplyBudgetActionPayload =
       };
     };
 
+type BudgetTemplateNotification = {
+  message: string;
+  values?: Record<string, unknown> | undefined;
+};
+
+// goal-template.ts and template-notes.ts run in loot-core and can't depend on
+// i18next, so they return English keys. These literal `t()` calls exist so
+// the i18next-parser extraction (which can't follow a variable key) picks up
+// the strings; the switch below performs the actual translation at runtime.
+function translateBudgetTemplateMessage(
+  t: TFunction,
+  notification: BudgetTemplateNotification,
+): string {
+  switch (notification.message) {
+    case 'Everything is up to date':
+      return t('Everything is up to date');
+    case 'There were errors interpreting some templates:':
+      return t('There were errors interpreting some templates:');
+    case 'All templates passed! 🎉':
+      return t('All templates passed! 🎉');
+    case 'Successfully applied templates to {{count}} categories':
+      return t(
+        'Successfully applied templates to {{count}} categories',
+        notification.values,
+      );
+    default:
+      return notification.message;
+  }
+}
+
 export function useBudgetActions() {
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -824,7 +854,10 @@ export function useBudgetActions() {
       if (notification) {
         dispatch(
           addNotification({
-            notification,
+            notification: {
+              ...notification,
+              message: translateBudgetTemplateMessage(t, notification),
+            },
           }),
         );
       }

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -11,6 +11,7 @@ type Notification = {
   pre?: string | undefined;
   title?: string | undefined;
   message: string;
+  values?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 

--- a/packages/loot-core/src/server/budget/goal-template.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.test.ts
@@ -338,6 +338,7 @@ describe('applyMultipleCategoryTemplates', () => {
     });
 
     expect(result.message).toMatch(/Successfully applied/);
+    expect(result.values).toEqual({ count: 2 });
     expect(actions.setBudget).toHaveBeenCalledTimes(2);
     const budgetCalls = vi
       .mocked(actions.setBudget)

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -39,6 +39,7 @@ type Notification = {
   pre?: string | undefined;
   title?: string | undefined;
   message: string;
+  values?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 
@@ -355,7 +356,8 @@ async function processTemplate(
 
   return {
     type: 'message',
-    message: `Successfully applied templates to ${contexts.length} categories`,
+    message: 'Successfully applied templates to {{count}} categories',
+    values: { count: contexts.length },
   };
 }
 

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -13,6 +13,7 @@ type Notification = {
   type?: 'message' | 'error' | 'warning' | undefined;
   pre?: string | undefined;
   message: string;
+  values?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 

--- a/upcoming-release-notes/8413.md
+++ b/upcoming-release-notes/8413.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kaydenletk]
+---
+
+Make budget template notifications ("Check templates", "Apply budget template", "Overwrite with budget template") translatable instead of always showing in English


### PR DESCRIPTION
Fixes #8413

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB → 13.11 MB (+648 B) | +0.00%
loot-core | 1 | 4.82 MB → 4.82 MB (+30 B) | +0.00%
api | 2 | 3.88 MB → 3.88 MB (+29 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB → 13.11 MB (+648 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budget/mutations.ts` | 📈 +648 B (+4.84%) | 13.08 kB → 13.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+648 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.66 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.82 MB → 4.82 MB (+30 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +30 B (+0.40%) | 7.24 kB → 7.27 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DsAI-d3y.js | 0 B → 4.82 MB (+4.82 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C3B--RpG.js | 4.82 MB → 0 B (-4.82 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+29 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +29 B (+0.40%) | 7.07 kB → 7.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+29 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->