### PR TITLE
Plugin PR Stack: Add sync-server plugin loader [1/9]

### DIFF
--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@actual-app/crdt": "workspace:*",
     "@actual-app/web": "workspace:*",
+    "adm-zip": "^0.5.17",
     "akahu": "^2.5.1",
     "argon2": "^0.44.0",
     "bcrypt": "^6.0.0",

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -1,4 +1,5 @@
 import fs, { readFileSync } from 'node:fs';
+import type { Server } from 'node:http';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -19,6 +20,7 @@ import * as secretApp from './app-secrets';
 import * as simpleFinApp from './app-simplefin/app-simplefin';
 import * as syncApp from './app-sync';
 import { config } from './load-config';
+import { bootstrapPlugins, shutdownPlugins } from './plugins/plugins-bootstrap';
 
 const app = express();
 
@@ -216,6 +218,10 @@ export async function run() {
     }
   }
 
+  await bootstrapPlugins();
+
+  let server: Server;
+
   if (config.get('https.key') && config.get('https.cert')) {
     const https = await import('node:https');
     const httpsOptions = {
@@ -223,12 +229,45 @@ export async function run() {
       key: parseHTTPSConfig(config.get('https.key')),
       cert: parseHTTPSConfig(config.get('https.cert')),
     };
-    https.createServer(httpsOptions, app).listen(port, hostname, () => {
-      sendServerStartedMessage();
-    });
+    server = https
+      .createServer(httpsOptions, app)
+      .listen(port, hostname, () => {
+        sendServerStartedMessage();
+      });
   } else {
-    app.listen(port, hostname, () => {
+    server = app.listen(port, hostname, () => {
       sendServerStartedMessage();
     });
   }
+
+  let isShuttingDown = false;
+
+  async function onShutdown(signal: string) {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+    console.log(`${signal} received. Starting graceful shutdown...`);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await shutdownPlugins();
+      process.exit(0);
+    } catch (error) {
+      console.error('Error during shutdown:', error);
+      await shutdownPlugins();
+      process.exit(1);
+    }
+  }
+
+  process.on('SIGTERM', () => onShutdown('SIGTERM'));
+  process.on('SIGINT', () => onShutdown('SIGINT'));
 }

--- a/packages/sync-server/src/plugins/plugin-helpers.test.ts
+++ b/packages/sync-server/src/plugins/plugin-helpers.test.ts
@@ -1,0 +1,138 @@
+import path from 'path';
+
+import {
+  isPluginPathInsideDir,
+  normalizeDevPluginLocator,
+  resolvePluginPath,
+  sanitizePluginSlug,
+  validateManifest,
+} from './plugin-helpers.js';
+
+describe('plugin helpers', () => {
+  describe('sanitizePluginSlug', () => {
+    it('maps special path slugs to a safe fallback', () => {
+      expect(sanitizePluginSlug('')).toBe('plugin');
+      expect(sanitizePluginSlug('.')).toBe('plugin');
+      expect(sanitizePluginSlug('..')).toBe('plugin');
+      expect(sanitizePluginSlug('../plugin')).toBe('..-plugin');
+    });
+  });
+
+  describe('validateManifest', () => {
+    it('accepts a mixed plugin with frontend and sync-server entries', () => {
+      const manifest = validateManifest({
+        name: 'test-plugin',
+        version: '1.0.0',
+        type: 'mixed',
+        frontend: { entry: 'frontend/index.js' },
+        syncserver: { entry: 'syncserver/index.js' },
+      });
+
+      expect(manifest.name).toBe('test-plugin');
+      expect(manifest.syncserver?.entry).toBe('syncserver/index.js');
+    });
+
+    it('rejects invalid capability combinations', () => {
+      expect(() =>
+        validateManifest({
+          name: 'frontend-plugin',
+          version: '1.0.0',
+          type: 'frontend',
+          frontend: { entry: 'frontend/index.js' },
+          syncserver: { entry: 'syncserver/index.js' },
+        }),
+      ).toThrow(/Frontend-only plugins cannot specify syncserver/);
+
+      expect(() =>
+        validateManifest({
+          name: 'sync-plugin',
+          version: '1.0.0',
+          type: 'syncserver',
+          frontend: { entry: 'frontend/index.js' },
+          syncserver: { entry: 'syncserver/index.js' },
+        }),
+      ).toThrow(/Sync-server-only plugins cannot specify frontend/);
+    });
+  });
+
+  describe('resolvePluginPath', () => {
+    const pluginPath = path.join(path.sep, 'tmp', 'actual-plugin');
+
+    it('resolves relative paths inside the plugin directory', () => {
+      expect(resolvePluginPath(pluginPath, 'syncserver/index.js')).toBe(
+        path.join(pluginPath, 'syncserver', 'index.js'),
+      );
+    });
+
+    it('rejects absolute and parent-relative entries', () => {
+      expect(() => resolvePluginPath(pluginPath, '/etc/passwd')).toThrow(
+        /relative path/,
+      );
+      expect(() => resolvePluginPath(pluginPath, '../outside.js')).toThrow(
+        /inside the plugin directory/,
+      );
+    });
+
+    it('checks that capability entries stay in their capability directory', () => {
+      expect(
+        isPluginPathInsideDir(pluginPath, 'frontend', 'frontend/index.js'),
+      ).toBe(true);
+      expect(
+        isPluginPathInsideDir(pluginPath, 'frontend', 'syncserver/index.js'),
+      ).toBe(false);
+    });
+  });
+
+  describe('normalizeDevPluginLocator', () => {
+    it('normalizes supported local dev plugin locator forms', () => {
+      expect(normalizeDevPluginLocator(3000)).toEqual({
+        port: '3000',
+        path: '/manifest.json',
+        search: '',
+      });
+      expect(
+        normalizeDevPluginLocator({
+          port: '3001',
+          path: '/plugins/demo/manifest.json',
+          search: '?v=1',
+        }),
+      ).toEqual({
+        port: '3001',
+        path: '/plugins/demo/manifest.json',
+        search: '?v=1',
+      });
+      expect(
+        normalizeDevPluginLocator('http://127.0.0.1:3002/plugin.json?x=1'),
+      ).toEqual({
+        port: '3002',
+        path: '/plugin.json',
+        search: '?x=1',
+      });
+    });
+
+    it('rejects invalid ports and paths that leave the origin', () => {
+      expect(() => normalizeDevPluginLocator(0)).toThrow(/valid TCP port/);
+      expect(() =>
+        normalizeDevPluginLocator({ port: 3000, path: '/../secret' }),
+      ).toThrow(/stay inside the origin/);
+      expect(() =>
+        normalizeDevPluginLocator({
+          port: 3000,
+          path: '/plugins/%2e%2e/secret',
+        }),
+      ).toThrow(/stay inside the origin/);
+      expect(() =>
+        normalizeDevPluginLocator({
+          port: 3000,
+          path: '/plugins/%252e%252e/secret',
+        }),
+      ).toThrow(/stay inside the origin/);
+      expect(() =>
+        normalizeDevPluginLocator({
+          port: 3000,
+          path: '/plugins/%5c..%5csecret',
+        }),
+      ).toThrow(/stay inside the origin/);
+    });
+  });
+});

--- a/packages/sync-server/src/plugins/plugin-helpers.ts
+++ b/packages/sync-server/src/plugins/plugin-helpers.ts
@@ -1,0 +1,249 @@
+import path from 'path';
+
+import type AdmZip from 'adm-zip';
+
+import type {
+  DevPluginLocator,
+  DevPluginLocatorInput,
+  FrontendManifest,
+  JsonRecord,
+  Manifest,
+  SyncServerManifest,
+} from './plugin-types.js';
+
+const windowsDrivePathPattern = /^[a-zA-Z]:/;
+
+// Narrows untrusted JSON and IPC payloads before reading fields from them.
+export function isRecord(value: unknown): value is JsonRecord {
+  return value != null && typeof value === 'object';
+}
+
+// Keeps catch blocks useful without assuming thrown values are Error objects.
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Turns plugin package names into directory-safe ids for storage and URLs.
+export function sanitizePluginSlug(pluginName: string): string {
+  const slug = pluginName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  return slug === '' || slug === '.' || slug === '..' ? 'plugin' : slug;
+}
+
+// Prevents plugin entries and zip contents from escaping their plugin root.
+function isPathInside(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
+// Resolves manifest-relative paths only after enforcing the plugin sandbox.
+export function resolvePluginPath(
+  pluginPath: string,
+  relativeEntry: string,
+): string {
+  if (typeof relativeEntry !== 'string' || path.isAbsolute(relativeEntry)) {
+    throw new Error('Plugin entry must be a relative path');
+  }
+
+  const resolvedPluginPath = path.resolve(pluginPath);
+  const resolvedEntryPath = path.resolve(resolvedPluginPath, relativeEntry);
+  if (!isPathInside(resolvedPluginPath, resolvedEntryPath)) {
+    throw new Error('Plugin entry must stay inside the plugin directory');
+  }
+  return resolvedEntryPath;
+}
+
+// Ensures frontend and sync-server entrypoints stay in their capability dirs.
+export function isPluginPathInsideDir(
+  pluginPath: string,
+  relativeDir: string,
+  relativeEntry: string,
+): boolean {
+  const resolvedDir = resolvePluginPath(pluginPath, relativeDir);
+  const resolvedEntry = resolvePluginPath(pluginPath, relativeEntry);
+  return isPathInside(resolvedDir, resolvedEntry);
+}
+
+// Rejects zip-slip payloads before extracting uploaded plugin archives.
+export function assertSafeZipEntries(zip: AdmZip): void {
+  for (const entry of zip.getEntries()) {
+    const entryName = entry.entryName.replace(/\\/g, '/');
+    const normalizedEntryName = path.posix.normalize(entryName);
+    if (
+      windowsDrivePathPattern.test(entryName) ||
+      windowsDrivePathPattern.test(normalizedEntryName) ||
+      normalizedEntryName === '..' ||
+      normalizedEntryName.startsWith('../') ||
+      path.posix.isAbsolute(normalizedEntryName)
+    ) {
+      throw new Error('Plugin zip contains an unsafe path');
+    }
+  }
+}
+
+// Keeps local dev plugin registration out of production servers.
+export function assertDevPluginRegistrationAllowed() {
+  if (process.env.NODE_ENV !== 'development') {
+    throw new Error('Dev plugins can only be registered in development mode');
+  }
+}
+
+// Accepts dev-server paths while keeping manifest and entry fetches same-origin.
+export function normalizeDevPluginPath(rawPath: unknown): string {
+  const rawPathname =
+    typeof rawPath === 'string' && rawPath !== '' ? rawPath : '/';
+  const decodedPathname = decodeDevPluginPathForValidation(rawPathname);
+  const validationPathname = decodedPathname.replace(/\\/g, '/');
+
+  if (
+    !rawPathname.startsWith('/') ||
+    !validationPathname.startsWith('/') ||
+    validationPathname.split('/').includes('..')
+  ) {
+    throw new Error('Dev plugin URL path must stay inside the origin');
+  }
+
+  return path.posix.normalize(rawPathname);
+}
+
+function decodeDevPluginPathForValidation(rawPathname: string): string {
+  let decodedPathname = rawPathname;
+
+  while (true) {
+    let nextPathname: string;
+    try {
+      nextPathname = decodeURIComponent(decodedPathname);
+    } catch {
+      if (decodedPathname === rawPathname) {
+        throw new Error('Dev plugin URL path must stay inside the origin');
+      }
+      return decodedPathname;
+    }
+
+    if (nextPathname === decodedPathname) {
+      return decodedPathname;
+    }
+    decodedPathname = nextPathname;
+  }
+}
+
+// Allows a compact dev plugin config while still rejecting invalid ports.
+function normalizeDevPluginPort(rawPort: unknown): string {
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error('Dev plugin port must be a valid TCP port');
+  }
+
+  return String(port);
+}
+
+// Normalizes every supported dev plugin locator shape into one fetch target.
+export function normalizeDevPluginLocator(
+  rawLocator: DevPluginLocatorInput,
+): DevPluginLocator {
+  if (
+    typeof rawLocator === 'number' ||
+    (typeof rawLocator === 'string' && /^\d+$/.test(rawLocator))
+  ) {
+    return {
+      port: normalizeDevPluginPort(rawLocator),
+      path: '/manifest.json',
+      search: '',
+    };
+  }
+
+  if (isRecord(rawLocator)) {
+    return {
+      port: normalizeDevPluginPort(rawLocator.port),
+      path: normalizeDevPluginPath(rawLocator.path ?? '/manifest.json'),
+      search:
+        typeof rawLocator.search === 'string' &&
+        rawLocator.search.startsWith('?')
+          ? rawLocator.search
+          : '',
+    };
+  }
+
+  if (typeof rawLocator !== 'string') {
+    throw new Error('Dev plugin manifest location must be a string or object');
+  }
+
+  const url = new URL(rawLocator);
+  return {
+    port: normalizeDevPluginPort(url.port),
+    path: normalizeDevPluginPath(url.pathname),
+    search: url.search,
+  };
+}
+
+// Centralizes dev plugin fetch URL construction after locator validation.
+export function buildDevPluginUrl(locator: DevPluginLocator): string {
+  return `http://127.0.0.1:${locator.port}${locator.path}${locator.search}`;
+}
+
+// Type guard for plugins that expose frontend assets to desktop-client.
+export function isFrontendPlugin(
+  manifest: Manifest,
+): manifest is FrontendManifest {
+  return manifest.type === 'frontend' || manifest.type === 'mixed';
+}
+
+// Type guard for plugins that need a forked sync-server runner.
+export function isSyncServerPlugin(
+  manifest: Manifest,
+): manifest is SyncServerManifest {
+  return manifest.type === 'syncserver' || manifest.type === 'mixed';
+}
+
+// Validates the shared manifest before any plugin code is imported or served.
+export function validateManifest(manifest: unknown): Manifest {
+  if (!isRecord(manifest)) {
+    throw new Error('Plugin manifest must be an object');
+  }
+
+  const candidate = manifest as Partial<Manifest>;
+
+  if (!candidate.name || typeof candidate.name !== 'string') {
+    throw new Error('Plugin manifest must specify a name');
+  }
+
+  if (!candidate.version || typeof candidate.version !== 'string') {
+    throw new Error('Plugin manifest must specify a version');
+  }
+
+  if (
+    candidate.type !== 'frontend' &&
+    candidate.type !== 'syncserver' &&
+    candidate.type !== 'mixed'
+  ) {
+    throw new Error(
+      "Plugin manifest type must be 'frontend', 'syncserver', or 'mixed'",
+    );
+  }
+
+  if (
+    (candidate.type === 'frontend' || candidate.type === 'mixed') &&
+    typeof candidate.frontend?.entry !== 'string'
+  ) {
+    throw new Error('Frontend plugins must specify frontend.entry');
+  }
+
+  if (
+    (candidate.type === 'syncserver' || candidate.type === 'mixed') &&
+    typeof candidate.syncserver?.entry !== 'string'
+  ) {
+    throw new Error('Sync-server plugins must specify syncserver.entry');
+  }
+
+  if (candidate.type === 'frontend' && candidate.syncserver) {
+    throw new Error('Frontend-only plugins cannot specify syncserver config');
+  }
+
+  if (candidate.type === 'syncserver' && candidate.frontend) {
+    throw new Error('Sync-server-only plugins cannot specify frontend config');
+  }
+
+  return candidate as Manifest;
+}

--- a/packages/sync-server/src/plugins/plugin-loader.test.ts
+++ b/packages/sync-server/src/plugins/plugin-loader.test.ts
@@ -1,0 +1,347 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import AdmZip from 'adm-zip';
+
+import { assertSafeZipEntries } from './plugin-helpers.js';
+import {
+  cleanupExtractedPlugin,
+  extractZipPlugin,
+  findInstallablePlugins,
+  getPluginSlugFromManifest,
+  readPluginManifest,
+  resolveSyncServerEntry,
+} from './plugin-loader.js';
+import { PluginManager } from './plugin-manager.js';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'actual-plugin-test-'));
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+function writeFrontendPlugin(
+  pluginPath: string,
+  name = 'frontend-plugin',
+): void {
+  writeJson(path.join(pluginPath, 'manifest.json'), {
+    name,
+    version: '1.0.0',
+    type: 'frontend',
+    frontend: { entry: 'frontend/index.js' },
+  });
+  fs.mkdirSync(path.join(pluginPath, 'frontend', 'nested'), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(pluginPath, 'frontend', 'index.js'),
+    'export default {};',
+  );
+  fs.writeFileSync(
+    path.join(pluginPath, 'frontend', 'nested', 'style.css'),
+    '',
+  );
+  fs.writeFileSync(
+    path.join(pluginPath, 'frontend', 'nested', 'logo.bin'),
+    Buffer.from([0, 159, 255]),
+  );
+}
+
+function makeZip(entries: Record<string, string>): string {
+  const zipPath = path.join(makeTempDir(), 'plugin.zip');
+  const zip = new AdmZip();
+  for (const [entryName, content] of Object.entries(entries)) {
+    zip.addFile(entryName, Buffer.from(content));
+  }
+  zip.writeZip(zipPath);
+  return zipPath;
+}
+
+describe('plugin loader', () => {
+  const tempDirs: string[] = [];
+  const extractedPlugins = new Map<string, string>();
+
+  afterEach(() => {
+    for (const extractPath of extractedPlugins.values()) {
+      fs.rmSync(extractPath, { recursive: true, force: true });
+    }
+    extractedPlugins.clear();
+
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function trackedTempDir(): string {
+    const tempDir = makeTempDir();
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  it('reads plugin slugs and validates manifests from plugin directories', () => {
+    const pluginPath = path.join(trackedTempDir(), 'plugin');
+    writeFrontendPlugin(pluginPath, 'manifest-name');
+
+    expect(getPluginSlugFromManifest(pluginPath)).toBe('manifest-name');
+    expect(readPluginManifest('manifest-name', pluginPath)).toMatchObject({
+      name: 'manifest-name',
+      type: 'frontend',
+    });
+  });
+
+  it('returns null for missing or invalid manifest slugs', () => {
+    const pluginPath = path.join(trackedTempDir(), 'plugin');
+    fs.mkdirSync(pluginPath, { recursive: true });
+
+    expect(getPluginSlugFromManifest(pluginPath)).toBeNull();
+
+    fs.writeFileSync(path.join(pluginPath, 'manifest.json'), '{');
+    expect(getPluginSlugFromManifest(pluginPath)).toBeNull();
+
+    writeJson(path.join(pluginPath, 'manifest.json'), { name: 123 });
+    expect(getPluginSlugFromManifest(pluginPath)).toBeNull();
+  });
+
+  it('discovers directory plugins and zip plugins', () => {
+    const pluginsDir = trackedTempDir();
+    writeFrontendPlugin(path.join(pluginsDir, 'directory-plugin'), 'from-dir');
+
+    const zip = new AdmZip();
+    zip.addFile(
+      'manifest.json',
+      Buffer.from(
+        JSON.stringify({
+          name: 'from-zip',
+          version: '1.0.0',
+          type: 'frontend',
+          frontend: { entry: 'frontend/index.js' },
+        }),
+      ),
+    );
+    zip.addFile('frontend/index.js', Buffer.from('export default {};'));
+    zip.writeZip(path.join(pluginsDir, 'archive-plugin.1.2.3.zip'));
+
+    expect(findInstallablePlugins(pluginsDir, extractedPlugins)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'directory',
+          name: 'directory-plugin',
+          slug: 'from-dir',
+        }),
+        expect.objectContaining({
+          type: 'zip',
+          name: 'archive-plugin.1.2.3.zip',
+          slug: 'from-zip',
+        }),
+      ]),
+    );
+  });
+
+  it('extracts safe plugin zips and cleans them up', () => {
+    const zipPath = makeZip({
+      'manifest.json': JSON.stringify({
+        name: 'safe-zip',
+        version: '1.0.0',
+        type: 'frontend',
+        frontend: { entry: 'frontend/index.js' },
+      }),
+      'frontend/index.js': 'export default {};',
+    });
+    tempDirs.push(path.dirname(zipPath));
+
+    const extractPath = extractZipPlugin(
+      zipPath,
+      'safe-zip-test',
+      extractedPlugins,
+    );
+
+    expect(fs.existsSync(path.join(extractPath, 'manifest.json'))).toBe(true);
+    cleanupExtractedPlugin(
+      {
+        type: 'zip',
+        name: 'safe.zip',
+        slug: 'safe-zip-test',
+        path: extractPath,
+        zipPath,
+      },
+      extractedPlugins,
+    );
+    expect(fs.existsSync(extractPath)).toBe(false);
+    expect(extractedPlugins.has('safe-zip-test')).toBe(false);
+  });
+
+  it('cleans extracted zips when the manifest slug differs from the filename', () => {
+    const pluginsDir = trackedTempDir();
+    const zip = new AdmZip();
+    zip.addFile(
+      'manifest.json',
+      Buffer.from(
+        JSON.stringify({
+          name: 'manifest-slug',
+          version: '1.0.0',
+          type: 'frontend',
+          frontend: { entry: 'frontend/index.js' },
+        }),
+      ),
+    );
+    zip.addFile('frontend/index.js', Buffer.from('export default {};'));
+    zip.writeZip(path.join(pluginsDir, 'filename-slug.zip'));
+
+    const [candidate] = findInstallablePlugins(pluginsDir, extractedPlugins);
+
+    expect(candidate.slug).toBe('manifest-slug');
+    expect(extractedPlugins.has('manifest-slug')).toBe(true);
+    expect(extractedPlugins.has('filename-slug')).toBe(false);
+
+    cleanupExtractedPlugin(candidate, extractedPlugins);
+
+    expect(fs.existsSync(candidate.path)).toBe(false);
+    expect(extractedPlugins.has('manifest-slug')).toBe(false);
+  });
+
+  it('rejects zip entries that would escape the extraction directory', () => {
+    expect(() =>
+      assertSafeZipEntries({
+        getEntries: () => [{ entryName: '../escape.txt' }],
+      } as AdmZip),
+    ).toThrow(/unsafe path/);
+
+    expect(() =>
+      assertSafeZipEntries({
+        getEntries: () => [{ entryName: 'nested/../../escape.txt' }],
+      } as AdmZip),
+    ).toThrow(/unsafe path/);
+  });
+
+  it('rejects Windows drive-letter zip entries', () => {
+    expect(() =>
+      assertSafeZipEntries({
+        getEntries: () => [{ entryName: 'C:\\Windows\\System32\\evil.dll' }],
+      } as AdmZip),
+    ).toThrow(/unsafe path/);
+
+    expect(() =>
+      assertSafeZipEntries({
+        getEntries: () => [{ entryName: 'safe/../C:/evil.dll' }],
+      } as AdmZip),
+    ).toThrow(/unsafe path/);
+  });
+
+  it('resolves sync-server entries only when they exist inside the plugin', () => {
+    const pluginPath = path.join(trackedTempDir(), 'plugin');
+    fs.mkdirSync(path.join(pluginPath, 'syncserver'), { recursive: true });
+    fs.writeFileSync(path.join(pluginPath, 'syncserver', 'index.js'), '');
+
+    expect(
+      resolveSyncServerEntry('sync-plugin', pluginPath, {
+        name: 'sync-plugin',
+        version: '1.0.0',
+        type: 'syncserver',
+        syncserver: { entry: 'syncserver/index.js' },
+      }),
+    ).toBe(path.join(pluginPath, 'syncserver', 'index.js'));
+
+    expect(() =>
+      resolveSyncServerEntry('sync-plugin', pluginPath, {
+        name: 'sync-plugin',
+        version: '1.0.0',
+        type: 'syncserver',
+        syncserver: { entry: '../outside.js' },
+      }),
+    ).toThrow(/inside the plugin directory/);
+  });
+});
+
+describe('PluginManager frontend plugin loading', () => {
+  let pluginsDir: string;
+
+  beforeEach(() => {
+    pluginsDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(pluginsDir, { recursive: true, force: true });
+  });
+
+  it('loads frontend-only plugins without starting a sync-server runner', async () => {
+    writeFrontendPlugin(path.join(pluginsDir, 'frontend-plugin'));
+
+    const pluginManager = new PluginManager(pluginsDir);
+    await pluginManager.loadPlugins();
+
+    expect(pluginManager.getInstalledPluginManifests()).toEqual([
+      expect.objectContaining({
+        name: 'frontend-plugin',
+        source: 'sync-server',
+      }),
+    ]);
+    expect(pluginManager.getFrontendPluginFiles('frontend-plugin')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'index.js' }),
+        expect.objectContaining({ name: path.join('nested', 'style.css') }),
+        expect.objectContaining({
+          name: path.join('nested', 'logo.bin'),
+          content: Buffer.from([0, 159, 255]).toString('base64'),
+          encoding: 'base64',
+        }),
+      ]),
+    );
+  });
+
+  it('keeps the first plugin when duplicate manifest slugs are found', async () => {
+    writeFrontendPlugin(path.join(pluginsDir, 'first'), 'duplicate-plugin');
+    writeFrontendPlugin(path.join(pluginsDir, 'second'), 'duplicate-plugin');
+
+    const pluginManager = new PluginManager(pluginsDir);
+    await pluginManager.loadPlugins();
+
+    expect(pluginManager.getInstalledPluginManifests()).toHaveLength(1);
+    expect(pluginManager.getInstalledPluginManifests()[0].name).toBe(
+      'duplicate-plugin',
+    );
+  });
+
+  it('does not register sync-server plugins with invalid entries', async () => {
+    const pluginPath = path.join(pluginsDir, 'bad-sync-plugin');
+    writeJson(path.join(pluginPath, 'manifest.json'), {
+      name: 'bad-sync-plugin',
+      version: '1.0.0',
+      type: 'syncserver',
+      syncserver: { entry: 'syncserver/missing.js' },
+    });
+
+    const pluginManager = new PluginManager(pluginsDir);
+
+    await expect(
+      pluginManager.loadPlugin('bad-sync-plugin', pluginPath),
+    ).rejects.toThrow(/entry point does not exist/);
+    expect(pluginManager.getInstalledPluginManifests()).toEqual([]);
+  });
+
+  it('rejects uploaded plugin versions with path separators', async () => {
+    const zip = new AdmZip();
+    zip.addFile(
+      'manifest.json',
+      Buffer.from(
+        JSON.stringify({
+          name: 'unsafe-version',
+          version: '../evil',
+          type: 'frontend',
+          frontend: { entry: 'frontend/index.js' },
+        }),
+      ),
+    );
+    zip.addFile('frontend/index.js', Buffer.from('export default {};'));
+
+    const pluginManager = new PluginManager(pluginsDir);
+
+    await expect(
+      pluginManager.installPluginZip(zip.toBuffer()),
+    ).rejects.toThrow(/version cannot contain path separators/);
+    expect(fs.existsSync(path.join(pluginsDir, 'evil.zip'))).toBe(false);
+  });
+});

