### PR TITLE
[WIP] [AI] Add pinned accounts to sidebar

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -63,6 +63,32 @@ test.describe('Accounts', () => {
     await expect(menu.getByRole('button', { name: 'Rename' })).toBeVisible();
   });
 
+  test('pins an account in the sidebar', async () => {
+    await navigation.rightClickAccount('Roth IRA');
+    await page
+      .getByRole('menu')
+      .getByRole('button', { name: 'Pin account' })
+      .click();
+
+    const pinnedSection = page.getByTestId('sidebar-pinned-accounts');
+    await expect(pinnedSection).toBeVisible();
+    await expect(pinnedSection.getByText('Pinned')).toBeVisible();
+    await expect(
+      pinnedSection.getByRole('link', { name: /^Roth IRA/ }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: /^Roth IRA/ })).toHaveCount(2);
+
+    await pinnedSection
+      .getByRole('link', { name: /^Roth IRA/ })
+      .click({ button: 'right' });
+    await page
+      .getByRole('menu')
+      .getByRole('button', { name: 'Unpin account' })
+      .click();
+
+    await expect(pinnedSection).not.toBeVisible();
+  });
+
   test('right clicking a transaction row opens context menu', async () => {
     accountPage = await navigation.createAccount({
       name: 'New Account',

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -62,6 +62,9 @@ type AccountProps<FieldName extends SheetFields<'account'>> = {
   outerStyle?: CSSProperties;
   onDragChange?: OnDragChangeCallback<{ id: string }>;
   onDrop?: OnDropCallback;
+  canReorder?: boolean;
+  isPinned?: boolean;
+  onTogglePinned?: (account: AccountEntity) => void;
   titleAccount?: boolean;
   isExactPathMatch?: boolean;
   balanceTestId?: string;
@@ -80,6 +83,9 @@ export function Account<FieldName extends SheetFields<'account'>>({
   outerStyle,
   onDragChange,
   onDrop,
+  canReorder = true,
+  isPinned = false,
+  onTogglePinned,
   titleAccount,
   isExactPathMatch,
   balanceTestId,
@@ -100,12 +106,12 @@ export function Account<FieldName extends SheetFields<'account'>>({
     type,
     onDragChange,
     item: { id: account && account.id },
-    canDrag: account != null,
+    canDrag: account != null && canReorder,
   });
   const handleDragRef = useDragRef(dragRef);
 
   const { dropRef, dropPos } = useDroppable({
-    types: account ? [type] : [],
+    types: account && canReorder ? [type] : [],
     id: account && account.id,
     onDrop,
   });
@@ -143,6 +149,13 @@ export function Account<FieldName extends SheetFields<'account'>>({
         text: t('Rename'),
         onClick: () => setIsEditing(true),
       },
+      account &&
+        !account.closed &&
+        onTogglePinned && {
+          name: isPinned ? 'account-unpin' : 'account-pin',
+          text: isPinned ? t('Unpin account') : t('Pin account'),
+          onClick: () => onTogglePinned(account),
+        },
       account?.closed
         ? {
             name: 'account-reopen',

--- a/packages/desktop-client/src/components/sidebar/Accounts.tsx
+++ b/packages/desktop-client/src/components/sidebar/Accounts.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { theme } from '@actual-app/components/theme';
@@ -12,6 +13,7 @@ import { useClosedAccounts } from '#hooks/useClosedAccounts';
 import { useLocalPref } from '#hooks/useLocalPref';
 import { useOffBudgetAccounts } from '#hooks/useOffBudgetAccounts';
 import { useOnBudgetAccounts } from '#hooks/useOnBudgetAccounts';
+import { useSyncedPref } from '#hooks/useSyncedPref';
 import { useUpdatedAccounts } from '#hooks/useUpdatedAccounts';
 import { useSelector } from '#redux';
 import * as bindings from '#spreadsheet/bindings';
@@ -20,6 +22,22 @@ import { Account } from './Account';
 import { SecondaryItem } from './SecondaryItem';
 
 const fontWeight = 600;
+const PINNED_ACCOUNTS_PREF = 'side-nav.pinned-accounts';
+
+function parsePinnedAccountIds(value?: string) {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed.filter((id): id is string => typeof id === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
 
 export function Accounts() {
   const { t } = useTranslation();
@@ -30,6 +48,13 @@ export function Accounts() {
   const { data: onBudgetAccounts = [] } = useOnBudgetAccounts();
   const { data: closedAccounts = [] } = useClosedAccounts();
   const syncingAccountIds = useSelector(state => state.account.accountsSyncing);
+  const [pinnedAccountsPref, setPinnedAccountsPref] =
+    useSyncedPref(PINNED_ACCOUNTS_PREF);
+  const pinnedAccountIds = parsePinnedAccountIds(pinnedAccountsPref);
+  const activeAccounts = accounts.filter(account => !account.closed);
+  const pinnedAccounts = pinnedAccountIds
+    .map(id => activeAccounts.find(account => account.id === id))
+    .filter((account): account is AccountEntity => !!account);
 
   const getAccountPath = (account: AccountEntity) => `/accounts/${account.id}`;
 
@@ -71,6 +96,37 @@ export function Accounts() {
     setShowClosedAccountsPref(!showClosedAccounts);
   };
 
+  const onTogglePinnedAccount = (account: AccountEntity) => {
+    const nextPinnedAccountIds = pinnedAccountIds.includes(account.id)
+      ? pinnedAccountIds.filter(id => id !== account.id)
+      : [...pinnedAccountIds, account.id];
+
+    setPinnedAccountsPref(JSON.stringify(nextPinnedAccountIds));
+  };
+
+  const renderAccount = (
+    account: AccountEntity,
+    options: { canReorder?: boolean; outerStyle?: CSSProperties } = {},
+  ) => (
+    <Account
+      key={account.id}
+      name={account.name}
+      account={account}
+      connected={!!account.bank}
+      pending={syncingAccountIds.includes(account.id)}
+      failed={isAccountFailedSync(account)}
+      updated={updatedAccounts.includes(account.id)}
+      to={getAccountPath(account)}
+      query={bindings.accountBalance(account.id)}
+      onDragChange={onDragChange}
+      onDrop={onReorder}
+      canReorder={options.canReorder}
+      isPinned={pinnedAccountIds.includes(account.id)}
+      onTogglePinned={onTogglePinnedAccount}
+      outerStyle={options.outerStyle}
+    />
+  );
+
   return (
     <View
       style={{
@@ -99,6 +155,20 @@ export function Accounts() {
           balanceTestId="sidebar-all-accounts-balance"
         />
 
+        {pinnedAccounts.length > 0 && (
+          <View data-testid="sidebar-pinned-accounts">
+            <SecondaryItem
+              style={{ marginTop: 13, marginBottom: 5 }}
+              title={t('Pinned')}
+              bold
+            />
+
+            {pinnedAccounts.map(account =>
+              renderAccount(account, { canReorder: false }),
+            )}
+          </View>
+        )}
+
         {onBudgetAccounts.length > 0 && (
           <Account
             name={t('On budget')}
@@ -114,22 +184,9 @@ export function Accounts() {
           />
         )}
 
-        {onBudgetAccounts.map((account, i) => (
-          <Account
-            key={account.id}
-            name={account.name}
-            account={account}
-            connected={!!account.bank}
-            pending={syncingAccountIds.includes(account.id)}
-            failed={isAccountFailedSync(account)}
-            updated={updatedAccounts.includes(account.id)}
-            to={getAccountPath(account)}
-            query={bindings.accountBalance(account.id)}
-            onDragChange={onDragChange}
-            onDrop={onReorder}
-            outerStyle={makeDropPadding(i)}
-          />
-        ))}
+        {onBudgetAccounts.map((account, i) =>
+          renderAccount(account, { outerStyle: makeDropPadding(i) }),
+        )}
 
         {offbudgetAccounts.length > 0 && (
           <Account
@@ -146,22 +203,9 @@ export function Accounts() {
           />
         )}
 
-        {offbudgetAccounts.map((account, i) => (
-          <Account
-            key={account.id}
-            name={account.name}
-            account={account}
-            connected={!!account.bank}
-            pending={syncingAccountIds.includes(account.id)}
-            failed={isAccountFailedSync(account)}
-            updated={updatedAccounts.includes(account.id)}
-            to={getAccountPath(account)}
-            query={bindings.accountBalance(account.id)}
-            onDragChange={onDragChange}
-            onDrop={onReorder}
-            outerStyle={makeDropPadding(i)}
-          />
-        ))}
+        {offbudgetAccounts.map((account, i) =>
+          renderAccount(account, { outerStyle: makeDropPadding(i) }),
+        )}
 
         {closedAccounts.length > 0 && (
           <SecondaryItem

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -30,6 +30,7 @@ export type SyncedPrefs = Partial<
     | 'currencySpaceBetweenAmountAndSymbol'
     | 'defaultCurrencyCode'
     | `show-account-${string}-net-worth-chart`
+    | 'side-nav.pinned-accounts'
     | `side-nav.show-balance-history-${string}`
     | `show-balances-${string}`
     | `show-extra-balances-${string}`

--- a/upcoming-release-notes/pin-accounts-sidebar.md
+++ b/upcoming-release-notes/pin-accounts-sidebar.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [omar]
+---
+
+Add pinned accounts to the sidebar for quick access


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

This change adds a “Pinned” section to the sidebar so users can pin frequently used accounts for quick access.

Users can pin or unpin accounts from the account context menu. Closed accounts are excluded from the “Pinned” section, and pinned accounts remain visible in their normal on-budget or off-budget account lists.
<img width="346" height="639" alt="image" src="https://github.com/user-attachments/assets/36d4b708-6e78-4418-bf9a-84170d7f3d22" />

The initial implementation was drafted with gpt-5.5 and then reviewed and tested.


## Related issue(s)


## Testing

- `yarn typecheck`
- `yarn lint:fix`
- `yarn workspace @actual-app/web run playwright test accounts.test.ts -g "pins an account in the sidebar"`
- `yarn workspace @actual-app/web run playwright test accounts.test.ts`

Also manually verified pinning, unpinning, and that closed accounts are not retained in the “Pinned” section.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->