### PR TITLE
decrease time-to-stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
+          stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
           days-before-stale: 14
           days-before-close: 3
           days-before-issue-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-pr-message: 'This PR is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 3 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 3 days with no activity. If you would like to resume working on this, please reach out to the maintainer team on Discord or leave a comment here to have it reopened.'
           days-before-stale: 14
           days-before-close: 3
           days-before-issue-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR was closed because it has been stalled for 5 days with no activity.'
-          days-before-stale: 30
-          days-before-close: 5
+          days-before-stale: 14
+          days-before-close: 3
           days-before-issue-stale: -1
   stale-wip:
     permissions:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
           days-before-stale: 14
           days-before-close: 3
           days-before-issue-stale: -1
+          include-only-assigned: true
   stale-wip:
     permissions:
       pull-requests: write

--- a/upcoming-release-notes/stale-time.md
+++ b/upcoming-release-notes/stale-time.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Decrease time after which a PR is considered stale


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

We've got a lot of PRs sitting with comments and no response, they make the list hard to read and take up maintainer bandwidth for new changes. If a PR is stale and closed, then subsequently reopened when the author has time then that is more than okay, but they don't need to sit in the list if not.

Ideally I'd get 3 approvals on this before merging

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
