### PR TITLE
Allow searching for 'Transfer: ' prefix on payees page

### DIFF
--- a/packages/desktop-client/src/components/payees/ManagePayees.tsx
+++ b/packages/desktop-client/src/components/payees/ManagePayees.tsx
@@ -86,7 +86,9 @@ export const ManagePayees = ({
     let filtered = payees;
     if (filter) {
       filtered = filtered.filter(p =>
-        getNormalisedString(p.name).includes(getNormalisedString(filter)),
+        getNormalisedString(
+          (p.transfer_acct ? t('Transfer: ') : '') + p.name,
+        ).includes(getNormalisedString(filter)),
       );
     }
     if (orphanedOnly) {
@@ -95,7 +97,7 @@ export const ManagePayees = ({
       );
     }
     return filtered;
-  }, [payees, filter, orphanedOnly, orphanedPayees]);
+  }, [payees, filter, orphanedOnly, orphanedPayees, t]);
 
   const selected = useSelected('payees', filteredPayees, initialSelectedIds);
 

--- a/upcoming-release-notes/search-transfer-prefix-payees.md
+++ b/upcoming-release-notes/search-transfer-prefix-payees.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [jfdoming]
+---
+
+Allow searching for 'Transfer: ' prefix on payees page


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

I'm having Codex do a UX/bug review of the app holistically using some patterns I was shown by a coworker. It obviously flagged a bunch of irrelevant things, but it caught some nice things too.

In this case, I think it's fairly intuitive that searching for "Transfer" should show transfers. This only applies to the "Manage Payees" page, and it won't affect existing searches which will still be substrings of the payee name.

## Related issue(s)

n/a

## Testing

Manually tested this locally by searching for "Transfer" and also regular payees.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.19 MB → 13.19 MB (+106 B) | +0.00%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.19 MB → 13.19 MB (+106 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/payees/ManagePayees.tsx` | 📈 +106 B (+0.68%) | 15.12 kB → 15.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 270.84 kB → 270.94 kB (+106 B) | +0.04%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.55 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 140.4 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.07 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 209.06 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 168.31 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 330.95 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.5 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.91 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->