### PR TITLE
[AI] Keep split transaction focus on parent amount

### DIFF
--- a/packages/desktop-client/e2e/transactions.test.ts
+++ b/packages/desktop-client/e2e/transactions.test.ts
@@ -244,6 +244,28 @@ test.describe('Transactions', () => {
     await expect(page).toMatchThemeScreenshots();
   });
 
+  test('keeps focus on the parent amount when splitting with the keyboard', async () => {
+    await accountPage.addNewTransactionButton.click();
+
+    const parentTransaction = accountPage.newTransactionRow.first();
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await expect(
+      parentTransaction.getByTestId('category').getByRole('textbox'),
+    ).toBeFocused();
+    await page.keyboard.press('Tab');
+    await page.keyboard.type('55');
+    await page.keyboard.press('Shift+Tab');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+
+    await expect(accountPage.newTransactionRow).toHaveCount(3);
+    await expect(
+      parentTransaction.getByTestId('debit').getByRole('textbox'),
+    ).toBeFocused();
+  });
+
   test('creates a transfer test transaction', async () => {
     await accountPage.enterSingleTransaction({
       payee: 'Bank of America',

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -970,6 +970,25 @@ describe('Transactions', () => {
     expect(getTransactions()[2].amount).toBe(-1000);
   });
 
+  test('splitting a new transaction keeps focus on the parent amount', async () => {
+    const { container, updateProps } = renderTransactions();
+    updateProps({ isAdding: true });
+
+    let input = await editNewField(container, 'debit');
+    await userEvent.type(input, '55.00');
+
+    input = await editNewField(container, 'category');
+    await userEvent.type(input, '[ArrowDown][Enter]');
+    await waitForAutocomplete();
+
+    expect(
+      container.querySelectorAll(
+        '[data-testid="new-transaction"] [data-testid="row"]',
+      ),
+    ).toHaveLength(3);
+    expectToBeEditingField(container, 'debit', 0, true);
+  });
+
   test('escape closes the new transaction rows', async () => {
     const { container, updateProps } = renderTransactions({
       onCloseAddTransaction: () => {

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -3323,24 +3323,14 @@ export const TransactionTable = forwardRef(
         if (isTemporaryId(id)) {
           const { newNavigator } = latestState.current;
           const newTrans = latestState.current.newTransactions;
-          const { data, diff } = splitTransaction(
+          const { data } = splitTransaction(
             newTrans,
             id,
             makeEmptySplitSubtransactions,
           );
           setNewTransactions(data);
 
-          // Jump next to "debit" field if it is empty
-          // Otherwise jump to the same field as before, but downwards
-          // to the added split transaction
-          if (newTrans[0].amount === null) {
-            newNavigator.onEdit(newTrans[0].id, 'debit');
-          } else {
-            newNavigator.onEdit(
-              diff.added[0].id,
-              latestState.current.newNavigator.focusedField,
-            );
-          }
+          newNavigator.onEdit(newTrans[0].id, 'debit');
         } else {
           const trans = latestState.current.transactions.find(t => t.id === id);
           const newId = onSplitProp(id);

--- a/upcoming-release-notes/keep-parent-focus-when-splitting.md
+++ b/upcoming-release-notes/keep-parent-focus-when-splitting.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [fjbarrett]
+---
+
+Keep keyboard focus on the parent amount when creating a split transaction.


### PR DESCRIPTION
## Description

修复新建拆分交易时键盘焦点跳到第一个拆分行的问题。创建拆分后，焦点现在保留在父交易的付款金额字段，使用户可以先完成父交易，再填写拆分明细。

本次更改由 OpenAI Codex 辅助完成，包括实现、测试、发布说明和验证。

## Related issue(s)

Fixes #8522

## Testing

- 运行 `yarn lint:fix`
- 运行 `yarn typecheck`
- 运行 TransactionsTable 单元测试：28 个通过，1 个已有测试跳过
- 使用 Playwright 验证键盘操作流程，确认创建拆分后父交易的付款金额字段保持焦点

## Checklist

- [x] Release notes added
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 31 | 13.52 MB → 13.51 MB (-7.81 kB) | -0.06%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
31 | 13.52 MB → 13.51 MB (-7.81 kB) | -0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +1.45 kB (+0.70%) | 206.88 kB → 208.33 kB
`src/components/transactions/TransactionsTable.tsx` | 📉 -148 B (-0.16%) | 93.1 kB → 92.96 kB
`locale/de.json` | 📉 -627 B (-0.34%) | 179.91 kB → 179.3 kB
`locale/ca.json` | 📉 -609 B (-0.34%) | 172.43 kB → 171.84 kB
`locale/es.json` | 📉 -627 B (-0.37%) | 165.92 kB → 165.3 kB
`locale/zh-Hans.json` | 📉 -418 B (-0.38%) | 108.06 kB → 107.65 kB
`locale/fr.json` | 📉 -656 B (-0.38%) | 167.48 kB → 166.83 kB
`locale/pt-BR.json` | 📉 -720 B (-0.39%) | 180.58 kB → 179.87 kB
`locale/uk.json` | 📉 -817 B (-0.40%) | 201.7 kB → 200.9 kB
`locale/it.json` | 📉 -644 B (-0.41%) | 153.37 kB → 152.74 kB
`locale/nl.json` | 📉 -620 B (-0.42%) | 145.55 kB → 144.95 kB
`locale/nb-NO.json` | 📉 -599 B (-0.43%) | 137.24 kB → 136.65 kB
`locale/pl.json` | 📉 -606 B (-0.43%) | 137.76 kB → 137.17 kB
`locale/ru.json` | 📉 -721 B (-0.49%) | 143.08 kB → 142.38 kB
`locale/th.json` | 📉 -1009 B (-0.59%) | 166.6 kB → 165.62 kB
`locale/da.json` | 📉 -665 B (-0.67%) | 96.58 kB → 95.93 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 206.88 kB → 208.33 kB (+1.45 kB) | +0.70%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 166.6 kB → 165.62 kB (-1009 B) | -0.59%
static/js/uk.js | 201.7 kB → 200.9 kB (-817 B) | -0.40%
static/js/ru.js | 143.08 kB → 142.38 kB (-721 B) | -0.49%
static/js/pt-BR.js | 180.58 kB → 179.87 kB (-720 B) | -0.39%
static/js/da.js | 96.58 kB → 95.93 kB (-665 B) | -0.67%
static/js/fr.js | 167.48 kB → 166.83 kB (-656 B) | -0.38%
static/js/it.js | 153.37 kB → 152.74 kB (-644 B) | -0.41%
static/js/de.js | 179.91 kB → 179.3 kB (-627 B) | -0.34%
static/js/es.js | 165.92 kB → 165.3 kB (-627 B) | -0.37%
static/js/nl.js | 145.55 kB → 144.95 kB (-620 B) | -0.42%
static/js/ca.js | 172.43 kB → 171.84 kB (-609 B) | -0.34%
static/js/pl.js | 137.76 kB → 137.17 kB (-606 B) | -0.43%
static/js/nb-NO.js | 137.24 kB → 136.65 kB (-599 B) | -0.43%
static/js/zh-Hans.js | 108.06 kB → 107.65 kB (-418 B) | -0.38%
static/js/index.js | 5.25 MB → 5.25 MB (-148 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.3 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 368.57 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.89 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->