### PR TITLE
[AI] Improve localized dates and display labels

### DIFF
--- a/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/budgetsummary/TotalsList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { CSSProperties } from 'react';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 
 import { AlignedText } from '@actual-app/components/aligned-text';
 import { Block } from '@actual-app/components/block';
@@ -47,6 +47,7 @@ type TotalsListProps = {
 };
 
 export function TotalsList({ prevMonthName, style }: TotalsListProps) {
+  const { t } = useTranslation();
   const format = useFormat();
   const signedFormatter = makeSignedFormatter(format);
   const invertedSignedFormatter = makeSignedFormatter(format, true);
@@ -72,7 +73,7 @@ export function TotalsList({ prevMonthName, style }: TotalsListProps) {
           content={
             <>
               <AlignedText
-                left="Income:"
+                left={t('Income:')}
                 right={
                   <EnvelopeCellValue
                     binding={envelopeBudget.totalIncome}
@@ -81,7 +82,7 @@ export function TotalsList({ prevMonthName, style }: TotalsListProps) {
                 }
               />
               <AlignedText
-                left="From Last Month:"
+                left={t('From Last Month:')}
                 right={
                   <EnvelopeCellValue
                     binding={envelopeBudget.fromLastMonth}

--- a/packages/desktop-client/src/components/reports/ReportOptions.test.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.test.ts
@@ -1,0 +1,43 @@
+import { categoryLists, ReportOptions } from './ReportOptions';
+
+const translationState = vi.hoisted(() => ({ language: 'en' }));
+
+vi.mock('i18next', () => ({
+  t: (key: string) =>
+    translationState.language === 'zh-Hans' ? `zh:${key}` : key,
+}));
+describe('ReportOptions', () => {
+  beforeEach(() => {
+    translationState.language = 'en';
+  });
+
+  it('translates option descriptions at access time', () => {
+    expect(
+      ReportOptions.balanceType.find(option => option.key === 'Payment')
+        ?.description,
+    ).toBe('Payment');
+
+    translationState.language = 'zh-Hans';
+
+    expect(
+      ReportOptions.balanceType.find(option => option.key === 'Payment')
+        ?.description,
+    ).toBe('zh:Payment');
+  });
+
+  it('translates special categories when building category lists', () => {
+    translationState.language = 'zh-Hans';
+
+    const [categories, groups] = categoryLists({
+      grouped: [],
+      list: [],
+    });
+
+    expect(categories.map(category => category.name)).toEqual([
+      'zh:Uncategorized',
+      'zh:Off budget',
+      'zh:Transfers',
+    ]);
+    expect(groups.at(-1)?.name).toBe('zh:Uncategorized & Off budget');
+  });
+});

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -35,33 +35,33 @@ export const defaultReport: CustomReportEntity = {
 };
 
 const balanceTypeOptions = [
-  { description: t('Payment'), key: 'Payment', format: 'totalDebts' as const },
-  { description: t('Deposit'), key: 'Deposit', format: 'totalAssets' as const },
-  { description: t('Net'), key: 'Net', format: 'totalTotals' as const },
+  { description: 'Payment', key: 'Payment', format: 'totalDebts' as const },
+  { description: 'Deposit', key: 'Deposit', format: 'totalAssets' as const },
+  { description: 'Net', key: 'Net', format: 'totalTotals' as const },
   {
-    description: t('Net Payment'),
+    description: 'Net Payment',
     key: 'Net Payment',
     format: 'netDebts' as const,
   },
   {
-    description: t('Net Deposit'),
+    description: 'Net Deposit',
     key: 'Net Deposit',
     format: 'netAssets' as const,
   },
   {
-    description: t('Budgeted'),
+    description: 'Budgeted',
     key: 'Budgeted',
     format: 'totalBudgeted' as const,
   },
 ];
 
 const groupByOptions = [
-  { description: t('Category'), key: 'Category' },
-  { description: t('Group'), key: 'Group' },
-  { description: t('Category+Group'), key: 'CategoryGroup' }, // new: two-ring donut support
-  { description: t('Payee'), key: 'Payee' },
-  { description: t('Account'), key: 'Account' },
-  { description: t('Interval'), key: 'Interval' },
+  { description: 'Category', key: 'Category' },
+  { description: 'Group', key: 'Group' },
+  { description: 'Category+Group', key: 'CategoryGroup' }, // new: two-ring donut support
+  { description: 'Payee', key: 'Payee' },
+  { description: 'Account', key: 'Account' },
+  { description: 'Interval', key: 'Interval' },
 ];
 
 const sortByOptions: {
@@ -69,10 +69,10 @@ const sortByOptions: {
   key: string;
   format: sortByOpType;
 }[] = [
-  { description: t('Ascending'), key: 'Ascending', format: 'asc' as const },
-  { description: t('Descending'), key: 'Descending', format: 'desc' as const },
-  { description: t('Name'), key: 'Name', format: 'name' as const },
-  { description: t('Budget'), key: 'Budget', format: 'budget' as const },
+  { description: 'Ascending', key: 'Ascending', format: 'asc' as const },
+  { description: 'Descending', key: 'Descending', format: 'desc' as const },
+  { description: 'Name', key: 'Name', format: 'name' as const },
+  { description: 'Budget', key: 'Budget', format: 'budget' as const },
 ];
 
 export type dateRangeProps = {
@@ -88,7 +88,7 @@ export type dateRangeProps = {
 
 const dateRangeOptions: dateRangeProps[] = [
   {
-    description: t('This week'),
+    description: 'This week',
     key: 'This week',
     name: 0,
     type: 'Week',
@@ -98,7 +98,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last week'),
+    description: 'Last week',
     key: 'Last week',
     name: 1,
     type: 'Week',
@@ -108,7 +108,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('This month'),
+    description: 'This month',
     key: 'This month',
     name: 0,
     type: 'Month',
@@ -118,7 +118,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last month'),
+    description: 'Last month',
     key: 'Last month',
     name: 1,
     type: 'Month',
@@ -128,7 +128,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last 30 days'),
+    description: 'Last 30 days',
     key: 'Last 30 days',
     name: 'last30Days',
     type: 'Day',
@@ -138,7 +138,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last 3 months'),
+    description: 'Last 3 months',
     key: 'Last 3 months',
     name: 3,
     type: 'Month',
@@ -148,7 +148,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last 6 months'),
+    description: 'Last 6 months',
     key: 'Last 6 months',
     name: 6,
     type: 'Month',
@@ -158,7 +158,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Last 12 months'),
+    description: 'Last 12 months',
     key: 'Last 12 months',
     name: 12,
     type: 'Month',
@@ -168,7 +168,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: false,
   },
   {
-    description: t('Year to date'),
+    description: 'Year to date',
     key: 'Year to date',
     name: 'yearToDate',
     type: 'Month',
@@ -178,7 +178,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: true,
   },
   {
-    description: t('Last year'),
+    description: 'Last year',
     key: 'Last year',
     name: 'lastYear',
     type: 'Month',
@@ -188,7 +188,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: true,
   },
   {
-    description: t('Prior year to date'),
+    description: 'Prior year to date',
     key: 'Prior year to date',
     name: 'priorYearToDate',
     type: 'Month',
@@ -198,7 +198,7 @@ const dateRangeOptions: dateRangeProps[] = [
     Yearly: true,
   },
   {
-    description: t('All time'),
+    description: 'All time',
     key: 'All time',
     name: 'allTime',
     type: 'Month',
@@ -223,28 +223,28 @@ type intervalOptionsProps = {
 
 const intervalOptions: intervalOptionsProps[] = [
   {
-    description: t('Daily'),
+    description: 'Daily',
     key: 'Daily',
     name: 'Day',
     format: 'yy-MM-dd',
     range: 'dayRangeInclusive',
   },
   {
-    description: t('Weekly'),
+    description: 'Weekly',
     key: 'Weekly',
     name: 'Week',
     format: 'yy-MM-dd',
     range: 'weekRangeInclusive',
   },
   {
-    description: t('Monthly'),
+    description: 'Monthly',
     key: 'Monthly',
     name: 'Month',
     format: "MMM ''yy",
     range: 'rangeInclusive',
   },
   {
-    description: t('Yearly'),
+    description: 'Yearly',
     key: 'Yearly',
     name: 'Year',
     format: 'yyyy',
@@ -252,19 +252,38 @@ const intervalOptions: intervalOptionsProps[] = [
   },
 ];
 
+function translateOptionDescriptions<T extends { description: string }>(
+  options: readonly T[],
+) {
+  return options.map(option => ({
+    ...option,
+    description: t(option.description),
+  }));
+}
+
 export const ReportOptions = {
-  groupBy: groupByOptions,
+  get groupBy() {
+    return translateOptionDescriptions(groupByOptions);
+  },
   groupByItems: new Set(groupByOptions.map(item => item.key)),
-  balanceType: balanceTypeOptions,
+  get balanceType() {
+    return translateOptionDescriptions(balanceTypeOptions);
+  },
   balanceTypeMap: new Map(
     balanceTypeOptions.map(item => [item.key, item.format]),
   ),
-  sortBy: sortByOptions,
+  get sortBy() {
+    return translateOptionDescriptions(sortByOptions);
+  },
   sortByMap: new Map(sortByOptions.map(item => [item.key, item.format])),
-  dateRange: dateRangeOptions,
+  get dateRange() {
+    return translateOptionDescriptions(dateRangeOptions);
+  },
   dateRangeMap: new Map(dateRangeOptions.map(item => [item.key, item.name])),
   dateRangeType: new Map(dateRangeOptions.map(item => [item.key, item.type])),
-  interval: intervalOptions,
+  get interval() {
+    return translateOptionDescriptions(intervalOptions);
+  },
   intervalMap: new Map<string, 'Day' | 'Week' | 'Month' | 'Year'>(
     intervalOptions.map(item => [item.key, item.name]),
   ),
@@ -300,25 +319,6 @@ export type UncategorizedEntity = Pick<
   uncategorized_id?: UncategorizedId;
 };
 
-const uncategorizedCategory: UncategorizedEntity = {
-  id: '',
-  name: t('Uncategorized'),
-  uncategorized_id: 'other',
-  hidden: false,
-};
-const transferCategory: UncategorizedEntity = {
-  id: '',
-  name: t('Transfers'),
-  uncategorized_id: 'transfer',
-  hidden: false,
-};
-const offBudgetCategory: UncategorizedEntity = {
-  id: '',
-  name: t('Off budget'),
-  uncategorized_id: 'off_budget',
-  hidden: false,
-};
-
 type UncategorizedGroupEntity = Pick<
   CategoryGroupEntity,
   'name' | 'id' | 'hidden'
@@ -327,18 +327,51 @@ type UncategorizedGroupEntity = Pick<
   uncategorized_id?: UncategorizedId;
 };
 
-const uncategorizedGroup: UncategorizedGroupEntity = {
-  name: t('Uncategorized & Off budget'),
-  id: 'uncategorized',
-  hidden: false,
-  uncategorized_id: 'all',
-  categories: [uncategorizedCategory, transferCategory, offBudgetCategory],
-};
+function getSpecialCategories() {
+  const uncategorizedCategory: UncategorizedEntity = {
+    id: '',
+    name: t('Uncategorized'),
+    uncategorized_id: 'other',
+    hidden: false,
+  };
+  const transferCategory: UncategorizedEntity = {
+    id: '',
+    name: t('Transfers'),
+    uncategorized_id: 'transfer',
+    hidden: false,
+  };
+  const offBudgetCategory: UncategorizedEntity = {
+    id: '',
+    name: t('Off budget'),
+    uncategorized_id: 'off_budget',
+    hidden: false,
+  };
+  const uncategorizedGroup: UncategorizedGroupEntity = {
+    name: t('Uncategorized & Off budget'),
+    id: 'uncategorized',
+    hidden: false,
+    uncategorized_id: 'all',
+    categories: [uncategorizedCategory, transferCategory, offBudgetCategory],
+  };
+
+  return {
+    offBudgetCategory,
+    transferCategory,
+    uncategorizedCategory,
+    uncategorizedGroup,
+  };
+}
 
 export const categoryLists = (categories: {
   list: CategoryEntity[];
   grouped: CategoryGroupEntity[];
 }) => {
+  const {
+    offBudgetCategory,
+    transferCategory,
+    uncategorizedCategory,
+    uncategorizedGroup,
+  } = getSpecialCategories();
   const categoriesToSort = [...categories.list];
   const categoryList: UncategorizedEntity[] = [
     ...categoriesToSort.sort((a, b) => {

--- a/packages/desktop-client/src/components/reports/graphs/CalendarGraph.tsx
+++ b/packages/desktop-client/src/components/reports/graphs/CalendarGraph.tsx
@@ -16,10 +16,12 @@ import {
   startOfMonth,
   startOfWeek,
 } from 'date-fns';
+import type { Locale } from 'date-fns';
 
 import { FinancialText } from '#components/FinancialText';
 import { PrivacyFilter } from '#components/PrivacyFilter';
 import { useFormat } from '#hooks/useFormat';
+import { useLocale } from '#hooks/useLocale';
 import { useResizeObserver } from '#hooks/useResizeObserver';
 
 type CalendarGraphProps = {
@@ -43,6 +45,7 @@ export function CalendarGraph({
   onDayClick,
 }: CalendarGraphProps) {
   const format = useFormat();
+  const locale = useLocale();
 
   const startingDate = startOfWeek(new Date(), {
     weekStartsOn:
@@ -90,7 +93,7 @@ export function CalendarGraph({
               marginBottom: 4,
             }}
           >
-            {formatDate(addDays(startingDate, index), 'EEEEE')}
+            {formatDate(addDays(startingDate, index), 'EEEEE', { locale })}
           </View>
         ))}
       </View>
@@ -117,7 +120,9 @@ export function CalendarGraph({
               content={
                 <View>
                   <View style={{ marginBottom: 10 }}>
-                    <strong>{formatDate(day.date, 'MMM dd')}</strong>
+                    <strong>
+                      {formatDate(day.date, 'MMM dd', { locale })}
+                    </strong>
                   </View>
                   <View style={{ lineHeight: 1.5 }}>
                     <View
@@ -209,6 +214,7 @@ export function CalendarGraph({
                 }}
                 fontSize={fontSize}
                 day={day}
+                locale={locale}
                 onPress={() => onDayClick(day.date)}
               />
             </Tooltip>
@@ -222,6 +228,7 @@ export function CalendarGraph({
               }}
               fontSize={fontSize}
               day={day}
+              locale={locale}
               onPress={() => onDayClick(day.date)}
             />
           ),
@@ -239,9 +246,16 @@ type DayButtonProps = {
     incomeSize: number;
     expenseSize: number;
   };
+  locale: Locale;
   onPress: () => void;
 };
-function DayButton({ day, onPress, fontSize, resizeRef }: DayButtonProps) {
+function DayButton({
+  day,
+  locale,
+  onPress,
+  fontSize,
+  resizeRef,
+}: DayButtonProps) {
   const [currentFontSize, setCurrentFontSize] = useState(fontSize);
 
   useEffect(() => {
@@ -251,7 +265,7 @@ function DayButton({ day, onPress, fontSize, resizeRef }: DayButtonProps) {
   return (
     <Button
       ref={resizeRef}
-      aria-label={formatDate(day.date, 'MMMM d, yyyy')}
+      aria-label={formatDate(day.date, 'MMMM d, yyyy', { locale })}
       style={{
         borderColor: 'transparent',
         backgroundColor: theme.calendarCellBackground,

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -803,6 +803,7 @@ function CalendarWithHeader({
   format,
 }: CalendarWithHeaderProps) {
   const { t } = useTranslation();
+  const locale = useLocale();
 
   return (
     <View
@@ -858,7 +859,7 @@ function CalendarWithHeader({
             });
           }}
         >
-          {formatDate(calendar.start, 'MMMM yyyy')}
+          {formatDate(calendar.start, 'MMMM yyyy', { locale })}
         </Button>
         <View
           style={{ display: 'grid', gridTemplateColumns: '16px 1fr', gap: 2 }}

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.test.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.test.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { act, render, screen } from '@testing-library/react';
+
+import { CalendarCardInner } from './CalendarCard';
+
+const localeState = vi.hoisted(() => ({
+  language: 'en',
+  listeners: new Set<() => void>(),
+}));
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ children }: { children: ReactNode }) => children,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('#components/reports/graphs/CalendarGraph', () => ({
+  CalendarGraph: () => null,
+}));
+
+vi.mock('#hooks/useLocale', async () => {
+  const { useSyncExternalStore } = await import('react');
+  const { enUS, zhCN } = await import('date-fns/locale');
+
+  return {
+    useLocale: () => {
+      const language = useSyncExternalStore(
+        listener => {
+          localeState.listeners.add(listener);
+          return () => {
+            localeState.listeners.delete(listener);
+          };
+        },
+        () => localeState.language,
+      );
+
+      return language === 'zh-Hans' ? zhCN : enUS;
+    },
+  };
+});
+
+vi.mock('#hooks/useNavigate', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('#hooks/useResizeObserver', () => ({
+  useResizeObserver: () => vi.fn(),
+}));
+
+function CalendarCardInnerHarness() {
+  const [monthNameFormats, setMonthNameFormats] = useState(['MMMM yyyy']);
+
+  return (
+    <CalendarCardInner
+      calendar={{
+        start: new Date(2026, 8, 1),
+        end: new Date(2026, 8, 30),
+        data: [],
+        totalExpense: 0,
+        totalIncome: 0,
+      }}
+      firstDayOfWeekIdx="0"
+      setMonthNameFormats={setMonthNameFormats}
+      selectedMonthNameFormat={monthNameFormats[0]}
+      index={0}
+      widgetId="calendar-widget"
+      format={() => ''}
+    />
+  );
+}
+
+describe('CalendarCardInner', () => {
+  beforeEach(() => {
+    localeState.language = 'en';
+    localeState.listeners.clear();
+
+    vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(
+      function (this: HTMLElement) {
+        if (this instanceof HTMLSpanElement) {
+          return (this.textContent ?? '').length * 10;
+        }
+
+        return 100;
+      },
+    );
+    vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(100);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('re-measures the month label after an in-place language change', async () => {
+    render(<CalendarCardInnerHarness />);
+
+    expect(
+      await screen.findByRole('button', { name: 'Sep 2026' }),
+    ).toBeVisible();
+
+    act(() => {
+      localeState.language = 'zh-Hans';
+      localeState.listeners.forEach(listener => listener());
+    });
+
+    expect(
+      await screen.findByRole('button', { name: '九月 2026' }),
+    ).toBeVisible();
+  });
+});

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -335,7 +335,7 @@ type CalendarCardInnerProps = {
   isEditing?: boolean;
   format: (value: unknown, type: FormatType) => string;
 };
-function CalendarCardInner({
+export function CalendarCardInner({
   calendar,
   firstDayOfWeekIdx,
   setMonthNameFormats,
@@ -399,6 +399,10 @@ function CalendarCardInner({
   );
 
   const monthNameResizeRef = useResizeObserver(debouncedResizeCallback);
+
+  useEffect(() => {
+    debouncedResizeCallback();
+  }, [debouncedResizeCallback, locale]);
 
   useEffect(() => {
     const toCancel = debouncedResizeCallback;

--- a/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CalendarCard.tsx
@@ -39,6 +39,7 @@ import type { CalendarDataType } from '#components/reports/spreadsheets/calendar
 import { useReport } from '#components/reports/useReport';
 import { useFormat } from '#hooks/useFormat';
 import type { FormatType } from '#hooks/useFormat';
+import { useLocale } from '#hooks/useLocale';
 import { useMergedRefs } from '#hooks/useMergedRefs';
 import { useNavigate } from '#hooks/useNavigate';
 import { useResizeObserver } from '#hooks/useResizeObserver';
@@ -345,6 +346,7 @@ function CalendarCardInner({
   format,
 }: CalendarCardInnerProps) {
   const { t } = useTranslation();
+  const locale = useLocale();
   const [monthNameVisible, setMonthNameVisible] = useState(true);
   const monthFormatSizeContainers = useRef<(HTMLSpanElement | null)[]>(
     new Array(5),
@@ -413,10 +415,19 @@ function CalendarCardInner({
   const navigate = useNavigate();
 
   const monthFormats = [
-    { format: 'MMMM yyyy', text: formatDate(calendar.start, 'MMMM yyyy') },
-    { format: 'MMM yyyy', text: formatDate(calendar.start, 'MMM yyyy') },
-    { format: 'MMM yy', text: formatDate(calendar.start, 'MMM yy') },
-    { format: 'MMM', text: formatDate(calendar.start, 'MMM') },
+    {
+      format: 'MMMM yyyy',
+      text: formatDate(calendar.start, 'MMMM yyyy', { locale }),
+    },
+    {
+      format: 'MMM yyyy',
+      text: formatDate(calendar.start, 'MMM yyyy', { locale }),
+    },
+    {
+      format: 'MMM yy',
+      text: formatDate(calendar.start, 'MMM yy', { locale }),
+    },
+    { format: 'MMM', text: formatDate(calendar.start, 'MMM', { locale }) },
     { format: '', text: '' },
   ];
 
@@ -462,7 +473,7 @@ function CalendarCardInner({
             }}
           >
             {selectedMonthNameFormat &&
-              formatDate(calendar.start, selectedMonthNameFormat)}
+              formatDate(calendar.start, selectedMonthNameFormat, { locale })}
           </Button>
         </View>
         <View

--- a/packages/desktop-client/src/components/rules/Value.tsx
+++ b/packages/desktop-client/src/components/rules/Value.tsx
@@ -92,7 +92,7 @@ export function Value<T>({
     if (value == null || value === '') {
       return t('(nothing)');
     } else if (typeof value === 'boolean') {
-      return value ? 'true' : 'false';
+      return value ? t('true') : t('false');
     } else {
       switch (field) {
         case 'amount':

--- a/packages/desktop-client/src/components/settings/Themes.tsx
+++ b/packages/desktop-client/src/components/settings/Themes.tsx
@@ -64,7 +64,9 @@ export function ThemeSettings() {
 
   const buildOptions = useCallback(() => {
     const options: Array<readonly [string, string] | typeof Menu.line> = [
-      ...themeOptions,
+      ...themeOptions.map(
+        ([key, name]) => [key, t(name)] satisfies readonly [string, string],
+      ),
     ];
 
     if (theme !== 'auto' && installedCustomLightTheme) {
@@ -96,7 +98,9 @@ export function ThemeSettings() {
 
   const buildDarkOptions = useCallback(() => {
     const options: Array<readonly [string, string] | typeof Menu.line> = [
-      ...darkThemeOptions,
+      ...darkThemeOptions.map(
+        ([key, name]) => [key, t(name)] satisfies readonly [string, string],
+      ),
     ];
     if (installedCustomDarkTheme) {
       options.push([

--- a/packages/loot-core/src/shared/locale.test.ts
+++ b/packages/loot-core/src/shared/locale.test.ts
@@ -1,0 +1,33 @@
+import { de, enUS, nb, ptBR, zhCN, zhHK, zhTW } from 'date-fns/locale';
+
+import { getLocale } from './locale';
+
+describe('getLocale', () => {
+  it('maps common BCP-47 tags to date-fns locales', () => {
+    expect(getLocale('en-US')).toBe(enUS);
+    expect(getLocale('pt-BR')).toBe(ptBR);
+    expect(getLocale('pt_BR')).toBe(ptBR);
+    expect(getLocale('de')).toBe(de);
+    expect(getLocale('nb-NO')).toBe(nb);
+  });
+
+  it('maps Chinese script/region tags to zhCN / zhTW / zhHK', () => {
+    expect(getLocale('zh-Hans')).toBe(zhCN);
+    expect(getLocale('zh-CN')).toBe(zhCN);
+    expect(getLocale('zh')).toBe(zhCN);
+    expect(getLocale('ZH-HANS')).toBe(zhCN);
+    expect(getLocale('zh_CN')).toBe(zhCN);
+    expect(getLocale('zh-Hant')).toBe(zhTW);
+    expect(getLocale('zh-TW')).toBe(zhTW);
+    expect(getLocale('zh-HK')).toBe(zhHK);
+  });
+
+  it('falls back safely for invalid input', () => {
+    expect(getLocale('')).toBe(enUS);
+    expect(getLocale(null)).toBe(enUS);
+    expect(getLocale(undefined)).toBe(enUS);
+    expect(getLocale('not-a-locale')).toBe(enUS);
+    // @ts-expect-error intentional invalid type
+    expect(getLocale(123)).toBe(enUS);
+  });
+});

--- a/packages/loot-core/src/shared/locale.test.ts
+++ b/packages/loot-core/src/shared/locale.test.ts
@@ -27,6 +27,7 @@ describe('getLocale', () => {
     expect(getLocale(null)).toBe(enUS);
     expect(getLocale(undefined)).toBe(enUS);
     expect(getLocale('not-a-locale')).toBe(enUS);
+    expect(getLocale('fil')).toBe(enUS);
     // @ts-expect-error intentional invalid type
     expect(getLocale(123)).toBe(enUS);
   });

--- a/packages/loot-core/src/shared/locale.ts
+++ b/packages/loot-core/src/shared/locale.ts
@@ -5,22 +5,67 @@ const locales: Record<string, localesNamespace.Locale> = {
   ...localesNamespace,
 };
 
-export function getLocale(language: string) {
+/**
+ * Map app / browser language tags to date-fns locale export names.
+ * Keys are lowercased with hyphens/underscores removed.
+ * date-fns uses camelCase: zhCN, zhTW, zhHK, ptBR, enUS, …
+ */
+const LANGUAGE_TO_DATE_FNS: Partial<
+  Record<string, keyof typeof localesNamespace>
+> = {
+  // Chinese: app uses zh-Hans / zh-Hant; browsers often zh-CN / zh-TW / zh-HK
+  zh: 'zhCN',
+  zhhans: 'zhCN',
+  zhcn: 'zhCN',
+  zhhant: 'zhTW',
+  zhtw: 'zhTW',
+  zhhk: 'zhHK',
+};
+
+function normalizeLanguageTag(language: string): string {
+  return language.trim().toLowerCase().replace(/[-_]/g, '');
+}
+
+/**
+ * Resolve a BCP-47 language tag to a date-fns Locale.
+ * Never throws; unknown tags fall back to enUS.
+ */
+export function getLocale(
+  language: string | null | undefined,
+): localesNamespace.Locale {
   if (!language || typeof language !== 'string') {
     return locales.enUS;
   }
 
-  let localeKey = language.replace('-', '');
-
-  if (localeKey in locales) {
-    return locales[localeKey];
+  const normalized = normalizeLanguageTag(language);
+  if (!normalized) {
+    return locales.enUS;
   }
 
-  //if language was not found with four letters, try with two
-  localeKey = language.replace('-', '').substring(0, 2);
+  // 1) Explicit aliases (zh-Hans → zhCN, etc.)
+  const aliased = LANGUAGE_TO_DATE_FNS[normalized];
+  if (aliased) {
+    return locales[aliased];
+  }
 
-  if (localeKey in locales) {
-    return locales[localeKey];
+  // 2) BCP-47 segments → date-fns keys (pt-BR → ptBR, en-GB → enGB)
+  // date-fns uses language lowercase + region uppercase (not title case).
+  const stripped = language
+    .trim()
+    .replace(/_/g, '-')
+    .split('-')
+    .filter(Boolean)
+    .map((part, i) => (i === 0 ? part.toLowerCase() : part.toUpperCase()))
+    .join('');
+
+  if (stripped && stripped in locales) {
+    return locales[stripped];
+  }
+
+  // 3) Two-letter language only (nb-NO → nb, de-AT → de)
+  const twoLetter = normalized.slice(0, 2);
+  if (twoLetter && twoLetter in locales) {
+    return locales[twoLetter];
   }
 
   return locales.enUS;

--- a/packages/loot-core/src/shared/locale.ts
+++ b/packages/loot-core/src/shared/locale.ts
@@ -50,11 +50,12 @@ export function getLocale(
 
   // 2) BCP-47 segments → date-fns keys (pt-BR → ptBR, en-GB → enGB)
   // date-fns uses language lowercase + region uppercase (not title case).
-  const stripped = language
+  const languageParts = language
     .trim()
     .replace(/_/g, '-')
     .split('-')
-    .filter(Boolean)
+    .filter(Boolean);
+  const stripped = languageParts
     .map((part, i) => (i === 0 ? part.toLowerCase() : part.toUpperCase()))
     .join('');
 
@@ -63,9 +64,9 @@ export function getLocale(
   }
 
   // 3) Two-letter language only (nb-NO → nb, de-AT → de)
-  const twoLetter = normalized.slice(0, 2);
-  if (twoLetter && twoLetter in locales) {
-    return locales[twoLetter];
+  const primaryLanguage = languageParts[0]?.toLowerCase();
+  if (primaryLanguage?.length === 2 && primaryLanguage in locales) {
+    return locales[primaryLanguage];
   }
 
   return locales.enUS;

--- a/upcoming-release-notes/improve-localized-date-labels.md
+++ b/upcoming-release-notes/improve-localized-date-labels.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [hezhongtang]
+---
+
+Show calendar dates and report options in the selected language


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

This PR improves date and display-layer localization for non-English languages, with a focus on Simplified Chinese:

- Normalize language tags and map Simplified Chinese, Traditional Chinese, and common regional tags to the correct date-fns locale.
- Format calendar months, weekdays, tooltips, and accessibility labels using the active application language.
- Translate report option descriptions when they are accessed so an in-place language change does not reuse text cached during module initialization.
- Translate additional display-layer labels, including budget summary tooltips, rule boolean values, and built-in theme names.
- Add regression coverage for locale resolution and report option translation, along with a release note.

OpenAI Codex assisted with the implementation and review. This is a focused replacement for the closed #8634, excluding higher-risk changes that persisted localized default names or depended on fork-specific translation overrides.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Relates to and supersedes the closed #8634.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

- Formatting and lint checks passed.
- Full repository typecheck passed across all 10 workspaces.
- Desktop-client unit tests passed: 60 test files, 867 passed, 1 skipped.
- Focused locale tests passed: 3 tests.
- Focused report option tests passed: 2 tests.
- Focused report browser tests passed: 2 tests.
- GitHub CI passed functional tests, visual regression tests, builds, static checks, and release-note validation.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 → 36 | 13.4 MB → 13.04 MB (-367.49 kB) | -2.68%
loot-core | 1 | 4.63 MB → 4.63 MB (-5.06 kB) | -0.11%
api | 2 | 3.85 MB → 3.84 MB (-4.62 kB) | -0.12%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 → 36 | 13.4 MB → 13.04 MB (-367.49 kB) | -2.68%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/locale.ts` | 📈 +617 B (+144.84%) | 426 B → 1.02 kB
`locale/en.json` | 📈 +26.8 kB (+12.79%) | 209.56 kB → 236.36 kB
`src/components/budget/envelope/budgetsummary/TotalsList.tsx` | 📈 +659 B (+11.41%) | 5.64 kB → 6.28 kB
`src/components/reports/ReportOptions.ts` | 📈 +562 B (+7.57%) | 7.25 kB → 7.8 kB
`locale/nl.json` | 📈 +7.56 kB (+5.22%) | 144.82 kB → 152.38 kB
`src/components/reports/graphs/CalendarGraph.tsx` | 📈 +213 B (+2.07%) | 10.03 kB → 10.24 kB
`src/components/reports/reports/CalendarCard.tsx` | 📈 +195 B (+1.54%) | 12.4 kB → 12.59 kB
`src/components/settings/Themes.tsx` | 📈 +82 B (+1.06%) | 7.58 kB → 7.66 kB
`src/components/reports/reports/Calendar.tsx` | 📈 +79 B (+0.28%) | 27.62 kB → 27.7 kB
`src/components/rules/Value.tsx` | 📈 +6 B (+0.13%) | 4.51 kB → 4.51 kB
`src/components/accounts/Account.tsx` | 📉 -14 B (-0.03%) | 40.62 kB → 40.61 kB
`src/components/modals/ImportTransactionsModal/ImportTransactionsModal.tsx` | 📉 -118 B (-0.35%) | 33.37 kB → 33.26 kB
`src/languages.ts` | 📉 -297 B (-17.44%) | 1.66 kB → 1.37 kB
`locale/th.json` | 🔥 -165.36 kB (-100%) | 165.36 kB → 0 B
`locale/ru.json` | 🔥 -142.56 kB (-100%) | 142.56 kB → 0 B
`locale/da.json` | 🔥 -95.87 kB (-100%) | 95.87 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/th.js | 165.36 kB → 0 B (-165.36 kB) | -100%
static/js/ru.js | 142.56 kB → 0 B (-142.56 kB) | -100%
static/js/da.js | 95.87 kB → 0 B (-95.87 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 209.56 kB → 236.36 kB (+26.8 kB) | +12.79%
static/js/nl.js | 144.82 kB → 152.38 kB (+7.56 kB) | +5.22%
static/js/ReportRouter.js | 1.39 MB → 1.39 MB (+1.02 kB) | +0.07%
static/js/Value.js | 2 MB → 2 MB (+665 B) | +0.03%
static/js/useDateFormat.js | 2.92 MB → 2.92 MB (+320 B) | +0.01%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB → 1.56 MB (-36 B) | -0.00%
static/js/wide.js | 272.23 kB → 272.21 kB (-14 B) | -0.01%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.8 kB | 0%
static/js/ScheduleEditForm.js | 73.39 kB | 0%
static/js/SchedulesTable.js | 171.06 kB | 0%
static/js/TransactionEdit.js | 219.25 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 168.15 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 284.96 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (-5.06 kB) | -0.11%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/locale.ts` | 📈 +633 B (+145.52%) | 435 B → 1.04 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -2 B (-0.01%) | 24.99 kB → 24.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -2 B (-0.01%) | 24.83 kB → 24.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -2 B (-0.01%) | 21.54 kB → 21.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-projection.ts` | 📉 -2 B (-0.04%) | 5.33 kB → 5.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📉 -2 B (-0.04%) | 5.33 kB → 5.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -6 B (-0.04%) | 15.73 kB → 15.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -4 B (-0.05%) | 8.07 kB → 8.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📉 -6 B (-0.07%) | 8.9 kB → 8.89 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📉 -4 B (-0.07%) | 5.74 kB → 5.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📉 -10 B (-0.15%) | 6.33 kB → 6.32 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/find-schedules.ts` | 📉 -24 B (-0.33%) | 7.21 kB → 7.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/handlebars-helpers.ts` | 📉 -12 B (-0.35%) | 3.34 kB → 3.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📉 -529 B (-8.45%) | 6.11 kB → 5.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/mt9402json.ts` | 🔥 -5.09 kB (-100%) | 5.09 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bgrj8yH-.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D8wpU0sr.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.84 MB (-4.62 kB) | -0.12%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/locale.ts` | 📈 +917 B (+215.26%) | 426 B → 1.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📉 -2 B (-0.01%) | 24.49 kB → 24.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📉 -2 B (-0.01%) | 24.23 kB → 24.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📉 -2 B (-0.01%) | 21.11 kB → 21.11 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-projection.ts` | 📉 -2 B (-0.04%) | 5.21 kB → 5.21 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📉 -2 B (-0.04%) | 5.14 kB → 5.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -6 B (-0.04%) | 15.4 kB → 15.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📉 -4 B (-0.05%) | 7.6 kB → 7.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📉 -4 B (-0.06%) | 6.36 kB → 6.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📉 -6 B (-0.07%) | 8.41 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📉 -10 B (-0.16%) | 6.29 kB → 6.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/find-schedules.ts` | 📉 -24 B (-0.34%) | 7 kB → 6.97 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/handlebars-helpers.ts` | 📉 -12 B (-0.36%) | 3.25 kB → 3.24 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📉 -508 B (-8.12%) | 6.11 kB → 5.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/mt9402json.ts` | 🔥 -4.94 kB (-100%) | 4.94 kB → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.84 MB (-4.62 kB) | -0.12%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->