### PR TITLE
Disable the shared worker on Android (same as is done for iOS already)

### DIFF
--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -38,7 +38,8 @@ const worker = startBrowserBackend({
   },
   createSharedWorker: () =>
     new SharedBrowserServerWorker({ name: 'actual-backend' }),
-  forceDirectWorker: Platform.isPlaywright || Platform.isIOS,
+  forceDirectWorker:
+    Platform.isPlaywright || Platform.isIOS || Platform.isAndroid,
 });
 
 let isUpdateReadyForDownload = false;

--- a/packages/loot-core/src/platform/client/browser-preload/start.ts
+++ b/packages/loot-core/src/platform/client/browser-preload/start.ts
@@ -74,6 +74,8 @@ export function startBrowserBackend(
           'SharedArrayBufferOverride',
         ),
       });
+      bridge.markInitialized();
+
       window.addEventListener('beforeunload', () => {
         sharedPort.postMessage({ type: 'tab-closing' });
       });

--- a/packages/loot-core/src/platform/client/browser-preload/worker-bridge.ts
+++ b/packages/loot-core/src/platform/client/browser-preload/worker-bridge.ts
@@ -2,11 +2,6 @@ import { initBackend as initSQLBackend } from 'absurd-sql/dist/indexeddb-main-th
 
 import { logger } from '#platform/server/log';
 
-// After sending a __resume-tab ping we wait for any response from the shared worker.
-// A live shared worker replies well below this threshold; no response means
-// it might have been killed by the OS, and we need to reload.
-const RESUME_TAB_RESPONSE_TIMEOUT_MS = 1_000;
-
 type BridgeMessage = { type?: string; [key: string]: unknown };
 
 /** The Worker-like surface the connection layer interacts with. */
