### PR TITLE
[AI] Fix daily auto-post schedules skipping days (#8276)

### DIFF
--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -707,6 +707,88 @@ describe('schedule app', () => {
       }
     });
 
+    it('does not skip earlier daily occurrences when a later transaction exists', async () => {
+      // Regression for the "irregular daily schedules" bug: a transaction dated
+      // *after* an occurrence must not mark that earlier occurrence as paid, or
+      // the catch-up loop advances past it without posting, leaving gaps.
+      // today = 2017-01-01 (test constant). Daily schedule from 2016-12-28.
+      MockDate.set(new Date(2016, 11, 31, 12));
+      schedulesApp.startServices();
+
+      try {
+        const accountId = await db.insertAccount({
+          name: 'Checking',
+          offbudget: 0,
+          closed: 0,
+        });
+
+        const id = await createSchedule({
+          schedule: { posts_transaction: true },
+          conditions: [
+            { op: 'is', field: 'account', value: accountId },
+            { op: 'is', field: 'amount', value: -10000 },
+            {
+              op: 'is',
+              field: 'date',
+              value: {
+                start: '2016-12-28',
+                frequency: 'daily',
+                patterns: [],
+              },
+            },
+          ],
+        });
+
+        const nextDateRow = await db.first<{
+          id: string;
+        }>('SELECT id FROM schedules_next_date WHERE schedule_id = ?', [id]);
+        await db.update('schedules_next_date', {
+          id: nextDateRow.id,
+          local_next_date: 20161228,
+          local_next_date_ts: Date.now(),
+          base_next_date: 20161228,
+          base_next_date_ts: Date.now(),
+        });
+
+        // A transaction already exists for a *later* occurrence (2016-12-30),
+        // e.g. from an out-of-order sync or manual entry.
+        await db.insertTransaction({
+          account: accountId,
+          amount: -10000,
+          date: '2016-12-30',
+          schedule: id,
+        });
+
+        await advanceSchedulesService(true);
+
+        const { data: transactions } = await aqlQuery(
+          q('transactions')
+            .filter({ schedule: id })
+            .select(['date', 'amount'])
+            .orderBy({ date: 'asc' }),
+        );
+
+        // Every day 2016-12-28 .. 2017-01-01 has exactly one transaction; the
+        // pre-existing 2016-12-30 one is not duplicated and no day is skipped.
+        expect(transactions.map(({ date }) => date)).toEqual([
+          '2016-12-28',
+          '2016-12-29',
+          '2016-12-30',
+          '2016-12-31',
+          '2017-01-01',
+        ]);
+
+        const {
+          data: [schedule],
+        } = await aqlQuery(q('schedules').filter({ id }).select(['next_date']));
+
+        expect(schedule.next_date).toBe('2017-01-02');
+      } finally {
+        MockDate.reset();
+        await schedulesApp.stopServices();
+      }
+    });
+
     it('completes one-time auto-post schedules that are already paid', async () => {
       MockDate.set(new Date(2016, 11, 31, 12));
       schedulesApp.startServices();

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -708,10 +708,6 @@ describe('schedule app', () => {
     });
 
     it('does not skip earlier daily occurrences when a later transaction exists', async () => {
-      // Regression for the "irregular daily schedules" bug: a transaction dated
-      // *after* an occurrence must not mark that earlier occurrence as paid, or
-      // the catch-up loop advances past it without posting, leaving gaps.
-      // today = 2017-01-01 (test constant). Daily schedule from 2016-12-28.
       MockDate.set(new Date(2016, 11, 31, 12));
       schedulesApp.startServices();
 

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -5,6 +5,7 @@ import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
+  getHasTransactionsQuery,
   getNextDate,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
@@ -335,6 +336,44 @@ describe('schedules', () => {
           occurrenceDate,
         ),
       ).toBe(occurrenceDate);
+    });
+  });
+
+  describe('getHasTransactionsQuery', () => {
+    type DateBound = { $gte: string } | { $lte: string };
+    type HasTransactionsFilter = {
+      $or: Array<{ $and: { schedule: string; date: DateBound[] } }>;
+    };
+
+    function dateFilter(schedule: Partial<ScheduleEntity>): DateBound[] {
+      const query = getHasTransactionsQuery([schedule]);
+      const [orFilter] = query.serialize()
+        .filterExpressions as HasTransactionsFilter[];
+      return orFilter.$or[0].$and.date;
+    }
+
+    it('bounds an auto-posted schedule to its exact occurrence date', () => {
+      // Lower and upper bound are both the occurrence date, so a transaction
+      // dated on a *different* day cannot mark this occurrence as paid.
+      expect(
+        dateFilter({
+          id: 'sched-1',
+          next_date: '2024-03-10',
+          posts_transaction: true,
+        }),
+      ).toEqual([{ $gte: '2024-03-10' }, { $lte: '2024-03-10' }]);
+    });
+
+    it('caps the 2-day lookback for manual recurring schedules at the occurrence date', () => {
+      // The lower bound looks back to catch early payments, but the upper bound
+      // stays at the occurrence date so later transactions are excluded.
+      expect(
+        dateFilter({
+          id: 'sched-2',
+          next_date: '2024-03-10',
+          posts_transaction: false,
+        }),
+      ).toEqual([{ $gte: '2024-03-08' }, { $lte: '2024-03-10' }]);
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -122,20 +122,13 @@ export function isScheduleOccurrencePosted({
  * - Otherwise (manual recurring with `isapprox`, etc.): 2-day lookback to catch
  *   early payments.
  *
- * The upper-bound is always `next_date`: a transaction dated *after* the current
- * occurrence belongs to a later occurrence and must not mark this one as paid.
- * Without it, a single later transaction (e.g. an out-of-order or manually
- * entered one) would make every earlier unposted occurrence look already-paid,
- * causing the auto-post catch-up to skip those days and leave gaps.
+ * The date upper-bound is always exactly `next_date` to avoid marking future occurrences as paid.
  */
 export function getHasTransactionsQuery(schedules) {
   const filters = schedules.map(schedule => {
     return {
       $and: {
         schedule: schedule.id,
-        // An array of conditions for a field is implicitly AND-ed, giving us a
-        // `[matchStart, next_date]` range. (A single `{ $gte, $lte }` object
-        // would silently drop the second operator in the AQL compiler.)
         date: [
           {
             $gte: getScheduleOccurrenceMatchStartDate(

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -111,7 +111,8 @@ export function isScheduleOccurrencePosted({
 }
 
 /**
- * Builds a query to check if each schedule already has a matching transaction.
+ * Builds a query to check if each schedule already has a matching transaction
+ * for its current `next_date` occurrence.
  *
  * The date lower-bound varies:
  * - `dateCond.op === 'is'` (one-time or recurring): exact `next_date`, no lookback.
@@ -120,18 +121,30 @@ export function isScheduleOccurrencePosted({
  *   yesterday's transaction to falsely match today's occurrence.
  * - Otherwise (manual recurring with `isapprox`, etc.): 2-day lookback to catch
  *   early payments.
+ *
+ * The upper-bound is always `next_date`: a transaction dated *after* the current
+ * occurrence belongs to a later occurrence and must not mark this one as paid.
+ * Without it, a single later transaction (e.g. an out-of-order or manually
+ * entered one) would make every earlier unposted occurrence look already-paid,
+ * causing the auto-post catch-up to skip those days and leave gaps.
  */
 export function getHasTransactionsQuery(schedules) {
   const filters = schedules.map(schedule => {
     return {
       $and: {
         schedule: schedule.id,
-        date: {
-          $gte: getScheduleOccurrenceMatchStartDate(
-            schedule,
-            schedule.next_date,
-          ),
-        },
+        // An array of conditions for a field is implicitly AND-ed, giving us a
+        // `[matchStart, next_date]` range. (A single `{ $gte, $lte }` object
+        // would silently drop the second operator in the AQL compiler.)
+        date: [
+          {
+            $gte: getScheduleOccurrenceMatchStartDate(
+              schedule,
+              schedule.next_date,
+            ),
+          },
+          { $lte: schedule.next_date },
+        ],
       },
     };
   });

--- a/upcoming-release-notes/8276.md
+++ b/upcoming-release-notes/8276.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [kaydenletk]
----
-
-Fix daily (and other recurring) auto-post schedules skipping days when a later transaction already exists, so every occurrence is posted while catching up.

--- a/upcoming-release-notes/8276.md
+++ b/upcoming-release-notes/8276.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [kaydenletk]
+---
+
+Fix daily (and other recurring) auto-post schedules skipping days when a later transaction already exists, so every occurrence is posted while catching up.

--- a/upcoming-release-notes/fix-daily-schedule-skipped-days.md
+++ b/upcoming-release-notes/fix-daily-schedule-skipped-days.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kaydenletk]
+---
+
+Fix daily schedules skipping days so a transaction is posted for every day


### PR DESCRIPTION
## Description

Daily schedules with "automatically add transaction" turned on were skipping days.

The check for "does this occurrence already have a transaction?" only had a lower bound on the date (`date >= next_date`). Any transaction dated after the occurrence counted as a match, so the occurrence looked paid. The catch-up loop then moved the next date forward without posting anything, and every day in between was lost.

I added an upper bound so the match window is `matchStart <= date <= next_date`. The AQL compiler only keeps the first key of a condition object, so the two bounds go in as an array, which compiles to an AND.

## Related issue(s)

Closes #8276

## Testing

I ran the same steps on the deploy preview and on edge.actualbudget.org so I could compare. Today's date was 07/27/2026.

1. Open the demo budget, go to Bank of America
2. Add New: date 08/02/2026, payment 10.00. Answer "No, keep as transaction" to the convert-to-schedule prompt
3. Schedules > Add new schedule: account Bank of America, amount 10.00, Every day, tick "Automatically add transaction", and tick the 08/02/2026 transaction in the match list so it links on save
4. Trigger the schedule service. The demo has no sync server, so I ran `$send('schedule/force-run-service')` from the console, which is the same call the sync-complete handler makes

edge (no fix): the schedule shows Paid the moment it is saved. After the service runs, nothing is posted and the next date jumps from 07/27/2026 to 08/03/2026. Six days silently skipped.

preview (with the fix): the schedule shows Due. After the service runs, a transaction is posted for 07/27/2026 and the next date moves to 07/28/2026.

Automated coverage, all three fail without the fix:

- `packages/loot-core/src/server/schedules/app.test.ts` - daily catch-up posts every day when a later transaction exists
- `packages/loot-core/src/shared/schedules.test.ts` - two tests on the query's date range

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
