### PR TITLE
[WIP] [AI] Fix selected balance and range selection over split transactions

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.test.ts
+++ b/packages/desktop-client/src/components/accounts/Account.test.ts
@@ -1,0 +1,96 @@
+import type { TransactionEntity } from '@actual-app/core/types/models';
+
+import { getSelectableTransactions } from './Account';
+
+function makeTransaction(
+  id: string,
+  extra: Partial<TransactionEntity> = {},
+): TransactionEntity {
+  return {
+    id,
+    account: 'account-1',
+    date: '2026-03-24',
+    amount: -1000,
+    ...extra,
+  } as TransactionEntity;
+}
+
+const alwaysExpanded = () => true;
+const neverExpanded = () => false;
+
+describe('getSelectableTransactions', () => {
+  test('keeps standalone transactions', () => {
+    const transactions = [makeTransaction('tx-1'), makeTransaction('tx-2')];
+
+    expect(
+      getSelectableTransactions(transactions, true, alwaysExpanded).map(
+        t => t.id,
+      ),
+    ).toEqual(['tx-1', 'tx-2']);
+  });
+
+  test('drops reconciled transactions when they are hidden', () => {
+    const transactions = [
+      makeTransaction('tx-1'),
+      makeTransaction('tx-2', { reconciled: true }),
+    ];
+
+    expect(
+      getSelectableTransactions(transactions, false, alwaysExpanded).map(
+        t => t.id,
+      ),
+    ).toEqual(['tx-1']);
+
+    expect(
+      getSelectableTransactions(transactions, true, alwaysExpanded).map(
+        t => t.id,
+      ),
+    ).toEqual(['tx-1', 'tx-2']);
+  });
+
+  test('drops split children while their parent is collapsed', () => {
+    const transactions = [
+      makeTransaction('parent-1', { is_parent: true }),
+      makeTransaction('child-1', { parent_id: 'parent-1' }),
+      makeTransaction('child-2', { parent_id: 'parent-1' }),
+      makeTransaction('tx-9'),
+    ];
+
+    expect(
+      getSelectableTransactions(transactions, true, neverExpanded).map(
+        t => t.id,
+      ),
+    ).toEqual(['parent-1', 'tx-9']);
+  });
+
+  test('keeps split children once their parent is expanded', () => {
+    const transactions = [
+      makeTransaction('parent-1', { is_parent: true }),
+      makeTransaction('child-1', { parent_id: 'parent-1' }),
+      makeTransaction('tx-9'),
+    ];
+
+    expect(
+      getSelectableTransactions(transactions, true, alwaysExpanded).map(
+        t => t.id,
+      ),
+    ).toEqual(['parent-1', 'child-1', 'tx-9']);
+  });
+
+  test('expansion is resolved per parent', () => {
+    const transactions = [
+      makeTransaction('parent-1', { is_parent: true }),
+      makeTransaction('child-1', { parent_id: 'parent-1' }),
+      makeTransaction('parent-2', { is_parent: true }),
+      makeTransaction('child-2', { parent_id: 'parent-2' }),
+    ];
+
+    expect(
+      getSelectableTransactions(
+        transactions,
+        true,
+        id => id === 'parent-2',
+      ).map(t => t.id),
+    ).toEqual(['parent-1', 'parent-2', 'child-2']);
+  });
+});

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -203,6 +203,18 @@ function getField(field?: string) {
   }
 }
 
