### PR TITLE
[AI] Add tooltips to titlebar theme, privacy, and server status icons

### DIFF
--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -9,6 +9,7 @@ import { Popover } from '@actual-app/components/popover';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
 import type { RemoteFile, SyncedLocalFile } from '@actual-app/core/types/file';
@@ -139,6 +140,28 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
     return t('Server online');
   }
 
+  function serverTooltip() {
+    if (!serverUrl) {
+      return (
+        <Trans>
+          A server syncs your budget across devices and keeps a backup of your
+          data. Click to set one up.
+        </Trans>
+      );
+    }
+
+    if (userData?.offline) {
+      return (
+        <Trans>
+          Can&apos;t reach your server right now. Changes are saved locally and
+          will sync once it&apos;s reachable again.
+        </Trans>
+      );
+    }
+
+    return <Trans>Connected to your server — your budget is syncing.</Trans>;
+  }
+
   if (hideIfNoServer && !serverUrl) return null;
 
   if (loading && serverUrl) {
@@ -217,9 +240,19 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
 
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', ...style }}>
-      <Button ref={triggerRef} variant="bare" onPress={() => setMenuOpen(true)}>
-        {serverMessage()}
-      </Button>
+      <Tooltip
+        placement="bottom end"
+        content={serverTooltip()}
+        triggerProps={{ isDisabled: menuOpen }}
+      >
+        <Button
+          ref={triggerRef}
+          variant="bare"
+          onPress={() => setMenuOpen(true)}
+        >
+          {serverMessage()}
+        </Button>
+      </Tooltip>
       {!loading &&
         multiuserEnabled &&
         userData &&

--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -128,38 +128,37 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
     }
   };
 
-  function serverMessage() {
+  function getServerStatus() {
     if (!serverUrl) {
-      return t('No server');
+      return {
+        message: t('No server'),
+        tooltip: (
+          <Trans>
+            A server syncs your budget across devices and keeps a backup of your
+            data. Click to set one up.
+          </Trans>
+        ),
+      };
     }
 
     if (userData?.offline) {
-      return t('Server offline');
+      return {
+        message: t('Server offline'),
+        tooltip: (
+          <Trans>
+            Can&apos;t reach your server right now. Changes are saved locally
+            and will sync once it&apos;s reachable again.
+          </Trans>
+        ),
+      };
     }
 
-    return t('Server online');
-  }
-
-  function serverTooltip() {
-    if (!serverUrl) {
-      return (
-        <Trans>
-          A server syncs your budget across devices and keeps a backup of your
-          data. Click to set one up.
-        </Trans>
-      );
-    }
-
-    if (userData?.offline) {
-      return (
-        <Trans>
-          Can&apos;t reach your server right now. Changes are saved locally and
-          will sync once it&apos;s reachable again.
-        </Trans>
-      );
-    }
-
-    return <Trans>Connected to your server — your budget is syncing.</Trans>;
+    return {
+      message: t('Server online'),
+      tooltip: (
+        <Trans>Connected to your server — your budget is syncing.</Trans>
+      ),
+    };
   }
 
   if (hideIfNoServer && !serverUrl) return null;
@@ -238,11 +237,13 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
     return [...adminMenu, ...baseMenu];
   };
 
+  const serverStatus = getServerStatus();
+
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center', ...style }}>
       <Tooltip
         placement="bottom end"
-        content={serverTooltip()}
+        content={serverStatus.tooltip}
         triggerProps={{ isDisabled: menuOpen }}
       >
         <Button
@@ -250,7 +251,7 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
           variant="bare"
           onPress={() => setMenuOpen(true)}
         >
-          {serverMessage()}
+          {serverStatus.message}
         </Button>
       </Tooltip>
       {!loading &&

--- a/packages/desktop-client/src/components/LoggedInUser.tsx
+++ b/packages/desktop-client/src/components/LoggedInUser.tsx
@@ -135,7 +135,9 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
         tooltip: (
           <Trans>
             A server syncs your budget across devices and keeps a backup of your
-            data. Click to set one up.
+            data.
+            <br />
+            Click to set one up.
           </Trans>
         ),
       };
