### PR TITLE
[WIP] [AI] Fix stale running balances after transaction edits

### DIFF
--- a/packages/desktop-client/e2e/accounts.test.ts
+++ b/packages/desktop-client/e2e/accounts.test.ts
@@ -76,6 +76,43 @@ test.describe('Accounts', () => {
     await expect(menu.getByRole('button', { name: 'Delete' })).toBeVisible();
   });
 
+  test('updates the running balance after editing a transaction amount', async () => {
+    accountPage = await navigation.createAccount({
+      name: 'Running Balance',
+      offBudget: false,
+      balance: 100,
+    });
+    await accountPage.createSingleTransaction({
+      notes: 'running balance edit',
+      debit: '10.00',
+    });
+    await accountPage.createSingleTransaction({
+      notes: 'newer transaction',
+      debit: '5.00',
+    });
+
+    await accountPage.accountMenuButton.click();
+    await page.getByRole('button', { name: 'Show running balance' }).click();
+
+    const transaction = accountPage.transactionTableRow.filter({
+      hasText: 'running balance edit',
+    });
+    const newerTransaction = accountPage.transactionTableRow.filter({
+      hasText: 'newer transaction',
+    });
+    await expect(transaction.getByTestId('balance')).toHaveText('90.00');
+    await expect(newerTransaction.getByTestId('balance')).toHaveText('85.00');
+
+    const debitCell = transaction.getByTestId('debit');
+    await debitCell.click();
+    const debitInput = debitCell.getByRole('textbox');
+    await debitInput.fill('25.00');
+    await debitInput.press('Tab');
+
+    await expect(transaction.getByTestId('balance')).toHaveText('75.00');
+    await expect(newerTransaction.getByTestId('balance')).toHaveText('70.00');
+  });
+
   test('shift-click range selection skips hidden reconciled transactions', async () => {
     accountPage = await navigation.createAccount({
       name: 'Range Select',

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -206,6 +206,45 @@ function getField(field?: string) {
   }
 }
 
+function updateRunningBalancesAfterAmountChange(
+  balances: Record<TransactionEntity['id'], IntegerAmount> | null,
+  transactions: readonly TransactionEntity[],
+  updatedTransaction: TransactionEntity,
+) {
+  if (!balances) {
+    return balances;
+  }
+
+  const updatedIndex = transactions.findIndex(
+    transaction => transaction.id === updatedTransaction.id,
+  );
+  if (updatedIndex === -1) {
+    return balances;
+  }
+
+  const previousAmount = transactions[updatedIndex].amount;
+  const updatedAmount = updatedTransaction._deleted
+    ? 0
+    : updatedTransaction.amount;
+  const amountDelta = updatedAmount - previousAmount;
+  if (amountDelta === 0) {
+    return balances;
+  }
+
+  const updatedBalances = { ...balances };
+  for (const transaction of transactions.slice(0, updatedIndex + 1)) {
+    if (Object.hasOwn(updatedBalances, transaction.id)) {
+      updatedBalances[transaction.id] += amountDelta;
+    }
+  }
+
+  if (updatedTransaction._deleted) {
+    delete updatedBalances[updatedTransaction.id];
+  }
+
+  return updatedBalances;
+}
+
 type AccountInternalProps = {
   accountId?:
     | AccountEntity['id']
@@ -304,6 +343,10 @@ class AccountInternal extends PureComponent<
   unlisten?: () => void;
   dispatchSelected?: (action: Actions) => void;
   _isOptimisticUpdate: boolean = false;
+  _optimisticBalances:
+    | Record<TransactionEntity['id'], IntegerAmount>
+    | null
+    | undefined;
 
   constructor(props: AccountInternalProps) {
     super(props);
@@ -492,6 +535,10 @@ class AccountInternal extends PureComponent<
         if (this._isOptimisticUpdate) {
           this._isOptimisticUpdate = false;
           const transactionsSnapshot = data;
+          const balancesSnapshot =
+            this._optimisticBalances === undefined
+              ? this.state.balances
+              : this._optimisticBalances;
           // Wrap in startTransition so React treats this as a low-priority
           // update. Without this, setState blocks the main thread for the
           // full duration of the re-render (~40–220ms with large transaction
@@ -500,7 +547,17 @@ class AccountInternal extends PureComponent<
           // into chunks and yield to the browser between them, keeping the
           // UI responsive while the row update happens in the background.
           startTransition(() => {
-            this.setState({ transactions: transactionsSnapshot });
+            this.setState(
+              {
+                transactions: transactionsSnapshot,
+                balances: balancesSnapshot,
+              },
+              () => {
+                if (this._optimisticBalances === balancesSnapshot) {
+                  this._optimisticBalances = undefined;
+                }
+              },
+            );
           });
           return;
         }
@@ -659,6 +716,16 @@ class AccountInternal extends PureComponent<
     // onData skips the expensive aggregate DB queries for this update.
     this._isOptimisticUpdate = true;
     this.paged?.optimisticUpdate(data => {
+      const currentBalances =
+        this._optimisticBalances === undefined
+          ? this.state.balances
+          : this._optimisticBalances;
+      this._optimisticBalances = updateRunningBalancesAfterAmountChange(
+        currentBalances,
+        data,
+        updatedTransaction,
+      );
+
       if (updatedTransaction._deleted) {
         return data.filter(t => t.id !== updatedTransaction.id);
       } else {

--- a/upcoming-release-notes/8482.md
+++ b/upcoming-release-notes/8482.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [iamdhrv]
+---
+
+Fix running balances not updating immediately after editing a transaction amount.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (+1.29 kB) | +0.01%
loot-core | 1 | 4.83 MB | 0%
api | 2 | 3.88 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (+1.29 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Account.tsx` | 📈 +1.29 kB (+2.90%) | 44.27 kB → 45.56 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 304.69 kB → 305.98 kB (+1.29 kB) | +0.42%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.28 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->