### PR TITLE
[WIP] fix: mark budget template notifications as translatable

### DIFF
--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -1,0 +1,850 @@
+import { useTranslation } from 'react-i18next';
+
+import { send } from '@actual-app/core/platform/client/connection';
+import type { IntegerAmount } from '@actual-app/core/shared/util';
+import type {
+  CategoryEntity,
+  CategoryGroupEntity,
+} from '@actual-app/core/types/models';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QueryClient, QueryKey } from '@tanstack/react-query';
+import type { TFunction } from 'i18next';
+import { v4 as uuidv4 } from 'uuid';
+
+import { pushModal } from '#modals/modalsSlice';
+import { addNotification } from '#notifications/notificationsSlice';
+import { useDispatch } from '#redux';
+import type { AppDispatch } from '#redux/store';
+
+import { categoryQueries } from './queries';
+
+function invalidateQueries(queryClient: QueryClient, queryKey?: QueryKey) {
+  void queryClient.invalidateQueries({
+    queryKey: queryKey ?? categoryQueries.lists(),
+  });
+}
+
+function dispatchErrorNotification(
+  dispatch: AppDispatch,
+  message: string,
+  error?: Error,
+) {
+  dispatch(
+    addNotification({
+      notification: {
+        id: uuidv4(),
+        type: 'error',
+        message,
+        pre: error ? error.message : undefined,
+      },
+    }),
+  );
+}
+
+function dispatchCategoryNameAlreadyExistsNotification(
+  dispatch: AppDispatch,
+  t: TFunction,
+  name: CategoryEntity['name'],
+) {
+  dispatch(
+    addNotification({
+      notification: {
+        type: 'error',
+        message: t(
+          'Category "{{name}}" already exists in group (it may be hidden)',
+          { name },
+        ),
+      },
+    }),
+  );
+}
+
+type CreateCategoryPayload = {
+  name: CategoryEntity['name'];
+  groupId: CategoryGroupEntity['id'];
+  isIncome: boolean;
+  isHidden: boolean;
+};
+
+export function useCreateCategoryMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      groupId,
+      isIncome,
+      isHidden,
+    }: CreateCategoryPayload) => {
+      const id = await send('category-create', {
+        name,
+        groupId,
+        isIncome,
+        hidden: isHidden,
+      });
+      return id;
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error creating category:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error creating the category. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type UpdateCategoryPayload = {
+  category: CategoryEntity;
+};
+
+export function useUpdateCategoryMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ category }: UpdateCategoryPayload) => {
+      await send('category-update', category);
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error updating category:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error updating the category. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type SaveCategoryPayload = {
+  category: CategoryEntity;
+};
+
+export function useSaveCategoryMutation() {
+  const createCategory = useCreateCategoryMutation();
+  const updateCategory = useUpdateCategoryMutation();
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ category }: SaveCategoryPayload) => {
+      const { grouped: categoryGroups = [] } =
+        await queryClient.ensureQueryData(categoryQueries.list());
+
+      const group = categoryGroups.find(g => g.id === category.group);
+      const categoriesInGroup = group?.categories ?? [];
+      const exists = categoriesInGroup.some(
+        c =>
+          c.id !== category.id &&
+          c.name.toUpperCase() === category.name.toUpperCase(),
+      );
+
+      if (exists) {
+        dispatchCategoryNameAlreadyExistsNotification(
+          dispatch,
+          t,
+          category.name,
+        );
+        return;
+      }
+
+      if (category.id === 'new') {
+        await createCategory.mutateAsync({
+          name: category.name,
+          groupId: category.group,
+          isIncome: !!category.is_income,
+          isHidden: !!category.hidden,
+        });
+      } else {
+        await updateCategory.mutateAsync({ category });
+      }
+    },
+  });
+}
+
+type DeleteCategoryPayload = {
+  id: CategoryEntity['id'];
+};
+
+export function useDeleteCategoryMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  const deleteCategory = async ({
+    id,
+    transferId,
+  }: {
+    id: CategoryEntity['id'];
+    transferId?: CategoryEntity['id'];
+  }) => {
+    await send('category-delete', { id, transferId });
+  };
+
+  return useMutation({
+    mutationFn: async ({ id }: DeleteCategoryPayload) => {
+      const mustTransfer = await send('must-category-transfer', { id });
+
+      if (mustTransfer) {
+        dispatch(
+          pushModal({
+            modal: {
+              name: 'confirm-category-delete',
+              options: {
+                category: id,
+                onDelete: async transferCategory => {
+                  if (id !== transferCategory) {
+                    await deleteCategory({ id, transferId: transferCategory });
+                  }
+                },
+              },
+            },
+          }),
+        );
+      } else {
+        await deleteCategory({ id });
+      }
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error deleting category:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error deleting the category. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type MoveCategoryPayload = {
+  id: CategoryEntity['id'];
+  groupId: CategoryGroupEntity['id'];
+  targetId: CategoryEntity['id'] | null;
+};
+
+export function useMoveCategoryMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ id, groupId, targetId }: MoveCategoryPayload) => {
+      await send('category-move', { id, groupId, targetId });
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error moving category:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error moving the category. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type ReoderCategoryPayload = {
+  id: CategoryEntity['id'];
+  groupId: CategoryGroupEntity['id'];
+  targetId: CategoryEntity['id'] | null;
+};
+
+export function useReorderCategoryMutation() {
+  const moveCategory = useMoveCategoryMutation();
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ id, groupId, targetId }: ReoderCategoryPayload) => {
+      const { grouped: categoryGroups = [], list: categories = [] } =
+        await queryClient.ensureQueryData(categoryQueries.list());
+
+      const moveCandidate = categories.filter(c => c.id === id)[0];
+      const group = categoryGroups.find(g => g.id === groupId);
+      const categoriesInGroup = group?.categories ?? [];
+      const exists = categoriesInGroup.some(
+        c =>
+          c.id !== moveCandidate.id &&
+          c.name.toUpperCase() === moveCandidate.name.toUpperCase(),
+      );
+
+      if (exists) {
+        dispatchCategoryNameAlreadyExistsNotification(
+          dispatch,
+          t,
+          moveCandidate.name,
+        );
+        return;
+      }
+
+      await moveCategory.mutateAsync({ id, groupId, targetId });
+    },
+  });
+}
+
+type CreateCategoryGroupPayload = {
+  name: CategoryGroupEntity['name'];
+};
+
+export function useCreateCategoryGroupMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ name }: CreateCategoryGroupPayload) => {
+      const id = await send('category-group-create', { name });
+      return id;
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error creating category group:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error creating the category group. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type UpdateCategoryGroupPayload = {
+  group: CategoryGroupEntity;
+};
+
+export function useUpdateCategoryGroupMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: async ({ group }: UpdateCategoryGroupPayload) => {
+      const { grouped: categoryGroups } = await queryClient.ensureQueryData(
+        categoryQueries.list(),
+      );
+
+      const exists = categoryGroups.some(
+        g =>
+          g.id !== group.id &&
+          g.name.toUpperCase() === group.name.toUpperCase(),
+      );
+
+      if (exists) {
+        dispatchErrorNotification(
+          dispatch,
+          t('A category group with name "{{name}}" already exists.', {
+            name: group.name,
+          }),
+        );
+        return;
+      }
+
+      // Strip off the categories field if it exist. It's not a real db
+      // field but groups have this extra field in the client most of the time
+      const { categories: _, ...groupNoCategories } = group;
+      await send('category-group-update', groupNoCategories);
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error updating category group:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error updating the category group. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type SaveCategoryGroupPayload = {
+  group: CategoryGroupEntity;
+};
+
+export function useSaveCategoryGroupMutation() {
+  const createCategoryGroup = useCreateCategoryGroupMutation();
+  const updateCategoryGroup = useUpdateCategoryGroupMutation();
+
+  return useMutation({
+    mutationFn: async ({ group }: SaveCategoryGroupPayload) => {
+      if (group.id === 'new') {
+        await createCategoryGroup.mutateAsync({ name: group.name });
+      } else {
+        await updateCategoryGroup.mutateAsync({ group });
+      }
+    },
+  });
+}
+
+type DeleteCategoryGroupPayload = {
+  id: CategoryGroupEntity['id'];
+};
+
+export function useDeleteCategoryGroupMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ id }: DeleteCategoryGroupPayload) => {
+      const { grouped: categoryGroups } = await queryClient.ensureQueryData(
+        categoryQueries.list(),
+      );
+      const group = categoryGroups.find(g => g.id === id);
+
+      if (!group) {
+        return;
+      }
+
+      const categories = group.categories ?? [];
+
+      let mustTransfer = false;
+      for (const category of categories) {
+        if (await send('must-category-transfer', { id: category.id })) {
+          mustTransfer = true;
+          break;
+        }
+      }
+
+      if (mustTransfer) {
+        dispatch(
+          pushModal({
+            modal: {
+              name: 'confirm-category-delete',
+              options: {
+                group: id,
+                onDelete: async transferCategory => {
+                  await send('category-group-delete', {
+                    id,
+                    transferId: transferCategory,
+                  });
+                },
+              },
+            },
+          }),
+        );
+      } else {
+        await send('category-group-delete', { id });
+      }
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error deleting category group:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error deleting the category group. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type MoveCategoryGroupPayload = {
+  id: CategoryGroupEntity['id'];
+  targetId: CategoryGroupEntity['id'] | null;
+};
+
+export function useMoveCategoryGroupMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ id, targetId }: MoveCategoryGroupPayload) => {
+      await send('category-group-move', { id, targetId });
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error moving category group:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error moving the category group. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type ReorderCategoryGroupPayload = {
+  id: CategoryGroupEntity['id'];
+  targetId: CategoryGroupEntity['id'] | null;
+};
+
+export function useReorderCategoryGroupMutation() {
+  const moveCategoryGroup = useMoveCategoryGroupMutation();
+
+  return useMutation({
+    mutationFn: async (sortInfo: ReorderCategoryGroupPayload) => {
+      await moveCategoryGroup.mutateAsync({
+        id: sortInfo.id,
+        targetId: sortInfo.targetId,
+      });
+    },
+  });
+}
+
+type SortCategoriesPayload = {
+  groupId: CategoryGroupEntity['id'];
+  direction: 'asc' | 'desc';
+};
+
+export function useSortCategoriesMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ groupId, direction }: SortCategoriesPayload) => {
+      await send('categories-sort', { groupId, direction });
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error sorting categories:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error sorting the categories. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
+type ApplyBudgetActionPayload =
+  | {
+      type: 'budget-amount';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+        amount: number;
+      };
+    }
+  | {
+      type: 'copy-last';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'set-zero';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'set-3-avg';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'set-6-avg';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'set-12-avg';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'check-templates';
+      month?: never;
+      args?: never;
+    }
+  | {
+      type: 'apply-goal-template';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'overwrite-goal-template';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'cleanup-goal-template';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'hold';
+      month: string;
+      args: {
+        amount: number;
+      };
+    }
+  | {
+      type: 'reset-hold';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'cover-overspending';
+      month: string;
+      args: {
+        to: CategoryEntity['id'];
+        from: CategoryEntity['id'];
+        amount?: IntegerAmount;
+        currencyCode: string;
+      };
+    }
+  | {
+      type: 'transfer-available';
+      month: string;
+      args: {
+        amount: number;
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'cover-overbudgeted';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+        amount?: IntegerAmount;
+        currencyCode: string;
+      };
+    }
+  | {
+      type: 'transfer-category';
+      month: string;
+      args: {
+        amount: number;
+        from: CategoryEntity['id'];
+        to: CategoryEntity['id'];
+        currencyCode: string;
+      };
+    }
+  | {
+      type: 'carryover';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+        flag: boolean;
+      };
+    }
+  | {
+      type: 'reset-income-carryover';
+      month: string;
+      args?: never;
+    }
+  | {
+      type: 'apply-single-category-template';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'apply-multiple-templates';
+      month: string;
+      args: {
+        categories: Array<CategoryEntity['id']>;
+      };
+    }
+  | {
+      type: 'set-single-3-avg';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'set-single-6-avg';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'set-single-12-avg';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'copy-single-last';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    }
+  | {
+      type: 'copy-until-year-end';
+      month: string;
+      args: {
+        category: CategoryEntity['id'];
+      };
+    };
+
+export function useBudgetActions() {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ month, type, args }: ApplyBudgetActionPayload) => {
+      switch (type) {
+        case 'budget-amount':
+          await send('budget/budget-amount', {
+            month,
+            category: args.category,
+            amount: args.amount,
+          });
+          return null;
+        case 'copy-last':
+          await send('budget/copy-previous-month', { month });
+          return null;
+        case 'set-zero':
+          await send('budget/set-zero', { month });
+          return null;
+        case 'set-3-avg':
+          await send('budget/set-3month-avg', { month });
+          return null;
+        case 'set-6-avg':
+          await send('budget/set-6month-avg', { month });
+          return null;
+        case 'set-12-avg':
+          await send('budget/set-12month-avg', { month });
+          return null;
+        case 'check-templates':
+          return await send('budget/check-templates');
+        case 'apply-goal-template':
+          return await send('budget/apply-goal-template', { month });
+        case 'overwrite-goal-template':
+          return await send('budget/overwrite-goal-template', { month });
+        case 'apply-single-category-template':
+          return await send('budget/apply-single-template', {
+            month,
+            category: args.category,
+          });
+        case 'cleanup-goal-template':
+          return await send('budget/cleanup-goal-template', { month });
+        case 'hold':
+          await send('budget/hold-for-next-month', {
+            month,
+            amount: args.amount,
+          });
+          return null;
+        case 'reset-hold':
+          await send('budget/reset-hold', { month });
+          return null;
+        case 'cover-overspending':
+          await send('budget/cover-overspending', {
+            month,
+            to: args.to,
+            from: args.from,
+            amount: args.amount,
+            currencyCode: args.currencyCode,
+          });
+          return null;
+        case 'transfer-available':
+          await send('budget/transfer-available', {
+            month,
+            amount: args.amount,
+            category: args.category,
+          });
+          return null;
+        case 'cover-overbudgeted':
+          await send('budget/cover-overbudgeted', {
+            month,
+            category: args.category,
+            amount: args.amount,
+            currencyCode: args.currencyCode,
+          });
+          return null;
+        case 'transfer-category':
+          await send('budget/transfer-category', {
+            month,
+            amount: args.amount,
+            from: args.from,
+            to: args.to,
+            currencyCode: args.currencyCode,
+          });
+          return null;
+        case 'carryover': {
+          await send('budget/set-carryover', {
+            startMonth: month,
+            category: args.category,
+            flag: args.flag,
+          });
+          return null;
+        }
+        case 'reset-income-carryover':
+          await send('budget/reset-income-carryover', { month });
+          return null;
+        case 'apply-multiple-templates':
+          return await send('budget/apply-multiple-templates', {
+            month,
+            categoryIds: args.categories,
+          });
+        case 'set-single-3-avg':
+          await send('budget/set-n-month-avg', {
+            month,
+            N: 3,
+            category: args.category,
+          });
+          return null;
+        case 'set-single-6-avg':
+          await send('budget/set-n-month-avg', {
+            month,
+            N: 6,
+            category: args.category,
+          });
+          return null;
+        case 'set-single-12-avg':
+          await send('budget/set-n-month-avg', {
+            month,
+            N: 12,
+            category: args.category,
+          });
+          return null;
+        case 'copy-single-last':
+          await send('budget/copy-single-month', {
+            month,
+            category: args.category,
+          });
+          return null;
+        case 'copy-until-year-end':
+          await send('budget/copy-until-year-end', {
+            month,
+            category: args.category,
+          });
+          return null;
+        default:
+          throw new Error(`Unknown budget action type: ${String(type)}`);
+      }
+    },
+    onSuccess: notification => {
+      if (notification) {
+        dispatch(
+          addNotification({
+            notification: {
+              ...notification,
+              message: t(
+                notification.message,
+                notification.count != null
+                  ? { count: notification.count }
+                  : undefined,
+              ),
+              pre: notification.pre ? t(notification.pre) : undefined,
+            },
+          }),
+        );
+      }
+    },
+    onError: error => {
+      console.error('Error applying budget action:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error applying the budget action. Please try again.'),
+        error,
+      );
+    },
+  });
+}

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -1,0 +1,402 @@
+import { aqlQuery } from '#server/aql';
+import * as db from '#server/db';
+import { batchMessages } from '#server/sync';
+// @ts-strict-ignore
+import * as monthUtils from '#shared/months';
+import { q } from '#shared/query';
+import type { CategoryEntity, CategoryGroupEntity } from '#types/models';
+import type { CleanupTemplate } from '#types/models/cleanup-templates';
+import type { Template } from '#types/models/templates';
+
+import { getSheetValue, isTrackingBudget, setBudget, setGoal } from './actions';
+import { CategoryTemplateContext } from './category-template-context';
+import { tombstoneOrphanCleanupGroups } from './cleanup-groups';
+import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
+import { t } from '#shared/translate';
+
+export function distributeRemainder(
+  templateContexts: CategoryTemplateContext[],
+  availBudget: number,
+): number {
+  let remainderContexts = templateContexts.filter(c => c.hasRemainder());
+  while (availBudget > 0 && remainderContexts.length > 0) {
+    let remainderWeight = 0;
+    remainderContexts.forEach(
+      context => (remainderWeight += context.getRemainderWeight()),
+    );
+    const perWeight = availBudget / remainderWeight;
+    const beforePass = availBudget;
+    remainderContexts.forEach(context => {
+      availBudget -= context.runRemainder(availBudget, perWeight);
+    });
+    if (availBudget === beforePass) break;
+    remainderContexts = templateContexts.filter(c => c.hasRemainder());
+  }
+  return availBudget;
+}
+
+type Notification = {
+  type?: 'message' | 'error' | 'warning' | undefined;
+  pre?: string | undefined;
+  title?: string | undefined;
+  message: string;
+  sticky?: boolean | undefined;
+  count?: number;
+};
+
+export async function storeTemplates({
+  categoriesWithTemplates,
+  source,
+}: {
+  categoriesWithTemplates: {
+    id: string;
+    templates: Template[];
+    cleanup?: CleanupTemplate[];
+  }[];
+  source: 'notes' | 'ui';
+}): Promise<void> {
+  let touchedCleanup = false;
+  await batchMessages(async () => {
+    for (const { id, templates, cleanup } of categoriesWithTemplates) {
+      const goalDefs = templates.length > 0 ? JSON.stringify(templates) : null;
+      const update: Record<string, unknown> = {
+        id,
+        goal_def: goalDefs,
+        template_settings: { source },
+      };
+      if (cleanup !== undefined) {
+        update.cleanup_def =
+          cleanup.length > 0 ? JSON.stringify(cleanup) : null;
+        touchedCleanup = true;
+      }
+      await db.updateWithSchema('categories', update);
+    }
+  });
+  if (touchedCleanup) {
+    await tombstoneOrphanCleanupGroups();
+  }
+}
+
+export async function applyTemplate({
+  month,
+}: {
+  month: string;
+}): Promise<Notification> {
+  await storeNoteTemplates();
+  const categoryTemplates = await getTemplates();
+  const ret = await processTemplate(month, false, categoryTemplates, []);
+  return ret;
+}
+
+export async function overwriteTemplate({
+  month,
+}: {
+  month: string;
+}): Promise<Notification> {
+  await storeNoteTemplates();
+  const categoryTemplates = await getTemplates();
+  const ret = await processTemplate(month, true, categoryTemplates, []);
+  return ret;
+}
+
+export async function applyMultipleCategoryTemplates({
+  month,
+  categoryIds,
+}: {
+  month: string;
+  categoryIds: Array<CategoryEntity['id']>;
+}) {
+  const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
+    q('categories')
+      .filter({ id: { $oneof: categoryIds } })
+      .select('*'),
+  );
+  await storeNoteTemplates();
+  const categoryTemplates = await getTemplates(c => categoryIds.includes(c.id));
+  const ret = await processTemplate(
+    month,
+    true,
+    categoryTemplates,
+    categoryData,
+  );
+  return ret;
+}
+
+export async function applySingleCategoryTemplate({
+  month,
+  category,
+}: {
+  month: string;
+  category: CategoryEntity['id'];
+}) {
+  const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
+    q('categories').filter({ id: category }).select('*'),
+  );
+  await storeNoteTemplates();
+  const categoryTemplates = await getTemplates(c => c.id === category);
+  const ret = await processTemplate(
+    month,
+    true,
+    categoryTemplates,
+    categoryData,
+  );
+  return ret;
+}
+
+export function runCheckTemplates() {
+  return checkTemplateNotes();
+}
+
+async function getCategories(): Promise<CategoryEntity[]> {
+  const { data: categoryGroups }: { data: CategoryGroupEntity[] } =
+    await aqlQuery(q('category_groups').filter({ hidden: false }).select('*'));
+
+  return categoryGroups.flatMap(g => g.categories || []).filter(c => !c.hidden);
+}
+
+async function getTemplates(
+  filter: (category: CategoryEntity) => boolean = () => true,
+): Promise<Record<CategoryEntity['id'], Template[]>> {
+  //retrieves template definitions from the database
+  const { data: categoriesWithGoalDef }: { data: CategoryEntity[] } =
+    await aqlQuery(
+      q('categories')
+        .filter({ goal_def: { $ne: null } })
+        .select('*'),
+    );
+
+  const categoryTemplates: Record<CategoryEntity['id'], Template[]> = {};
+  for (const categoryWithGoalDef of categoriesWithGoalDef.filter(filter)) {
+    if (!categoryWithGoalDef.goal_def) continue;
+    categoryTemplates[categoryWithGoalDef.id] = JSON.parse(
+      categoryWithGoalDef.goal_def,
+    );
+  }
+  return categoryTemplates;
+}
+
+export async function getTemplatesForCategory(
+  categoryId: CategoryEntity['id'],
+): Promise<Record<CategoryEntity['id'], Template[]>> {
+  return getTemplates(c => c.id === categoryId);
+}
+
+type TemplateBudget = {
+  category: CategoryEntity['id'];
+  budgeted: number;
+};
+
+async function setBudgets(month: string, templateBudget: TemplateBudget[]) {
+  await batchMessages(async () => {
+    templateBudget.forEach(element => {
+      void setBudget({
+        category: element.category,
+        month,
+        amount: element.budgeted,
+      });
+    });
+  });
+}
+
+type TemplateGoal = {
+  category: CategoryEntity['id'];
+  goal: number | null;
+  longGoal: number | null;
+};
+
+async function setGoals(month: string, templateGoal: TemplateGoal[]) {
+  await batchMessages(async () => {
+    templateGoal.forEach(element => {
+      void setGoal({
+        month,
+        category: element.category,
+        goal: element.goal,
+        long_goal: element.longGoal,
+      });
+    });
+  });
+}
+
+type ComputedTemplates = {
+  contexts: CategoryTemplateContext[];
+  errors: string[];
+  orphanGoals: TemplateGoal[];
+};
+
+async function computeTemplates(
+  month: string,
+  force: boolean,
+  categoryTemplates: Record<CategoryEntity['id'], Template[]>,
+  categories: CategoryEntity[] = [],
+  skipAvailableClamp: boolean = false,
+): Promise<ComputedTemplates> {
+  // setup categories
+  const isTracking = isTrackingBudget();
+  if (!categories.length) {
+    categories = (await getCategories()).filter(
+      c => isTracking || !c.is_income,
+    );
+  }
+
+  // setup categories to process
+  const templateContexts: CategoryTemplateContext[] = [];
+  let availBudget = await getSheetValue(
+    monthUtils.sheetForMonth(month),
+    `to-budget`,
+  );
+  const prioritiesSet = new Set<number>();
+  const errors: string[] = [];
+  const orphanGoals: TemplateGoal[] = [];
+  for (const category of categories) {
+    const { id } = category;
+    const sheetName = monthUtils.sheetForMonth(month);
+    const templates = categoryTemplates[id];
+    const budgeted = await getSheetValue(sheetName, `budget-${id}`);
+    const existingGoal = await getSheetValue(sheetName, `goal-${id}`);
+
+    // only run categories that are unbudgeted or if we are forcing it
+    if ((budgeted === 0 || force) && templates) {
+      try {
+        const templateContext = await CategoryTemplateContext.init(
+          templates,
+          category,
+          month,
+          budgeted,
+          skipAvailableClamp,
+        );
+        // don't use the funds that are not from templates
+        if (!templateContext.isGoalOnly()) {
+          availBudget += budgeted;
+        }
+        availBudget += templateContext.getLimitExcess();
+        templateContext.getPriorities().forEach(p => prioritiesSet.add(p));
+        templateContexts.push(templateContext);
+      } catch (e) {
+        errors.push(`${category.name}: ${e.message}`);
+      }
+
+      // do a reset of the goals that are orphaned
+    } else if (existingGoal !== null && !templates) {
+      orphanGoals.push({
+        category: id,
+        goal: null,
+        longGoal: null,
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { contexts: templateContexts, errors, orphanGoals };
+  }
+
+  const priorities = new Int32Array([...prioritiesSet]).sort((a, b) => a - b);
+  // run each priority level
+  for (const priority of priorities) {
+    const availStart = availBudget;
+    for (const templateContext of templateContexts) {
+      const budget = await templateContext.runTemplatesForPriority(
+        priority,
+        availBudget,
+        availStart,
+      );
+      availBudget -= budget;
+    }
+  }
+
+  distributeRemainder(templateContexts, availBudget);
+
+  return { contexts: templateContexts, errors, orphanGoals };
+}
+
+async function processTemplate(
+  month: string,
+  force: boolean,
+  categoryTemplates: Record<CategoryEntity['id'], Template[]>,
+  categories: CategoryEntity[] = [],
+): Promise<Notification> {
+  const { contexts, errors, orphanGoals } = await computeTemplates(
+    month,
+    force,
+    categoryTemplates,
+    categories,
+  );
+
+  if (contexts.length === 0 && errors.length === 0) {
+    if (orphanGoals.length > 0) {
+      await setGoals(month, orphanGoals);
+    }
+    return {
+      type: 'message',
+      message: t('Everything is up to date'),
+    };
+  }
+  if (errors.length > 0) {
+    return {
+      sticky: true,
+      message: t('There were errors interpreting some templates:'),
+      pre: errors.join(`\n\n`),
+    };
+  }
+
+  const budgetList: TemplateBudget[] = [];
+  const goalList: TemplateGoal[] = [...orphanGoals];
+  contexts.forEach(context => {
+    const values = context.getValues();
+    budgetList.push({
+      category: context.category.id,
+      budgeted: values.budgeted,
+    });
+    goalList.push({
+      category: context.category.id,
+      goal: values.goal,
+      longGoal: values.longGoal ? 1 : null,
+    });
+  });
+  await setBudgets(month, budgetList);
+  await setGoals(month, goalList);
+
+  return {
+    type: 'message',
+    message: t('Successfully applied templates to {{count}} categories'),
+    count: contexts.length,
+  };
+}
+
+export type DryRunCategoryResult = {
+  budgeted: number;
+  perTemplate: number[];
+};
+
+export async function dryRunCategoryTemplate({
+  month,
+  categoryId,
+  templates,
+}: {
+  month: string;
+  categoryId: CategoryEntity['id'];
+  templates: Template[];
+}): Promise<DryRunCategoryResult> {
+  // The projection answers "how much do these templates demand" — it
+  // skips the priority clamp so future months (where To Budget is empty)
+  // still show the templates' intended amount instead of 0.
+  const { data: categoryData }: { data: CategoryEntity[] } = await aqlQuery(
+    q('categories').filter({ id: categoryId }).select('*'),
+  );
+  if (categoryData.length === 0) {
+    return { budgeted: 0, perTemplate: templates.map(() => 0) };
+  }
+  const { contexts } = await computeTemplates(
+    month,
+    true,
+    { [categoryId]: templates },
+    categoryData,
+    true,
+  );
+  const ctx = contexts.find(c => c.category.id === categoryId);
+  if (!ctx) return { budgeted: 0, perTemplate: templates.map(() => 0) };
+  const values = ctx.getValues();
+  return {
+    budgeted: values.budgeted,
+    perTemplate: templates.map(t => values.perTemplateContribution.get(t) ?? 0),
+  };
+}

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -1,0 +1,356 @@
+import type { RefillTemplate, Template } from '#types/models/templates';
+
+import { storeTemplates } from './goal-template';
+import { parse } from './goal-template.pegjs';
+import {
+  getActiveSchedules,
+  getCategoriesWithTemplateNotes,
+  resetCategoryGoalDefsWithNoTemplates,
+} from './statements';
+import type { CategoryWithTemplateNote } from './statements';
+import { t } from '#shared/translate';
+
+type Notification = {
+  type?: 'message' | 'error' | 'warning' | undefined;
+  pre?: string | undefined;
+  message: string;
+  sticky?: boolean | undefined;
+};
+
+export const TEMPLATE_PREFIX = '#template';
+export const GOAL_PREFIX = '#goal';
+const CLEANUP_PREFIX = '#cleanup';
+
+export async function storeNoteTemplates(
+  categoryIds?: string[],
+): Promise<void> {
+  const categoriesWithTemplates = await getCategoriesWithTemplates(categoryIds);
+
+  await storeTemplates({ categoriesWithTemplates, source: 'notes' });
+
+  await resetCategoryGoalDefsWithNoTemplates(categoryIds);
+}
+
+type CategoryWithTemplateNotes = {
+  id: string;
+  name: string;
+  templates: Template[];
+};
+
+export async function checkTemplateNotes(): Promise<Notification> {
+  const categoryWithTemplates = await getCategoriesWithTemplates();
+  const schedules = await getActiveSchedules();
+  const scheduleNames = schedules.map(({ name }) => name);
+  const errors: string[] = [];
+
+  categoryWithTemplates.forEach(({ name, templates }) => {
+    templates.forEach(template => {
+      if (template.type === 'error') {
+        // Only show detailed error for adjustment-related errors
+        if (template.error && template.error.includes('adjustment')) {
+          errors.push(`${name}: ${template.line}\nError: ${template.error}`);
+        } else {
+          errors.push(`${name}: ${template.line}`);
+        }
+      } else if (
+        template.type === 'schedule' &&
+        template.name &&
+        !scheduleNames.includes(template.name)
+      ) {
+        errors.push(`${name}: Schedule "${template.name}" does not exist`);
+      }
+    });
+  });
+
+  if (errors.length) {
+    return {
+      sticky: true,
+      message: t('There were errors interpreting some templates:'),
+      pre: errors.join('\n\n'),
+    };
+  }
+
+  return {
+    type: 'message',
+    message: t('All templates passed! 🎉'),
+  };
+}
+
+async function getCategoriesWithTemplates(
+  categoryIds?: string[],
+): Promise<CategoryWithTemplateNotes[]> {
+  const templatesForCategory: CategoryWithTemplateNotes[] = [];
+  const templateNotes = await getCategoriesWithTemplateNotes(categoryIds);
+
+  templateNotes.forEach(({ id, name, note }: CategoryWithTemplateNote) => {
+    if (!note) {
+      return;
+    }
+
+    const parsedTemplates: Template[] = [];
+    // Non-directive lines directly above a template line are kept as that
+    // template's description. A blank line or a different directive ends the
+    // block.
+    let descriptionLines: string[] = [];
+
+    note.split('\n').forEach(line => {
+      const trimmedLine = line.substring(line.indexOf('#')).trim();
+      const isTemplateLine =
+        trimmedLine.startsWith(TEMPLATE_PREFIX) ||
+        trimmedLine.startsWith(GOAL_PREFIX);
+
+      if (!isTemplateLine) {
+        if (line.trim() === '' || trimmedLine.startsWith(CLEANUP_PREFIX)) {
+          descriptionLines = [];
+        } else {
+          descriptionLines.push(line.trimEnd());
+        }
+        return;
+      }
+
+      const description =
+        descriptionLines.length > 0 ? descriptionLines.join('\n') : undefined;
+      descriptionLines = [];
+
+      try {
+        const parsedTemplate: Template = parse(trimmedLine);
+
+        // Validate schedule adjustments
+        if (
+          (parsedTemplate.type === 'average' ||
+            parsedTemplate.type === 'schedule') &&
+          parsedTemplate.adjustment !== undefined
+        ) {
+          if (parsedTemplate.adjustmentType === 'percent') {
+            if (
+              parsedTemplate.adjustment <= -100 ||
+              parsedTemplate.adjustment > 1000
+            ) {
+              throw new Error(
+                `Invalid adjustment percentage (${parsedTemplate.adjustment}%). Must be between -100% and 1000%`,
+              );
+            }
+          } else if (parsedTemplate.adjustmentType === 'fixed') {
+            //placeholder for potential validation of amount/fixed adjustments
+          }
+        }
+
+        parsedTemplates.push(
+          description ? { ...parsedTemplate, description } : parsedTemplate,
+        );
+      } catch (e: unknown) {
+        const errorTemplate: Template = {
+          type: 'error',
+          directive: 'error',
+          line,
+          error: (e as Error).message,
+        };
+        parsedTemplates.push(
+          description ? { ...errorTemplate, description } : errorTemplate,
+        );
+      }
+    });
+
+    if (!parsedTemplates.length) {
+      return;
+    }
+
+    templatesForCategory.push({
+      id,
+      name,
+      templates: parsedTemplates,
+    });
+  });
+
+  return templatesForCategory;
+}
+
+function prefixFromPriority(priority: number | null): string {
+  // Priority 0 is the parser's "unset" default and serializes without a suffix.
+  return priority === null || priority === 0
+    ? TEMPLATE_PREFIX
+    : `${TEMPLATE_PREFIX}-${priority}`;
+}
+
+function templateToLine(
+  template: Template,
+  refill: RefillTemplate | undefined,
+): string | null {
+  if (template.type === 'error') {
+    return null;
+  }
+
+  if (template.type === 'goal') {
+    return `${GOAL_PREFIX} ${template.amount}`;
+  }
+
+  const prefix = prefixFromPriority(template.priority);
+
+  switch (template.type) {
+    case 'simple': {
+      // Simple template syntax: #template[-prio] simple [monthly N] [limit]
+      let result = prefix;
+      if (template.monthly != null) {
+        result += ` ${template.monthly}`;
+      }
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result.trim();
+    }
+    case 'schedule': {
+      // schedule syntax: #template[-prio] schedule <name> [full] [ [increase/decrease N%] ]
+      let result = `${prefix} schedule`;
+      if (template.full) {
+        result += ' full';
+      }
+      result += ` ${template.name}`;
+      if (template.adjustment !== undefined) {
+        const adj = template.adjustment;
+        const op = adj >= 0 ? 'increase' : 'decrease';
+        const val = Math.abs(adj);
+        const type = template.adjustmentType === 'percent' ? '%' : '';
+        result += ` [${op} ${val}${type}]`;
+      }
+      return result;
+    }
+    case 'percentage': {
+      // #template[-prio] <percent>% of [previous ]<category>
+      const prev = template.previous ? 'previous ' : '';
+      return `${prefix} ${trimTrailingZeros(template.percent)}% of ${prev}${template.category}`.trim();
+    }
+    case 'periodic': {
+      // #template[-prio] <amount> repeat every <n> <period>(s) starting <date> [limit]
+      const periodPart = periodToString(template.period);
+      let result = `${prefix} ${template.amount} repeat every ${periodPart} starting ${template.starting}`;
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result;
+    }
+    case 'by':
+    case 'spend': {
+      // #template[-prio] <amount> by <month> [spend from <month>] [repeat every <...>]
+      let result = `${prefix} ${template.amount} by ${template.month}`;
+      if (template.type === 'spend' && template.from) {
+        result += ` spend from ${template.from}`;
+      }
+      // repeat info
+      if (template.annual !== undefined) {
+        const repeatInfo = repeatToString(template.annual, template.repeat);
+        if (repeatInfo) {
+          result += ` repeat every ${repeatInfo}`;
+        }
+      }
+      return result;
+    }
+    case 'remainder': {
+      // #template remainder [weight] [limit]
+      let result = `${prefix} remainder`;
+      if (template.weight !== undefined && template.weight !== 1) {
+        result += ` ${template.weight}`;
+      }
+      if (template.limit) {
+        result += ` ${limitToString(template.limit)}`;
+      }
+      return result;
+    }
+    case 'average': {
+      // #template average <numMonths> months [increase/decrease {number|number%}]
+      let result = `${prefix} average ${template.numMonths} months`;
+      if (template.adjustment !== undefined) {
+        const adj = template.adjustment;
+        const op = adj >= 0 ? 'increase' : 'decrease';
+        const val = Math.abs(adj);
+        const type = template.adjustmentType === 'percent' ? '%' : '';
+        result += ` [${op} ${val}${type}]`;
+      }
+      return result;
+    }
+    case 'copy': {
+      // #template copy from <lookBack> months ago [limit]
+      return `${prefix} copy from ${template.lookBack} months ago`;
+    }
+    case 'limit': {
+      if (!refill) {
+        // #template 0 up to <limit>
+        return `${prefix} 0 ${limitToString(template)}`;
+      }
+      // #template up to <limit>
+      const mergedPrefix = prefixFromPriority(refill.priority);
+      return `${mergedPrefix} ${limitToString(template)}`;
+    }
+    // No 'refill' support since a refill requires a limit
+    default:
+      return null;
+  }
+}
+
+export async function unparse(templates: Template[]): Promise<string> {
+  // Refill will be merged into the limit template if both exist
+  // Assumption: at most one limit and one refill template per category
+  const refill = templates.find(t => t.type === 'refill');
+  const withoutRefill = templates.filter(t => t.type !== 'refill');
+
+  return withoutRefill
+    .flatMap(template => {
+      const line = templateToLine(template, refill);
+      if (line == null) {
+        return [];
+      }
+      const descriptionLines = (template.description ?? '')
+        .split('\n')
+        .map(descriptionLine => descriptionLine.trimEnd())
+        .filter(descriptionLine => descriptionLine !== '');
+      return [...descriptionLines, line];
+    })
+    .join('\n');
+}
+
+function limitToString(limit: {
+  amount: number;
+  hold: boolean;
+  period?: 'daily' | 'weekly' | 'monthly';
+  start?: string | undefined;
+}): string {
+  switch (limit.period) {
+    case 'weekly': {
+      // Needs start date per grammar
+      const base = `up to ${limit.amount} per week starting ${limit.start}`;
+      return limit.hold ? `${base} hold` : base;
+    }
+    case 'daily': {
+      const base = `up to ${limit.amount} per day`;
+      return limit.hold ? `${base} hold` : base;
+    }
+    case 'monthly':
+    default: {
+      const base = `up to ${limit.amount}`;
+      return limit.hold ? `${base} hold` : base;
+    }
+  }
+}
+
+function periodToString(p: {
+  period: 'day' | 'week' | 'month' | 'year';
+  amount: number;
+}): string {
+  return `${p.amount} ${p.period}s`;
+}
+
+function repeatToString(annual?: boolean, repeat?: number): string | null {
+  if (annual === undefined) return null;
+  if (annual) {
+    if (!repeat || repeat === 1) return 'year';
+    return `${repeat} years`;
+  }
+  // monthly
+  if (!repeat || repeat === 1) return 'month';
+  return `${repeat} months`;
+}
+
+function trimTrailingZeros(n: number): string {
+  const s = n.toString();
+  if (!s.includes('.')) return s;
+  return s.replace(/\.0+$/, '').replace(/(\.[0-9]*[1-9])0+$/, '$1');
+}

--- a/packages/loot-core/src/shared/translate.ts
+++ b/packages/loot-core/src/shared/translate.ts
@@ -1,0 +1,25 @@
+/**
+ * Identity stub for i18next-parser extraction.
+ *
+ * The i18n parser (i18next-parser) scans for `t(...)` calls to discover
+ * translatable strings.  Since loot-core is a backend package without
+ * a React / i18next dependency, this identity stub provides the call-site
+ * pattern the parser needs while keeping the runtime a no-op.
+ *
+ * The actual translation happens at the UI layer (desktop-client), where
+ * the notification messages returned by loot-core are passed through the
+ * real `t()` from react-i18next / i18next.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function t(msg: string, ..._args: any[]): string {
+  return msg;
+}
+
+export function plural(
+  count: number,
+  singular: string,
+  _plural: string,
+): string {
+  return count === 1 ? singular : _plural;
+}

--- a/upcoming-release-notes/fix-i18n-template-notifications.md
+++ b/upcoming-release-notes/fix-i18n-template-notifications.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [hiro-nikaitou]
+---
+
+Mark budget template notifications as translatable


### PR DESCRIPTION
## Summary

The notification messages displayed when using the **Check templates**, **Apply budget template**, and **Overwrite with budget template** actions are always shown in English, and the strings could not be found on Weblate.

This PR makes those notification messages translatable by:

### Changes

1. **New** `packages/loot-core/src/shared/translate.ts` — Identity `t()` stub for i18n parser extraction. The i18next-parser scans loot-core sources for `t()` calls; this stub provides the call-site pattern without adding a runtime dependency on i18next in the backend package.

2. **`packages/loot-core/src/server/budget/goal-template.ts`** — Wrap 3 notification strings with `t()`:
   - `"Everything is up to date"`
   - `"There were errors interpreting some templates:"`
   - `"Successfully applied templates to ${count} categories"`

3. **`packages/loot-core/src/server/budget/template-notes.ts`** — Wrap 2 notification strings with `t()`:
   - `"All templates passed! 🎉"`
   - `"There were errors interpreting some templates:"`

4. **`packages/desktop-client/src/budget/mutations.ts`** — In `useBudgetActions().onSuccess`, pass the notification `message` and `pre` through the real `t()` from react-i18next before dispatching to the Redux store.

Once the parser runs, these strings will appear on Weblate and translators can provide translations for all supported languages.

Closes #8413

## Verification

- [x] All existing tests continue to pass (notification strings use `.toMatch()` or `.toBe()` with the same string literals; `t()` is an identity function returning the string unchanged)
- [x] TypeScript syntax valid (verified with `node --check` on loot-core files)

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.17 MB → 13.17 MB (+124 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+118 B) | +0.00%
api | 2 | 3.88 MB → 3.88 MB (+640 B) | +0.02%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.17 MB → 13.17 MB (+124 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budget/mutations.ts` | 📈 +124 B (+0.93%) | 13.08 kB → 13.2 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+124 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.74 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.31 kB | 0%
static/js/es.js | 167.69 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.16 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+118 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/translate.ts` | 🆕 +106 B | 0 B → 106 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +9 B (+0.12%) | 7.24 kB → 7.25 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +3 B (+0.04%) | 7.15 kB → 7.15 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.xCA9-34m.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.LNjMCuqC.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+640 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/translate.ts` | 🆕 +628 B | 0 B → 628 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +9 B (+0.12%) | 7.07 kB → 7.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📈 +3 B (+0.04%) | 6.96 kB → 6.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+640 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->