### PR TITLE
[AI] Fix stale session token recovery

### DIFF
--- a/packages/loot-core/src/server/cloud-storage.test.ts
+++ b/packages/loot-core/src/server/cloud-storage.test.ts
@@ -1,0 +1,73 @@
+const { mockedFetch, mockedGetItem, mockedRemoveItem } = vi.hoisted(() => ({
+  mockedFetch: vi.fn(),
+  mockedGetItem: vi.fn(),
+  mockedRemoveItem: vi.fn(),
+}));
+
+vi.unmock('#server/post');
+vi.unmock('./post');
+
+vi.mock('#platform/server/fetch', () => ({
+  fetch: mockedFetch,
+}));
+
+vi.mock('#platform/server/asyncStorage', () => ({
+  getItem: mockedGetItem,
+  removeItem: mockedRemoveItem,
+}));
+
+describe('listRemoteFiles', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedFetch.mockReset();
+    mockedGetItem.mockReset().mockResolvedValue('stale-token');
+    mockedRemoveItem.mockReset();
+  });
+
+  it('removes a token whose server session no longer exists', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'error',
+          reason: 'unauthorized',
+          details: 'token-not-found',
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const { setServer } = await import('./server-config');
+    setServer('https://test.env');
+    const { listRemoteFiles } = await import('./cloud-storage');
+    await listRemoteFiles();
+
+    expect(mockedGetItem).toHaveBeenCalledWith('user-token');
+    expect(mockedFetch).toHaveBeenCalledOnce();
+    expect(mockedRemoveItem).toHaveBeenCalledWith('user-token');
+  });
+
+  it('removes an expired token reported by an older server', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'error',
+          data: { reason: 'token-expired' },
+        }),
+        {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const { setServer } = await import('./server-config');
+    setServer('https://test.env');
+    const { listRemoteFiles } = await import('./cloud-storage');
+    await listRemoteFiles();
+
+    expect(mockedRemoveItem).toHaveBeenCalledWith('user-token');
+  });
+});

--- a/packages/loot-core/src/server/cloud-storage.ts
+++ b/packages/loot-core/src/server/cloud-storage.ts
@@ -17,7 +17,7 @@ import {
   PostError,
 } from './errors';
 import { runMutator } from './mutators';
