### PR TITLE
Update PikaPods deployment cost in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Want to say thanks? Click the ⭐ at the top of the page.
 
 There are four ways to deploy Actual:
 
-1. One-click deployment [via PikaPods](https://www.pikapods.com/pods?run=actual) (~1.40 $/month) - recommended for non-technical users
+1. One-click deployment [via PikaPods](https://www.pikapods.com/pods?run=actual) (~2.00 $/month) - recommended for non-technical users
 1. Managed hosting [via Fly.io](https://actualbudget.org/docs/install/fly) (~1.50 $/month)
 1. Self-hosted by using [a Docker image](https://actualbudget.org/docs/install/docker)
 1. Local-only apps - [downloadable Windows, Mac and Linux apps](https://actualbudget.org/download/) you can run on your device

--- a/upcoming-release-notes/8597.md
+++ b/upcoming-release-notes/8597.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MAkcanca]
+---
+
+Update PikaPods deployment cost in README


### PR DESCRIPTION
PikaPods now charges ~$2.00/month to run Actual, but the README still lists the old ~$1.40/month price. This updates the one-click deployment cost in the README to match the current pricing.