### PR TITLE
[AI] Fix running balance updates after transaction edits

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -42,6 +42,30 @@ test.describe('Accounts', () => {
     await expect(page).toMatchThemeScreenshots();
   });
 
+  test('updates the running balance after editing a transaction', async () => {
+    accountPage = await navigation.createAccount({
+      name: 'Running Balance',
+      offBudget: false,
+      balance: 100,
+    });
+    await accountPage.createSingleTransaction({
+      payee: '',
+      debit: '10.00',
+    });
+
+    await accountPage.accountMenuButton.click();
+    await page.getByRole('button', { name: 'Show running balance' }).click();
+
+    const transaction = accountPage.getNthTransaction(0);
+    await expect(transaction.balance).toHaveText('90.00');
+
+    await transaction.debit.click();
+    await transaction.debit.getByRole('textbox').fill('20.00');
+    await page.keyboard.press('Tab');
+
+    await expect(transaction.balance).toHaveText('80.00');
+  });
+
   test('closes an account', async () => {
     accountPage = await navigation.goToAccountPage('Roth IRA');
 

--- a/packages/desktop-client/e2e/page-models/account-page.ts
+++ b/packages/desktop-client/e2e/page-models/account-page.ts
@@ -159,6 +159,7 @@ export class AccountPage {
       category: row.getByTestId('category'),
       debit: row.getByTestId('debit'),
       credit: row.getByTestId('credit'),
+      balance: row.getByTestId('balance'),
     };
   }
 

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -655,9 +655,9 @@ class AccountInternal extends PureComponent<
   };
 
   onTransactionsChange = (updatedTransaction: TransactionEntity) => {
-    // Apply changes to pagedQuery data optimistically. Set the flag so that
-    // onData skips the expensive aggregate DB queries for this update.
-    this._isOptimisticUpdate = true;
+    // Apply changes to pagedQuery data optimistically. Skip the aggregate DB
+    // queries unless running balances need to stay in sync with the edit.
+    this._isOptimisticUpdate = !this.state.showBalances;
     this.paged?.optimisticUpdate(data => {
       if (updatedTransaction._deleted) {
         return data.filter(t => t.id !== updatedTransaction.id);

--- a/upcoming-release-notes/fix-running-balance-transaction-edit.md
+++ b/upcoming-release-notes/fix-running-balance-transaction-edit.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Sushanth012]
+---
+
+Update running balances immediately after editing a transaction


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

修复编辑现有交易后运行余额保持旧值的问题。显示运行余额时，交易的乐观更新现在会重新执行余额聚合查询；隐藏该列时，原有的快速更新路径保持不变。

新增端到端回归测试，覆盖借记金额从 10.00 修改为 20.00 后运行余额从 90.00 更新为 80.00 的场景。

本次实现由 OpenCode 人工智能代理生成并进行自我审查。

## Related issue(s)

修复 #8475

## Testing

- `yarn typecheck`
- `yarn workspace @actual-app/web build:browser`
- 对变更文件运行 `oxfmt --check` 和 `oxlint --type-aware`
- Playwright 已成功发现新增测试；本地完整执行在 Windows 环境的测试文件创建步骤超时，因此等待持续集成环境完成端到端验证

## Checklist

- [x] 已添加发布说明
- [x] 受影响区域没有明显回归
- [x] 已完成自我审查，并理解每一处变更的目的

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (+20 B) | +0.00%
loot-core | 1 | 4.83 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (+20 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Account.tsx` | 📈 +20 B (+0.04%) | 44.27 kB → 44.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 304.69 kB → 304.71 kB (+20 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.28 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->