### PR TITLE
[AI] Fix payee placeholder for deposit transactions on mobile

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -452,7 +452,11 @@ const ChildTransactionEdit = forwardRef<
             <FieldLabel title={t('Payee')} />
             <TapField
               icon={<SvgUser width={17} height={17} />}
-              placeholder={t('Who did you pay?')}
+              placeholder={
+                transaction.amount > 0
+                  ? t('Who paid you?')
+                  : t('Who did you pay?')
+              }
               rightContent={dropdownChevron}
               isDisabled={
                 !!editingField &&
@@ -1163,7 +1167,11 @@ const TransactionEditInner = memo<TransactionEditInnerProps>(
             <FieldLabel title={t('Payee')} />
             <TapField
               icon={<SvgUser width={17} height={17} />}
-              placeholder={t('Who did you pay?')}
+              placeholder={
+                transaction.amount > 0
+                  ? t('Who paid you?')
+                  : t('Who did you pay?')
+              }
               textStyle={{
                 ...(transaction.is_parent && {
                   fontStyle: 'italic',

--- a/upcoming-release-notes/fix-payee-placeholder-deposit.md
+++ b/upcoming-release-notes/fix-payee-placeholder-deposit.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [KesleyDavid]
+---
+
+Show a deposit-appropriate payee placeholder on the mobile transaction entry form when the amount is an inflow


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

在移动端交易录入表单中,无论金额方向如何,收款人(payee)字段的占位符始终显示 "Who did you pay?"。本次修改让占位符根据金额方向变化:

- 付款/支出(金额 ≤ 0):"Who did you pay?"(保持不变)
- 存款/收入(金额 > 0):"Who paid you?"(新增的翻译字符串)

修改位于 `packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx`,同时应用于主交易表单和拆分交易的子行。存款的判断方式(`transaction.amount > 0`)沿用了代码库中已有的约定(例如交易列表和交易表格中的 `isDeposit`)。

初始实现由 AI 辅助工具(Kimi Code)起草,已由我本人(KesleyDavid)逐行审查、测试并修改。我对本次提交的全部内容负责。

## Related issue(s)

Fixes #8605

## Testing

- `yarn typecheck` — 通过(10/10 个包)
- `yarn lint:fix` — 0 个错误
- `yarn workspace @actual-app/web run test` — 864 个测试通过,1 个跳过
- 手动验证步骤:在移动端视图中打开某个账户 → 添加交易 → 输入付款金额时,收款人占位符显示 "Who did you pay?";输入存款(正数)金额后,占位符切换为 "Who paid you?"。

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
