### PR TITLE
[AI] Fix updateTransaction crash when converting a transaction to a split

### DIFF
--- a/packages/loot-core/src/shared/transactions.test.ts
+++ b/packages/loot-core/src/shared/transactions.test.ts
@@ -383,4 +383,42 @@ describe('Transactions', () => {
       id: 't2',
     });
   });
+
+  test('converting a simple transaction into a split stamps children with the parent account (#8207)', () => {
+    const transactions = [
+      makeTransaction({ amount: 2001 }),
+      makeTransaction({ id: 't1', amount: 5000, account: 'acc-id-1' }),
+      makeTransaction({ amount: 3002 }),
+    ];
+
+    // Mirrors `api.updateTransaction(id, { subtransactions: [...] })`, which
+    // reaches this reducer as `updateTransaction(transactions, { id, ...fields })`
+    // (see `api/transaction-update` in server/api.ts).
+    const { data, diff } = updateTransaction(transactions, {
+      id: 't1',
+      subtransactions: [{ amount: 4000 }, { amount: 1000 }],
+    } as TransactionEntity);
+
+    const parent = data.find(d => d.id === 't1');
+    expect(parent?.is_parent).toBe(true);
+
+    const children = data.filter(t => t.parent_id === 't1');
+    expect(children).toHaveLength(2);
+    // Regression (#8207): children used to be emitted without an account/date,
+    // so the DB rejected the insert with
+    // `"account" is required for table "transactions"`.
+    for (const child of children) {
+      expect(child.account).toBe('acc-id-1');
+      expect(child.date).toBe('2020-01-05');
+      expect(child.is_child).toBe(true);
+      expect(child.parent_id).toBe('t1');
+    }
+    expect(children.map(c => c.amount).sort((a, b) => b - a)).toEqual([
+      4000, 1000,
+    ]);
+
+    // The new child rows are inserted, and every one must carry the account.
+    expect(diff.added).toHaveLength(2);
+    expect(diff.added.every(t => t.account === 'acc-id-1')).toBe(true);
+  });
 });

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -314,7 +314,7 @@ export function updateTransaction(
         ...transaction,
         is_parent: true,
         is_child: false,
-        parent_id: null,
+        parent_id: undefined,
       };
       return recalculateSplit({
         ...parent,

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -309,7 +309,13 @@ export function updateTransaction(
       // parent and materialise each subtransaction as a proper child so it
       // inherits the parent's account/date; otherwise the children are inserted
       // without an `account` and the DB rejects them (#8207).
-      const parent = { ...trans, ...transaction, is_parent: true };
+      const parent = {
+        ...trans,
+        ...transaction,
+        is_parent: true,
+        is_child: false,
+        parent_id: null,
+      };
       return recalculateSplit({
         ...parent,
         subtransactions: transaction.subtransactions.map((sub, index) =>

--- a/packages/loot-core/src/shared/transactions.ts
+++ b/packages/loot-core/src/shared/transactions.ts
@@ -300,6 +300,25 @@ export function updateTransaction(
         ...parent,
         ...(sub && { subtransactions: sub }),
       });
+    } else if (
+      transaction.subtransactions &&
+      transaction.subtransactions.length > 0
+    ) {
+      // Converting a simple (non-split) transaction into a split — e.g.
+      // `api.updateTransaction(id, { subtransactions: [...] })`. Mark it as a
+      // parent and materialise each subtransaction as a proper child so it
+      // inherits the parent's account/date; otherwise the children are inserted
+      // without an `account` and the DB rejects them (#8207).
+      const parent = { ...trans, ...transaction, is_parent: true };
+      return recalculateSplit({
+        ...parent,
+        subtransactions: transaction.subtransactions.map((sub, index) =>
+          makeChild(parent, {
+            ...sub,
+            sort_order: sub.sort_order ?? -(index + 1),
+          }),
+        ),
+      });
     } else {
       return transaction;
     }

--- a/upcoming-release-notes/fix-api-update-transaction-split.md
+++ b/upcoming-release-notes/fix-api-update-transaction-split.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [aturzone]
+---
+
+Fixed a crash when converting a regular transaction into a split via the API.


### PR DESCRIPTION
…plit

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Calling `api.updateTransaction(id, { subtransactions: [...] })` on a normal (non-split)
transaction throws `"account" is required for table "transactions"`, so you can't turn a
regular transaction into a split through the API.
The problem is in `updateTransaction` (`packages/loot-core/src/shared/transactions.ts`): the
`else` branch returned the transaction as-is. The subtransactions were never turned into real
children, so they had no `account`/`date`/`parent_id`/`is_child`, and the parent was never
marked `is_parent` — which is why the child inserts get rejected.
The fix follows what `splitTransaction`/`addSplitTransaction` already do: when a simple
transaction is updated with `subtransactions`, flag it `is_parent` and run each subtransaction
through the existing `makeChild` helper so they inherit the parent's `account` and `date`.
Disclosure: a significant part of this change was written with an AI coding assistant (Claude
Code / Claude), which I reviewed line by line and tested.

## Related issue(s)

Fixes #8207

## Testing

Added a regression test that fails on master and passes with the fix — it checks the children
come back with the parent's `account`/`date`, `is_child`, and a `parent_id`. Ran the loot-core
test suite locally (passes), `yarn typecheck` is clean, and the formatter/linter pass on the
changed files. To reproduce the original bug: call `api.updateTransaction` on a plain
transaction with a `subtransactions` array — on master it throws the `"account" is required`
error; with this change the split is created correctly.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.21 MB → 13.21 MB (+419 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+434 B) | +0.01%
api | 2 | 3.88 MB → 3.88 MB (+419 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.21 MB → 13.21 MB (+419 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +419 B (+4.90%) | 8.36 kB → 8.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.22 MB → 5.22 MB (+419 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.84 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+434 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +434 B (+6.94%) | 6.1 kB → 6.53 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.WVLMsjhx.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dml_BZtE.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+419 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +419 B (+6.93%) | 5.9 kB → 6.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+419 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->