### PR TITLE
update vrt-update comment to reflect a more realistic time

### DIFF
--- a/.github/workflows/e2e-vrt-comment.yml
+++ b/.github/workflows/e2e-vrt-comment.yml
@@ -66,4 +66,4 @@ jobs:
             <!-- vrt-comment -->
             VRT tests ❌ failed. [View the test report](${{ steps.metadata.outputs.artifact_url }}).
 
-            To update the VRT screenshots, comment `/update-vrt` on this PR. The VRT update operation takes about 50 minutes.
+            To update the VRT screenshots, comment `/update-vrt` on this PR. The VRT update operation takes about 10 to 15 minutes.

--- a/upcoming-release-notes/vrt-comment-time.md
+++ b/upcoming-release-notes/vrt-comment-time.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [matt-fidd]
+---
+
+Update vrt-update comment to reflect a more realistic time


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

The job doesn't take 50 mins anymore, looking at the average run time it tends to sit around 10 mins, sometimes lower.

https://github.com/actualbudget/actual/actions/workflows/vrt-update-generate.yml?query=is%3Asuccess

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
