### PR TITLE
[AI] Return error from changePassword when no password row exists

### DIFF
--- a/packages/sync-server/src/accounts/password.js
+++ b/packages/sync-server/src/accounts/password.js
@@ -161,9 +161,13 @@ export async function changePassword(newPassword) {
   }
 
   const hashed = await hashPassword(newPassword);
-  accountDb.mutate("UPDATE auth SET extra_data = ? WHERE method = 'password'", [
-    hashed,
-  ]);
+  const { changes } = accountDb.mutate(
+    "UPDATE auth SET extra_data = ? WHERE method = 'password'",
+    [hashed],
+  );
+  if (changes === 0) {
+    return { error: 'password-auth-not-active' };
+  }
   return {};
 }
 

--- a/packages/sync-server/src/accounts/password.test.js
+++ b/packages/sync-server/src/accounts/password.test.js
@@ -156,6 +156,19 @@ describe('bootstrapPassword / changePassword', () => {
   it('rejects an empty password on changePassword', async () => {
     expect(await changePassword('')).toEqual({ error: 'invalid-password' });
   });
+
+  it('returns password-auth-not-active when no password row exists (OIDC-only setup)', async () => {
+    // Simulate an OIDC-only deployment: bootstrapPassword was never called,
+    // so the `auth` table has no `method='password'` row.
+    expect(getStoredPasswordHash()).toBeNull();
+
+    const result = await changePassword('new password');
+
+    expect(result).toEqual({ error: 'password-auth-not-active' });
+    // The auth table is still empty — the failed UPDATE must not silently
+    // succeed or insert a row.
+    expect(getStoredPasswordHash()).toBeNull();
+  });
 });
 
 describe('checkPassword', () => {

--- a/upcoming-release-notes/fix-changepassword-update-no-row.md
+++ b/upcoming-release-notes/fix-changepassword-update-no-row.md
@@ -3,4 +3,4 @@ category: Bugfix
 authors: [dikshit-n]
 ---
 
-Return an error from `changePassword` when no `method='password'` row exists, instead of silently succeeding (e.g. OIDC-only deployments).
+Changing a password now reports an error when password authentication is not enabled.

--- a/upcoming-release-notes/fix-changepassword-update-no-row.md
+++ b/upcoming-release-notes/fix-changepassword-update-no-row.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [dikshit-n]
+---
+
+Return an error from `changePassword` when no `method='password'` row exists, instead of silently succeeding (e.g. OIDC-only deployments).


### PR DESCRIPTION
## Description

`changePassword` in `packages/sync-server/src/accounts/password.js` issues an
`UPDATE auth SET extra_data = ? WHERE method = 'password'` and discards the
return value of `accountDb.mutate()`. On a server that was set up with OIDC as
the only auth method (e.g. the `change-password.js` script in an OIDC-only
deployment, where `bootstrapPassword` was never called), the `auth` table has
no `method='password'` row, so the UPDATE matches zero rows and the function
returns `{}`. The HTTP `/change-password` route then replies 200 OK with an
empty body even though nothing was stored, which is misleading.

This change captures the `changes` count from `mutate()` and returns
`{ error: 'password-auth-not-active' }` when zero rows were affected, so the
HTTP layer surfaces a real failure. The error string matches the existing
`details: 'password-auth-not-active'` value that the route already returns
for sessions whose `auth_method` is not `'password'`, so the error shape is
consistent across the two failure modes.

The initial implementation was drafted with Claude and then reviewed, edited,
and tested by me.

## Related issue(s)

Fixes #8596

## Testing

- New unit test in `packages/sync-server/src/accounts/password.test.js`:
  `changePassword` returns `{ error: 'password-auth-not-active' }` and leaves
  the `auth` table empty when no `method='password'` row exists (the
  OIDC-only setup from the issue).
- Existing unit test `replaces the stored hash on changePassword and verifies
  the new one` still passes (16/16 in `password.test.js`).
- Existing HTTP tests in `src/app-account.test.js` still pass (23/23),
  including the `should return 200 when admin with password-auth session
  sends valid password` case which exercises the normal UPDATE path.
- `tsgo -b` and `tsc-strict` clean.
- `oxlint --type-aware --quiet` and `oxfmt --check` clean on the changed files.

## Checklist

- [x] Release notes added (see `upcoming-release-notes/fix-changepassword-update-no-row.md`)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed
