### PR TITLE
[AI] Fix category_group rule conditions never matching live transactions

### DIFF
--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -426,6 +426,7 @@ describe('Transaction rules', () => {
     });
 
     expect(transaction.notes).toBe('bills-matched');
+    expect(transaction).not.toHaveProperty('category_group');
   });
 
   test('category_group condition does not match an unrelated group (live)', async () => {
@@ -451,6 +452,48 @@ describe('Transaction rules', () => {
     });
 
     expect(transaction.notes).toBe('');
+    expect(transaction).not.toHaveProperty('category_group');
+  });
+
+  test('category_group condition observes a category set earlier in the same rule chain (live)', async () => {
+    await loadRules();
+    const billsGroupId = await db.insertCategoryGroup({ name: 'Bills' });
+    const electricId = await db.insertCategory({
+      name: 'Electric',
+      cat_group: billsGroupId,
+    });
+    await db.insertPayee({ id: 'power_co_id', name: 'Power Co' });
+
+    // Runs first (pre stage): sets category based on payee. Nothing
+    // about category_group is checked here.
+    await insertRule({
+      stage: 'pre',
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'payee', value: 'power_co_id' }],
+      actions: [{ op: 'set', field: 'category', value: electricId }],
+    });
+
+    // Runs after (post stage): checks category_group. This should see
+    // the category the *first* rule just set, not whatever the
+    // transaction started with.
+    await insertRule({
+      stage: 'post',
+      conditionsOp: 'and',
+      conditions: [
+        { op: 'is', field: 'category_group', value: billsGroupId },
+      ],
+      actions: [{ op: 'set', field: 'notes', value: 'bills-matched' }],
+    });
+
+    const transaction = await runRules({
+      date: '2020-01-01',
+      payee: 'power_co_id',
+      category: null,
+      notes: '',
+    });
+
+    expect(transaction.category).toBe(electricId);
+    expect(transaction.notes).toBe('bills-matched');
   });
 
   test('transactions can be queried by rule', async () => {

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -404,6 +404,55 @@ describe('Transaction rules', () => {
     });
   });
 
