### PR TITLE
[AI] Persist transaction table filters per account

### DIFF
--- a/packages/desktop-client/e2e/transactions.test.ts
+++ b/packages/desktop-client/e2e/transactions.test.ts
@@ -351,4 +351,37 @@ test.describe('Transactions', () => {
       await expect(header).not.toContainText('Notes');
     });
   });
+
+  test.describe('filter persistence', () => {
+    test('persists the applied filters per account', async () => {
+      const deleteFilterButtons = page.getByRole('button', {
+        name: 'Delete filter',
+      });
+
+      // Apply a category filter on Ally Savings
+      const filterTooltip = await accountPage.filterBy('Category');
+      await page.getByTestId('Clothing-category-item').click();
+      await filterTooltip.applyButton.click();
+      await expect(deleteFilterButtons).toHaveCount(1);
+
+      // Another account is unaffected
+      accountPage = await navigation.goToAccountPage('Bank of America');
+      await expect(deleteFilterButtons).toHaveCount(0);
+
+      // Returning to the account restores the filter
+      accountPage = await navigation.goToAccountPage('Ally Savings');
+      await expect(deleteFilterButtons).toHaveCount(1);
+      for (let i = 0; i < 5; i++) {
+        await expect(accountPage.getNthTransaction(i).category).toHaveText(
+          'Clothing',
+        );
+      }
+
+      // Removing the filter persists too
+      await accountPage.removeFilter(0);
+      accountPage = await navigation.goToAccountPage('Bank of America');
+      accountPage = await navigation.goToAccountPage('Ally Savings');
+      await expect(deleteFilterButtons).toHaveCount(0);
+    });
+  });
 });

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -71,6 +71,8 @@ import {
 } from '#hooks/useSplitsExpanded';
 import { useSyncedPref } from '#hooks/useSyncedPref';
 import { useTransactionBatchActions } from '#hooks/useTransactionBatchActions';
+import { useTransactionFilterConditions } from '#hooks/useTransactionFilterConditions';
+import type { ConditionEntity } from '#hooks/useTransactionFilterConditions';
 import { useTransactionFilters } from '#hooks/useTransactionFilters';
 import { calculateRunningBalancesBottomUp } from '#hooks/useTransactions';
 import {
@@ -95,8 +97,6 @@ import { updateNewTransactions } from '#transactions/transactionsSlice';
 
 import { AccountEmptyMessage } from './AccountEmptyMessage';
 import { AccountHeader } from './Header';
-
-type ConditionEntity = Partial<RuleConditionEntity> | TransactionFilterEntity;
 
 function isTransactionFilterEntity(
   filter: ConditionEntity,
@@ -218,7 +218,12 @@ type AccountInternalProps = {
     | 'offbudget'
     | 'uncategorized'
     | undefined;
-  filterConditions: RuleConditionEntity[];
+  filterConditions: ConditionEntity[];
+  filterConditionsOp: 'and' | 'or';
+  onSaveFilterConditions: (
+    conditions: ConditionEntity[],
+    conditionsOp: 'and' | 'or',
+  ) => void;
   showBalances?: boolean;
   showNetWorthChart: boolean;
   setShowNetWorthChart: (newValue: boolean) => void;
@@ -321,7 +326,7 @@ class AccountInternal extends PureComponent<
       search: '',
       filterConditions: props.filterConditions || [],
       filterId: undefined,
-      filterConditionsOp: 'and',
+      filterConditionsOp: props.filterConditionsOp,
       loading: true,
       workingHard: false,
       reconcileAmount: null,
@@ -422,9 +427,10 @@ class AccountInternal extends PureComponent<
       }, 100);
     }
 
-    //Resest sort/filter/search on account change
+    // Reset sort/search on account change; the filters for the new view are
+    // restored by UNSAFE_componentWillReceiveProps via fetchTransactions.
     if (this.props.accountId !== prevProps.accountId) {
-      this.setState({ sort: null, search: '', filterConditions: [] });
+      this.setState({ sort: null, search: '' });
     }
   }
 
