### PR TITLE
[AI] Fix budget template notification translations

### DIFF
--- a/packages/desktop-client/src/budget/mutations.test.ts
+++ b/packages/desktop-client/src/budget/mutations.test.ts
@@ -1,0 +1,44 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+
+import { translateBudgetTemplateNotification } from './mutations';
+
+const t = ((key: string, options?: Record<string, unknown>) => {
+  if (!options) {
+    return `translated:${key}`;
+  }
+  return `${key}:${JSON.stringify(options)}`;
+}) as TFunction;
+
+describe('translateBudgetTemplateNotification', () => {
+  it('translates static budget template notification keys', () => {
+    expect(
+      translateBudgetTemplateNotification(
+        { message: 'templates-check-passed' },
+        t,
+      ).message,
+    ).toBe('translated:All templates passed! 🎉');
+    expect(
+      translateBudgetTemplateNotification({ message: 'template-errors' }, t)
+        .message,
+    ).toBe('translated:There were errors interpreting some templates:');
+  });
+
+  it('translates template notification counts', () => {
+    expect(
+      translateBudgetTemplateNotification(
+        { message: 'templates-applied', count: 3 },
+        t,
+      ).message,
+    ).toBe(
+      'Successfully applied templates to {{count}} categories:{"count":3}',
+    );
+  });
+
+  it('leaves non-template notifications unchanged', () => {
+    expect(
+      translateBudgetTemplateNotification({ message: 'Already translated' }, t)
+        .message,
+    ).toBe('Already translated');
+  });
+});

