### PR TITLE
[WIP] [AI] Tolerate newer app-version migrations; enforce additive-only migrations in CI

### DIFF
--- a/packages/desktop-client/src/util/error.ts
+++ b/packages/desktop-client/src/util/error.ts
@@ -1,4 +1,8 @@
-import { getUnsafeZipMeta, toMB } from '@actual-app/core/shared/errors';
+import {
+  getUnsafeZipMeta,
+  isDatabaseSchemaMismatch,
+  toMB,
+} from '@actual-app/core/shared/errors';
 import type { UnsafeZipMeta } from '@actual-app/core/shared/errors';
 import { t } from 'i18next';
 
@@ -83,21 +87,6 @@ export function getUploadError({ reason, meta }: ErrorWithMeta) {
         { reason },
       );
   }
-}
-
-function isDatabaseSchemaMismatch(meta?: unknown): boolean {
-  if (
-    meta &&
-    typeof meta === 'object' &&
-    'error' in meta &&
-    meta.error &&
-    typeof meta.error === 'object' &&
-    'message' in meta.error &&
-    typeof meta.error.message === 'string'
-  ) {
-    return /no such (column|table)/i.test(meta.error.message);
-  }
-  return false;
 }
 
 function getSchemaMismatchError() {

--- a/packages/loot-core/src/server/migrate/additive-migrations.test.ts
+++ b/packages/loot-core/src/server/migrate/additive-migrations.test.ts
@@ -1,0 +1,170 @@
+import * as nativeFs from 'fs';
+import * as path from 'path';
+
+import type { Database } from '@jlongster/sql.js';
+import { describe, expect, it } from 'vitest';
+
+import * as sqlite from '#platform/server/sqlite';
+
+import { applyMigration, getMigrationId, getMigrationList } from './migrations';
+import { findAdditiveViolations, snapshotSchema } from './schema-diff';
+
+// Migrations newer than this id must be additive-only. Clients tolerate
+// budgets and sync messages from newer app versions (see
+// `replayPendingMessages` and `checkDatabaseValidity`), which is only
+// safe if newer migrations never remove or rename what older clients
+// depend on. This is enforced by actually running the migration chain
+// and diffing the real schema around each new migration (see
+// ./schema-diff.ts), so nothing a migration does — comments, string
+// literals, table rebuilds — can hide a destructive change.
+// Dropping/recreating views is fine: they hold no data, but their
+// columns must stay backwards-compatible (a code-review concern, not
+// enforceable here).
+const ADDITIVE_ONLY_CUTOFF = 1780606215001;
+
+const MIGRATIONS_DIR = path.resolve(__dirname, '../../../migrations');
+const INIT_SQL = path.resolve(__dirname, '../sql/init.sql');
+
+// Tables that are not CRDT-synced. Sync builds rows one column at a
+// time, so in a synced table every column beyond the primary key must
+// be nullable or have a DEFAULT — otherwise the first per-column INSERT
+// can never satisfy the constraints. Internal tables are always written
+// with full rows by app code, so they may use NOT NULL freely. Add new
+// internal tables here.
+const NON_SYNCED_TABLES = new Set(['messages_pending']);
+
+async function openTestDb(setupSql: string): Promise<Database> {
+  await sqlite.init();
+  const db = await sqlite.openDatabase(':memory:');
+  sqlite.execQuery(db, setupSql);
+  return db;
+}
+
+// The additive-only violations that `migrationSql` introduces on a
+// database prepared with `setupSql`
+async function violationsFor(
+  setupSql: string,
+  migrationSql: string,
+): Promise<string[]> {
+  const db = await openTestDb(setupSql);
+  const before = snapshotSchema(db);
+  sqlite.execQuery(db, migrationSql);
+  const violations = findAdditiveViolations(
+    before,
+    snapshotSchema(db),
+    NON_SYNCED_TABLES,
+  );
+  sqlite.closeDatabase(db);
+  return violations;
+}
+
+describe('migrations are additive-only', () => {
+  it('every migration after the cutoff is additive-only', async () => {
+    const db = await openTestDb(nativeFs.readFileSync(INIT_SQL, 'utf8'));
+
+    const violations: string[] = [];
+    for (const name of await getMigrationList(MIGRATIONS_DIR)) {
+      const before = snapshotSchema(db);
+      await applyMigration(db, name, MIGRATIONS_DIR);
+      if (getMigrationId(name) > ADDITIVE_ONLY_CUTOFF) {
+        violations.push(
+          ...findAdditiveViolations(
+            before,
+            snapshotSchema(db),
+            NON_SYNCED_TABLES,
+          ).map(violation => `${name}: ${violation}`),
+        );
+      }
+    }
+    sqlite.closeDatabase(db);
+
+    expect(
+      violations,
+      'Migrations must be additive-only so that older clients keep ' +
+        'working: no dropping or renaming tables/columns, new columns ' +
+        'in synced tables must be nullable or have a DEFAULT, and new ' +
+        'synced tables need a single primary key named "id" (sync ' +
+        'builds rows one column at a time, addressed by id). If you ' +
+        'need to retire a column, stop reading it but leave it in ' +
+        'place. New internal (non-synced) tables go in ' +
+        'NON_SYNCED_TABLES in this test.',
+    ).toEqual([]);
+  });
+
+  const TABLE_FOO = 'CREATE TABLE foo (id TEXT PRIMARY KEY, a TEXT, b TEXT);';
+
+  it.each([
+    ['dropping a table', TABLE_FOO, 'DROP TABLE foo;'],
+    ['renaming a table', TABLE_FOO, 'ALTER TABLE foo RENAME TO bar;'],
+    ['renaming a column', TABLE_FOO, 'ALTER TABLE foo RENAME COLUMN a TO c;'],
+    [
+      'dropping a column via table rebuild',
+      TABLE_FOO,
+      `CREATE TABLE foo_new (id TEXT PRIMARY KEY, b TEXT);
+       INSERT INTO foo_new SELECT id, b FROM foo;
+       DROP TABLE foo;
+       ALTER TABLE foo_new RENAME TO foo;`,
+    ],
+    [
+      'adding a required column without a default',
+      TABLE_FOO,
+      'ALTER TABLE foo ADD COLUMN c TEXT NOT NULL;',
+    ],
+    [
+      'creating a synced table with required columns lacking defaults',
+      TABLE_FOO,
+      `CREATE TABLE gadgets
+         (id TEXT PRIMARY KEY,
+          name TEXT NOT NULL,
+          size INTEGER NOT NULL,
+          color TEXT,
+          shape TEXT DEFAULT 'round');`,
+    ],
+    [
+      'creating a synced table whose primary key is not "id"',
+      TABLE_FOO,
+      'CREATE TABLE gadgets (uuid TEXT PRIMARY KEY, name TEXT);',
+    ],
+    [
+      'creating a synced table with a composite primary key',
+      TABLE_FOO,
+      'CREATE TABLE gadgets (id TEXT, name TEXT, PRIMARY KEY (id, name));',
+    ],
+    [
+      'creating a synced table with no primary key',
+      TABLE_FOO,
+      'CREATE TABLE gadgets (name TEXT);',
+    ],
+  ])('sanity check: flags %s', async (_case, setup, migration) => {
+    expect(await violationsFor(setup, migration)).not.toEqual([]);
+  });
+
+  it.each([
+    [
+      'adding nullable and defaulted columns',
+      TABLE_FOO,
+      `ALTER TABLE foo ADD COLUMN c TEXT;
+       ALTER TABLE foo ADD COLUMN d TEXT NOT NULL DEFAULT 'x';`,
+    ],
+    [
+      'creating a table with nullable and defaulted columns',
+      TABLE_FOO,
+      `CREATE TABLE gadgets
+         (id TEXT PRIMARY KEY, name TEXT, size INTEGER NOT NULL DEFAULT 0);`,
+    ],
+    [
+      'dropping and recreating a view',
+      TABLE_FOO + 'CREATE VIEW v_foo AS SELECT id, a FROM foo;',
+      `DROP VIEW v_foo;
+       CREATE VIEW v_foo AS SELECT id, a, b FROM foo;`,
+    ],
+    [
+      'creating an internal (non-synced) table with required columns',
+      TABLE_FOO,
+      `CREATE TABLE messages_pending
+         (timestamp TEXT PRIMARY KEY, dataset TEXT NOT NULL);`,
+    ],
+  ])('sanity check: allows %s', async (_case, setup, migration) => {
+    expect(await violationsFor(setup, migration)).toEqual([]);
+  });
+});

--- a/packages/loot-core/src/server/migrate/migrations.test.ts
+++ b/packages/loot-core/src/server/migrate/migrations.test.ts
@@ -58,6 +58,43 @@ describe('Migrations', () => {
     );
   });
 
