### PR TITLE
add month picker component to automations UI

### DIFF
--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -33,6 +33,7 @@
     "./label": "./src/Label.tsx",
     "./menu": "./src/Menu.tsx",
     "./mode-button": "./src/ModeButton.tsx",
+    "./month-picker": "./src/MonthPicker.tsx",
     "./paragraph": "./src/Paragraph.tsx",
     "./popover": "./src/Popover.tsx",
     "./select": "./src/Select.tsx",

--- a/packages/component-library/src/MonthPicker.stories.tsx
+++ b/packages/component-library/src/MonthPicker.stories.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+
+import { MonthPicker } from './MonthPicker';
+
+const meta = {
+  title: 'Components/MonthPicker',
+  component: MonthPicker,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    value: '2024-06',
+    locale: 'en-US',
+    labels: { previous: 'Previous', next: 'Next' },
+    onChange: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MonthPicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value);
+    return <MonthPicker {...args} value={value} onChange={setValue} />;
+  },
+};
+
+export const WithBounds: Story = {
+  args: {
+    minDate: '2023-04',
+    maxDate: '2025-09',
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: '',
+    placeholder: 'Select month',
+  },
+};

--- a/packages/component-library/src/MonthPicker.tsx
+++ b/packages/component-library/src/MonthPicker.tsx
@@ -1,0 +1,113 @@
+import { useRef, useState } from 'react';
+
+import { Button } from '#Button';
+import { Popover } from '#Popover';
+import type { CSSProperties } from '#styles';
+import { View } from '#View';
+
+import { MonthGrid } from './date-range-picker/MonthGrid';
+import { NavRow } from './date-range-picker/NavRow';
+import {
+  currentMonth,
+  formatDate,
+  getMonth,
+  getYear,
+} from './date-range-picker/util';
+
+export type MonthPickerLabels = {
+  previous: string;
+  next: string;
+};
+
+type MonthPickerProps = {
+  value: string;
+  minDate?: string;
+  maxDate?: string;
+  locale: string;
+  placeholder?: string;
+  labels: MonthPickerLabels;
+  id?: string;
+  style?: CSSProperties;
+  onChange: (month: string) => void;
+};
+
+// Far-past/far-future sentinels: sort before/after any real month string.
+const NO_MIN = '0001-01';
+const NO_MAX = '9999-12';
+
+export function MonthPicker({
+  value,
+  minDate,
+  maxDate,
+  locale,
+  placeholder,
+  labels,
+  id,
+  style,
+  onChange,
+}: MonthPickerProps) {
+  const month = value ? getMonth(value) : '';
+  const min = minDate ? getMonth(minDate) : NO_MIN;
+  const max = maxDate ? getMonth(maxDate) : NO_MAX;
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [viewYear, setViewYear] = useState(() =>
+    getYear(month || currentMonth()),
+  );
+
+  function openPopover() {
+    setViewYear(getYear(month || currentMonth()));
+    setIsOpen(true);
+  }
+
+  const label = month
+    ? formatDate(month, locale, { month: 'short', year: 'numeric' })
+    : (placeholder ?? '');
+
+  return (
+    <View>
+      <Button
+        id={id}
+        ref={triggerRef}
+        data-testid="month-picker-trigger"
+        onPress={() => (isOpen ? setIsOpen(false) : openPopover())}
+        style={{ justifyContent: 'flex-start', ...style }}
+      >
+        {label}
+      </Button>
+
+      <Popover
+        triggerRef={triggerRef}
+        placement="bottom start"
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        <View style={{ padding: 15, minWidth: 180 }}>
+          <NavRow
+            label={viewYear}
+            previousLabel={labels.previous}
+            nextLabel={labels.next}
+            canPrev={viewYear > getYear(min)}
+            canNext={viewYear < getYear(max)}
+            onPrev={() => setViewYear(String(Number(viewYear) - 1))}
+            onNext={() => setViewYear(String(Number(viewYear) + 1))}
+          />
+          <MonthGrid
+            year={viewYear}
+            rangeStart={month}
+            rangeEnd={month}
+            minMonth={min}
+            maxMonth={max}
+            locale={locale}
+            onSelect={next => {
+              setIsOpen(false);
+              if (next !== month) {
+                onChange(next);
+              }
+            }}
+          />
+        </View>
+      </Popover>
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SvgInformationCircle } from '@actual-app/components/icons/v2';
 import { Input } from '@actual-app/components/input';
 import { Select } from '@actual-app/components/select';
@@ -18,57 +17,11 @@ import type {
 import { updateTemplate } from '#components/budget/goals/actions';
 import type { Action } from '#components/budget/goals/actions';
 import { TWO_UP_FIELD_FLEX } from '#components/budget/goals/editor/fieldLayout';
+import { MonthField } from '#components/budget/goals/editor/MonthField';
 import { FormField, FormLabel } from '#components/forms';
 import { LabeledCheckbox } from '#components/forms/LabeledCheckbox';
-import {
-  hideNativeDateIconClassName,
-  InputField,
-} from '#components/mobile/MobileForms';
 import { AmountInput } from '#components/util/AmountInput';
-import { GenericInput } from '#components/util/GenericInput';
 import { useFormat } from '#hooks/useFormat';
-
-type MonthFieldProps = {
-  id: string;
-  value: string;
-  onChange: (month: string) => void;
-};
-
-// we can use a month picker for mobile because we use the native datepicker
-// no such luck on desktop (yet!)
-function MonthField({ id, value, onChange }: MonthFieldProps) {
-  const { isNarrowWidth } = useResponsive();
-  if (isNarrowWidth) {
-    return (
-      <InputField
-        id={id}
-        type="month"
-        value={value}
-        onChange={event => onChange(event.target.value)}
-        className={hideNativeDateIconClassName}
-        style={{
-          width: '100%',
-          marginLeft: 0,
-          marginRight: 0,
-          boxSizing: 'border-box',
-          WebkitAppearance: 'none',
-          appearance: 'none',
-        }}
-      />
-    );
-  }
-  return (
-    <GenericInput
-      // remount when the stored month changes so the picker re-syncs
-      // to day 01 instead of lingering on whatever day the user picked
-      key={value}
-      type="date"
-      field="date"
-      value={value ? `${value}-01` : ''}
-      onChange={(next: string) => onChange(next ? next.slice(0, 7) : '')}
-    />
-  );
-}
 
 type BySaveAutomationProps = {
   template: ByTemplate | SpendTemplate;

--- a/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/BySaveAutomation.tsx
@@ -17,10 +17,10 @@ import type {
 import { updateTemplate } from '#components/budget/goals/actions';
 import type { Action } from '#components/budget/goals/actions';
 import { TWO_UP_FIELD_FLEX } from '#components/budget/goals/editor/fieldLayout';
-import { MonthField } from '#components/budget/goals/editor/MonthField';
 import { FormField, FormLabel } from '#components/forms';
 import { LabeledCheckbox } from '#components/forms/LabeledCheckbox';
 import { AmountInput } from '#components/util/AmountInput';
+import { MonthInput } from '#components/util/MonthInput';
 import { useFormat } from '#hooks/useFormat';
 
 type BySaveAutomationProps = {
@@ -88,7 +88,7 @@ export const BySaveAutomation = ({
         </FormField>
         <FormField style={{ flex: TWO_UP_FIELD_FLEX }}>
           <FormLabel title={t('Target month')} htmlFor="by-month-field" />
-          <MonthField
+          <MonthInput
             id="by-month-field"
             value={template.month ?? ''}
             onChange={month =>
@@ -238,7 +238,7 @@ export const BySaveAutomation = ({
               title={t('Start spending in')}
               htmlFor="by-spend-from-field"
             />
-            <MonthField
+            <MonthInput
               id="by-spend-from-field"
               value={fromMonth ?? ''}
               onChange={from =>

--- a/packages/desktop-client/src/components/budget/goals/editor/MonthField.tsx
+++ b/packages/desktop-client/src/components/budget/goals/editor/MonthField.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from 'react-i18next';
+
+import { useResponsive } from '@actual-app/components/hooks/useResponsive';
+import { MonthPicker } from '@actual-app/components/month-picker';
+
+import {
+  hideNativeDateIconClassName,
+  InputField,
+} from '#components/mobile/MobileForms';
+import { useLanguage } from '#hooks/useLocale';
+
+type MonthFieldProps = {
+  id: string;
+  value: string;
+  onChange: (month: string) => void;
+};
+
+// mobile keeps the native month input; desktop uses the custom month picker
+export function MonthField({ id, value, onChange }: MonthFieldProps) {
+  const { t } = useTranslation();
+  const language = useLanguage();
+  const { isNarrowWidth } = useResponsive();
+  if (isNarrowWidth) {
+    return (
+      <InputField
+        id={id}
+        type="month"
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        className={hideNativeDateIconClassName}
+        style={{
+          width: '100%',
+          marginLeft: 0,
+          marginRight: 0,
+          boxSizing: 'border-box',
+          WebkitAppearance: 'none',
+          appearance: 'none',
+        }}
+      />
+    );
+  }
+  return (
+    <MonthPicker
+      id={id}
+      value={value}
+      locale={language}
+      placeholder={t('Select month')}
+      labels={{ previous: t('Previous'), next: t('Next') }}
+      onChange={onChange}
+    />
+  );
+}

--- a/packages/desktop-client/src/components/util/MonthInput.tsx
+++ b/packages/desktop-client/src/components/util/MonthInput.tsx
@@ -9,14 +9,14 @@ import {
 } from '#components/mobile/MobileForms';
 import { useLanguage } from '#hooks/useLocale';
 
-type MonthFieldProps = {
+type MonthInputProps = {
   id: string;
   value: string;
   onChange: (month: string) => void;
 };
 
 // mobile keeps the native month input; desktop uses the custom month picker
-export function MonthField({ id, value, onChange }: MonthFieldProps) {
+export function MonthInput({ id, value, onChange }: MonthInputProps) {
   const { t } = useTranslation();
   const language = useLanguage();
   const { isNarrowWidth } = useResponsive();

--- a/upcoming-release-notes/automation-month-picker.md
+++ b/upcoming-release-notes/automation-month-picker.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Use a month picker instead of a full date picker when choosing months in budget automations


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Creates a new month picker component from the innards of the new datepicker component, and wires it into the automation UI.

I chose to keep the mobile one using the native picker since we do for the rest of them. I couldn't put the util component in the component-library because I didn't want to move all of the mobile form code out with it, we might need to do that down the line

Claude assisted

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Related https://github.com/actualbudget/actual/issues/8514

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Before:
<img width="620" height="605" alt="image" src="https://github.com/user-attachments/assets/c1babacc-8460-4d1f-8051-66f99626015f" />


After:
<img width="629" height="527" alt="image" src="https://github.com/user-attachments/assets/2c371874-7956-4676-8118-9f23f2fbf173" />



## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 30 | 13.37 MB → 13.37 MB (+5.1 kB) | +0.04%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
30 | 13.37 MB → 13.37 MB (+5.1 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/component-library/src/MonthPicker.tsx` | 🆕 +4.82 kB | 0 B → 4.82 kB
`src/components/util/MonthInput.tsx` | 🆕 +1.87 kB | 0 B → 1.87 kB
`node_modules/date-fns/isWeekend.js` | 📈 +2 B (+1.09%) | 183 B → 185 B
`node_modules/date-fns/getDay.js` | 📈 +2 B (+0.77%) | 260 B → 262 B
`home/runner/work/actual/actual/packages/component-library/src/date-range-picker/RangeSelector.tsx` | 📈 +12 B (+0.33%) | 3.58 kB → 3.59 kB
`home/runner/work/actual/actual/packages/component-library/src/DateRangePicker.tsx` | 📈 +24 B (+0.22%) | 10.43 kB → 10.45 kB
`home/runner/work/actual/actual/packages/component-library/src/date-range-picker/MonthGrid.tsx` | 📈 +4 B (+0.21%) | 1.89 kB → 1.9 kB
`src/components/budget/goals/automationExamples.ts` | 📈 +2 B (+0.20%) | 996 B → 998 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +12 B (+0.17%) | 6.9 kB → 6.91 kB
`src/components/transactions/table/utils.ts` | 📈 +4 B (+0.16%) | 2.4 kB → 2.4 kB
`src/hooks/useScheduleEdit.ts` | 📈 +8 B (+0.12%) | 6.5 kB → 6.51 kB
`home/runner/work/actual/actual/packages/component-library/src/date-range-picker/NavRow.tsx` | 📈 +2 B (+0.09%) | 2.1 kB → 2.1 kB
`src/components/schedules/ScheduleEditModal.tsx` | 📈 +4 B (+0.07%) | 5.33 kB → 5.33 kB
`src/hooks/useCategoryScheduleGoalTemplateIndicator.ts` | 📈 +2 B (+0.07%) | 2.69 kB → 2.69 kB
`src/components/modals/BudgetAutomationsModal/migrateTemplatesToAutomations.ts` | 📈 +2 B (+0.07%) | 2.97 kB → 2.97 kB
`src/components/budget/goals/reducer.ts` | 📈 +4 B (+0.06%) | 6.14 kB → 6.14 kB
`src/components/accounts/BalanceHistoryGraph.tsx` | 📈 +6 B (+0.06%) | 9.4 kB → 9.4 kB
`src/components/reports/reports/BalanceForecast.tsx` | 📈 +9 B (+0.05%) | 17.03 kB → 17.03 kB
`node_modules/re-resizable/lib/index.js` | 📈 +10 B (+0.04%) | 25.5 kB → 25.51 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsModal.tsx` | 📈 +2 B (+0.03%) | 5.64 kB → 5.65 kB
`src/components/reports/reports/AgeOfMoney.tsx` | 📈 +5 B (+0.03%) | 18.13 kB → 18.13 kB
`src/components/modals/EditFieldModal.tsx` | 📈 +2 B (+0.02%) | 8.25 kB → 8.25 kB
`src/components/transactions/TransactionList.tsx` | 📈 +4 B (+0.02%) | 17.26 kB → 17.26 kB
`src/components/transactions/SimpleTransactionsTable.tsx` | 📈 +2 B (+0.02%) | 8.82 kB → 8.82 kB
`src/components/select/RecurringSchedulePicker.tsx` | 📈 +6 B (+0.02%) | 28.38 kB → 28.39 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +5 B (+0.02%) | 25.37 kB → 25.38 kB
`src/components/budget/goals/editor/LimitAutomation.tsx` | 📈 +2 B (+0.02%) | 10.63 kB → 10.64 kB
`src/components/modals/BudgetAutomationsModal/AutomationEditorPane.tsx` | 📈 +2 B (+0.01%) | 14.78 kB → 14.78 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +6 B (+0.01%) | 74.41 kB → 74.42 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +2 B (+0.00%) | 43.51 kB → 43.51 kB
`src/components/reports/reports/Calendar.tsx` | 📉 -3 B (-0.01%) | 27.59 kB → 27.59 kB
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📉 -4 B (-0.01%) | 29.44 kB → 29.44 kB
`src/components/reports/ReportTopbar.tsx` | 📉 -2 B (-0.01%) | 14.52 kB → 14.52 kB
`src/components/reports/reports/Crossover.tsx` | 📉 -6 B (-0.01%) | 42.02 kB → 42.01 kB
`src/components/reports/reports/Summary.tsx` | 📉 -4 B (-0.02%) | 25.58 kB → 25.57 kB
`src/components/reports/reports/Sankey.tsx` | 📉 -6 B (-0.02%) | 31.65 kB → 31.64 kB
`src/components/reports/reports/CrossoverCard.tsx` | 📉 -2 B (-0.02%) | 9.36 kB → 9.36 kB
`src/components/reports/reports/CashFlowCard.tsx` | 📉 -2 B (-0.02%) | 9.33 kB → 9.32 kB
`src/components/reports/reports/AgeOfMoneyCard.tsx` | 📉 -2 B (-0.03%) | 7.02 kB → 7.02 kB
`src/hooks/useFormulaExecution.ts` | 📉 -4 B (-0.03%) | 13.71 kB → 13.7 kB
`src/components/reports/reports/NetWorthCard.tsx` | 📉 -2 B (-0.03%) | 6.76 kB → 6.75 kB
`src/components/reports/reports/Spending.tsx` | 📉 -10 B (-0.04%) | 24.59 kB → 24.58 kB
`src/components/reports/reports/CashFlow.tsx` | 📉 -4 B (-0.04%) | 9.16 kB → 9.15 kB
`src/components/reports/reports/CustomReport.tsx` | 📉 -20 B (-0.05%) | 42.31 kB → 42.29 kB
`src/components/reports/reports/CalendarCard.tsx` | 📉 -6 B (-0.05%) | 12.41 kB → 12.4 kB
`src/components/reports/ReportOptions.ts` | 📉 -4 B (-0.05%) | 7.25 kB → 7.25 kB
`src/components/reports/reports/CustomReportListCards.tsx` | 📉 -4 B (-0.05%) | 7.22 kB → 7.21 kB
`src/components/reports/spendingAverageRange.ts` | 📉 -2 B (-0.07%) | 2.88 kB → 2.88 kB
`src/components/reports/Header.tsx` | 📉 -8 B (-0.07%) | 10.94 kB → 10.93 kB
`src/components/reports/spreadsheets/calendar-spreadsheet.ts` | 📉 -4 B (-0.08%) | 5.05 kB → 5.05 kB
`src/components/reports/spreadsheets/spending-spreadsheet.ts` | 📉 -6 B (-0.08%) | 7.07 kB → 7.06 kB
`src/components/reports/reports/SpendingCard.tsx` | 📉 -6 B (-0.08%) | 7 kB → 6.99 kB
`src/components/reports/spreadsheets/budgetDataQuery.ts` | 📉 -4 B (-0.09%) | 4.47 kB → 4.46 kB
`src/components/reports/reports/BalanceForecastCard.tsx` | 📉 -10 B (-0.09%) | 10.9 kB → 10.89 kB
`src/components/reports/reports/SummaryCard.tsx` | 📉 -6 B (-0.11%) | 5.26 kB → 5.26 kB
`src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts` | 📉 -6 B (-0.11%) | 5.24 kB → 5.23 kB
`src/components/reports/spreadsheets/crossover-spreadsheet.ts` | 📉 -10 B (-0.12%) | 7.97 kB → 7.96 kB
`src/components/modals/TrackingBudgetSummaryModal.tsx` | 📉 -2 B (-0.12%) | 1.59 kB → 1.59 kB
`src/components/reports/reports/BudgetAnalysisCard.tsx` | 📉 -8 B (-0.13%) | 6.17 kB → 6.16 kB
`src/components/formula/QueryManager.tsx` | 📉 -36 B (-0.14%) | 24.99 kB → 24.95 kB
`src/components/reports/spreadsheets/summary-spreadsheet.ts` | 📉 -14 B (-0.24%) | 5.58 kB → 5.57 kB
`src/components/reports/reports/balanceForecastChartData.ts` | 📉 -12 B (-0.30%) | 3.88 kB → 3.87 kB
`src/components/reports/spreadsheets/age-of-money-spreadsheet.ts` | 📉 -18 B (-0.31%) | 5.72 kB → 5.7 kB
`src/components/reports/spreadsheets/net-worth-spreadsheet.ts` | 📉 -18 B (-0.31%) | 5.64 kB → 5.62 kB
`src/components/reports/spreadsheets/cash-flow-spreadsheet.tsx` | 📉 -20 B (-0.33%) | 5.95 kB → 5.93 kB
`src/components/reports/reportRanges.ts` | 📉 -33 B (-0.60%) | 5.37 kB → 5.34 kB
`src/components/formula/queryTimeFrame.ts` | 📉 -4 B (-0.89%) | 448 B → 444 B
`src/components/reports/getLiveRange.ts` | 📉 -18 B (-1.11%) | 1.58 kB → 1.57 kB
`src/components/budget/envelope/EnvelopeBudgetContext.tsx` | 📉 -16 B (-1.13%) | 1.38 kB → 1.36 kB
`src/components/budget/tracking/TrackingBudgetContext.tsx` | 📉 -16 B (-1.13%) | 1.38 kB → 1.36 kB
`node_modules/date-fns/getDate.js` | 📉 -2 B (-1.38%) | 145 B → 143 B
`src/components/budget/goals/editor/BySaveAutomation.tsx` | 📉 -1.37 kB (-9.94%) | 13.8 kB → 12.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.23 MB → 5.24 MB (+13.1 kB) | +0.24%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.31 MB → 1.3 MB (-7.99 kB) | -0.60%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 172.48 kB | 0%
static/js/da.js | 96.58 kB | 0%
static/js/de.js | 179.91 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.28 kB | 0%
static/js/es.js | 165.92 kB | 0%
static/js/fr.js | 167.53 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 153.37 kB | 0%
static/js/narrow.js | 367.84 kB | 0%
static/js/nb-NO.js | 137.24 kB | 0%
static/js/nl.js | 145.55 kB | 0%
static/js/pl.js | 137.76 kB | 0%
static/js/pt-BR.js | 180.63 kB | 0%
static/js/th.js | 166.6 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.62 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 108.09 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->