### PR TITLE
[WIP] [AI] Fix file import silently merging transactions the preview showed as new (#8464)

### DIFF
--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -854,10 +854,15 @@ export function ImportTransactionsModal({
               // Pin the preview's match decision so the actual import honors
               // it instead of re-running the fuzzy matching on a different
               // set of transactions (which can silently merge rows the
-              // preview showed as new). Rows without any preview entry were
-              // shown as new (null = don't match); ignored rows keep the
-              // default matching (undefined).
-              currentTrx.matchedTransactionId = entry ? existingTrx?.id : null;
+              // preview showed as new). Rows without any preview entry, and
+              // tombstone entries (existing === false), were shown as new
+              // (null = don't match); ignored rows keep the default matching
+              // (undefined).
+              currentTrx.matchedTransactionId = existingTrx
+                ? existingTrx.id
+                : entry && !entry.tombstone
+                  ? undefined
+                  : null;
 
               currentTrx.tombstone = entry?.tombstone || false;
 

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx
@@ -356,6 +356,7 @@ export function ImportTransactionsModal({
           ignored: _ignored,
           selected: _selected,
           selected_merge: _selected_merge,
+          matchedTransactionId: _matchedTransactionId,
           tombstone: _tombstone,
           ...finalTransaction
         } = trans;
@@ -684,19 +685,27 @@ export function ImportTransactionsModal({
         ignored: _ignored,
         selected: _selected,
         selected_merge: _selected_merge,
+        matchedTransactionId: _matchedTransactionId,
         trx_id: _trx_id,
         ...finalTransaction
       } = trans;
 
-      if (
-        reconcile &&
-        ((trans.ignored && trans.selected) ||
-          (trans.existing && trans.selected && !trans.selected_merge))
-      ) {
-        // in reconcile mode, force transaction add for
-        // - ignored transactions (aleardy existing) that are checked
-        // - transactions with existing (merged transactions) that are not selected_merge
-        finalTransaction.forceAddTransaction = true;
+      if (reconcile) {
+        if (
+          (trans.ignored && trans.selected) ||
+          (trans.existing && trans.selected && !trans.selected_merge)
+        ) {
+          // in reconcile mode, force transaction add for
+          // - ignored transactions (aleardy existing) that are checked
+          // - transactions with existing (merged transactions) that are not selected_merge
+          finalTransaction.forceAddTransaction = true;
+        }
+
+        if (trans.matchedTransactionId !== undefined) {
+          // pass the preview's match decision along so the import doesn't
+          // re-run the fuzzy matching with a potentially different result
+          finalTransaction.matchedTransactionId = trans.matchedTransactionId;
+        }
       }
 
       finalTransactions.push({
@@ -842,6 +851,14 @@ export function ImportTransactionsModal({
               // (reconciled transactions or no change detected)
               currentTrx.ignored = entry?.ignored || false;
 
+              // Pin the preview's match decision so the actual import honors
+              // it instead of re-running the fuzzy matching on a different
+              // set of transactions (which can silently merge rows the
+              // preview showed as new). Rows without any preview entry were
+              // shown as new (null = don't match); ignored rows keep the
+              // default matching (undefined).
+              currentTrx.matchedTransactionId = entry ? existingTrx?.id : null;
+
               currentTrx.tombstone = entry?.tombstone || false;
 
               currentTrx.selected = !currentTrx.ignored;
@@ -887,6 +904,13 @@ export function ImportTransactionsModal({
     fieldMappings,
     parseDateFormat,
     reimportDeleted,
+    // the preview matches on amounts, so any option that changes how amounts
+    // are parsed must refresh the preview (and its pinned match decisions)
+    flipAmount,
+    splitMode,
+    inOutMode,
+    outValue,
+    multiplierAmount,
   ]);
 
   const headers: ComponentProps<typeof TableHeader>['headers'] = [

--- a/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
+++ b/packages/desktop-client/src/components/modals/ImportTransactionsModal/utils.ts
@@ -128,6 +128,10 @@ export type ImportTransaction = {
   ignored: boolean;
   selected: boolean;
   selected_merge: boolean;
+  /** The match decision from the import preview: the id of the existing
+   * transaction this row matched, null if the preview found no match, or
+   * undefined if the preview didn't decide (e.g. ignored rows). */
+  matchedTransactionId?: string | null;
   amount: number;
   inflow: number;
   outflow: number;
@@ -137,7 +141,7 @@ export type ImportTransaction = {
   notes?: string;
   category?: string;
   date?: string;
-} & Record<string, string | number | boolean>;
+} & Record<string, string | number | boolean | null>;
 
 type ImportCategory = {
   id: string;
@@ -181,6 +185,7 @@ export function applyFieldMappings(
   result.ignored = transaction.ignored;
   result.selected = transaction.selected;
   result.selected_merge = transaction.selected_merge;
+  result.matchedTransactionId = transaction.matchedTransactionId;
   result.tombstone = transaction.tombstone;
   return result as ImportTransaction;
 }
@@ -306,6 +311,7 @@ export function stripCsvImportTransaction(transaction: ImportTransaction) {
     ignored: _ignored,
     selected: _selected,
     selected_merge: _selected_merge,
+    matchedTransactionId: _matchedTransactionId,
     trx_id: _trx_id,
     tombstone: _tombstone,
     ...trans

--- a/packages/loot-core/src/server/accounts/csv-import-silent-drop.test.ts
+++ b/packages/loot-core/src/server/accounts/csv-import-silent-drop.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Regression tests for: CSV import silently drops transactions when an
+ * existing transaction in the same account has the same amount within
+ * ±7 days (https://github.com/actualbudget/actual/issues/8464).
+ *
+ * These tests simulate the exact flow of the CSV import dialog
+ * (ImportTransactionsModal):
+ *   1. preview call  -> reconcileTransactions(..., isPreview = true)
+ *   2. default toggle state assignment (onImportPreview onSuccess handler),
+ *      including pinning each row's match decision (matchedTransactionId)
+ *   3. final import  -> reconcileTransactions(..., isPreview = false),
+ *      with forceAddTransaction and matchedTransactionId set per the
+ *      modal's onImport rules.
+ *
+ * The import used to re-run the greedy fuzzy matching from scratch on the
+ * (possibly smaller) set of rows the user left selected, so it could match
+ * — and silently merge — rows the preview had shown as brand-new. Pinning
+ * the preview's match decision makes the import honor what the user saw.
+ */
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import { loadRules } from '#server/transactions/transaction-rules';
+
+import { reconcileTransactions } from './sync';
+import type { ReconcileTransactionsResult } from './sync';
+
+const emptyDatabase = (
+  global as unknown as {
+    emptyDatabase: () => () => Promise<void>;
+  }
+).emptyDatabase;
+
+beforeEach(async () => {
+  await emptyDatabase()();
+  await loadMappings();
+  await loadRules();
+});
+
+type UiRow = {
+  trx_id: string;
+  date: string;
+  amount: number;
+  payee_name: string;
+  // UI state managed by the modal:
+  existing?: boolean;
+  ignored?: boolean;
+  selected?: boolean;
+  selected_merge?: boolean;
+  matchedTransactionId?: string | null;
+};
+
+async function setupAccountWithExistingTransaction() {
+  const acctId = await db.insertAccount({ id: 'chase', name: 'Chase Bank' });
+  await db.insertPayee({
+    id: 'transfer-' + acctId,
+    name: '',
+    transfer_acct: acctId,
+  });
+
+  const netflixPayeeId = await db.insertPayee({ name: 'Netflix' });
+  // A manually-entered transaction already in the register: $8.99 on May 10
+  await db.insertTransaction({
+    id: 'existing-netflix',
+    account: acctId,
+    amount: -899,
+    date: '2024-05-10',
+    payee: netflixPayeeId,
+    cleared: 1,
+  });
+
+  return acctId;
+}
+
+function getAllTransactions() {
+  return db.all<db.DbViewTransactionInternal>(
+    `SELECT * FROM v_transactions_internal ORDER BY date DESC, id`,
+  );
+}
+
+/**
+ * Mirrors ImportTransactionsModal.onImportPreview onSuccess: assigns the
+ * default toggle state to each parsed CSV row based on the preview result,
+ * and pins the preview's match decision on the row.
+ */
+function applyPreviewDefaults(
+  rows: UiRow[],
+  updatedPreview: ReconcileTransactionsResult['updatedPreview'],
+): UiRow[] {
+  const matchedUpdateMap = new Map(
+    // trx_id is an extra field the modal attaches to each parsed row; it
+    // survives normalization but isn't part of TransactionEntity (the modal
+    // reads it the same way, via a ts-expect-error).
+    updatedPreview.map(entry => [
+      (entry.transaction as { trx_id?: string }).trx_id,
+      entry,
+    ]),
+  );
+
+  return rows.map(row => {
+    const entry = matchedUpdateMap.get(row.trx_id);
+    const existingTrx = entry?.existing;
+    const existing = !!existingTrx;
+    const ignored = entry?.ignored || false;
+    return {
+      ...row,
+      existing,
+      ignored,
+      selected: !ignored,
+      selected_merge: existing,
+      matchedTransactionId: entry
+        ? typeof existingTrx === 'object' && existingTrx !== null
+          ? existingTrx.id
+          : undefined
+        : null,
+    };
+  });
+}
+
+/**
+ * Mirrors ImportTransactionsModal.onImport: filters rows and sets
+ * forceAddTransaction and matchedTransactionId according to the toggle
+ * state and the preview's pinned match decision, producing the payload
+ * sent to the non-preview 'transactions-import' call. reconcile = true.
+ */
+function buildImportPayload(rows: UiRow[]) {
+  const finalTransactions = [];
+  for (const row of rows) {
+    if (!row.selected && !row.ignored) {
+      // unselected transactions that are not ignored are skipped
+      continue;
+    }
+
+    const {
+      existing: _existing,
+      ignored: _ignored,
+      selected: _selected,
+      selected_merge: _selected_merge,
+      matchedTransactionId: _matchedTransactionId,
+      trx_id: _trx_id,
+      ...finalTransaction
+    } = row;
+
+    const forceAddTransaction =
+      (row.ignored && row.selected) ||
+      (row.existing && row.selected && !row.selected_merge);
+
+    finalTransactions.push({
+      ...finalTransaction,
+      ...(forceAddTransaction ? { forceAddTransaction: true } : {}),
+      ...(row.matchedTransactionId !== undefined
+        ? { matchedTransactionId: row.matchedTransactionId }
+        : {}),
+    });
+  }
+  return finalTransactions;
+}
+
+describe('CSV import preview/import consistency', () => {
+  test('a new same-amount transaction previewed as new is imported, not silently merged', async () => {
+    const acctId = await setupAccountWithExistingTransaction();
+
+    // CSV contains a true duplicate of the existing Netflix transaction AND a
+    // genuinely new same-amount purchase.
+    const csvRows: UiRow[] = [
+      {
+        trx_id: 'row-dup',
+        date: '2024-05-10',
+        payee_name: 'Netflix',
+        amount: -899,
+      },
+      {
+        trx_id: 'row-new',
+        date: '2024-05-12',
+        payee_name: 'Corner Coffee',
+        amount: -899,
+      },
+    ];
+
+    const preview = await reconcileTransactions(
+      acctId,
+      csvRows,
+      false,
+      true,
+      true,
+    );
+
+    // In the preview, the duplicate row claims the match with the existing
+    // transaction. The new row matches nothing: the dialog shows it as a
+    // plain new transaction — checked, no merge indicator, no ignore flag.
+    const previewIds = preview.updatedPreview.map(
+      e => (e.transaction as { trx_id?: string }).trx_id,
+    );
+    expect(previewIds).toContain('row-dup');
+    expect(previewIds).not.toContain('row-new');
+
+    let uiRows = applyPreviewDefaults(csvRows, preview.updatedPreview);
+    // The preview's decision is pinned on each row:
+    expect(uiRows.find(r => r.trx_id === 'row-dup')?.matchedTransactionId).toBe(
+      'existing-netflix',
+    );
+    expect(
+      uiRows.find(r => r.trx_id === 'row-new')?.matchedTransactionId,
+    ).toBeNull();
+
+    // The user recognizes row-dup as a duplicate and unchecks it (clicking
+    // the 3-state toggle until fully unselected). row-new stays checked.
+    uiRows = uiRows.map(row =>
+      row.trx_id === 'row-dup'
+        ? { ...row, selected: false, selected_merge: false }
+        : row,
+    );
+
+    const payload = buildImportPayload(uiRows);
+    // Only the genuinely new row is sent to the import:
+    expect(payload.map(t => t.payee_name)).toEqual(['Corner Coffee']);
+
+    const result = await reconcileTransactions(
+      acctId,
+      payload,
+      false,
+      true,
+      false,
+    );
+
+    // The import honors the preview: even though the existing Netflix
+    // transaction is no longer claimed by the (deselected) duplicate row,
+    // the new row was previewed as new and must be added, not merged.
+    expect(result.added).toHaveLength(1);
+
+    const transactions = await getAllTransactions();
+    expect(transactions).toHaveLength(2);
+    // The existing transaction was not touched:
+    expect(
+      transactions.find(t => t.id === 'existing-netflix')?.imported_payee,
+    ).toBeNull();
+  });
+
+  test('the default merge toggle state merges into exactly the previewed transaction', async () => {
+    // Note: this documents the *intended* dedup behavior of the default
+    // "merge" toggle state — a fuzzy-matched row that the user leaves in its
+    // default state is merged into the existing transaction it was previewed
+    // against (and only that one), not imported as a new transaction. See
+    // issue #8464 for discussion of making this state more visible in the UI.
+    const acctId = await setupAccountWithExistingTransaction();
+
+    // The CSV contains a different purchase that happens to have the same
+    // amount ($8.99) two days later.
+    const csvRows: UiRow[] = [
+      {
+        trx_id: 'row-1',
+        date: '2024-05-12',
+        payee_name: 'Corner Coffee',
+        amount: -899,
+      },
+    ];
+
+    // Step 1: the modal's preview call
+    const preview = await reconcileTransactions(
+      acctId,
+      csvRows,
+      false, // isBankSyncAccount
+      true, // strictIdChecking
+      true, // isPreview
+    );
+
+    // The CSV row fuzzy-matched the existing Netflix transaction purely on
+    // amount + date proximity, and shows in the default "merge" state.
+    expect(preview.updatedPreview).toHaveLength(1);
+    expect(preview.updatedPreview[0].ignored).not.toBe(true);
+    expect(preview.updatedPreview[0].existing).toBeTruthy();
+
+    // Step 2 + 3: default toggle state, then the real import
+    const uiRows = applyPreviewDefaults(csvRows, preview.updatedPreview);
+    expect(uiRows[0]).toMatchObject({
+      selected: true,
+      ignored: false,
+      selected_merge: true, // the default action for matched rows is MERGE
+      matchedTransactionId: 'existing-netflix',
+    });
+
+    const result = await reconcileTransactions(
+      acctId,
+      buildImportPayload(uiRows),
+      false,
+      true,
+      false, // real import
+    );
+
+    // Merged into the pinned existing transaction; nothing new is added.
+    expect(result.added).toHaveLength(0);
+    expect(result.updated).toEqual(['existing-netflix']);
+
+    const transactions = await getAllTransactions();
+    expect(transactions).toHaveLength(1);
+    // The merge only fills blank fields of the existing transaction:
+    expect(transactions[0].imported_payee).toBe('Corner Coffee');
+  });
+
+  test('a pinned match that no longer exists falls back to adding the transaction', async () => {
+    const acctId = await setupAccountWithExistingTransaction();
+
+    const csvRows: UiRow[] = [
+      {
+        trx_id: 'row-1',
+        date: '2024-05-12',
+        payee_name: 'Corner Coffee',
+        amount: -899,
+      },
+    ];
+
+    const preview = await reconcileTransactions(
+      acctId,
+      csvRows,
+      false,
+      true,
+      true,
+    );
+    const uiRows = applyPreviewDefaults(csvRows, preview.updatedPreview);
+    expect(uiRows[0].matchedTransactionId).toBe('existing-netflix');
+
+    // The previewed match is deleted before the user hits Import (e.g. by a
+    // sync from another device).
+    await db.deleteTransaction({ id: 'existing-netflix' });
+
+    const result = await reconcileTransactions(
+      acctId,
+      buildImportPayload(uiRows),
+      false,
+      true,
+      false,
+    );
+
+    // The pinned transaction is gone, so the row is added as new instead of
+    // being fuzzy-matched onto something else.
+    expect(result.added).toHaveLength(1);
+    expect(result.updated).toHaveLength(0);
+  });
+
+  test('callers that do not pin matches (e.g. the API) keep the fuzzy matching behavior', async () => {
+    const acctId = await setupAccountWithExistingTransaction();
+
+    // No preview, no matchedTransactionId — a same-amount transaction within
+    // the ±7 day window is still deduplicated by merging, as before.
+    const result = await reconcileTransactions(
+      acctId,
+      [
+        {
+          date: '2024-05-12',
+          payee_name: 'Corner Coffee',
+          amount: -899,
+        },
+      ],
+      false,
+      true,
+      false,
+    );
+
+    expect(result.added).toHaveLength(0);
+    expect(result.updated).toEqual(['existing-netflix']);
+    expect(await getAllTransactions()).toHaveLength(1);
+  });
+
+  test('CONTROL: same amount but outside the ±7 day window imports fine', async () => {
+    const acctId = await setupAccountWithExistingTransaction();
+
+    const csvRows: UiRow[] = [
+      {
+        trx_id: 'row-1',
+        date: '2024-05-20', // 10 days after the existing transaction
+        payee_name: 'Corner Coffee',
+        amount: -899,
+      },
+    ];
+
+    const preview = await reconcileTransactions(
+      acctId,
+      csvRows,
+      false,
+      true,
+      true,
+    );
+    expect(preview.updatedPreview).toHaveLength(0); // no match in preview
+
+    const uiRows = applyPreviewDefaults(csvRows, preview.updatedPreview);
+    // No preview entry means the row was shown as new, which pins "no match":
+    expect(uiRows[0].matchedTransactionId).toBeNull();
+
+    const result = await reconcileTransactions(
+      acctId,
+      buildImportPayload(uiRows),
+      false,
+      true,
+      false,
+    );
+
+    expect(result.added).toHaveLength(1);
+    expect(await getAllTransactions()).toHaveLength(2);
+  });
+
+  test('toggling a matched row to "add as new" forces the add', async () => {
+    const acctId = await setupAccountWithExistingTransaction();
+
+    const csvRows: UiRow[] = [
+      {
+        trx_id: 'row-1',
+        date: '2024-05-12',
+        payee_name: 'Corner Coffee',
+        amount: -899,
+      },
+    ];
+
+    const preview = await reconcileTransactions(
+      acctId,
+      csvRows,
+      false,
+      true,
+      true,
+    );
+    let uiRows = applyPreviewDefaults(csvRows, preview.updatedPreview);
+
+    // One click on the 3-state toggle: (selected + merge) -> (selected, no
+    // merge) = "add as new transaction"
+    uiRows = uiRows.map(row => ({ ...row, selected_merge: false }));
+
+    const result = await reconcileTransactions(
+      acctId,
+      buildImportPayload(uiRows),
+      false,
+      true,
+      false,
+    );
+
+    expect(result.added).toHaveLength(1);
+    expect(await getAllTransactions()).toHaveLength(2);
+  });
+});

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -710,7 +710,11 @@ export async function reconcileTransactions(
       }
     } else {
       // Insert a new transaction
-      const { forceAddTransaction: _forceAddTransaction, ...newTrans } = trans;
+      const {
+        forceAddTransaction: _forceAddTransaction,
+        matchedTransactionId: _matchedTransactionId,
+        ...newTrans
+      } = trans;
       const finalTransaction = {
         ...newTrans,
         id: uuidv4(),
@@ -798,10 +802,38 @@ export async function matchTransactions(
     let match = null;
     let fuzzyDataset = null;
 
-    // First, match with an existing transaction's imported_id. This
-    // is the highest fidelity match and should always be attempted
-    // first.
-    if (trans.imported_id) {
+    // If the caller already ran a preview and pinned this transaction's
+    // match decision, honor it instead of re-running matching. The fuzzy
+    // passes below are greedy and stateful, so re-running them on a
+    // different set of transactions (e.g. after the user deselected some
+    // rows in the import dialog) can pick different matches than the
+    // preview showed — silently merging transactions the preview presented
+    // as new. A pinned id of null means the preview found no match, so the
+    // transaction is added as new. The field comes in on import payloads
+    // (see ImportTransactionEntity) and is not part of TransactionEntity.
+    const { matchedTransactionId } = trans as {
+      matchedTransactionId?: string | null;
+    };
+    const hasPinnedMatch = matchedTransactionId !== undefined;
+
+    if (hasPinnedMatch) {
+      if (matchedTransactionId) {
+        const table = reimportDeleted
+          ? 'v_transactions'
+          : 'v_transactions_internal';
+        match = await db.first<db.DbTransaction>(
+          `SELECT * FROM ${table} WHERE id = ? AND account = ?`,
+          [matchedTransactionId, acctId],
+        );
+
+        if (match) {
+          hasMatched.add(match.id);
+        }
+      }
+    } else if (trans.imported_id) {
+      // First, match with an existing transaction's imported_id. This
+      // is the highest fidelity match and should always be attempted
+      // first.
       const table = reimportDeleted
         ? 'v_transactions'
         : 'v_transactions_internal';
@@ -816,7 +848,7 @@ export async function matchTransactions(
     }
 
     // If it didn't match, query data needed for fuzzy matching
-    if (!match) {
+    if (!match && !hasPinnedMatch) {
       // Fuzzy matching looks 7 days ahead and 7 days back. This
       // needs to select all fields that need to be read from the
       // matched transaction. See the final pass below for the needed

--- a/packages/loot-core/src/types/models/import-transaction.ts
+++ b/packages/loot-core/src/types/models/import-transaction.ts
@@ -44,6 +44,13 @@ export type ImportTransactionEntity = {
   /** A flag indicating if the transaction has cleared or not */
   cleared?: boolean;
 
+  /** Set by the import preview flow to pin the match decision shown in the
+   * preview: the id of the existing transaction this one matched, or null if
+   * the preview found no match. When present, importing skips the fuzzy
+   * matching for this transaction and honors the pinned decision instead.
+   * When absent, transactions are matched normally. */
+  matchedTransactionId?: string | null;
+
   /** An array of subtransactions for a split transaction.
    * Only available in get or create/import requests.
    * If amounts don't equal total amount, API call will succeed but error will show in app */

--- a/upcoming-release-notes/fix-csv-import-silent-merge.md
+++ b/upcoming-release-notes/fix-csv-import-silent-merge.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [clintharris]
+---
+
+Fix file imports silently merging new transactions that the preview showed as new, when an existing transaction had the same amount around the same date


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

File imports (CSV/OFX/QIF) can silently drop genuinely new transactions. The import preview and the actual import each run the greedy fuzzy matcher from scratch, so deselecting a row in the dialog changed what the remaining rows matched against: a row the preview showed as plain "new" could get merged into an unrelated existing transaction with the same amount within the ±7-day fuzzy-match window — with no warning, and no new row in the register.

This PR makes the import honor the preview's matching decisions. The import dialog now pins each row's previewed match (`matchedTransactionId`: the matched transaction's id, or `null` when the preview found no match) and the import uses the pin instead of re-running fuzzy matching. Callers that don't send the field (API, bank sync) keep the existing matching behavior unchanged. Amount-affecting import options (flip amount, split mode, in/out, multiplier) now also refresh the preview so pinned decisions can't go stale.

The related UX issue of the default "merge" toggle state being easy to misread as "will import" is intentionally left for a follow-up — see the discussion in the issue.

AI disclosure: a significant part of this change was written with Claude Code (Fable 5). See the agent's notes comment on this PR for design details.


## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Fixes #8464

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Reproduced the issue from #8464: an account with an existing manually-entered transaction (Netflix −8.99), then imported a CSV containing a true duplicate of it plus a different new purchase with the same amount two days away. Unchecked the duplicate in the preview and imported.

- Before: the new transaction silently vanished (merged into the existing one).
- After: the new transaction lands in the register and the existing transaction is untouched.

Also verified:

- Re-importing the same file still dedupes (no duplicate rows created).
- Leaving a matched row in its default merge state still merges, into exactly the transaction shown in the preview.
- New regression tests in `packages/loot-core/src/server/accounts/csv-import-silent-drop.test.ts` simulate the full preview → toggle-state → import pipeline (6 tests), including the API/no-pin path and a pin whose target was deleted between preview and import.
- `yarn typecheck`, `yarn lint`, and the full loot-core test suite pass.


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.21 MB → 13.21 MB (+522 B) | +0.00%
loot-core | 1 | 4.83 MB → 4.83 MB (+476 B) | +0.01%
api | 2 | 3.88 MB → 3.88 MB (+468 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.21 MB → 13.21 MB (+522 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/ImportTransactionsModal/utils.ts` | 📈 +110 B (+2.09%) | 5.14 kB → 5.25 kB
`src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx` | 📈 +412 B (+1.22%) | 33.02 kB → 33.42 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.22 MB → 5.22 MB (+522 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.84 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+476 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +476 B (+1.87%) | 24.91 kB → 25.37 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Ct6U6TKK.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dml_BZtE.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+468 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +468 B (+1.87%) | 24.41 kB → 24.87 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+468 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->