### PR TITLE
[AI] Add Discord notifications for new tags and published releases

### DIFF
--- a/.github/workflows/discord-release-notifications.yml
+++ b/.github/workflows/discord-release-notifications.yml
@@ -1,7 +1,8 @@
 name: Discord Release Notifications
 
 # Sends a Discord notification when a new tag is pushed or when a release
-# is published. Requires the DISCORD_WEBHOOK_URL secret.
+# is published. Uses the DISCORD_WEBHOOK_URL secret from the nightly-alerts
+# environment (shared with the nightly theme catalog scan).
 #
 # Draft releases are not covered: GitHub does not deliver the `created`
 # release activity type for drafts, so the earliest observable event is
@@ -22,6 +23,7 @@ jobs:
     name: Notify Discord
     runs-on: depot-ubuntu-latest
     if: github.repository == 'actualbudget/actual'
+    environment: nightly-alerts
     timeout-minutes: 5
     steps:
       - name: Notify Discord of new tag

--- a/.github/workflows/discord-release-notifications.yml
+++ b/.github/workflows/discord-release-notifications.yml
@@ -34,7 +34,7 @@ jobs:
           status: Success
           title: 'New tag: ${{ github.ref_name }}'
           description: Tag `${{ github.ref_name }}` was pushed to ${{ github.repository }}.
-          url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+          url: ${{ github.server_url }}/${{ github.repository }}/tree/${{ github.ref_name }}
           username: Actual Releases
           nofail: true
 

--- a/.github/workflows/discord-release-notifications.yml
+++ b/.github/workflows/discord-release-notifications.yml
@@ -1,0 +1,62 @@
+name: Discord Release Notifications
+
+# Sends a Discord notification when a new tag is pushed or when a release
+# is drafted or published. Requires the DISCORD_WEBHOOK_URL secret.
+
+on:
+  push:
+    tags:
+      - '**'
+  release:
+    types: [created, published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: depot-ubuntu-latest
+    if: github.repository == 'actualbudget/actual'
+    timeout-minutes: 5
+    steps:
+      - name: Notify Discord of new tag
+        if: github.event_name == 'push'
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: Success
+          title: 'New tag: ${{ github.ref_name }}'
+          description: Tag `${{ github.ref_name }}` was pushed to ${{ github.repository }}.
+          url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+          username: Actual Releases
+          nofail: true
+
+      # GitHub does not deliver the `created` activity type for draft
+      # releases (see the release event docs), so this step is best-effort.
+      # The draft guard also prevents a duplicate notification when a
+      # release is published directly, which fires both `created` and
+      # `published`.
+      - name: Notify Discord of drafted release
+        if: github.event_name == 'release' && github.event.action == 'created' && github.event.release.draft
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: Success
+          title: 'Release drafted: ${{ github.event.release.name || github.event.release.tag_name }}'
+          description: A new release draft was created for ${{ github.repository }}.
+          url: ${{ github.event.release.html_url }}
+          username: Actual Releases
+          nofail: true
+
+      - name: Notify Discord of published release
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          status: Success
+          title: 'Release published: ${{ github.event.release.name || github.event.release.tag_name }}'
+          description: A new release was published for ${{ github.repository }}.
+          url: ${{ github.event.release.html_url }}
+          username: Actual Releases
+          nofail: true

--- a/.github/workflows/discord-release-notifications.yml
+++ b/.github/workflows/discord-release-notifications.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Notify Discord of new tag
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.event.created == true
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-release-notifications.yml
+++ b/.github/workflows/discord-release-notifications.yml
@@ -1,14 +1,18 @@
 name: Discord Release Notifications
 
 # Sends a Discord notification when a new tag is pushed or when a release
-# is drafted or published. Requires the DISCORD_WEBHOOK_URL secret.
+# is published. Requires the DISCORD_WEBHOOK_URL secret.
+#
+# Draft releases are not covered: GitHub does not deliver the `created`
+# release activity type for drafts, so the earliest observable event is
+# `published`.
 
 on:
   push:
     tags:
       - '**'
   release:
-    types: [created, published]
+    types: [published]
 
 permissions:
   contents: read
@@ -32,25 +36,8 @@ jobs:
           username: Actual Releases
           nofail: true
 
-      # GitHub does not deliver the `created` activity type for draft
-      # releases (see the release event docs), so this step is best-effort.
-      # The draft guard also prevents a duplicate notification when a
-      # release is published directly, which fires both `created` and
-      # `published`.
-      - name: Notify Discord of drafted release
-        if: github.event_name == 'release' && github.event.action == 'created' && github.event.release.draft
-        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          status: Success
-          title: 'Release drafted: ${{ github.event.release.name || github.event.release.tag_name }}'
-          description: A new release draft was created for ${{ github.repository }}.
-          url: ${{ github.event.release.html_url }}
-          username: Actual Releases
-          nofail: true
-
       - name: Notify Discord of published release
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1.16.0
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/upcoming-release-notes/add-discord-release-notifications.md
+++ b/upcoming-release-notes/add-discord-release-notifications.md
@@ -3,4 +3,4 @@ category: Maintenance
 authors: [MatissJanis]
 ---
 
-Add GitHub action that sends a Discord notification when a new tag is pushed or a release is drafted or published
+Add GitHub action that sends a Discord notification when a new tag is pushed or a release is published

--- a/upcoming-release-notes/add-discord-release-notifications.md
+++ b/upcoming-release-notes/add-discord-release-notifications.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add GitHub action that sends a Discord notification when a new tag is pushed or a release is drafted or published


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Send a discord notification to our private channel for every release publish and tag.

## Related issue(s)

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

---
_Generated by [Claude Code](https://claude.ai/code/session_018a3c6gvegH5cGjpMBfkV3N)_