### PR TITLE
[AI] Add tooltip with status icon legend to cleared column header

### DIFF
--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -354,12 +354,12 @@ function ClearedColumnLegend() {
     {
       Icon: SvgCheckCircleHollow,
       color: theme.pageTextSubdued,
-      label: <Trans>Uncleared: not yet confirmed by your bank</Trans>,
+      label: <Trans>Uncleared: not yet verified</Trans>,
     },
     {
       Icon: SvgCheckCircle1,
       color: theme.noticeTextLight,
-      label: <Trans>Cleared: confirmed by your bank</Trans>,
+      label: <Trans>Cleared: verified against your account</Trans>,
     },
     {
       Icon: SvgLockClosed,

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -34,9 +34,14 @@ import {
   SvgCheveronDown,
 } from '@actual-app/components/icons/v1';
 import {
+  SvgAlertTriangle,
   SvgArrowsSynchronize,
   SvgCalendar3,
+  SvgCheckCircle1,
+  SvgCheckCircleHollow,
+  SvgEditSkull1,
   SvgHyperlink2,
+  SvgLockClosed,
   SvgSubtract,
 } from '@actual-app/components/icons/v2';
 import { Popover } from '@actual-app/components/popover';
@@ -327,6 +332,7 @@ const TransactionHeader = memo(
             width={38}
             alignItems="center"
             id="cleared"
+            tooltip={<ClearedColumnLegend />}
             icon={field === 'cleared' ? ascDesc : 'clickable'}
             onClick={() => {
               onSort(
@@ -342,6 +348,63 @@ const TransactionHeader = memo(
 );
 
 TransactionHeader.displayName = 'TransactionHeader';
+
+function ClearedColumnLegend() {
+  const legendItems = [
+    {
+      Icon: SvgCheckCircleHollow,
+      color: theme.pageTextSubdued,
+      label: <Trans>Uncleared: not yet confirmed by your bank</Trans>,
+    },
+    {
+      Icon: SvgCheckCircle1,
+      color: theme.noticeTextLight,
+      label: <Trans>Cleared: confirmed by your bank</Trans>,
+    },
+    {
+      Icon: SvgLockClosed,
+      color: theme.noticeTextLight,
+      label: <Trans>Reconciled: locked after reconciliation</Trans>,
+    },
+    {
+      Icon: SvgCalendar3,
+      color: theme.pageTextSubdued,
+      label: <Trans>Upcoming scheduled transaction</Trans>,
+    },
+    {
+      Icon: SvgAlertTriangle,
+      color: theme.warningText,
+      label: <Trans>Due scheduled transaction</Trans>,
+    },
+    {
+      Icon: SvgEditSkull1,
+      color: theme.errorText,
+      label: <Trans>Missed scheduled transaction</Trans>,
+    },
+  ];
+
+  return (
+    <View style={{ maxWidth: 260, padding: 4 }}>
+      <Text style={{ fontWeight: 600 }}>
+        <Trans>Transaction status</Trans>
+      </Text>
+      {legendItems.map(({ Icon, color, label }, index) => (
+        <View
+          key={index}
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 6,
+            marginTop: 6,
+          }}
+        >
+          <Icon style={{ width: 13, height: 13, color, flexShrink: 0 }} />
+          <Text>{label}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
 
 type StatusCellProps = {
   id: TransactionEntity['id'];
@@ -436,6 +499,7 @@ type HeaderCellProps = {
   value: string;
   id: string;
   icon?: 'asc' | 'desc' | 'clickable';
+  tooltip?: ReactNode;
   onClick?: () => void;
 } & Pick<CSSProperties, 'width' | 'alignItems' | 'marginLeft' | 'marginRight'>;
 
@@ -447,6 +511,7 @@ function HeaderCell({
   marginLeft,
   marginRight,
   icon,
+  tooltip,
   onClick,
 }: HeaderCellProps) {
   const style = {
@@ -469,8 +534,8 @@ function HeaderCell({
         borderTopWidth: 0,
         borderBottomWidth: 0,
       }}
-      unexposedContent={({ value: cellValue }) =>
-        onClick ? (
+      unexposedContent={({ value: cellValue }) => {
+        const content = onClick ? (
           <Button variant="bare" onPress={onClick} style={style}>
             <UnexposedCellContent value={cellValue} />
             {icon === 'asc' && (
@@ -482,8 +547,16 @@ function HeaderCell({
           </Button>
         ) : (
           <Text style={style}>{cellValue}</Text>
-        )
-      }
+        );
+
+        return tooltip ? (
+          <Tooltip content={tooltip} placement="bottom end">
+            {content}
+          </Tooltip>
+        ) : (
+          content
+        );
+      }}
     />
   );
 }

--- a/upcoming-release-notes/add-cleared-column-tooltip.md
+++ b/upcoming-release-notes/add-cleared-column-tooltip.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [rtwfroody]
+---
+
+Add a tooltip to the cleared column header explaining the transaction status icons


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

As a new user, it wasn't obvious to me what the transaction status column was for. I figured it had something to do with reconciling transactions, but the GUI wasn't helpful. This change adds a tool tip so when you hover over the column you get an explanation:

<img width="1235" height="864" alt="image" src="https://github.com/user-attachments/assets/b94f9e0f-307a-4c32-ba8f-0f73a1eef647" />

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

The changes were made by claude code, using Fable and Opus.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Run the GUI locally, and confirmed that hovering over the checkmark column header results in the explanation popping up.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.37 MB → 13.37 MB (+3.08 kB) | +0.02%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.37 MB → 13.37 MB (+3.08 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📈 +3.08 kB (+3.42%) | 90.02 kB → 93.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.23 MB → 5.23 MB (+3.08 kB) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.31 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 172.48 kB | 0%
static/js/da.js | 96.58 kB | 0%
static/js/de.js | 179.91 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.28 kB | 0%
static/js/es.js | 165.92 kB | 0%
static/js/fr.js | 167.53 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 153.37 kB | 0%
static/js/narrow.js | 367.84 kB | 0%
static/js/nb-NO.js | 137.24 kB | 0%
static/js/nl.js | 145.55 kB | 0%
static/js/pl.js | 137.76 kB | 0%
static/js/pt-BR.js | 180.63 kB | 0%
static/js/th.js | 166.6 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.62 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 108.09 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->