### PR TITLE
fix relinking a bank account

### DIFF
--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
@@ -1,0 +1,99 @@
+import type {
+  AccountEntity,
+  SyncServerSimpleFinAccount,
+} from '@actual-app/core/types/models';
+import { describe, expect, it } from 'vitest';
+
+import { computeInitialLinkState } from './SelectLinkedAccountsModal';
+
+function makeLocalAccount(
+  overrides: Partial<AccountEntity> & { id: string },
+): AccountEntity {
+  return {
+    name: overrides.id,
+    offbudget: 0,
+    closed: 0,
+    sort_order: 0,
+    last_reconciled: null,
+    tombstone: 0,
+    account_id: null,
+    bank: null,
+    bankName: null,
+    bankId: null,
+    mask: null,
+    official_name: null,
+    balance_current: null,
+    balance_available: null,
+    balance_limit: null,
+    account_sync_source: null,
+    last_sync: null,
+    bank_sync_status: null,
+    ...overrides,
+  };
+}
+
+function makeExternalAccount(accountId: string): SyncServerSimpleFinAccount {
+  return { account_id: accountId, name: accountId, balance: 0 };
+}
+
+describe('computeInitialLinkState', () => {
+  it('preselects the upgrading account when there is exactly one unmatched external account', () => {
+    const localAccounts = [makeLocalAccount({ id: 'local-1' })];
+    const externalAccounts = [makeExternalAccount('ext-1')];
+
+    const { initiallyChosenAccounts } = computeInitialLinkState(
+      localAccounts,
+      externalAccounts,
+      'local-1',
+    );
+
+    expect(initiallyChosenAccounts['ext-1']).toBe('local-1');
+  });
+
+  it('does not preselect when there are multiple unmatched external accounts (regression for #8518)', () => {
+    const localAccounts = [makeLocalAccount({ id: 'local-1' })];
+    const externalAccounts = [
+      makeExternalAccount('ext-1'),
+      makeExternalAccount('ext-2'),
+    ];
+
+    const { initiallyChosenAccounts } = computeInitialLinkState(
+      localAccounts,
+      externalAccounts,
+      'local-1',
+    );
+
+    expect(Object.values(initiallyChosenAccounts)).not.toContain('local-1');
+  });
+
+  it('does not preselect when upgradingAccountId is not set', () => {
+    const localAccounts = [makeLocalAccount({ id: 'local-1' })];
+    const externalAccounts = [makeExternalAccount('ext-1')];
+
+    const { initiallyChosenAccounts } = computeInitialLinkState(
+      localAccounts,
+      externalAccounts,
+      undefined,
+    );
+
+    expect(Object.values(initiallyChosenAccounts)).not.toContain('local-1');
+  });
+
+  it('leaves an already-linked upgrading account untouched', () => {
+    const localAccounts = [
+      makeLocalAccount({ id: 'local-1', account_id: 'ext-1' }),
+    ];
+    const externalAccounts = [
+      makeExternalAccount('ext-1'),
+      makeExternalAccount('ext-2'),
+    ];
+
+    const { initiallyChosenAccounts } = computeInitialLinkState(
+      localAccounts,
+      externalAccounts,
+      'local-1',
+    );
+
+    expect(initiallyChosenAccounts).toEqual({ 'ext-1': 'local-1' });
+  });
+});

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
@@ -73,6 +73,57 @@ function isNewAccountOption(
   );
 }
 
