### PR TITLE
fix context menu showing on multi-account views

### DIFF
--- a/packages/desktop-client/src/components/sidebar/Account.test.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { DndProvider } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import { MemoryRouter } from 'react-router';
+
+import { generateAccount } from '@actual-app/core/mocks';
+import { initServer } from '@actual-app/core/platform/client/connection';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { SpreadsheetProvider } from '#hooks/useSpreadsheet';
+import {
+  configureTestAppStore,
+  createTestQueryClient,
+  TestProviders,
+} from '#mocks';
+import * as bindings from '#spreadsheet/bindings';
+
+import { Account } from './Account';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+// jsdom does not implement matchMedia, which the component uses for
+// touch-device detection
+window.matchMedia = (query: string): MediaQueryList => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(() => false),
+});
+
+describe('sidebar Account context menu', () => {
+  let store: ReturnType<typeof configureTestAppStore>;
+
+  beforeEach(() => {
+    initServer({
+      query: async () => ({ data: [], dependencies: [] }),
+      'get-cell': async () => ({ name: 'test-cell', value: 0 }),
+    });
+
+    store = configureTestAppStore({ queryClient: createTestQueryClient() });
+  });
+
+  async function renderRow(children: ReactNode) {
+    const result = render(
+      <TestProviders store={store}>
+        <SpreadsheetProvider>
+          <MemoryRouter>
+            <DndProvider backend={HTML5Backend}>{children}</DndProvider>
+          </MemoryRouter>
+        </SpreadsheetProvider>
+      </TestProviders>,
+    );
+    // Flush the async notes/balance queries kicked off on mount
+    await act(() => Promise.resolve());
+    return result;
+  }
+
+  function contextMenuItemNames() {
+    return store
+      .getState()
+      .contextMenu.items.map(item =>
+        typeof item === 'object' ? item.name : null,
+      );
+  }
+
+  it('does not open on the All accounts row', async () => {
+    await renderRow(
+      <Account
+        name="All accounts"
+        to="/accounts"
+        query={bindings.allAccountBalance()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('All accounts'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(false);
+    expect(contextMenuItemNames()).toEqual([]);
+  });
+
+  it('does not open on the On budget row', async () => {
+    await renderRow(
+      <Account
+        name="On budget"
+        to="/accounts/onbudget"
+        query={bindings.onBudgetAccountBalance()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('On budget'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(false);
+    expect(contextMenuItemNames()).toEqual([]);
+  });
+
+  it('opens rename/close on an account row', async () => {
+    const account = generateAccount('Bank of America');
+
+    await renderRow(
+      <Account
+        name={account.name}
+        account={account}
+        to={`/accounts/${account.id}`}
+        query={bindings.accountBalance(account.id)}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Bank of America'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(true);
+    expect(contextMenuItemNames()).toEqual(['account-rename', 'account-close']);
+  });
+});

--- a/packages/desktop-client/src/components/sidebar/Account.tsx
+++ b/packages/desktop-client/src/components/sidebar/Account.tsx
@@ -136,7 +136,7 @@ export function Account<FieldName extends SheetFields<'account'>>({
   );
   useContextMenu({
     triggerRef,
-    enabled: account && needsTooltip,
+    enabled: account != null && needsTooltip,
     items: [
       {
         name: 'account-rename',

--- a/upcoming-release-notes/account-context-menu.md
+++ b/upcoming-release-notes/account-context-menu.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [matt-fidd]
+---
+
+Fix context menu showing on multi-account views

--- a/upcoming-release-notes/account-context-menu.md
+++ b/upcoming-release-notes/account-context-menu.md
@@ -1,5 +1,5 @@
 ---
-category: Bugfixes
+category: Bugfix
 authors: [matt-fidd]
 ---
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

As it says on the tin, we shouldn't show the rename/close context menu when you right click on the all accounts, on budget, off budget, closed items.

Claude wrote the test

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
Before: right clicking on the multi-account views showed the context menu
After: it doesn't

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (+3.71 kB) | +0.03%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (+3.71 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/fr.json` | 📈 +3.7 kB (+2.20%) | 168.15 kB → 171.84 kB
`src/components/sidebar/Account.tsx` | 📈 +8 B (+0.11%) | 6.88 kB → 6.89 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 168.15 kB → 171.84 kB (+3.7 kB) | +2.20%
static/js/index.js | 1.57 MB → 1.57 MB (+8 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.79 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2.03 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C7Thu0FH.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->