### PR TITLE
[AI] Add UYU currency

### DIFF
--- a/packages/desktop-client/src/components/settings/Currency.tsx
+++ b/packages/desktop-client/src/components/settings/Currency.tsx
@@ -66,6 +66,7 @@ export function CurrencySettings() {
         ['TWD', t('New Taiwan Dollar')],
         ['UAH', t('Ukrainian Hryvnia')],
         ['USD', t('US Dollar')],
+        ['UYU', t('Uruguayan Peso')],
         ['UZS', t('Uzbek Soum')],
       ]),
     [t],

--- a/packages/loot-core/src/shared/currencies.ts
+++ b/packages/loot-core/src/shared/currencies.ts
@@ -67,6 +67,7 @@ export const currencies: Currency[] = [
   { code: 'TWD', name: 'New Taiwan Dollar', symbol: 'NT$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
   { code: 'UAH', name: 'Ukrainian Hryvnia', symbol: '₴', decimalPlaces: 2, numberFormat: 'space-comma', symbolFirst: false },
   { code: 'USD', name: 'US Dollar', symbol: '$', decimalPlaces: 2, numberFormat: 'comma-dot', symbolFirst: true },
+  { code: 'UYU', name: 'Uruguayan Peso', symbol: '$U', decimalPlaces: 2, numberFormat: 'dot-comma', symbolFirst: true },
   { code: 'UZS', name: 'Uzbek Soum', symbol: 'UZS', decimalPlaces: 2, numberFormat: 'space-comma', symbolFirst: false },
 ];
 

--- a/upcoming-release-notes/add-uyu-currency.md
+++ b/upcoming-release-notes/add-uyu-currency.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [diecoscai]
+---
+
+Add Uruguayan Peso (UYU) to the list of available currencies.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds the Uruguayan Peso (UYU) to the list of available currencies.

Uruguay writes amounts as `$U 1.234,56` — dot as the thousands separator, comma as the decimal separator, symbol before the amount. That maps to `numberFormat: 'dot-comma'`, `symbolFirst: true` and `decimalPlaces: 2`, matching the other Latin American entries already in the list (ARS, CLP, COP).

For the symbol I used `$U` rather than a constructed tag like `CLP$` or `Arg$`, because `$U` is the symbol actually used in Uruguay — the same reasoning behind `RD$` for the Dominican Peso. It also avoids the bare `$` already taken by USD.

I budget in Uruguayan pesos and UYU was the only piece missing from the currency list.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Written with Claude Code (Claude Opus 5).

## Related issue(s)

N/A — no existing issue tracks UYU specifically.

## Testing

Verified on this PR's deploy preview (https://deploy-preview-8638.demo.actualbudget.org) using the demo budget, with the `Currency support` experimental flag enabled:

- Settings → Currency settings lists `UYU - Uruguayan Peso ($U)`, in the expected alphabetical position between USD and UZS.
- Selecting it switches the Numbers format to `1.000,33` and sets Symbol Position to `Before amount`, which is what `numberFormat: 'dot-comma'` and `symbolFirst: true` should produce.
- Amounts then render as `$U49.912,51` in the sidebar account balances and throughout the budget table, with negatives as `-$U334.575,12`.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (+4.09 kB) | +0.03%
loot-core | 1 | 4.63 MB → 4.63 MB (+141 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+133 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (+4.09 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/fr.json` | 📈 +3.7 kB (+2.20%) | 168.15 kB → 171.84 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +133 B (+1.98%) | 6.56 kB → 6.69 kB
`src/components/settings/Currency.tsx` | 📈 +273 B (+1.30%) | 20.47 kB → 20.74 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 168.15 kB → 171.84 kB (+3.7 kB) | +2.20%
static/js/index.js | 1.57 MB → 1.57 MB (+273 B) | +0.02%
static/js/useDateFormat.js | 2.93 MB → 2.93 MB (+133 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.79 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2.03 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+141 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +141 B (+2.01%) | 6.84 kB → 6.98 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bcf_a9eI.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C7Thu0FH.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+133 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +133 B (+2.01%) | 6.46 kB → 6.59 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+133 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->