### PR TITLE
Change query to typescript

### DIFF
--- a/packages/api/app/query.ts
+++ b/packages/api/app/query.ts
@@ -42,7 +42,14 @@ class Query {
     });
   }
 
-  select(exprs = []) {
+  select(
+    exprs:
+      | Array<ObjectExpression | string>
+      | ObjectExpression
+      | string
+      | '*'
+      | ['*'] = [],
+  ) {
     if (!Array.isArray(exprs)) {
       exprs = [exprs];
     }

--- a/packages/api/app/query.ts
+++ b/packages/api/app/query.ts
@@ -32,7 +32,7 @@ class Query {
     });
   }
 
-  unfilter(exprs?: Array<keyof ObjectExpression>) {
+  unfilter(exprs?: string[]) {
     const exprSet = new Set(exprs);
     return new Query({
       ...this.state,

--- a/packages/api/app/query.ts
+++ b/packages/api/app/query.ts
@@ -1,9 +1,16 @@
+import type {
+  ObjectExpression,
+  QueryState,
+} from '@actual-app/core/shared/query';
+import type { WithRequired } from '@actual-app/core/types/util';
+
 class Query {
   /** @type {import('@actual-app/core/shared/query').QueryState} */
-  state;
+  state: QueryState;
 
-  constructor(state) {
+  constructor(state: WithRequired<Partial<QueryState>, 'table'>) {
     this.state = {
+      tableOptions: state.tableOptions || {},
       filterExpressions: state.filterExpressions || [],
       selectExpressions: state.selectExpressions || [],
       groupExpressions: state.groupExpressions || [],
@@ -18,14 +25,14 @@ class Query {
     };
   }
 
-  filter(expr) {
+  filter(expr: ObjectExpression) {
     return new Query({
       ...this.state,
       filterExpressions: [...this.state.filterExpressions, expr],
     });
   }
 
-  unfilter(exprs) {
+  unfilter(exprs?: Array<keyof ObjectExpression>) {
     const exprSet = new Set(exprs);
     return new Query({
       ...this.state,
@@ -40,18 +47,23 @@ class Query {
       exprs = [exprs];
     }
 
-    const query = new Query({ ...this.state, selectExpressions: exprs });
-    query.state.calculation = false;
+    const query = new Query({
+      ...this.state,
+      selectExpressions: exprs,
+      calculation: false,
+    });
     return query;
   }
 
-  calculate(expr) {
-    const query = this.select({ result: expr });
-    query.state.calculation = true;
-    return query;
+  calculate(expr: ObjectExpression | string) {
+    return new Query({
+      ...this.state,
+      selectExpressions: [{ result: expr }],
+      calculation: true,
+    });
   }
 
-  groupBy(exprs) {
+  groupBy(exprs: ObjectExpression | string | Array<ObjectExpression | string>) {
     if (!Array.isArray(exprs)) {
       exprs = [exprs];
     }
@@ -62,7 +74,7 @@ class Query {
     });
   }
 
-  orderBy(exprs) {
+  orderBy(exprs: ObjectExpression | string | Array<ObjectExpression | string>) {
     if (!Array.isArray(exprs)) {
       exprs = [exprs];
     }
@@ -73,11 +85,11 @@ class Query {
     });
   }
 
-  limit(num) {
+  limit(num: number) {
     return new Query({ ...this.state, limit: num });
   }
 
-  offset(num) {
+  offset(num: number) {
     return new Query({ ...this.state, offset: num });
   }
 
@@ -93,7 +105,7 @@ class Query {
     return new Query({ ...this.state, validateRefs: false });
   }
 
-  options(opts) {
+  options(opts: Record<string, unknown>) {
     return new Query({ ...this.state, tableOptions: opts });
   }
 
@@ -110,6 +122,6 @@ class Query {
   }
 }
 
-export function q(table) {
+export function q(table: QueryState['table']) {
   return new Query({ table });
 }

--- a/packages/loot-core/src/shared/query.ts
+++ b/packages/loot-core/src/shared/query.ts
@@ -1,6 +1,6 @@
 import type { WithRequired } from '#types/util';
 
-type ObjectExpression = {
+export type ObjectExpression = {
   [key: string]: ObjectExpression | unknown;
 };
 

--- a/upcoming-release-notes/8545.md
+++ b/upcoming-release-notes/8545.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [shahidsarker]
+---
+
+Migrate api/app/query to TypeScript


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Migrate `packages/api/app/query.js` to TypeScript

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Relates to #1483 

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Ran `yarn test` and `yarn typecheck` successfully to confirm changes.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.18 MB → 13.18 MB (-1.85 kB) | -0.01%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB → 3.84 MB (-56 B) | -0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.18 MB → 13.18 MB (-1.85 kB) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +562 B (+0.26%) | 208.33 kB → 208.88 kB
`locale/ru.json` | 📈 +124 B (+0.09%) | 142.38 kB → 142.5 kB
`locale/es.json` | 📉 -54 B (-0.03%) | 165.3 kB → 165.25 kB
`locale/pt-BR.json` | 📉 -59 B (-0.03%) | 179.87 kB → 179.81 kB
`locale/fr.json` | 📉 -58 B (-0.03%) | 166.83 kB → 166.78 kB
`locale/pl.json` | 📉 -56 B (-0.04%) | 137.17 kB → 137.12 kB
`locale/zh-Hans.json` | 📉 -46 B (-0.04%) | 107.65 kB → 107.6 kB
`src/components/transactions/TransactionList.tsx` | 📉 -25 B (-0.19%) | 12.96 kB → 12.93 kB
`src/components/transactions/TransactionsTable.tsx` | 📉 -1.13 kB (-1.28%) | 88.2 kB → 87.07 kB
`src/components/accounts/Account.tsx` | 📉 -554 B (-1.35%) | 40.13 kB → 39.59 kB
`src/components/accounts/Header.tsx` | 📉 -575 B (-1.97%) | 28.45 kB → 27.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 208.33 kB → 208.88 kB (+562 B) | +0.26%
static/js/ru.js | 142.38 kB → 142.5 kB (+124 B) | +0.09%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 2 MB → 2 MB (-1.15 kB) | -0.06%
static/js/wide.js | 270.84 kB → 269.73 kB (-1.1 kB) | -0.41%
static/js/pt-BR.js | 179.87 kB → 179.81 kB (-59 B) | -0.03%
static/js/fr.js | 166.83 kB → 166.78 kB (-58 B) | -0.03%
static/js/pl.js | 137.17 kB → 137.12 kB (-56 B) | -0.04%
static/js/es.js | 165.3 kB → 165.25 kB (-54 B) | -0.03%
static/js/zh-Hans.js | 107.65 kB → 107.6 kB (-46 B) | -0.04%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 68.85 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.3 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CLKxGEvc.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (-56 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`app/query.ts` | 🆕 +2.12 kB | 0 B → 2.12 kB
`app/query.js` | 🔥 -2.17 kB (-100%) | 2.17 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (-56 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->