@@ -146,8 +148,9 @@ export function LoggedInUser({ hideIfNoServer, style }: LoggedInUserProps) {
         message: t('Server offline'),
         tooltip: (
           <Trans>
-            Can&apos;t reach your server right now. Changes are saved locally
-            and will sync once it&apos;s reachable again.
+            Can't reach your server right now.
+            <br />
+            Changes are saved locally and will sync once it's reachable again.
           </Trans>
         ),
       };

--- a/packages/desktop-client/src/components/ThemeSelector.tsx
+++ b/packages/desktop-client/src/components/ThemeSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
@@ -11,6 +11,7 @@ import {
 } from '@actual-app/components/icons/v2';
 import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
+import { Tooltip } from '@actual-app/components/tooltip';
 import type { Theme } from '@actual-app/core/types/prefs';
 
 import { themeOptions, useTheme } from '#style';
@@ -49,15 +50,21 @@ export function ThemeSelector({ style }: ThemeSelectorProps) {
 
   return (
     <>
-      <Button
-        ref={triggerRef}
-        variant="bare"
-        aria-label={t('Switch theme')}
-        onPress={() => setMenuOpen(true)}
-        style={style}
+      <Tooltip
+        placement="bottom end"
+        content={<Trans>Switch theme</Trans>}
+        triggerProps={{ isDisabled: menuOpen }}
       >
-        <Icon style={{ width: 13, height: 13, color: 'inherit' }} />
-      </Button>
+        <Button
+          ref={triggerRef}
+          variant="bare"
+          aria-label={t('Switch theme')}
+          onPress={() => setMenuOpen(true)}
+          style={style}
+        >
+          <Icon style={{ width: 13, height: 13, color: 'inherit' }} />
+        </Button>
+      </Tooltip>
 
       <Popover
         offset={8}

--- a/packages/desktop-client/src/components/Titlebar.tsx
+++ b/packages/desktop-client/src/components/Titlebar.tsx
@@ -17,6 +17,7 @@ import type { CSSProperties } from '@actual-app/components/styles';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { listen } from '@actual-app/core/platform/client/connection';
 import { isDevelopmentEnvironment } from '@actual-app/core/shared/environment';
@@ -89,20 +90,33 @@ function PrivacyButton({ style }: PrivacyButtonProps) {
   );
 
   return (
-    <Button
-      variant="bare"
-      aria-label={
-        isPrivacyEnabled ? t('Disable privacy mode') : t('Enable privacy mode')
+    <Tooltip
+      placement="bottom end"
+      content={
+        isPrivacyEnabled ? (
+          <Trans>Disable privacy mode</Trans>
+        ) : (
+          <Trans>Enable privacy mode</Trans>
+        )
       }
-      onPress={() => setPrivacyEnabledPref(String(!isPrivacyEnabled))}
-      style={style}
     >
-      {isPrivacyEnabled ? (
-        <SvgViewHide style={privacyIconStyle} />
-      ) : (
-        <SvgViewShow style={privacyIconStyle} />
-      )}
-    </Button>
+      <Button
+        variant="bare"
+        aria-label={
+          isPrivacyEnabled
+            ? t('Disable privacy mode')
+            : t('Enable privacy mode')
+        }
+        onPress={() => setPrivacyEnabledPref(String(!isPrivacyEnabled))}
+        style={style}
+      >
+        {isPrivacyEnabled ? (
+          <SvgViewHide style={privacyIconStyle} />
+        ) : (
+          <SvgViewShow style={privacyIconStyle} />
+        )}
+      </Button>
+    </Tooltip>
   );
 }
 
@@ -210,44 +224,62 @@ function ServerSyncButton({ style, isMobile = false }: ServerSyncButtonProps) {
     [onSync],
   );
 
+  const tooltipContent =
+    syncState === 'error' ? (
+      <Trans>Sync error — click to retry</Trans>
+    ) : syncState === 'offline' ? (
+      <Trans>Offline — will sync when reconnected</Trans>
+    ) : syncState === 'local' ? (
+      <Trans>Local file, not connected to a server</Trans>
+    ) : syncState === 'disabled' ? (
+      <Trans>Syncing disabled for this file</Trans>
+    ) : (
+      <Trans>
+        Sync with your server to back up this file and access it on other
+        devices
+      </Trans>
+    );
+
   return (
-    <Button
-      variant="bare"
-      aria-label={t('Server Sync')}
-      className={css({
-        ...(isMobile
-          ? {
-              ...style,
-              WebkitAppRegion: 'none',
-              ...mobileIconStyle,
-            }
-          : {
-              ...style,
-              WebkitAppRegion: 'none',
-              color: desktopColor,
-            }),
-        '&[data-hovered]': hoveredStyle,
-        '&[data-pressed]': activeStyle,
-      })}
-      onPress={onSync}
-      isDisabled={syncState === 'offline'}
-      aria-disabled={syncState === 'offline'}
-    >
-      {isMobile ? (
-        syncState === 'error' ? (
-          <SvgAlertTriangle width={14} height={14} />
+    <Tooltip placement="bottom end" content={tooltipContent}>
+      <Button
+        variant="bare"
+        aria-label={t('Server Sync')}
+        className={css({
+          ...(isMobile
+            ? {
+                ...style,
+                WebkitAppRegion: 'none',
+                ...mobileIconStyle,
+              }
+            : {
+                ...style,
+                WebkitAppRegion: 'none',
+                color: desktopColor,
+              }),
+          '&[data-hovered]': hoveredStyle,
+          '&[data-pressed]': activeStyle,
+        })}
+        onPress={onSync}
+        isDisabled={syncState === 'offline'}
+        aria-disabled={syncState === 'offline'}
+      >
+        {isMobile ? (
+          syncState === 'error' ? (
+            <SvgAlertTriangle width={14} height={14} />
+          ) : (
+            <AnimatedRefresh width={18} height={18} animating={syncing} />
+          )
+        ) : syncState === 'error' ? (
+          <SvgAlertTriangle width={13} />
         ) : (
-          <AnimatedRefresh width={18} height={18} animating={syncing} />
-        )
-      ) : syncState === 'error' ? (
-        <SvgAlertTriangle width={13} />
-      ) : (
-        <AnimatedRefresh animating={syncing} />
-      )}
-      <Text style={isMobile ? { ...mobileTextStyle } : null}>
-        {syncState === 'disabled' ? ` ${t('Disabled')}` : null}
-      </Text>
-    </Button>
+          <AnimatedRefresh animating={syncing} />
+        )}
+        <Text style={isMobile ? { ...mobileTextStyle } : null}>
+          {syncState === 'disabled' ? ` ${t('Disabled')}` : null}
+        </Text>
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/upcoming-release-notes/adding-tooltip-to-title-icons.md
+++ b/upcoming-release-notes/adding-tooltip-to-title-icons.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tabedzki]
+---
+
+Add tooltips to the theme, privacy, and server status icons in the top bar


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds hover tooltips to three icons in the top titlebar.

All changes wrap existing buttons with the shared `Tooltip` component (`@actual-app/components/tooltip`)s.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

This change was written by an AI tool (Claude Code, model claude-sonnet-5).

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

N/A.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

- `yarn typecheck` — passes.
- `yarn lint:fix` — passes, no errors.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (+3.15 kB) | +0.02%
loot-core | 1 | 4.83 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (+3.15 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/ThemeSelector.tsx` | 📈 +588 B (+20.82%) | 2.76 kB → 3.33 kB
`src/components/LoggedInUser.tsx` | 📈 +942 B (+16.60%) | 5.54 kB → 6.46 kB
`src/components/Titlebar.tsx` | 📈 +1.66 kB (+13.86%) | 11.95 kB → 13.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.28 MB → 5.28 MB (+3.15 kB) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->