### PR TITLE
[AI] Show edge commit hash as client version

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -81,6 +81,8 @@ jobs:
           # Avoid restoring potentially poisoned caches in release jobs.
           cache: 'false'
       - name: Build Web
+        env:
+          REACT_APP_COMMIT_REF: ${{ github.sha }}
         run: yarn build:server
 
       - name: Build image for testing

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -82,7 +82,7 @@ jobs:
           cache: 'false'
       - name: Build Web
         env:
-          REACT_APP_COMMIT_REF: ${{ github.sha }}
+          COMMIT_REF: ${{ github.sha }}
         run: yarn build:server
 
       - name: Build image for testing

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build Server & Web
         env:
-          REACT_APP_COMMIT_REF: ${{ github.event_name != 'push' && github.sha || '' }}
+          COMMIT_REF: ${{ github.event_name != 'push' && github.sha || '' }}
         run: yarn build:server
 
       - name: Pack the web and server packages

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -56,6 +56,8 @@ jobs:
           yarn workspace @actual-app/core pack --filename @actual-app/core.tgz
 
       - name: Build Server & Web
+        env:
+          REACT_APP_COMMIT_REF: ${{ github.event_name != 'push' && github.sha || '' }}
         run: yarn build:server
 
       - name: Pack the web and server packages

--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -6,6 +6,7 @@ import { registerSW } from 'virtual:pwa-register';
 import packageJson from '../package.json';
 
 import SharedBrowserServerWorker from './shared-browser-server.ts?sharedworker';
+import { getClientVersion } from './util/clientVersion';
 
 const backendWorkerUrl = new URL('./browser-server.js', import.meta.url);
 
@@ -15,11 +16,12 @@ const backendWorkerUrl = new URL('./browser-server.js', import.meta.url);
 // everything else.
 
 const IS_DEV = import.meta.env.DEV;
-const ACTUAL_VERSION = Platform.isPlaywright
-  ? '99.9.9'
-  : import.meta.env.REACT_APP_REVIEW_ID
-    ? '.preview'
-    : packageJson.version;
+const ACTUAL_VERSION = getClientVersion({
+  packageVersion: packageJson.version,
+  isPlaywright: Platform.isPlaywright,
+  reviewId: import.meta.env.REACT_APP_REVIEW_ID,
+  commitRef: import.meta.env.REACT_APP_COMMIT_REF,
+});
 
 // The OIDC callback (/openid-cb) is reached via a full-page navigation back
 // from the OpenID provider. Routing it through the SharedWorker coordinator is

--- a/packages/desktop-client/src/util/clientVersion.test.ts
+++ b/packages/desktop-client/src/util/clientVersion.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { getClientVersion } from './clientVersion';
+
+const defaultOptions = {
+  packageVersion: '26.7.0',
+  isPlaywright: false,
+};
+
+describe('getClientVersion', () => {
+  it('uses the test version for Playwright', () => {
+    expect(getClientVersion({ ...defaultOptions, isPlaywright: true })).toBe(
+      '99.9.9',
+    );
+  });
+
+  it('uses the preview version for pull request deploys', () => {
+    expect(getClientVersion({ ...defaultOptions, reviewId: '2939' })).toBe(
+      '.preview',
+    );
+  });
+
+  it('adds the short commit hash as SemVer build metadata', () => {
+    expect(
+      getClientVersion({
+        ...defaultOptions,
+        commitRef: 'e18c8adddee6dc699ff8a8a8c65aa93e97b3a81d',
+      }),
+    ).toBe('26.7.0+e18c8ad');
+  });
+
+  it('keeps the preview version when commit metadata is also provided', () => {
+    expect(
+      getClientVersion({
+        ...defaultOptions,
+        reviewId: '2939',
+        commitRef: 'e18c8adddee6dc699ff8a8a8c65aa93e97b3a81d',
+      }),
+    ).toBe('.preview');
+  });
+
+  it('keeps a nightly package identifier without commit metadata', () => {
+    expect(
+      getClientVersion({
+        ...defaultOptions,
+        packageVersion: '26.8.0-nightly.20260719',
+      }),
+    ).toBe('26.8.0-nightly.20260719');
+  });
+
+  it('uses the package version for release builds', () => {
+    expect(getClientVersion(defaultOptions)).toBe('26.7.0');
+  });
+});

