### PR TITLE
[WIP] [AI] Skip whole-account balance recompute for edits that can't change it

### DIFF
--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -312,9 +312,10 @@ class AccountInternal extends PureComponent<
   dispatchSelected?: (action: Actions) => void;
   _isOptimisticUpdate: boolean = false;
   // Whether the pending optimistic update could change a transaction's
-  // contribution to the running balance (added/deleted, or its amount/account
-  // changed). Edits like cleared/notes/category/payee can't affect balances,
-  // so we skip the expensive recompute for those.
+  // contribution to the running balance (added/deleted, or its date/amount/
+  // account changed — balances are a running sum in date order, so moving a
+  // row changes every later row). Edits like cleared/notes/category/payee
+  // can't affect balances, so we skip the expensive recompute for those.
   _optimisticUpdateAffectsBalance: boolean = true;
 
   constructor(props: AccountInternalProps) {
@@ -687,6 +688,7 @@ class AccountInternal extends PureComponent<
     this._optimisticUpdateAffectsBalance =
       !!updatedTransaction._deleted ||
       !previousTransaction ||
+      previousTransaction.date !== updatedTransaction.date ||
       previousTransaction.amount !== updatedTransaction.amount ||
       previousTransaction.account !== updatedTransaction.account;
 

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -311,6 +311,11 @@ class AccountInternal extends PureComponent<
   unlisten?: () => void;
   dispatchSelected?: (action: Actions) => void;
   _isOptimisticUpdate: boolean = false;
+  // Whether the pending optimistic update could change a transaction's
+  // contribution to the running balance (added/deleted, or its amount/account
+  // changed). Edits like cleared/notes/category/payee can't affect balances,
+  // so we skip the expensive recompute for those.
+  _optimisticUpdateAffectsBalance: boolean = true;
 
   constructor(props: AccountInternalProps) {
     super(props);
@@ -499,9 +504,13 @@ class AccountInternal extends PureComponent<
         if (this._isOptimisticUpdate) {
           this._isOptimisticUpdate = false;
           const transactionsSnapshot = data;
-          const balances = this.state.showBalances
-            ? await this.calculateBalances()
-            : null;
+          // Only recompute balances (a whole-account aggregate query) when the
+          // edit could actually change one — e.g. cleared/notes/category/payee
+          // edits can't, so reuse the last-known balances for those.
+          const balances =
+            this.state.showBalances && this._optimisticUpdateAffectsBalance
+              ? await this.calculateBalances()
+              : this.state.balances;
           // Wrap in startTransition so React treats this as a low-priority
           // update. Without this, setState blocks the main thread for the
           // full duration of the re-render (~40–220ms with large transaction
@@ -671,6 +680,16 @@ class AccountInternal extends PureComponent<
     // Apply changes to pagedQuery data optimistically. Set the flag so that
     // onData skips the expensive aggregate DB queries for this update.
     this._isOptimisticUpdate = true;
+
+    const previousTransaction = this.state.transactions.find(
+      t => t.id === updatedTransaction.id,
+    );
+    this._optimisticUpdateAffectsBalance =
+      !!updatedTransaction._deleted ||
+      !previousTransaction ||
+      previousTransaction.amount !== updatedTransaction.amount ||
+      previousTransaction.account !== updatedTransaction.account;
+
     this.paged?.optimisticUpdate(data => {
       if (updatedTransaction._deleted) {
         return data.filter(t => t.id !== updatedTransaction.id);

--- a/upcoming-release-notes/fix-slow-transaction-balance-recompute.md
+++ b/upcoming-release-notes/fix-slow-transaction-balance-recompute.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix transaction rows becoming sluggish when adding, editing, or clearing transactions, and when reconciling an account


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (+469 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (+469 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Account.tsx` | 📈 +469 B (+1.13%) | 40.61 kB → 41.07 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 274.04 kB → 274.5 kB (+469 B) | +0.17%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.79 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2.03 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 168.15 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DMvmLzbd.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->