### PR TITLE
Return an error when changing password with no password method

### DIFF
--- a/packages/sync-server/src/accounts/password.js
+++ b/packages/sync-server/src/accounts/password.js
@@ -161,9 +161,13 @@ export async function changePassword(newPassword) {
   }
 
   const hashed = await hashPassword(newPassword);
-  accountDb.mutate("UPDATE auth SET extra_data = ? WHERE method = 'password'", [
-    hashed,
-  ]);
+  const result = accountDb.mutate(
+    "UPDATE auth SET extra_data = ? WHERE method = 'password'",
+    [hashed],
+  );
+  if (result.changes === 0) {
+    return { error: 'no-password-method' };
+  }
   return {};
 }
 

--- a/packages/sync-server/src/accounts/password.test.js
+++ b/packages/sync-server/src/accounts/password.test.js
@@ -22,6 +22,17 @@ function getStoredPasswordHash() {
   return row ? row.extra_data : null;
 }
 
+function getAuthMethods() {
+  return getAccountDb().all('SELECT method, active FROM auth ORDER BY method');
+}
+
+function insertOpenIdAuth(extraData) {
+  getAccountDb().mutate(
+    'INSERT INTO auth (method, display_name, extra_data, active) VALUES (?, ?, ?, ?)',
+    ['openid', 'OpenID', JSON.stringify(extraData), 1],
+  );
+}
+
 function ensureOwner() {
   const db = getAccountDb();
   const owner = db.first("SELECT id FROM users WHERE user_name = ''");
@@ -155,6 +166,25 @@ describe('bootstrapPassword / changePassword', () => {
 
   it('rejects an empty password on changePassword', async () => {
     expect(await changePassword('')).toEqual({ error: 'invalid-password' });
+  });
+});
+
+describe('changePassword on an OIDC-only instance', () => {
+  it('reports an error instead of silently succeeding', async () => {
+    insertOpenIdAuth({ issuer: 'https://issuer.example.com' });
+
+    expect(await changePassword('new password')).toEqual({
+      error: 'no-password-method',
+    });
+    expect(getStoredPasswordHash()).toBeNull();
+  });
+
+  it('does not disable the existing openid method', async () => {
+    insertOpenIdAuth({ issuer: 'https://issuer.example.com' });
+
+    await changePassword('new password');
+
+    expect(getAuthMethods()).toEqual([{ method: 'openid', active: 1 }]);
   });
 });
 

--- a/upcoming-release-notes/change-password-no-password-method.md
+++ b/upcoming-release-notes/change-password-no-password-method.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [Gautamstar]
+---
+
+Report an error when changing the password on an instance with no password auth method configured, instead of reporting success without saving.


### PR DESCRIPTION
## Description

On an OIDC-only instance, the `reset-password` script says it changed the password but never saves one.

`needsBootstrap()` looks for any row in `auth` table. An OIDC only instance has an `openid` row, it returns false and the script assumed you already have a password set. `changePassword`  runs `UPDATE auth SET extra_data = ? WHERE method = 'password'`. Which matches nothing. The function returns `{}`, which is the success value, so the script reports the password changed and exits 0.

`setPasswordHash` is in the same file and handles the missing row. It deletes any password row and inserts a new one in a transaction, and `bootstrapPassword` calls it. `changePassword` was the only place running a bare UPDATE, so it didn't do anything when there was no row to update.

This checks the UPDATE result and returns `{ error: 'no-password-method' }` when nothing matches, following the rest of the module.

I returned an error rather than inserting the password row. Calling `setPasswordHash` would fix the symptom, but it also runs `UPDATE auth SET active = 0`, which deactivates openid. A password reset would then switch the instance to password auth. That seemed like the operator's call. 

I used Claude Code to draft the fix and tests, which I reviewed and wrote in myself.

## Related issue(s)

Fixes #8596

## Testing

Two tests in `packages/sync-server/src/accounts/password.test.js`, both run against an auth table holding only an `openid` row.

`reports an error instead of silently succeeding` fails on master at `98ee00e01`: with AssertionError: expected {} to deeply equal { error: 'no-password-method' } and passes with the change.

`does not disable the existing openid method` covers the side effect stated above. It passes before and after.

The rest of the sync-server suite still passes: 589 tests over 46 files. `oxfmt --check` and `oxlint` are clean on both files.

To reproduce, configure an instance with OIDC and no password, then run the `reset-password` script. Before, it reports success and saves nothing. After, it prints `no-password-method` and exits non-zero.

I didn't add a route test. `/change-password` can't reach this state, since `app-account.js` returns 403 for any session where `auth_method !== 'password'` before `changePassword` runs. An OIDC-only instance has no password session, so this only shows up through the CLI script, which is the path in the report.

## Checklist
- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
<!--- actual-bot-sections --->