+export function getSelectableTransactions(
+  transactions: TransactionEntity[],
+  showReconciled: boolean,
+  isSplitExpanded: (id: string) => boolean,
+) {
+  return transactions.filter(
+    transaction =>
+      (showReconciled || !transaction.reconciled) &&
+      (!transaction.parent_id || isSplitExpanded(transaction.parent_id)),
+  );
+}
+
 type AccountInternalProps = {
   accountId?:
     | AccountEntity['id']
@@ -226,6 +238,7 @@ type AccountInternalProps = {
   newTransactions: Array<TransactionEntity['id']>;
   matchedTransactions: Array<TransactionEntity['id']>;
   splitsExpandedDispatch: ReturnType<typeof useSplitsExpanded>['dispatch'];
+  isSplitExpanded: ReturnType<typeof useSplitsExpanded>['isExpanded'];
   expandSplits?: boolean | undefined;
   savedFilters: TransactionFilterEntity[];
   onBatchEdit: ReturnType<typeof useTransactionBatchActions>['onBatchEdit'];
@@ -1746,16 +1759,17 @@ class AccountInternal extends PureComponent<
         {(allTransactions, allBalances) => (
           <SelectedProviderWithItems
             name="transactions"
-            // When reconciled transactions are hidden they are still
-            // loaded (e.g. to calculate running balances), but they must
-            // not be selectable. Mirror the filtering the transaction
-            // table applies when rendering so that range selection
-            // (shift+click) only covers visible transactions.
-            items={
-              showReconciled
-                ? allTransactions
-                : allTransactions.filter(t => !t.reconciled)
-            }
+            // Hidden transactions are still loaded (reconciled ones to
+            // calculate running balances, split children so they can be
+            // revealed without a refetch), but they must not be selectable.
+            // Mirror the filtering the transaction table applies when
+            // rendering so that range selection (shift+click) only covers
+            // visible transactions.
+            items={getSelectableTransactions(
+              allTransactions,
+              showReconciled,
+              this.props.isSplitExpanded,
+            )}
             fetchAllIds={this.fetchAllIds}
             registerDispatch={dispatch => (this.dispatchSelected = dispatch)}
             selectAllFilter={selectAllFilter}
@@ -1916,6 +1930,7 @@ type AccountHackProps = Omit<
   AccountInternalProps,
   | 'dispatch'
   | 'splitsExpandedDispatch'
+  | 'isSplitExpanded'
   | 'onBatchEdit'
   | 'onBatchDuplicate'
   | 'onBatchLinkSchedule'
@@ -1925,7 +1940,8 @@ type AccountHackProps = Omit<
 >;
 
 function AccountHack(props: AccountHackProps) {
-  const { dispatch: splitsExpandedDispatch } = useSplitsExpanded();
+  const { dispatch: splitsExpandedDispatch, isExpanded: isSplitExpanded } =
+    useSplitsExpanded();
   const dispatch = useDispatch();
   const {
     onBatchEdit,
@@ -1940,6 +1956,7 @@ function AccountHack(props: AccountHackProps) {
     <AccountInternal
       dispatch={dispatch}
       splitsExpandedDispatch={splitsExpandedDispatch}
+      isSplitExpanded={isSplitExpanded}
       onBatchEdit={onBatchEdit}
       onBatchDuplicate={onBatchDuplicate}
       onBatchLinkSchedule={onBatchLinkSchedule}

--- a/packages/desktop-client/src/components/accounts/Balance.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.test.tsx
@@ -44,6 +44,13 @@ function makeSchedule(
   } satisfies ScheduleEntity;
 }
 
+// `useSheetValue` is generic over the sheet field, so the mock resolves to the
+// numeric balance signature. The child-lookup binding returns rows instead, and
+// needs widening before it can be fed to the same mock.
+function mockedRows(rows: Array<{ id: string }>) {
+  return rows as unknown as number;
+}
+
 function mockedSchedules(schedules: ScheduleEntity[]) {
   return {
     isLoading: false,
@@ -84,6 +91,71 @@ describe('SelectedBalance – normal transactions', () => {
     );
 
     expect(screen.getByText('Selected balance:')).toBeInTheDocument();
+  });
+});
+
+describe('SelectedBalance – split transactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCachedSchedules).mockReturnValue(mockedSchedules([]));
+  });
+
+  function sumBinding() {
+    // The second useSheetValue call is the one that sums the amounts.
+    return vi.mocked(useSheetValue).mock.calls[1][0] as {
+      name: string;
+      query: { serializeAsString: () => string };
+    };
+  }
+
+  test('excludes selected split children from the summed ids', () => {
+    vi.mocked(useSheetValue)
+      .mockReturnValueOnce(mockedRows([{ id: 'child-1' }, { id: 'child-2' }]))
+      .mockReturnValueOnce(-5951);
+
+    render(
+      <TestProviders>
+        <SelectedBalance
+          selectedItems={new Set(['parent-1', 'child-1', 'child-2', 'tx-9'])}
+        />
+      </TestProviders>,
+    );
+
+    expect(sumBinding().query.serializeAsString()).toContain('parent-1');
+    expect(sumBinding().query.serializeAsString()).not.toContain('child-1');
+    expect(screen.getByText('-59.51')).toBeInTheDocument();
+  });
+
+  test('keys the sum on the ids it sums, not on the selection', () => {
+    // While the child lookup is still resolving it returns null, and every
+    // selected id — parents and children alike — ends up in the sum. That
+    // intermediate double-counts the parent, so it must not share a cell
+    // name with the resolved sum or its value gets served from the cache.
+    vi.mocked(useSheetValue).mockReturnValueOnce(null).mockReturnValueOnce(0);
+
+    const selectedItems = new Set(['parent-1', 'child-1']);
+    const { rerender } = render(
+      <TestProviders>
+        <SelectedBalance selectedItems={selectedItems} />
+      </TestProviders>,
+    );
+
+    const pendingName = sumBinding().name;
+
+    vi.clearAllMocks();
+    vi.mocked(useCachedSchedules).mockReturnValue(mockedSchedules([]));
+    vi.mocked(useSheetValue)
+      .mockReturnValueOnce(mockedRows([{ id: 'child-1' }]))
+      .mockReturnValueOnce(-5951);
+
+    rerender(
+      <TestProviders>
+        <SelectedBalance selectedItems={selectedItems} />
+      </TestProviders>,
+    );
+
+    expect(sumBinding().name).not.toBe(pendingName);
+    expect(sumBinding().name).toBe('selected-balance-parent-1-sum');
   });
 });
 

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -67,10 +67,9 @@ export function SelectedBalance({
   const { t } = useTranslation();
 
   const selectedIds = [...selectedItems];
-  const name = `selected-balance-${selectedIds.join('-')}`;
 
   const rows = useSheetValue<'balance', `selected-transactions-${string}`>({
-    name: name as `selected-transactions-${string}`,
+    name: `selected-transactions-${selectedIds.join('-')}`,
     query: q('transactions')
       .filter({
         id: { $oneof: selectedIds },

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -66,22 +66,28 @@ export function SelectedBalance({
 }: SelectedBalanceProps) {
   const { t } = useTranslation();
 
-  const name = `selected-balance-${[...selectedItems].join('-')}`;
+  const selectedIds = [...selectedItems];
+  const name = `selected-balance-${selectedIds.join('-')}`;
 
   const rows = useSheetValue<'balance', `selected-transactions-${string}`>({
     name: name as `selected-transactions-${string}`,
     query: q('transactions')
       .filter({
-        id: { $oneof: [...selectedItems] },
-        parent_id: { $oneof: [...selectedItems] },
+        id: { $oneof: selectedIds },
+        parent_id: { $oneof: selectedIds },
       })
       .select('id'),
   });
   const ids = new Set((rows || []).map((r: { id: string }) => r.id));
 
-  const finalIds = [...selectedItems].filter(id => !ids.has(id));
+  const finalIds = selectedIds.filter(id => !ids.has(id));
+  // The spreadsheet caches cell values by name alone, so this sum must be
+  // keyed on the ids it actually covers. While the query above is still
+  // resolving, `finalIds` also holds the selected split children, and summing
+  // those with `splits: 'all'` counts their parent twice. Keying on
+  // `selectedItems` would cache that intermediate under the final name.
   let balance = useSheetValue<'balance', `selected-balance-${string}`>({
-    name: (name + '-sum') as `selected-balance-${string}`,
+    name: `selected-balance-${finalIds.join('-')}-sum`,
     query: q('transactions')
       .filter({ id: { $oneof: finalIds } })
       .options({ splits: 'all' })

--- a/upcoming-release-notes/fix-shift-click-selected-totals.md
+++ b/upcoming-release-notes/fix-shift-click-selected-totals.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [fjbarrett]
+---
+
+Fix the selected balance double-counting split transactions, and stop shift+click range selection from covering collapsed split children.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 31 | 13.52 MB → 13.51 MB (-8 kB) | -0.06%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
31 | 13.52 MB → 13.51 MB (-8 kB) | -0.06%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Account.tsx` | 📈 +359 B (+0.81%) | 43.18 kB → 43.53 kB
`locale/en.json` | 📈 +1.45 kB (+0.70%) | 206.88 kB → 208.33 kB
`locale/de.json` | 📉 -627 B (-0.34%) | 179.91 kB → 179.3 kB
`locale/ca.json` | 📉 -609 B (-0.34%) | 172.43 kB → 171.84 kB
`locale/es.json` | 📉 -627 B (-0.37%) | 165.92 kB → 165.3 kB
`locale/zh-Hans.json` | 📉 -418 B (-0.38%) | 108.06 kB → 107.65 kB
`locale/fr.json` | 📉 -656 B (-0.38%) | 167.48 kB → 166.83 kB
`locale/pt-BR.json` | 📉 -720 B (-0.39%) | 180.58 kB → 179.87 kB
`locale/uk.json` | 📉 -817 B (-0.40%) | 201.7 kB → 200.9 kB
`locale/it.json` | 📉 -644 B (-0.41%) | 153.37 kB → 152.74 kB
`locale/nl.json` | 📉 -620 B (-0.42%) | 145.55 kB → 144.95 kB
`locale/nb-NO.json` | 📉 -599 B (-0.43%) | 137.24 kB → 136.65 kB
`locale/pl.json` | 📉 -606 B (-0.43%) | 137.76 kB → 137.17 kB
`locale/ru.json` | 📉 -721 B (-0.49%) | 143.08 kB → 142.38 kB
`locale/th.json` | 📉 -1009 B (-0.59%) | 166.6 kB → 165.62 kB
`locale/da.json` | 📉 -665 B (-0.67%) | 96.58 kB → 95.93 kB
`src/components/accounts/Balance.tsx` | 📉 -697 B (-6.71%) | 10.14 kB → 9.46 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 206.88 kB → 208.33 kB (+1.45 kB) | +0.70%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 166.6 kB → 165.62 kB (-1009 B) | -0.59%
static/js/uk.js | 201.7 kB → 200.9 kB (-817 B) | -0.40%
static/js/ru.js | 143.08 kB → 142.38 kB (-721 B) | -0.49%
static/js/pt-BR.js | 180.58 kB → 179.87 kB (-720 B) | -0.39%
static/js/da.js | 96.58 kB → 95.93 kB (-665 B) | -0.67%
static/js/fr.js | 167.48 kB → 166.83 kB (-656 B) | -0.38%
static/js/it.js | 153.37 kB → 152.74 kB (-644 B) | -0.41%
static/js/de.js | 179.91 kB → 179.3 kB (-627 B) | -0.34%
static/js/es.js | 165.92 kB → 165.3 kB (-627 B) | -0.37%
static/js/nl.js | 145.55 kB → 144.95 kB (-620 B) | -0.42%
static/js/ca.js | 172.43 kB → 171.84 kB (-609 B) | -0.34%
static/js/pl.js | 137.76 kB → 137.17 kB (-606 B) | -0.43%
static/js/nb-NO.js | 137.24 kB → 136.65 kB (-599 B) | -0.43%
static/js/zh-Hans.js | 108.06 kB → 107.65 kB (-418 B) | -0.38%
static/js/wide.js | 303.89 kB → 303.56 kB (-338 B) | -0.11%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.25 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/ReportRouter.js | 1.3 MB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 368.57 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->