### PR TITLE
fix maintainer points counting script PR categorisation

### DIFF
--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -296,10 +296,18 @@ async function countContributorPoints() {
           // Award points to PR author if they are a core maintainer
           const prAuthor = pr.user?.login;
           if (prAuthor && orgMemberLogins.has(prAuthor)) {
-            const releaseNoteFile = modifiedFiles.find(
-              file =>
-                file.filename === `upcoming-release-notes/${pr.number}.md`,
-            );
+            const isReleaseNoteFile = file =>
+              file.filename.startsWith('upcoming-release-notes/') &&
+              file.filename.endsWith('.md') &&
+              file.filename !== 'upcoming-release-notes/README.md';
+            const releaseNoteFile =
+              modifiedFiles.find(
+                file =>
+                  file.filename === `upcoming-release-notes/${pr.number}.md`,
+              ) ??
+              modifiedFiles.find(
+                file => file.status === 'added' && isReleaseNoteFile(file),
+              );
             const categoryAndPoints = await getPRCategoryAndPoints(
               octokit,
               owner,

--- a/.github/scripts/count-points.mjs
+++ b/.github/scripts/count-points.mjs
@@ -303,7 +303,8 @@ async function countContributorPoints() {
             const releaseNoteFile =
               modifiedFiles.find(
                 file =>
-                  file.filename === `upcoming-release-notes/${pr.number}.md`,
+                  file.filename === `upcoming-release-notes/${pr.number}.md` &&
+                  file.status !== 'removed',
               ) ??
               modifiedFiles.find(
                 file => file.status === 'added' && isReleaseNoteFile(file),

--- a/upcoming-release-notes/count-points-fix.md
+++ b/upcoming-release-notes/count-points-fix.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Fix maintainer points counting script PR categorisation


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Looks like this was broken when we changed release note naming scheme.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