--- a/packages/sync-server/src/plugins/plugin-loader.ts
+++ b/packages/sync-server/src/plugins/plugin-loader.ts
@@ -1,0 +1,221 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import AdmZip from 'adm-zip';
+
+import {
+  assertSafeZipEntries,
+  getErrorMessage,
+  resolvePluginPath,
+  validateManifest,
+} from './plugin-helpers.js';
+import type {
+  Manifest,
+  PluginSourceCandidate,
+  SyncServerManifest,
+} from './plugin-types.js';
+
+export function extractZipPlugin(
+  zipPath: string,
+  pluginSlug: string,
+  extractedPlugins: Map<string, string>,
+): string {
+  try {
+    const zip = new AdmZip(zipPath);
+    assertSafeZipEntries(zip);
+    const extractPath = path.join(os.tmpdir(), 'actual-plugins', pluginSlug);
+
+    if (fs.existsSync(extractPath)) {
+      fs.rmSync(extractPath, { recursive: true, force: true });
+    }
+
+    zip.extractAllTo(extractPath, true);
+    installPluginDependencies(extractPath, pluginSlug);
+    extractedPlugins.set(pluginSlug, extractPath);
+
+    return extractPath;
+  } catch (error) {
+    throw new Error(
+      `Failed to extract zip plugin ${pluginSlug}: ${getErrorMessage(error)}`,
+    );
+  }
+}
+
+export function getPluginSlugFromManifest(pluginPath: string): string | null {
+  const manifestPath = path.join(pluginPath, 'manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  try {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return typeof manifest.name === 'string' ? manifest.name : null;
+  } catch {
+    return null;
+  }
+}
+
+export function findInstallablePlugins(
+  pluginsDir: string,
+  extractedPlugins: Map<string, string>,
+): PluginSourceCandidate[] {
+  const pluginsToLoad: PluginSourceCandidate[] = [];
+
+  for (const entry of fs.readdirSync(pluginsDir, { withFileTypes: true })) {
+    try {
+      const candidate = toPluginSourceCandidate(
+        pluginsDir,
+        entry,
+        extractedPlugins,
+      );
+      if (candidate) {
+        pluginsToLoad.push(candidate);
+      }
+    } catch (error) {
+      console.error(
+        `Failed to process plugin ${entry.name}:`,
+        getErrorMessage(error),
+      );
+    }
+  }
+
+  return pluginsToLoad;
+}
+
+export function cleanupExtractedPlugin(
+  plugin: PluginSourceCandidate,
+  extractedPlugins: Map<string, string>,
+): void {
+  if (plugin.type !== 'zip' || !extractedPlugins.has(plugin.slug)) {
+    return;
+  }
+
+  const extractPath = extractedPlugins.get(plugin.slug);
+  if (extractPath && fs.existsSync(extractPath)) {
+    fs.rmSync(extractPath, { recursive: true, force: true });
+  }
+  extractedPlugins.delete(plugin.slug);
+}
+
+export function readPluginManifest(
+  pluginSlug: string,
+  pluginPath: string,
+): Manifest {
+  const manifestPath = path.join(pluginPath, 'manifest.json');
+
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`Plugin ${pluginSlug} does not have a manifest.json`);
+  }
+
+  return validateManifest(JSON.parse(fs.readFileSync(manifestPath, 'utf8')));
+}
+
+export function resolveSyncServerEntry(
+  pluginSlug: string,
+  pluginPath: string,
+  manifest: SyncServerManifest,
+): string {
+  const entryPath = resolvePluginPath(pluginPath, manifest.syncserver.entry);
+  if (!fs.existsSync(entryPath)) {
+    throw new Error(
+      `Plugin ${pluginSlug} entry point does not exist: ${entryPath}`,
+    );
+  }
+
+  return entryPath;
+}
+
+function installPluginDependencies(
+  extractPath: string,
+  pluginSlug: string,
+): void {
+  const packageJsonPath = path.join(extractPath, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    return;
+  }
+
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    if (
+      packageJson.dependencies &&
+      Object.keys(packageJson.dependencies).length > 0
+    ) {
+      console.log(`Installing dependencies for plugin ${pluginSlug}...`);
+      execFileSync(
+        'npm',
+        [
+          'install',
+          '--production',
+          '--ignore-scripts',
+          '--no-audit',
+          '--no-fund',
+        ],
+        {
+          cwd: extractPath,
+          stdio: 'inherit',
+        },
+      );
+      console.log(`Dependencies installed for plugin ${pluginSlug}`);
+    }
+  } catch (error) {
+    console.warn(
+      `Failed to install dependencies for plugin ${pluginSlug}:`,
+      getErrorMessage(error),
+    );
+  }
+}
+
+function toPluginSourceCandidate(
+  pluginsDir: string,
+  entry: fs.Dirent,
+  extractedPlugins: Map<string, string>,
+): PluginSourceCandidate | null {
+  if (entry.isDirectory()) {
+    const pluginPath = path.join(pluginsDir, entry.name);
+    return {
+      type: 'directory',
+      name: entry.name,
+      slug: getPluginSlugFromManifest(pluginPath) || entry.name,
+      path: pluginPath,
+    };
+  }
+
+  if (entry.isFile() && entry.name.endsWith('.zip')) {
+    return toZipPluginSourceCandidate(pluginsDir, entry.name, extractedPlugins);
+  }
+
+  return null;
+}
+
+function toZipPluginSourceCandidate(
+  pluginsDir: string,
+  filename: string,
+  extractedPlugins: Map<string, string>,
+): PluginSourceCandidate | null {
+  const zipPath = path.join(pluginsDir, filename);
+  const tempSlug = filename
+    .replace(/\.zip$/, '')
+    .replace(/\.\d+\.\d+\.\d+$/, '');
+
+  try {
+    const extractedPath = extractZipPlugin(zipPath, tempSlug, extractedPlugins);
+    const slug = getPluginSlugFromManifest(extractedPath) || tempSlug;
+    if (slug !== tempSlug) {
+      extractedPlugins.set(slug, extractedPath);
+      extractedPlugins.delete(tempSlug);
+    }
+
+    return {
+      type: 'zip',
+      name: filename,
+      slug,
+      path: extractedPath,
+      zipPath,
+    };
+  } catch (error) {
+    console.error(`Failed to extract zip ${filename}:`, getErrorMessage(error));
+    return null;
+  }
+}

