### PR TITLE
docs: add missing steps for activating experimental features

### DIFF
--- a/packages/docs/docs/advanced/bank-sync/enable-banking.md
+++ b/packages/docs/docs/advanced/bank-sync/enable-banking.md
@@ -6,7 +6,9 @@
 All functionality described here may not be available in the latest stable release. See [Experimental Features](../../experimental/index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
-To set up Enable Banking, start by creating and signing in to your account: https://enablebanking.com/sign-in/
+Due to being an experimental feature, it is not made available by default. To enable it, you will need to go into **More** and **Settings**, scroll at the bottom and **open the advanced settings**, scroll once again and **accept the risks to show experimental features**. Then you can tick the *Enable Banking sync (EU banks)* box. With this, you should be able to see the EnableBanking provider appear in your Bank Sync page.
+
+You can then go to https://enablebanking.com/sign-in/ and start by creating and signing in to your account.
 
 Create a new application: https://enablebanking.com/cp/applications. Select **Production** and make sure the redirect URL uses `https` and your domain.
 

--- a/packages/docs/docs/advanced/bank-sync/enable-banking.md
+++ b/packages/docs/docs/advanced/bank-sync/enable-banking.md
@@ -6,8 +6,6 @@
 All functionality described here may not be available in the latest stable release. See [Experimental Features](../../experimental/index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
-Due to being an experimental feature, it is not made available by default. To enable it, you will need to go into **More** and **Settings**, scroll at the bottom and **open the advanced settings**, scroll once again and **accept the risks to show experimental features**. Then you can tick the _Enable Banking sync (EU banks)_ box. With this, you should be able to see the EnableBanking provider appear in your Bank Sync page.
-
 You can then go to https://enablebanking.com/sign-in/ and start by creating and signing in to your account.
 
 Create a new application: https://enablebanking.com/cp/applications. Select **Production** and make sure the redirect URL uses `https` and your domain.

--- a/packages/docs/docs/advanced/bank-sync/enable-banking.md
+++ b/packages/docs/docs/advanced/bank-sync/enable-banking.md
@@ -6,7 +6,7 @@
 All functionality described here may not be available in the latest stable release. See [Experimental Features](../../experimental/index.md) for instructions to enable experimental features. Use the `nightly` images for the latest implementation.
 :::
 
-Due to being an experimental feature, it is not made available by default. To enable it, you will need to go into **More** and **Settings**, scroll at the bottom and **open the advanced settings**, scroll once again and **accept the risks to show experimental features**. Then you can tick the *Enable Banking sync (EU banks)* box. With this, you should be able to see the EnableBanking provider appear in your Bank Sync page.
+Due to being an experimental feature, it is not made available by default. To enable it, you will need to go into **More** and **Settings**, scroll at the bottom and **open the advanced settings**, scroll once again and **accept the risks to show experimental features**. Then you can tick the _Enable Banking sync (EU banks)_ box. With this, you should be able to see the EnableBanking provider appear in your Bank Sync page.
 
 You can then go to https://enablebanking.com/sign-in/ and start by creating and signing in to your account.
 

--- a/packages/docs/src/components/ExperimentalFeatureWarning.tsx
+++ b/packages/docs/src/components/ExperimentalFeatureWarning.tsx
@@ -38,6 +38,13 @@ export function ExperimentalFeatureWarning({
         )}{' '}
         or post a message in the Discord.
       </p>
+      <p>
+        Due to being an experimental feature, it is not made available by default.
+        To enable it, you will need to go into <strong>More</strong> and <strong>Settings</strong>,
+        scroll at the bottom and <strong>open the advanced settings</strong>, scroll once again and
+        <strong>accept the risks to show experimental features</strong>.
+        Then you can tick the <em>checkbox<em> related to this feature.
+      </p>
       {children}
     </Admonition>
   );


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Add the missing steps as discussed on discord. This PR augment the ExperimentalFeatureWarning with an extra `<p>` containing instructions of where to enable the feature currently displayed.

Wrote fully with my small fingers. Did a local CodeRabbit review, found no findings.

## Related issue(s)

None.

## Testing

N/A.

## Checklist

- [?] Release notes added (see link above) - is this necessary for docs quick edit? 
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