--- a/packages/desktop-client/src/util/clientVersion.ts
+++ b/packages/desktop-client/src/util/clientVersion.ts
@@ -1,0 +1,27 @@
+type ClientVersionOptions = {
+  packageVersion: string;
+  isPlaywright: boolean;
+  reviewId?: string;
+  commitRef?: string;
+};
+
+export function getClientVersion({
+  packageVersion,
+  isPlaywright,
+  reviewId,
+  commitRef,
+}: ClientVersionOptions): string {
+  if (isPlaywright) {
+    return '99.9.9';
+  }
+
+  if (reviewId) {
+    return '.preview';
+  }
+
+  if (commitRef) {
+    return `${packageVersion}+${commitRef.slice(0, 7)}`;
+  }
+
+  return packageVersion;
+}

--- a/packages/desktop-client/vite.config.mts
+++ b/packages/desktop-client/vite.config.mts
@@ -249,6 +249,9 @@ export default defineConfig(async ({ mode, command }) => {
     process.env.REACT_APP_REVIEW_ID = process.env.REVIEW_ID;
     process.env.REACT_APP_BRANCH = process.env.BRANCH;
   }
+  if (process.env.COMMIT_REF) {
+    process.env.REACT_APP_COMMIT_REF = process.env.COMMIT_REF;
+  }
 
   // Electron packaging (--mode=desktop) bundles loot-core directly, so skip
   // all browser-only staging there.

--- a/upcoming-release-notes/show-edge-commit-version.md
+++ b/upcoming-release-notes/show-edge-commit-version.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [LuBoys]
+---
+
+Show a unique client version for nightly builds across deployment methods.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fix Docker and npm nightly builds by forwarding `github.sha` to the client build.

Edge deployments now show a unique build identifier instead of only the package version. Netlify forwards `COMMIT_REF`; the Docker nightly workflow and the npm nightly packaging workflow forward GitHub's commit SHA before building the web client. The displayed value preserves the package version and includes the short SHA, for example `26.7.0+e18c8ad`.

Stable releases, pull request previews, local builds, and Playwright tests retain their existing version behavior. Nightly packages without commit metadata keep their unique nightly package version.

OpenAI Codex was used to draft a significant part of the implementation. The resulting diff was reviewed and validated by the contributor.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Fixes #2939

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

- `yarn workspace @actual-app/web vitest run src/util/clientVersion.test.ts` — 6 tests passed.
- `yarn lint`
- `yarn typecheck`
- `yarn test:debug` (full suite without cache)
- `COMMIT_REF=e18c8adddee6dc699ff8a8a8c65aa93e97b3a81d yarn workspace @actual-app/web build:browser`
- `REACT_APP_COMMIT_REF=e18c8adddee6dc699ff8a8a8c65aa93e97b3a81d yarn build:server`
- Confirmed that the generated browser bundle contains the commit metadata and that preview and stable version behavior remain unchanged.

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+606 B) | +0.00%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+606 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/util/clientVersion.ts` | 🆕 +297 B | 0 B → 297 B
`src/browser-preload.js` | 📈 +67 B (+1.66%) | 3.93 kB → 4 kB
`locale/en.json` | 📈 +179 B (+0.08%) | 208.88 kB → 209.06 kB
`locale/fr.json` | 📈 +63 B (+0.04%) | 168.24 kB → 168.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB → 1.55 MB (+364 B) | +0.02%
static/js/en.js | 208.88 kB → 209.06 kB (+179 B) | +0.08%
static/js/fr.js | 168.24 kB → 168.31 kB (+63 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 270.84 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->