--- a/packages/sync-server/src/plugins/plugin-manager.ts
+++ b/packages/sync-server/src/plugins/plugin-manager.ts
@@ -1,0 +1,384 @@
+import fs from 'fs';
+import { randomUUID } from 'node:crypto';
+import os from 'os';
+import path from 'path';
+
+import createDebug from 'debug';
+
+import {
+  assertDevPluginRegistrationAllowed,
+  buildDevPluginUrl,
+  getErrorMessage,
+  isFrontendPlugin,
+  isPluginPathInsideDir,
+  isSyncServerPlugin,
+  normalizeDevPluginLocator,
+  normalizeDevPluginPath,
+  resolvePluginPath,
+  sanitizePluginSlug,
+  validateManifest,
+} from './plugin-helpers.js';
+import {
+  cleanupExtractedPlugin,
+  extractZipPlugin,
+  findInstallablePlugins,
+  getPluginSlugFromManifest,
+  readPluginManifest,
+  resolveSyncServerEntry,
+} from './plugin-loader.js';
+import type {
+  DevPluginLocatorInput,
+  FrontendPluginFile,
+  Manifest,
+  PluginSource,
+  PluginSourceCandidate,
+} from './plugin-types.js';
+
+const debug = createDebug('actual:config');
+const pluginArchiveSegmentPattern = /^[a-zA-Z0-9._-]+$/;
+
+class PluginManager {
+  pluginsDir: string;
+  extractedPlugins: Map<string, string>;
+  pluginSources: Map<string, PluginSource>;
+
+  constructor(pluginsDir: string) {
+    this.pluginsDir = pluginsDir;
+    this.extractedPlugins = new Map(); // Track extracted zip plugins for cleanup
+    this.pluginSources = new Map();
+  }
+
+  /**
+   * Extract a zip file to a temporary directory
+   */
+  extractZipPlugin(zipPath: string, pluginSlug: string): string {
+    return extractZipPlugin(zipPath, pluginSlug, this.extractedPlugins);
+  }
+
+  /**
+   * Get plugin slug from manifest
+   */
+  getPluginSlugFromManifest(pluginPath: string): string | null {
+    return getPluginSlugFromManifest(pluginPath);
+  }
+
+  /**
+   * Load all plugins from the plugins directory
+   * Supports both subdirectories and .zip files
+   * On slug clash, loads the first plugin and warns about duplicates
+   */
+  async loadPlugins(): Promise<void> {
+    if (!fs.existsSync(this.pluginsDir)) {
+      console.log('Plugins directory does not exist:', this.pluginsDir);
+      return;
+    }
+
+    const loadedSlugs = new Set<string>();
+    const pluginsToLoad = findInstallablePlugins(
+      this.pluginsDir,
+      this.extractedPlugins,
+    );
+
+    for (const plugin of pluginsToLoad) {
+      try {
+        if (this.skipDuplicatePlugin(plugin, loadedSlugs)) {
+          continue;
+        }
+
+        await this.loadPlugin(
+          plugin.slug,
+          plugin.path,
+          plugin.type === 'zip',
+          plugin.zipPath,
+        );
+        loadedSlugs.add(plugin.slug);
+        console.log(`✅ Loaded plugin: ${plugin.slug} (from ${plugin.name})`);
+
+        this.debugPluginMetadata(plugin.slug);
+      } catch (error) {
+        console.error(
+          `Failed to load plugin ${plugin.name}:`,
+          getErrorMessage(error),
+        );
+
+        cleanupExtractedPlugin(plugin, this.extractedPlugins);
+      }
+    }
+  }
+
+  /**
+   * Load a single plugin by slug
+   * @param {string} pluginSlug - The plugin identifier
+   * @param {string} pluginPath - Path to the plugin directory
+   * @param {boolean} _isExtracted - Whether this plugin was extracted from a zip
+   */
+  async loadPlugin(
+    pluginSlug: string,
+    pluginPath: string,
+    _isExtracted = false,
+    zipPath: string | null | undefined = null,
+  ): Promise<void> {
+    const manifest = readPluginManifest(pluginSlug, pluginPath);
+
+    if (isSyncServerPlugin(manifest)) {
+      resolveSyncServerEntry(pluginSlug, pluginPath, manifest);
+    }
+
+    this.rememberPluginSource(pluginSlug, manifest, pluginPath, zipPath);
+  }
+
+  getInstalledPluginManifests(): Array<Manifest & { source: string }> {
+    return Array.from(this.pluginSources.values()).map(source => ({
+      ...source.manifest,
+      source: 'sync-server',
+    }));
+  }
+
+  getFrontendPluginFiles(pluginSlug: string): FrontendPluginFile[] {
+    const source = this.pluginSources.get(pluginSlug);
+    if (!source) {
+      throw new Error(`Plugin '${pluginSlug}' is not installed`);
+    }
+
+    if (!isFrontendPlugin(source.manifest)) {
+      throw new Error(`Plugin '${pluginSlug}' has no frontend capability`);
+    }
+
+    const frontendDir = path.join(source.path, 'frontend');
+    if (!fs.existsSync(frontendDir)) {
+      throw new Error(`Plugin '${pluginSlug}' has no frontend directory`);
+    }
+
+    const files: FrontendPluginFile[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const entryPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(entryPath);
+        } else {
+          const relativePath = path.relative(frontendDir, entryPath);
+          files.push({
+            name: relativePath,
+            content: fs.readFileSync(entryPath).toString('base64'),
+            encoding: 'base64',
+          });
+        }
+      }
+    };
+
+    walk(frontendDir);
+    return files;
+  }
+
+  async installPluginZip(zipBuffer: Buffer): Promise<Manifest> {
+    fs.mkdirSync(this.pluginsDir, { recursive: true });
+
+    const tempSlug = `upload-${randomUUID()}`;
+    const tempZipPath = path.join(os.tmpdir(), `${tempSlug}.zip`);
+    fs.writeFileSync(tempZipPath, zipBuffer);
+
+    let extractedPath: string | null = null;
+    try {
+      extractedPath = this.extractZipPlugin(tempZipPath, tempSlug);
+      const manifest = validateManifest(
+        JSON.parse(
+          fs.readFileSync(path.join(extractedPath, 'manifest.json'), 'utf8'),
+        ),
+      );
+      const pluginSlug = sanitizePluginSlug(manifest.name);
+
+      if (isFrontendPlugin(manifest)) {
+        const frontendDir = resolvePluginPath(extractedPath, 'frontend');
+        const frontendEntry = resolvePluginPath(
+          extractedPath,
+          manifest.frontend.entry,
+        );
+        if (
+          !isPluginPathInsideDir(
+            extractedPath,
+            'frontend',
+            manifest.frontend.entry,
+          ) ||
+          !fs.existsSync(frontendDir) ||
+          !fs.existsSync(frontendEntry)
+        ) {
+          throw new Error(
+            `Plugin ${manifest.name} frontend files must live under frontend/`,
+          );
+        }
+      }
+
+      if (isSyncServerPlugin(manifest)) {
+        const syncserverEntry = resolvePluginPath(
+          extractedPath,
+          manifest.syncserver.entry,
+        );
+        if (
+          !isPluginPathInsideDir(
+            extractedPath,
+            'syncserver',
+            manifest.syncserver.entry,
+          ) ||
+          !fs.existsSync(syncserverEntry)
+        ) {
+          throw new Error(
+            `Plugin ${manifest.name} sync-server files must live under syncserver/`,
+          );
+        }
+      }
+
+      const zipPath = this.getPluginZipPath(pluginSlug, manifest.version);
+      fs.writeFileSync(zipPath, zipBuffer);
+
+      await this.reloadPlugins();
+      return manifest;
+    } finally {
+      if (extractedPath) {
+        fs.rmSync(extractedPath, { recursive: true, force: true });
+      }
+      fs.rmSync(tempZipPath, { force: true });
+      this.extractedPlugins.delete(tempSlug);
+    }
+  }
+
+  async registerDevPlugin(
+    devPluginLocator: DevPluginLocatorInput,
+  ): Promise<Manifest> {
+    assertDevPluginRegistrationAllowed();
+    const manifestLocator = normalizeDevPluginLocator(devPluginLocator);
+    const manifestUrlForFetch = buildDevPluginUrl(manifestLocator);
+    const manifestResponse = await fetch(manifestUrlForFetch);
+    if (!manifestResponse.ok) {
+      throw new Error(
+        `Failed to fetch dev plugin manifest: ${manifestUrlForFetch}`,
+      );
+    }
+
+    const manifest = validateManifest(await manifestResponse.json());
+
+    if (!isSyncServerPlugin(manifest)) {
+      return manifest;
+    }
+
+    const pluginSlug = sanitizePluginSlug(manifest.name);
+    const devPath = path.join(os.tmpdir(), 'actual-dev-plugins', pluginSlug);
+    if (
+      !isPluginPathInsideDir(devPath, 'syncserver', manifest.syncserver.entry)
+    ) {
+      throw new Error(
+        `Plugin ${manifest.name} sync-server files must live under syncserver/`,
+      );
+    }
+    fs.rmSync(devPath, { recursive: true, force: true });
+    fs.mkdirSync(path.join(devPath, 'syncserver'), { recursive: true });
+    fs.writeFileSync(
+      path.join(devPath, 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
+    );
+
+    const parsedEntryUrl = new URL(
+      manifest.syncserver.entry,
+      manifestUrlForFetch,
+    );
+    const entryLocator = {
+      ...manifestLocator,
+      path: normalizeDevPluginPath(parsedEntryUrl.pathname),
+      search: parsedEntryUrl.search,
+    };
+    const entryUrlForFetch = buildDevPluginUrl(entryLocator);
+    const entryResponse = await fetch(entryUrlForFetch);
+    if (!entryResponse.ok) {
+      throw new Error(`Failed to fetch dev plugin entry: ${entryUrlForFetch}`);
+    }
+
+    const devEntryPath = path.join(devPath, manifest.syncserver.entry);
+    fs.mkdirSync(path.dirname(devEntryPath), { recursive: true });
+    fs.writeFileSync(devEntryPath, await entryResponse.text(), 'utf8');
+
+    await this.loadPlugin(pluginSlug, devPath, false);
+    return manifest;
+  }
+
+  async reloadPlugins(): Promise<void> {
+    await this.shutdown();
+    await this.loadPlugins();
+  }
+
+  /**
+   * Debug loaded plugin metadata when DEBUG=actual:config is set.
+   */
+  debugPluginMetadata(pluginSlug: string): void {
+    const source = this.pluginSources.get(pluginSlug);
+    if (!source || !isSyncServerPlugin(source.manifest)) {
+      return;
+    }
+
+    debug(`Plugin: ${pluginSlug}`);
+    debug(`  Version: ${source.manifest.version}`);
+    debug(`  Description: ${source.manifest.description || 'N/A'}`);
+    debug(`  Entry: ${source.manifest.syncserver.entry}`);
+    debug(''); // Empty line for readability
+  }
+
+  /**
+   * Shutdown all plugins
+   */
+  async shutdown(): Promise<void> {
+    this.pluginSources.clear();
+
+    for (const [pluginSlug, extractPath] of this.extractedPlugins) {
+      try {
+        if (fs.existsSync(extractPath)) {
+          fs.rmSync(extractPath, { recursive: true, force: true });
+          console.log(`Cleaned up extracted plugin: ${pluginSlug}`);
+        }
+      } catch (error) {
+        console.error(
+          `Failed to clean up plugin ${pluginSlug}:`,
+          getErrorMessage(error),
+        );
+      }
+    }
+    this.extractedPlugins.clear();
+  }
+
+  private skipDuplicatePlugin(
+    plugin: PluginSourceCandidate,
+    loadedSlugs: Set<string>,
+  ): boolean {
+    if (!loadedSlugs.has(plugin.slug)) {
+      return false;
+    }
+
+    console.warn(
+      `⚠️  Plugin slug clash detected: "${plugin.slug}" from "${plugin.name}" ` +
+        `is already loaded. Skipping this plugin.`,
+    );
+    cleanupExtractedPlugin(plugin, this.extractedPlugins);
+    return true;
+  }
+
+  private rememberPluginSource(
+    pluginSlug: string,
+    manifest: Manifest,
+    pluginPath: string,
+    zipPath: string | null | undefined,
+  ): void {
+    this.pluginSources.set(pluginSlug, {
+      slug: pluginSlug,
+      manifest,
+      path: pluginPath,
+      zipPath,
+    });
+  }
+
+  private getPluginZipPath(pluginSlug: string, pluginVersion: string): string {
+    if (!pluginArchiveSegmentPattern.test(pluginVersion)) {
+      throw new Error('Plugin version cannot contain path separators');
+    }
+
+    return path.join(this.pluginsDir, `${pluginSlug}-${pluginVersion}.zip`);
+  }
+}
+
+export { PluginManager };

