### PR TITLE
[AI] Stop scanning every transaction once per rendered register row

### DIFF
--- a/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
+++ b/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
@@ -63,7 +63,13 @@ export function useTransactionRowContextActions({
       .map(id => id.split('/')[1]);
   }, [selectedIds]);
 
+  // This hook runs for every rendered transaction row, so only subscribe to
+  // schedules when the selection actually contains previews. Passing no query
+  // keeps `useSchedules` from opening live queries for ordinary transactions.
   const scheduleQuery = useMemo(() => {
+    if (scheduleIds.length === 0) {
+      return undefined;
+    }
     return q('schedules')
       .filter({ id: { $oneof: scheduleIds } })
       .select('*');

--- a/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
+++ b/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
@@ -63,9 +63,6 @@ export function useTransactionRowContextActions({
       .map(id => id.split('/')[1]);
   }, [selectedIds]);
 
-  // This hook runs for every rendered transaction row, so only subscribe to
-  // schedules when the selection actually contains previews. Passing no query
-  // keeps `useSchedules` from opening live queries for ordinary transactions.
   const scheduleQuery = useMemo(() => {
     if (scheduleIds.length === 0) {
       return undefined;

--- a/packages/desktop-client/src/hooks/useSchedules.test.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.test.ts
@@ -1,9 +1,9 @@
 import { q } from '@actual-app/core/shared/query';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Mock } from 'vitest';
 
 import { liveQuery } from '#queries/liveQuery';
+import type { LiveQuery } from '#queries/liveQuery';
 
 import { useSchedules } from './useSchedules';
 
@@ -16,8 +16,8 @@ vi.mock('./useSyncedPref', () => ({
 }));
 
 type LiveQueryCall = {
-  onData: (data: unknown[]) => void;
-  unsubscribe: Mock;
+  onData: (data: unknown[], previousData: unknown[]) => void;
+  unsubscribe: ReturnType<typeof vi.fn>;
 };
 
 describe('useSchedules', () => {
@@ -27,13 +27,18 @@ describe('useSchedules', () => {
     vi.clearAllMocks();
     calls = [];
 
-    (liveQuery as unknown as Mock).mockImplementation(
-      (_query, { onData }: { onData: (data: unknown[]) => void }) => {
-        const handle = { onData, unsubscribe: vi.fn() };
-        calls.push(handle);
-        return handle;
-      },
-    );
+    // `vi.mocked` keeps the mock bound to the real `liveQuery` signature, so a
+    // change to how the hook calls it still fails typecheck.
+    vi.mocked(liveQuery).mockImplementation((_query, { onData }) => {
+      const handle = {
+        onData: onData ?? vi.fn(),
+        unsubscribe: vi.fn(),
+      };
+      calls.push(handle);
+      // `LiveQuery` is a class with private state; only the subscription
+      // surface used by the hook is faked here.
+      return handle as unknown as LiveQuery<unknown>;
+    });
   });
 
   it('does not open any live query when no query is given', () => {
@@ -43,32 +48,30 @@ describe('useSchedules', () => {
   });
 
   it('unsubscribes the previous status query when schedules refresh', () => {
-    renderHook(() =>
-      useSchedules({ query: q('schedules').select('*') as never }),
-    );
+    renderHook(() => useSchedules({ query: q('schedules').select('*') }));
 
     // The schedules query is opened first; its onData opens the status query.
     expect(calls).toHaveLength(1);
     const schedulesQuery = calls[0];
 
-    schedulesQuery.onData([]);
+    schedulesQuery.onData([], []);
     expect(calls).toHaveLength(2);
     const firstStatusQuery = calls[1];
     expect(firstStatusQuery.unsubscribe).not.toHaveBeenCalled();
 
     // A refresh must tear down the previous status query rather than orphaning
     // it — an orphan stays subscribed to sync events and keeps re-running.
-    schedulesQuery.onData([]);
+    schedulesQuery.onData([], []);
     expect(firstStatusQuery.unsubscribe).toHaveBeenCalledTimes(1);
     expect(calls).toHaveLength(3);
   });
 
   it('unsubscribes both queries on unmount', () => {
     const { unmount } = renderHook(() =>
-      useSchedules({ query: q('schedules').select('*') as never }),
+      useSchedules({ query: q('schedules').select('*') }),
     );
 
-    calls[0].onData([]);
+    calls[0].onData([], []);
     expect(calls).toHaveLength(2);
 
     unmount();

--- a/packages/desktop-client/src/hooks/useSchedules.test.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.test.ts
@@ -1,0 +1,79 @@
+import { q } from '@actual-app/core/shared/query';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import { liveQuery } from '#queries/liveQuery';
+
+import { useSchedules } from './useSchedules';
+
+vi.mock('#queries/liveQuery', () => ({
+  liveQuery: vi.fn(),
+}));
+
+vi.mock('./useSyncedPref', () => ({
+  useSyncedPref: () => ['7', vi.fn()],
+}));
+
+type LiveQueryCall = {
+  onData: (data: unknown[]) => void;
+  unsubscribe: Mock;
+};
+
+describe('useSchedules', () => {
+  let calls: LiveQueryCall[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calls = [];
+
+    (liveQuery as unknown as Mock).mockImplementation(
+      (_query, { onData }: { onData: (data: unknown[]) => void }) => {
+        const handle = { onData, unsubscribe: vi.fn() };
+        calls.push(handle);
+        return handle;
+      },
+    );
+  });
+
+  it('does not open any live query when no query is given', () => {
+    renderHook(() => useSchedules({}));
+
+    expect(liveQuery).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes the previous status query when schedules refresh', () => {
+    renderHook(() =>
+      useSchedules({ query: q('schedules').select('*') as never }),
+    );
+
+    // The schedules query is opened first; its onData opens the status query.
+    expect(calls).toHaveLength(1);
+    const schedulesQuery = calls[0];
+
+    schedulesQuery.onData([]);
+    expect(calls).toHaveLength(2);
+    const firstStatusQuery = calls[1];
+    expect(firstStatusQuery.unsubscribe).not.toHaveBeenCalled();
+
+    // A refresh must tear down the previous status query rather than orphaning
+    // it — an orphan stays subscribed to sync events and keeps re-running.
+    schedulesQuery.onData([]);
+    expect(firstStatusQuery.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('unsubscribes both queries on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useSchedules({ query: q('schedules').select('*') as never }),
+    );
+
+    calls[0].onData([]);
+    expect(calls).toHaveLength(2);
+
+    unmount();
+
+    expect(calls[0].unsubscribe).toHaveBeenCalled();
+    expect(calls[1].unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -106,6 +106,10 @@ export function useSchedules({
 
     scheduleQueryRef.current = liveQuery<ScheduleEntity>(query, {
       onData: async schedules => {
+        // `onData` fires again whenever the schedules change, so tear down the
+        // previous status query first. Otherwise each refresh orphans a live
+        // query that stays subscribed to sync events and keeps re-running.
+        statusQueryRef.current?.unsubscribe();
         statusQueryRef.current = loadStatuses(
           schedules,
           (statuses: ScheduleStatuses) => {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -5,6 +5,7 @@ import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
+  getHasTransactionsQuery,
   getNextDate,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
@@ -266,6 +267,35 @@ describe('schedules', () => {
 
       // Should not crash; schedule with past end date produces its next_date entry only
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('getHasTransactionsQuery', () => {
+    it('matches nothing when there are no schedules', () => {
+      // An empty `$or` compiles away to no constraint at all, which would make
+      // this scan every transaction in the budget. It must never do that.
+      const filters = getHasTransactionsQuery([]).serialize().filterExpressions;
+
+      expect(filters).toEqual([{ id: null }]);
+      expect(filters[0]).not.toHaveProperty('$or');
+    });
+
+    it('filters by schedule and date when schedules are given', () => {
+      const filters = getHasTransactionsQuery([
+        {
+          id: 'schedule-1',
+          next_date: '2024-03-10',
+          _conditions: [{ op: 'is', field: 'date', value: '2024-03-10' }],
+        },
+      ]).serialize().filterExpressions;
+
+      expect(filters).toEqual([
+        {
+          $or: [
+            { $and: { schedule: 'schedule-1', date: { $gte: '2024-03-10' } } },
+          ],
+        },
+      ]);
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -136,11 +136,19 @@ export function getHasTransactionsQuery(schedules) {
     };
   });
 
-  return q('transactions')
+  const query = q('transactions')
     .options({ splits: 'all' })
-    .filter({ $or: filters })
     .orderBy({ date: 'desc' })
     .select(['schedule', 'date']);
+
+  // An empty `$or` compiles away to no constraint at all (`WHERE 1`), which
+  // would scan every transaction in the budget to answer a question about zero
+  // schedules. Match nothing instead — `id` is a primary key and never null.
+  if (filters.length === 0) {
+    return query.filter({ id: null });
+  }
+
+  return query.filter({ $or: filters });
 }
 
 type ScheduleRuleOptions = IRuleOptions & {

--- a/upcoming-release-notes/fix-per-row-schedule-fullscan.md
+++ b/upcoming-release-notes/fix-per-row-schedule-fullscan.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix the transaction list getting slower as a budget grows, especially when adding, clearing, or deleting transactions and when reconciling


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
This seems to be the real cause of the recent slowdowns.  Things are much faster when testing with an export of my budget.  Reconciling many transactions or adding a new transaction is much faster now.
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->
Found and fixed by Claude Opus
## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing
Import a budget file that has a large accounts > a year or so. 
Add new transactions.  The new transactions will take a long time to get added on edge but be fast here.
<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (+233 B) | +0.00%
loot-core | 1 | 4.63 MB → 4.63 MB (+86 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+84 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (+233 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useSchedules.ts` | 📈 +44 B (+1.38%) | 3.12 kB → 3.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +84 B (+1.19%) | 6.88 kB → 6.96 kB
`src/components/transactions/useTransactionRowContextActions.ts` | 📈 +105 B (+0.88%) | 11.66 kB → 11.76 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 2.03 MB → 2.03 MB (+233 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.79 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 168.15 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+86 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +86 B (+1.47%) | 5.73 kB → 5.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C7Thu0FH.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DMvmLzbd.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+84 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +84 B (+1.29%) | 6.36 kB → 6.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+84 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->