### PR TITLE
[AI] Fix rule modal restoration after undo

### DIFF
--- a/packages/desktop-client/src/components/modals/EditRuleModal.test.tsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.test.tsx
@@ -1,0 +1,61 @@
+import type { NewRuleEntity } from '@actual-app/core/types/models';
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EditRuleModal } from './EditRuleModal';
+
+const undoMocks = vi.hoisted(() => ({
+  getUndoState: vi.fn(),
+  setUndoState: vi.fn(),
+}));
+
+vi.mock('@actual-app/core/platform/client/undo', () => undoMocks);
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (value: string) => value }),
+}));
+
+vi.mock('#components/common/Modal', () => ({
+  Modal: () => null,
+  ModalCloseButton: () => null,
+  ModalHeader: () => null,
+}));
+
+vi.mock('#components/rules/RuleEditor', () => ({
+  RuleEditor: () => null,
+}));
+
+describe('EditRuleModal', () => {
+  beforeEach(() => {
+    undoMocks.getUndoState.mockReset();
+    undoMocks.setUndoState.mockReset();
+  });
+
+  it('restores the edit modal when undoing a rule application', () => {
+    const previousModal = {
+      name: 'manage-rules',
+      options: { payeeId: 'payee-id' },
+    };
+    const rule = {
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [],
+      actions: [],
+    } satisfies NewRuleEntity;
+    const onSave = vi.fn();
+    undoMocks.getUndoState.mockReturnValue(previousModal);
+
+    const { unmount } = render(<EditRuleModal rule={rule} onSave={onSave} />);
+
+    expect(undoMocks.setUndoState).toHaveBeenCalledWith('openModal', {
+      name: 'edit-rule',
+      options: { rule, onSave },
+    });
+
+    unmount();
+    expect(undoMocks.setUndoState).toHaveBeenLastCalledWith(
+      'openModal',
+      previousModal,
+    );
+  });
+});

--- a/packages/desktop-client/src/components/modals/EditRuleModal.tsx
+++ b/packages/desktop-client/src/components/modals/EditRuleModal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { theme } from '@actual-app/components/theme';
+import * as undo from '@actual-app/core/platform/client/undo';
 import type { NewRuleEntity, RuleEntity } from '@actual-app/core/types/models';
 
 import { Modal, ModalCloseButton, ModalHeader } from '#components/common/Modal';
@@ -17,6 +18,16 @@ export function EditRuleModal({
   onSave: originalOnSave,
 }: EditRuleModalProps) {
   const { t } = useTranslation();
+
+  useEffect(() => {
+    const previousModal = undo.getUndoState('openModal');
+    undo.setUndoState('openModal', {
+      name: 'edit-rule',
+      options: { rule: defaultRule, onSave: originalOnSave },
+    });
+
+    return () => undo.setUndoState('openModal', previousModal);
+  }, [defaultRule, originalOnSave]);
 
   return (
     <Modal name="edit-rule">

--- a/upcoming-release-notes/fix-rule-modal-undo.md
+++ b/upcoming-release-notes/fix-rule-modal-undo.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [ColumbusLabs]
+---
+
+Reopen the rule editor when undoing changes applied from a rule.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

修复撤销规则应用后规则编辑器无法重新打开的问题。`EditRuleModal` 现在会在打开时保存可撤销的模态框状态，并在卸载时恢复此前状态，使用户撤销由规则触发的更改时能够回到原来的规则编辑器。

本次实现和测试由 OpenAI Codex 协助完成；提交前已逐行复查改动。

## Related issue(s)

Fixes #1945

## Testing

新增 `EditRuleModal.test.tsx` 回归测试，覆盖编辑器打开时注册撤销状态以及卸载时恢复先前模态框状态。GitHub CI 中测试、类型检查、lint、构建、迁移、约束检查、Electron 平台任务、功能测试、视觉回归、CodeQL 和发布说明检查均已通过。

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->