-import { post } from './post';
+import { getServerErrorReason, post } from './post';
 import * as prefs from './prefs';
 import { getServer } from './server-config';
 import {
@@ -47,25 +47,24 @@ export type RemoteFile = {
 };
 
 async function checkHTTPStatus(res) {
-  if (res.status !== 200) {
-    if (res.status === 403) {
-      try {
-        const text = await res.text();
-        const data = JSON.parse(text)?.data;
-        if (data?.reason === 'token-expired') {
-          await asyncStorage.removeItem('user-token');
-          throw new HTTPError(403, 'token-expired');
-        }
-      } catch (e) {
-        if (e instanceof HTTPError) throw e;
-      }
-    }
-    return res.text().then(str => {
-      throw new HTTPError(res.status, str);
-    });
-  } else {
+  if (res.status === 200) {
     return res;
   }
+
+  const text = await res.text();
+  if (res.status === 401 || res.status === 403) {
+    try {
+      const body = JSON.parse(text);
+      const error = res.status === 403 ? body.data : body;
+      if (getServerErrorReason(error) === 'token-expired') {
+        await asyncStorage.removeItem('user-token');
+      }
+    } catch {
+      // Preserve the original HTTP error when the response is not JSON.
+    }
+  }
+
+  throw new HTTPError(res.status, text);
 }
 
 async function fetchJSON(...args: Parameters<typeof fetch>) {

--- a/packages/loot-core/src/server/post.test.ts
+++ b/packages/loot-core/src/server/post.test.ts
@@ -54,6 +54,29 @@ describe('postBinary', () => {
     expect((error as PostError).reason).toBe('network-failure');
     expect((error as PostError).cause).toBe(underlying);
   });
+
+  it('treats a missing server session as an expired token', async () => {
+    mockedFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 'error',
+          reason: 'unauthorized',
+          details: 'token-not-found',
+        }),
+        {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    const error = await captureError(
+      postBinary('https://test.env/sync/sync', new Uint8Array([1]), {}),
+    );
+
+    expect(error).toBeInstanceOf(PostError);
+    expect((error as PostError).reason).toBe('token-expired');
+  });
 });
 
 describe('post', () => {

--- a/packages/loot-core/src/server/post.ts
+++ b/packages/loot-core/src/server/post.ts
@@ -5,6 +5,12 @@ import * as Platform from '#shared/platform';
 
 import { PostError } from './errors';
 
+export function getServerErrorReason(error) {
+  return error.reason === 'unauthorized' && error.details === 'token-not-found'
+    ? 'token-expired'
+    : error.reason;
+}
+
 function throwIfNot200(res: Response, text: string) {
   if (res.status !== 200) {
     if (res.status === 500) {
@@ -14,7 +20,7 @@ function throwIfNot200(res: Response, text: string) {
     const contentType = res.headers.get('Content-Type') ?? '';
     if (contentType.toLowerCase().indexOf('application/json') !== -1) {
       const json = JSON.parse(text);
-      throw new PostError(json.reason);
+      throw new PostError(getServerErrorReason(json));
     }
 
     // Actual Sync Server may be exposed via a tunnel (e.g. ngrok). Tunnel errors should be treated as network errors.

--- a/upcoming-release-notes/fix-stale-session-token.md
+++ b/upcoming-release-notes/fix-stale-session-token.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [rezanmz]
+---
+
+Return to login when a saved server session is no longer valid


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Recover from stale Actual server sessions instead of leaving a locally cached budget stuck on repeated authentication failures.

When the sync server returns HTTP 401 with `reason: unauthorized` and `details: token-not-found`, the client now treats that specific response as `token-expired`. This reuses the existing expired-token sign-out flow while leaving other authorization failures unchanged.

Raw cloud-storage requests now also remove the stale `user-token` for the current HTTP 401/top-level response format. The existing HTTP 403/`data.reason` format remains supported for compatibility with older servers.

The implementation and tests were prepared with OpenAI OpenCode and reviewed and verified before submission.
<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Fixes #8647

## Testing

- Ran `yarn lint:fix` successfully.
- Ran `yarn typecheck` successfully across all workspaces.
- Ran the complete `@actual-app/core` test suite: 1,021 tests passed and 2 were skipped.
- Added regression coverage for HTTP 401 `token-not-found` responses.
- Added compatibility coverage for legacy HTTP 403 nested `token-expired` responses.
- Confirmed all 49 GitHub status checks completed with zero failures, including lint, typecheck, tests, E2E, visual regression, CodeQL, CodeRabbit, release notes, and platform builds.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.03 MB | 0%
loot-core | 1 | 4.63 MB → 4.63 MB (+84 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+88 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.03 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.56 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 69.17 kB | 0%
static/js/PayeeRuleCountLabel.js | 9.8 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 73.39 kB | 0%
static/js/SchedulesTable.js | 171.06 kB | 0%
static/js/TransactionEdit.js | 219.25 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.14 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 168.15 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 284.96 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.38 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.92 MB | 0%
static/js/useFormatList.js | 9.31 kB | 0%
static/js/useTransactionBatchActions.js | 9.77 kB | 0%
static/js/wide.js | 272.21 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+84 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +172 B (+3.74%) | 4.49 kB → 4.66 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -88 B (-0.93%) | 9.23 kB → 9.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dgjc98dd.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DMvmLzbd.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+88 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +169 B (+3.80%) | 4.34 kB → 4.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -81 B (-0.88%) | 8.95 kB → 8.88 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+88 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->