### PR TITLE
[AI] Make summary card formula fit narrow screens

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -319,6 +319,14 @@ function SummaryInner({ widget }: SummaryInnerProps) {
     return format(Math.round(value), 'financial');
   };
 
+  const fractionNumberStyle = {
+    fontSize: isNarrowWidth ? '32px' : '50px',
+    width: '100%',
+    textAlign: 'center',
+  } satisfies CSSProperties;
+  const fractionRuleMargin = isNarrowWidth ? 12 : 32;
+  const totalWidth = isNarrowWidth ? '100%' : '250px';
+
   return (
     <Page
       header={
@@ -462,13 +470,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
                 <SvgEquals width={50} style={{ marginLeft: 56 }} />
               )}
               <View style={{ padding: 16 }}>
-                <Text
-                  style={{
-                    fontSize: isNarrowWidth ? '32px' : '50px',
-                    width: '100%',
-                    textAlign: 'center',
-                  }}
-                >
+                <Text style={fractionNumberStyle}>
                   <PrivacyFilter>
                     <FinancialText>
                       {format(data?.dividend ?? 0, 'financial')}
@@ -478,19 +480,13 @@ function SummaryInner({ widget }: SummaryInnerProps) {
                 <div
                   style={{
                     width: '100%',
-                    marginTop: isNarrowWidth ? 12 : 32,
-                    marginBottom: isNarrowWidth ? 12 : 32,
+                    marginTop: fractionRuleMargin,
+                    marginBottom: fractionRuleMargin,
                     borderTop: '2px solid',
                     borderBottom: '2px solid',
                   }}
                 />
-                <Text
-                  style={{
-                    fontSize: isNarrowWidth ? '32px' : '50px',
-                    width: '100%',
-                    textAlign: 'center',
-                  }}
-                >
+                <Text style={fractionNumberStyle}>
                   <PrivacyFilter>
                     {getDivisorFormatted(content.type, data?.divisor ?? 0)}
                   </PrivacyFilter>
@@ -505,8 +501,8 @@ function SummaryInner({ widget }: SummaryInnerProps) {
             style={{
               flexGrow: isNarrowWidth ? 0 : 1,
               textAlign: 'center',
-              width: isNarrowWidth ? '100%' : '250px',
-              maxWidth: isNarrowWidth ? '100%' : '250px',
+              width: totalWidth,
+              maxWidth: totalWidth,
               justifyItems: 'center',
               alignItems: 'center',
               marginLeft: isNarrowWidth ? 0 : 16,
@@ -617,6 +613,16 @@ function SumWithRange({
   const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
   const sigmaSize = isNarrowWidth ? 34 : 50;
+  // The range labels hang outside the sigma column; `nowrap` keeps them off the glyph.
+  const rangeLabelStyle = {
+    position: 'absolute',
+    right: -30,
+    fontSize: isNarrowWidth ? '11px' : undefined,
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties;
+  const rangeLabelOffset = isNarrowWidth ? -14 : -20;
+  const sigmaColumnWidth = isNarrowWidth ? sigmaSize : 70;
+  const conditionsMargin = isNarrowWidth ? 8 : 16;
 
   return (
     <View
@@ -627,9 +633,7 @@ function SumWithRange({
         alignItems: 'center',
         position: 'relative',
         display: 'grid',
-        gridTemplateColumns: isNarrowWidth
-          ? `${sigmaSize}px 15px 1fr 15px`
-          : '70px 15px 1fr 15px',
+        gridTemplateColumns: `${sigmaColumnWidth}px 15px 1fr 15px`,
       }}
     >
       <View
@@ -640,33 +644,17 @@ function SumWithRange({
         }}
       >
         <SvgSum width={sigmaSize} height={sigmaSize} />
-        <Text
-          style={{
-            position: 'absolute',
-            right: -30,
-            top: isNarrowWidth ? -14 : -20,
-            fontSize: isNarrowWidth ? '11px' : undefined,
-          }}
-        >
-          {to}
-        </Text>
-        <Text
-          style={{
-            position: 'absolute',
-            right: -30,
-            bottom: isNarrowWidth ? -14 : -20,
-            fontSize: isNarrowWidth ? '11px' : undefined,
-          }}
-        >
+        <Text style={{ ...rangeLabelStyle, top: rangeLabelOffset }}>{to}</Text>
+        <Text style={{ ...rangeLabelStyle, bottom: rangeLabelOffset }}>
           {from}
         </Text>
       </View>
       <SvgOpenParenthesis width={15} style={{ height: '100%' }} />
       <View
         style={{
-          marginLeft: isNarrowWidth ? 8 : 16,
+          marginLeft: conditionsMargin,
           maxWidth: isNarrowWidth ? '150px' : '220px',
-          marginRight: isNarrowWidth ? 8 : 16,
+          marginRight: conditionsMargin,
         }}
       >
         {(filterObject.conditions?.length ?? 0) === 0 ? (

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -437,10 +437,11 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       >
         <View
           style={{
-            flexDirection: 'row',
+            flexDirection: isNarrowWidth ? 'column' : 'row',
             justifyContent: 'center',
             width: '100%',
             alignItems: 'center',
+            gap: isNarrowWidth ? 24 : 0,
           }}
         >
           <Operator
@@ -457,11 +458,13 @@ function SummaryInner({ widget }: SummaryInnerProps) {
           />
           {content.type !== 'sum' && (
             <>
-              <SvgEquals width={50} style={{ marginLeft: 56 }} />
+              {!isNarrowWidth && (
+                <SvgEquals width={50} style={{ marginLeft: 56 }} />
+              )}
               <View style={{ padding: 16 }}>
                 <Text
                   style={{
-                    fontSize: '50px',
+                    fontSize: isNarrowWidth ? '32px' : '50px',
                     width: '100%',
                     textAlign: 'center',
                   }}
@@ -475,15 +478,15 @@ function SummaryInner({ widget }: SummaryInnerProps) {
                 <div
                   style={{
                     width: '100%',
-                    marginTop: 32,
-                    marginBottom: 32,
+                    marginTop: isNarrowWidth ? 12 : 32,
+                    marginBottom: isNarrowWidth ? 12 : 32,
                     borderTop: '2px solid',
                     borderBottom: '2px solid',
                   }}
                 />
                 <Text
                   style={{
-                    fontSize: '50px',
+                    fontSize: isNarrowWidth ? '32px' : '50px',
                     width: '100%',
                     textAlign: 'center',
                   }}
@@ -495,17 +498,19 @@ function SummaryInner({ widget }: SummaryInnerProps) {
               </View>
             </>
           )}
-          <SvgEquals width={50} style={{ marginLeft: 16 }} />
+          {!isNarrowWidth && (
+            <SvgEquals width={50} style={{ marginLeft: 16 }} />
+          )}
           <View
             style={{
-              flexGrow: 1,
+              flexGrow: isNarrowWidth ? 0 : 1,
               textAlign: 'center',
-              width: '250px',
-              maxWidth: '250px',
+              width: isNarrowWidth ? '100%' : '250px',
+              maxWidth: isNarrowWidth ? '100%' : '250px',
               justifyItems: 'center',
               alignItems: 'center',
-              marginLeft: 16,
-              fontSize: '50px',
+              marginLeft: isNarrowWidth ? 0 : 16,
+              fontSize: isNarrowWidth ? '40px' : '50px',
               justifyContent: 'center',
               color:
                 (data?.total ?? 0) === 0
@@ -610,6 +615,8 @@ function SumWithRange({
   filterObject,
 }: SumWithRangeProps) {
   const { t } = useTranslation();
+  const { isNarrowWidth } = useResponsive();
+  const sigmaSize = isNarrowWidth ? 34 : 50;
 
   return (
     <View
@@ -620,20 +627,55 @@ function SumWithRange({
         alignItems: 'center',
         position: 'relative',
         display: 'grid',
-        gridTemplateColumns: '70px 15px 1fr 15px',
+        gridTemplateColumns: isNarrowWidth
+          ? `${sigmaSize}px 15px 1fr 15px`
+          : '70px 15px 1fr 15px',
       }}
     >
-      <View style={{ position: 'relative', height: '50px', marginRight: 50 }}>
-        <SvgSum width={50} height={50} />
-        <Text style={{ position: 'absolute', right: -30, top: -20 }}>{to}</Text>
-        <Text style={{ position: 'absolute', right: -30, bottom: -20 }}>
+      <View
+        style={{
+          position: 'relative',
+          height: sigmaSize,
+          marginRight: isNarrowWidth ? 28 : 50,
+        }}
+      >
+        <SvgSum width={sigmaSize} height={sigmaSize} />
+        <Text
+          style={{
+            position: 'absolute',
+            right: -30,
+            top: isNarrowWidth ? -14 : -20,
+            fontSize: isNarrowWidth ? '11px' : undefined,
+          }}
+        >
+          {to}
+        </Text>
+        <Text
+          style={{
+            position: 'absolute',
+            right: -30,
+            bottom: isNarrowWidth ? -14 : -20,
+            fontSize: isNarrowWidth ? '11px' : undefined,
+          }}
+        >
           {from}
         </Text>
       </View>
       <SvgOpenParenthesis width={15} style={{ height: '100%' }} />
-      <View style={{ marginLeft: 16, maxWidth: '220px', marginRight: 16 }}>
+      <View
+        style={{
+          marginLeft: isNarrowWidth ? 8 : 16,
+          maxWidth: isNarrowWidth ? '150px' : '220px',
+          marginRight: isNarrowWidth ? 8 : 16,
+        }}
+      >
         {(filterObject.conditions?.length ?? 0) === 0 ? (
-          <Text style={{ fontSize: '25px', color: theme.pageTextPositive }}>
+          <Text
+            style={{
+              fontSize: isNarrowWidth ? '16px' : '25px',
+              color: theme.pageTextPositive,
+            }}
+          >
             {t('all transactions')}
           </Text>
         ) : (
@@ -647,7 +689,13 @@ function SumWithRange({
         )}
       </View>
       <SvgCloseParenthesis width={15} style={{ height: '100%' }} />
-      <View style={{ position: 'absolute', top: -15, right: -55 }}>
+      <View
+        style={{
+          position: 'absolute',
+          top: -15,
+          right: isNarrowWidth ? -42 : -55,
+        }}
+      >
         <FilterButton
           compact={false}
           onApply={filterObject.onApply}

--- a/upcoming-release-notes/summary-card-mobile-layout.md
+++ b/upcoming-release-notes/summary-card-mobile-layout.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [zannis]
 ---
 
-Fit the summary report's formula on narrow screens instead of letting it overflow
+Fit the summary report on narrow screens

--- a/upcoming-release-notes/summary-card-mobile-layout.md
+++ b/upcoming-release-notes/summary-card-mobile-layout.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [zannis]
+---
+
+Fit the summary report's formula on narrow screens instead of letting it overflow


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

This PR fixes the summary card view on mobile which was overflowing.    

Change was implemented using Claude Code.

## Related issue(s)

Fixes #8582 

## Testing

Tested the view on both desktop and mobile.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.33 MB → 13.33 MB (+2.27 kB) | +0.02%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.33 MB → 13.33 MB (+2.27 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/Summary.tsx` | 📈 +2.27 kB (+8.85%) | 25.61 kB → 27.88 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.42 MB → 1.42 MB (+2.27 kB) | +0.16%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.39 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->