### PR TITLE
[AI] Fix budget keyboard navigation across hidden categories

### DIFF
--- a/packages/desktop-client/e2e/budget.test.ts
+++ b/packages/desktop-client/e2e/budget.test.ts
@@ -59,6 +59,60 @@ test.describe('Budget', () => {
     });
   });
 
+  test('enter skips hidden categories when moving to the next budget cell', async () => {
+    await page.evaluate(async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const $send = (window as any).$send as (
+        type: string,
+        args?: unknown,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ) => Promise<any>;
+      const { grouped } = await $send('get-categories');
+      const medicalCategory = grouped
+        .flatMap(
+          (group: { categories?: Array<{ name: string }> }) =>
+            group.categories || [],
+        )
+        .find((category: { name: string }) => category.name === 'Medical');
+
+      if (!medicalCategory) {
+        throw new Error('Medical category not found');
+      }
+
+      await $send('category-update', {
+        ...medicalCategory,
+        hidden: true,
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (window as any).__TANSTACK_QUERY_CLIENT__.invalidateQueries({
+        queryKey: ['categories', 'lists'],
+      });
+    });
+
+    await expect(page.getByText('Medical', { exact: true })).toBeHidden();
+
+    const giftBudget = budgetPage.budgetTable
+      .getByTestId('row')
+      .filter({ hasText: 'Gift' })
+      .first()
+      .getByTestId('budget')
+      .first();
+    await giftBudget.click();
+    const giftInput = giftBudget.locator('input');
+    await giftInput.fill('10');
+    await giftInput.press('Enter');
+
+    const savingsInput = budgetPage.budgetTable
+      .getByTestId('row')
+      .filter({ hasText: 'Savings' })
+      .first()
+      .getByTestId('budget')
+      .first()
+      .locator('input');
+    await expect(savingsInput).toBeVisible();
+    await expect(savingsInput).toBeFocused();
+  });
+
   test('clicking on spent amounts opens a transaction page', async () => {
     const accountPage = await budgetPage.clickOnSpentAmountForRow(1);
     expect(page.url()).toContain('/accounts');

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -164,40 +164,29 @@ export function BudgetTable(props: BudgetTableProps) {
   };
 
   const moveVertically = (dir: 1 | -1) => {
-    const flattened = categoryGroups.reduce(
-      (all, group) => {
-        if (collapsedGroupIds.includes(group.id)) {
-          return all.concat({ id: group.id, isGroup: true });
-        }
-        return all.concat([
-          { id: group.id, isGroup: true },
-          ...(group?.categories || []),
-        ]);
-      },
-      [] as Array<
-        { id: CategoryGroupEntity['id']; isGroup: boolean } | CategoryEntity
-      >,
-    );
+    const navigableCategories = categoryGroups.flatMap(group => {
+      const isHiddenExpenseGroup =
+        !group.is_income && group.hidden && !showHiddenCategories;
+
+      if (collapsedGroupIds.includes(group.id) || isHiddenExpenseGroup) {
+        return [];
+      }
+
+      return (group.categories || []).filter(
+        category =>
+          (showHiddenCategories || !category.hidden) &&
+          (type === 'tracking' || !category.is_income),
+      );
+    });
 
     if (editing) {
-      const idx = flattened.findIndex(item => item.id === editing.id);
-      let nextIdx = idx + dir;
+      const idx = navigableCategories.findIndex(
+        category => category.id === editing.id,
+      );
+      const next = navigableCategories[idx + dir];
 
-      while (nextIdx >= 0 && nextIdx < flattened.length) {
-        const next = flattened[nextIdx];
-
-        if ('isGroup' in next && next.isGroup) {
-          nextIdx += dir;
-          continue;
-        } else if (
-          type === 'tracking' ||
-          ('is_income' in next && !next.is_income)
-        ) {
-          onEditMonth(next.id, editing.cell);
-          return;
-        } else {
-          break;
-        }
+      if (next) {
+        onEditMonth(next.id, editing.cell);
       }
     }
   };

--- a/upcoming-release-notes/fix-budget-enter-navigation.md
+++ b/upcoming-release-notes/fix-budget-enter-navigation.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [iamdhrv]
+---
+
+Fix Enter and Tab navigation stopping at hidden budget categories


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (-53 B) | -0.00%
loot-core | 1 | 4.83 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (-53 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/BudgetTable.tsx` | 📉 -53 B (-0.47%) | 10.97 kB → 10.92 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 304.69 kB → 304.64 kB (-53 B) | -0.02%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.28 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->