### PR TITLE
[WIP] [AI] Add optional add/subtract terms to summary card percentage

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useEffectEvent, useMemo, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
@@ -52,6 +52,7 @@ import { useDispatch } from '#redux';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
 const MAX_EXTRA_TERMS = 2;
+const EMPTY_TERMS: PercentageSummaryTerm[] = [];
 
 export function Summary() {
   const params = useParams();
@@ -119,8 +120,12 @@ function SummaryInner({ widget }: SummaryInnerProps) {
   );
 
   const isPct = content.type === 'percentage';
-  const dividendTerms = isPct ? (content.dividendExtraTerms ?? []) : [];
-  const divisorTerms = isPct ? (content.divisorExtraTerms ?? []) : [];
+  const dividendTerms = isPct
+    ? (content.dividendExtraTerms ?? EMPTY_TERMS)
+    : EMPTY_TERMS;
+  const divisorTerms = isPct
+    ? (content.divisorExtraTerms ?? EMPTY_TERMS)
+    : EMPTY_TERMS;
 
   const params = useMemo(
     () =>
@@ -589,7 +594,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
           >
             <PrivacyFilter>
               {content.type === 'percentage'
-                ? format(Math.abs(data?.total ?? 0), 'number')
+                ? format(data?.total ?? 0, 'number')
                 : format(Math.abs(Math.round(data?.total ?? 0)), 'financial')}
               {content.type === 'percentage' ? '%' : ''}
             </PrivacyFilter>
@@ -636,6 +641,10 @@ function Operator({
   const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
 
+  const termsCallbacks = { onAddTerm, onRemoveTerm, onToggleOp, onChangeTerm };
+  const divisorFrom = showDivisorDateRange ? fromRange : '';
+  const divisorTo = showDivisorDateRange ? toRange : '';
+
   return (
     <View style={{ gap: isNarrowWidth ? 46 : 52, paddingTop: 24 }}>
       <SumRow
@@ -649,10 +658,7 @@ function Operator({
           terms={dividendTerms}
           from={fromRange}
           to={toRange}
-          onAddTerm={onAddTerm}
-          onRemoveTerm={onRemoveTerm}
-          onToggleOp={onToggleOp}
-          onChangeTerm={onChangeTerm}
+          {...termsCallbacks}
         />
       )}
       {type === 'percentage' && (
@@ -665,19 +671,16 @@ function Operator({
             }}
           />
           <SumRow
-            from={!showDivisorDateRange ? '' : fromRange}
-            to={!showDivisorDateRange ? '' : toRange}
+            from={divisorFrom}
+            to={divisorTo}
             filterObject={divisorFilterObject}
           />
           <TermsSection
             side="divisor"
             terms={divisorTerms}
-            from={!showDivisorDateRange ? '' : fromRange}
-            to={!showDivisorDateRange ? '' : toRange}
-            onAddTerm={onAddTerm}
-            onRemoveTerm={onRemoveTerm}
-            onToggleOp={onToggleOp}
-            onChangeTerm={onChangeTerm}
+            from={divisorFrom}
+            to={divisorTo}
+            {...termsCallbacks}
           />
         </>
       )}
@@ -784,14 +787,15 @@ function ExtraTermRow({
 
   const filterConditions = filter.conditions;
   const filterConditionsOp = filter.conditionsOp;
-  const termId = term.id;
 
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
+  const onSync = useEffectEvent(
+    (conditions: RuleConditionEntity[], conditionsOp: 'and' | 'or') =>
+      onChange(term.id, conditions, conditionsOp),
+  );
 
   useEffect(() => {
-    onChangeRef.current(termId, filterConditions, filterConditionsOp);
-  }, [termId, filterConditions, filterConditionsOp]);
+    onSync(filterConditions, filterConditionsOp);
+  }, [filterConditions, filterConditionsOp]);
 
   return (
     <SumRow

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -498,10 +498,11 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       >
         <View
           style={{
-            flexDirection: 'row',
+            flexDirection: isNarrowWidth ? 'column' : 'row',
             justifyContent: 'center',
             width: '100%',
             alignItems: 'center',
+            gap: isNarrowWidth ? 24 : 0,
           }}
         >
           <Operator
@@ -524,11 +525,13 @@ function SummaryInner({ widget }: SummaryInnerProps) {
           />
           {content.type !== 'sum' && (
             <>
-              <SvgEquals width={50} style={{ marginLeft: 56 }} />
+              {!isNarrowWidth && (
+                <SvgEquals width={50} style={{ marginLeft: 56 }} />
+              )}
               <View style={{ padding: 16 }}>
                 <Text
                   style={{
-                    fontSize: '50px',
+                    fontSize: isNarrowWidth ? '32px' : '50px',
                     width: '100%',
                     textAlign: 'center',
                   }}
@@ -542,15 +545,15 @@ function SummaryInner({ widget }: SummaryInnerProps) {
                 <div
                   style={{
                     width: '100%',
-                    marginTop: 32,
-                    marginBottom: 32,
+                    marginTop: isNarrowWidth ? 12 : 32,
+                    marginBottom: isNarrowWidth ? 12 : 32,
                     borderTop: '2px solid',
                     borderBottom: '2px solid',
                   }}
                 />
                 <Text
                   style={{
-                    fontSize: '50px',
+                    fontSize: isNarrowWidth ? '32px' : '50px',
                     width: '100%',
                     textAlign: 'center',
                   }}
@@ -562,17 +565,19 @@ function SummaryInner({ widget }: SummaryInnerProps) {
               </View>
             </>
           )}
-          <SvgEquals width={50} style={{ marginLeft: 16 }} />
+          {!isNarrowWidth && (
+            <SvgEquals width={50} style={{ marginLeft: 16 }} />
+          )}
           <View
             style={{
-              flexGrow: 1,
+              flexGrow: isNarrowWidth ? 0 : 1,
               textAlign: 'center',
-              width: '250px',
-              maxWidth: '250px',
+              width: isNarrowWidth ? '100%' : '250px',
+              maxWidth: isNarrowWidth ? '100%' : '250px',
               justifyItems: 'center',
               alignItems: 'center',
-              marginLeft: 16,
-              fontSize: '50px',
+              marginLeft: isNarrowWidth ? 0 : 16,
+              fontSize: isNarrowWidth ? '40px' : '50px',
               justifyContent: 'center',
               color:
                 (data?.total ?? 0) === 0
@@ -629,9 +634,10 @@ function Operator({
   onChangeTerm,
 }: OperatorProps) {
   const { t } = useTranslation();
+  const { isNarrowWidth } = useResponsive();
 
   return (
-    <View style={{ gap: 40, paddingTop: 24 }}>
+    <View style={{ gap: isNarrowWidth ? 28 : 40, paddingTop: 24 }}>
       <SumRow
         from={fromRange}
         to={toRange}
@@ -773,6 +779,7 @@ function ExtraTermRow({
   onRemove,
 }: ExtraTermRowProps) {
   const { t } = useTranslation();
+  const { isNarrowWidth } = useResponsive();
   const filter = useRuleConditionFilters(term.conditions, term.conditionsOp);
 
   const filterConditions = filter.conditions;
@@ -795,7 +802,7 @@ function ExtraTermRow({
       operator={
         <Button
           variant="bare"
-          style={{ fontSize: '32px' }}
+          style={{ fontSize: isNarrowWidth ? '22px' : '32px' }}
           onPress={() => onToggleOp(term.id)}
         >
           {term.op === 'subtract' ? t('−') : t('+')}
@@ -813,11 +820,12 @@ type SumRowProps = {
   filterObject: FilterObject;
 };
 function SumRow({ operator, onRemove, from, to, filterObject }: SumRowProps) {
+  const { isNarrowWidth } = useResponsive();
   return (
     <View style={{ flexDirection: 'row', alignItems: 'center' }}>
       <View
         style={{
-          width: 40,
+          width: isNarrowWidth ? 24 : 40,
           marginRight: 8,
           alignItems: 'center',
           justifyContent: 'center',
@@ -848,6 +856,8 @@ function SumWithRange({
   filterObject,
 }: SumWithRangeProps) {
   const { t } = useTranslation();
+  const { isNarrowWidth } = useResponsive();
+  const sigmaSize = isNarrowWidth ? 34 : 50;
 
   return (
     <View
@@ -858,20 +868,55 @@ function SumWithRange({
         alignItems: 'center',
         position: 'relative',
         display: 'grid',
-        gridTemplateColumns: '70px 15px 1fr 15px',
+        gridTemplateColumns: isNarrowWidth
+          ? `${sigmaSize}px 12px 1fr 12px`
+          : '70px 15px 1fr 15px',
       }}
     >
-      <View style={{ position: 'relative', height: '50px', marginRight: 50 }}>
-        <SvgSum width={50} height={50} />
-        <Text style={{ position: 'absolute', right: -30, top: -20 }}>{to}</Text>
-        <Text style={{ position: 'absolute', right: -30, bottom: -20 }}>
+      <View
+        style={{
+          position: 'relative',
+          height: sigmaSize,
+          marginRight: isNarrowWidth ? 28 : 50,
+        }}
+      >
+        <SvgSum width={sigmaSize} height={sigmaSize} />
+        <Text
+          style={{
+            position: 'absolute',
+            right: -30,
+            top: -20,
+            fontSize: isNarrowWidth ? '11px' : undefined,
+          }}
+        >
+          {to}
+        </Text>
+        <Text
+          style={{
+            position: 'absolute',
+            right: -30,
+            bottom: -20,
+            fontSize: isNarrowWidth ? '11px' : undefined,
+          }}
+        >
           {from}
         </Text>
       </View>
       <SvgOpenParenthesis width={15} style={{ height: '100%' }} />
-      <View style={{ marginLeft: 16, maxWidth: '220px', marginRight: 16 }}>
+      <View
+        style={{
+          marginLeft: isNarrowWidth ? 8 : 16,
+          maxWidth: isNarrowWidth ? '150px' : '220px',
+          marginRight: isNarrowWidth ? 8 : 16,
+        }}
+      >
         {(filterObject.conditions?.length ?? 0) === 0 ? (
-          <Text style={{ fontSize: '25px', color: theme.pageTextPositive }}>
+          <Text
+            style={{
+              fontSize: isNarrowWidth ? '16px' : '25px',
+              color: theme.pageTextPositive,
+            }}
+          >
             {t('all transactions')}
           </Text>
         ) : (
@@ -885,7 +930,13 @@ function SumWithRange({
         )}
       </View>
       <SvgCloseParenthesis width={15} style={{ height: '100%' }} />
-      <View style={{ position: 'absolute', top: -15, right: -55 }}>
+      <View
+        style={{
+          position: 'absolute',
+          top: -15,
+          right: isNarrowWidth ? -42 : -55,
+        }}
+      >
         <FilterButton
           compact={false}
           onApply={filterObject.onApply}

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
@@ -658,7 +658,11 @@ function Operator({
           />
         ))}
       {type === 'percentage' && dividendTerms.length < 2 && (
-        <Button variant="bare" onPress={() => onAddTerm('dividend')}>
+        <Button
+          variant="bare"
+          style={{ marginTop: 24, alignSelf: 'flex-start' }}
+          onPress={() => onAddTerm('dividend')}
+        >
           <Trans>Add term</Trans>
         </Button>
       )}
@@ -692,7 +696,11 @@ function Operator({
             />
           ))}
           {divisorTerms.length < 2 && (
-            <Button variant="bare" onPress={() => onAddTerm('divisor')}>
+            <Button
+              variant="bare"
+              style={{ marginTop: 24, alignSelf: 'flex-start' }}
+              onPress={() => onAddTerm('divisor')}
+            >
               <Trans>Add term</Trans>
             </Button>
           )}
@@ -751,17 +759,28 @@ function ExtraTermRow({
   const filterConditionsOp = filter.conditionsOp;
   const termId = term.id;
 
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
   useEffect(() => {
-    onChange(termId, filterConditions, filterConditionsOp);
-  }, [termId, filterConditions, filterConditionsOp, onChange]);
+    onChangeRef.current(termId, filterConditions, filterConditionsOp);
+  }, [termId, filterConditions, filterConditionsOp]);
 
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-      <Button variant="bare" onPress={() => onToggleOp(term.id)}>
+    <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 48 }}>
+      <Button
+        variant="bare"
+        style={{ fontSize: '32px', marginRight: 8 }}
+        onPress={() => onToggleOp(term.id)}
+      >
         {term.op === 'subtract' ? t('−') : t('+')}
       </Button>
       <SumWithRange from={from} to={to} filterObject={filter} />
-      <Button variant="bare" onPress={() => onRemove(term.id)}>
+      <Button
+        variant="bare"
+        style={{ marginLeft: 8 }}
+        onPress={() => onRemove(term.id)}
+      >
         <Trans>Remove</Trans>
       </Button>
     </View>

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
@@ -632,7 +632,7 @@ function Operator({
 
   return (
     <View style={{ gap: 40, paddingTop: 24 }}>
-      <SumWithRange
+      <SumRow
         from={fromRange}
         to={toRange}
         filterObject={dividendFilterObject}
@@ -658,7 +658,7 @@ function Operator({
               borderBottom: '2px solid',
             }}
           />
-          <SumWithRange
+          <SumRow
             from={!showDivisorDateRange ? '' : fromRange}
             to={!showDivisorDateRange ? '' : toRange}
             filterObject={divisorFilterObject}
@@ -787,22 +787,50 @@ function ExtraTermRow({
   }, [termId, filterConditions, filterConditionsOp]);
 
   return (
+    <SumRow
+      from={from}
+      to={to}
+      filterObject={filter}
+      onRemove={() => onRemove(term.id)}
+      operator={
+        <Button
+          variant="bare"
+          style={{ fontSize: '32px' }}
+          onPress={() => onToggleOp(term.id)}
+        >
+          {term.op === 'subtract' ? t('−') : t('+')}
+        </Button>
+      }
+    />
+  );
+}
+
+type SumRowProps = {
+  operator?: ReactNode;
+  onRemove?: () => void;
+  from: string;
+  to: string;
+  filterObject: FilterObject;
+};
+function SumRow({ operator, onRemove, from, to, filterObject }: SumRowProps) {
+  return (
     <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-      <Button
-        variant="bare"
-        style={{ fontSize: '32px', marginRight: 8 }}
-        onPress={() => onToggleOp(term.id)}
+      <View
+        style={{
+          width: 40,
+          marginRight: 8,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
-        {term.op === 'subtract' ? t('−') : t('+')}
-      </Button>
-      <SumWithRange from={from} to={to} filterObject={filter} />
-      <Button
-        variant="bare"
-        style={{ marginLeft: 8 }}
-        onPress={() => onRemove(term.id)}
-      >
-        <Trans>Remove</Trans>
-      </Button>
+        {operator}
+      </View>
+      <SumWithRange from={from} to={to} filterObject={filterObject} />
+      {onRemove && (
+        <Button variant="bare" style={{ marginLeft: 8 }} onPress={onRemove}>
+          <Trans>Remove</Trans>
+        </Button>
+      )}
     </View>
   );
 }

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -17,6 +17,7 @@ import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
+  PercentageSummaryTerm,
   SummaryContent,
   SummaryWidget,
   TimeFrame,
@@ -113,6 +114,27 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       : 'and',
   );
 
+  const isPct = content.type === 'percentage';
+  const dividendTerms = isPct ? (content.dividendExtraTerms ?? []) : [];
+  const divisorTerms = isPct ? (content.divisorExtraTerms ?? []) : [];
+
+  const dividendTerm0 = useRuleConditionFilters(
+    dividendTerms[0]?.conditions ?? [],
+    dividendTerms[0]?.conditionsOp ?? 'and',
+  );
+  const dividendTerm1 = useRuleConditionFilters(
+    dividendTerms[1]?.conditions ?? [],
+    dividendTerms[1]?.conditionsOp ?? 'and',
+  );
+  const divisorTerm0 = useRuleConditionFilters(
+    divisorTerms[0]?.conditions ?? [],
+    divisorTerms[0]?.conditionsOp ?? 'and',
+  );
+  const divisorTerm1 = useRuleConditionFilters(
+    divisorTerms[1]?.conditions ?? [],
+    divisorTerms[1]?.conditionsOp ?? 'and',
+  );
+
   const params = useMemo(
     () =>
       summarySpreadsheet(
@@ -142,6 +164,65 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       divisorConditionsOp: divisorFilters.conditionsOp,
     }));
   }, [divisorFilters.conditions, divisorFilters.conditionsOp]);
+
+  const dividendTerm0Conditions = dividendTerm0.conditions;
+  const dividendTerm0ConditionsOp = dividendTerm0.conditionsOp;
+  const dividendTerm1Conditions = dividendTerm1.conditions;
+  const dividendTerm1ConditionsOp = dividendTerm1.conditionsOp;
+  const divisorTerm0Conditions = divisorTerm0.conditions;
+  const divisorTerm0ConditionsOp = divisorTerm0.conditionsOp;
+  const divisorTerm1Conditions = divisorTerm1.conditions;
+  const divisorTerm1ConditionsOp = divisorTerm1.conditionsOp;
+
+  useEffect(() => {
+    setContent(prev => {
+      if (prev.type !== 'percentage') return prev;
+      const syncSide = (
+        terms: PercentageSummaryTerm[] = [],
+        editorConditions: Array<{
+          conditions: FilterObject['conditions'];
+          conditionsOp: FilterObject['conditionsOp'];
+        }>,
+      ) =>
+        terms.map((term, i) => ({
+          ...term,
+          conditions: editorConditions[i].conditions,
+          conditionsOp: editorConditions[i].conditionsOp,
+        }));
+      return {
+        ...prev,
+        dividendExtraTerms: syncSide(prev.dividendExtraTerms, [
+          {
+            conditions: dividendTerm0Conditions,
+            conditionsOp: dividendTerm0ConditionsOp,
+          },
+          {
+            conditions: dividendTerm1Conditions,
+            conditionsOp: dividendTerm1ConditionsOp,
+          },
+        ]),
+        divisorExtraTerms: syncSide(prev.divisorExtraTerms, [
+          {
+            conditions: divisorTerm0Conditions,
+            conditionsOp: divisorTerm0ConditionsOp,
+          },
+          {
+            conditions: divisorTerm1Conditions,
+            conditionsOp: divisorTerm1ConditionsOp,
+          },
+        ]),
+      };
+    });
+  }, [
+    dividendTerm0Conditions,
+    dividendTerm0ConditionsOp,
+    dividendTerm1Conditions,
+    dividendTerm1ConditionsOp,
+    divisorTerm0Conditions,
+    divisorTerm0ConditionsOp,
+    divisorTerm1Conditions,
+    divisorTerm1ConditionsOp,
+  ]);
 
   const [allMonths, setAllMonths] = useState<
     Array<{
@@ -319,6 +400,53 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     return format(Math.round(value), 'financial');
   };
 
+  const addTerm = (side: 'dividend' | 'divisor') =>
+    setContent(prev => {
+      if (prev.type !== 'percentage') return prev;
+      const key =
+        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
+      const terms = prev[key] ?? [];
+      if (terms.length >= 2) return prev;
+      return {
+        ...prev,
+        [key]: [...terms, { op: 'add', conditions: [], conditionsOp: 'and' }],
+      };
+    });
+
+  const removeTerm = (side: 'dividend' | 'divisor', index: number) =>
+    setContent(prev => {
+      if (prev.type !== 'percentage') return prev;
+      const key =
+        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
+      return {
+        ...prev,
+        [key]: (prev[key] ?? []).filter((_, i) => i !== index),
+      };
+    });
+
+  const setTermOp = (
+    side: 'dividend' | 'divisor',
+    index: number,
+    op: 'add' | 'subtract',
+  ) =>
+    setContent(prev => {
+      if (prev.type !== 'percentage') return prev;
+      const key =
+        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
+      return {
+        ...prev,
+        [key]: (prev[key] ?? []).map((term, i) =>
+          i === index ? { ...term, op } : term,
+        ),
+      };
+    });
+
+  const onToggleOp = (side: 'dividend' | 'divisor', index: number) => {
+    const terms = side === 'dividend' ? dividendTerms : divisorTerms;
+    const currentOp = terms[index]?.op;
+    setTermOp(side, index, currentOp === 'subtract' ? 'add' : 'subtract');
+  };
+
   return (
     <Page
       header={
@@ -454,6 +582,13 @@ function SummaryInner({ widget }: SummaryInnerProps) {
             }
             fromRange={data?.fromRange ?? ''}
             toRange={data?.toRange ?? ''}
+            dividendTermEditors={[dividendTerm0, dividendTerm1]}
+            divisorTermEditors={[divisorTerm0, divisorTerm1]}
+            dividendTerms={dividendTerms}
+            divisorTerms={divisorTerms}
+            onAddTerm={addTerm}
+            onRemoveTerm={removeTerm}
+            onToggleOp={onToggleOp}
           />
           {content.type !== 'sum' && (
             <>
@@ -535,6 +670,13 @@ type OperatorProps = {
   fromRange: string;
   toRange: string;
   showDivisorDateRange: boolean;
+  dividendTermEditors: FilterObject[];
+  divisorTermEditors: FilterObject[];
+  dividendTerms: PercentageSummaryTerm[];
+  divisorTerms: PercentageSummaryTerm[];
+  onAddTerm: (side: 'dividend' | 'divisor') => void;
+  onRemoveTerm: (side: 'dividend' | 'divisor', index: number) => void;
+  onToggleOp: (side: 'dividend' | 'divisor', index: number) => void;
 };
 function Operator({
   type,
@@ -543,6 +685,13 @@ function Operator({
   fromRange,
   toRange,
   showDivisorDateRange,
+  dividendTermEditors,
+  divisorTermEditors,
+  dividendTerms,
+  divisorTerms,
+  onAddTerm,
+  onRemoveTerm,
+  onToggleOp,
 }: OperatorProps) {
   const { t } = useTranslation();
 
@@ -553,6 +702,27 @@ function Operator({
         to={toRange}
         filterObject={dividendFilterObject}
       />
+      {type === 'percentage' &&
+        dividendTerms.map((term, i) => (
+          <View key={i} style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <Button variant="bare" onPress={() => onToggleOp('dividend', i)}>
+              {term.op === 'subtract' ? t('−') : t('+')}
+            </Button>
+            <SumWithRange
+              from={fromRange}
+              to={toRange}
+              filterObject={dividendTermEditors[i]}
+            />
+            <Button variant="bare" onPress={() => onRemoveTerm('dividend', i)}>
+              <Trans>Remove</Trans>
+            </Button>
+          </View>
+        ))}
+      {type === 'percentage' && dividendTerms.length < 2 && (
+        <Button variant="bare" onPress={() => onAddTerm('dividend')}>
+          <Trans>Add term</Trans>
+        </Button>
+      )}
       {type === 'percentage' && (
         <>
           <div
@@ -569,6 +739,29 @@ function Operator({
             to={!showDivisorDateRange ? '' : toRange}
             filterObject={divisorFilterObject}
           />
+          {divisorTerms.map((term, i) => (
+            <View
+              key={i}
+              style={{ flexDirection: 'row', alignItems: 'center' }}
+            >
+              <Button variant="bare" onPress={() => onToggleOp('divisor', i)}>
+                {term.op === 'subtract' ? t('−') : t('+')}
+              </Button>
+              <SumWithRange
+                from={!showDivisorDateRange ? '' : fromRange}
+                to={!showDivisorDateRange ? '' : toRange}
+                filterObject={divisorTermEditors[i]}
+              />
+              <Button variant="bare" onPress={() => onRemoveTerm('divisor', i)}>
+                <Trans>Remove</Trans>
+              </Button>
+            </View>
+          ))}
+          {divisorTerms.length < 2 && (
+            <Button variant="bare" onPress={() => onAddTerm('divisor')}>
+              <Trans>Add term</Trans>
+            </Button>
+          )}
         </>
       )}
       {type !== 'percentage' && type !== 'sum' && (

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -18,11 +18,13 @@ import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
   PercentageSummaryTerm,
+  RuleConditionEntity,
   SummaryContent,
   SummaryWidget,
   TimeFrame,
 } from '@actual-app/core/types/models';
 import { parseISO } from 'date-fns';
+import { v4 as uuidv4 } from 'uuid';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
@@ -118,23 +120,6 @@ function SummaryInner({ widget }: SummaryInnerProps) {
   const dividendTerms = isPct ? (content.dividendExtraTerms ?? []) : [];
   const divisorTerms = isPct ? (content.divisorExtraTerms ?? []) : [];
 
-  const dividendTerm0 = useRuleConditionFilters(
-    dividendTerms[0]?.conditions ?? [],
-    dividendTerms[0]?.conditionsOp ?? 'and',
-  );
-  const dividendTerm1 = useRuleConditionFilters(
-    dividendTerms[1]?.conditions ?? [],
-    dividendTerms[1]?.conditionsOp ?? 'and',
-  );
-  const divisorTerm0 = useRuleConditionFilters(
-    divisorTerms[0]?.conditions ?? [],
-    divisorTerms[0]?.conditionsOp ?? 'and',
-  );
-  const divisorTerm1 = useRuleConditionFilters(
-    divisorTerms[1]?.conditions ?? [],
-    divisorTerms[1]?.conditionsOp ?? 'and',
-  );
-
   const params = useMemo(
     () =>
       summarySpreadsheet(
@@ -164,65 +149,6 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       divisorConditionsOp: divisorFilters.conditionsOp,
     }));
   }, [divisorFilters.conditions, divisorFilters.conditionsOp]);
-
-  const dividendTerm0Conditions = dividendTerm0.conditions;
-  const dividendTerm0ConditionsOp = dividendTerm0.conditionsOp;
-  const dividendTerm1Conditions = dividendTerm1.conditions;
-  const dividendTerm1ConditionsOp = dividendTerm1.conditionsOp;
-  const divisorTerm0Conditions = divisorTerm0.conditions;
-  const divisorTerm0ConditionsOp = divisorTerm0.conditionsOp;
-  const divisorTerm1Conditions = divisorTerm1.conditions;
-  const divisorTerm1ConditionsOp = divisorTerm1.conditionsOp;
-
-  useEffect(() => {
-    setContent(prev => {
-      if (prev.type !== 'percentage') return prev;
-      const syncSide = (
-        terms: PercentageSummaryTerm[] = [],
-        editorConditions: Array<{
-          conditions: FilterObject['conditions'];
-          conditionsOp: FilterObject['conditionsOp'];
-        }>,
-      ) =>
-        terms.map((term, i) => ({
-          ...term,
-          conditions: editorConditions[i].conditions,
-          conditionsOp: editorConditions[i].conditionsOp,
-        }));
-      return {
-        ...prev,
-        dividendExtraTerms: syncSide(prev.dividendExtraTerms, [
-          {
-            conditions: dividendTerm0Conditions,
-            conditionsOp: dividendTerm0ConditionsOp,
-          },
-          {
-            conditions: dividendTerm1Conditions,
-            conditionsOp: dividendTerm1ConditionsOp,
-          },
-        ]),
-        divisorExtraTerms: syncSide(prev.divisorExtraTerms, [
-          {
-            conditions: divisorTerm0Conditions,
-            conditionsOp: divisorTerm0ConditionsOp,
-          },
-          {
-            conditions: divisorTerm1Conditions,
-            conditionsOp: divisorTerm1ConditionsOp,
-          },
-        ]),
-      };
-    });
-  }, [
-    dividendTerm0Conditions,
-    dividendTerm0ConditionsOp,
-    dividendTerm1Conditions,
-    dividendTerm1ConditionsOp,
-    divisorTerm0Conditions,
-    divisorTerm0ConditionsOp,
-    divisorTerm1Conditions,
-    divisorTerm1ConditionsOp,
-  ]);
 
   const [allMonths, setAllMonths] = useState<
     Array<{
@@ -409,25 +335,44 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       if (terms.length >= 2) return prev;
       return {
         ...prev,
-        [key]: [...terms, { op: 'add', conditions: [], conditionsOp: 'and' }],
+        [key]: [
+          ...terms,
+          { id: uuidv4(), op: 'add', conditions: [], conditionsOp: 'and' },
+        ],
       };
     });
 
-  const removeTerm = (side: 'dividend' | 'divisor', index: number) =>
+  const removeTerm = (side: 'dividend' | 'divisor', id: string) =>
     setContent(prev => {
       if (prev.type !== 'percentage') return prev;
       const key =
         side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
       return {
         ...prev,
-        [key]: (prev[key] ?? []).filter((_, i) => i !== index),
+        [key]: (prev[key] ?? []).filter(term => term.id !== id),
       };
     });
 
-  const setTermOp = (
+  const onToggleOp = (side: 'dividend' | 'divisor', id: string) =>
+    setContent(prev => {
+      if (prev.type !== 'percentage') return prev;
+      const key =
+        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
+      return {
+        ...prev,
+        [key]: (prev[key] ?? []).map(term =>
+          term.id === id
+            ? { ...term, op: term.op === 'subtract' ? 'add' : 'subtract' }
+            : term,
+        ),
+      };
+    });
+
+  const onChangeTerm = (
     side: 'dividend' | 'divisor',
-    index: number,
-    op: 'add' | 'subtract',
+    id: string,
+    conditions: RuleConditionEntity[],
+    conditionsOp: 'and' | 'or',
   ) =>
     setContent(prev => {
       if (prev.type !== 'percentage') return prev;
@@ -435,17 +380,11 @@ function SummaryInner({ widget }: SummaryInnerProps) {
         side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
       return {
         ...prev,
-        [key]: (prev[key] ?? []).map((term, i) =>
-          i === index ? { ...term, op } : term,
+        [key]: (prev[key] ?? []).map(term =>
+          term.id === id ? { ...term, conditions, conditionsOp } : term,
         ),
       };
     });
-
-  const onToggleOp = (side: 'dividend' | 'divisor', index: number) => {
-    const terms = side === 'dividend' ? dividendTerms : divisorTerms;
-    const currentOp = terms[index]?.op;
-    setTermOp(side, index, currentOp === 'subtract' ? 'add' : 'subtract');
-  };
 
   return (
     <Page
@@ -582,13 +521,12 @@ function SummaryInner({ widget }: SummaryInnerProps) {
             }
             fromRange={data?.fromRange ?? ''}
             toRange={data?.toRange ?? ''}
-            dividendTermEditors={[dividendTerm0, dividendTerm1]}
-            divisorTermEditors={[divisorTerm0, divisorTerm1]}
             dividendTerms={dividendTerms}
             divisorTerms={divisorTerms}
             onAddTerm={addTerm}
             onRemoveTerm={removeTerm}
             onToggleOp={onToggleOp}
+            onChangeTerm={onChangeTerm}
           />
           {content.type !== 'sum' && (
             <>
@@ -670,13 +608,17 @@ type OperatorProps = {
   fromRange: string;
   toRange: string;
   showDivisorDateRange: boolean;
-  dividendTermEditors: FilterObject[];
-  divisorTermEditors: FilterObject[];
   dividendTerms: PercentageSummaryTerm[];
   divisorTerms: PercentageSummaryTerm[];
   onAddTerm: (side: 'dividend' | 'divisor') => void;
-  onRemoveTerm: (side: 'dividend' | 'divisor', index: number) => void;
-  onToggleOp: (side: 'dividend' | 'divisor', index: number) => void;
+  onRemoveTerm: (side: 'dividend' | 'divisor', id: string) => void;
+  onToggleOp: (side: 'dividend' | 'divisor', id: string) => void;
+  onChangeTerm: (
+    side: 'dividend' | 'divisor',
+    id: string,
+    conditions: RuleConditionEntity[],
+    conditionsOp: 'and' | 'or',
+  ) => void;
 };
 function Operator({
   type,
@@ -685,13 +627,12 @@ function Operator({
   fromRange,
   toRange,
   showDivisorDateRange,
-  dividendTermEditors,
-  divisorTermEditors,
   dividendTerms,
   divisorTerms,
   onAddTerm,
   onRemoveTerm,
   onToggleOp,
+  onChangeTerm,
 }: OperatorProps) {
   const { t } = useTranslation();
 
@@ -703,20 +644,18 @@ function Operator({
         filterObject={dividendFilterObject}
       />
       {type === 'percentage' &&
-        dividendTerms.map((term, i) => (
-          <View key={i} style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Button variant="bare" onPress={() => onToggleOp('dividend', i)}>
-              {term.op === 'subtract' ? t('−') : t('+')}
-            </Button>
-            <SumWithRange
-              from={fromRange}
-              to={toRange}
-              filterObject={dividendTermEditors[i]}
-            />
-            <Button variant="bare" onPress={() => onRemoveTerm('dividend', i)}>
-              <Trans>Remove</Trans>
-            </Button>
-          </View>
+        dividendTerms.map(term => (
+          <ExtraTermRow
+            key={term.id}
+            term={term}
+            from={fromRange}
+            to={toRange}
+            onChange={(id, conditions, conditionsOp) =>
+              onChangeTerm('dividend', id, conditions, conditionsOp)
+            }
+            onToggleOp={id => onToggleOp('dividend', id)}
+            onRemove={id => onRemoveTerm('dividend', id)}
+          />
         ))}
       {type === 'percentage' && dividendTerms.length < 2 && (
         <Button variant="bare" onPress={() => onAddTerm('dividend')}>
@@ -739,23 +678,18 @@ function Operator({
             to={!showDivisorDateRange ? '' : toRange}
             filterObject={divisorFilterObject}
           />
-          {divisorTerms.map((term, i) => (
-            <View
-              key={i}
-              style={{ flexDirection: 'row', alignItems: 'center' }}
-            >
-              <Button variant="bare" onPress={() => onToggleOp('divisor', i)}>
-                {term.op === 'subtract' ? t('−') : t('+')}
-              </Button>
-              <SumWithRange
-                from={!showDivisorDateRange ? '' : fromRange}
-                to={!showDivisorDateRange ? '' : toRange}
-                filterObject={divisorTermEditors[i]}
-              />
-              <Button variant="bare" onPress={() => onRemoveTerm('divisor', i)}>
-                <Trans>Remove</Trans>
-              </Button>
-            </View>
+          {divisorTerms.map(term => (
+            <ExtraTermRow
+              key={term.id}
+              term={term}
+              from={!showDivisorDateRange ? '' : fromRange}
+              to={!showDivisorDateRange ? '' : toRange}
+              onChange={(id, conditions, conditionsOp) =>
+                onChangeTerm('divisor', id, conditions, conditionsOp)
+              }
+              onToggleOp={id => onToggleOp('divisor', id)}
+              onRemove={id => onRemoveTerm('divisor', id)}
+            />
           ))}
           {divisorTerms.length < 2 && (
             <Button variant="bare" onPress={() => onAddTerm('divisor')}>
@@ -786,6 +720,50 @@ function Operator({
           </Text>
         </>
       )}
+    </View>
+  );
+}
+
+type ExtraTermRowProps = {
+  term: PercentageSummaryTerm;
+  from: string;
+  to: string;
+  onChange: (
+    id: string,
+    conditions: RuleConditionEntity[],
+    conditionsOp: 'and' | 'or',
+  ) => void;
+  onToggleOp: (id: string) => void;
+  onRemove: (id: string) => void;
+};
+function ExtraTermRow({
+  term,
+  from,
+  to,
+  onChange,
+  onToggleOp,
+  onRemove,
+}: ExtraTermRowProps) {
+  const { t } = useTranslation();
+  const filter = useRuleConditionFilters(term.conditions, term.conditionsOp);
+
+  const filterConditions = filter.conditions;
+  const filterConditionsOp = filter.conditionsOp;
+  const termId = term.id;
+
+  useEffect(() => {
+    onChange(termId, filterConditions, filterConditionsOp);
+  }, [termId, filterConditions, filterConditionsOp, onChange]);
+
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+      <Button variant="bare" onPress={() => onToggleOp(term.id)}>
+        {term.op === 'subtract' ? t('−') : t('+')}
+      </Button>
+      <SumWithRange from={from} to={to} filterObject={filter} />
+      <Button variant="bare" onPress={() => onRemove(term.id)}>
+        <Trans>Remove</Trans>
+      </Button>
     </View>
   );
 }

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -637,7 +637,7 @@ function Operator({
   const { isNarrowWidth } = useResponsive();
 
   return (
-    <View style={{ gap: isNarrowWidth ? 28 : 40, paddingTop: 24 }}>
+    <View style={{ gap: isNarrowWidth ? 46 : 52, paddingTop: 24 }}>
       <SumRow
         from={fromRange}
         to={toRange}
@@ -751,7 +751,7 @@ function TermsSection({
           style={{ alignSelf: 'flex-start' }}
           onPress={() => onAddTerm(side)}
         >
-          <Trans>Add term</Trans>
+          <Trans>Add another sum</Trans>
         </Button>
       )}
     </>
@@ -885,7 +885,7 @@ function SumWithRange({
           style={{
             position: 'absolute',
             right: -30,
-            top: -20,
+            top: isNarrowWidth ? -14 : -20,
             fontSize: isNarrowWidth ? '11px' : undefined,
           }}
         >
@@ -895,7 +895,7 @@ function SumWithRange({
           style={{
             position: 'absolute',
             right: -30,
-            bottom: -20,
+            bottom: isNarrowWidth ? -14 : -20,
             fontSize: isNarrowWidth ? '11px' : undefined,
           }}
         >

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -51,6 +51,8 @@ import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
+const MAX_EXTRA_TERMS = 2;
+
 export function Summary() {
   const params = useParams();
   const { data: widget, isPending } = useDashboardWidget<SummaryWidget>({
@@ -326,47 +328,38 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     return format(Math.round(value), 'financial');
   };
 
-  const addTerm = (side: 'dividend' | 'divisor') =>
+  const updateTerms = (
+    side: 'dividend' | 'divisor',
+    updater: (terms: PercentageSummaryTerm[]) => PercentageSummaryTerm[],
+  ) =>
     setContent(prev => {
       if (prev.type !== 'percentage') return prev;
       const key =
         side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
-      const terms = prev[key] ?? [];
-      if (terms.length >= 2) return prev;
-      return {
-        ...prev,
-        [key]: [
-          ...terms,
-          { id: uuidv4(), op: 'add', conditions: [], conditionsOp: 'and' },
-        ],
-      };
+      return { ...prev, [key]: updater(prev[key] ?? []) };
     });
+
+  const addTerm = (side: 'dividend' | 'divisor') =>
+    updateTerms(side, terms =>
+      terms.length >= MAX_EXTRA_TERMS
+        ? terms
+        : [
+            ...terms,
+            { id: uuidv4(), op: 'add', conditions: [], conditionsOp: 'and' },
+          ],
+    );
 
   const removeTerm = (side: 'dividend' | 'divisor', id: string) =>
-    setContent(prev => {
-      if (prev.type !== 'percentage') return prev;
-      const key =
-        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
-      return {
-        ...prev,
-        [key]: (prev[key] ?? []).filter(term => term.id !== id),
-      };
-    });
+    updateTerms(side, terms => terms.filter(term => term.id !== id));
 
   const onToggleOp = (side: 'dividend' | 'divisor', id: string) =>
-    setContent(prev => {
-      if (prev.type !== 'percentage') return prev;
-      const key =
-        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
-      return {
-        ...prev,
-        [key]: (prev[key] ?? []).map(term =>
-          term.id === id
-            ? { ...term, op: term.op === 'subtract' ? 'add' : 'subtract' }
-            : term,
-        ),
-      };
-    });
+    updateTerms(side, terms =>
+      terms.map(term =>
+        term.id === id
+          ? { ...term, op: term.op === 'subtract' ? 'add' : 'subtract' }
+          : term,
+      ),
+    );
 
   const onChangeTerm = (
     side: 'dividend' | 'divisor',
@@ -374,17 +367,11 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     conditions: RuleConditionEntity[],
     conditionsOp: 'and' | 'or',
   ) =>
-    setContent(prev => {
-      if (prev.type !== 'percentage') return prev;
-      const key =
-        side === 'dividend' ? 'dividendExtraTerms' : 'divisorExtraTerms';
-      return {
-        ...prev,
-        [key]: (prev[key] ?? []).map(term =>
-          term.id === id ? { ...term, conditions, conditionsOp } : term,
-        ),
-      };
-    });
+    updateTerms(side, terms =>
+      terms.map(term =>
+        term.id === id ? { ...term, conditions, conditionsOp } : term,
+      ),
+    );
 
   return (
     <Page
@@ -643,28 +630,17 @@ function Operator({
         to={toRange}
         filterObject={dividendFilterObject}
       />
-      {type === 'percentage' &&
-        dividendTerms.map(term => (
-          <ExtraTermRow
-            key={term.id}
-            term={term}
-            from={fromRange}
-            to={toRange}
-            onChange={(id, conditions, conditionsOp) =>
-              onChangeTerm('dividend', id, conditions, conditionsOp)
-            }
-            onToggleOp={id => onToggleOp('dividend', id)}
-            onRemove={id => onRemoveTerm('dividend', id)}
-          />
-        ))}
-      {type === 'percentage' && dividendTerms.length < 2 && (
-        <Button
-          variant="bare"
-          style={{ marginTop: 24, alignSelf: 'flex-start' }}
-          onPress={() => onAddTerm('dividend')}
-        >
-          <Trans>Add term</Trans>
-        </Button>
+      {type === 'percentage' && (
+        <TermsSection
+          side="dividend"
+          terms={dividendTerms}
+          from={fromRange}
+          to={toRange}
+          onAddTerm={onAddTerm}
+          onRemoveTerm={onRemoveTerm}
+          onToggleOp={onToggleOp}
+          onChangeTerm={onChangeTerm}
+        />
       )}
       {type === 'percentage' && (
         <>
@@ -682,28 +658,16 @@ function Operator({
             to={!showDivisorDateRange ? '' : toRange}
             filterObject={divisorFilterObject}
           />
-          {divisorTerms.map(term => (
-            <ExtraTermRow
-              key={term.id}
-              term={term}
-              from={!showDivisorDateRange ? '' : fromRange}
-              to={!showDivisorDateRange ? '' : toRange}
-              onChange={(id, conditions, conditionsOp) =>
-                onChangeTerm('divisor', id, conditions, conditionsOp)
-              }
-              onToggleOp={id => onToggleOp('divisor', id)}
-              onRemove={id => onRemoveTerm('divisor', id)}
-            />
-          ))}
-          {divisorTerms.length < 2 && (
-            <Button
-              variant="bare"
-              style={{ marginTop: 24, alignSelf: 'flex-start' }}
-              onPress={() => onAddTerm('divisor')}
-            >
-              <Trans>Add term</Trans>
-            </Button>
-          )}
+          <TermsSection
+            side="divisor"
+            terms={divisorTerms}
+            from={!showDivisorDateRange ? '' : fromRange}
+            to={!showDivisorDateRange ? '' : toRange}
+            onAddTerm={onAddTerm}
+            onRemoveTerm={onRemoveTerm}
+            onToggleOp={onToggleOp}
+            onChangeTerm={onChangeTerm}
+          />
         </>
       )}
       {type !== 'percentage' && type !== 'sum' && (
@@ -729,6 +693,59 @@ function Operator({
         </>
       )}
     </View>
+  );
+}
+
+type TermsSectionProps = {
+  side: 'dividend' | 'divisor';
+  terms: PercentageSummaryTerm[];
+  from: string;
+  to: string;
+  onAddTerm: (side: 'dividend' | 'divisor') => void;
+  onRemoveTerm: (side: 'dividend' | 'divisor', id: string) => void;
+  onToggleOp: (side: 'dividend' | 'divisor', id: string) => void;
+  onChangeTerm: (
+    side: 'dividend' | 'divisor',
+    id: string,
+    conditions: RuleConditionEntity[],
+    conditionsOp: 'and' | 'or',
+  ) => void;
+};
+function TermsSection({
+  side,
+  terms,
+  from,
+  to,
+  onAddTerm,
+  onRemoveTerm,
+  onToggleOp,
+  onChangeTerm,
+}: TermsSectionProps) {
+  return (
+    <>
+      {terms.map(term => (
+        <ExtraTermRow
+          key={term.id}
+          term={term}
+          from={from}
+          to={to}
+          onChange={(id, conditions, conditionsOp) =>
+            onChangeTerm(side, id, conditions, conditionsOp)
+          }
+          onToggleOp={id => onToggleOp(side, id)}
+          onRemove={id => onRemoveTerm(side, id)}
+        />
+      ))}
+      {terms.length < MAX_EXTRA_TERMS && (
+        <Button
+          variant="bare"
+          style={{ marginTop: 24, alignSelf: 'flex-start' }}
+          onPress={() => onAddTerm(side)}
+        >
+          <Trans>Add term</Trans>
+        </Button>
+      )}
+    </>
   );
 }
 

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -421,6 +421,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
         style={{
           width: '100%',
           background: theme.pageBackground,
+          paddingBottom: 24,
         }}
       >
         <View
@@ -463,23 +464,29 @@ function SummaryInner({ widget }: SummaryInnerProps) {
               )
             }
           />
-        </View>
-        {content.type === 'percentage' && (
-          <View style={{ flexDirection: 'row', marginLeft: 16 }}>
-            <Checkbox
-              id="enabled-field"
-              checked={content.divisorAllTimeDateRange ?? false}
-              onChange={() => {
-                const currentValue = content.divisorAllTimeDateRange ?? false;
-                setContent(prev => ({
-                  ...prev,
-                  divisorAllTimeDateRange: !currentValue,
-                }));
+          {content.type === 'percentage' && (
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                marginLeft: 16,
               }}
-            />{' '}
-            <Trans>All time divisor</Trans>
-          </View>
-        )}
+            >
+              <Checkbox
+                id="enabled-field"
+                checked={content.divisorAllTimeDateRange ?? false}
+                onChange={() => {
+                  const currentValue = content.divisorAllTimeDateRange ?? false;
+                  setContent(prev => ({
+                    ...prev,
+                    divisorAllTimeDateRange: !currentValue,
+                  }));
+                }}
+              />{' '}
+              <Trans>All time divisor</Trans>
+            </View>
+          )}
+        </View>
       </View>
       <View
         style={{
@@ -624,7 +631,7 @@ function Operator({
   const { t } = useTranslation();
 
   return (
-    <View>
+    <View style={{ gap: 40, paddingTop: 24 }}>
       <SumWithRange
         from={fromRange}
         to={toRange}
@@ -647,8 +654,6 @@ function Operator({
           <div
             style={{
               width: '100%',
-              marginTop: 32,
-              marginBottom: 32,
               borderTop: '2px solid',
               borderBottom: '2px solid',
             }}
@@ -675,8 +680,6 @@ function Operator({
           <div
             style={{
               width: '100%',
-              marginTop: 32,
-              marginBottom: 32,
               borderTop: '2px solid',
               borderBottom: '2px solid',
             }}
@@ -739,7 +742,7 @@ function TermsSection({
       {terms.length < MAX_EXTRA_TERMS && (
         <Button
           variant="bare"
-          style={{ marginTop: 24, alignSelf: 'flex-start' }}
+          style={{ alignSelf: 'flex-start' }}
           onPress={() => onAddTerm(side)}
         >
           <Trans>Add term</Trans>
@@ -784,7 +787,7 @@ function ExtraTermRow({
   }, [termId, filterConditions, filterConditionsOp]);
 
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 48 }}>
+    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
       <Button
         variant="bare"
         style={{ fontSize: '32px', marginRight: 8 }}

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
@@ -1,4 +1,4 @@
-import { combineTerms } from './summary-spreadsheet';
+import { combineTerms, computePercentage } from './summary-spreadsheet';
 
 describe('combineTerms', () => {
   it('returns the base when there are no terms', () => {
@@ -31,5 +31,69 @@ describe('combineTerms', () => {
     // expenses are stored negative; subtracting one must reduce the total
     expect(combineTerms(-3000, [{ op: 'subtract', value: -500 }])).toBe(2500);
     expect(combineTerms(-3000, [{ op: 'add', value: -500 }])).toBe(3500);
+  });
+
+  it('uses the magnitude of every term across mixed signs', () => {
+    // base and each term contribute their absolute value, regardless of sign
+    expect(
+      combineTerms(-1000, [
+        { op: 'add', value: 400 },
+        { op: 'subtract', value: -250 },
+        { op: 'add', value: -100 },
+      ]),
+    ).toBe(1000 + 400 - 250 + 100);
+    expect(
+      combineTerms(2000, [
+        { op: 'subtract', value: -1500 },
+        { op: 'subtract', value: 300 },
+      ]),
+    ).toBe(2000 - 1500 - 300);
+  });
+});
+
+describe('computePercentage', () => {
+  it('computes a basic ratio as a percentage', () => {
+    expect(computePercentage(1000, 2500)).toBe(40);
+    expect(computePercentage(5237.74, 5237.74)).toBe(100);
+  });
+
+  it('stays positive regardless of the sign of dividend or divisor', () => {
+    const cases: Array<[number, number]> = [
+      [1000, 2500],
+      [-1000, 2500],
+      [1000, -2500],
+      [-1000, -2500],
+      [-333.75, 12968.07],
+      [-9999.99, 1000],
+      [5237.74, -5237.74],
+    ];
+    for (const [dividend, divisor] of cases) {
+      expect(computePercentage(dividend, divisor)).toBeGreaterThanOrEqual(0);
+    }
+    // magnitude ratio: sign of the operands never changes the result
+    expect(computePercentage(-1000, 2500)).toBe(40);
+    expect(computePercentage(1000, -2500)).toBe(40);
+    expect(computePercentage(-1000, -2500)).toBe(40);
+  });
+
+  it('returns 0 when the divisor is 0 instead of Infinity/NaN', () => {
+    expect(computePercentage(1000, 0)).toBe(0);
+    expect(computePercentage(0, 0)).toBe(0);
+    expect(Number.isFinite(computePercentage(1000, 0))).toBe(true);
+  });
+
+  it('keeps the percentage positive end-to-end with magnitude terms', () => {
+    // savings 1000 over (income 5000 - taxes 1200), with expenses stored negative
+    const dividend = combineTerms(1000, []);
+    const divisor = combineTerms(5000, [{ op: 'subtract', value: -1200 }]);
+    expect(divisor).toBe(3800);
+    expect(computePercentage(dividend, divisor)).toBeCloseTo(26.32, 2);
+
+    // even when subtracted terms exceed the base, the % is still reported positive
+    const negativeDividend = combineTerms(200, [
+      { op: 'subtract', value: -500 },
+    ]);
+    expect(negativeDividend).toBe(-300);
+    expect(computePercentage(negativeDividend, 1000)).toBe(30);
   });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
@@ -1,0 +1,29 @@
+import { combineTerms } from './summary-spreadsheet';
+
+describe('combineTerms', () => {
+  it('returns the base when there are no terms', () => {
+    expect(combineTerms(1000, [])).toBe(1000);
+  });
+
+  it('adds an added term', () => {
+    expect(combineTerms(1000, [{ op: 'add', value: 250 }])).toBe(1250);
+  });
+
+  it('subtracts a subtracted term', () => {
+    expect(combineTerms(3000, [{ op: 'subtract', value: 500 }])).toBe(2500);
+  });
+
+  it('applies multiple terms left to right', () => {
+    expect(
+      combineTerms(3000, [
+        { op: 'subtract', value: 500 },
+        { op: 'add', value: 100 },
+      ]),
+    ).toBe(2600);
+  });
+
+  it('models savings over income minus taxes denominator', () => {
+    const denominator = combineTerms(3000, [{ op: 'subtract', value: 500 }]);
+    expect(Math.round((1000 / denominator) * 10000) / 100).toBe(40);
+  });
+});

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.test.ts
@@ -26,4 +26,10 @@ describe('combineTerms', () => {
     const denominator = combineTerms(3000, [{ op: 'subtract', value: 500 }]);
     expect(Math.round((1000 / denominator) * 10000) / 100).toBe(40);
   });
+
+  it('treats each amount as a magnitude regardless of stored sign', () => {
+    // expenses are stored negative; subtracting one must reduce the total
+    expect(combineTerms(-3000, [{ op: 'subtract', value: -500 }])).toBe(2500);
+    expect(combineTerms(-3000, [{ op: 'add', value: -500 }])).toBe(3500);
+  });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -11,6 +11,17 @@ import type { Locale } from 'date-fns';
 import type { useSpreadsheet } from '#hooks/useSpreadsheet';
 import { aqlQuery } from '#queries/aqlQuery';
 
+export function combineTerms(
+  base: number,
+  terms: Array<{ op: 'add' | 'subtract'; value: number }>,
+): number {
+  return terms.reduce(
+    (acc, term) =>
+      term.op === 'subtract' ? acc - term.value : acc + term.value,
+    base,
+  );
+}
+
 export function summarySpreadsheet(
   start: string,
   end: string,

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -280,68 +280,80 @@ async function calculatePercentage(
     };
   }
 
-  const conditionsOpKey =
-    summaryContent.divisorConditionsOp === 'or' ? '$or' : '$and';
-  let filters = [];
-  try {
-    const response = await send('make-filters-from-conditions', {
-      conditions: summaryContent?.divisorConditions?.filter(
-        cond => !cond.customName,
-      ),
-    });
-    filters = response.filters;
-  } catch (error) {
-    console.error('Error creating filters:', error);
-    return {
-      total: 0,
-      dividend: 0,
-      divisor: 0,
-    };
-  }
+  const sumForConditions = async (
+    conditions: RuleConditionEntity[] = [],
+    conditionsOp: 'and' | 'or' = 'and',
+    applyDateRange: boolean,
+  ): Promise<number> => {
+    const opKey = conditionsOp === 'or' ? '$or' : '$and';
+    let filters = [];
+    try {
+      const response = await send('make-filters-from-conditions', {
+        conditions: conditions.filter(cond => !cond.customName),
+      });
+      filters = response.filters;
+    } catch (error) {
+      console.error('Error creating filters:', error);
+      return 0;
+    }
 
-  const makeDivisorQuery = () =>
-    q('transactions')
-      .filter({
-        [conditionsOpKey]: filters,
-      })
+    let query = q('transactions')
+      .filter({ [opKey]: filters })
       .select([{ amount: { $sum: '$amount' } }]);
 
-  let query = makeDivisorQuery();
+    if (applyDateRange) {
+      query = query.filter({
+        $and: [
+          { date: { $gte: d.format(startDay, 'yyyy-MM-dd') } },
+          { date: { $lte: d.format(endDay, 'yyyy-MM-dd') } },
+        ],
+      });
+    }
 
-  if (!(summaryContent.divisorAllTimeDateRange ?? false)) {
-    query = query.filter({
-      $and: [
-        {
-          date: {
-            $gte: d.format(startDay, 'yyyy-MM-dd'),
-          },
-        },
-        {
-          date: {
-            $lte: d.format(endDay, 'yyyy-MM-dd'),
-          },
-        },
-      ],
-    });
-  }
+    try {
+      const result = (await aqlQuery(query)) as { data: { amount: number }[] };
+      return result?.data?.[0]?.amount ?? 0;
+    } catch (error) {
+      console.error('Error executing sum query:', error);
+      return 0;
+    }
+  };
 
-  let divisorData;
-  try {
-    divisorData = (await aqlQuery(query)) as { data: { amount: number }[] };
-  } catch (error) {
-    console.error('Error executing divisor query:', error);
-    return {
-      total: 0,
-      dividend: 0,
-      divisor: 0,
-    };
-  }
+  const divisorAppliesDateRange = !(
+    summaryContent.divisorAllTimeDateRange ?? false
+  );
 
-  const divisorValue = divisorData?.data?.[0]?.amount ?? 0;
+  const baseDivisor = await sumForConditions(
+    summaryContent.divisorConditions,
+    summaryContent.divisorConditionsOp,
+    divisorAppliesDateRange,
+  );
 
-  const dividend = data.reduce((prev, ac) => prev + (ac?.amount ?? 0), 0);
+  const divisorExtraValues = await Promise.all(
+    (summaryContent.divisorExtraTerms ?? []).map(async term => ({
+      op: term.op,
+      value: await sumForConditions(
+        term.conditions,
+        term.conditionsOp,
+        divisorAppliesDateRange,
+      ),
+    })),
+  );
+
+  const dividendExtraValues = await Promise.all(
+    (summaryContent.dividendExtraTerms ?? []).map(async term => ({
+      op: term.op,
+      value: await sumForConditions(term.conditions, term.conditionsOp, true),
+    })),
+  );
+
+  const baseDividend = data.reduce((prev, ac) => prev + (ac?.amount ?? 0), 0);
+
+  const dividend = combineTerms(baseDividend, dividendExtraValues);
+  const divisorValue = combineTerms(baseDivisor, divisorExtraValues);
+
   return {
-    total: Math.round(((dividend ?? 0) / (divisorValue ?? 1)) * 10000) / 100,
+    total: Math.round((dividend / (divisorValue ?? 1)) * 10000) / 100,
     divisor: divisorValue ?? 0,
     dividend: dividend ?? 0,
   };

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -2,6 +2,7 @@ import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import { q } from '@actual-app/core/shared/query';
 import type {
+  PercentageSummaryTerm,
   RuleConditionEntity,
   SummaryContent,
 } from '@actual-app/core/types/models';
@@ -323,29 +324,31 @@ async function calculatePercentage(
     summaryContent.divisorAllTimeDateRange ?? false
   );
 
-  const baseDivisor = await sumForConditions(
-    summaryContent.divisorConditions,
-    summaryContent.divisorConditionsOp,
-    divisorAppliesDateRange,
-  );
+  const sumExtraTerms = (
+    terms: PercentageSummaryTerm[] = [],
+    applyDateRange: boolean,
+  ) =>
+    Promise.all(
+      terms.map(async term => ({
+        op: term.op,
+        value: await sumForConditions(
+          term.conditions,
+          term.conditionsOp,
+          applyDateRange,
+        ),
+      })),
+    );
 
-  const divisorExtraValues = await Promise.all(
-    (summaryContent.divisorExtraTerms ?? []).map(async term => ({
-      op: term.op,
-      value: await sumForConditions(
-        term.conditions,
-        term.conditionsOp,
+  const [baseDivisor, divisorExtraValues, dividendExtraValues] =
+    await Promise.all([
+      sumForConditions(
+        summaryContent.divisorConditions,
+        summaryContent.divisorConditionsOp,
         divisorAppliesDateRange,
       ),
-    })),
-  );
-
-  const dividendExtraValues = await Promise.all(
-    (summaryContent.dividendExtraTerms ?? []).map(async term => ({
-      op: term.op,
-      value: await sumForConditions(term.conditions, term.conditionsOp, true),
-    })),
-  );
+      sumExtraTerms(summaryContent.divisorExtraTerms, divisorAppliesDateRange),
+      sumExtraTerms(summaryContent.dividendExtraTerms, true),
+    ]);
 
   const baseDividend = data.reduce((prev, ac) => prev + (ac?.amount ?? 0), 0);
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -27,6 +27,15 @@ export function combineTerms(
   );
 }
 
+// The percentage is a magnitude ratio: always non-negative, and 0 when the
+// divisor is 0 (rather than Infinity/NaN).
+export function computePercentage(dividend: number, divisor: number): number {
+  if (divisor === 0) {
+    return 0;
+  }
+  return Math.abs(Math.round((dividend / divisor) * 10000) / 100);
+}
+
 export function summarySpreadsheet(
   start: string,
   end: string,
@@ -360,8 +369,8 @@ async function calculatePercentage(
   const divisorValue = combineTerms(baseDivisor, divisorExtraValues);
 
   return {
-    total: Math.round((dividend / (divisorValue ?? 1)) * 10000) / 100,
-    divisor: divisorValue ?? 0,
-    dividend: dividend ?? 0,
+    total: computePercentage(dividend, divisorValue),
+    divisor: divisorValue,
+    dividend,
   };
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/summary-spreadsheet.ts
@@ -12,14 +12,18 @@ import type { Locale } from 'date-fns';
 import type { useSpreadsheet } from '#hooks/useSpreadsheet';
 import { aqlQuery } from '#queries/aqlQuery';
 
+// Each sum is combined by magnitude; the op sign controls add/subtract, so
+// subtracting an expense (stored negative) reduces the total as expected.
 export function combineTerms(
   base: number,
   terms: Array<{ op: 'add' | 'subtract'; value: number }>,
 ): number {
   return terms.reduce(
     (acc, term) =>
-      term.op === 'subtract' ? acc - term.value : acc + term.value,
-    base,
+      term.op === 'subtract'
+        ? acc - Math.abs(term.value)
+        : acc + Math.abs(term.value),
+    Math.abs(base),
   );
 }
 

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -190,6 +190,7 @@ export type BaseSummaryContent = {
 };
 
 export type PercentageSummaryTerm = {
+  id: string;
   op: 'add' | 'subtract';
   conditions: RuleConditionEntity[];
   conditionsOp: 'and' | 'or';

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -189,11 +189,19 @@ export type BaseSummaryContent = {
   fontSize?: number;
 };
 
+export type PercentageSummaryTerm = {
+  op: 'add' | 'subtract';
+  conditions: RuleConditionEntity[];
+  conditionsOp: 'and' | 'or';
+};
+
 export type PercentageSummaryContent = {
   type: 'percentage';
   divisorConditions: RuleConditionEntity[];
   divisorConditionsOp: 'and' | 'or';
   divisorAllTimeDateRange?: boolean;
+  dividendExtraTerms?: PercentageSummaryTerm[];
+  divisorExtraTerms?: PercentageSummaryTerm[];
   fontSize?: number;
 };
 

--- a/upcoming-release-notes/summary-card-percentage-extra-terms.md
+++ b/upcoming-release-notes/summary-card-percentage-extra-terms.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [zannis]
+---
+
+Add or subtract extra filtered sums in a summary card's percentage, so you can build metrics like savings rate after taxes.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Added this feature as I wanted to create an "after taxes" summary card, where I want to subtract a sum of one category from another sum in the summary denominator. I ended up adapting the percentage case of the summary card, where you can add up to 3 sums in the nominator and the denominator. Those can be added or subtracted depending on your use case. As a bonus - I fixed the mobile view of the summary edit view which was not really working.    

Change was implemented using Claude Code.

## Related issue(s)

Fixes #8582 

## Testing

Tested both adding / subtracting multiple sums in the desktop and mobile views. Adding / removing sums all seems to be working well.

## Checklist

- [ ] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