+/**
+ * Computes which local accounts should be pre-linked to which external
+ * accounts when the modal first opens. When `upgradingAccountId` is set and
+ * there's exactly one external account that doesn't already match a known
+ * local account, it's unambiguous which row it belongs to, so it's
+ * preselected. If there's more than one unmatched external account, guessing
+ * would risk claiming the wrong row (and hiding the account from every other
+ * row's picker), so it's left for the user to pick manually.
+ */
+export function computeInitialLinkState(
+  localAccounts: AccountEntity[],
+  externalAccounts: ExternalAccount[],
+  upgradingAccountId: string | undefined,
+): {
+  initialDraftLinkAccounts: Map<string, 'linking' | 'unlinking'>;
+  initiallyChosenAccounts: Record<string, string>;
+} {
+  const externalAccountIds = new Set(externalAccounts.map(a => a.account_id));
+  const initialDraftLinkAccounts = new Map<string, 'linking' | 'unlinking'>();
+  for (const acc of localAccounts) {
+    if (acc.account_id && externalAccountIds.has(acc.account_id)) {
+      initialDraftLinkAccounts.set(acc.account_id, 'linking');
+    }
+  }
+
+  const initiallyChosenAccounts: Record<string, string> = Object.fromEntries(
+    localAccounts
+      .filter(acc => acc.account_id)
+      .map(acc => [acc.account_id, acc.id]),
+  );
+
+  const unmatchedExternalAccounts = externalAccounts.filter(
+    account => initiallyChosenAccounts[account.account_id] == null,
+  );
+
+  if (
+    upgradingAccountId &&
+    unmatchedExternalAccounts.length === 1 &&
+    !Object.values(initiallyChosenAccounts).includes(upgradingAccountId)
+  ) {
+    initiallyChosenAccounts[unmatchedExternalAccounts[0].account_id] =
+      upgradingAccountId;
+    initialDraftLinkAccounts.set(
+      unmatchedExternalAccounts[0].account_id,
+      'linking',
+    );
+  }
+
+  return { initialDraftLinkAccounts, initiallyChosenAccounts };
+}
+
 export type SelectLinkedAccountsModalProps =
   | {
       requisitionId: string;
@@ -161,48 +212,19 @@ export function SelectLinkedAccountsModal({
   const dispatch = useDispatch();
   const { data: allAccounts = [] } = useAccounts();
   const localAccounts = allAccounts.filter(a => a.closed === 0);
-  const { initialDraftLinkAccounts, initiallyChosenAccounts } = useMemo(() => {
-    const externalAccountIds = new Set(
-      externalAccounts?.map(a => a.account_id) || [],
-    );
-    const initialDraftLinkAccounts = new Map<string, 'linking' | 'unlinking'>();
-    for (const acc of localAccounts) {
-      if (acc.account_id && externalAccountIds.has(acc.account_id)) {
-        initialDraftLinkAccounts.set(acc.account_id, 'linking');
-      }
-    }
-
-    const initiallyChosenAccounts = Object.fromEntries(
-      localAccounts
-        .filter(acc => acc.account_id)
-        .map(acc => [acc.account_id, acc.id]),
-    );
-
-    const preselectedExternalAccount =
-      propsWithSortedExternalAccounts.externalAccounts.find(
-        account => initiallyChosenAccounts[account.account_id] == null,
-      );
-
-    if (
-      upgradingAccountId &&
-      preselectedExternalAccount &&
-      !Object.values(initiallyChosenAccounts).includes(upgradingAccountId)
-    ) {
-      initiallyChosenAccounts[preselectedExternalAccount.account_id] =
-        upgradingAccountId;
-      initialDraftLinkAccounts.set(
-        preselectedExternalAccount.account_id,
-        'linking',
-      );
-    }
-
-    return { initialDraftLinkAccounts, initiallyChosenAccounts };
-  }, [
-    localAccounts,
-    externalAccounts,
-    propsWithSortedExternalAccounts.externalAccounts,
-    upgradingAccountId,
-  ]);
+  const { initialDraftLinkAccounts, initiallyChosenAccounts } = useMemo(
+    () =>
+      computeInitialLinkState(
+        localAccounts,
+        propsWithSortedExternalAccounts.externalAccounts,
+        upgradingAccountId,
+      ),
+    [
+      localAccounts,
+      propsWithSortedExternalAccounts.externalAccounts,
+      upgradingAccountId,
+    ],
+  );
 
   const [draftLinkAccounts, setDraftLinkAccounts] = useState<
     Map<string, 'linking' | 'unlinking'>

--- a/upcoming-release-notes/fix-relink-account-picker.md
+++ b/upcoming-release-notes/fix-relink-account-picker.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [youngcw]
+---
+
+Fix relinking a bank account that had been unlinked.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
Fix an issue where an unlinked bank account is not available in the list of accounts to connect when linking.  This fixed my broken account after testing the issue :laughing: 

Fix description:
SelectLinkedAccountsModal.tsx extracted the initial-link-state computation into a pure computeInitialLinkState helper, and changed the preselection guess to only fire when there's exactly one unmatched external account (previously it blindly grabbed the first unmatched one). With multiple unmatched external accounts, the account being relinked now stays available in every row's "Account in Actual" dropdown instead of getting silently claimed by the wrong row

Fixed by Claude
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->
fixes #8518
## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 31 | 13.52 MB → 13.52 MB (-203 B) | -0.00%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
31 | 13.52 MB → 13.52 MB (-203 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/transactions/TransactionEdit.tsx` | 📉 -8 B (-0.01%) | 74.42 kB → 74.41 kB
`src/components/modals/MergeUnusedPayeesModal.tsx` | 📉 -4 B (-0.05%) | 7.75 kB → 7.74 kB
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📉 -191 B (-0.43%) | 43.51 kB → 43.33 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.25 MB → 5.25 MB (-203 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.3 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 172.43 kB | 0%
static/js/da.js | 96.58 kB | 0%
static/js/de.js | 179.91 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.88 kB | 0%
static/js/es.js | 165.92 kB | 0%
static/js/fr.js | 167.48 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 153.37 kB | 0%
static/js/narrow.js | 368.57 kB | 0%
static/js/nb-NO.js | 137.24 kB | 0%
static/js/nl.js | 145.55 kB | 0%
static/js/pl.js | 137.76 kB | 0%
static/js/pt-BR.js | 180.58 kB | 0%
static/js/ru.js | 143.08 kB | 0%
static/js/th.js | 166.6 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.89 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 108.06 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->