### PR TITLE
[WIP] [AI] Fix category select always choosing first item on touch devices

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -344,6 +344,12 @@ function SingleAutocomplete<T extends AutocompleteItem>({
 
         if (clearOnSelect) {
           setValue('');
+        } else {
+          // Keep the controlled input synchronized with the selected item.
+          // onInputValueChange skips clickItem (see the early-return filter
+          // above), so the input value must be set here for click/tap
+          // selections when it is not cleared.
+          setValue(item ? getItemName(item) : '');
         }
 
         if (closeOnSelect) {

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -389,7 +389,17 @@ function SingleAutocomplete<T extends AutocompleteItem>({
             // Do nothing if it is a "touch" selection event
             Downshift.stateChangeTypes.touchEnd,
             Downshift.stateChangeTypes.mouseUp,
+            // Do nothing if it is a click/tap selection event — the
+            // `onSelect` handler already manages all necessary state
+            // (selectedItem, highlightedIndex, isOpen, and the selection
+            // callback). Allowing this handler to proceed for `clickItem`
+            // causes it to re-filter suggestions, reset `highlightedIndex`
+            // to the first item, and call `open()`, which triggers re-
+            // renders mid-touch-event on touch devices. That re-render
+            // disrupts the touchstart → touchend → click sequence so the
+            // `click` lands on the first item instead of the tapped one.
             // @ts-expect-error Types say there is no type
+            Downshift.stateChangeTypes.clickItem,
           ].includes(changes.type)
         ) {
           return;
@@ -402,10 +412,7 @@ function SingleAutocomplete<T extends AutocompleteItem>({
         if (value === '') {
           // A blank value shouldn't highlight any item so that the field
           // can be left blank if desired
-          // @ts-expect-error Types say there is no type
-          if (changes.type !== Downshift.stateChangeTypes.clickItem) {
-            fireUpdate(onUpdate, strict, filteredSuggestions, null, null);
-          }
+          fireUpdate(onUpdate, strict, filteredSuggestions, null, null);
 
           setHighlightedIndex(null);
         } else {
@@ -415,16 +422,13 @@ function SingleAutocomplete<T extends AutocompleteItem>({
           const highlightedIndex = (
             getHighlightedIndex || defaultGetHighlightedIndex
           )(filteredSuggestions);
-          // @ts-expect-error Types say there is no type
-          if (changes.type !== Downshift.stateChangeTypes.clickItem) {
-            fireUpdate(
-              onUpdate,
-              strict,
-              filteredSuggestions,
-              highlightedIndex,
-              value,
-            );
-          }
+          fireUpdate(
+            onUpdate,
+            strict,
+            filteredSuggestions,
+            highlightedIndex,
+            value,
+          );
 
           setHighlightedIndex(highlightedIndex);
         }


### PR DESCRIPTION
Fixes #6401

## Description

On touch devices (notably Android tablets), selecting a category from the autocomplete search results always picked the first item in the list regardless of which item was actually tapped. Regression that appeared around v25.12.0.

## Root cause

In `packages/desktop-client/src/components/autocomplete/Autocomplete.tsx`, the `onInputValueChange` handler handled a `clickItem` state change only partially: it skipped `fireUpdate` but still executed the remaining state updates (`setHighlightedIndex(0)`, `setValue`, `setIsChanged`, `open()`).

On touch devices the event sequence is `touchstart -> touchend -> mousemove -> mousedown -> mouseup -> click`. The intermediate state changes trigger React re-renders **mid-touch-sequence**, disrupting the event flow so the `click` lands on the first item (now at the tapped position after re-render) instead of the actually-tapped item.

The `onSelect` handler (which fires later in Downshift's `setState` callback) already correctly manages all necessary state: `selectedItem`, `highlightedIndex` (set to `null`), `isOpen` (closed via `close()`), and the selection callback.

## Fix

Add `Downshift.stateChangeTypes.clickItem` to the early-return filter list in `onInputValueChange`, so the entire handler is skipped for click/tap selection events. Remove the now-redundant inline `clickItem` guards (which only skipped `fireUpdate` but allowed the problematic state changes to proceed).

## Testing

- [ ] Android tablet (Chrome) — searching for a category and tapping a non-first result now selects the tapped item
- [ ] Desktop (Chrome/Firefox) — keyboard navigation, mouse click, and tab-to-select still work
- [ ] No regressions in payee/account autocomplete (same Autocomplete component)

> Title is prefixed `[AI]` per the repo's AI usage policy (AGENTS.md / `.github/agents/pr-and-commit-rules.md`) for contributions produced with AI assistance.