### PR TITLE
[AI] Migrate health-check script to TypeScript

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -95,7 +95,7 @@
         "app.ts",
         "src/app.ts",
         "bin/**/*.js",
-        "src/scripts/**/*.js",
+        "src/scripts/**/*.{js,ts}",
         "src/app-*/app-*.{ts,js}"
       ]
     }

--- a/packages/sync-server/src/scripts/health-check.ts
+++ b/packages/sync-server/src/scripts/health-check.ts
@@ -5,13 +5,27 @@ const protocol =
 const hostname =
   config.get('hostname') === '::' ? 'localhost' : config.get('hostname');
 
+function getHealthStatus(response: unknown) {
+  if (
+    typeof response === 'object' &&
+    response !== null &&
+    'status' in response
+  ) {
+    return response.status;
+  }
+
+  return undefined;
+}
+
 fetch(`${protocol}://${hostname}:${config.get('port')}/health`)
-  .then(res => res.json())
-  .then(res => {
-    if (res.status !== 'UP') {
+  .then(response => response.json())
+  .then(response => {
+    const status = getHealthStatus(response);
+
+    if (status !== 'UP') {
       throw new Error(
         'Health check failed: Server responded to health check with status ' +
-          res.status,
+          status,
       );
     }
   })

--- a/packages/sync-server/src/scripts/health-check.ts
+++ b/packages/sync-server/src/scripts/health-check.ts
@@ -5,11 +5,12 @@ const protocol =
 const hostname =
   config.get('hostname') === '::' ? 'localhost' : config.get('hostname');
 
-function getHealthStatus(response: unknown) {
+function getHealthStatus(response: unknown): string | undefined {
   if (
     typeof response === 'object' &&
     response !== null &&
-    'status' in response
+    'status' in response &&
+    typeof response.status === 'string'
   ) {
     return response.status;
   }

--- a/packages/sync-server/vite.config.mts
+++ b/packages/sync-server/vite.config.mts
@@ -55,7 +55,7 @@ export default defineConfig({
         ),
         'scripts/health-check': path.resolve(
           __dirname,
-          'src/scripts/health-check.js',
+          'src/scripts/health-check.ts',
         ),
       },
       output: {

--- a/upcoming-release-notes/migrate-health-check-typescript.md
+++ b/upcoming-release-notes/migrate-health-check-typescript.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [anjupathak03]
+---
+
+Migrate the sync-server health-check script to TypeScript


### PR DESCRIPTION
## Description

### What

Moved the sync-server health check from `health-check.js` to `health-check.ts`.

Behaviour is unchanged: the script calls the `/health` endpoint and only
succeeds when the server reports status `UP`.

### Why

TypeScript catches type mistakes in the code itself at compile time, so things
like passing the wrong type around get flagged before the script ever runs.
That doesn't help with what the API actually sends back at runtime, though,
which is what the validation below is for. Overall this makes the script safer
and easier to maintain.

### Status validation

Whatever comes back from `response.json()` isn't trusted, so it's validated at
runtime before we read anything off it:

- the parsed value is an object
- it isn't `null`
- a `status` property exists
- `status` is a string

Only `UP` counts as healthy. A missing status, a non-string status, or any
other value fails the check.

### Other changes

- Vite config: health-check entry now points at the `.ts` file instead of `.js`
- Knip config: updated so it picks up TypeScript scripts and not just JS
- added an upcoming release note documenting the migration

### AI disclosure

OpenAI Codex assisted with the implementation, code review and testing. I read
through the changes myself and reviewed them before marking this PR ready for
review.

## Related issue(s)

Relates to #1483

## Testing

Ran locally:

- `yarn lint:fix`
- `yarn typecheck`
- `yarn test`
- `yarn build:server`
- `yarn knip`
- `yarn workspace @actual-app/sync-server typecheck`

For runtime verification I pointed the script at a temporary local HTTP test
endpoint and confirmed it succeeds on `UP` and fails on `DOWN`.

GitHub CI is green on this branch.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed