### PR TITLE
[AI] Count filtered-out on-budget transfers in Age of Money

### DIFF
--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import type { RuleConditionEntity } from '@actual-app/core/types/models';
+import { describe, expect, it } from 'vitest';
 
 import type {
   Transaction,

--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
@@ -699,6 +699,27 @@ describe('Age of Money calculations', () => {
       });
     });
 
+    it('treats empty oneOf as matching no accounts (inverted notOneOf is tautology)', () => {
+      // account oneOf [] inverts to notOneOf []. Everything is outside the
+      // empty set, so on-budget transfers to any counterpart are included.
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'oneOf', value: [] },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              { 'payee.transfer_acct': { $ne: null } },
+            ],
+          },
+        ],
+      });
+    });
+
     it('combines multiple account conditions with De Morgan for and/or', () => {
       const conditions: RuleConditionEntity[] = [
         { field: 'account', op: 'is', value: 'a' },

--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import type { RuleConditionEntity } from '@actual-app/core/types/models';
 
 import type {
   Transaction,
   TransactionWithCategory,
 } from './age-of-money-spreadsheet';
 import {
+  buildTransferInclusionFilter,
   calculateAgeOfMoney,
   calculateAverageAge,
   calculateGraphData,
@@ -615,6 +617,150 @@ describe('Age of Money calculations', () => {
       });
 
       expect(result.insufficientData).toBe(false);
+    });
+  });
+
+  describe('buildTransferInclusionFilter', () => {
+    const defaultFilter = {
+      $or: [
+        { 'payee.transfer_acct': null },
+        { 'payee.transfer_acct.offbudget': true },
+      ],
+    };
+
+    it('excludes on-budget transfers when no account filter is set', () => {
+      expect(buildTransferInclusionFilter([])).toEqual(defaultFilter);
+      expect(
+        buildTransferInclusionFilter([
+          { field: 'category', op: 'is', value: 'cat-1' },
+        ]),
+      ).toEqual(defaultFilter);
+    });
+
+    it('includes transfers to filtered-out accounts for "is" account filter', () => {
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'is', value: 'chequing' },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              { 'payee.transfer_acct': { $ne: 'chequing' } },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('includes only transfers to excluded accounts for "isNot" filter', () => {
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'isNot', value: 'credit-card' },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              { 'payee.transfer_acct': { $eq: 'credit-card' } },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('keeps transfers within a multi-account filter excluded', () => {
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'oneOf', value: ['chequing', 'savings'] },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              {
+                $and: [
+                  { 'payee.transfer_acct': { $ne: 'chequing' } },
+                  { 'payee.transfer_acct': { $ne: 'savings' } },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('combines multiple account conditions with De Morgan for and/or', () => {
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'is', value: 'a' },
+        { field: 'account', op: 'isNot', value: 'b' },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions, 'and')).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              {
+                $or: [
+                  { 'payee.transfer_acct': { $ne: 'a' } },
+                  { 'payee.transfer_acct': { $eq: 'b' } },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(buildTransferInclusionFilter(conditions, 'or')).toEqual({
+        $or: [
+          { 'payee.transfer_acct': null },
+          { 'payee.transfer_acct.offbudget': true },
+          {
+            $and: [
+              { 'payee.transfer_acct.offbudget': false },
+              {
+                $and: [
+                  { 'payee.transfer_acct': { $ne: 'a' } },
+                  { 'payee.transfer_acct': { $eq: 'b' } },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('falls back to default exclusion for unsupported account ops', () => {
+      const conditions: RuleConditionEntity[] = [
+        { field: 'account', op: 'matches', value: 'cheq.*' },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual(defaultFilter);
+    });
+
+    it('ignores customName conditions when detecting account filters', () => {
+      const conditions: RuleConditionEntity[] = [
+        {
+          field: 'account',
+          op: 'is',
+          value: 'chequing',
+          customName: 'saved-filter',
+        },
+      ];
+
+      expect(buildTransferInclusionFilter(conditions)).toEqual(defaultFilter);
     });
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
@@ -365,13 +365,16 @@ function accountConditionToTransferAcctAql(
     case 'isNot':
       return { [field]: { $ne: value } };
     case 'oneOf': {
-      const values = value as string[];
+      if (!Array.isArray(value)) return null;
+      const values = value;
       if (values.length === 0) return { id: null };
       return { $or: values.map(v => ({ [field]: { $eq: v } })) };
     }
     case 'notOneOf': {
-      const values = value as string[];
-      if (values.length === 0) return { id: null };
+      if (!Array.isArray(value)) return null;
+      const values = value;
+      // Empty notOneOf is a tautology (everything is outside the empty set).
+      if (values.length === 0) return { [field]: { $ne: null } };
       return { $and: values.map(v => ({ [field]: { $ne: v } })) };
     }
     case 'onBudget':

--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
@@ -315,6 +315,156 @@ export type AgeOfMoneyParams = {
   granularity?: AgeOfMoneyGranularity;
 };
 
+type AccountCondition = Extract<RuleConditionEntity, { field: 'account' }>;
+
+/**
+ * Invert an account filter op so we can match counterpart accounts that
+ * fall *outside* the filtered set.
+ */
+function invertAccountOp(
+  op: AccountCondition['op'],
+): AccountCondition['op'] | null {
+  switch (op) {
+    case 'is':
+      return 'isNot';
+    case 'isNot':
+      return 'is';
+    case 'oneOf':
+      return 'notOneOf';
+    case 'notOneOf':
+      return 'oneOf';
+    case 'onBudget':
+      return 'offBudget';
+    case 'offBudget':
+      return 'onBudget';
+    case 'contains':
+      return 'doesNotContain';
+    case 'doesNotContain':
+      return 'contains';
+    // `matches` has no clean inverse in AQL — skip transfer special-casing
+    case 'matches':
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build an AQL clause that matches `payee.transfer_acct` against a single
+ * (already inverted) account condition.
+ */
+function accountConditionToTransferAcctAql(
+  op: AccountCondition['op'],
+  value: AccountCondition['value'],
+): Record<string, unknown> | null {
+  const field = 'payee.transfer_acct';
+
+  switch (op) {
+    case 'is':
+      return { [field]: { $eq: value } };
+    case 'isNot':
+      return { [field]: { $ne: value } };
+    case 'oneOf': {
+      const values = value as string[];
+      if (values.length === 0) return { id: null };
+      return { $or: values.map(v => ({ [field]: { $eq: v } })) };
+    }
+    case 'notOneOf': {
+      const values = value as string[];
+      if (values.length === 0) return { id: null };
+      return { $and: values.map(v => ({ [field]: { $ne: v } })) };
+    }
+    case 'onBudget':
+      return { 'payee.transfer_acct.offbudget': false };
+    case 'offBudget':
+      return { 'payee.transfer_acct.offbudget': true };
+    case 'contains':
+      return {
+        'payee.transfer_acct.name': {
+          $transform: '$lower',
+          $like: `%${value}%`,
+        },
+      };
+    case 'doesNotContain':
+      return {
+        'payee.transfer_acct.name': {
+          $transform: '$lower',
+          $notlike: `%${value}%`,
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build the transfer-inclusion filter for Age of Money queries.
+ *
+ * Default (no account filters): exclude on-budget↔on-budget transfers —
+ * they are just moving money within the budget pool.
+ *
+ * With account filters: also include on-budget transfers whose counterpart
+ * account is filtered out. From the filtered subset's perspective those
+ * transfers are real money leaving (or entering) the pool — e.g. filtering
+ * to a chequing account should treat a CC payment as an expenditure so the
+ * report reflects "age of cash" rather than budget-wide AoM.
+ */
+export function buildTransferInclusionFilter(
+  conditions: RuleConditionEntity[],
+  conditionsOp: 'and' | 'or' = 'and',
+): Record<string, unknown> {
+  const base: Array<Record<string, unknown>> = [
+    { 'payee.transfer_acct': null },
+    { 'payee.transfer_acct.offbudget': true },
+  ];
+
+  const accountConditions = conditions.filter(
+    (c): c is AccountCondition => !c.customName && c.field === 'account',
+  );
+
+  if (accountConditions.length === 0) {
+    return { $or: base };
+  }
+
+  // Destination/source is outside the filtered set when it fails the
+  // account conditions. De Morgan: AND → OR of negations, OR → AND of
+  // negations.
+  const negations: Array<Record<string, unknown>> = [];
+  for (const cond of accountConditions) {
+    const invertedOp = invertAccountOp(cond.op);
+    if (invertedOp == null) {
+      // Unsupported op — fall back to default transfer exclusion
+      return { $or: base };
+    }
+    const clause = accountConditionToTransferAcctAql(invertedOp, cond.value);
+    if (clause == null) {
+      return { $or: base };
+    }
+    negations.push(clause);
+  }
+
+  const filteredOutCounterpart =
+    conditionsOp === 'and'
+      ? negations.length === 1
+        ? negations[0]
+        : { $or: negations }
+      : negations.length === 1
+        ? negations[0]
+        : { $and: negations };
+
+  return {
+    $or: [
+      ...base,
+      {
+        $and: [
+          { 'payee.transfer_acct.offbudget': false },
+          filteredOutCounterpart,
+        ],
+      },
+    ],
+  };
+}
+
 export function createAgeOfMoneySpreadsheet({
   start,
   end,
@@ -330,15 +480,21 @@ export function createAgeOfMoneySpreadsheet({
     const today = monthUtils.currentDay();
     const fixedEnd = endDate > today ? today : endDate;
 
+    const activeConditions = conditions.filter(cond => !cond.customName);
     const { filters } = await send('make-filters-from-conditions', {
-      conditions: conditions.filter(cond => !cond.customName),
+      conditions: activeConditions,
     });
     const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
+    const transferFilter = buildTransferInclusionFilter(
+      activeConditions,
+      conditionsOp,
+    );
 
     // Query for ALL income transactions up to the end date
     // FIFO requires complete income history to calculate ages correctly
-    // Includes: regular income + transfers from off-budget accounts (money entering budget)
-    // Excludes: on-budget-to-on-budget transfers (just moving money between accounts)
+    // Includes: regular income + transfers from off-budget accounts
+    //   + (when account-filtered) transfers from filtered-out on-budget accounts
+    // Excludes: on-budget transfers within the filtered account set
     function makeIncomeQuery() {
       return q('transactions')
         .filter({
@@ -347,10 +503,7 @@ export function createAgeOfMoneySpreadsheet({
         .filter({
           date: { $lte: fixedEnd },
           'account.offbudget': false,
-          $or: [
-            { 'payee.transfer_acct': null },
-            { 'payee.transfer_acct.offbudget': true },
-          ],
+          ...transferFilter,
           amount: { $gt: 0 },
         })
         .select(['id', 'date', 'amount']);
@@ -358,8 +511,9 @@ export function createAgeOfMoneySpreadsheet({
 
     // Query for ALL expense transactions up to the end date
     // FIFO requires complete expense history to properly consume income buckets
-    // Includes: regular expenses + transfers to off-budget accounts (categorized spending)
-    // Excludes: on-budget-to-on-budget transfers (just moving money between accounts)
+    // Includes: regular expenses + transfers to off-budget accounts
+    //   + (when account-filtered) transfers to filtered-out on-budget accounts
+    // Excludes: on-budget transfers within the filtered account set
     function makeExpenseQuery() {
       return q('transactions')
         .filter({
@@ -368,10 +522,7 @@ export function createAgeOfMoneySpreadsheet({
         .filter({
           date: { $lte: fixedEnd },
           'account.offbudget': false,
-          $or: [
-            { 'payee.transfer_acct': null },
-            { 'payee.transfer_acct.offbudget': true },
-          ],
+          ...transferFilter,
           amount: { $lt: 0 },
         })
         .select(['id', 'date', 'amount']);

--- a/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/age-of-money-spreadsheet.ts
@@ -378,20 +378,24 @@ function accountConditionToTransferAcctAql(
       return { 'payee.transfer_acct.offbudget': false };
     case 'offBudget':
       return { 'payee.transfer_acct.offbudget': true };
-    case 'contains':
+    case 'contains': {
+      if (typeof value !== 'string') return null;
       return {
         'payee.transfer_acct.name': {
           $transform: '$lower',
           $like: `%${value}%`,
         },
       };
-    case 'doesNotContain':
+    }
+    case 'doesNotContain': {
+      if (typeof value !== 'string') return null;
       return {
         'payee.transfer_acct.name': {
           $transform: '$lower',
           $notlike: `%${value}%`,
         },
       };
+    }
     default:
       return null;
   }

--- a/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
+++ b/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [saahiljaffer]
+---
+
+Fix Age of Money account filters so transfers to filtered-out on-budget accounts count as expenditures (e.g. filtering to chequing treats credit-card payments as cash leaving the account).

--- a/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
+++ b/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
@@ -3,4 +3,4 @@ category: Bugfixes
 authors: [saahiljaffer]
 ---
 
-Fix Age of Money account filters so transfers to filtered-out on-budget accounts count as expenditures (e.g. filtering to chequing treats credit-card payments as cash leaving the account).
+Fix Age of Money account filters so transfers between included and filtered-out on-budget accounts count as money entering or leaving the filtered accounts.


### PR DESCRIPTION
## Description

on-budget transfers should count as expenses when using a filter on the age-of-money report. this allows you to create an "age of cash" report where you filter out credit card accounts to see how long actual cash sticks around in your accounts (i.e considering the credit float to extend the age of your money)

## Related issue(s)

Relates to #7006

## Testing
- tests added

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.31 MB → 13.31 MB (+2.41 kB) | +0.02%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.31 MB → 13.31 MB (+2.41 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/age-of-money-spreadsheet.ts` | 📈 +2.41 kB (+42.21%) | 5.7 kB → 8.11 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.28 MB → 1.28 MB (+2.41 kB) | +0.18%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.29 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.62 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 367.84 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useDateFormat.js | 2.85 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.62 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->