### PR TITLE
[AI] Fix Android touch category selection

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
@@ -65,6 +65,48 @@ describe('Autocomplete', () => {
     },
   );
 
+  test('preserves a custom item mouse move handler on touch devices', () => {
+    const onMouseMove = vi.fn();
+    vi.mocked(window.matchMedia).mockImplementation(
+      query =>
+        ({
+          matches: query === '(hover: none)',
+          media: query,
+        }) as MediaQueryList,
+    );
+
+    render(
+      <Autocomplete
+        embedded
+        strict
+        value={null}
+        suggestions={suggestions}
+        onSelect={vi.fn()}
+        renderItems={(items, getItemProps) => (
+          <div>
+            {items.map(item => (
+              <div
+                key={item.id}
+                role="button"
+                {...getItemProps({ item, onMouseMove })}
+              >
+                {item.name}
+              </div>
+            ))}
+          </div>
+        )}
+      />,
+    );
+
+    const secondItem = screen.getByRole('option', {
+      name: 'Second category',
+    });
+    fireEvent.mouseMove(secondItem);
+
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    expect(secondItem).toHaveAttribute('aria-selected', 'false');
+  });
+
   test('refilters suggestions when the input value changes', async () => {
     const user = userEvent.setup();
     const filterSuggestions = vi.fn(

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
@@ -135,30 +135,4 @@ describe('Autocomplete', () => {
       screen.queryByRole('button', { name: 'First category' }),
     ).not.toBeInTheDocument();
   });
-
-  test('does not refilter suggestions when an item is clicked', async () => {
-    const user = userEvent.setup();
-    const onSelect = vi.fn();
-    const filterSuggestions = vi.fn((items: typeof suggestions) => items);
-
-    render(
-      <Autocomplete
-        strict
-        value={null}
-        suggestions={suggestions}
-        onSelect={onSelect}
-        filterSuggestions={filterSuggestions}
-      />,
-    );
-
-    filterSuggestions.mockClear();
-    await user.click(screen.getByRole('textbox'));
-    await user.click(screen.getByRole('button', { name: 'Second category' }));
-
-    await waitFor(() => {
-      expect(onSelect).toHaveBeenCalledWith('second', expect.any(String));
-      expect(screen.queryByTestId('autocomplete')).not.toBeInTheDocument();
-    });
-    expect(filterSuggestions).not.toHaveBeenCalled();
-  });
 });

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { Autocomplete } from './Autocomplete';
+
+const suggestions = [
+  { id: 'first', name: 'First category' },
+  { id: 'second', name: 'Second category' },
+];
+
+describe('Autocomplete', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(
+        query =>
+          ({
+            matches: false,
+            media: query,
+          }) as MediaQueryList,
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test.each([
+    { canHover: true, isHighlighted: true },
+    { canHover: false, isHighlighted: false },
+  ])(
+    'sets highlighted item from mouse movement when canHover is $canHover',
+    async ({ canHover, isHighlighted }) => {
+      vi.mocked(window.matchMedia).mockImplementation(
+        query =>
+          ({
+            matches: query === '(hover: none)' ? !canHover : false,
+            media: query,
+          }) as MediaQueryList,
+      );
+
+      render(
+        <Autocomplete
+          embedded
+          strict
+          value={null}
+          suggestions={suggestions}
+          onSelect={vi.fn()}
+        />,
+      );
+
+      const secondItem = screen.getByRole('button', {
+        name: 'Second category',
+      });
+      fireEvent.mouseMove(secondItem);
+
+      await waitFor(() => {
+        expect(secondItem).toHaveAttribute(
+          'aria-selected',
+          String(isHighlighted),
+        );
+      });
+    },
+  );
+
+  test('refilters suggestions when the input value changes', async () => {
+    const user = userEvent.setup();
+    const filterSuggestions = vi.fn(
+      (items: typeof suggestions, value: string) =>
+        items.filter(item => item.name.includes(value)),
+    );
+
+    render(
+      <Autocomplete
+        strict
+        value={null}
+        suggestions={suggestions}
+        onSelect={vi.fn()}
+        filterSuggestions={filterSuggestions}
+      />,
+    );
+
+    filterSuggestions.mockClear();
+    await user.type(screen.getByRole('textbox'), 'Second');
+
+    expect(filterSuggestions).toHaveBeenCalledWith(suggestions, 'Second');
+    expect(
+      screen.getByRole('button', { name: 'Second category' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'First category' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not refilter suggestions when an item is clicked', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const filterSuggestions = vi.fn((items: typeof suggestions) => items);
+
+    render(
+      <Autocomplete
+        strict
+        value={null}
+        suggestions={suggestions}
+        onSelect={onSelect}
+        filterSuggestions={filterSuggestions}
+      />,
+    );
+
+    filterSuggestions.mockClear();
+    await user.click(screen.getByRole('textbox'));
+    await user.click(screen.getByRole('button', { name: 'Second category' }));
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledWith('second', expect.any(String));
+      expect(screen.queryByTestId('autocomplete')).not.toBeInTheDocument();
+    });
+    expect(filterSuggestions).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -389,6 +389,7 @@ function SingleAutocomplete<T extends AutocompleteItem>({
             // Do nothing if it is a "touch" selection event
             Downshift.stateChangeTypes.touchEnd,
             Downshift.stateChangeTypes.mouseUp,
+            Downshift.stateChangeTypes.clickItem,
             // @ts-expect-error Types say there is no type
           ].includes(changes.type)
         ) {
@@ -483,7 +484,15 @@ function SingleAutocomplete<T extends AutocompleteItem>({
         inputValue,
         highlightedIndex,
       }) => {
-        const wrappedGetItemProps = itemProps => getItemProps({ ...itemProps });
+        const wrappedGetItemProps = itemProps =>
+          getItemProps({
+            ...itemProps,
+            onMouseMove: e => {
+              if (window.matchMedia?.('(hover: none)').matches) {
+                e['preventDownshiftDefault'] = true;
+              }
+            },
+          });
         return (
           // Super annoying but it works best to return a div so we
           // can't use a View here, but we can fake it be using the

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -32,7 +32,9 @@ type CommonAutocompleteProps<T extends AutocompleteItem> = {
   renderInput?: (props: ComponentProps<typeof Input>) => ReactNode;
   renderItems?: (
     items: T[],
-    getItemProps: (arg: { item: T }) => ComponentProps<typeof View>,
+    getItemProps: (
+      arg: { item: T } & ComponentProps<typeof View>,
+    ) => ComponentProps<typeof View>,
     idx: number,
     value?: string,
   ) => ReactNode;
@@ -488,6 +490,8 @@ function SingleAutocomplete<T extends AutocompleteItem>({
           getItemProps({
             ...itemProps,
             onMouseMove: e => {
+              itemProps.onMouseMove?.(e);
+
               if (window.matchMedia?.('(hover: none)').matches) {
                 e['preventDownshiftDefault'] = true;
               }

--- a/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/Autocomplete.tsx
@@ -391,7 +391,6 @@ function SingleAutocomplete<T extends AutocompleteItem>({
             // Do nothing if it is a "touch" selection event
             Downshift.stateChangeTypes.touchEnd,
             Downshift.stateChangeTypes.mouseUp,
-            Downshift.stateChangeTypes.clickItem,
             // @ts-expect-error Types say there is no type
           ].includes(changes.type)
         ) {

--- a/upcoming-release-notes/fix-android-category-selection.md
+++ b/upcoming-release-notes/fix-android-category-selection.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [LuBoys]
+---
+
+Fix category selection on Android touch devices.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fix category selection on Android touch devices. Chrome Android emits synthetic mouse-move events after a touch, which can change Downshift's highlighted item before the click is handled. In addition, the `clickItem` state change was refiltering and resetting the suggestion list during selection.

This change ignores Downshift's synthetic hover behavior on devices without hover support and lets the existing selection handler complete click selections. Caller-provided mouse-move handlers are preserved, and mouse hover behavior remains unchanged on hover-capable devices.

OpenAI Codex assisted with a significant part of the implementation. The contributor reviewed the resulting diff and validated the behavior.

## Related issue(s)

Fixes #6401

## Testing

- `yarn workspace @actual-app/web test`: 57 test files passed, 796 tests passed, 1 skipped.
- Autocomplete regression suite: 5 tests passed.
- `yarn typecheck`
- `yarn lint`
- `yarn build:browser`
- Manually tested category selection in Chrome on an Android 15 emulator, including selecting multiple categories that were not the first result.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+306 B) | +0.00%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+306 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/autocomplete/Autocomplete.tsx` | 📈 +169 B (+1.05%) | 15.76 kB → 15.92 kB
`locale/de.json` | 📈 +137 B (+0.07%) | 179.3 kB → 179.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 2 MB → 2 MB (+169 B) | +0.01%
static/js/de.js | 179.3 kB → 179.43 kB (+137 B) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 68.85 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 208.88 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 168.24 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 269.73 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->