@@ -33,8 +28,9 @@ export class WorkerBridge {
   _onmessage: ((e: MessageEvent) => void) | null;
   _listeners: Array<{ type: string; handler: (e: MessageEvent) => void }>;
   _started: boolean;
+  _isInitialized: boolean;
   _currentBudgetId: string | null;
-  _sharedWorkerLivenessTimeout: { start: () => void; clear: () => void };
+  _wasHidden: boolean;
   _onVisibilityChange: () => void;
   localBackendWorker: Worker | null;
   backendWorkerUrl: URL;
@@ -44,21 +40,19 @@ export class WorkerBridge {
     this._onmessage = null;
     this._listeners = [];
     this._started = false;
+    this._isInitialized = false;
     this._currentBudgetId = null;
-    this._sharedWorkerLivenessTimeout =
-      this._createSharedWorkerLivenessTimeout();
+    this._wasHidden = document.visibilityState === 'hidden';
     this.localBackendWorker = null;
     this.backendWorkerUrl = backendWorkerUrl;
 
     this._onVisibilityChange = () => {
-      if (document.visibilityState === 'hidden' || !this._started) {
-        return;
+      if (document.visibilityState === 'hidden') {
+        this._wasHidden = true;
+      } else if (this._wasHidden) {
+        this._wasHidden = false;
+        this._resumeAssociation();
       }
-
-      // Cancel any pending reload from a prior transition, then re-check shared worker's liveness
-      this._sharedWorkerLivenessTimeout.clear();
-      this._resumeAssociation();
-      this._sharedWorkerLivenessTimeout.start();
     };
 
     // Listen for all messages from the SharedWorker port
@@ -112,9 +106,6 @@ export class WorkerBridge {
   }
 
   _onSharedMessage(event: MessageEvent) {
-    // Cancel any pending reload — the shared worker is alive.
-    this._sharedWorkerLivenessTimeout.clear();
-
     const msg = event.data as BridgeMessage;
 
     // Elected as leader: create the real backend Worker on this tab
@@ -192,6 +183,10 @@ export class WorkerBridge {
     this._dispatch(event);
   }
 
+  markInitialized() {
+    this._isInitialized = true;
+  }
+
   _normalizeBudgetId(budgetId: string | null): string | null {
     if (
       typeof budgetId === 'string' &&
@@ -212,6 +207,9 @@ export class WorkerBridge {
   }
 
   _resumeAssociation() {
+    if (!this._isInitialized) {
+      return;
+    }
     this._sharedPort.postMessage({
       type: '__resume-tab',
       budgetId: this._currentBudgetId,
@@ -272,22 +270,5 @@ export class WorkerBridge {
     };
 
     localWorker.postMessage(initMsg);
-  }
-
-  _createSharedWorkerLivenessTimeout() {
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    return {
-      start() {
-        timer = setTimeout(() => {
-          window.location.reload();
-        }, RESUME_TAB_RESPONSE_TIMEOUT_MS);
-      },
-      clear() {
-        if (timer !== null) {
-          clearTimeout(timer);
-          timer = null;
-        }
-      },
-    };
   }
 }

--- a/packages/loot-core/src/shared/platform.api.ts
+++ b/packages/loot-core/src/shared/platform.api.ts
@@ -5,3 +5,4 @@ export const env: 'web' | 'mobile' | 'unknown' = 'unknown';
 export const isBrowser: boolean = false;
 
 export const isIOSAgent = false;
+export const isAndroid = false;

--- a/packages/loot-core/src/shared/platform.electron.ts
+++ b/packages/loot-core/src/shared/platform.electron.ts
@@ -20,3 +20,4 @@ export const isBrowser: typeof T.isBrowser = false;
 
 export const isIOSAgent: typeof T.isIOSAgent = false;
 export const isIOS: typeof T.isIOS = false;
+export const isAndroid: typeof T.isAndroid = false;

--- a/packages/loot-core/src/shared/platform.ts
+++ b/packages/loot-core/src/shared/platform.ts
@@ -25,6 +25,8 @@ const userAgent = navigator.userAgent;
 // True for all browsers on iOS (iPhone/iPad/iPod) — not macOS.
 export const isIOS = /iP(hone|ad|od)/.test(userAgent);
 
+export const isAndroid = /Android/.test(userAgent);
+
 // True only for Safari on iOS — Chrome (CriOS), Firefox (FxiOS), Edge (EdgiOS),
 // etc. carry their own tokens and are excluded.
 export const isIOSAgent =

--- a/upcoming-release-notes/disable-shared-worker-on-android.md
+++ b/upcoming-release-notes/disable-shared-worker-on-android.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [martin-lukas]
+---
+
+Fix app becoming unresponsive on Android when reopening after being in the background for a while.

--- a/upcoming-release-notes/fix-android-shared-worker-liveness.md
+++ b/upcoming-release-notes/fix-android-shared-worker-liveness.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [martin-lukas]
----
-
-Fixed issue on Android where app becomes unresponsive when reopening after period of inactivity.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

I've been trying to figure out the instability of the Actual PWA on Android for a few weeks now. I created a PR previously, now merged to master (https://github.com/actualbudget/actual/pull/8322), to address Android OS killing the shared worker process when the PWA is in the background, but later I found out that it didn't fully resolve the issue, just made it less frequent.

Since then, I've tried many workarounds, as I found that Android can interfere with many different parts of the Actual processes. At some point I decided to search around online to check how other apps deal with these issues on Android. I found out that this instability in Actual PWA is quite recent (I do rememeber the app being quite stable just a month or 2 ago). Chrome 148 [re-enabled SharedWorker feature](https://developer.chrome.com/release-notes/148#sharedworker_on_android) on Android, release in May this year. So that definitely fits the time when I started noticing the issues. That code was never used before in Actual on Android.

So I'd like to propose disabling the SharedWorker feature for Android for the time being (plus revert my already merged "fix", to prevent any regressions). At the moment, I don't believe it's feasible to ensure the app is always able to recover, from all the different ways Android can freeze or kill certain parts of the app and make it enter unrecoverable state without restarting manually. I've been testing this for a couple of days now, and haven't encountered invalid state since. It's been rock solid (especially compared to previously needing to kill it every few hours, which meant basically... every other time I opened the app).

## Related issue(s)

https://github.com/actualbudget/actual/issues/8260

Related issue in Chrome on Android: https://issues.chromium.org/issues/40290702

## Testing

The invalid state can be reproduced even on non-mobile Chrome, by following the steps in the linked issue (killing the shared worker thread manually).

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.21 MB → 13.21 MB (-228 B) | -0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+44 B) | +0.00%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.21 MB → 13.21 MB (-228 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +43 B (+5.95%) | 723 B → 766 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/browser-preload/start.ts` | 📈 +28 B (+2.02%) | 1.35 kB → 1.38 kB
`src/browser-preload.js` | 📈 +13 B (+0.33%) | 3.81 kB → 3.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/browser-preload/worker-bridge.ts` | 📉 -312 B (-6.15%) | 4.96 kB → 4.65 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useDateFormat.js | 2.84 MB → 2.84 MB (+43 B) | +0.00%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.22 MB → 5.22 MB (-271 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+44 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +44 B (+6.74%) | 653 B → 697 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CYg1Q8H7.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dml_BZtE.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->