### PR TITLE
[AI] Migrate spending analysis month pickers

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -7,6 +7,7 @@ import { Block } from '@actual-app/components/block';
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { ModeButton } from '@actual-app/components/mode-button';
+import { MonthPicker } from '@actual-app/components/month-picker';
 import { Paragraph } from '@actual-app/components/paragraph';
 import { Select } from '@actual-app/components/select';
 import { SpaceBetween } from '@actual-app/components/space-between';
@@ -46,7 +47,7 @@ import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
-import { useLocale } from '#hooks/useLocale';
+import { useLanguage, useLocale } from '#hooks/useLocale';
 import { useNavigate } from '#hooks/useNavigate';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { useSyncedPref } from '#hooks/useSyncedPref';
@@ -74,6 +75,7 @@ type SpendingInternalProps = {
 
 function SpendingInternal({ widget }: SpendingInternalProps) {
   const locale = useLocale();
+  const language = useLanguage();
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const format = useFormat();
@@ -238,6 +240,12 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
       : reportMode === 'average'
         ? averageRangeOptions
         : [['label', t('Budgeted')] as const];
+  const earliestInterval = allIntervals.at(-1)?.name;
+  const latestInterval = allIntervals[0]?.name;
+  const monthPickerLabels = {
+    previous: t('Previous'),
+    next: t('Next'),
+  };
   const onComparisonChange = (value: string) => {
     if (reportMode === 'single-month') {
       setCompareTo(value);
@@ -323,26 +331,38 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               <Text>
                 <Trans>Compare</Trans>
               </Text>
-              <Select
+              <MonthPicker
                 value={compare}
+                minDate={earliestInterval}
+                maxDate={latestInterval}
+                locale={language}
+                labels={monthPickerLabels}
                 onChange={setCompare}
-                options={allIntervals.map(
-                  ({ name, pretty }) => [name, pretty] as const,
-                )}
                 style={{ width: 150 }}
-                popoverStyle={{ width: 150 }}
               />
               <Text>
                 <Trans>to</Trans>
               </Text>
-              <Select
-                value={comparisonValue}
-                onChange={onComparisonChange}
-                options={comparisonOptions}
-                disabled={reportMode === 'budget'}
-                style={{ width: 150 }}
-                popoverStyle={{ width: 150 }}
-              />
+              {reportMode === 'single-month' ? (
+                <MonthPicker
+                  value={compareTo}
+                  minDate={earliestInterval}
+                  maxDate={latestInterval}
+                  locale={language}
+                  labels={monthPickerLabels}
+                  onChange={setCompareTo}
+                  style={{ width: 150 }}
+                />
+              ) : (
+                <Select
+                  value={comparisonValue}
+                  onChange={onComparisonChange}
+                  options={comparisonOptions}
+                  disabled={reportMode === 'budget'}
+                  style={{ width: 150 }}
+                  popoverStyle={{ width: 150 }}
+                />
+              )}
             </SpaceBetween>
 
             <View

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -229,17 +229,13 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const averageRangeLabel = getSpendingAverageRangeLabel(averageRange, t);
   const averageRangeOptions = getSpendingAverageRangeOptions(t);
   const comparisonValue =
-    reportMode === 'single-month'
-      ? compareTo
-      : reportMode === 'average'
-        ? spendingAverageRangeToKey(averageRange)
-        : 'label';
+    reportMode === 'average'
+      ? spendingAverageRangeToKey(averageRange)
+      : 'label';
   const comparisonOptions =
-    reportMode === 'single-month'
-      ? allIntervals.map(({ name, pretty }) => [name, pretty] as const)
-      : reportMode === 'average'
-        ? averageRangeOptions
-        : [['label', t('Budgeted')] as const];
+    reportMode === 'average'
+      ? averageRangeOptions
+      : [['label', t('Budgeted')] as const];
   const earliestInterval = allIntervals.at(-1)?.name;
   const latestInterval = allIntervals[0]?.name;
   const monthPickerLabels = {
@@ -247,9 +243,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
     next: t('Next'),
   };
   const onComparisonChange = (value: string) => {
-    if (reportMode === 'single-month') {
-      setCompareTo(value);
-    } else if (reportMode === 'average') {
+    if (reportMode === 'average') {
       setAverageRange(spendingAverageRangeFromKey(value));
     }
   };

--- a/upcoming-release-notes/spending-analysis-month-pickers.md
+++ b/upcoming-release-notes/spending-analysis-month-pickers.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [AnayGarodia]
+---
+
+Use the calendar month picker when choosing months in spending analysis.


### PR DESCRIPTION
## Description

The spending analysis report still picked its two comparison months with plain `Select` dropdowns. This moves them onto the shared `MonthPicker` calendar component, so spending analysis matches what budget automations already do (#8515) and one more box in #8514 can be ticked.

- The **Compare** control is now always a `MonthPicker`, clamped via `minDate`/`maxDate` to the earliest and latest intervals that actually have data.
- The **to** control becomes a `MonthPicker` in `single-month` mode, and stays a `Select` in `average` / `budget` mode, where the options are ranges and labels rather than months.
- Because `single-month` no longer feeds the `Select`, the now-unreachable `single-month` branches in `comparisonValue`, `comparisonOptions`, and `onComparisonChange` are removed rather than left dangling.
- The picker receives the active language via `useLanguage()` so month names localize, and its previous/next labels go through `t()`.

The underlying `compare` / `compareTo` state is read and written exactly as before, so saved widgets and existing dashboards are unaffected.

**AI usage disclosure:** this change was written with Claude Code (Anthropic), per the [AI usage policy](https://actualbudget.org/docs/contributing/ai-usage-policy). I have reviewed every line of the diff myself.

## Related issue(s)

Relates to #8514

## Testing

CI is green on this branch: functional (3 shards), visual regression (3 shards), functional desktop app, and the web / macOS / Ubuntu / Windows builds all pass.

Manually exercised on the [deploy preview](https://deploy-preview-8532.demo.actualbudget.org) using the demo budget (data spans Jul 2025 – Jul 2026), on the "This Month" spending widget:

- **Compare picker** opens a calendar. `Next` is disabled on the 2026 page and Aug–Dec 2026 are greyed out; paging back, `Previous` is disabled on the 2025 page and Jan–Jun 2025 are greyed out. So both `minDate` and `maxDate` clamp correctly. Picking Dec 2025 updated the legend and the spent figures.
- **Single month mode:** the *to* control is also a `MonthPicker` with the same clamping, with the current value marked pressed. Picking May 2026 updated the chart.
- **Average mode:** the *to* control switches back to the `Select`, offering Last 3 / 6 / 12 months, YTD, All time.
- **Budgeted mode:** the *to* control is the `Select`, disabled, reading "Budgeted" — same as before.
- **Round trip:** switching back to Single month restores the picker with the previously chosen month intact.
- **Localization:** with the UI set to Deutsch, the picker renders `Januar`, `März`, `Mai`, `Oktober`, `Dezember` correctly.
- No console errors at any point.

One thing worth flagging: the picker's `Previous` / `Next` labels still render in English under a German UI. `Previous` and `Next` are new source strings introduced by this PR, so they only exist in `en.json` and fall back to English until Weblate picks them up. Happy to handle it differently if you'd rather reuse existing keys.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 31 | 13.52 MB → 13.51 MB (-6.91 kB) | -0.05%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.83 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
31 | 13.52 MB → 13.51 MB (-6.91 kB) | -0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Spending.tsx` | 📈 +781 B (+3.10%) | 24.58 kB → 25.34 kB
`locale/en.json` | 📈 +1.45 kB (+0.70%) | 206.88 kB → 208.33 kB
`src/components/reports/reports/Calendar.tsx` | 📉 -2 B (-0.01%) | 27.59 kB → 27.59 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📉 -2 B (-0.01%) | 25.38 kB → 25.37 kB
`locale/de.json` | 📉 -627 B (-0.34%) | 179.91 kB → 179.3 kB
`locale/ca.json` | 📉 -609 B (-0.34%) | 172.43 kB → 171.84 kB
`locale/es.json` | 📉 -627 B (-0.37%) | 165.92 kB → 165.3 kB
`locale/zh-Hans.json` | 📉 -418 B (-0.38%) | 108.06 kB → 107.65 kB
`locale/fr.json` | 📉 -656 B (-0.38%) | 167.48 kB → 166.83 kB
`locale/pt-BR.json` | 📉 -720 B (-0.39%) | 180.58 kB → 179.87 kB
`locale/uk.json` | 📉 -817 B (-0.40%) | 201.7 kB → 200.9 kB
`locale/it.json` | 📉 -644 B (-0.41%) | 153.37 kB → 152.74 kB
`locale/nl.json` | 📉 -620 B (-0.42%) | 145.55 kB → 144.95 kB
`locale/nb-NO.json` | 📉 -599 B (-0.43%) | 137.24 kB → 136.65 kB
`locale/pl.json` | 📉 -606 B (-0.43%) | 137.76 kB → 137.17 kB
`locale/ru.json` | 📉 -721 B (-0.49%) | 143.08 kB → 142.38 kB
`locale/th.json` | 📉 -1009 B (-0.59%) | 166.6 kB → 165.62 kB
`locale/da.json` | 📉 -665 B (-0.67%) | 96.58 kB → 95.93 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 206.88 kB → 208.33 kB (+1.45 kB) | +0.70%
static/js/ReportRouter.js | 1.3 MB → 1.3 MB (+777 B) | +0.06%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 166.6 kB → 165.62 kB (-1009 B) | -0.59%
static/js/uk.js | 201.7 kB → 200.9 kB (-817 B) | -0.40%
static/js/ru.js | 143.08 kB → 142.38 kB (-721 B) | -0.49%
static/js/pt-BR.js | 180.58 kB → 179.87 kB (-720 B) | -0.39%
static/js/da.js | 96.58 kB → 95.93 kB (-665 B) | -0.67%
static/js/fr.js | 167.48 kB → 166.83 kB (-656 B) | -0.38%
static/js/it.js | 153.37 kB → 152.74 kB (-644 B) | -0.41%
static/js/de.js | 179.91 kB → 179.3 kB (-627 B) | -0.34%
static/js/es.js | 165.92 kB → 165.3 kB (-627 B) | -0.37%
static/js/nl.js | 145.55 kB → 144.95 kB (-620 B) | -0.42%
static/js/ca.js | 172.43 kB → 171.84 kB (-609 B) | -0.34%
static/js/pl.js | 137.76 kB → 137.17 kB (-606 B) | -0.43%
static/js/nb-NO.js | 137.24 kB → 136.65 kB (-599 B) | -0.43%
static/js/zh-Hans.js | 108.06 kB → 107.65 kB (-418 B) | -0.38%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 5.25 MB | 0%
static/js/AppliedFilters.js | 36.47 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 760.33 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.33 kB | 0%
static/js/TransactionList.js | 88.69 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 368.57 kB | 0%
static/js/theme.js | 30.94 kB | 0%
static/js/useDateFormat.js | 2.95 MB | 0%
static/js/useTransactionBatchActions.js | 9.71 kB | 0%
static/js/wide.js | 303.89 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CPfUHQJ6.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.83 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.83 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->
