### PR TITLE
[AI] Complete mobile error boundaries

### DIFF
--- a/packages/desktop-client/src/components/FinancesApp.tsx
+++ b/packages/desktop-client/src/components/FinancesApp.tsx
@@ -389,7 +389,14 @@ export function FinancesApp() {
 
                   <Route
                     path="/accounts"
-                    element={<NarrowAlternate name="Accounts" />}
+                    element={
+                      <ErrorBoundary
+                        FallbackComponent={FeatureErrorFallback}
+                        resetKeys={[location.pathname]}
+                      >
+                        <NarrowAlternate name="Accounts" />
+                      </ErrorBoundary>
+                    }
                   />
 
                   <Route
@@ -420,7 +427,14 @@ export function FinancesApp() {
 
                   <Route
                     path="/categories/:id"
-                    element={<NarrowAlternate name="Category" />}
+                    element={
+                      <ErrorBoundary
+                        FallbackComponent={FeatureErrorFallback}
+                        resetKeys={[location.pathname]}
+                      >
+                        <NarrowAlternate name="Category" />
+                      </ErrorBoundary>
+                    }
                   />
                   {multiuserEnabled && (
                     <Route

--- a/upcoming-release-notes/complete-mobile-error-boundaries.md
+++ b/upcoming-release-notes/complete-mobile-error-boundaries.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [russlan23]
+---
+
+Wrap the mobile accounts list and category transactions pages in scoped error boundaries, so rendering errors show a recoverable fallback instead of crashing the whole app.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds scoped error boundaries to the mobile accounts-list and category-transactions routes. Both routes reuse the existing feature error fallback and reset the error state when the route pathname changes. A rendering error in either page will therefore show a recoverable local fallback instead of crashing the entire application.

Codex assisted with implementation, review, and validation. Russlan explicitly authorized completion of this description and transition of the pull request to ready for review.

## Related issue(s)

Fixes #7391

## Testing

- `yarn lint` passed
- `yarn typecheck` passed across all 10 workspaces
- `yarn workspace @actual-app/web test` passed 792 tests with one pre-existing skip
- All applicable upstream checks passed, including builds, code scanning, end-to-end tests, visual regression tests, release-note validation, and the deploy preview

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