--- a/packages/desktop-client/src/budget/mutations.test.ts
+++ b/packages/desktop-client/src/budget/mutations.test.ts
@@ -13,6 +13,9 @@ const t = ((key: string, options?: Record<string, unknown>) => {
 
 const pluralI18n = i18next.createInstance();
 const pluralT = pluralI18n.t.bind(pluralI18n) as TFunction;
+const cleanupAppliedMessage =
+  'Successfully returned funds from $t(budget-template-source, {"count": {{sourceCount}}}) and funded $t(budget-template-sinking-fund, {"count": {{sinkCount}}}).';
+const cleanupAppliedWithErrorsMessage = `${cleanupAppliedMessage} There were errors interpreting some templates:`;
 
 beforeAll(async () => {
   await pluralI18n.init({
@@ -21,10 +24,12 @@ beforeAll(async () => {
     resources: {
       en: {
         translation: {
-          source_one: 'source',
-          source_other: 'sources',
-          'sinking fund_one': 'sinking fund',
-          'sinking fund_other': 'sinking funds',
+          'budget-template-source_one': '{{count}} source',
+          'budget-template-source_other': '{{count}} sources',
+          'budget-template-sinking-fund_one': '{{count}} sinking fund',
+          'budget-template-sinking-fund_other': '{{count}} sinking funds',
+          [cleanupAppliedMessage]: cleanupAppliedMessage,
+          [cleanupAppliedWithErrorsMessage]: cleanupAppliedWithErrorsMessage,
         },
       },
     },
@@ -64,7 +69,7 @@ describe('translateBudgetTemplateNotification', () => {
     ).toBe('Already translated');
   });
 
-  it('translates cleanup notification counts with i18next pluralization', () => {
+  it('translates cleanup notifications with i18next nesting', () => {
     const cases = [
       [
         0,
@@ -101,5 +106,18 @@ describe('translateBudgetTemplateNotification', () => {
         ).message,
       ).toBe(expected);
     }
+
+    expect(
+      translateBudgetTemplateNotification(
+        {
+          message: 'cleanup-applied-with-errors',
+          sourceCount: 1,
+          sinkCount: 2,
+        },
+        pluralT,
+      ).message,
+    ).toBe(
+      'Successfully returned funds from 1 source and funded 2 sinking funds. There were errors interpreting some templates:',
+    );
   });
 });

--- a/packages/desktop-client/src/budget/mutations.test.ts
+++ b/packages/desktop-client/src/budget/mutations.test.ts
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next';
-import { describe, expect, it } from 'vitest';
+import i18next from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { translateBudgetTemplateNotification } from './mutations';
 
@@ -9,6 +10,27 @@ const t = ((key: string, options?: Record<string, unknown>) => {
   }
   return `${key}:${JSON.stringify(options)}`;
 }) as TFunction;
+
+const pluralI18n = i18next.createInstance();
+const pluralT = pluralI18n.t.bind(pluralI18n) as TFunction;
+
+beforeAll(async () => {
+  await pluralI18n.init({
+    lng: 'en',
+    fallbackLng: false,
+    resources: {
+      en: {
+        translation: {
+          source_one: 'source',
+          source_other: 'sources',
+          'sinking fund_one': 'sinking fund',
+          'sinking fund_other': 'sinking funds',
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+  });
+});
 
 describe('translateBudgetTemplateNotification', () => {
   it('translates static budget template notification keys', () => {
@@ -40,5 +62,44 @@ describe('translateBudgetTemplateNotification', () => {
       translateBudgetTemplateNotification({ message: 'Already translated' }, t)
         .message,
     ).toBe('Already translated');
+  });
+
+  it('translates cleanup notification counts with i18next pluralization', () => {
+    const cases = [
+      [
+        0,
+        0,
+        'Successfully returned funds from 0 sources and funded 0 sinking funds.',
+      ],
+      [
+        1,
+        1,
+        'Successfully returned funds from 1 source and funded 1 sinking fund.',
+      ],
+      [
+        1,
+        2,
+        'Successfully returned funds from 1 source and funded 2 sinking funds.',
+      ],
+      [
+        2,
+        1,
+        'Successfully returned funds from 2 sources and funded 1 sinking fund.',
+      ],
+      [
+        2,
+        2,
+        'Successfully returned funds from 2 sources and funded 2 sinking funds.',
+      ],
+    ] as const;
+
+    for (const [sourceCount, sinkCount, expected] of cases) {
+      expect(
+        translateBudgetTemplateNotification(
+          { message: 'cleanup-applied', sourceCount, sinkCount },
+          pluralT,
+        ).message,
+      ).toBe(expected);
+    }
   });
 });

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -60,7 +60,7 @@ function dispatchCategoryNameAlreadyExistsNotification(
   );
 }
 
-type BudgetTemplateNotification = Notification & {
+export type BudgetTemplateNotification = Notification & {
   count?: number | undefined;
   sourceCount?: number | undefined;
   sinkCount?: number | undefined;
@@ -73,27 +73,20 @@ function formatCleanupApplied(
   const sourceCount = notification.sourceCount ?? 0;
   const sinkCount = notification.sinkCount ?? 0;
 
-  if (sourceCount === 1 && sinkCount === 1) {
-    return t(
-      'Successfully returned funds from {{sourceCount}} source and funded {{sinkCount}} sinking fund.',
-      { sourceCount, sinkCount },
-    );
-  }
-  if (sourceCount === 1) {
-    return t(
-      'Successfully returned funds from {{sourceCount}} source and funded {{sinkCount}} sinking funds.',
-      { sourceCount, sinkCount },
-    );
-  }
-  if (sinkCount === 1) {
-    return t(
-      'Successfully returned funds from {{sourceCount}} sources and funded {{sinkCount}} sinking fund.',
-      { sourceCount, sinkCount },
-    );
-  }
+  const source = t('source', {
+    count: sourceCount,
+    defaultValue_one: 'source',
+    defaultValue_other: 'sources',
+  });
+  const sink = t('sinking fund', {
+    count: sinkCount,
+    defaultValue_one: 'sinking fund',
+    defaultValue_other: 'sinking funds',
+  });
+
   return t(
-    'Successfully returned funds from {{sourceCount}} sources and funded {{sinkCount}} sinking funds.',
-    { sourceCount, sinkCount },
+    'Successfully returned funds from {{sourceCount}} {{source}} and funded {{sinkCount}} {{sink}}.',
+    { sourceCount, source, sinkCount, sink },
   );
 }
 

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -66,6 +66,9 @@ export type BudgetTemplateNotification = Notification & {
   sinkCount?: number | undefined;
 };
 
+// i18next-parser does not extract keys nested inside translation strings.
+// t('budget-template-source', { count: 1, defaultValue_one: '{{count}} source', defaultValue_other: '{{count}} sources' })
+// t('budget-template-sinking-fund', { count: 1, defaultValue_one: '{{count}} sinking fund', defaultValue_other: '{{count}} sinking funds' })
 function formatCleanupApplied(
   notification: BudgetTemplateNotification,
   t: TFunction,
@@ -73,20 +76,22 @@ function formatCleanupApplied(
   const sourceCount = notification.sourceCount ?? 0;
   const sinkCount = notification.sinkCount ?? 0;
 
-  const source = t('source', {
-    count: sourceCount,
-    defaultValue_one: 'source',
-    defaultValue_other: 'sources',
-  });
-  const sink = t('sinking fund', {
-    count: sinkCount,
-    defaultValue_one: 'sinking fund',
-    defaultValue_other: 'sinking funds',
-  });
+  return t(
+    'Successfully returned funds from $t(budget-template-source, {"count": {{sourceCount}}}) and funded $t(budget-template-sinking-fund, {"count": {{sinkCount}}}).',
+    { sourceCount, sinkCount },
+  );
+}
+
+function formatCleanupAppliedWithErrors(
+  notification: BudgetTemplateNotification,
+  t: TFunction,
+) {
+  const sourceCount = notification.sourceCount ?? 0;
+  const sinkCount = notification.sinkCount ?? 0;
 
   return t(
-    'Successfully returned funds from {{sourceCount}} {{source}} and funded {{sinkCount}} {{sink}}.',
-    { sourceCount, source, sinkCount, sink },
+    'Successfully returned funds from $t(budget-template-source, {"count": {{sourceCount}}}) and funded $t(budget-template-sinking-fund, {"count": {{sinkCount}}}). There were errors interpreting some templates:',
+    { sourceCount, sinkCount },
   );
 }
 
@@ -123,10 +128,7 @@ export function translateBudgetTemplateNotification(
     case 'cleanup-applied-with-errors':
       return {
         ...notification,
-        message: t(
-          '{{appliedMessage}} There were errors interpreting some templates:',
-          { appliedMessage: formatCleanupApplied(notification, t) },
-        ),
+        message: formatCleanupAppliedWithErrors(notification, t),
       };
     default:
       return notification;

--- a/packages/desktop-client/src/budget/mutations.ts
+++ b/packages/desktop-client/src/budget/mutations.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
+import type { Notification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 import type { AppDispatch } from '#redux/store';
 
@@ -57,6 +58,86 @@ function dispatchCategoryNameAlreadyExistsNotification(
       },
     }),
   );
+}
+
+type BudgetTemplateNotification = Notification & {
+  count?: number | undefined;
+  sourceCount?: number | undefined;
+  sinkCount?: number | undefined;
+};
+
+function formatCleanupApplied(
+  notification: BudgetTemplateNotification,
+  t: TFunction,
+) {
+  const sourceCount = notification.sourceCount ?? 0;
+  const sinkCount = notification.sinkCount ?? 0;
+
+  if (sourceCount === 1 && sinkCount === 1) {
+    return t(
+      'Successfully returned funds from {{sourceCount}} source and funded {{sinkCount}} sinking fund.',
+      { sourceCount, sinkCount },
+    );
+  }
+  if (sourceCount === 1) {
+    return t(
+      'Successfully returned funds from {{sourceCount}} source and funded {{sinkCount}} sinking funds.',
+      { sourceCount, sinkCount },
+    );
+  }
+  if (sinkCount === 1) {
+    return t(
+      'Successfully returned funds from {{sourceCount}} sources and funded {{sinkCount}} sinking fund.',
+      { sourceCount, sinkCount },
+    );
+  }
+  return t(
+    'Successfully returned funds from {{sourceCount}} sources and funded {{sinkCount}} sinking funds.',
+    { sourceCount, sinkCount },
+  );
+}
+
+export function translateBudgetTemplateNotification(
+  notification: BudgetTemplateNotification,
+  t: TFunction,
+): Notification {
+  switch (notification.message) {
+    case 'templates-up-to-date':
+      return { ...notification, message: t('Everything is up to date') };
+    case 'template-errors':
+      return {
+        ...notification,
+        message: t('There were errors interpreting some templates:'),
+      };
+    case 'templates-applied':
+      return {
+        ...notification,
+        message: t('Successfully applied templates to {{count}} categories', {
+          count: notification.count ?? 0,
+        }),
+      };
+    case 'templates-check-passed':
+      return { ...notification, message: t('All templates passed! 🎉') };
+    case 'cleanup-no-funds':
+      return { ...notification, message: t('Global: Funds not available:') };
+    case 'cleanup-up-to-date':
+      return { ...notification, message: t('All categories were up to date.') };
+    case 'cleanup-applied':
+      return {
+        ...notification,
+        message: formatCleanupApplied(notification, t),
+      };
+    case 'cleanup-applied-with-errors':
+      return {
+        ...notification,
+        message: t(
+          '{{appliedMessage}} There were errors interpreting some templates:',
+          { appliedMessage: formatCleanupApplied(notification, t) },
+        ),
+      };
+    default:
+      return notification;
+  }
 }
 
 type CreateCategoryPayload = {
@@ -824,7 +905,7 @@ export function useBudgetActions() {
       if (notification) {
         dispatch(
           addNotification({
-            notification,
+            notification: translateBudgetTemplateNotification(notification, t),
           }),
         );
       }

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -5,7 +5,6 @@ import type { CleanupTemplate } from '#types/models/cleanup-templates';
 
 import { getSheetValue, setBudget, setGoal } from './actions';
 import { storeNoteCleanups } from './cleanup-template-notes';
-import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
 import type { TemplateNotification } from './template-notification';
 
 export async function cleanupTemplate({ month }: { month: string }) {
@@ -304,26 +303,26 @@ async function processCleanup(month: string): Promise<TemplateNotification> {
       return {
         type: 'error',
         sticky: true,
-        message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
+        message: 'template-errors',
         pre: errors.join('\n\n'),
       };
     } else if (warnings.length) {
       return {
         type: 'warning',
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupNoFunds,
+        message: 'cleanup-no-funds',
         pre: warnings.join('\n\n'),
       };
     } else {
       return {
         type: 'message',
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupUpToDate,
+        message: 'cleanup-up-to-date',
       };
     }
   } else {
     if (errors.length) {
       return {
         sticky: true,
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupAppliedWithErrors,
+        message: 'cleanup-applied-with-errors',
         sourceCount: num_sources,
         sinkCount: num_sinks,
         pre: errors.join('\n\n'),
@@ -331,18 +330,18 @@ async function processCleanup(month: string): Promise<TemplateNotification> {
     } else if (warnings.length) {
       return {
         type: 'warning',
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupNoFunds,
+        message: 'cleanup-no-funds',
         pre: warnings.join('\n\n'),
       };
     } else if (budgetAvailable === 0) {
       return {
         type: 'message',
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupUpToDate,
+        message: 'cleanup-up-to-date',
       };
     } else {
       return {
         type: 'message',
-        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupApplied,
+        message: 'cleanup-applied',
         sourceCount: num_sources,
         sinkCount: num_sinks,
       };

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -5,14 +5,8 @@ import type { CleanupTemplate } from '#types/models/cleanup-templates';
 
 import { getSheetValue, setBudget, setGoal } from './actions';
 import { storeNoteCleanups } from './cleanup-template-notes';
-
-type Notification = {
-  type?: 'message' | 'error' | 'warning' | undefined;
-  pre?: string | undefined;
-  title?: string | undefined;
-  message: string;
-  sticky?: boolean | undefined;
-};
+import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
+import type { TemplateNotification } from './template-notification';
 
 export async function cleanupTemplate({ month }: { month: string }) {
   await storeNoteCleanups();
@@ -146,7 +140,7 @@ async function applyGroupCleanups(
   return warnings;
 }
 
-async function processCleanup(month: string): Promise<Notification> {
+async function processCleanup(month: string): Promise<TemplateNotification> {
   let num_sources = 0;
   let num_sinks = 0;
   let total_weight = 0;
@@ -310,46 +304,47 @@ async function processCleanup(month: string): Promise<Notification> {
       return {
         type: 'error',
         sticky: true,
-        message: 'There were errors interpreting some templates:',
+        message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
         pre: errors.join('\n\n'),
       };
     } else if (warnings.length) {
       return {
         type: 'warning',
-        message: 'Global: Funds not available:',
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupNoFunds,
         pre: warnings.join('\n\n'),
       };
     } else {
       return {
         type: 'message',
-        message: 'All categories were up to date.',
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupUpToDate,
       };
     }
   } else {
-    const applied = `Successfully returned funds from ${num_sources} ${
-      num_sources === 1 ? 'source' : 'sources'
-    } and funded ${num_sinks} sinking ${num_sinks === 1 ? 'fund' : 'funds'}.`;
     if (errors.length) {
       return {
         sticky: true,
-        message: `${applied} There were errors interpreting some templates:`,
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupAppliedWithErrors,
+        sourceCount: num_sources,
+        sinkCount: num_sinks,
         pre: errors.join('\n\n'),
       };
     } else if (warnings.length) {
       return {
         type: 'warning',
-        message: 'Global: Funds not available:',
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupNoFunds,
         pre: warnings.join('\n\n'),
       };
     } else if (budgetAvailable === 0) {
       return {
         type: 'message',
-        message: 'All categories were up to date.',
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupUpToDate,
       };
     } else {
       return {
         type: 'message',
-        message: applied,
+        message: TEMPLATE_NOTIFICATION_MESSAGES.cleanupApplied,
+        sourceCount: num_sources,
+        sinkCount: num_sinks,
       };
     }
   }

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -321,6 +321,7 @@ async function processCleanup(month: string): Promise<TemplateNotification> {
   } else {
     if (errors.length) {
       return {
+        type: 'error',
         sticky: true,
         message: 'cleanup-applied-with-errors',
         sourceCount: num_sources,

--- a/packages/loot-core/src/server/budget/goal-template.test.ts
+++ b/packages/loot-core/src/server/budget/goal-template.test.ts
@@ -337,7 +337,8 @@ describe('applyMultipleCategoryTemplates', () => {
       categoryIds: [cat1.id, cat2.id],
     });
 
-    expect(result.message).toMatch(/Successfully applied/);
+    expect(result.message).toBe('templates-applied');
+    expect(result.count).toBe(2);
     expect(actions.setBudget).toHaveBeenCalledTimes(2);
     const budgetCalls = vi
       .mocked(actions.setBudget)
@@ -414,7 +415,7 @@ describe('applyMultipleCategoryTemplates', () => {
       categoryIds: [cat1.id],
     });
 
-    expect(result.message).toMatch(/There were errors/);
+    expect(result.message).toBe('template-errors');
     expect(result.pre).toMatch(/Target month has passed/);
     expect(actions.setBudget).not.toHaveBeenCalled();
   });
@@ -434,7 +435,7 @@ describe('applyMultipleCategoryTemplates', () => {
       categoryIds: [cat1.id],
     });
 
-    expect(result.message).toBe('Everything is up to date');
+    expect(result.message).toBe('templates-up-to-date');
     const goalCalls = vi.mocked(actions.setGoal).mock.calls.map(c => c[0]);
     expect(goalCalls).toContainEqual(
       expect.objectContaining({ category: cat1.id, goal: null }),

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -12,6 +12,8 @@ import { getSheetValue, isTrackingBudget, setBudget, setGoal } from './actions';
 import { CategoryTemplateContext } from './category-template-context';
 import { tombstoneOrphanCleanupGroups } from './cleanup-groups';
 import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
+import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
+import type { TemplateNotification } from './template-notification';
 
 export function distributeRemainder(
   templateContexts: CategoryTemplateContext[],
@@ -33,14 +35,6 @@ export function distributeRemainder(
   }
   return availBudget;
 }
-
-type Notification = {
-  type?: 'message' | 'error' | 'warning' | undefined;
-  pre?: string | undefined;
-  title?: string | undefined;
-  message: string;
-  sticky?: boolean | undefined;
-};
 
 export async function storeTemplates({
   categoriesWithTemplates,
@@ -79,7 +73,7 @@ export async function applyTemplate({
   month,
 }: {
   month: string;
-}): Promise<Notification> {
+}): Promise<TemplateNotification> {
   await storeNoteTemplates();
   const categoryTemplates = await getTemplates();
   const ret = await processTemplate(month, false, categoryTemplates, []);
@@ -90,7 +84,7 @@ export async function overwriteTemplate({
   month,
 }: {
   month: string;
-}): Promise<Notification> {
+}): Promise<TemplateNotification> {
   await storeNoteTemplates();
   const categoryTemplates = await getTemplates();
   const ret = await processTemplate(month, true, categoryTemplates, []);
@@ -311,7 +305,7 @@ async function processTemplate(
   force: boolean,
   categoryTemplates: Record<CategoryEntity['id'], Template[]>,
   categories: CategoryEntity[] = [],
-): Promise<Notification> {
+): Promise<TemplateNotification> {
   const { contexts, errors, orphanGoals } = await computeTemplates(
     month,
     force,
@@ -325,13 +319,13 @@ async function processTemplate(
     }
     return {
       type: 'message',
-      message: 'Everything is up to date',
+      message: TEMPLATE_NOTIFICATION_MESSAGES.templatesUpToDate,
     };
   }
   if (errors.length > 0) {
     return {
       sticky: true,
-      message: 'There were errors interpreting some templates:',
+      message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
       pre: errors.join(`\n\n`),
     };
   }
@@ -355,7 +349,8 @@ async function processTemplate(
 
   return {
     type: 'message',
-    message: `Successfully applied templates to ${contexts.length} categories`,
+    message: TEMPLATE_NOTIFICATION_MESSAGES.templatesApplied,
+    count: contexts.length,
   };
 }
 

--- a/packages/loot-core/src/server/budget/goal-template.ts
+++ b/packages/loot-core/src/server/budget/goal-template.ts
@@ -12,7 +12,6 @@ import { getSheetValue, isTrackingBudget, setBudget, setGoal } from './actions';
 import { CategoryTemplateContext } from './category-template-context';
 import { tombstoneOrphanCleanupGroups } from './cleanup-groups';
 import { checkTemplateNotes, storeNoteTemplates } from './template-notes';
-import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
 import type { TemplateNotification } from './template-notification';
 
 export function distributeRemainder(
@@ -319,13 +318,13 @@ async function processTemplate(
     }
     return {
       type: 'message',
-      message: TEMPLATE_NOTIFICATION_MESSAGES.templatesUpToDate,
+      message: 'templates-up-to-date',
     };
   }
   if (errors.length > 0) {
     return {
       sticky: true,
-      message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
+      message: 'template-errors',
       pre: errors.join(`\n\n`),
     };
   }
@@ -349,7 +348,7 @@ async function processTemplate(
 
   return {
     type: 'message',
-    message: TEMPLATE_NOTIFICATION_MESSAGES.templatesApplied,
+    message: 'templates-applied',
     count: contexts.length,
   };
 }

--- a/packages/loot-core/src/server/budget/template-notes.test.ts
+++ b/packages/loot-core/src/server/budget/template-notes.test.ts
@@ -268,7 +268,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         type: 'message',
-        message: 'All templates passed! 🎉',
+        message: 'templates-check-passed',
       },
     },
     {
@@ -283,7 +283,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         type: 'message',
-        message: 'All templates passed! 🎉',
+        message: 'templates-check-passed',
       },
     },
     {
@@ -298,7 +298,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         sticky: true,
-        message: 'There were errors interpreting some templates:',
+        message: 'template-errors',
         pre: 'Category 1: #template broken template',
       },
     },
@@ -314,7 +314,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         sticky: true,
-        message: 'There were errors interpreting some templates:',
+        message: 'template-errors',
         pre: 'Category 1: Schedule "Non-existent Schedule" does not exist',
       },
     },
@@ -330,7 +330,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         sticky: true,
-        message: 'There were errors interpreting some templates:',
+        message: 'template-errors',
         pre: 'Category 1: #template schedule Mock Schedule 1 [increase 1001%]\nError: Invalid adjustment percentage (1001%). Must be between -100% and 1000%',
       },
     },
@@ -346,7 +346,7 @@ describe('checkTemplates', () => {
       mockSchedules: mockSchedules(),
       expected: {
         sticky: true,
-        message: 'There were errors interpreting some templates:',
+        message: 'template-errors',
         pre: 'Category 1: #template schedule Mock Schedule 1 [decrease 101%]\nError: Invalid adjustment percentage (-101%). Must be between -100% and 1000%',
       },
     },

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -8,13 +8,8 @@ import {
   resetCategoryGoalDefsWithNoTemplates,
 } from './statements';
 import type { CategoryWithTemplateNote } from './statements';
-
-type Notification = {
-  type?: 'message' | 'error' | 'warning' | undefined;
-  pre?: string | undefined;
-  message: string;
-  sticky?: boolean | undefined;
-};
+import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
+import type { TemplateNotification } from './template-notification';
 
 export const TEMPLATE_PREFIX = '#template';
 export const GOAL_PREFIX = '#goal';
@@ -36,7 +31,7 @@ type CategoryWithTemplateNotes = {
   templates: Template[];
 };
 
-export async function checkTemplateNotes(): Promise<Notification> {
+export async function checkTemplateNotes(): Promise<TemplateNotification> {
   const categoryWithTemplates = await getCategoriesWithTemplates();
   const schedules = await getActiveSchedules();
   const scheduleNames = schedules.map(({ name }) => name);
@@ -64,14 +59,14 @@ export async function checkTemplateNotes(): Promise<Notification> {
   if (errors.length) {
     return {
       sticky: true,
-      message: 'There were errors interpreting some templates:',
+      message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
       pre: errors.join('\n\n'),
     };
   }
 
   return {
     type: 'message',
-    message: 'All templates passed! 🎉',
+    message: TEMPLATE_NOTIFICATION_MESSAGES.templatesCheckPassed,
   };
 }
 

--- a/packages/loot-core/src/server/budget/template-notes.ts
+++ b/packages/loot-core/src/server/budget/template-notes.ts
@@ -8,7 +8,6 @@ import {
   resetCategoryGoalDefsWithNoTemplates,
 } from './statements';
 import type { CategoryWithTemplateNote } from './statements';
-import { TEMPLATE_NOTIFICATION_MESSAGES } from './template-notification';
 import type { TemplateNotification } from './template-notification';
 
 export const TEMPLATE_PREFIX = '#template';
@@ -59,14 +58,14 @@ export async function checkTemplateNotes(): Promise<TemplateNotification> {
   if (errors.length) {
     return {
       sticky: true,
-      message: TEMPLATE_NOTIFICATION_MESSAGES.templateErrors,
+      message: 'template-errors',
       pre: errors.join('\n\n'),
     };
   }
 
   return {
     type: 'message',
-    message: TEMPLATE_NOTIFICATION_MESSAGES.templatesCheckPassed,
+    message: 'templates-check-passed',
   };
 }
 

--- a/packages/loot-core/src/server/budget/template-notification.ts
+++ b/packages/loot-core/src/server/budget/template-notification.ts
@@ -1,0 +1,24 @@
+export const TEMPLATE_NOTIFICATION_MESSAGES = {
+  templatesUpToDate: 'templates-up-to-date',
+  templateErrors: 'template-errors',
+  templatesApplied: 'templates-applied',
+  templatesCheckPassed: 'templates-check-passed',
+  cleanupNoFunds: 'cleanup-no-funds',
+  cleanupUpToDate: 'cleanup-up-to-date',
+  cleanupApplied: 'cleanup-applied',
+  cleanupAppliedWithErrors: 'cleanup-applied-with-errors',
+} as const;
+
+export type TemplateNotificationMessage =
+  (typeof TEMPLATE_NOTIFICATION_MESSAGES)[keyof typeof TEMPLATE_NOTIFICATION_MESSAGES];
+
+export type TemplateNotification = {
+  type?: 'message' | 'error' | 'warning' | undefined;
+  pre?: string | undefined;
+  title?: string | undefined;
+  message: TemplateNotificationMessage;
+  sticky?: boolean | undefined;
+  count?: number | undefined;
+  sourceCount?: number | undefined;
+  sinkCount?: number | undefined;
+};

--- a/packages/loot-core/src/server/budget/template-notification.ts
+++ b/packages/loot-core/src/server/budget/template-notification.ts
@@ -1,16 +1,12 @@
-export const TEMPLATE_NOTIFICATION_MESSAGES = {
-  templatesUpToDate: 'templates-up-to-date',
-  templateErrors: 'template-errors',
-  templatesApplied: 'templates-applied',
-  templatesCheckPassed: 'templates-check-passed',
-  cleanupNoFunds: 'cleanup-no-funds',
-  cleanupUpToDate: 'cleanup-up-to-date',
-  cleanupApplied: 'cleanup-applied',
-  cleanupAppliedWithErrors: 'cleanup-applied-with-errors',
-} as const;
-
 export type TemplateNotificationMessage =
-  (typeof TEMPLATE_NOTIFICATION_MESSAGES)[keyof typeof TEMPLATE_NOTIFICATION_MESSAGES];
+  | 'templates-up-to-date'
+  | 'template-errors'
+  | 'templates-applied'
+  | 'templates-check-passed'
+  | 'cleanup-no-funds'
+  | 'cleanup-up-to-date'
+  | 'cleanup-applied'
+  | 'cleanup-applied-with-errors';
 
 export type TemplateNotification = {
   type?: 'message' | 'error' | 'warning' | undefined;

--- a/upcoming-release-notes/translate-budget-template-notifications.md
+++ b/upcoming-release-notes/translate-budget-template-notifications.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [DarthAmk97]
+---
+
+Translate budget template action notifications.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Budget template actions were returning English notification strings from `loot-core`, so the desktop client could only display them as-is.

This changes the server side to return stable notification keys plus the small bits of data the UI needs, like counts. The desktop client then maps those keys to normal translatable strings before showing the notification.

This follows the direction discussed on the existing PRs for #8413: keep i18n string extraction in the client instead of trying to make dynamic server strings translatable.

AI-assisted implementation drafted with Codex, then reviewed and edited before submission.

## Related issue(s)

Fixes #8413

## Testing

Tested locally:

- `corepack yarn generate:i18n`
- `corepack yarn workspace @actual-app/core test:node src/server/budget/goal-template.test.ts src/server/budget/template-notes.test.ts`
- `corepack yarn workspace @actual-app/web test src/budget/mutations.test.ts`
- `corepack yarn exec oxfmt --check ...`
- `corepack yarn exec oxlint --type-aware --quiet ...`
- `corepack yarn workspace @actual-app/core typecheck`
- `corepack yarn workspace @actual-app/web typecheck`

Also verified the PR diff only includes the intended budget-template notification files and release note.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (+1.82 kB) | +0.01%
loot-core | 1 | 4.83 MB → 4.83 MB (-275 B) | -0.01%
api | 2 | 3.88 MB → 3.88 MB (-278 B) | -0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (+1.82 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/budget/mutations.ts` | 📈 +1.82 kB (+13.89%) | 13.08 kB → 14.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.28 MB → 5.28 MB (+1.82 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (-275 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📉 -35 B (-0.48%) | 7.15 kB → 7.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📉 -54 B (-0.73%) | 7.24 kB → 7.19 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📉 -186 B (-2.24%) | 8.1 kB → 7.92 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BybqcATr.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (-278 B) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/template-notes.ts` | 📉 -35 B (-0.49%) | 6.96 kB → 6.93 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/goal-template.ts` | 📉 -55 B (-0.76%) | 7.07 kB → 7.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📉 -188 B (-2.33%) | 7.89 kB → 7.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (-278 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->