### PR TITLE
better simplefin errors

### DIFF
--- a/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
+++ b/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
@@ -403,8 +403,12 @@ export function useBuiltInBankSyncProviders({
 
     try {
       const results = await send('simplefin-accounts');
+      if (results.error_code === 'INVALID_ACCESS_TOKEN') {
+        onSimpleFinInit();
+        return;
+      }
       if (results.error_code) {
-        throw new Error(results.reason);
+        throw new Error(results.reason || results.error_code);
       }
       if ('error' in results && results.error) {
         throw new Error(results.reason || results.error);
@@ -433,8 +437,17 @@ export function useBuiltInBankSyncProviders({
           },
         }),
       );
-    } catch {
-      onSimpleFinInit();
+    } catch (error) {
+      dispatch(
+        addNotification({
+          notification: {
+            type: 'error',
+            title: t('Error when trying to contact SimpleFIN'),
+            message: error instanceof Error ? error.message : String(error),
+            timeout: 5000,
+          },
+        }),
+      );
     } finally {
       setLoadingSimpleFinAccounts(false);
     }
@@ -443,6 +456,7 @@ export function useBuiltInBankSyncProviders({
     isSimpleFinSetupComplete,
     loadingSimpleFinAccounts,
     onSimpleFinInit,
+    t,
     upgradingAccountId,
   ]);
 

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -34,22 +34,41 @@ app.post(
   handleError(async (req, res) => {
     let accessKey = secretsService.get(SecretName.simplefin_accessKey);
 
-    try {
-      if (isInvalidAccessKey(accessKey)) {
-        const token = secretsService.get(SecretName.simplefin_token);
-        if (token == null || isForbidden(token)) {
-          throw new Error('No token');
-        } else {
-          accessKey = await getAccessKey(token);
-          if (isInvalidAccessKey(accessKey)) {
-            throw new Error('No access key');
-          }
-          secretsService.set(SecretName.simplefin_accessKey, accessKey);
-        }
+    if (isInvalidAccessKey(accessKey)) {
+      const token = secretsService.get(SecretName.simplefin_token);
+      if (token == null || isForbidden(token)) {
+        invalidToken(res);
+        return;
       }
-    } catch {
-      invalidToken(res);
-      return;
+
+      const claimUrl = decodeClaimUrl(token);
+      if (claimUrl == null) {
+        console.log(
+          'SimpleFIN setup token does not decode to a claim URL - re-enter the token',
+        );
+        invalidToken(res);
+        return;
+      }
+
+      try {
+        accessKey = await claimAccessKey(claimUrl);
+      } catch (e) {
+        console.log('Failed to claim the SimpleFIN setup token:');
+        serverDown(e, res);
+        return;
+      }
+
+      if (isInvalidAccessKey(accessKey)) {
+        console.log(
+          `SimpleFIN rejected the setup token claim: ${
+            accessKey.slice(0, 200) || '(empty response)'
+          }`,
+        );
+        invalidToken(res);
+        return;
+      }
+
+      secretsService.set(SecretName.simplefin_accessKey, accessKey);
     }
 
     try {
@@ -289,6 +308,8 @@ function serverDown(e, res) {
   });
 }
 
+const ACCESS_KEY_FORMAT = /^.*\/\/.*:.*@.*$/;
+
 function parseAccessKey(accessKey) {
   let scheme = null;
   let rest = null;
@@ -296,7 +317,7 @@ function parseAccessKey(accessKey) {
   let username = null;
   let password = null;
   let baseUrl = null;
-  if (!accessKey || !accessKey.match(/^.*\/\/.*:.*@.*$/)) {
+  if (!accessKey || !ACCESS_KEY_FORMAT.test(accessKey)) {
     console.log('Invalid SimpleFIN access key');
     throw new Error(`Invalid access key`);
   }
@@ -311,15 +332,34 @@ function parseAccessKey(accessKey) {
   };
 }
 
-async function getAccessKey(base64Token) {
-  const token = Buffer.from(base64Token, 'base64').toString();
+function decodeClaimUrl(base64Token) {
+  const decoded = Buffer.from(base64Token, 'base64').toString();
+
+  let url;
+  try {
+    url = new URL(decoded);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return null;
+  }
+
+  return decoded;
+}
+
+async function claimAccessKey(claimUrl) {
   // Self-hosters may run their own SimpleFIN bridge on the local network, so
   // private addresses are allowed here; cloud metadata and other always-blocked
   // ranges are still rejected.
-  await assertUrlAllowed(token, { allowPrivateNetwork: true });
+  await assertUrlAllowed(claimUrl, { allowPrivateNetwork: true });
 
   // don't auto-follow redirects for SSRF safety
-  const response = await fetch(token, { method: 'POST', redirect: 'manual' });
+  const response = await fetch(claimUrl, {
+    method: 'POST',
+    redirect: 'manual',
+  });
   return (await response.text()).trim();
 }
 
@@ -330,8 +370,8 @@ function isForbidden(value) {
 function isInvalidAccessKey(accessKey) {
   return (
     typeof accessKey !== 'string' ||
-    accessKey.trim() === '' ||
-    isForbidden(accessKey)
+    isForbidden(accessKey) ||
+    !ACCESS_KEY_FORMAT.test(accessKey)
   );
 }
 

--- a/packages/sync-server/src/app-simplefin/app-simplefin.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.js
@@ -360,6 +360,11 @@ async function claimAccessKey(claimUrl) {
     method: 'POST',
     redirect: 'manual',
   });
+
+  if (!response.ok && response.status !== 403) {
+    throw new Error(`SimpleFIN claim failed with HTTP ${response.status}`);
+  }
+
   return (await response.text()).trim();
 }
 

--- a/packages/sync-server/src/app-simplefin/app-simplefin.test.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.test.js
@@ -15,11 +15,14 @@ const SETUP_TOKEN = Buffer.from(
   'https://bridge.example.com/claim/abc',
 ).toString('base64');
 
-const okResponse = body => ({
-  status: 200,
+const statusResponse = (status, body = '') => ({
+  ok: status >= 200 && status < 300,
+  status,
   headers: { get: () => null },
   text: () => Promise.resolve(body),
 });
+
+const okResponse = body => statusResponse(200, body);
 
 // The claim is a POST to the bridge; listing accounts is a GET. Route the mock
 // by method so a test can stub one or both.
@@ -185,6 +188,40 @@ describe('app-simplefin', () => {
 
       expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
       expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('treats a 403 Forbidden claim as an invalid token and does not persist it', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({
+        claim: statusResponse(403, 'Forbidden (was it already claimed?)'),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('reports SERVER_DOWN when the claim response is a redirect', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({ claim: statusResponse(302) });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('SERVER_DOWN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('reports SERVER_DOWN when the claim fails with a server error', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({
+        claim: statusResponse(502, '<html>Bad Gateway</html>'),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('SERVER_DOWN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
     });
 
     it('reports SERVER_DOWN when the claim request fails at the network level', async () => {

--- a/packages/sync-server/src/app-simplefin/app-simplefin.test.js
+++ b/packages/sync-server/src/app-simplefin/app-simplefin.test.js
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SecretName, secretsService } from '#services/secrets-service';
+import { assertUrlAllowed } from '#util/ssrf';
 
 import { handlers as app } from './app-simplefin';
 
@@ -140,6 +141,92 @@ describe('app-simplefin', () => {
       expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
         VALID_ACCESS_KEY,
       );
+    });
+
+    it('re-claims when a stale non-URL access key is cached', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      secretsService.set(
+        SecretName.simplefin_accessKey,
+        '<html>Bad Gateway</html>',
+      );
+      mockFetch({
+        claim: okResponse(VALID_ACCESS_KEY),
+        accounts: okResponse(
+          JSON.stringify({ accounts: [{ id: 'account-1' }] }),
+        ),
+      });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.accounts).toEqual([{ id: 'account-1' }]);
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBe(
+        VALID_ACCESS_KEY,
+      );
+    });
+
+    it('treats a claim response that is not an access URL as invalid and does not persist it', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      mockFetch({ claim: okResponse('<html>Service unavailable</html>') });
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('rejects a token that does not decode to a claim URL without contacting SimpleFIN', async () => {
+      secretsService.set(
+        SecretName.simplefin_token,
+        Buffer.from('not a claim url').toString('base64'),
+      );
+      global.fetch = vi.fn();
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('reports SERVER_DOWN when the claim request fails at the network level', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      global.fetch = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('SERVER_DOWN');
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+
+    it('reports SERVER_DOWN when the claim URL fails the SSRF preflight', async () => {
+      secretsService.set(SecretName.simplefin_token, SETUP_TOKEN);
+      assertUrlAllowed.mockRejectedValueOnce(
+        new Error('Unable to resolve host: bridge.example.com'),
+      );
+      global.fetch = vi.fn();
+
+      const res = await post('/accounts');
+
+      expect(res.body.data.error_code).toBe('SERVER_DOWN');
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(secretsService.get(SecretName.simplefin_accessKey)).toBeNull();
+    });
+  });
+
+  describe('/transactions', () => {
+    it('reports an invalid token when the cached access key is not an access URL', async () => {
+      secretsService.set(
+        SecretName.simplefin_accessKey,
+        '<html>Bad Gateway</html>',
+      );
+      global.fetch = vi.fn();
+
+      const res = await post('/transactions').send({
+        accountId: 'account-1',
+        startDate: '2026-07-01',
+      });
+
+      expect(res.body.data.error_code).toBe('INVALID_ACCESS_TOKEN');
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/upcoming-release-notes/fix-simplefin-claim-error-reporting.md
+++ b/upcoming-release-notes/fix-simplefin-claim-error-reporting.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Show a clearer error when SimpleFIN can't be reached while linking accounts, instead of wrongly reporting the token as invalid


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

The aim here is to provide better feedback when SimpleFIN linking doesn't work, I've seen it a lot in Discord and the hope is to narrow down an actual root cause.

Claude assisted from the bug reports

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Linked via the dev tokens

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+1.78 kB) | +0.01%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+1.78 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/useBuiltInBankSyncProviders.ts` | 📈 +326 B (+2.10%) | 15.16 kB → 15.48 kB
`locale/fr.json` | 📈 +1.47 kB (+0.88%) | 166.78 kB → 168.24 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 166.78 kB → 168.24 kB (+1.47 kB) | +0.88%
static/js/ManageRules.js | 68.85 kB → 69.17 kB (+326 B) | +0.46%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.3 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 208.88 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 269.73 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->