### PR TITLE
[WIP] [AI] Add show/hide upcoming transactions toggle to account menu

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -104,18 +104,25 @@ type AllTransactionsProps = {
   transactions: TransactionEntity[];
   balances: Record<TransactionEntity['id'], IntegerAmount> | null;
   showBalances?: boolean | undefined;
+  showUpcomingTransactions: boolean;
   filtered?: boolean | undefined;
   children: (
     transactions: TransactionEntity[],
     balances: Record<TransactionEntity['id'], IntegerAmount> | null,
+    hasUpcomingTransactions: boolean,
   ) => ReactElement;
 };
+
+function isUpcomingPreviewTransaction(transaction: TransactionEntity) {
+  return transaction.category === 'upcoming';
+}
 
 function AllTransactions({
   account,
   transactions,
   balances,
   showBalances,
+  showUpcomingTransactions,
   filtered,
   children,
 }: AllTransactionsProps) {
@@ -139,6 +146,13 @@ function AllTransactions({
 
   transactions ??= [];
 
+  const visiblePreviewTransactions = showUpcomingTransactions
+    ? previewTransactions
+    : previewTransactions.filter(t => !isUpcomingPreviewTransaction(t));
+
+  const hasUpcomingTransactions =
+    !filtered && previewTransactions.some(isUpcomingPreviewTransaction);
+
   const runningBalance = useMemo(() => {
     if (!showBalances) {
       return 0;
@@ -156,20 +170,20 @@ function AllTransactions({
 
     return Object.fromEntries(
       calculateRunningBalancesBottomUp(
-        previewTransactions,
+        visiblePreviewTransactions,
         'all',
         runningBalance,
       ),
     );
-  }, [showBalances, previewTransactions, runningBalance]);
+  }, [showBalances, visiblePreviewTransactions, runningBalance]);
 
   const allTransactions = useMemo(() => {
     // Don't prepend scheduled transactions if we are filtering
-    if (!filtered && previewTransactions.length > 0) {
-      return previewTransactions.concat(transactions);
+    if (!filtered && visiblePreviewTransactions.length > 0) {
+      return visiblePreviewTransactions.concat(transactions);
     }
     return transactions;
-  }, [filtered, previewTransactions, transactions]);
+  }, [filtered, visiblePreviewTransactions, transactions]);
 
   const allBalances = useMemo(() => {
     // Don't prepend scheduled transactions if we are filtering
@@ -180,9 +194,9 @@ function AllTransactions({
   }, [filtered, prependBalances, balances]);
 
   if (!previewTransactions?.length || filtered) {
-    return children(transactions, balances);
+    return children(transactions, balances, hasUpcomingTransactions);
   }
-  return children(allTransactions, allBalances);
+  return children(allTransactions, allBalances, hasUpcomingTransactions);
 }
 
 function getField(field?: string) {
@@ -222,6 +236,8 @@ type AccountInternalProps = {
   setShowCleared: (newValue: boolean) => void;
   showReconciled: boolean;
   setShowReconciled: (newValue: boolean) => void;
+  showUpcomingTransactions: boolean;
+  setShowUpcomingTransactions: (newValue: boolean) => void;
   showExtraBalances?: boolean;
   setShowExtraBalances: (newValue: boolean) => void;
   modalShowing?: boolean;
@@ -807,6 +823,7 @@ class AccountInternal extends PureComponent<
       | 'remove-sorting'
       | 'toggle-cleared'
       | 'toggle-reconciled'
+      | 'toggle-upcoming'
       | 'toggle-net-worth-chart',
   ) => {
     const accountId = this.props.accountId!;
@@ -908,6 +925,9 @@ class AccountInternal extends PureComponent<
             this.fetchTransactions(this.state.filterConditions),
           );
         }
+        break;
+      case 'toggle-upcoming':
+        this.onToggleUpcomingTransactions();
         break;
       case 'toggle-net-worth-chart':
         if (this.props.showNetWorthChart) {
@@ -1731,6 +1751,12 @@ class AccountInternal extends PureComponent<
     }
   };
 
+  onToggleUpcomingTransactions = () => {
+    this.props.setShowUpcomingTransactions(
+      !this.props.showUpcomingTransactions,
+    );
+  };
+
   render() {
     const {
       accounts,
@@ -1756,6 +1782,7 @@ class AccountInternal extends PureComponent<
       showReconciled,
       filteredAmount,
     } = this.state;
+    const { showUpcomingTransactions } = this.props;
 
     const account = accounts.find(account => account.id === accountId);
     const accountName = this.getAccountTitle(account, accountId);
@@ -1794,9 +1821,10 @@ class AccountInternal extends PureComponent<
         transactions={transactions}
         balances={balances}
         showBalances={showBalances}
+        showUpcomingTransactions={showUpcomingTransactions}
         filtered={transactionsFiltered}
       >
-        {(allTransactions, allBalances) => (
+        {(allTransactions, allBalances, hasUpcomingTransactions) => (
           <SelectedProviderWithItems
             name="transactions"
             // When reconciled transactions are hidden they are still
@@ -1836,6 +1864,8 @@ class AccountInternal extends PureComponent<
                 filteredAmount={filteredAmount}
                 isFiltered={transactionsFiltered ?? false}
                 isSorted={this.state.sort !== null}
+                hasUpcomingTransactions={hasUpcomingTransactions}
+                showUpcomingTransactions={showUpcomingTransactions}
                 reconcileAmount={reconcileAmount}
                 search={this.state.search}
                 // @ts-expect-error fix me
@@ -1894,6 +1924,8 @@ class AccountInternal extends PureComponent<
                   showBalances={!!allBalances}
                   showReconciled={showReconciled}
                   showCleared={!!showCleared}
+                  hasUpcomingTransactions={hasUpcomingTransactions}
+                  showUpcomingTransactions={showUpcomingTransactions}
                   showAccount={
                     !accountId ||
                     accountId === 'offbudget' ||
@@ -2033,6 +2065,9 @@ export function Account() {
   const [hideReconciled, setHideReconciled] = useSyncedPref(
     `hide-reconciled-${params.id}`,
   );
+  const [showUpcomingTransactions, setShowUpcomingTransactions] = useSyncedPref(
+    `show-upcoming-transactions-${params.id || 'all-accounts'}`,
+  );
   const [showExtraBalances, setShowExtraBalances] = useSyncedPref(
     `show-extra-balances-${params.id || 'all-accounts'}`,
   );
@@ -2088,6 +2123,12 @@ export function Account() {
             setShowCleared={val => setHideCleared(String(!val))}
             showReconciled={String(hideReconciled) !== 'true'}
             setShowReconciled={val => setHideReconciled(String(!val))}
+            showUpcomingTransactions={
+              String(showUpcomingTransactions) !== 'false'
+            }
+            setShowUpcomingTransactions={val =>
+              setShowUpcomingTransactions(String(val))
+            }
             showExtraBalances={String(showExtraBalances) === 'true'}
             setShowExtraBalances={extraBalances =>
               setShowExtraBalances(String(extraBalances))

--- a/packages/desktop-client/src/components/accounts/Header.tsx
+++ b/packages/desktop-client/src/components/accounts/Header.tsx
@@ -78,6 +78,8 @@ type AccountHeaderProps = {
   isFiltered: boolean;
   filteredAmount?: number | null;
   isSorted: boolean;
+  hasUpcomingTransactions: boolean;
+  showUpcomingTransactions: boolean;
   search: string;
   filterConditions: RuleConditionEntity[];
   filterConditionsOp: 'and' | 'or';
@@ -153,6 +155,8 @@ export function AccountHeader({
   isFiltered,
   filteredAmount,
   isSorted,
+  hasUpcomingTransactions,
+  showUpcomingTransactions,
   search,
   filterConditions,
   filterConditionsOp,
@@ -516,6 +520,8 @@ export function AccountHeader({
                       showBalances={showBalances}
                       showCleared={showCleared}
                       showReconciled={showReconciled}
+                      hasUpcomingTransactions={hasUpcomingTransactions}
+                      showUpcomingTransactions={showUpcomingTransactions}
                       onMenuSelect={onMenuSelect}
                     />
                   </Dialog>
@@ -554,6 +560,16 @@ export function AccountHeader({
                             ? t('Hide balance chart')
                             : t('Show balance chart'),
                         },
+                        ...(hasUpcomingTransactions
+                          ? [
+                              {
+                                name: 'toggle-upcoming',
+                                text: showUpcomingTransactions
+                                  ? t('Hide upcoming transactions')
+                                  : t('Show upcoming transactions'),
+                              } as const,
+                            ]
+                          : []),
                       ]}
                     />
                   </Dialog>
@@ -731,6 +747,8 @@ type AccountMenuProps = {
   canShowBalances: boolean;
   showCleared: boolean;
   showReconciled: boolean;
+  hasUpcomingTransactions: boolean;
+  showUpcomingTransactions: boolean;
   isSorted: boolean;
   onMenuSelect: (
     item:
@@ -743,6 +761,7 @@ type AccountMenuProps = {
       | 'remove-sorting'
       | 'toggle-cleared'
       | 'toggle-reconciled'
+      | 'toggle-upcoming'
       | 'toggle-net-worth-chart',
   ) => void;
 };
@@ -755,6 +774,8 @@ function AccountMenu({
   canShowBalances,
   showCleared,
   showReconciled,
+  hasUpcomingTransactions,
+  showUpcomingTransactions,
   isSorted,
   onMenuSelect,
 }: AccountMenuProps) {
@@ -804,6 +825,16 @@ function AccountMenu({
             ? t('Hide reconciled transactions')
             : t('Show reconciled transactions'),
         },
+        ...(hasUpcomingTransactions
+          ? [
+              {
+                name: 'toggle-upcoming',
+                text: showUpcomingTransactions
+                  ? t('Hide upcoming transactions')
+                  : t('Show upcoming transactions'),
+              } as const,
+            ]
+          : []),
         { name: 'export', text: t('Export') },
         ...(account && !account.closed
           ? canSync

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -276,6 +276,8 @@ type TransactionListProps = Pick<
   account: AccountEntity | undefined;
   category: CategoryEntity | undefined;
   isFiltered?: boolean;
+  hasUpcomingTransactions?: boolean;
+  showUpcomingTransactions?: boolean;
   allowReorder?: boolean;
   onChange: (
     transaction: TransactionEntity,
@@ -306,6 +308,8 @@ export function TransactionList({
   isNew,
   isMatched,
   isFiltered,
+  hasUpcomingTransactions,
+  showUpcomingTransactions,
   allowReorder = true,
   dateFormat,
   hideFraction,
@@ -739,6 +743,8 @@ export function TransactionList({
         showBalances={showBalances}
         showReconciled={showReconciled}
         showCleared={showCleared}
+        hasUpcomingTransactions={hasUpcomingTransactions}
+        showUpcomingTransactions={showUpcomingTransactions}
         showAccount={showAccount}
         showCategory
         currentAccountId={account && account.id}

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -2284,6 +2284,8 @@ type TransactionTableInnerProps = {
   showBalances: boolean;
   showReconciled: boolean;
   showCleared: boolean;
+  hasUpcomingTransactions?: boolean;
+  showUpcomingTransactions?: boolean;
   showAccount: boolean;
   showCategory: boolean;
   currentAccountId: AccountEntity['id'];
@@ -2356,6 +2358,8 @@ function TransactionTableInner({
   const containerRef = createRef<HTMLDivElement>();
   const isAddingPrev = usePrevious(props.isAdding);
   const [scrollWidth, setScrollWidth] = useState(0);
+  const showUpcomingTransactionsDivider =
+    props.showUpcomingTransactions === false && !!props.hasUpcomingTransactions;
 
   function saveScrollWidth(parent: number, child: number) {
     const width = parent > 0 && child > 0 && parent - child;
@@ -2580,6 +2584,14 @@ function TransactionTableInner({
           field={props.sortField}
           showSelection={props.showSelection}
         />
+        {showUpcomingTransactionsDivider && (
+          <View
+            style={{
+              height: 2,
+              backgroundColor: theme.upcomingText,
+            }}
+          />
+        )}
 
         {props.isAdding && (
           <View
@@ -2678,6 +2690,8 @@ export type TransactionTableProps = {
   showBalances: boolean;
   showReconciled: boolean;
   showCleared: boolean;
+  hasUpcomingTransactions?: boolean;
+  showUpcomingTransactions?: boolean;
   showAccount: boolean;
   showCategory: boolean;
   currentAccountId: AccountEntity['id'];

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -33,6 +33,7 @@ export type SyncedPrefs = Partial<
     | `side-nav.show-balance-history-${string}`
     | `show-balances-${string}`
     | `show-extra-balances-${string}`
+    | `show-upcoming-transactions-${string}`
     | `hide-cleared-${string}`
     | `hide-reconciled-${string}`
     // TODO: pull from src/components/modals/ImportTransactions.js

--- a/upcoming-release-notes/show-hide-upcoming.md
+++ b/upcoming-release-notes/show-hide-upcoming.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [Juulz, StephenBrown2]
+---
+
+Toggle Upcoming transactions in the account view from the account menu.


### PR DESCRIPTION
## Description

This is based on @Juulz PR, relocating the toggle to a menu item to avoid visual clutter and put it alongside other pre-existing toggles.

## Related issue(s)

Re-implements #8204
Fixes #4565

## Testing

Have _upcoming_ preview transactions in an account.
<img width="943" height="302" alt="Screenshot_20260707_101708" src="https://github.com/user-attachments/assets/8e6e572b-c909-4e6b-aadb-14c64dee1517" />

Go to the account menu.
<img width="943" height="392" alt="Screenshot_20260707_101722" src="https://github.com/user-attachments/assets/c4a0e521-4934-4796-bc51-58fdc9beab33" />

Click "Hide upcoming transactions"
<img width="943" height="392" alt="Screenshot_20260707_101743" src="https://github.com/user-attachments/assets/67b1146d-a324-449c-8e9b-aa511b9453b2" />

Poof! They're gone!
<img width="964" height="273" alt="Screenshot_20260707_101807" src="https://github.com/user-attachments/assets/f0b2a29a-0892-4dd5-9333-b934eb12023f" />

Go to the account menu.
Click "Show upcoming transactions"
<img width="964" height="284" alt="Screenshot_20260707_101827" src="https://github.com/user-attachments/assets/0c1b9912-dd2a-4dfe-9b4d-19a4049396da" />

Tada! They're back!
<img width="943" height="302" alt="Screenshot_20260707_101708" src="https://github.com/user-attachments/assets/8e6e572b-c909-4e6b-aadb-14c64dee1517" />

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
