### PR TITLE
[AI] Fix transaction row context-menu listener rebinding on every render

### DIFF
--- a/packages/desktop-client/src/hooks/useContextMenu.ts
+++ b/packages/desktop-client/src/hooks/useContextMenu.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import type { RefObject } from 'react';
 
 import type { Falsy } from '@actual-app/core/types/util';
@@ -23,10 +23,6 @@ export function useContextMenu({
   items,
 }: UseContextMenuProps) {
   const dispatch = useDispatch();
-
-  // Store actions in a ref to avoid re-binding the event listener on every render
-  const actionsRef = useRef(items);
-  actionsRef.current = items;
 
   const processedItems = items.filter(
     item => item && (typeof item === 'symbol' || !item.hidden),

--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -1,0 +1,97 @@
+import type { RefObject } from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRefEventListener } from './useRefEventListener';
+
+describe('useRefEventListener', () => {
+  function makeMockElement() {
+    return {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+  }
+
+  it('registers the listener once on mount', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    renderHook(() => useRefEventListener(ref, 'click', vi.fn()));
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+  });
+
+  it('does not re-bind the native listener when only the callback identity changes', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(
+      ({ callback }) => useRefEventListener(ref, 'click', callback),
+      { initialProps: { callback: vi.fn() } },
+    );
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.removeEventListener).not.toHaveBeenCalled();
+
+    // Simulate a caller passing a brand-new inline function every render.
+    rerender({ callback: vi.fn() });
+    rerender({ callback: vi.fn() });
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.removeEventListener).not.toHaveBeenCalled();
+  });
+
+  it('always invokes the latest callback, even after a re-render', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ callback }) => useRefEventListener(ref, 'click', callback),
+      { initialProps: { callback: firstCallback } },
+    );
+
+    rerender({ callback: secondCallback });
+
+    const registeredListener = el.addEventListener.mock.calls[0][1];
+    const event = { type: 'click' };
+    registeredListener(event);
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledWith(event);
+  });
+
+  it('rebinds when the event name changes', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook<void, { event: 'click' | 'keyup' }>(
+      ({ event }) => useRefEventListener(ref, event, vi.fn()),
+      { initialProps: { event: 'click' } },
+    );
+
+    rerender({ event: 'keyup' });
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(2);
+    expect(el.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { unmount } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    unmount();
+
+    expect(el.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 
 export function useRefEventListener<
@@ -10,16 +10,26 @@ export function useRefEventListener<
   // oxlint-disable-next-line typescript/no-explicit-any
   callback: (this: ElementType, ev: HTMLElementEventMap[EventType]) => any,
 ) {
-  // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  // Keep the latest callback in a ref so the effect below doesn't need to
+  // depend on it. Callers routinely pass a new inline function every render,
+  // which would otherwise tear down and re-add the native listener on every
+  // render instead of only when `ref`/`event` change.
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
   useEffect(() => {
     const el =
       ref instanceof Document || ref instanceof Window ? ref : ref.current;
     if (!el) return;
 
-    const callbackRef = callback as EventListener; // closure?
-    el.addEventListener(event, callbackRef);
+    const listener: EventListener = e =>
+      callbackRef.current.call(
+        el as ElementType,
+        e as HTMLElementEventMap[EventType],
+      );
+    el.addEventListener(event, listener);
     return () => {
-      el.removeEventListener(event, callbackRef);
+      el.removeEventListener(event, listener);
     };
-  }, [ref, event, callback]);
+  }, [ref, event]);
 }

--- a/upcoming-release-notes/fix-slow-transaction-context-menu-listener.md
+++ b/upcoming-release-notes/fix-slow-transaction-context-menu-listener.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [youngcw]
+---
+
+Prevent context menu listeners from rebinding every render

--- a/upcoming-release-notes/fix-slow-transaction-list-after-delete-reconcile-schedule-link.md
+++ b/upcoming-release-notes/fix-slow-transaction-list-after-delete-reconcile-schedule-link.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix transaction rows becoming sluggish to update after deleting a transaction, reconciling an account, or linking a schedule

--- a/upcoming-release-notes/fix-slow-transaction-list-after-delete-reconcile-schedule-link.md
+++ b/upcoming-release-notes/fix-slow-transaction-list-after-delete-reconcile-schedule-link.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [youngcw]
----
-
-Fix transaction rows becoming sluggish to update after deleting a transaction, reconciling an account, or linking a schedule


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
I am trying to track down why the app has gotten slower for certain actions in recent months.  This was the first change that Claude found that could cause issues.  It doesn't seem to fix the problem, but its probably worth fixing.

The actions that I have noticed being slower are adding new transactions, reconciling, and bank syncing (specifically the time between the sync finishing and new transactions showing up)
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->
Fixed by Claude
## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (-262 B) | -0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (-262 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useContextMenu.ts` | 📉 -82 B (-9.05%) | 906 B → 824 B
`src/hooks/useRefEventListener.ts` | 📉 -180 B (-25.57%) | 704 B → 524 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 2.03 MB → 2.03 MB (-262 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 171.84 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bcf_a9eI.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->