### PR TITLE
[WIP] Make budget template notifications translatable

### DIFF
--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -822,9 +822,18 @@ export function useBudgetActions() {
     },
     onSuccess: notification => {
       if (notification) {
+        // `message` is a stable i18next key (e.g. a plain sentence, or one
+        // containing `{{count}}`-style placeholders); `messageParams` carries
+        // any values to interpolate. Translating here, right before display,
+        // is what actually makes these notifications translatable — the
+        // server (loot-core) has no i18n of its own. See #8413.
+        const { messageParams, ...rest } = notification;
         dispatch(
           addNotification({
-            notification,
+            notification: {
+              ...rest,
+              message: t(notification.message, messageParams),
+            },
           }),
         );
       }

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -11,6 +11,8 @@ type Notification = {
   pre?: string | undefined;
   title?: string | undefined;
   message: string;
+  // See goal-template.ts's Notification type for why this exists.
+  messageParams?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 

--- a/packages/loot-core/src/server/budget/goal-template.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.test.ts
@@ -337,7 +337,14 @@ describe('applyMultipleCategoryTemplates', () => {
       categoryIds: [cat1.id, cat2.id],
     });
 
-    expect(result.message).toMatch(/Successfully applied/);
+    // The message must stay a stable, translatable key — the category count
+    // is passed separately via `messageParams` for the client to interpolate
+    // (via i18next) rather than being baked into the string, which would
+    // make it untranslatable (see #8413).
+    expect(result.message).toBe(
+      'Successfully applied templates to {{count}} categories',
+    );
+    expect(result.messageParams).toEqual({ count: 2 });
     expect(actions.setBudget).toHaveBeenCalledTimes(2);
     const budgetCalls = vi
       .mocked(actions.setBudget)

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -39,6 +39,11 @@ type Notification = {
   pre?: string | undefined;
   title?: string | undefined;
   message: string;
+  // Named values to interpolate into `message` when it is translated on the
+  // client. `message` itself must stay a stable i18next key (e.g.
+  // '{{count}} things happened'), not a string with values already baked in,
+  // otherwise it can never be translated (see #8413).
+  messageParams?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 
@@ -355,7 +360,8 @@ async function processTemplate(
 
   return {
     type: 'message',
-    message: `Successfully applied templates to ${contexts.length} categories`,
+    message: 'Successfully applied templates to {{count}} categories',
+    messageParams: { count: contexts.length },
   };
 }
 

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -13,6 +13,8 @@ type Notification = {
   type?: 'message' | 'error' | 'warning' | undefined;
   pre?: string | undefined;
   message: string;
+  // See goal-template.ts's Notification type for why this exists.
+  messageParams?: Record<string, unknown> | undefined;
   sticky?: boolean | undefined;
 };
 

--- a/upcoming-release-notes/8445.md
+++ b/upcoming-release-notes/8445.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [jchong06]
+---
+
+Make budget template notifications (check/apply/overwrite) translatable instead of always showing in English.


### PR DESCRIPTION
Fixes #8413.

Budget template notification messages (check/apply/overwrite templates) were shown only in English. One message baked a live category count directly into the string, which is fundamentally untranslatable — every distinct count is a different string. The others were static but never actually passed through `i18next` on the client either.

- `loot-core`: the dynamic message is now a stable key (`'...{{count}} categories'`) with the count passed via a new `messageParams` field.
- `desktop-client`: `useBudgetActions`'s `onSuccess` now translates `message`/`messageParams` via i18next before dispatching.

## Test plan
- Existing + strengthened unit tests pass (66/66 across `goal-template.test.ts`, `template-notes.test.ts`, `cleanup-template-notes.test.ts`)
- Full monorepo typecheck (`tsgo`) passes clean
- `oxlint --type-aware` and `oxfmt --check` pass clean on all touched files

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 29 | 13.17 MB → 13.17 MB (+140 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+37 B) | +0.00%
api | 2 | 3.88 MB → 3.88 MB (+36 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
29 | 13.17 MB → 13.17 MB (+140 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budget/mutations.ts` | 📈 +140 B (+1.05%) | 13.08 kB → 13.21 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 7.64 MB → 7.64 MB (+140 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 730.27 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.74 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.39 kB | 0%
static/js/es.js | 167.82 kB | 0%
static/js/extends.js | 435.59 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 176.56 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+37 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +37 B (+0.50%) | 7.24 kB → 7.28 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DKyosGpW.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.k7-O5h0q.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+36 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📈 +36 B (+0.50%) | 7.07 kB → 7.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+36 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->