### PR TITLE
[WIP] [AI] Add envelope budget start month

### DIFF
--- a/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
@@ -55,7 +55,7 @@ export function BudgetStartMonthSettings() {
           <ButtonWithLoading
             onPress={onSave}
             isLoading={isLoading}
-            disabled={!selectedMonth}
+            isDisabled={!selectedMonth}
           >
             <Trans>Save</Trans>
           </ButtonWithLoading>
@@ -63,7 +63,7 @@ export function BudgetStartMonthSettings() {
             <ButtonWithLoading
               onPress={onClear}
               isLoading={isLoading}
-              disabled={isLoading}
+              isDisabled={isLoading}
             >
               <Trans>Clear</Trans>
             </ButtonWithLoading>

--- a/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import { Trans } from 'react-i18next';
+
+import { ButtonWithLoading } from '@actual-app/components/button';
+import { Text } from '@actual-app/components/text';
+import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
+
+import { MonthInput } from '#components/util/MonthInput';
+import { useSyncedPref } from '#hooks/useSyncedPref';
+
+import { Setting } from './UI';
+
+export function BudgetStartMonthSettings() {
+  const [budgetType = 'envelope'] = useSyncedPref('budgetType');
+  const [budgetStartMonth, setBudgetStartMonth] =
+    useSyncedPref('budgetStartMonth');
+  const [selectedMonth, setSelectedMonth] = useState(budgetStartMonth || '');
+  const [isLoading, setIsLoading] = useState(false);
+
+  if (budgetType !== 'envelope') {
+    return null;
+  }
+
+  async function onSave() {
+    setIsLoading(true);
+    try {
+      setBudgetStartMonth(selectedMonth);
+      await send('rebuild-budget-spreadsheet');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function onClear() {
+    setIsLoading(true);
+    try {
+      setSelectedMonth('');
+      setBudgetStartMonth('');
+      await send('rebuild-budget-spreadsheet');
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Setting
+      primaryAction={
+        <View
+          style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-end' }}
+        >
+          <MonthInput
+            id="settings-budget-start-month"
+            value={selectedMonth}
+            onChange={setSelectedMonth}
+          />
+          <ButtonWithLoading
+            onPress={onSave}
+            isLoading={isLoading}
+            disabled={!selectedMonth}
+          >
+            <Trans>Save</Trans>
+          </ButtonWithLoading>
+          {budgetStartMonth && (
+            <ButtonWithLoading
+              onPress={onClear}
+              isLoading={isLoading}
+              disabled={isLoading}
+            >
+              <Trans>Clear</Trans>
+            </ButtonWithLoading>
+          )}
+        </View>
+      }
+    >
+      <Text>
+        <Trans>
+          Start envelope budgeting from a month while keeping your complete
+          transaction history. Earlier transactions remain available for
+          reports and reconciliation, but their income, overspending, and
+          category carryover do not affect this month or later months.
+        </Trans>
+      </Text>
+    </Setting>
+  );
+}

--- a/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
+++ b/packages/desktop-client/src/components/settings/BudgetStartMonthSettings.tsx
@@ -46,9 +46,7 @@ export function BudgetStartMonthSettings() {
   return (
     <Setting
       primaryAction={
-        <View
-          style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-end' }}
-        >
+        <View style={{ flexDirection: 'row', gap: 10, alignItems: 'flex-end' }}>
           <MonthInput
             id="settings-budget-start-month"
             value={selectedMonth}
@@ -76,9 +74,9 @@ export function BudgetStartMonthSettings() {
       <Text>
         <Trans>
           Start envelope budgeting from a month while keeping your complete
-          transaction history. Earlier transactions remain available for
-          reports and reconciliation, but their income, overspending, and
-          category carryover do not affect this month or later months.
+          transaction history. Earlier transactions remain available for reports
+          and reconciliation, but their income, overspending, and category
+          carryover do not affect this month or later months.
         </Trans>
       </Text>
     </Setting>

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -28,8 +28,8 @@ import { useDispatch, useSelector } from '#redux';
 
 import { AuthSettings } from './AuthSettings';
 import { Backups } from './Backups';
-import { BudgetTypeSettings } from './BudgetTypeSettings';
 import { BudgetStartMonthSettings } from './BudgetStartMonthSettings';
+import { BudgetTypeSettings } from './BudgetTypeSettings';
 import { CurrencySettings } from './Currency';
 import { EncryptionSettings } from './Encryption';
 import { ExperimentalFeatures } from './Experimental';

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -29,6 +29,7 @@ import { useDispatch, useSelector } from '#redux';
 import { AuthSettings } from './AuthSettings';
 import { Backups } from './Backups';
 import { BudgetTypeSettings } from './BudgetTypeSettings';
+import { BudgetStartMonthSettings } from './BudgetStartMonthSettings';
 import { CurrencySettings } from './Currency';
 import { EncryptionSettings } from './Encryption';
 import { ExperimentalFeatures } from './Experimental';
@@ -242,6 +243,7 @@ export function Settings() {
         <AuthSettings />
         <EncryptionSettings />
         <BudgetTypeSettings />
+        <BudgetStartMonthSettings />
         {isElectron() && <Backups />}
         <ExportBudget />
         <AdvancedToggle>

--- a/packages/loot-core/src/server/budget/base.test.ts
+++ b/packages/loot-core/src/server/budget/base.test.ts
@@ -3,13 +3,84 @@ import * as sheet from '#server/sheet';
 // @ts-strict-ignore
 import * as monthUtils from '#shared/months';
 
-import { createAllBudgets } from './base';
+import { setBudget } from './actions';
+import { createAllBudgets, rebuild } from './base';
 
 beforeEach(() => {
   return global.emptyDatabase()();
 });
 
 describe('Base budget', () => {
+  it('starts envelope budget calculations from the configured month', async () => {
+    await sheet.loadSpreadsheet(db);
+
+    await db.insertCategoryGroup({ id: 'expenses', name: 'Expenses' });
+    await db.insertCategoryGroup({
+      id: 'income',
+      name: 'Income',
+      is_income: 1,
+    });
+    const foodId = await db.insertCategory({
+      name: 'Food',
+      cat_group: 'expenses',
+    });
+    const incomeId = await db.insertCategory({
+      name: 'Income',
+      cat_group: 'income',
+      is_income: 1,
+    });
+    await db.insertAccount({ id: 'account', name: 'Account' });
+
+    await db.insertTransaction({
+      date: '2017-01-01',
+      amount: 10000,
+      account: 'account',
+      category: incomeId,
+    });
+    await db.insertTransaction({
+      date: '2017-01-02',
+      amount: -2000,
+      account: 'account',
+      category: foodId,
+    });
+    await db.insertTransaction({
+      date: '2017-02-02',
+      amount: -1000,
+      account: 'account',
+      category: foodId,
+    });
+    await createAllBudgets();
+    await sheet.waitOnSpreadsheet();
+
+    const january = monthUtils.sheetForMonth('2017-01');
+    const february = monthUtils.sheetForMonth('2017-02');
+
+    await setBudget({ category: foodId, month: '2017-01', amount: 5000 });
+    await sheet.waitOnSpreadsheet();
+
+    expect(sheet.getCellValue(january, 'total-income')).toBe(10000);
+    expect(sheet.getCellValue(january, `leftover-${foodId}`)).toBe(3000);
+    expect(sheet.getCellValue(february, 'from-last-month')).toBe(5000);
+    expect(sheet.getCellValue(february, `leftover-${foodId}`)).toBe(2000);
+
+    await db.update('preferences', {
+      id: 'budgetStartMonth',
+      value: '2017-02',
+    });
+    await rebuild();
+
+    expect(sheet.getCellValue(february, 'from-last-month')).toBe(0);
+    expect(sheet.getCellValue(february, 'last-month-overspent')).toBe(0);
+    expect(sheet.getCellValue(february, `leftover-${foodId}`)).toBe(-1000);
+
+    await db.update('preferences', { id: 'budgetStartMonth', value: '' });
+    await rebuild();
+
+    expect(sheet.getCellValue(february, 'from-last-month')).toBe(5000);
+    expect(sheet.getCellValue(february, 'last-month-overspent')).toBe(0);
+    expect(sheet.getCellValue(february, `leftover-${foodId}`)).toBe(2000);
+  });
+
   it('Recomputes budget cells when account fields change', async () => {
     await sheet.loadSpreadsheet(db);
 

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -17,6 +17,17 @@ export function getBudgetType() {
   return meta.budgetType || 'envelope';
 }
 
+export function getBudgetStartMonth(): string | null {
+  const preference = db.firstSync<Pick<db.DbPreference, 'value'>>(
+    'SELECT value FROM preferences WHERE id = ?',
+    ['budgetStartMonth'],
+  );
+
+  return preference && monthUtils.isValidYearMonth(preference.value)
+    ? preference.value
+    : null;
+}
+
 export function getBudgetRange(start: string, end: string) {
   start = monthUtils.getMonth(start);
   end = monthUtils.getMonth(end);
@@ -276,6 +287,7 @@ export async function createBudget(months) {
   meta.createdMonths = meta.createdMonths || new Set();
 
   const budgetType = getBudgetType();
+  const budgetStartMonth = getBudgetStartMonth();
 
   if (budgetType === 'envelope') {
     envelopeBudget.createBudget(meta, categories, months);
@@ -314,10 +326,12 @@ export async function createBudget(months) {
   const seededCells: string[] = [];
 
   monthsToCreate.forEach(month => {
-    const prevMonth = monthUtils.prevMonth(month);
     const { start, end } = monthUtils.bounds(month);
     const sheetName = monthUtils.sheetForMonth(month);
-    const prevSheetName = monthUtils.sheetForMonth(prevMonth);
+    const prevSheetName =
+      budgetType === 'envelope' && month === budgetStartMonth
+        ? meta.blankSheet
+        : monthUtils.sheetForMonth(monthUtils.prevMonth(month));
     const dbMonth = parseInt(month.replace('-', ''));
 
     categories.forEach(cat => {
@@ -410,6 +424,29 @@ export async function setType(type) {
   meta.createdMonths = new Set();
 
   // Go through and force all the cells to be recomputed
+  const nodes = sheet.get().getNodes();
+  db.transaction(() => {
+    for (const name of nodes.keys()) {
+      const [sheetName, cellName] = name.split('!');
+      if (sheetName.match(/^budget\d+/)) {
+        sheet.get().deleteCell(sheetName, cellName);
+      }
+    }
+  });
+
+  sheet.get().startCacheBarrier();
+  void sheet.loadUserBudgets(db);
+  const bounds = await createAllBudgets();
+  sheet.get().endCacheBarrier();
+
+  return bounds;
+}
+
+export async function rebuild() {
+  const meta = sheet.get().meta();
+  meta.createdMonths = new Set();
+  meta.blankSheet = undefined;
+
   const nodes = sheet.get().getNodes();
   db.transaction(() => {
     for (const name of nodes.keys()) {

--- a/packages/loot-core/src/server/budget/base.ts
+++ b/packages/loot-core/src/server/budget/base.ts
@@ -435,11 +435,12 @@ export async function setType(type) {
   });
 
   sheet.get().startCacheBarrier();
-  void sheet.loadUserBudgets(db);
-  const bounds = await createAllBudgets();
-  sheet.get().endCacheBarrier();
-
-  return bounds;
+  try {
+    void sheet.loadUserBudgets(db);
+    return await createAllBudgets();
+  } finally {
+    sheet.get().endCacheBarrier();
+  }
 }
 
 export async function rebuild() {

--- a/packages/loot-core/src/server/budgetfiles/app.ts
+++ b/packages/loot-core/src/server/budgetfiles/app.ts
@@ -54,6 +54,7 @@ export type BudgetFileHandlers = {
   'get-budgets': typeof getBudgets;
   'get-remote-files': typeof getRemoteFiles;
   'reset-budget-cache': typeof resetBudgetCache;
+  'rebuild-budget-spreadsheet': typeof rebuildBudgetSpreadsheet;
   'upload-budget': typeof uploadBudget;
   'download-budget': typeof downloadBudget;
   'sync-budget': typeof syncBudget;
@@ -78,6 +79,7 @@ app.method('unique-budget-name', handleUniqueBudgetName);
 app.method('get-budgets', getBudgets);
 app.method('get-remote-files', getRemoteFiles);
 app.method('reset-budget-cache', mutator(resetBudgetCache));
+app.method('rebuild-budget-spreadsheet', mutator(rebuildBudgetSpreadsheet));
 app.method('upload-budget', uploadBudget);
 app.method('download-budget', downloadBudget);
 app.method('sync-budget', syncBudget);
@@ -145,10 +147,14 @@ async function getRemoteFiles() {
 }
 
 async function resetBudgetCache() {
-  // Recomputing everything will update the cache
+  // Recomputing everything will update the cache.
   await sheet.loadUserBudgets(db);
   sheet.get().recomputeAll();
   await sheet.waitOnSpreadsheet();
+}
+
+async function rebuildBudgetSpreadsheet() {
+  await budget.rebuild();
 }
 
 async function uploadBudget({ id }: { id?: Budget['id'] } = {}): Promise<{

--- a/packages/loot-core/src/server/spreadsheet/spreadsheet.ts
+++ b/packages/loot-core/src/server/spreadsheet/spreadsheet.ts
@@ -28,6 +28,7 @@ export type Node = {
 
 export class Spreadsheet {
   _meta: {
+    blankSheet?: string;
     createdMonths: Set<string>;
     budgetType: BudgetType;
   };

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -12,6 +12,7 @@ import * as asyncStorage from '#platform/server/asyncStorage';
 import * as connection from '#platform/server/connection';
 import { logger } from '#platform/server/log';
 import {
+  rebuild as rebuildBudget,
   setType as setBudgetType,
   triggerBudgetChanges,
 } from '#server/budget/base';
@@ -365,8 +366,12 @@ export const applyMessages = sequential(async (messages: Message[]) => {
       }
 
       // Special treatment for some synced prefs
-      if (dataset === 'preferences' && row === 'budgetType') {
-        void setBudgetType(value);
+      if (dataset === 'preferences') {
+        if (row === 'budgetType') {
+          void setBudgetType(value);
+        } else if (row === 'budgetStartMonth') {
+          void rebuildBudget();
+        }
       }
     }
 

--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -336,6 +336,7 @@ export const applyMessages = sequential(async (messages: Message[]) => {
   // nothing is changed. This is critical to maintain consistency. We
   // also avoid any side effects to in-memory objects, and apply them
   // after this succeeds.
+  let shouldRebuildBudget = false;
   db.transaction(() => {
     const added = new Set();
 
@@ -370,7 +371,7 @@ export const applyMessages = sequential(async (messages: Message[]) => {
         if (row === 'budgetType') {
           void setBudgetType(value);
         } else if (row === 'budgetStartMonth') {
-          void rebuildBudget();
+          shouldRebuildBudget = true;
         }
       }
     }
@@ -388,6 +389,10 @@ export const applyMessages = sequential(async (messages: Message[]) => {
       );
     }
   });
+
+  if (shouldRebuildBudget && sheet.get()) {
+    await rebuildBudget();
+  }
 
   if (checkSyncingMode('enabled')) {
     // The transaction succeeded, so we can update in-memory objects

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -18,6 +18,7 @@ export type FeatureFlag =
 export type SyncedPrefs = Partial<
   Record<
     | 'budgetType'
+    | 'budgetStartMonth'
     | 'upcomingScheduledTransactionLength'
     | 'firstDayOfWeekIdx'
     | 'dateFormat'


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Allow an envelope budget to begin from a selected month while retaining its complete transaction history. The selected month uses the spreadsheet's zero-valued blank predecessor, so prior available funds, overspending, and category carryover do not affect it.

Persist the start month as a synced preference, rebuild the derived budget spreadsheet when it changes, and expose the setting only for envelope budgets. Historical transactions, account balances, reports, and reconciliation remain unchanged.

See related ticket for what and why this is solving my issue

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Fixed #8578 

## Testing

Unit test added, not build and tried with server/ui locally. Please comment if this would be required to merge

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+2.24 kB) | +0.02%
loot-core | 1 | 4.62 MB → 4.63 MB (+1.32 kB) | +0.03%
api | 2 | 3.84 MB → 3.84 MB (+1.29 kB) | +0.03%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+2.24 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/settings/BudgetStartMonthSettings.tsx` | 🆕 +2.11 kB | 0 B → 2.11 kB
`src/components/settings/index.tsx` | 📈 +132 B (+1.20%) | 10.76 kB → 10.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB → 1.55 MB (+2.24 kB) | +0.14%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 208.88 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 168.24 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 269.73 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB → 4.63 MB (+1.32 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +845 B (+9.66%) | 8.54 kB → 9.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +186 B (+3.41%) | 5.33 kB → 5.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +148 B (+1.26%) | 11.51 kB → 11.65 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +175 B (+1.21%) | 14.13 kB → 14.3 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dx_rgHRo.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB → 0 B (-4.62 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+1.29 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +822 B (+9.61%) | 8.36 kB → 9.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +180 B (+3.42%) | 5.14 kB → 5.32 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +144 B (+1.26%) | 11.14 kB → 11.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +170 B (+1.21%) | 13.68 kB → 13.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+1.29 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->