--- a/packages/sync-server/src/plugins/plugin-types.ts
+++ b/packages/sync-server/src/plugins/plugin-types.ts
@@ -1,0 +1,67 @@
+export type JsonRecord = Record<string, unknown>;
+type ManifestBase = {
+  name: string;
+  version: string;
+  description?: string;
+};
+type FrontendManifestConfig = {
+  entry: string;
+};
+type SyncServerManifestConfig = {
+  entry: string;
+};
+export type Manifest =
+  | (ManifestBase & {
+      type: 'frontend';
+      frontend: FrontendManifestConfig;
+      syncserver?: never;
+    })
+  | (ManifestBase & {
+      type: 'syncserver';
+      frontend?: never;
+      syncserver: SyncServerManifestConfig;
+    })
+  | (ManifestBase & {
+      type: 'mixed';
+      frontend: FrontendManifestConfig;
+      syncserver: SyncServerManifestConfig;
+    });
+export type PluginSource = {
+  slug: string;
+  manifest: Manifest;
+  path: string;
+  zipPath?: string | null;
+};
+export type FrontendManifest = Extract<
+  Manifest,
+  { frontend: FrontendManifestConfig }
+>;
+export type SyncServerManifest = Extract<
+  Manifest,
+  { syncserver: SyncServerManifestConfig }
+>;
+export type PluginSourceCandidate = {
+  type: 'directory' | 'zip';
+  name: string;
+  slug: string;
+  path: string;
+  zipPath?: string;
+};
+export type DevPluginLocator = {
+  port: string;
+  path: string;
+  search: string;
+};
+export type DevPluginLocatorInput =
+  | string
+  | number
+  | {
+      port?: unknown;
+      path?: unknown;
+      search?: unknown;
+    };
+export type FrontendPluginFile = {
+  name: string;
+  content: string;
+  encoding: 'base64';
+};