+  test('category_group condition matches categories in that group (live)', async () => {
+    await loadRules();
+    const billsGroupId = await db.insertCategoryGroup({ name: 'Bills' });
+    const electricId = await db.insertCategory({
+      name: 'Electric',
+      cat_group: billsGroupId,
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'category_group', value: billsGroupId }],
+      actions: [{ op: 'set', field: 'notes', value: 'bills-matched' }],
+    });
+
+    const transaction = await runRules({
+      date: '2020-01-01',
+      category: electricId,
+      notes: '',
+    });
+
+    expect(transaction.notes).toBe('bills-matched');
+  });
+
+  test('category_group condition does not match an unrelated group (live)', async () => {
+    await loadRules();
+    const billsGroupId = await db.insertCategoryGroup({ name: 'Bills' });
+    const funGroupId = await db.insertCategoryGroup({ name: 'Fun' });
+    const moviesId = await db.insertCategory({
+      name: 'Movies',
+      cat_group: funGroupId,
+    });
+
+    await insertRule({
+      stage: null,
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'category_group', value: billsGroupId }],
+      actions: [{ op: 'set', field: 'notes', value: 'bills-matched' }],
+    });
+
+    const transaction = await runRules({
+      date: '2020-01-01',
+      category: moviesId,
+      notes: '',
+    });
+
+    expect(transaction.notes).toBe('');
+  });
+
   test('transactions can be queried by rule', async () => {
     await loadRules();
     const account = await db.insertAccount({ name: 'bank' });

--- a/packages/loot-core/src/server/transactions/transaction-rules.test.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.test.ts
@@ -479,9 +479,7 @@ describe('Transaction rules', () => {
     await insertRule({
       stage: 'post',
       conditionsOp: 'and',
-      conditions: [
-        { op: 'is', field: 'category_group', value: billsGroupId },
-      ],
+      conditions: [{ op: 'is', field: 'category_group', value: billsGroupId }],
       actions: [{ op: 'set', field: 'notes', value: 'bills-matched' }],
     });
 

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -334,6 +334,7 @@ export async function runRules(
   }
 
   let finalTrans = await prepareTransactionForRules({ ...trans }, accountsMap);
+  let lastCategoryIdForGroup: string | null = finalTrans.category ?? null;
 
   let scheduleRuleID = '';
   // Check if a schedule is attached to this transaction and if so get the rule ID attached to that schedule.
@@ -371,6 +372,10 @@ export async function runRules(
         const changes = rules[i].execActions(finalTrans);
         finalTrans = Object.assign({}, finalTrans, changes);
         await resolvePayeeNameForRules(finalTrans);
+        lastCategoryIdForGroup = await refreshCategoryGroupIfChanged(
+          finalTrans,
+          lastCategoryIdForGroup,
+        );
       } else if (RuleIdsLinkedToSchedules.includes(rules[i].id)) {
         // skip all other rules that are linked to other schedules.
         continue;
@@ -378,11 +383,19 @@ export async function runRules(
         // if a rule is not linked to a schedule, run it.
         finalTrans = rules[i].apply(finalTrans);
         await resolvePayeeNameForRules(finalTrans);
+        lastCategoryIdForGroup = await refreshCategoryGroupIfChanged(
+          finalTrans,
+          lastCategoryIdForGroup,
+        );
       }
     } else {
       // if there is no scheduleRuleID then just run all rules.
       finalTrans = rules[i].apply(finalTrans);
       await resolvePayeeNameForRules(finalTrans);
+      lastCategoryIdForGroup = await refreshCategoryGroupIfChanged(
+        finalTrans,
+        lastCategoryIdForGroup,
+      );
     }
   }
 
@@ -1130,6 +1143,35 @@ async function resolvePayeeNameForRules(
   } else {
     trans.payee = null;
   }
+}
+
+/**
+ * `category_group` is only computed once, in prepareTransactionForRules,
+ * before any rules have run. Since rules apply as a chain and an earlier
+ * rule's action can change (or clear) `category`, a later rule's
+ * `category_group` condition would otherwise read a stale group id left
+ * over from before that change. Called after every rule application in
+ * the runRules loop; only re-resolves the group when `category` has
+ * actually changed since the last check, to avoid a database lookup on
+ * every rule when category was untouched.
+ */
+async function refreshCategoryGroupIfChanged(
+  trans: TransactionForRules,
+  lastCategoryId: string | null,
+): Promise<string | null> {
+  const currentCategoryId = trans.category ?? null;
+  if (currentCategoryId === lastCategoryId) {
+    return lastCategoryId;
+  }
+
+  if (currentCategoryId) {
+    const category = await getCategory(currentCategoryId);
+    trans.category_group = category?.cat_group;
+  } else {
+    delete trans.category_group;
+  }
+
+  return currentCategoryId;
 }
 
 export async function finalizeTransactionForRules(

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -989,6 +989,8 @@ export type TransactionForRules = TransactionEntity & {
   balance?: number;
   _category_name?: string;
   _account_name?: string;
+  /** The transaction's category's group id; see prepareTransactionForRules */
+  category_group?: string;
   parent_amount?: number;
   /** Prefetched cent balances for BALANCE_OF("…") in rule formulas; cleared in finalize */
   _balanceOfPrefetched?: Map<string, number>;
@@ -1095,6 +1097,16 @@ export async function prepareTransactionForRules(
     const category = await getCategory(trans.category);
     if (category) {
       r._category_name = category.name;
+
+      // Populate the group id so a `category_group` rule condition can
+      // actually match. Previously this was never set here, so
+      // Condition.eval()'s `object['category_group']` lookup always
+      // came back undefined and the condition silently never matched
+      // during live rule application (import/manual entry). The
+      // query/report path (conditionsToAQL) was unaffected, since it
+      // maps the field to a real join (`category.group`) instead of
+      // reading this property.
+      r.category_group = category.cat_group;
     }
   }
 
@@ -1130,6 +1142,13 @@ export async function finalizeTransactionForRules(
 
   if ('balance' in trans) {
     delete trans.balance;
+  }
+
+  // Synthetic field used only for `category_group` condition matching;
+  // never a real transaction column, so strip it before the
+  // transaction is returned/persisted.
+  if ('category_group' in trans) {
+    delete trans.category_group;
   }
 
   if ('_balanceOfPrefetched' in trans) {

--- a/upcoming-release-notes/fix-category-group-rule-matching.md
+++ b/upcoming-release-notes/fix-category-group-rule-matching.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [ReticentEclectic]
+---
+
+Rules and filters using "category group" as a condition now correctly match live transactions during import and manual entry.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

While working on an unrelated new feature I came across this bug which causes `category_group` rules to silently fail to apply for live application.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Code drafted by Claude (Anthropic). Bug initially discovered by Claude. I verified, reviewed the diff, ran the tests myself, and independently reproduced both the bug and the fix (see Before and After Testing below)

## Related issue(s)

Fixes #8498

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

### Before

Reproduced by temporarily adding this test directly to unmodified master (not included in this PR's changes) — the rule's set notes action never runs because the condition never matches.

```
yarn workspace @actual-app/core test:node transaction-rules

 ❯ src/server/transactions/transaction-rules.test.ts (28 tests | 1 failed)
   ❯ Transaction rules (17)
     ...
     × REPRO: category_group condition matches categories in that group (live) 14ms
     ✓ transactions can be queried by rule 16ms
     ...

 FAIL  src/server/transactions/transaction-rules.test.ts > Transaction rules > REPRO: category_group condition matches categories in that group (live)
AssertionError: expected '' to be 'bills-matched' // Object.is equality
- Expected
+ Received
- bills-matched

 ❯ src/server/transactions/transaction-rules.test.ts:432:31
    430|     });
    431|
    432|     expect(transaction.notes).toBe('bills-matched');
       |                               ^
    433|   });

 Tests  1 failed | 27 passed (28)
```

### After

Same test ran after fix

```
yarn workspace @actual-app/core test:node transaction-rules

 ✓ src/server/transactions/transaction-rules.test.ts (29 tests)
   ✓ Transaction rules (18)
     ...
     ✓ category_group condition matches categories in that group (live) 11ms
     ✓ category_group condition does not match an unrelated group (live) 10ms
     ...

 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Other tests:
yarn workspace @actual-app/core typecheck : pass
yarn workspace @actual-app/core test:node transaction-rules : pass
yarn workspace @actual-app/core test: pass
yarn lint:fix: pass

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB | 0%
loot-core | 1 | 4.62 MB → 4.62 MB (+835 B) | +0.02%
api | 2 | 3.84 MB → 3.84 MB (+1.33 kB) | +0.03%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 209.06 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 168.31 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 270.84 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB → 4.62 MB (+835 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +835 B (+3.79%) | 21.54 kB → 22.35 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D-IET8NJ.js | 0 B → 4.62 MB (+4.62 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB → 0 B (-4.62 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+1.33 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +1.33 kB (+6.30%) | 21.11 kB → 22.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+1.33 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->