@@ -459,7 +465,12 @@ class AccountInternal extends PureComponent<
   fetchTransactions = (filterConditions?: ConditionEntity[]) => {
     const query = this.makeRootTransactionsQuery();
     this.rootQuery = this.currentQuery = query;
-    if (filterConditions) void this.applyFilters(filterConditions);
+    // Default to the active filters so full refetches (e.g. after an
+    // import or applying rules) don't silently drop them. Only re-apply
+    // non-empty conditions: applyFilters([]) itself calls back into
+    // fetchTransactions, so recursing on empty conditions would loop.
+    const conditions = filterConditions ?? this.state.filterConditions;
+    if (conditions.length > 0) void this.applyFilters(conditions);
     else this.updateQuery(query);
 
     if (this.props.accountId) {
@@ -577,9 +588,12 @@ class AccountInternal extends PureComponent<
           showCleared: nextProps.showCleared,
           showReconciled: nextProps.showReconciled,
           reconcileAmount: null,
+          filterConditions: nextProps.filterConditions,
+          filterConditionsOp: nextProps.filterConditionsOp,
+          filterId: undefined,
         },
         () => {
-          this.fetchTransactions();
+          this.fetchTransactions(nextProps.filterConditions);
         },
       );
     }
@@ -979,13 +993,14 @@ class AccountInternal extends PureComponent<
         this.setState(
           {
             transactions: [],
-            filterConditions: [],
             search: '',
             sort: null,
             showBalances: true,
           },
           () => {
-            this.fetchTransactions();
+            // Refetch with the active filters so enabling the balance
+            // column doesn't silently clear them.
+            this.fetchTransactions(this.state.filterConditions);
           },
         );
       }
@@ -1574,6 +1589,7 @@ class AccountInternal extends PureComponent<
 
   applyFilters = async (conditions: ConditionEntity[]) => {
     if (conditions.length > 0) {
+      const accountId = this.props.accountId;
       const filteredCustomQueryFilters: Partial<RuleConditionEntity>[] =
         conditions.filter(cond => !isTransactionFilterEntity(cond));
       const customQueryFilters = filteredCustomQueryFilters.map(
@@ -1587,6 +1603,12 @@ class AccountInternal extends PureComponent<
           ),
         },
       );
+      // Bail if the user switched accounts while the conversion was in
+      // flight — otherwise the stale filters would be applied (and
+      // persisted) to the newly selected account.
+      if (this.props.accountId !== accountId) {
+        return;
+      }
       const conditionsOpKey =
         this.state.filterConditionsOp === 'or' ? '$or' : '$and';
       this.currentQuery = this.rootQuery.filter({
@@ -1612,6 +1634,13 @@ class AccountInternal extends PureComponent<
         },
       );
     }