--- a/packages/sync-server/src/plugins/plugins-bootstrap.ts
+++ b/packages/sync-server/src/plugins/plugins-bootstrap.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+
+import { config } from '#load-config';
+
+import { PluginManager } from './plugin-manager.js';
+
+const pluginsDir = path.join(config.get('serverFiles'), 'plugins');
+const pluginManager = new PluginManager(pluginsDir);
+
+async function bootstrapPlugins(): Promise<void> {
+  try {
+    await pluginManager.loadPlugins();
+    const loadedPlugins = pluginManager.getInstalledPluginManifests();
+    console.log(`Loaded ${loadedPlugins.length} plugin(s):`, loadedPlugins);
+  } catch (error) {
+    console.error('Error loading plugins:', error);
+  }
+}
+
+async function shutdownPlugins(): Promise<void> {
+  try {
+    await pluginManager.shutdown();
+    console.log('Plugins shut down successfully');
+  } catch (error) {
+    console.error('Error shutting down plugins:', error);
+  }
+}
+
+export { bootstrapPlugins, shutdownPlugins, pluginManager };

--- a/upcoming-release-notes/minimal-plugin-mvp-sync-server-loader.md
+++ b/upcoming-release-notes/minimal-plugin-mvp-sync-server-loader.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [lelemm]
+---
+
+Add the sync-server plugin loader foundation, including manifest validation, safe archive loading, plugin process startup, and focused loader tests.

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,6 +177,7 @@ __metadata:
     "@types/node": "npm:^22.19.21"
     "@types/supertest": "npm:^7.2.0"
     "@typescript/native-preview": "npm:beta"
