### PR TITLE
:electron: Fix logon not working after signout when using oidc

### DIFF
--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -100,7 +100,7 @@ const createOAuthServer = async () => {
   }
 
   return new Promise<{ url: string; server: Server }>(resolve => {
-    const server = createServer((req, res) => {
+    const server = createServer(async (req, res) => {
       const query = new URL(req.url || '', `http://localhost:${port}`)
         .searchParams;
 
@@ -118,8 +118,13 @@ const createOAuthServer = async () => {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
         res.end('OpenID login successful! You can close this tab.');
 
-        // Clean up the server after receiving the code
-        server.close();
+        // Clean up the server after receiving the code. Wait for the listener
+        // to fully release port 3010 before clearing the reference, otherwise a
+        // subsequent start-oauth-server request could try to bind the port
+        // while this listener is still shutting down.
+        await new Promise<void>(closeResolve => {
+          server.close(() => closeResolve());
+        });
         oAuthServer = null;
       } else {
         res.writeHead(400, { 'Content-Type': 'text/plain' });

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -92,9 +92,10 @@ const logMessage = (loglevel: 'info' | 'error', message: string) => {
 
 const createOAuthServer = async () => {
   const port = 3010;
-  logMessage('info', `OAuth server running on port: ${port}`);
 
   if (oAuthServer) {
+    logMessage('info', `OAuth server is already running on port: ${port}`);
+
     return { url: `http://localhost:${port}`, server: oAuthServer };
   }
 
@@ -119,6 +120,7 @@ const createOAuthServer = async () => {
 
         // Clean up the server after receiving the code
         server.close();
+        oAuthServer = null;
       } else {
         res.writeHead(400, { 'Content-Type': 'text/plain' });
         res.end('No token received.');
@@ -126,6 +128,7 @@ const createOAuthServer = async () => {
     });
 
     server.listen(port, '127.0.0.1', () => {
+      logMessage('info', `OAuth server started on port: ${port}`);
       resolve({ url: `http://localhost:${port}`, server });
     });
   });

--- a/upcoming-release-notes/8526.md
+++ b/upcoming-release-notes/8526.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix login issue that happens after signing out of a server with OIDC on Electron.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

If you setup OIDC on electron, then sign in, it starts a server in the background to facilitate the oidc callback. Once you sign in the server closes. If you then signout and try to sign back in again the reference to the original server is kept even though it's closed, which breaks the sign in.

Fix is to clear the reference to the closed server. When the next signin is attempted it will start a server again.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Tested on linux

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 31 | 13.52 MB | 0%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
31 | 13.52 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.25 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.3 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 172.43 kB | 0%
static/js/da.js | 96.58 kB | 0%
static/js/de.js | 179.91 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 206.88 kB | 0%
static/js/es.js | 165.92 kB | 0%
static/js/fr.js | 167.48 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 153.37 kB | 0%
static/js/narrow.js | 368.57 kB | 0%
static/js/nb-NO.js | 137.24 kB | 0%
static/js/nl.js | 145.55 kB | 0%
static/js/pl.js | 137.76 kB | 0%
static/js/pt-BR.js | 180.58 kB | 0%
static/js/ru.js | 143.08 kB | 0%
static/js/th.js | 166.6 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/uk.js | 201.7 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.89 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 108.06 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->