### PR TITLE
[WIP] Widget Duplicating with right-click menu

### DIFF
--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -52,6 +52,8 @@ test.describe('Reports', () => {
     const menu = page.getByRole('menu');
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Rename' })).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Duplicate to dashboard' })).toBeVisible();
+    await expect(menu.getByRole('button', { name: 'Copy to dashboard' })).toBeVisible();
   });
 
   test('loads net worth graph and checks visuals', async () => {

--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -52,8 +52,12 @@ test.describe('Reports', () => {
     const menu = page.getByRole('menu');
     await expect(menu).toBeVisible();
     await expect(menu.getByRole('button', { name: 'Rename' })).toBeVisible();
-    await expect(menu.getByRole('button', { name: 'Duplicate to dashboard' })).toBeVisible();
-    await expect(menu.getByRole('button', { name: 'Copy to dashboard' })).toBeVisible();
+    await expect(
+      menu.getByRole('button', { name: 'Duplicate to dashboard' }),
+    ).toBeVisible();
+    await expect(
+      menu.getByRole('button', { name: 'Copy to dashboard' }),
+    ).toBeVisible();
   });
 
   test('loads net worth graph and checks visuals', async () => {

--- a/packages/desktop-client/src/components/modals/CopyWidgetToDashboardModal.tsx
+++ b/packages/desktop-client/src/components/modals/CopyWidgetToDashboardModal.tsx
@@ -16,6 +16,7 @@ type CopyWidgetToDashboardModalProps = Extract<
 >['options'];
 
 export function CopyWidgetToDashboardModal({
+  title,
   onSelect,
 }: CopyWidgetToDashboardModalProps) {
   const { t } = useTranslation();
@@ -31,7 +32,7 @@ export function CopyWidgetToDashboardModal({
       {({ state }) => (
         <>
           <ModalHeader
-            title={t('Copy to dashboard')}
+            title={title ?? t('Copy to dashboard')}
             rightContent={<ModalCloseButton onPress={() => state.close()} />}
           />
 

--- a/packages/desktop-client/src/components/reports/ReportCard.tsx
+++ b/packages/desktop-client/src/components/reports/ReportCard.tsx
@@ -15,6 +15,7 @@ import { pushModal } from '#modals/modalsSlice';
 import { useDispatch } from '#redux';
 import {
   useCopyDashboardWidgetMutation,
+  useDuplicateDashboardWidgetMutation,
   useRemoveDashboardWidgetMutation,
 } from '#reports/mutations';
 
@@ -152,6 +153,8 @@ function Layout({
 
   const removeDashboardWidgetMutation = useRemoveDashboardWidgetMutation();
   const copyDashboardWidgetMutation = useCopyDashboardWidgetMutation();
+  const duplicateDashboardWidgetMutation =
+    useDuplicateDashboardWidgetMutation();
 
   useContextMenu({
     triggerRef: viewRef,
@@ -179,6 +182,29 @@ function Layout({
                 options: {
                   onSelect: targetDashboardId => {
                     copyDashboardWidgetMutation.mutate({
+                      id: widgetId,
+                      targetDashboardPageId: targetDashboardId,
+                    });
+                  },
+                },
+              },
+            }),
+          );
+        },
+        order: 1,
+      },
+      {
+        name: 'duplicate',
+        text: t('Duplicate to dashboard'),
+        onClick: () => {
+          dispatch(
+            pushModal({
+              modal: {
+                name: 'copy-widget-to-dashboard',
+                options: {
+                  title: t('Duplicate to dashboard'),
+                  onSelect: targetDashboardId => {
+                    duplicateDashboardWidgetMutation.mutate({
                       id: widgetId,
                       targetDashboardPageId: targetDashboardId,
                     });

--- a/packages/desktop-client/src/components/reports/useDashboardWidgetCopyMenu.ts
+++ b/packages/desktop-client/src/components/reports/useDashboardWidgetCopyMenu.ts
@@ -13,9 +13,13 @@ type DashboardWidgetCopyMenuResult = {
   handleMenuSelect: (item: string) => boolean;
 };
 
-export function useDashboardWidgetCopyMenu(
-  onCopy: (targetDashboardId: string) => void,
-): DashboardWidgetCopyMenuResult {
+export function useDashboardWidgetCopyMenu({
+  onCopy,
+  onDuplicate,
+}: {
+  onCopy: (targetDashboardId: string) => void;
+  onDuplicate: (targetDashboardId: string) => void;
+}): DashboardWidgetCopyMenuResult {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
@@ -23,6 +27,10 @@ export function useDashboardWidgetCopyMenu(
     {
       name: 'copy-to-dashboard',
       text: t('Copy to dashboard'),
+    },
+    {
+      name: 'duplicate-to-dashboard',
+      text: t('Duplicate to dashboard'),
     },
   ];
 
@@ -36,6 +44,21 @@ export function useDashboardWidgetCopyMenu(
               options: {
                 onSelect: targetDashboardId => {
                   onCopy(targetDashboardId);
+                },
+              },
+            },
+          }),
+        );
+        return true;
+      case 'duplicate-to-dashboard':
+        dispatch(
+          pushModal({
+            modal: {
+              name: 'copy-widget-to-dashboard',
+              options: {
+                title: t('Duplicate to dashboard'),
+                onSelect: targetDashboardId => {
+                  onDuplicate(targetDashboardId);
                 },
               },
             },

--- a/packages/desktop-client/src/modals/modalsSlice.ts
+++ b/packages/desktop-client/src/modals/modalsSlice.ts
@@ -590,6 +590,7 @@ export type Modal =
   | {
       name: 'copy-widget-to-dashboard';
       options: {
+        title?: string;
         onSelect: (dashboardId: string) => void;
       };
     }

--- a/packages/desktop-client/src/reports/mutations.ts
+++ b/packages/desktop-client/src/reports/mutations.ts
@@ -381,6 +381,40 @@ export function useCopyDashboardWidgetMutation() {
   });
 }
 
+type DuplicateDashboardWidgetMutationPayload = {
+  id: DashboardWidgetEntity['id'];
+  targetDashboardPageId: DashboardPageEntity['id'];
+};
+
+export function useDuplicateDashboardWidgetMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({
+      id,
+      targetDashboardPageId,
+    }: DuplicateDashboardWidgetMutationPayload) => {
+      return await sendThrow('dashboard-duplicate-widget', {
+        id,
+        targetDashboardPageId,
+      });
+    },
+    onSuccess: () => invalidateDashboardQueries(queryClient),
+    onError: error => {
+      console.error('Error duplicating dashboard widget:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t(
+          'There was an error duplicating the dashboard widget. Please try again.',
+        ),
+        error,
+      );
+    },
+  });
+}
+
 type ImportDashboardPageMutationPayload = {
   filePath: string;
   dashboardPageId: DashboardPageEntity['id'];

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -15,6 +15,7 @@ import { undoable } from '#server/undo';
 import { DEFAULT_DASHBOARD_STATE } from '#shared/dashboard';
 import { q } from '#shared/query';
 import type {
+  CustomReportData,
   DashboardWidgetEntity,
   ExportImportCustomReportWidget,
   ExportImportDashboard,
@@ -223,6 +224,106 @@ async function removeDashboardWidget(widgetId: string) {
   await db.delete_('dashboard', widgetId);
 }
 
+async function uniqueReportName(baseName: string): Promise<string> {
+  let idx = 1;
+  let newName = baseName;
+
+  while (true) {
+    const existing = await db.first<Pick<db.DbCustomReport, 'id'>>(
+      'SELECT id from custom_reports WHERE tombstone = 0 AND name = ?',
+      [newName],
+    );
+
+    if (!existing) {
+      return newName;
+    }
+
+    newName = `${baseName} ${idx}`;
+    idx++;
+  }
+}
+
+function duplicateWidgetMeta(
+  meta: Record<string, unknown>,
+): Record<string, unknown> {
+  const clonedMeta = JSON.parse(JSON.stringify(meta)) as Record<
+    string,
+    unknown
+  >;
+
+  if (typeof clonedMeta.name === 'string' && clonedMeta.name) {
+    clonedMeta.name = `${clonedMeta.name} (Duplicate)`;
+  }
+
+  return clonedMeta;
+}
+
+async function duplicateDashboardWidget({
+  id,
+  targetDashboardPageId,
+}: {
+  id: string;
+  targetDashboardPageId: string;
+}) {
+  const widget = await db.first<db.DbDashboard>(
+    'SELECT * FROM dashboard WHERE id = ? AND tombstone = 0',
+    [id],
+  );
+
+  if (!widget) {
+    throw new Error(`Widget not found: ${id}`);
+  }
+
+  const widgetType = widget.type;
+  if (!isWidgetType(widgetType)) {
+    throw new Error(`Unsupported widget type: ${widgetType}`);
+  }
+
+  const meta = widget.meta ? JSON.parse(widget.meta) : {};
+
+  await batchMessages(async () => {
+    let newMeta = duplicateWidgetMeta(meta);
+
+    if (widget.type === 'custom-report') {
+      const { data: reports }: { data: CustomReportData[] } = await aqlQuery(
+        q('custom_reports')
+          .filter({ id: meta.id as string })
+          .select('*'),
+      );
+      const report = reports[0];
+
+      if (!report) {
+        throw new Error(`Custom report not found: ${meta.id}`);
+      }
+
+      const reportEntity = reportModel.toJS(report);
+      const newReportId = uuidv4();
+      const newName = await uniqueReportName(
+        `${reportEntity.name} (Duplicate)`,
+      );
+
+      await db.insertWithSchema(
+        'custom_reports',
+        reportModel.fromJS({
+          ...reportEntity,
+          id: newReportId,
+          name: newName,
+        }),
+      );
+
+      newMeta = { id: newReportId };
+    }
+
+    await addDashboardWidget({
+      type: widgetType,
+      width: widget.width,
+      height: widget.height,
+      meta: newMeta,
+      dashboard_page_id: targetDashboardPageId,
+    });
+  });
+}
+
 async function copyDashboardWidget({
   id,
   targetDashboardPageId,
@@ -361,6 +462,7 @@ export type DashboardHandlers = {
   'dashboard-add-widget': typeof addDashboardWidget;
   'dashboard-remove-widget': typeof removeDashboardWidget;
   'dashboard-copy-widget': typeof copyDashboardWidget;
+  'dashboard-duplicate-widget': typeof duplicateDashboardWidget;
   'dashboard-import': typeof importDashboard;
 };
 
@@ -375,4 +477,8 @@ app.method('dashboard-reset', mutator(undoable(resetDashboard)));
 app.method('dashboard-add-widget', mutator(undoable(addDashboardWidget)));
 app.method('dashboard-remove-widget', mutator(undoable(removeDashboardWidget)));
 app.method('dashboard-copy-widget', mutator(undoable(copyDashboardWidget)));
+app.method(
+  'dashboard-duplicate-widget',
+  mutator(undoable(duplicateDashboardWidget)),
+);
 app.method('dashboard-import', mutator(undoable(importDashboard)));

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -256,6 +256,8 @@ export type DbCustomReport = {
   color_scheme: string;
   include_current: 1 | 0;
   sort_by: string;
+  trim_intervals: 1 | 0;
+  show_trend_lines: 1 | 0;
   tombstone: 1 | 0;
 };
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.28 MB → 13.28 MB (+1.66 kB) | +0.01%
loot-core | 1 | 4.83 MB → 4.83 MB (+1.82 kB) | +0.04%
api | 2 | 3.88 MB → 3.88 MB (+1.77 kB) | +0.04%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.28 MB → 13.28 MB (+1.66 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/ReportCard.tsx` | 📈 +1 kB (+12.31%) | 8.13 kB → 9.13 kB
`src/reports/mutations.ts` | 📈 +620 B (+7.98%) | 7.59 kB → 8.19 kB
`src/components/modals/CopyWidgetToDashboardModal.tsx` | 📈 +50 B (+2.39%) | 2.04 kB → 2.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.28 MB → 1.28 MB (+1.61 kB) | +0.12%
static/js/index.js | 5.28 MB → 5.28 MB (+50 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 7.1 kB | 0%
static/js/TransactionList.js | 85.19 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 201.68 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 359.49 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 304.69 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.83 MB → 4.83 MB (+1.82 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +1.82 kB (+24.30%) | 7.47 kB → 9.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.K_V1uSzf.js | 0 B → 4.83 MB (+4.83 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CEHtIopf.js | 4.83 MB → 0 B (-4.83 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.88 MB → 3.88 MB (+1.77 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +1.77 kB (+24.26%) | 7.31 kB → 9.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.88 MB → 3.88 MB (+1.77 kB) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->