### PR TITLE
[AI] Fix Crossover report refresh initialization

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Crossover.test.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.test.tsx
@@ -1,0 +1,206 @@
+import { useEffect } from 'react';
+
+import type {
+  AccountEntity,
+  CategoryEntity,
+  CategoryGroupEntity,
+  CrossoverWidget,
+} from '@actual-app/core/types/models';
+import { act, render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Crossover } from './Crossover';
+
+type CategoryResult = {
+  data: {
+    grouped: CategoryGroupEntity[];
+    list: CategoryEntity[];
+  };
+  isPending: boolean;
+};
+
+const mocks = vi.hoisted(() => ({
+  categoryResult: {
+    data: { grouped: [], list: [] },
+    isPending: true,
+  } as CategoryResult,
+  categoryListeners: new Set<() => void>(),
+  createCrossoverSpreadsheet: vi.fn(() => async () => undefined),
+  send: vi.fn(async () => ({ date: '2024-01-01' })),
+}));
+
+const expenseCategory = {
+  id: 'expense-1',
+  name: 'Food',
+  is_income: false,
+  hidden: false,
+} as CategoryEntity;
+
+const incomeAccount = {
+  id: 'account-1',
+  name: 'Investment',
+} as AccountEntity;
+
+const savedWidget = {
+  id: 'widget-1',
+  type: 'crossover-card',
+  meta: {
+    expenseCategoryIds: [expenseCategory.id],
+    incomeAccountIds: [incomeAccount.id],
+  },
+} as CrossoverWidget;
+
+vi.mock('react-router', async importOriginal => ({
+  ...(await importOriginal()),
+  useParams: () => ({ id: savedWidget.id }),
+}));
+
+vi.mock('@actual-app/core/platform/client/connection', () => ({
+  send: mocks.send,
+}));
+
+vi.mock('#components/reports/spreadsheets/crossover-spreadsheet', () => ({
+  createCrossoverSpreadsheet: mocks.createCrossoverSpreadsheet,
+}));
+
+vi.mock('#components/reports/useReport', () => ({
+  useReport: (
+    _sheetName: string,
+    getData: (spreadsheet: never, setData: () => void) => Promise<void>,
+  ) => {
+    useEffect(() => {
+      void getData({} as never, vi.fn());
+    }, [getData]);
+    return null;
+  },
+}));
+
+vi.mock('#hooks/useAccounts', () => ({
+  useAccounts: () => ({ data: [incomeAccount] }),
+}));
+
+vi.mock('#hooks/useCategories', async () => {
+  const { useSyncExternalStore } = await import('react');
+  return {
+    useCategories: () =>
+      useSyncExternalStore(
+        listener => {
+          mocks.categoryListeners.add(listener);
+          return () => mocks.categoryListeners.delete(listener);
+        },
+        () => mocks.categoryResult,
+      ),
+  };
+});
+
+vi.mock('#hooks/useDashboardWidget', () => ({
+  useDashboardWidget: () => ({ data: savedWidget, isPending: false }),
+}));
+
+vi.mock('#hooks/useFormat', () => ({
+  useFormat: () => vi.fn(),
+}));
+
+vi.mock('#hooks/useLocale', async () => {
+  const { enUS } = await import('date-fns/locale');
+  return { useLocale: () => enUS };
+});
+
+vi.mock('#hooks/useNavigate', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('#notifications/notificationsSlice', () => ({
+  addNotification: vi.fn(),
+}));
+
+vi.mock('#redux', () => ({
+  useDispatch: () => vi.fn(),
+}));
+
+vi.mock('#reports/mutations', () => ({
+  useUpdateDashboardWidgetMutation: () => ({ mutate: vi.fn() }),
+}));
+
+describe('Crossover', () => {
+  beforeEach(() => {
+    savedWidget.meta = {
+      expenseCategoryIds: [expenseCategory.id],
+      incomeAccountIds: [incomeAccount.id],
+    };
+    mocks.categoryResult = {
+      data: { grouped: [], list: [] },
+      isPending: true,
+    };
+    mocks.categoryListeners.clear();
+    mocks.createCrossoverSpreadsheet.mockClear();
+    mocks.send.mockClear();
+  });
+
+  it('waits for saved selections before calculating after a refresh', async () => {
+    render(<Crossover />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      mocks.categoryResult = {
+        data: {
+          grouped: [],
+          list: [expenseCategory],
+        },
+        isPending: false,
+      };
+      mocks.categoryListeners.forEach(listener => listener());
+    });
+
+    await waitFor(() => {
+      expect(mocks.createCrossoverSpreadsheet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expenseCategoryIds: [expenseCategory.id],
+          incomeAccountIds: [incomeAccount.id],
+        }),
+      );
+    });
+
+    expect(mocks.createCrossoverSpreadsheet).not.toHaveBeenCalledWith(
+      expect.objectContaining({ expenseCategoryIds: [] }),
+    );
+  });
+
+  it('calculates with intentionally empty selections after initialization', async () => {
+    savedWidget.meta = {
+      expenseCategoryIds: [],
+      incomeAccountIds: [],
+    };
+    render(<Crossover />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(mocks.createCrossoverSpreadsheet).not.toHaveBeenCalled();
+
+    await act(async () => {
+      mocks.categoryResult = {
+        data: {
+          grouped: [],
+          list: [expenseCategory],
+        },
+        isPending: false,
+      };
+      mocks.categoryListeners.forEach(listener => listener());
+    });
+
+    await waitFor(() => {
+      expect(mocks.createCrossoverSpreadsheet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expenseCategoryIds: [],
+          incomeAccountIds: [],
+        }),
+      );
+    });
+  });
+});

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -333,8 +333,8 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
       spreadsheet: ReturnType<typeof useSpreadsheet>,
       setData: (data: CrossoverData) => void,
     ) => {
-      // Don't run if dates are not yet initialized
-      if (!start || !end) {
+      // Don't run until dates and saved selections are initialized.
+      if (!selectionsInitialized || !start || !end) {
         return;
       }
 
@@ -356,6 +356,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
     [
       start,
       end,
+      selectionsInitialized,
       swr,
       useCustomGrowth,
       estimatedReturn,

--- a/upcoming-release-notes/fix-crossover-report-refresh.md
+++ b/upcoming-release-notes/fix-crossover-report-refresh.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [niujiangren]
+---
+
+keep saved Crossover report data intact after refreshing the page


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

修复 Crossover 报表刷新页面时，已保存的类别和账户选择可能被短暂的空初始状态覆盖，导致报表显示为空的问题。

现在报表会等待日期和已保存的筛选选择全部初始化完成后再执行计算。这样既能保留刷新前的选择，也仍然支持用户有意保存空选择的情况。

此 PR 的实现与测试主要由 OpenAI Codex 协助完成；提交者已逐行复核变更，并运行了相关自动化检查。

## Related issue(s)

Fixes #8429

## Testing

- 新增回归测试：刷新后等待已保存的选择完成初始化，再创建 Crossover spreadsheet。
- 新增测试：确认有意保存的空选择在初始化后仍会正常计算。
- 本地 lint 与 typecheck 通过。
- Vitest：54 个测试文件通过，765 个测试通过，1 个跳过。

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.21 MB → 13.21 MB (+96 B) | +0.00%
loot-core | 1 | 4.83 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.21 MB → 13.21 MB (+96 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Crossover.tsx` | 📈 +96 B (+0.22%) | 42.01 kB → 42.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.28 MB → 1.28 MB (+96 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.22 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 358.81 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.84 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CYg1Q8H7.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->