+
+    // Persist the active filters for this view so they are restored the
+    // next time it is opened (no-op when nothing changed).
+    this.props.onSaveFilterConditions(
+      conditions,
+      this.state.filterConditionsOp,
+    );
 
     if (this.state.sort !== null) {
       this.applySort();
@@ -2062,7 +2091,9 @@ export function Account() {
 
   const modalShowing = useSelector(state => state.modals.modalStack.length > 0);
   const accountsSyncing = useSelector(state => state.account.accountsSyncing);
-  const filterConditions = location?.state?.filterConditions || [];
+
+  const { filterConditions, filterConditionsOp, onSaveFilterConditions } =
+    useTransactionFilterConditions(params.id);
 
   const savedFiters = useTransactionFilters();
 
@@ -2120,6 +2151,8 @@ export function Account() {
             modalShowing={modalShowing}
             accountsSyncing={accountsSyncing}
             filterConditions={filterConditions}
+            filterConditionsOp={filterConditionsOp}
+            onSaveFilterConditions={onSaveFilterConditions}
             categoryGroups={categoryGroups}
             accountId={params.id}
             categoryId={location?.state?.categoryId}

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -1636,9 +1636,13 @@ class AccountInternal extends PureComponent<
     }
 
     // Persist the active filters for this view so they are restored the
-    // next time it is opened (no-op when nothing changed).
+    // next time it is opened (no-op when nothing changed). Conditions
+    // carrying a customName come from navigation (e.g. report drill-downs)
+    // and can't be recreated from the filter UI, so they aren't persisted.
     this.props.onSaveFilterConditions(
-      conditions,
+      conditions.filter(
+        cond => isTransactionFilterEntity(cond) || !cond.customName,
+      ),
       this.state.filterConditionsOp,
     );
 

--- a/packages/desktop-client/src/hooks/useTransactionFilterConditions.test.tsx
+++ b/packages/desktop-client/src/hooks/useTransactionFilterConditions.test.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+
+import type { RuleConditionEntity } from '@actual-app/core/types/models';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import { useSyncedPref } from '#hooks/useSyncedPref';
+
+import { useTransactionFilterConditions } from './useTransactionFilterConditions';
+
+vi.mock('#hooks/useSyncedPref', () => ({ useSyncedPref: vi.fn() }));
+
+const condition = {
+  field: 'category',
+  op: 'is',
+  value: 'clothing',
+  type: 'id',
+} satisfies RuleConditionEntity;
+
+describe('useTransactionFilterConditions', () => {
+  let setPref: Mock<(value: string | undefined) => void>;
+
+  function renderTestHook(
+    accountId: string | undefined,
+    locationState?: Record<string, unknown>,
+  ) {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter
+        initialEntries={[{ pathname: '/accounts/one', state: locationState }]}
+      >
+        {children}
+      </MemoryRouter>
+    );
+    return renderHook(() => useTransactionFilterConditions(accountId), {
+      wrapper,
+    });
+  }
+
+  function setSavedPref(value: string | undefined) {
+    vi.mocked(useSyncedPref).mockReturnValue([value, setPref]);
+  }
+
+  beforeEach(() => {
+    setPref = vi.fn<(value: string | undefined) => void>();
+    setSavedPref(undefined);
+  });
+
+  it('returns no filters when nothing is saved', () => {
+    const { result } = renderTestHook('one');
+
+    expect(result.current.filterConditions).toEqual([]);
+    expect(result.current.filterConditionsOp).toBe('and');
+  });
+
+  it('reads the pref for the given account', () => {
+    renderTestHook('one');
+    expect(useSyncedPref).toHaveBeenCalledWith('transaction-table-filters-one');
+
+    renderTestHook(undefined);
+    expect(useSyncedPref).toHaveBeenCalledWith(
+      'transaction-table-filters-all-accounts',
+    );
+  });
+
+  it('restores the saved filters and operator', () => {
+    setSavedPref(
+      JSON.stringify({ conditions: [condition], conditionsOp: 'or' }),
+    );
+
+    const { result } = renderTestHook('one');
+
+    expect(result.current.filterConditions).toEqual([condition]);
+    expect(result.current.filterConditionsOp).toBe('or');
+  });
+
+  it('prefers filters passed via navigation state over the saved ones', () => {
+    const locationCondition = { ...condition, value: 'food' };
+    setSavedPref(
+      JSON.stringify({ conditions: [condition], conditionsOp: 'or' }),
+    );
+
+    const { result } = renderTestHook('one', {
+      filterConditions: [locationCondition],
+    });
+
+    expect(result.current.filterConditions).toEqual([locationCondition]);
+    expect(result.current.filterConditionsOp).toBe('and');
+  });
+
+  it('ignores an unparseable saved value', () => {
+    setSavedPref('not json');
+
+    const { result } = renderTestHook('one');
+
+    expect(result.current.filterConditions).toEqual([]);
+    expect(result.current.filterConditionsOp).toBe('and');
+  });
+
+  it('ignores a saved value whose conditions are not an array', () => {
+    setSavedPref(JSON.stringify({ conditions: 5, conditionsOp: 'or' }));
+
+    const { result } = renderTestHook('one');
+
+    expect(result.current.filterConditions).toEqual([]);
+    expect(result.current.filterConditionsOp).toBe('and');
+  });
+
+  it('persists filters as serialized JSON', () => {
+    const { result } = renderTestHook('one');
+
+    result.current.onSaveFilterConditions([condition], 'or');
+
+    expect(setPref).toHaveBeenCalledWith(
+      JSON.stringify({ conditions: [condition], conditionsOp: 'or' }),
+    );
+  });
+
+  it('clears the pref when the filters are removed', () => {
+    setSavedPref(
+      JSON.stringify({ conditions: [condition], conditionsOp: 'and' }),
+    );
+    const { result } = renderTestHook('one');
+
+    result.current.onSaveFilterConditions([], 'and');
+
+    expect(setPref).toHaveBeenCalledWith('');
+  });
+
+  it('skips writing when the filters have not changed', () => {
+    setSavedPref(
+      JSON.stringify({ conditions: [condition], conditionsOp: 'and' }),
+    );
+    const { result } = renderTestHook('one');
+
+    result.current.onSaveFilterConditions([condition], 'and');
+
+    expect(setPref).not.toHaveBeenCalled();
+  });
+
+  it('skips clearing a pref that is already empty', () => {
+    const { result } = renderTestHook('one');
+
+    result.current.onSaveFilterConditions([], 'and');
+
+    expect(setPref).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/hooks/useTransactionFilterConditions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionFilterConditions.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router';
+
+import type {
+  RuleConditionEntity,
+  TransactionFilterEntity,
+} from '@actual-app/core/types/models';
+
+import { useSyncedPref } from '#hooks/useSyncedPref';
+
+export type ConditionEntity =
+  | Partial<RuleConditionEntity>
+  | TransactionFilterEntity;
+
+/**
+ * The active transaction-table filters for one view, persisted per account
+ * (like the column configuration). Filters passed via navigation state
+ * (e.g. from reports) win over the persisted ones.
+ */
+export function useTransactionFilterConditions(accountId: string | undefined) {
+  const location = useLocation();
+  const [savedFiltersPref, setSavedFiltersPref] = useSyncedPref(
+    `transaction-table-filters-${accountId || 'all-accounts'}`,
+  );
+  const savedFilters = useMemo(() => {
+    if (!savedFiltersPref) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(savedFiltersPref);
+      return Array.isArray(parsed?.conditions) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }, [savedFiltersPref]);
+
+  const locationConditions = location?.state?.filterConditions;
+  const filterConditions: ConditionEntity[] =
+    locationConditions || savedFilters?.conditions || [];
+  const filterConditionsOp: 'and' | 'or' =
+    !locationConditions && savedFilters?.conditionsOp === 'or' ? 'or' : 'and';
+
+  const onSaveFilterConditions = (
+    conditions: ConditionEntity[],
+    conditionsOp: 'and' | 'or',
+  ) => {
+    const serialized =
+      conditions.length > 0 ? JSON.stringify({ conditions, conditionsOp }) : '';
+    if (serialized !== (savedFiltersPref || '')) {
+      setSavedFiltersPref(serialized);
+    }
+  };
+
+  return { filterConditions, filterConditionsOp, onSaveFilterConditions };
+}

--- a/packages/docs/docs-sidebar.js
+++ b/packages/docs/docs-sidebar.js
@@ -297,6 +297,7 @@ const sidebars = {
           items: [
             'contributing/project-details/database',
             'contributing/project-details/architecture',
+            'contributing/project-details/preferences',
             'contributing/project-details/feature-flags',
             'contributing/project-details/electron',
             'contributing/project-details/migrations',

--- a/packages/docs/docs/contributing/project-details/preferences.md
+++ b/packages/docs/docs/contributing/project-details/preferences.md
@@ -1,0 +1,55 @@
+# Preferences
+
+Actual stores its settings — usually called "prefs" in the codebase — in several different places, depending on what the setting applies to: the device the app runs on, a single budget file, or a budget file on every device it is opened on. When you add a new setting, choosing the right type determines where the value lives, whether it follows the user across devices, and which hook you use to read and write it.
+
+All preference types are defined in `packages/loot-core/src/types/prefs.ts`, and each client-side type has a matching React hook in `packages/desktop-client/src/hooks/` (server prefs are the exception — they are saved through the sync server's API).
+
+## Comparison
+
+|                                               | Global prefs                                             | Synced prefs                                     | Local prefs                                     | Metadata prefs                                         |
+| --------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------------ |
+| **Scope**                                     | The device / app installation                            | A budget file                                    | A budget file on one device                     | A budget file on one device                            |
+| **Synced across devices**                     | No                                                       | Yes                                              | No                                              | No                                                     |
+| **Applies to every budget file**              | Yes                                                      | No                                               | No                                              | No                                                     |
+| **Stored in**                                 | `global-store.json` on desktop, IndexedDB in the browser | The `preferences` table in the budget's database | The browser's local storage, keyed by budget ID | The `metadata.json` file next to the budget's database |
+| **Part of the budget file (backups/exports)** | No                                                       | Yes                                              | No                                              | Yes                                                    |
+| **React hook**                                | `useGlobalPref`                                          | `useSyncedPref`                                  | `useLocalPref`                                  | `useMetadataPref`                                      |
+| **TypeScript type**                           | `GlobalPrefs`                                            | `SyncedPrefs`                                    | `LocalPrefs`                                    | `MetadataPrefs`                                        |
+
+## Global Prefs
+
+Global prefs apply to the whole app installation, no matter which budget file is open. They are read before any budget is loaded, which is why things that affect the app shell itself belong here.
+
+They are stored on the device: in a `global-store.json` file in the app's data directory on desktop, and in IndexedDB in the browser. They never sync anywhere.
+
+## Synced Prefs
+
+Synced prefs belong to a single budget file and travel with it. They are stored in the `preferences` table inside the budget's SQLite database, so changes replicate to every device through the regular sync engine — just like transactions or categories — and they are included in backups and exports.
+
+Use a synced pref when the setting is part of how the user works with that budget and they would expect it to look the same on every device.
+
+Two things to keep in mind:
+
+- Values are always strings. Store booleans as `'true'`/`'false'` and serialize anything more complex as JSON.
+- Every change generates a sync message, so avoid writing a synced pref when the value has not actually changed.
+
+## Local Prefs
+
+Local prefs are scoped to a budget file _and_ a device: they are stored in the browser's local storage (or the desktop app's equivalent), keyed by the budget ID. They are not part of the budget file, so they are lost when the browser's site data is cleared, and they never sync.
+
+Use a local pref for transient UI state that should not follow the user to another device.
+
+## Metadata Prefs
+
+Metadata prefs are bookkeeping about the budget file itself, stored in the `metadata.json` file that sits next to the budget's database on the device. They are almost entirely maintained by the app — identifiers, sync bookkeeping, encryption details — rather than being choices the user makes. You will rarely add a new one.
+
+## Server Prefs
+
+There is also a small `ServerPrefs` type for settings that configure the sync server itself. These are saved to the server over its API rather than stored in the client, and they only exist when a sync server is in use.
+
+## Which Type Should a New Setting Use?
+
+- Should the setting follow the budget to every device it is opened on? Use a **synced pref**.
+- Does it configure the app itself, regardless of which budget is open? Use a **global pref**.
+- Is it per-budget UI state that should stay on this device only? Use a **local pref**.
+- Is it something the app tracks about the budget file rather than a user choice? It is probably a **metadata pref**.

--- a/packages/docs/docs/contributing/project-details/preferences.md
+++ b/packages/docs/docs/contributing/project-details/preferences.md
@@ -53,3 +53,4 @@ There is also a small `ServerPrefs` type for settings that configure the sync se
 - Does it configure the app itself, regardless of which budget is open? Use a **global pref**.
 - Is it per-budget UI state that should stay on this device only? Use a **local pref**.
 - Is it something the app tracks about the budget file rather than a user choice? It is probably a **metadata pref**.
+- Does it configure the sync server itself rather than the app? Use a **server pref**.

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -39,6 +39,7 @@ export type SyncedPrefs = Partial<
     | `hide-reconciled-${string}`
     | 'transaction-table-columns'
     | `transaction-table-columns-${string}`
+    | `transaction-table-filters-${string}`
     | `show-group-${string}`
     // TODO: pull from src/components/modals/ImportTransactions.js
     | `parse-date-${string}-${'csv' | 'qif'}`

--- a/upcoming-release-notes/persist-transaction-filters-per-account.md
+++ b/upcoming-release-notes/persist-transaction-filters-per-account.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Remember the selected transaction filters for each account, so they are restored when you return to the account


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Could be controversial. Lets discuss. I am not married to the idea.

Base idea: lets persist the filter selection similar to how we persist active columns and other configuration knobs.

Allows people to set account-specific filters as the default view. No more ephemeral filters.

_Also adding docs page for "preferences"_

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Manually;

Set a filter for an account; navigate away of refresh; navigate back - you'll see the same filter

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.21 MB → 13.21 MB (+1.65 kB) | +0.01%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.21 MB → 13.21 MB (+1.65 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useTransactionFilterConditions.ts` | 🆕 +1.1 kB | 0 B → 1.1 kB
`src/components/accounts/Account.tsx` | 📈 +562 B (+1.35%) | 40.61 kB → 41.16 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 272.21 kB → 273.86 kB (+1.65 kB) | +0.61%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 185.01 kB | 0%
static/js/SchedulesTable.js | 170.95 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 78.97 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.84 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.93 kB | 0%
static/js/de.js | 179.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 209.06 kB | 0%
static/js/es.js | 165.25 kB | 0%
static/js/fr.js | 168.31 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.74 kB | 0%
static/js/narrow.js | 284.96 kB | 0%
static/js/nb-NO.js | 136.65 kB | 0%
static/js/nl.js | 144.95 kB | 0%
static/js/pl.js | 137.12 kB | 0%
static/js/pt-BR.js | 179.81 kB | 0%
static/js/ru.js | 142.72 kB | 0%
static/js/th.js | 165.62 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.9 kB | 0%
static/js/useDateFormat.js | 2.92 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.6 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->