+  test('tolerates migrations applied by a newer version of the app', async () => {
+    return withMigrationsDir(
+      __dirname + '/../../mocks/migrations',
+      async () => {
+        await migrate(db.getDatabase());
+
+        // Simulate a migration applied by a newer version of the app
+        // (its id is newer than anything this version knows about)
+        db.runQuery('INSERT INTO __migrations__ (id) VALUES (9999999999999)');
+
+        // Should not throw
+        await migrate(db.getDatabase());
+
+        const applied = await getAppliedMigrations(db.getDatabase());
+        expect(applied).toContain(9999999999999);
+      },
+    );
+  });
+
+  test('rejects a newer unknown migration when a known one is missing', async () => {
+    return withMigrationsDir(
+      __dirname + '/../../mocks/migrations',
+      async () => {
+        // A database that skipped known migrations but somehow contains
+        // one from a newer version — impossible via any legitimate flow
+        // (append-only migrations mean the newer version knew ours too),
+        // so it must be treated as corrupt, not migrated further
+        db.runQuery('INSERT INTO __migrations__ (id) VALUES (1508717984291)');
+        db.runQuery('INSERT INTO __migrations__ (id) VALUES (9999999999999)');
+
+        await expect(migrate(db.getDatabase())).rejects.toThrow(
+          'out-of-sync-migrations',
+        );
+      },
+    );
+  });
+
   test('app runs database migrations', async () => {
     return withMigrationsDir(
       __dirname + '/../../mocks/migrations',

--- a/packages/loot-core/src/server/migrate/migrations.ts
+++ b/packages/loot-core/src/server/migrate/migrations.ts
@@ -38,7 +38,7 @@ export function getMigrationsDir(): string {
   return MIGRATIONS_DIR;
 }
 
-function getMigrationId(name: string): number {
+export function getMigrationId(name: string): number {
   return parseInt(name.match(/^(\d)+/)[0]);
 }
 
@@ -147,6 +147,34 @@ function checkDatabaseValidity(
   appliedIds: number[],
   available: string[],
 ): void {
+  // Tolerate applied migrations newer than anything this app knows
+  // about: they were run by a newer version of the app on this budget.
+  // This is safe because migrations are additive-only (enforced by
+  // additive-migrations.test.ts). Unknown ids older than the newest
+  // known migration still fail below — those indicate a corrupt or
+  // incompatible database, not just a newer one.
+  const maxAvailableId = available.length
+    ? getMigrationId(available[available.length - 1])
+    : 0;
+  const hasNewerUnknownMigrations = appliedIds.some(id => id > maxAvailableId);
+  appliedIds = appliedIds.filter(id => id <= maxAvailableId);
+
+  // A database touched by a newer version must already contain every
+  // migration this app knows (append-only migrations guarantee the newer
+  // version knew them all). A known migration missing next to a newer
+  // unknown one means the database is corrupt — running it now, after
+  // later migrations already ran, would be unsafe.
+  if (hasNewerUnknownMigrations && appliedIds.length !== available.length) {
+    logger.error(
+      'Database is out of sync with migrations (missing known migration next to a newer unknown one):',
+      {
+        appliedIds,
+        available,
+      },
+    );
+    throw new Error('out-of-sync-migrations');
+  }
+
   if (appliedIds.length > available.length) {
     logger.error(
       'Database is out of sync with migrations (index past available):',

--- a/packages/loot-core/src/server/migrate/schema-diff.ts
+++ b/packages/loot-core/src/server/migrate/schema-diff.ts
@@ -1,0 +1,95 @@
+import type { Database } from '@jlongster/sql.js';
+
+import * as sqlite from '#platform/server/sqlite';
+
+// One entry per column, keyed "table.column". `required` means a row
+// cannot be inserted without explicitly providing this column (NOT NULL,
+// no DEFAULT, not the primary key). `pk` means the column is part of the
+// table's primary key.
+export type SchemaSnapshot = Map<
+  string,
+  { table: string; required: boolean; pk: boolean }
+>;
+
+export function snapshotSchema(db: Database): SchemaSnapshot {
+  const tables = sqlite.runQuery<{ name: string }>(
+    db,
+    "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+    [],
+    true,
+  );
+  return new Map(
+    tables.flatMap(({ name: table }) =>
+      sqlite
+        .runQuery<{
+          name: string;
+          notnull: number;
+          dflt_value: string | null;
+          pk: number;
+        }>(db, `PRAGMA table_info("${table}")`, [], true)
+        .map(
+          (
+            column,
+          ): [string, { table: string; required: boolean; pk: boolean }] => [
+            `${table}.${column.name}`,
+            {
+              table,
+              required:
+                column.notnull !== 0 &&
+                column.dflt_value == null &&
+                column.pk === 0,
+              pk: column.pk !== 0,
+            },
+          ],
+        ),
+    ),
+  );
+}
+
+// A schema change is additive-only when every column that existed before
+// still exists after (a dropped or renamed table shows up as all of its
+// columns disappearing), and any new column outside `nonSyncedTables` is
+// optional — sync builds rows one column at a time (see `apply` in
+// #server/sync), so a required column in a synced table can never be
+// inserted. This backs the additive-migrations guard that
+// `checkDatabaseValidity` relies on for cross-version compatibility.
+export function findAdditiveViolations(
+  before: SchemaSnapshot,
+  after: SchemaSnapshot,
+  nonSyncedTables: Set<string>,
+): string[] {
+  const tablesBefore = new Set([...before.values()].map(c => c.table));
+  const newSyncedTables = new Set(
+    [...after.values()]
+      .map(c => c.table)
+      .filter(table => !tablesBefore.has(table) && !nonSyncedTables.has(table)),
+  );
+
+  return [
+    ...[...before.keys()]
+      .filter(key => !after.has(key))
+      .map(key => `column "${key}" (or its table) was removed or renamed`),
+    ...[...after]
+      .filter(
+        ([key, column]) =>
+          !before.has(key) &&
+          column.required &&
+          !nonSyncedTables.has(column.table),
+      )
+      .map(([key]) => `new column "${key}" is NOT NULL without a DEFAULT`),
+    // Sync addresses rows by their `id` column (see `apply` in
+    // #server/sync), so a synced table needs exactly that as its
+    // primary key — no other name, no composite keys
+    ...[...newSyncedTables]
+      .filter(table => {
+        const pks = [...after]
+          .filter(([, c]) => c.table === table && c.pk)
+          .map(([key]) => key);
+        return pks.length !== 1 || pks[0] !== `${table}.id`;
+      })
+      .map(
+        table =>
+          `new table "${table}" must have a single primary key named "id"`,
+      ),
+  ];
+}

--- a/packages/loot-core/src/shared/errors.ts
+++ b/packages/loot-core/src/shared/errors.ts
@@ -54,7 +54,15 @@ function getUnsafeZipError(meta: UnsafeZipMeta): string {
 // plain English strings. User-facing, translated equivalents live in the
 // desktop-client (`src/util/error.ts`).
 
-function isDatabaseSchemaMismatch(meta?: unknown): boolean {
+// A SQLite error message meaning a query referenced a table or column
+// that doesn't exist in this database's schema. SQLite reports a missing
+// column as "no such column" in UPDATE/SELECT statements but as "has no
+// column named" in INSERT statements.
+export function isMissingSchemaErrorMessage(message: string): boolean {
+  return /no such (table|column)|has no column named/i.test(message);
+}
+
+export function isDatabaseSchemaMismatch(meta?: unknown): boolean {
   if (
     meta &&
     typeof meta === 'object' &&
@@ -64,7 +72,7 @@ function isDatabaseSchemaMismatch(meta?: unknown): boolean {
     'message' in meta.error &&
     typeof meta.error.message === 'string'
   ) {
-    return /no such (column|table)/i.test(meta.error.message);
+    return isMissingSchemaErrorMessage(meta.error.message);
   }
   return false;
 }

--- a/upcoming-release-notes/tolerate-newer-migrations.md
+++ b/upcoming-release-notes/tolerate-newer-migrations.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Allow opening a budget that was already updated by a newer version of Actual


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.31 MB → 13.31 MB (+116 B) | +0.00%
loot-core | 1 | 4.62 MB → 4.62 MB (+642 B) | +0.01%
api | 2 | 3.83 MB → 3.83 MB (+629 B) | +0.02%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.31 MB → 13.31 MB (+116 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +409 B (+75.74%) | 540 B → 949 B
`src/util/error.ts` | 📉 -293 B (-4.18%) | 6.85 kB → 6.56 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useDateFormat.js | 2.85 MB → 2.85 MB (+116 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.29 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.28 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 174.64 kB | 0%
static/js/da.js | 98.1 kB | 0%
static/js/de.js | 181.92 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.62 kB | 0%
static/js/es.js | 168.08 kB | 0%
static/js/fr.js | 169.79 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 155.52 kB | 0%
static/js/narrow.js | 367.84 kB | 0%
static/js/nb-NO.js | 139.35 kB | 0%
static/js/nl.js | 116.92 kB | 0%
static/js/pl.js | 139.95 kB | 0%
static/js/pt-BR.js | 182.8 kB | 0%
static/js/th.js | 170 kB | 0%
static/js/theme.js | 31.02 kB | 0%
static/js/uk.js | 204.6 kB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.62 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 109.57 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB → 4.62 MB (+642 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +523 B (+15.64%) | 3.27 kB → 3.78 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +119 B (+2.50%) | 4.66 kB → 4.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DRPg5Lgu.js | 0 B → 4.62 MB (+4.62 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB → 0 B (-4.62 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB → 3.83 MB (+629 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +513 B (+15.73%) | 3.19 kB → 3.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +116 B (+2.46%) | 4.6 kB → 4.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB → 3.83 MB (+629 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->