### PR TITLE
Autoupdate the appimage, nsis, and dmg packages

### DIFF
--- a/.github/workflows/electron-master.yml
+++ b/.github/workflows/electron-master.yml
@@ -125,8 +125,12 @@ jobs:
             packages/desktop-electron/dist/*.dmg
             packages/desktop-electron/dist/*.exe
             !packages/desktop-electron/dist/Actual-windows.exe
+            packages/desktop-electron/dist/*.zip
             packages/desktop-electron/dist/*.AppImage
             packages/desktop-electron/dist/*.flatpak
+            packages/desktop-electron/dist/*.blockmap
+            !packages/desktop-electron/dist/Actual-windows.exe.blockmap
+            packages/desktop-electron/dist/latest*.yml
       - name: Upload Windows Store Build
         if: ${{ startsWith(matrix.os, 'windows') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -144,9 +148,12 @@ jobs:
           files=(
             packages/desktop-electron/dist/*.dmg
             packages/desktop-electron/dist/!(Actual-windows).exe
+            packages/desktop-electron/dist/*.zip
             packages/desktop-electron/dist/*.AppImage
             packages/desktop-electron/dist/*.flatpak
             packages/desktop-electron/dist/*.appx
+            packages/desktop-electron/dist/!(Actual-windows.exe).blockmap
+            packages/desktop-electron/dist/latest*.yml
           )
           if [ ${#files[@]} -gt 0 ]; then
             gh release upload "$TAG" --clobber "${files[@]}"

--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -221,6 +221,7 @@ global.Actual = {
   onEventFromMain: () => {
     // Only for electron app
   },
+  supportsAutoUpdate: false,
   isUpdateReadyForDownload: () => isUpdateReadyForDownload,
   waitForUpdateReadyForDownload: () => isUpdateReadyForDownloadPromise,
   applyAppUpdate: async () => {

--- a/packages/desktop-client/src/components/settings/index.tsx
+++ b/packages/desktop-client/src/components/settings/index.tsx
@@ -47,6 +47,7 @@ function About() {
     useGlobalPref('notifyWhenUpdateIsAvailable', () => {
       void dispatch(getLatestAppVersion());
     });
+  const [autoUpdate, setAutoUpdatePref] = useGlobalPref('autoUpdate');
   const dispatch = useDispatch();
 
   return (
@@ -121,6 +122,20 @@ function About() {
           </label>
         </Text>
       </View>
+      {isElectron() && window.Actual?.supportsAutoUpdate && (
+        <View>
+          <Text style={{ display: 'flex' }}>
+            <Checkbox
+              id="settings-autoUpdate"
+              checked={autoUpdate !== false}
+              onChange={e => setAutoUpdatePref(e.currentTarget.checked)}
+            />
+            <label htmlFor="settings-autoUpdate">
+              <Trans>Automatically download and install updates</Trans>
+            </label>
+          </Text>
+        </View>
+      )}
     </Setting>
   );
 }

--- a/packages/desktop-electron/index.ts
+++ b/packages/desktop-electron/index.ts
@@ -28,6 +28,11 @@ import type {
 import { getMenu } from './menu';
 import { retry as promiseRetry } from './retry';
 import {
+  getIsUpdateDownloaded,
+  initAutoUpdater,
+  isAutoUpdateSupported,
+} from './updater';
+import {
   get as getWindowState,
   listen as listenToWindowState,
 } from './window-state';
@@ -523,6 +528,17 @@ app.on('ready', async () => {
   });
 
   await createBackgroundProcess();
+
+  initAutoUpdater({
+    getClientWindow: () => clientWin,
+    isAutoUpdateEnabled: async () => {
+      // Read the pref fresh on every check so toggling it in the settings
+      // takes effect without a restart
+      const prefs = await loadGlobalPrefs();
+      return prefs.autoUpdate !== false; // default to enabled
+    },
+    log: logMessage,
+  });
 });
 
 app.on('window-all-closed', () => {
@@ -548,12 +564,18 @@ app.on('activate', () => {
 export type GetBootstrapDataPayload = {
   version: string;
   isDev: boolean;
+  isAutoUpdateSupported: boolean;
+  isUpdateDownloaded: boolean;
 };
 
 ipcMain.on('get-bootstrap-data', event => {
   const payload: GetBootstrapDataPayload = {
     version: isPlaywrightTest ? '99.9.9' : app.getVersion(),
     isDev,
+    isAutoUpdateSupported: isAutoUpdateSupported(),
+    // Covers a window (re)load happening after the update was already
+    // downloaded - the 'update-downloaded' push event would have been missed
+    isUpdateDownloaded: getIsUpdateDownloaded(),
   };
 
   event.returnValue = payload;

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "update-client": "bin/update-client",
-    "build": "yarn build:dist && electron-builder",
+    "build": "yarn build:dist && electron-builder --publish never",
     "build:dist": "tsgo && yarn copy-static-assets",
     "typecheck": "tsgo -b && tsc-strict",
     "copy-static-assets": "copyfiles --exclude 'build/**/*' **/*.html icons/**/* build/desktop-electron",
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "@actual-app/sync-server": "workspace:*",
-    "better-sqlite3": "^12.11.1"
+    "better-sqlite3": "^12.11.1",
+    "electron-updater": "^6.6.2"
   },
   "devDependencies": {
     "@actual-app/core": "workspace:*",
@@ -33,6 +34,13 @@
   },
   "build": {
     "appId": "com.actualbudget.actual",
+    "publish": [
+      {
+        "provider": "github",
+        "owner": "actualbudget",
+        "repo": "actual"
+      }
+    ],
     "files": [
       "build",
       "!node_modules/@actual-app/web",
@@ -60,6 +68,13 @@
       "target": [
         {
           "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
           "arch": [
             "x64",
             "arm64"

--- a/packages/desktop-electron/preload.ts
+++ b/packages/desktop-electron/preload.ts
@@ -8,8 +8,22 @@ import type {
   SaveFileDialogPayload,
 } from './index';
 
-const { version: VERSION, isDev: IS_DEV }: GetBootstrapDataPayload =
-  ipcRenderer.sendSync('get-bootstrap-data');
+const {
+  version: VERSION,
+  isDev: IS_DEV,
+  isAutoUpdateSupported: IS_AUTO_UPDATE_SUPPORTED,
+  isUpdateDownloaded,
+}: GetBootstrapDataPayload = ipcRenderer.sendSync('get-bootstrap-data');
+
+let isUpdateReadyForDownload = isUpdateDownloaded;
+const isUpdateReadyForDownloadPromise = isUpdateReadyForDownload
+  ? Promise.resolve()
+  : new Promise<void>(resolve => {
+      ipcRenderer.on('update-downloaded', () => {
+        isUpdateReadyForDownload = true;
+        resolve();
+      });
+    });
 
 contextBridge.exposeInMainWorld('Actual', {
   IS_DEV,
@@ -75,12 +89,10 @@ contextBridge.exposeInMainWorld('Actual', {
     ipcRenderer.on(type, handler);
   },
 
-  // No auto-updates in the desktop app
-  isUpdateReadyForDownload: () => false,
-  waitForUpdateReadyForDownload: () =>
-    new Promise<void>(() => {
-      // This is used in browser environment; do nothing in electron
-    }),
+  supportsAutoUpdate: IS_AUTO_UPDATE_SUPPORTED,
+
+  isUpdateReadyForDownload: () => isUpdateReadyForDownload,
+  waitForUpdateReadyForDownload: () => isUpdateReadyForDownloadPromise,
 
   getServerSocket: async () => {
     return null;
@@ -106,6 +118,6 @@ contextBridge.exposeInMainWorld('Actual', {
   },
 
   applyAppUpdate: async () => {
-    throw new Error('applyAppUpdate not implemented in electron app');
+    await ipcRenderer.invoke('apply-app-update');
   },
 } satisfies typeof global.Actual);

--- a/packages/desktop-electron/updater.ts
+++ b/packages/desktop-electron/updater.ts
@@ -1,0 +1,90 @@
+import { app, ipcMain } from 'electron';
+import type { BrowserWindow } from 'electron';
+import { autoUpdater } from 'electron-updater';
+
+const UPDATE_CHECK_INTERVAL = 6 * 60 * 60 * 1000; // check again every 6 hours
+
+let isUpdateDownloaded = false;
+
+// In-app updates only make sense for builds installed directly from a GitHub
+// release (NSIS exe, dmg, AppImage). Store-distributed builds update through
+// their store instead: the Microsoft Store build (appx) reports
+// process.windowsStore, and the Flathub build runs inside a flatpak sandbox.
+export function isAutoUpdateSupported(): boolean {
+  if (!app.isPackaged || process.env.EXECUTION_CONTEXT === 'playwright') {
+    return false;
+  }
+
+  switch (process.platform) {
+    case 'win32':
+      return !process.windowsStore;
+    case 'linux':
+      // electron-updater can only replace the AppImage it was launched from
+      return (
+        !process.env.FLATPAK_ID &&
+        process.env.container !== 'flatpak' &&
+        Boolean(process.env.APPIMAGE)
+      );
+    case 'darwin':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function getIsUpdateDownloaded(): boolean {
+  return isUpdateDownloaded;
+}
+
+type InitAutoUpdaterOptions = {
+  getClientWindow: () => BrowserWindow | null;
+  isAutoUpdateEnabled: () => Promise<boolean>;
+  log: (loglevel: 'info' | 'error', message: string) => void;
+};
+
+export function initAutoUpdater({
+  getClientWindow,
+  isAutoUpdateEnabled,
+  log,
+}: InitAutoUpdaterOptions) {
+  ipcMain.handle('apply-app-update', () => {
+    if (isUpdateDownloaded) {
+      autoUpdater.quitAndInstall();
+    }
+  });
+
+  if (!isAutoUpdateSupported()) {
+    return;
+  }
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+
+  autoUpdater.on('update-downloaded', info => {
+    isUpdateDownloaded = true;
+    log('info', `Auto-update: version ${info.version} downloaded`);
+    getClientWindow()?.webContents.send('update-downloaded', {
+      version: info.version,
+    });
+  });
+
+  autoUpdater.on('error', error => {
+    // A failed update must never break the running app - just log it
+    log('error', `Auto-update: ${String(error)}`);
+  });
+
+  const checkForUpdates = async () => {
+    if (!(await isAutoUpdateEnabled())) {
+      return;
+    }
+
+    try {
+      await autoUpdater.checkForUpdates();
+    } catch (error) {
+      log('error', `Auto-update: check failed: ${String(error)}`);
+    }
+  };
+
+  void checkForUpdates();
+  setInterval(() => void checkForUpdates(), UPDATE_CHECK_INTERVAL);
+}

--- a/packages/loot-core/src/server/preferences/app.ts
+++ b/packages/loot-core/src/server/preferences/app.ts
@@ -139,6 +139,9 @@ async function saveGlobalPrefs(prefs: GlobalPrefs) {
       prefs.notifyWhenUpdateIsAvailable,
     );
   }
+  if (prefs.autoUpdate !== undefined) {
+    await asyncStorage.setItem('autoUpdate', prefs.autoUpdate);
+  }
   return 'ok';
 }
 
@@ -158,6 +161,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
     'server-self-signed-cert': serverSelfSignedCert,
     syncServerConfig,
     notifyWhenUpdateIsAvailable,
+    autoUpdate,
   } = await asyncStorage.multiGet([
     'floating-sidebar',
     'category-expanded-state',
@@ -173,6 +177,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
     'server-self-signed-cert',
     'syncServerConfig',
     'notifyWhenUpdateIsAvailable',
+    'autoUpdate',
   ] as const);
   return {
     floatingSidebar: floatingSidebar === 'true',
@@ -201,6 +206,7 @@ async function loadGlobalPrefs(): Promise<GlobalPrefs> {
       notifyWhenUpdateIsAvailable === undefined
         ? true
         : notifyWhenUpdateIsAvailable, // default to true
+    autoUpdate: autoUpdate === undefined ? true : autoUpdate, // default to true
   };
 }
 

--- a/packages/loot-core/src/types/prefs.ts
+++ b/packages/loot-core/src/types/prefs.ts
@@ -140,6 +140,7 @@ export type GlobalPrefs = Partial<{
     port?: number;
   };
   notifyWhenUpdateIsAvailable: boolean;
+  autoUpdate: boolean; // Electron only
 }>;
 
 // GlobalPrefsJson represents what's saved in the global-store.json file
@@ -168,6 +169,7 @@ export type GlobalPrefsJson = Partial<{
   'server-self-signed-cert'?: GlobalPrefs['serverSelfSignedCert'];
   syncServerConfig?: GlobalPrefs['syncServerConfig'];
   notifyWhenUpdateIsAvailable?: GlobalPrefs['notifyWhenUpdateIsAvailable'];
+  autoUpdate?: GlobalPrefs['autoUpdate'];
 }>;
 
 export type AuthMethods = 'password' | 'openid';

--- a/packages/loot-core/typings/window.ts
+++ b/packages/loot-core/typings/window.ts
@@ -40,6 +40,7 @@ type Actual = {
     event: string,
     listener: (...args: unknown[]) => void,
   ) => void;
+  supportsAutoUpdate: boolean;
   isUpdateReadyForDownload: () => boolean;
   waitForUpdateReadyForDownload: () => Promise<void>;
   startSyncServer: () => Promise<void>;

--- a/upcoming-release-notes/electron-autoupdate.md
+++ b/upcoming-release-notes/electron-autoupdate.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [MikesGlitch]
+---
+
+Add automatic in-app updates to the desktop app for the Windows installer, macOS, and Linux AppImage builds

--- a/yarn.lock
+++ b/yarn.lock
@@ -11117,6 +11117,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"builder-util-runtime@npm:9.7.0":
+  version: 9.7.0
+  resolution: "builder-util-runtime@npm:9.7.0"
+  dependencies:
+    debug: "npm:^4.3.4"
+    sax: "npm:^1.2.4"
+  checksum: 10/ec27cdce62f85aa1dde3c6f924d40f45df4574058483c9d70b25816c6cfb89f9369a1994bf4163c1aa21829e8b337165b6047b9cc8948394a05237efb478878c
+  languageName: node
+  linkType: hard
+
 "builder-util@npm:26.8.1":
   version: 26.8.1
   resolution: "builder-util@npm:26.8.1"
@@ -13487,6 +13497,7 @@ __metadata:
     cross-env: "npm:^10.1.0"
     electron: "npm:41.7.1"
     electron-builder: "npm:26.8.1"
+    electron-updater: "npm:^6.6.2"
     typescript-strict-plugin: "npm:^2.4.4"
   languageName: unknown
   linkType: soft
@@ -13931,6 +13942,22 @@ __metadata:
   version: 1.5.363
   resolution: "electron-to-chromium@npm:1.5.363"
   checksum: 10/2a2a0e32b9e8a3264839d7f174d1f945007fc3e11f0ce68bf47be31ad5bbd912ad562d15cbcfada9e886d0489a3f039b1fac6fcecf46d75ef1a54425ceb2fadd
+  languageName: node
+  linkType: hard
+
+"electron-updater@npm:^6.6.2":
+  version: 6.8.9
+  resolution: "electron-updater@npm:6.8.9"
+  dependencies:
+    builder-util-runtime: "npm:9.7.0"
+    fs-extra: "npm:^10.1.0"
+    js-yaml: "npm:^4.1.0"
+    lazy-val: "npm:^1.0.5"
+    lodash.escaperegexp: "npm:^4.1.2"
+    lodash.isequal: "npm:^4.5.0"
+    semver: "npm:~7.7.3"
+    tiny-typed-emitter: "npm:^2.1.0"
+  checksum: 10/656b7a276e2f2df48736de3df55b817f40f8252f10d94d594c98a880287ab495718d2db67f8ee3a84ea178e90283f1e0c0d2a199b3f282bafd020cff1bd67999
   languageName: node
   linkType: hard
 
@@ -18538,6 +18565,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.escaperegexp@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "lodash.escaperegexp@npm:4.1.2"
+  checksum: 10/6d99452b1cfd6073175a9b741a9b09ece159eac463f86f02ea3bee2e2092923fce812c8d2bf446309cc52d1d61bf9af51c8118b0d7421388e6cead7bd3798f0f
+  languageName: node
+  linkType: hard
+
 "lodash.includes@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.includes@npm:4.3.0"
@@ -18549,6 +18583,13 @@ __metadata:
   version: 3.0.3
   resolution: "lodash.isboolean@npm:3.0.3"
   checksum: 10/b70068b4a8b8837912b54052557b21fc4774174e3512ed3c5b94621e5aff5eb6c68089d0a386b7e801d679cd105d2e35417978a5e99071750aa2ed90bffd0250
+  languageName: node
+  linkType: hard
+
+"lodash.isequal@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.isequal@npm:4.5.0"
+  checksum: 10/82fc58a83a1555f8df34ca9a2cd300995ff94018ac12cc47c349655f0ae1d4d92ba346db4c19bbfc90510764e0c00ddcc985a358bdcd4b3b965abf8f2a48a214
   languageName: node
   linkType: hard
 
@@ -26309,6 +26350,13 @@ __metadata:
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 10/5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
+  languageName: node
+  linkType: hard
+
+"tiny-typed-emitter@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "tiny-typed-emitter@npm:2.1.0"
+  checksum: 10/709bca410054e08df4dc29d5ea0916328bb2900d60245c6a743068ea223887d9fd2c945b6070eb20336275a557a36c2808e5c87d2ed4b60633458632be4a3e10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Claude Fable helped with this.

TODO: 

- [ ] Try and test the update process on own repo
- [ ] Check the UI

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

https://github.com/actualbudget/actual/issues/8614#issuecomment-5164037780

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 | 13.21 MB → 13.21 MB (+742 B) | +0.01%
loot-core | 1 | 4.63 MB → 4.63 MB (+169 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+166 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 | 13.21 MB → 13.21 MB (+742 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/settings/index.tsx` | 📈 +714 B (+6.48%) | 10.76 kB → 11.46 kB
`src/browser-preload.js` | 📈 +28 B (+0.69%) | 3.93 kB → 3.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB → 1.56 MB (+742 B) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.8 kB | 0%
static/js/ReportRouter.js | 1.2 MB | 0%
static/js/ScheduleEditForm.js | 185.01 kB | 0%
static/js/SchedulesTable.js | 171.06 kB | 0%
static/js/TransactionEdit.js | 107.62 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/da.js | 95.87 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 209.56 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 168.15 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 284.96 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 144.82 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/ru.js | 142.56 kB | 0%
static/js/th.js | 165.36 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.92 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 272.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+169 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +169 B (+3.09%) | 5.33 kB → 5.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B_Q_D6pb.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.B_eIwPzT.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+166 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +166 B (+3.11%) | 5.22 kB → 5.38 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+166 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->