### PR TITLE
[AI] Allow null in SQL query parameter types via shared SqlParam type

### DIFF
--- a/packages/loot-core/src/platform/server/sqlite/index.electron.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.electron.ts
@@ -6,7 +6,10 @@ import { getDataDir, readFile, removeFile } from '#platform/server/fs';
 import { logger } from '#platform/server/log';
 
 import { normalise } from './normalise';
+import type { SqlParam } from './types';
 import { unicodeLike } from './unicodeLike';
+
+export type { SqlParam } from './types';
 
 function verifyParamTypes(sql, arr) {
   arr.forEach(val => {
@@ -35,7 +38,7 @@ export function prepare(db, sql) {
 export function runQuery(
   db: SQL.Database,
   sql: string | SQL.Statement,
-  params: (string | number)[] = [],
+  params: SqlParam[] = [],
   fetchAll = false,
 ) {
   if (params) {

--- a/packages/loot-core/src/platform/server/sqlite/index.ts
+++ b/packages/loot-core/src/platform/server/sqlite/index.ts
@@ -5,7 +5,10 @@ import type { Database, SqlJsStatic, Statement } from '@jlongster/sql.js';
 import { logger } from '#platform/server/log';
 
 import { normalise } from './normalise';
+import type { SqlParam } from './types';
 import { unicodeLike } from './unicodeLike';
+
+export type { SqlParam } from './types';
 
 // Types exported from sql.js (and Emscripten) are incomplete, so we need to redefine them here
 type FSStream = (typeof FS)['FSStream'] & {
@@ -70,10 +73,7 @@ export function _getModule() {
   return SQL;
 }
 
-function verifyParamTypes(
-  sql: string | Statement,
-  arr: (string | number)[] = [],
-) {
+function verifyParamTypes(sql: string | Statement, arr: SqlParam[] = []) {
   arr.forEach(val => {
     if (typeof val !== 'string' && typeof val !== 'number' && val !== null) {
       throw new Error('Invalid field type ' + val + ' for sql ' + sql);
@@ -88,19 +88,19 @@ export function prepare(db: Database, sql: string) {
 export function runQuery(
   db: Database,
   sql: string | Statement,
-  params?: (string | number)[],
+  params?: SqlParam[],
   fetchAll?: false,
 ): { changes: unknown };
 export function runQuery<T>(
   db: Database,
   sql: string | Statement,
-  params: (string | number)[],
+  params: SqlParam[],
   fetchAll: true,
 ): T[];
 export function runQuery<T>(
   db: Database,
   sql: string | Statement,
-  params: (string | number)[] = [],
+  params: SqlParam[] = [],
   fetchAll = false,
 ): T[] | { changes: unknown } {
   if (params) {

--- a/packages/loot-core/src/platform/server/sqlite/types.ts
+++ b/packages/loot-core/src/platform/server/sqlite/types.ts
@@ -1,0 +1,2 @@
+// Value types SQLite accepts as bound query parameters
+export type SqlParam = string | number | null;

--- a/packages/loot-core/src/server/db/index.test.ts
+++ b/packages/loot-core/src/server/db/index.test.ts
@@ -30,6 +30,22 @@ async function getTransactions(latestDate) {
 // validated in the same event loop and it's same to not await)
 
 describe('Database', () => {
+  test('all and first accept null params', async () => {
+    await db.insertAccount({ id: 'foo', name: 'bar' });
+
+    const rows = await db.all<{ id: string }>(
+      'SELECT id FROM accounts WHERE official_name IS ?',
+      [null],
+    );
+    expect(rows).toEqual([{ id: 'foo' }]);
+
+    const row = await db.first<{ id: string }>(
+      'SELECT id FROM accounts WHERE official_name IS ?',
+      [null],
+    );
+    expect(row).toEqual({ id: 'foo' });
+  });
+
   test('inserting a category works', async () => {
     await db.insertCategoryGroup({ id: 'group1', name: 'group1' });
     await db.insertCategory({

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -116,19 +116,19 @@ export async function loadClock() {
 // Functions
 export function runQuery(
   sql: string | Statement,
-  params?: Array<string | number>,
+  params?: sqlite.SqlParam[],
   fetchAll?: false,
 ): { changes: unknown };
 
 export function runQuery<T>(
   sql: string | Statement,
-  params: Array<string | number> | undefined,
+  params: sqlite.SqlParam[] | undefined,
   fetchAll: true,
 ): T[];
 
 export function runQuery<T>(
   sql: string | Statement,
-  params: (string | number)[],
+  params: sqlite.SqlParam[],
   fetchAll: boolean,
 ) {
   if (fetchAll) {
@@ -171,18 +171,18 @@ export function asyncTransaction(fn: () => Promise<void>) {
 // This function is marked as async because `runQuery` is no longer
 // async. We return a promise here until we've audited all the code to
 // make sure nothing calls `.then` on this.
-export async function all<T>(sql: string, params?: (string | number)[]) {
+export async function all<T>(sql: string, params?: sqlite.SqlParam[]) {
   return runQuery<T>(sql, params, true);
 }
 
-export async function first<T>(sql, params?: (string | number)[]) {
+export async function first<T>(sql, params?: sqlite.SqlParam[]) {
   const arr = runQuery<T>(sql, params, true);
   return arr.length === 0 ? null : arr[0];
 }
 
 // The underlying sql system is now sync, but we can't update `first` yet
 // without auditing all uses of it
-export function firstSync<T>(sql, params?: (string | number)[]) {
+export function firstSync<T>(sql, params?: sqlite.SqlParam[]) {
   const arr = runQuery<T>(sql, params, true);
   return arr.length === 0 ? null : arr[0];
 }
@@ -190,7 +190,7 @@ export function firstSync<T>(sql, params?: (string | number)[]) {
 // This function is marked as async because `runQuery` is no longer
 // async. We return a promise here until we've audited all the code to
 // make sure nothing calls `.then` on this.
-export async function run(sql, params?: (string | number)[]) {
+export async function run(sql, params?: sqlite.SqlParam[]) {
   return runQuery(sql, params);
 }
 

--- a/upcoming-release-notes/allow-null-sql-query-params.md
+++ b/upcoming-release-notes/allow-null-sql-query-params.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Allow `null` in database query parameter types via a shared `SqlParam` type


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Extracted from https://github.com/actualbudget/actual/pull/8492 to reduce the scope there.

## Related issue(s)

N/A

## Testing

N/A

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.3 MB | 0%
loot-core | 1 | 4.61 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.3 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.29 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 203.07 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 367.84 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.62 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.61 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Ct-vqSsP.js | 4.61 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->