### PR TITLE
[WIP] [AI] Restore missing Delete option in scheduled transaction menu

### DIFF
--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -198,6 +198,11 @@ function ScheduleRow({
             onClick: () => onAction('complete', schedule.id),
             hidden: status === 'completed',
           },
+          {
+            name: 'delete',
+            text: t('Delete'),
+            onClick: () => onAction('delete', schedule.id),
+          },
         ]
       : [],
   });

--- a/upcoming-release-notes/fix-schedule-delete-menu-option.md
+++ b/upcoming-release-notes/fix-schedule-delete-menu-option.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Restore the missing "Delete" option in the scheduled transaction row menu


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.21 MB → 13.2 MB (-1.37 kB) | -0.01%
loot-core | 1 | 4.62 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.21 MB → 13.2 MB (-1.37 kB) | -0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/schedules/SchedulesTable.tsx` | 📈 +110 B (+0.73%) | 14.64 kB → 14.75 kB
`locale/en.json` | 📈 +512 B (+0.24%) | 209.06 kB → 209.56 kB
`locale/pl.json` | 📉 -75 B (-0.05%) | 137.12 kB → 137.04 kB
`locale/zh-Hans.json` | 📉 -63 B (-0.06%) | 107.6 kB → 107.54 kB
`locale/da.json` | 📉 -59 B (-0.06%) | 95.93 kB → 95.87 kB
`locale/de.json` | 📉 -140 B (-0.08%) | 179.43 kB → 179.29 kB
`locale/pt-BR.json` | 📉 -156 B (-0.08%) | 179.81 kB → 179.66 kB
`locale/es.json` | 📉 -146 B (-0.09%) | 165.25 kB → 165.11 kB
`locale/nl.json` | 📉 -129 B (-0.09%) | 144.95 kB → 144.82 kB
`locale/uk.json` | 📉 -182 B (-0.09%) | 200.9 kB → 200.72 kB
`locale/ca.json` | 📉 -161 B (-0.09%) | 171.84 kB → 171.68 kB
`locale/fr.json` | 📉 -164 B (-0.10%) | 168.31 kB → 168.15 kB
`locale/nb-NO.json` | 📉 -146 B (-0.10%) | 136.65 kB → 136.51 kB
`locale/it.json` | 📉 -168 B (-0.11%) | 152.74 kB → 152.57 kB
`locale/ru.json` | 📉 -168 B (-0.11%) | 142.72 kB → 142.56 kB
`locale/th.json` | 📉 -269 B (-0.16%) | 165.62 kB → 165.36 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 209.06 kB → 209.56 kB (+512 B) | +0.24%
static/js/SchedulesTable.js | 170.95 kB → 171.06 kB (+110 B) | +0.06%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 165.62 kB → 165.36 kB (-269 B) | -0.16%
static/js/uk.js | 200.9 kB → 200.72 kB (-182 B) | -0.09%
static/js/it.js | 152.74 kB → 152.57 kB (-168 B) | -0.11%
static/js/ru.js | 142.72 kB → 142.56 kB (-168 B) | -0.11%
static/js/fr.js | 168.31 kB → 168.15 kB (-164 B) | -0.10%
static/js/ca.js | 171.84 kB → 171.68 kB (-161 B) | -0.09%
static/js/pt-BR.js | 179.81 kB → 179.66 kB (-156 B) | -0.08%
static/js/es.js | 165.25 kB → 165.11 kB (-146 B) | -0.09%
static/js/nb-NO.js | 136.65 kB → 136.51 kB (-146 B) | -0.10%
static/js/de.js | 179.43 kB → 179.29 kB (-140 B) | -0.08%
static/js/nl.js | 144.95 kB → 144.82 kB (-129 B) | -0.09%
static/js/pl.js | 137.12 kB → 137.04 kB (-75 B) | -0.05%
static/js/zh-Hans.js | 107.6 kB → 107.54 kB (-63 B) | -0.06%
static/js/da.js | 95.93 kB → 95.87 kB (-59 B) | -0.06%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.41 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 185.01 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 284.96 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/useDateFormat.js | 2.92 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 272.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->