### PR TITLE
[WIP] [AI] Make spreadsheet topological sort O(V+E) instead of O(n²)

### DIFF
--- a/packages/loot-core/src/server/spreadsheet/graph-data-structure.test.ts
+++ b/packages/loot-core/src/server/spreadsheet/graph-data-structure.test.ts
@@ -1,0 +1,120 @@
+import { Graph } from './graph-data-structure';
+
+function isTopologicallyValid(
+  graph: ReturnType<typeof Graph>,
+  order: string[],
+): boolean {
+  const position = new Map<string, number>();
+  order.forEach((node, i) => position.set(node, i));
+
+  const { edges } = graph.getEdges();
+  for (const [from, outgoing] of edges) {
+    if (!position.has(from)) {
+      continue;
+    }
+    for (const to of outgoing as Set<string>) {
+      if (!position.has(to)) {
+        continue;
+      }
+      // `topologicalSort` lists a node before the nodes it points to.
+      if (position.get(from)! > position.get(to)!) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+// Small deterministic pseudo-random generator so the tests are reproducible.
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe('Graph.topologicalSort', () => {
+  it('returns an empty list for a single node with no edges', () => {
+    const graph = Graph();
+    graph.addNode('a');
+    // No source depends on anything reachable, but the source itself is sorted.
+    expect(graph.topologicalSort(['a'])).toEqual(['a']);
+  });
+
+  it('orders a node before the nodes it depends on', () => {
+    const graph = Graph();
+    graph.addEdge('a', 'b');
+    graph.addEdge('a', 'c');
+    graph.addEdge('b', 'd');
+    graph.addEdge('c', 'd');
+
+    expect(graph.topologicalSort(['a'])).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('visits every node reachable from the sources exactly once', () => {
+    const graph = Graph();
+    graph.addEdge('a', 'b');
+    graph.addEdge('b', 'c');
+    graph.addEdge('a', 'c');
+
+    const sorted = graph.topologicalSort(['a']);
+    expect([...sorted].sort((a, b) => a.localeCompare(b))).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    expect(new Set(sorted).size).toBe(sorted.length);
+  });
+
+  it('produces a valid ordering across many random DAGs', () => {
+    for (let seed = 0; seed < 500; seed++) {
+      const random = mulberry32(seed + 1);
+      const size = 2 + Math.floor(random() * 40);
+      const graph = Graph();
+      const nodes = Array.from({ length: size }, (_, i) => `n${i}`);
+      nodes.forEach(node => graph.addNode(node));
+
+      // Only add forward edges (i -> j where i < j) so the graph stays acyclic.
+      for (let i = 0; i < size; i++) {
+        const degree = Math.floor(random() * 4);
+        for (let d = 0; d < degree; d++) {
+          if (i + 1 >= size) {
+            break;
+          }
+          const j = i + 1 + Math.floor(random() * (size - i - 1));
+          graph.addEdge(nodes[i], nodes[j]);
+        }
+      }
+
+      const sources = nodes.filter(() => random() < 0.6);
+      if (sources.length === 0) {
+        sources.push(nodes[0]);
+      }
+
+      const sorted = graph.topologicalSort(sources);
+      expect(isTopologicallyValid(graph, sorted)).toBe(true);
+    }
+  });
+
+  // Regression guard: a large budget produces very deep dependency chains (each
+  // transaction's running balance depends on the previous one). The sort must
+  // handle that without overflowing the stack and without blowing up in time.
+  it('handles a very deep dependency chain', () => {
+    const graph = Graph();
+    const depth = 50000;
+    for (let i = 1; i < depth; i++) {
+      graph.addEdge(`c${i}`, `c${i - 1}`);
+    }
+
+    const sorted = graph.topologicalSort([`c${depth - 1}`]);
+
+    expect(sorted).toHaveLength(depth);
+    expect(sorted[0]).toBe(`c${depth - 1}`);
+    expect(sorted[depth - 1]).toBe('c0');
+    expect(isTopologicallyValid(graph, sorted)).toBe(true);
+  });
+});

--- a/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts
+++ b/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts
@@ -86,56 +86,66 @@ export function Graph() {
       }
     });
 
+    // Nodes are collected in the order they finish (post-order). A topological
+    // order is the reverse of that, so flip the list once at the end instead of
+    // prepending each node as we go (which would be O(n) per node).
+    sorted.reverse();
+
     return sorted;
   }
 
+  // Iterative depth-first, post-order traversal. We use an explicit stack rather
+  // than recursion so that very deep dependency chains — e.g. the per-transaction
+  // running-balance cells in a large budget — can't overflow the call stack.
+  //
+  // Each stack frame keeps a cursor into its own list of neighbors. That makes
+  // finishing a node O(1): when a child finishes we simply return to its parent
+  // frame, which is right below it on the stack — no scanning to find the parent
+  // and no per-node bookkeeping that grows with the depth of the graph. The whole
+  // sort is therefore O(nodes + edges).
   function topologicalSortIterable(name, visited, sorted) {
-    const stackTrace: StackItem[] = [];
+    const stack: StackFrame[] = [{ value: name, neighbors: null, index: 0 }];
 
-    stackTrace.push({
-      count: -1,
-      value: name,
-      parent: '',
-      level: 0,
-    });
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
 
-    while (stackTrace.length > 0) {
-      const current = stackTrace.slice(-1)[0];
-
-      const adjacents = adjacent(current.value);
-      if (current.count === -1) {
-        current.count = adjacents.size;
+      if (frame.neighbors === null) {
+        if (visited.has(frame.value)) {
+          stack.pop();
+          continue;
+        }
+        // Snapshot the neighbors up front, in reverse. Because we pull them off a
+        // LIFO stack, reversing here keeps the visit order identical to the
+        // previous implementation.
+        const adjacents = adjacent(frame.value);
+        const neighbors = new Array(adjacents.size);
+        let i = adjacents.size - 1;
+        for (const neighbor of adjacents.values()) {
+          neighbors[i--] = neighbor;
+        }
+        frame.neighbors = neighbors;
       }
 
-      if (current.count > 0) {
-        const iter = adjacents.values();
-        let cur = iter.next();
-        while (!cur.done) {
-          if (!visited.has(cur.value)) {
-            stackTrace.push({
-              count: -1,
-              parent: current.value,
-              value: cur.value,
-              level: current.level + 1,
-            });
-          } else {
-            current.count--;
-          }
-          cur = iter.next();
-        }
-      } else {
-        if (!visited.has(current.value)) {
-          visited.add(current.value);
-          sorted.unshift(current.value);
-        }
-
-        const removed = stackTrace.pop();
-        for (let i = 0; i < stackTrace.length; i++) {
-          if (stackTrace[i].value === removed.parent) {
-            stackTrace[i].count--;
-          }
+      // Descend into the next unvisited neighbor, if there is one.
+      let descended = false;
+      while (frame.index < frame.neighbors.length) {
+        const neighbor = frame.neighbors[frame.index++];
+        if (!visited.has(neighbor)) {
+          stack.push({ value: neighbor, neighbors: null, index: 0 });
+          descended = true;
+          break;
         }
       }
+      if (descended) {
+        continue;
+      }
+
+      // All neighbors done: this node is finished.
+      if (!visited.has(frame.value)) {
+        visited.add(frame.value);
+        sorted.push(frame.value);
+      }
+      stack.pop();
     }
   }
 
@@ -157,9 +167,8 @@ export function Graph() {
   return graph;
 }
 
-type StackItem = {
-  count: number;
+type StackFrame = {
   value: string;
-  parent: string;
-  level: number;
+  neighbors: string[] | null;
+  index: number;
 };

--- a/upcoming-release-notes/faster-spreadsheet-topological-sort.md
+++ b/upcoming-release-notes/faster-spreadsheet-topological-sort.md
@@ -1,0 +1,6 @@
+---
+category: Performance
+authors: [mbrevda]
+---
+
+Speed up loading large budgets by making the spreadsheet's dependency sort scale linearly instead of quadratically.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+242 B) | +0.00%
loot-core | 1 | 4.62 MB → 4.62 MB (+48 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+42 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+242 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +179 B (+0.08%) | 208.88 kB → 209.06 kB
`locale/fr.json` | 📈 +63 B (+0.04%) | 168.24 kB → 168.31 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 208.88 kB → 209.06 kB (+179 B) | +0.08%
static/js/fr.js | 168.24 kB → 168.31 kB (+63 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 270.84 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB → 4.62 MB (+48 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts` | 📈 +48 B (+1.54%) | 3.04 kB → 3.09 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D0r-ytBI.js | 0 B → 4.62 MB (+4.62 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB → 0 B (-4.62 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+42 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/graph-data-structure.ts` | 📈 +42 B (+1.40%) | 2.93 kB → 2.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+42 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->