+    adm-zip: "npm:^0.5.17"
     akahu: "npm:^2.5.1"
     argon2: "npm:^0.44.0"
     bcrypt: "npm:^6.0.0"


### PR DESCRIPTION
This PR adds the first sync-server plugin loading layer.

It introduces the minimum foundation needed for the sync server to discover plugin packages and validate their shape before later PRs add route execution, IPC, bank sync metadata, and desktop runtime support.

This PR includes:

- plugin discovery from folders and zip files
- generated dummy plugin package for loader testing
- `manifest.json` loading and validation
- safe path resolution for plugin entries
- zip-slip protection for plugin archives
- temporary zip extraction cleanup
- sync-server entry validation

The manifest contract is intentionally small in this PR. It only supports the fields needed to load and validate a plugin package:

- `name`
- `version`
- `type`
- `frontend.entry`
- `syncserver.entry`

This PR does not run plugin code yet. It only proves that plugin packages can be found, extracted, validated, and registered by the sync server.

## Dummy Plugin Testing

This PR includes `@actual-app/bank-sync-plugin-dummy` as a minimal plugin package for validating the loader.

Build the dummy plugin zip:

```sh
yarn workspace @actual-app/bank-sync-plugin-dummy build:zip
```

To install the plugin on sync-server:
```sh
yarn workspace @actual-app/bank-sync-plugin-dummy install:sync-server
```

To test:
```sh
yarn start:server-dev
```

This should show when server starts:
```sh
✅ Loaded plugin: dummy-bank-sync (from dummy-bank-sync.zip)
Loaded 1 plugin(s): [
  {
    name: 'dummy-bank-sync',
    version: '0.0.1',
    description: 'Dummy bank sync provider for validating plugin loading.',
    type: 'syncserver',
    syncserver: { entry: 'syncserver/index.js' },
    source: 'sync-server'
  }
]
```

when stopping the execution:

```sh
^CSIGINT received. Starting graceful shutdown...
[nodemon] still waiting for 1 sub-process to finish...
Cleaned up extracted plugin: dummy-bank-sync
Plugins shut down successfully
```