### PR TITLE
[AI] Skip unused transfer payees in nYNAB import

### DIFF
--- a/packages/loot-core/src/server/importers/ynab5.test.ts
+++ b/packages/loot-core/src/server/importers/ynab5.test.ts
@@ -1,10 +1,76 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getBudgetName, parseFile } from './ynab5';
+import { send } from '#server/main-app';
+
+import { getBudgetName, importPayees, parseFile } from './ynab5';
+import type { Payee } from './ynab5-types';
+
+vi.mock('#server/main-app', () => ({
+  send: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(send).mockReset();
+});
 
 function toBuffer(obj: unknown): Buffer {
   return Buffer.from(JSON.stringify(obj));
 }
+
+function makePayee(overrides: Partial<Payee> = {}): Payee {
+  return {
+    id: 'payee-1',
+    name: 'Some Payee',
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('importPayees', () => {
+  it('does not create an Actual payee for a YNAB transfer-linked payee', async () => {
+    vi.mocked(send).mockResolvedValue('created-payee-id');
+
+    const transferPayee = makePayee({
+      id: 'ynab-transfer-payee',
+      name: 'Transfer : Savings',
+      transfer_account_id: 'ynab-account-2',
+    });
+    const normalPayee = makePayee({
+      id: 'ynab-normal-payee',
+      name: 'Coffee Shop',
+    });
+
+    const entityIdMap = new Map<string, string>();
+    await importPayees(
+      { payees: [transferPayee, normalPayee] } as Parameters<
+        typeof importPayees
+      >[0],
+      entityIdMap,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('api/payee-create', {
+      payee: { name: 'Coffee Shop' },
+    });
+    expect(entityIdMap.has('ynab-transfer-payee')).toBe(false);
+    expect(entityIdMap.get('ynab-normal-payee')).toBe('created-payee-id');
+  });
+
+  it('still skips deleted payees', async () => {
+    vi.mocked(send).mockResolvedValue('created-payee-id');
+
+    const deletedPayee = makePayee({ id: 'deleted-1', deleted: true });
+    const entityIdMap = new Map<string, string>();
+
+    await importPayees(
+      { payees: [deletedPayee] } as Parameters<typeof importPayees>[0],
+      entityIdMap,
+    );
+
+    expect(send).not.toHaveBeenCalled();
+    expect(entityIdMap.size).toBe(0);
+  });
+});
 
 describe('ynab5 parseFile', () => {
   it('unwraps the legacy `budget` wrapper', () => {

--- a/packages/loot-core/src/server/importers/ynab5.test.ts
+++ b/packages/loot-core/src/server/importers/ynab5.test.ts
@@ -2,8 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { send } from '#server/main-app';
 
-import { getBudgetName, importPayees, parseFile } from './ynab5';
-import type { Payee } from './ynab5-types';
+import {
+  getBudgetName,
+  importPayees,
+  importTransactions,
+  parseFile,
+} from './ynab5';
+import type { Payee, Transaction } from './ynab5-types';
 
 vi.mock('#server/main-app', () => ({
   send: vi.fn(),
@@ -69,6 +74,98 @@ describe('importPayees', () => {
 
     expect(send).not.toHaveBeenCalled();
     expect(entityIdMap.size).toBe(0);
+  });
+});
+
+function makeTransaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'txn-1',
+    date: '2026-01-01',
+    amount: -10000,
+    cleared: 'cleared',
+    approved: true,
+    account_id: 'ynab-account-1',
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('importTransactions', () => {
+  it('resolves a transfer transaction to the account-transfer payee', async () => {
+    const entityIdMap = new Map<string, string>([
+      ['ynab-account-1', 'actual-account-1'],
+      ['ynab-account-2', 'actual-account-2'],
+    ]);
+
+    const transactionOut = makeTransaction({
+      id: 'txn-out',
+      account_id: 'ynab-account-1',
+      amount: -10000,
+      transfer_account_id: 'ynab-account-2',
+      transfer_transaction_id: 'txn-in',
+      payee_id: 'ynab-transfer-payee',
+    });
+    const transactionIn = makeTransaction({
+      id: 'txn-in',
+      account_id: 'ynab-account-2',
+      amount: 10000,
+      transfer_account_id: 'ynab-account-1',
+      transfer_transaction_id: 'txn-out',
+      payee_id: 'ynab-transfer-payee',
+    });
+
+    vi.mocked(send).mockImplementation(async (name: string) => {
+      if (name === 'api/payees-get') {
+        return [
+          {
+            id: 'actual-payee-for-account-1',
+            transfer_acct: 'actual-account-1',
+          },
+          {
+            id: 'actual-payee-for-account-2',
+            transfer_acct: 'actual-account-2',
+          },
+        ];
+      }
+      if (name === 'api/categories-get') {
+        return [];
+      }
+      if (name === 'api/transactions-add') {
+        return null;
+      }
+      throw new Error(`Unexpected send call: ${name}`);
+    });
+
+    await importTransactions(
+      {
+        payees: [],
+        transactions: [transactionOut, transactionIn],
+        subtransactions: [],
+      } as unknown as Parameters<typeof importTransactions>[0],
+      entityIdMap,
+      new Set(),
+    );
+
+    const transactionsAddCalls = vi
+      .mocked(send)
+      .mock.calls.filter(([name]) => name === 'api/transactions-add');
+    expect(transactionsAddCalls).toHaveLength(2);
+
+    const allImportedTransactions = transactionsAddCalls.flatMap(
+      ([, args]) => args.transactions,
+    );
+    const outImported = allImportedTransactions.find(
+      t => t.id === entityIdMap.get('txn-out'),
+    );
+    const inImported = allImportedTransactions.find(
+      t => t.id === entityIdMap.get('txn-in'),
+    );
+
+    expect(outImported.payee).toBe('actual-payee-for-account-2');
+    expect(inImported.payee).toBe('actual-payee-for-account-1');
+
+    expect(outImported.transfer_id).toBe(inImported.id);
+    expect(inImported.transfer_id).toBe(outImported.id);
   });
 });
 

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -447,10 +447,10 @@ async function importCategories(
   }
 }
 
-function importPayees(data: Budget, entityIdMap: Map<string, string>) {
+export function importPayees(data: Budget, entityIdMap: Map<string, string>) {
   return Promise.all(
     data.payees.map(async payee => {
-      if (!payee.deleted) {
+      if (!payee.deleted && !payee.transfer_account_id) {
         const id = await send('api/payee-create', {
           payee: { name: payee.name },
         });

--- a/packages/loot-core/src/server/importers/ynab5.ts
+++ b/packages/loot-core/src/server/importers/ynab5.ts
@@ -566,7 +566,7 @@ async function importFlagsAsTags(
   );
 }
 
-async function importTransactions(
+export async function importTransactions(
   data: Budget,
   entityIdMap: Map<string, string>,
   flagNameConflicts: Set<string>,

--- a/upcoming-release-notes/skip-ynab-transfer-payees.md
+++ b/upcoming-release-notes/skip-ynab-transfer-payees.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [claude]
+---
+
+Stop the nYNAB importer from creating an unused duplicate payee for each linked transfer account.


### PR DESCRIPTION
## Description

The nYNAB importer created an unused `Transfer : <Account>` payee for every linked transfer account, cluttering the Payees list after import. `importPayees` now skips any YNAB payee with `transfer_account_id` set, since transactions already resolve transfers to Actual's own account-transfer payee. I didn't have the import skip all unused Payees, though I would like to do that next.

### AI usage disclosure

Written with Claude Code (Sonnet 5).

## Related issue(s)

Discord comment: https://discord.com/channels/937901803608096828/969693280226906162/1523401795735392277 (and my own use case)

## Testing

Run `yarn workspace @actual-app/core run test ynab5`. Import a nYNAB export with linked transfer accounts and confirm the Payees list has no `Transfer : <Account>` entries.
Verified against a real export with 34 linked transfer payees across 702 transactions, confirming every one resolves through `transfer_account_id` and never needed the skipped payee's id.

### Screenshots

Loading (import in progress):

<img width="620" height="359" alt="Screenshot_20260706_144831" src="https://github.com/user-attachments/assets/6a814742-feba-46ab-b39b-108a07304b11" />
<img width="526" height="259" alt="Screenshot_20260706_144955" src="https://github.com/user-attachments/assets/134b2923-3b98-4662-9e3e-ff89d50e089d" />

Before (`Transfer : <Account>` payees present and unused):

<img width="943" height="726" alt="Screenshot_20260706_153020" src="https://github.com/user-attachments/assets/2432894b-2206-420d-85bc-8a2bcd13cbfd" />

After (`Transfer : <Account>` payees gone):

<img width="943" height="176" alt="Screenshot_20260706_152802" src="https://github.com/user-attachments/assets/5f924bdd-9b85-4e4c-9f6c-d5f6fd4b013a" />

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.11 MB | 0%
loot-core | 1 | 4.83 MB → 4.83 MB (+114 B) | +0.00%
api | 2 | 3.88 MB → 3.88 MB (+114 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.11 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.22 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.74 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.73 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+114 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +114 B (+0.45%) | 24.76 kB → 24.87 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.k7-O5h0q.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.LNjMCuqC.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+114 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +114 B (+0.46%) | 24.15 kB → 24.27 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+114 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->