### PR TITLE
[WIP] ✨ Add date ranges to dashboard

### DIFF
--- a/packages/component-library/src/DateRangePicker.tsx
+++ b/packages/component-library/src/DateRangePicker.tsx
@@ -55,6 +55,7 @@ type DateRangePickerProps = {
   formatDayLabel?: (date: string) => string;
   labels: DateRangePickerLabels;
   onChangeDates: (start: string, end: string) => void;
+  isDisabled?: boolean;
 };
 
 // Far-future sentinel: sorts after any real date string.
@@ -80,6 +81,7 @@ export function DateRangePicker({
   formatDayLabel,
   labels,
   onChangeDates,
+  isDisabled,
 }: DateRangePickerProps) {
   const effectiveMax = maxDate ?? NO_MAX;
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -193,6 +195,7 @@ export function DateRangePicker({
       <Button
         ref={triggerRef}
         data-testid="date-range-picker-trigger"
+        isDisabled={isDisabled}
         onPress={() => (isOpen ? closeAndCommit() : openPopover())}
       >
         {label}

--- a/packages/component-library/src/DateRangePicker.tsx
+++ b/packages/component-library/src/DateRangePicker.tsx
@@ -42,6 +42,10 @@ type DateRangePickerProps = {
   minDate: string;
   /** Inclusive upper bound; omit for no upper limit. */
   maxDate?: string;
+  /** Month treated as current when LIVE dates use an external reference. */
+  referenceMonth?: string;
+  /** Explanation shown below the picker when an external reference is active. */
+  referenceHint?: string;
   /** Pass `['month', 'day']` for callers that handle day-shaped values. */
   granularities?: DateRangeGranularity[];
   presets?: DateRangePreset[];
@@ -74,6 +78,8 @@ export function DateRangePicker({
   end,
   minDate,
   maxDate,
+  referenceMonth,
+  referenceHint,
   granularities = ['month'],
   presets,
   firstDayOfWeek = 'sun',
@@ -212,95 +218,111 @@ export function DateRangePicker({
         }}
         style={{ padding: 0 }}
       >
-        <View style={{ flexDirection: isNarrowWidth ? 'column' : 'row' }}>
-          <View
-            style={{
-              padding: 15,
-              ...(hasSidebar &&
-                (isNarrowWidth
-                  ? { borderBottom: `1px solid ${theme.tableBorder}` }
-                  : { borderRight: `1px solid ${theme.tableBorder}` })),
-            }}
-          >
-            {isDay ? (
-              <DayRangeCalendar
-                start={draftStart}
-                end={draftEnd}
-                min={dayMin}
-                max={dayMax}
-                firstDayOfWeek={firstDayOfWeek}
-                locale={locale}
-                labels={labels}
-                onChange={setDraft}
-              />
-            ) : (
-              <RangeSelector
-                start={draftStart}
-                end={draftEnd}
-                min={monthMin}
-                max={monthMax}
-                locale={locale}
-                labels={labels}
-                onChange={setDraft}
-              />
+        <View>
+          <View style={{ flexDirection: isNarrowWidth ? 'column' : 'row' }}>
+            <View
+              style={{
+                padding: 15,
+                ...(hasSidebar &&
+                  (isNarrowWidth
+                    ? { borderBottom: `1px solid ${theme.tableBorder}` }
+                    : { borderRight: `1px solid ${theme.tableBorder}` })),
+              }}
+            >
+              {isDay ? (
+                <DayRangeCalendar
+                  start={draftStart}
+                  end={draftEnd}
+                  min={dayMin}
+                  max={dayMax}
+                  firstDayOfWeek={firstDayOfWeek}
+                  locale={locale}
+                  labels={labels}
+                  onChange={setDraft}
+                />
+              ) : (
+                <RangeSelector
+                  start={draftStart}
+                  end={draftEnd}
+                  min={monthMin}
+                  max={monthMax}
+                  referenceMonth={referenceMonth}
+                  locale={locale}
+                  labels={labels}
+                  onChange={setDraft}
+                />
+              )}
+            </View>
+
+            {hasSidebar && (
+              <View style={{ padding: 15, minWidth: 140, gap: 16 }}>
+                {showGranularityToggle && (
+                  <View>
+                    <Text style={sectionTitleStyle}>{labels.selectBy}</Text>
+                    <GranularityToggle
+                      value={isDay ? 'day' : 'month'}
+                      monthLabel={labels.month}
+                      dayLabel={labels.day}
+                      onChange={changeGranularity}
+                    />
+                  </View>
+                )}
+
+                {Boolean(presets?.length) && (
+                  <View>
+                    <Text style={sectionTitleStyle}>{labels.quickSelect}</Text>
+                    <View style={{ gap: 4 }}>
+                      {presets?.map(preset => {
+                        // Derive the active preset from the shown range instead
+                        // of storing it, so it survives closing and reopening
+                        // without persisting anything.
+                        const [presetStart, presetEnd] = preset.getRange();
+                        const isActive =
+                          presetStart === draftStart && presetEnd === draftEnd;
+                        return (
+                          <Button
+                            key={preset.key}
+                            variant={isActive ? 'primary' : 'bare'}
+                            aria-pressed={isActive}
+                            onPress={() => {
+                              // Preview in the draft; the commit happens on
+                              // close, like manual selection.
+                              setDraftStart(presetStart);
+                              setDraftEnd(presetEnd);
+                              setDraftPreset(preset);
+                            }}
+                            style={{
+                              justifyContent: 'flex-start',
+                              fontSize: 13,
+                              // Match primary's 1px border so toggling the
+                              // active preset doesn't shift the list.
+                              ...(!isActive && {
+                                border: '1px solid transparent',
+                              }),
+                            }}
+                          >
+                            {preset.label}
+                          </Button>
+                        );
+                      })}
+                    </View>
+                  </View>
+                )}
+              </View>
             )}
           </View>
 
-          {hasSidebar && (
-            <View style={{ padding: 15, minWidth: 140, gap: 16 }}>
-              {showGranularityToggle && (
-                <View>
-                  <Text style={sectionTitleStyle}>{labels.selectBy}</Text>
-                  <GranularityToggle
-                    value={isDay ? 'day' : 'month'}
-                    monthLabel={labels.month}
-                    dayLabel={labels.day}
-                    onChange={changeGranularity}
-                  />
-                </View>
-              )}
-
-              {Boolean(presets?.length) && (
-                <View>
-                  <Text style={sectionTitleStyle}>{labels.quickSelect}</Text>
-                  <View style={{ gap: 4 }}>
-                    {presets?.map(preset => {
-                      // Derive the active preset from the shown range instead
-                      // of storing it, so it survives closing and reopening
-                      // without persisting anything.
-                      const [presetStart, presetEnd] = preset.getRange();
-                      const isActive =
-                        presetStart === draftStart && presetEnd === draftEnd;
-                      return (
-                        <Button
-                          key={preset.key}
-                          variant={isActive ? 'primary' : 'bare'}
-                          aria-pressed={isActive}
-                          onPress={() => {
-                            // Preview in the draft; the commit happens on
-                            // close, like manual selection.
-                            setDraftStart(presetStart);
-                            setDraftEnd(presetEnd);
-                            setDraftPreset(preset);
-                          }}
-                          style={{
-                            justifyContent: 'flex-start',
-                            fontSize: 13,
-                            // Match primary's 1px border so toggling the
-                            // active preset doesn't shift the list.
-                            ...(!isActive && {
-                              border: '1px solid transparent',
-                            }),
-                          }}
-                        >
-                          {preset.label}
-                        </Button>
-                      );
-                    })}
-                  </View>
-                </View>
-              )}
-            </View>
+          {referenceHint && (
+            <Text
+              style={{
+                padding: '8px 15px',
+                borderTop: `1px solid ${theme.tableBorder}`,
+                color: theme.pageTextSubdued,
+                fontSize: 11,
+              }}
+            >
+              {referenceHint}
+            </Text>
           )}
         </View>
       </Popover>

--- a/packages/component-library/src/ModeButton.tsx
+++ b/packages/component-library/src/ModeButton.tsx
@@ -11,6 +11,7 @@ type ModeButtonProps = {
   children: ReactNode;
   style?: CSSProperties;
   onSelect: () => void;
+  isDisabled?: boolean;
 };
 
 export function ModeButton({
@@ -18,6 +19,7 @@ export function ModeButton({
   children,
   style,
   onSelect,
+  isDisabled,
 }: ModeButtonProps) {
   return (
     <Button
@@ -37,6 +39,7 @@ export function ModeButton({
         }),
       })}
       onPress={onSelect}
+      isDisabled={isDisabled}
     >
       {children}
     </Button>

--- a/packages/component-library/src/date-range-picker/GridButton.tsx
+++ b/packages/component-library/src/date-range-picker/GridButton.tsx
@@ -10,6 +10,8 @@ type GridButtonProps = {
   disabled: boolean;
   /** Marks the current month/day so it stands out even when not selected. */
   isToday?: boolean;
+  /** Marks an externally referenced current month. */
+  isReferenceDate?: boolean;
   /** Where the cell falls in the range band (or the hover preview). */
   position?: RangePosition;
   /** Full accessible name (e.g. the complete localized date). */
@@ -24,6 +26,7 @@ export function GridButton({
   selected,
   disabled,
   isToday = false,
+  isReferenceDate = false,
   position = null,
   label,
   onSelect,
@@ -38,6 +41,7 @@ export function GridButton({
       isDisabled={disabled}
       aria-label={label}
       aria-pressed={selected}
+      aria-current={isToday || isReferenceDate ? 'date' : undefined}
       onPress={onSelect}
       onHoverStart={onHover}
       style={{
@@ -51,6 +55,12 @@ export function GridButton({
           fontWeight: 'bold',
           // Inset ring marks the current period without shifting layout.
           boxShadow: `inset 0 0 0 1px ${theme.pageTextPositive}`,
+          ...(!selected && { color: theme.pageTextPositive }),
+        }),
+        ...(isReferenceDate && {
+          fontWeight: 'bold',
+          outline: `1px dashed ${theme.pageTextPositive}`,
+          outlineOffset: -2,
           ...(!selected && { color: theme.pageTextPositive }),
         }),
         ...(inRange &&

--- a/packages/component-library/src/date-range-picker/MonthGrid.tsx
+++ b/packages/component-library/src/date-range-picker/MonthGrid.tsx
@@ -16,6 +16,7 @@ type MonthGridProps = {
   rangeEnd: string;
   minMonth: string;
   maxMonth: string;
+  referenceMonth?: string;
   /** BCP 47 language tag driving the month labels. */
   locale: string;
   onSelect: (month: string) => void;
@@ -29,6 +30,7 @@ export function MonthGrid({
   rangeEnd,
   minMonth,
   maxMonth,
+  referenceMonth,
   locale,
   onSelect,
   onHover,
@@ -65,6 +67,7 @@ export function MonthGrid({
           selected={month === rangeStart || month === rangeEnd}
           disabled={month < minMonth || month > maxMonth}
           isToday={month === thisMonth}
+          isReferenceDate={month === referenceMonth}
           position={rangePosition(month, rangeStart, rangeEnd)}
           label={fullLabel}
           onSelect={() => onSelect(month)}

--- a/packages/component-library/src/date-range-picker/RangeSelector.tsx
+++ b/packages/component-library/src/date-range-picker/RangeSelector.tsx
@@ -13,6 +13,7 @@ type RangeSelectorProps = {
   end: string;
   min: string;
   max: string;
+  referenceMonth?: string;
   locale: string;
   labels: Pick<DateRangePickerLabels, 'previous' | 'next'>;
   onChange: (start: string, end: string) => void;
@@ -24,6 +25,7 @@ export function RangeSelector({
   end,
   min,
   max,
+  referenceMonth,
   locale,
   labels,
   onChange,
@@ -83,6 +85,7 @@ export function RangeSelector({
         rangeEnd={bandEnd}
         minMonth={min}
         maxMonth={max}
+        referenceMonth={referenceMonth}
         locale={locale}
         onSelect={pick}
         onHover={anchor ? setHoverValue : undefined}

--- a/packages/component-library/src/date-range-picker/RangeSelector.web.test.tsx
+++ b/packages/component-library/src/date-range-picker/RangeSelector.web.test.tsx
@@ -29,4 +29,33 @@ describe('RangeSelector', () => {
     rerender(<RangeSelector {...defaultProps} start="2024-05" end="2025-03" />);
     expect(screen.getByText('2025')).toBeTruthy();
   });
+
+  it('marks an external reference month as current', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00Z'));
+    try {
+      render(
+        <RangeSelector
+          {...defaultProps}
+          start="2026-05"
+          end="2026-05"
+          referenceMonth="2026-08"
+        />,
+      );
+
+      expect(
+        screen
+          .getByRole('button', { name: 'August 2026' })
+          .getAttribute('aria-current'),
+      ).toBe('date');
+
+      expect(
+        screen
+          .getByRole('button', { name: 'May 2026' })
+          .getAttribute('aria-current'),
+      ).toBe('date');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -54,15 +54,14 @@ test.describe('Reports', () => {
     await expect(menu.getByRole('button', { name: 'Rename' })).toBeVisible();
   });
 
-  test('enables shared dashboard date controls', async () => {
-    await page.getByRole('button', { name: 'Menu' }).click();
-    await page
-      .getByRole('menu')
-      .getByRole('button', { name: 'Enable date ranges' })
-      .click();
-
+  test('shows shared dashboard date controls', async () => {
     const controls = page.getByTestId('dashboard-date-range-controls');
-    await expect(controls.getByRole('button', { name: 'Live' })).toBeVisible();
+    await expect(
+      controls.getByRole('button', { name: 'Clear' }),
+    ).not.toBeVisible();
+    await expect(
+      controls.getByRole('button', { name: 'Live' }),
+    ).not.toBeVisible();
     await expect(
       controls.getByTestId('date-range-picker-trigger'),
     ).toBeVisible();

--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -54,6 +54,21 @@ test.describe('Reports', () => {
     await expect(menu.getByRole('button', { name: 'Rename' })).toBeVisible();
   });
 
+  test('enables shared dashboard date controls', async () => {
+    await page.getByRole('button', { name: 'Menu' }).click();
+    await page
+      .getByRole('menu')
+      .getByRole('button', { name: 'Enable date ranges' })
+      .click();
+
+    const controls = page.getByTestId('dashboard-date-range-controls');
+    await expect(controls.getByRole('button', { name: 'Live' })).toBeVisible();
+    await expect(
+      controls.getByTestId('date-range-picker-trigger'),
+    ).toBeVisible();
+    await expect(controls).toMatchThemeScreenshots();
+  });
+
   test('loads net worth graph and checks visuals', async () => {
     await reportsPage.goToNetWorthPage();
     await expect(page).toMatchThemeScreenshots();

--- a/packages/desktop-client/src/components/formula/QueryManager.tsx
+++ b/packages/desktop-client/src/components/formula/QueryManager.tsx
@@ -11,10 +11,13 @@ import { Popover } from '@actual-app/components/popover';
 import { Select } from '@actual-app/components/select';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Toggle } from '@actual-app/components/toggle';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
+  DashboardDateScope,
+  FormulaQueryConfig,
   RuleConditionEntity,
   TimeFrame,
 } from '@actual-app/core/types/models';
@@ -42,12 +45,6 @@ import {
   normalizeQueryTimeFrameStart,
 } from './queryTimeFrame';
 
-type QueryConfig = {
-  conditions?: RuleConditionEntity[];
-  conditionsOp?: 'and' | 'or';
-  timeFrame?: TimeFrame;
-};
-
 type PresetTimeRangeMode = Exclude<
   TimeFrame['mode'],
   'sliding-window' | 'static'
@@ -60,11 +57,16 @@ function isPresetTimeRangeMode(
 }
 
 type QueryManagerProps = {
-  queries: Record<string, QueryConfig>;
-  onQueriesChange: (queries: Record<string, QueryConfig>) => void;
+  queries: Record<string, FormulaQueryConfig>;
+  onQueriesChange: (queries: Record<string, FormulaQueryConfig>) => void;
+  dashboardScope?: DashboardDateScope | null;
 };
 
-export function QueryManager({ queries, onQueriesChange }: QueryManagerProps) {
+export function QueryManager({
+  queries,
+  onQueriesChange,
+  dashboardScope,
+}: QueryManagerProps) {
   const { t } = useTranslation();
   const [newQueryName, setNewQueryName] = useState('');
   const [isAddingQuery, setIsAddingQuery] = useState(false);
@@ -95,6 +97,7 @@ export function QueryManager({ queries, onQueriesChange }: QueryManagerProps) {
           end: monthUtils.currentDay(),
           mode: 'sliding-window',
         },
+        ...(dashboardScope ? { useDashboardDateRange: true } : null),
       },
     });
 
@@ -108,7 +111,7 @@ export function QueryManager({ queries, onQueriesChange }: QueryManagerProps) {
     onQueriesChange(newQueries);
   }
 
-  function handleUpdateQuery(queryName: string, config: QueryConfig) {
+  function handleUpdateQuery(queryName: string, config: FormulaQueryConfig) {
     onQueriesChange({
       ...queries,
       [queryName]: config,
@@ -198,6 +201,7 @@ export function QueryManager({ queries, onQueriesChange }: QueryManagerProps) {
               defaultConfig={config}
               onUpdate={newConfig => handleUpdateQuery(queryName, newConfig)}
               onRemove={() => handleRemoveQuery(queryName)}
+              dashboardScope={dashboardScope}
             />
           ))}
         </View>
@@ -208,9 +212,10 @@ export function QueryManager({ queries, onQueriesChange }: QueryManagerProps) {
 
 type QueryItemProps = {
   queryName: string;
-  defaultConfig: QueryConfig;
-  onUpdate: (config: QueryConfig) => void;
+  defaultConfig: FormulaQueryConfig;
+  onUpdate: (config: FormulaQueryConfig) => void;
   onRemove: () => void;
+  dashboardScope?: DashboardDateScope | null;
 };
 
 function QueryItem({
@@ -218,6 +223,7 @@ function QueryItem({
   defaultConfig,
   onUpdate,
   onRemove,
+  dashboardScope,
 }: QueryItemProps) {
   const locale = useLocale();
   const { t } = useTranslation();
@@ -225,6 +231,9 @@ function QueryItem({
   const dispatch = useDispatch<AppDispatch>();
   const timeRangeMenuTriggerRef = useRef(null);
   const [timeRangeMenuOpen, setTimeRangeMenuOpen] = useState(false);
+  const [useDashboardDateRange, setUseDashboardDateRange] = useState(
+    defaultConfig.useDashboardDateRange ?? true,
+  );
 
   // Time range state
   const [startDate, setStartDate] = useState(
@@ -344,6 +353,7 @@ function QueryItem({
       onUpdate({
         conditions,
         conditionsOp,
+        useDashboardDateRange,
         timeFrame: {
           start: newStartDate,
           end: newEndDate,
@@ -358,6 +368,7 @@ function QueryItem({
       startDate,
       endDate,
       onUpdate,
+      useDashboardDateRange,
     ],
   );
 
@@ -493,6 +504,18 @@ function QueryItem({
   }
 
   const timeRangeMode = timeRangeRef.current as TimeFrame['mode'];
+  const isUsingDashboardDateRange = Boolean(
+    dashboardScope && useDashboardDateRange,
+  );
+  const displayedStartDate = isUsingDashboardDateRange
+    ? (dashboardScope?.start ?? startDate)
+    : startDate;
+  const displayedEndDate = isUsingDashboardDateRange
+    ? (dashboardScope?.end ?? endDate)
+    : endDate;
+  const displayedTimeRangeMode = isUsingDashboardDateRange
+    ? (dashboardScope?.mode ?? timeRangeMode)
+    : timeRangeMode;
   const isPresetTimeRange = isPresetTimeRangeMode(timeRangeMode);
   const timeRangeLabels = {
     'sliding-window': t('Live'),
@@ -503,7 +526,7 @@ function QueryItem({
     yearToDate: t('Year to date'),
     priorYearToDate: t('Prior year to date'),
   } satisfies Record<TimeFrame['mode'], string>;
-  const timeRangeLabel = timeRangeLabels[timeRangeMode];
+  const timeRangeLabel = timeRangeLabels[displayedTimeRangeMode];
   const presetTimeRangeLabels = {
     full: t('All time transactions'),
     lastMonth: t('Last month transactions'),
@@ -557,6 +580,31 @@ function QueryItem({
             alignItems: 'center',
           }}
         >
+          {dashboardScope && (
+            <View
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              <label
+                htmlFor={`formula-query-dashboard-range-${queryName}`}
+                style={{ fontSize: 12 }}
+              >
+                <Trans>Dashboard dates</Trans>
+              </label>
+              <Toggle
+                id={`formula-query-dashboard-range-${queryName}`}
+                isOn={useDashboardDateRange}
+                onToggle={value => {
+                  setUseDashboardDateRange(value);
+                  onUpdate({ ...defaultConfig, useDashboardDateRange: value });
+                }}
+              />
+            </View>
+          )}
           <View style={{ display: 'flex', flexDirection: 'row', gap: 4 }}>
             <Button
               variant="bare"
@@ -656,17 +704,19 @@ function QueryItem({
 
       <View style={{ marginBottom: 12 }}>
         <View
+          inert={isUsingDashboardDateRange}
           style={{
             display: 'flex',
             flexDirection: 'row',
             justifyContent: 'flex-end',
             gap: 8,
             marginTop: 16,
+            ...(isUsingDashboardDateRange ? { opacity: 0.5 } : null),
           }}
         >
           <Button
             style={{ minWidth: 50 }}
-            variant={timeRangeMode === 'static' ? 'normal' : 'primary'}
+            variant={displayedTimeRangeMode === 'static' ? 'normal' : 'primary'}
             onPress={() => {
               const newMode =
                 timeRangeMode === 'static' ? 'sliding-window' : 'static';
@@ -829,7 +879,7 @@ function QueryItem({
           </Popover>
         </View>
 
-        {presetTimeRangeLabel ? (
+        {!isUsingDashboardDateRange && presetTimeRangeLabel ? (
           <Input
             value={presetTimeRangeLabel}
             readOnly
@@ -842,7 +892,7 @@ function QueryItem({
           />
         ) : null}
 
-        {allMonths.length > 0 && (
+        {(isUsingDashboardDateRange || allMonths.length > 0) && (
           <View
             style={{
               display: 'flex',
@@ -853,10 +903,10 @@ function QueryItem({
             }}
           >
             <Select
-              disabled={isPresetTimeRange}
-              value={fromDateRepr(startDate)}
+              disabled={isUsingDashboardDateRange || isPresetTimeRange}
+              value={fromDateRepr(displayedStartDate)}
               defaultLabel={monthUtils.format(
-                fromDateRepr(startDate),
+                fromDateRepr(displayedStartDate),
                 'MMMM yyyy',
                 locale,
               )}
@@ -876,10 +926,10 @@ function QueryItem({
               <Trans>to</Trans>
             </Text>
             <Select
-              disabled={isPresetTimeRange}
-              value={fromDateRepr(endDate)}
+              disabled={isUsingDashboardDateRange || isPresetTimeRange}
+              value={fromDateRepr(displayedEndDate)}
               defaultLabel={monthUtils.format(
-                fromDateRepr(endDate),
+                fromDateRepr(displayedEndDate),
                 'MMMM yyyy',
                 locale,
               )}

--- a/packages/desktop-client/src/components/formula/QueryManager.tsx
+++ b/packages/desktop-client/src/components/formula/QueryManager.tsx
@@ -11,7 +11,6 @@ import { Popover } from '@actual-app/components/popover';
 import { Select } from '@actual-app/components/select';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
-import { Toggle } from '@actual-app/components/toggle';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
@@ -348,12 +347,13 @@ function QueryItem({
       newStartDate = startDate,
       newEndDate = endDate,
       mode = timeRangeRef.current as TimeFrame['mode'],
+      newUseDashboardDateRange = useDashboardDateRange,
     ) => {
       timeRangeRef.current = mode;
       onUpdate({
         conditions,
         conditionsOp,
-        useDashboardDateRange,
+        useDashboardDateRange: newUseDashboardDateRange,
         timeFrame: {
           start: newStartDate,
           end: newEndDate,
@@ -526,7 +526,9 @@ function QueryItem({
     yearToDate: t('Year to date'),
     priorYearToDate: t('Prior year to date'),
   } satisfies Record<TimeFrame['mode'], string>;
-  const timeRangeLabel = timeRangeLabels[displayedTimeRangeMode];
+  const timeRangeLabel = isUsingDashboardDateRange
+    ? t('Dashboard')
+    : timeRangeLabels[displayedTimeRangeMode];
   const presetTimeRangeLabels = {
     full: t('All time transactions'),
     lastMonth: t('Last month transactions'),
@@ -580,31 +582,6 @@ function QueryItem({
             alignItems: 'center',
           }}
         >
-          {dashboardScope && (
-            <View
-              style={{
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                gap: 4,
-              }}
-            >
-              <label
-                htmlFor={`formula-query-dashboard-range-${queryName}`}
-                style={{ fontSize: 12 }}
-              >
-                <Trans>Dashboard dates</Trans>
-              </label>
-              <Toggle
-                id={`formula-query-dashboard-range-${queryName}`}
-                isOn={useDashboardDateRange}
-                onToggle={value => {
-                  setUseDashboardDateRange(value);
-                  onUpdate({ ...defaultConfig, useDashboardDateRange: value });
-                }}
-              />
-            </View>
-          )}
           <View style={{ display: 'flex', flexDirection: 'row', gap: 4 }}>
             <Button
               variant="bare"
@@ -704,20 +681,35 @@ function QueryItem({
 
       <View style={{ marginBottom: 12 }}>
         <View
-          inert={isUsingDashboardDateRange}
           style={{
             display: 'flex',
             flexDirection: 'row',
             justifyContent: 'flex-end',
             gap: 8,
             marginTop: 16,
-            ...(isUsingDashboardDateRange ? { opacity: 0.5 } : null),
           }}
         >
           <Button
             style={{ minWidth: 50 }}
-            variant={displayedTimeRangeMode === 'static' ? 'normal' : 'primary'}
+            variant={
+              isUsingDashboardDateRange || displayedTimeRangeMode !== 'static'
+                ? 'primary'
+                : 'normal'
+            }
             onPress={() => {
+              if (isUsingDashboardDateRange) {
+                setUseDashboardDateRange(false);
+                onUpdate({ ...defaultConfig, useDashboardDateRange: false });
+                return;
+              }
+
+              if (timeRangeMode === 'static' && dashboardScope) {
+                setUseDashboardDateRange(true);
+                onUpdate({ ...defaultConfig, useDashboardDateRange: true });
+                return;
+              }
+
+              setUseDashboardDateRange(false);
               const newMode =
                 timeRangeMode === 'static' ? 'sliding-window' : 'static';
               const [newStart, newEnd] = calculateTimeRange(
@@ -737,6 +729,7 @@ function QueryItem({
                 newStart,
                 newEnd,
                 newMode,
+                false,
               );
             }}
           >
@@ -850,6 +843,7 @@ function QueryItem({
                 }
                 setStartDate(start);
                 setEndDate(end);
+                setUseDashboardDateRange(false);
                 timeRangeRef.current = mode;
                 sendUpdate(
                   filters.conditions,
@@ -857,6 +851,7 @@ function QueryItem({
                   start,
                   end,
                   mode,
+                  false,
                 );
                 setTimeRangeMenuOpen(false);
               }}

--- a/packages/desktop-client/src/components/reports/DashboardDateRangeControls.tsx
+++ b/packages/desktop-client/src/components/reports/DashboardDateRangeControls.tsx
@@ -1,48 +1,40 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+import { Button } from '@actual-app/components/button';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
   DashboardDateScope,
-  DashboardPageEntity,
   TimeFrame,
 } from '@actual-app/core/types/models';
-
-import { useUpdateDashboardDateRangeMutation } from '#reports/mutations';
 
 import { Header } from './Header';
 
 type DashboardDateRangeControlsProps = {
-  dashboard: DashboardPageEntity;
+  timeFrame: TimeFrame | null;
   scope: DashboardDateScope | null;
+  onChange: (timeFrame: TimeFrame) => void;
+  onClear: () => void;
   allMonths: Array<{ name: string }>;
   earliestTransaction: string;
   latestTransaction: string;
 };
 
 export function DashboardDateRangeControls({
-  dashboard,
+  timeFrame,
   scope,
+  onChange,
+  onClear,
   allMonths,
   earliestTransaction,
   latestTransaction,
 }: DashboardDateRangeControlsProps) {
-  const updateDateRange = useUpdateDashboardDateRangeMutation();
-  const timeFrame: TimeFrame = dashboard.time_frame ?? {
+  const { t } = useTranslation();
+  const displayedTimeFrame = timeFrame ?? {
     start: monthUtils.subMonths(monthUtils.currentMonth(), 5),
     end: monthUtils.currentMonth(),
     mode: 'sliding-window',
   };
-
-  function update(time_frame: TimeFrame) {
-    updateDateRange.mutate({
-      id: dashboard.id,
-      date_range_enabled: true,
-      time_frame,
-    });
-  }
-
-  if (!dashboard.date_range_enabled || !scope) {
-    return null;
-  }
 
   return (
     <View
@@ -52,19 +44,29 @@ export function DashboardDateRangeControls({
         alignItems: 'center',
         flexWrap: 'wrap',
         gap: 5,
+        opacity: timeFrame ? 1 : 0.6,
       }}
     >
       <Header
         allMonths={allMonths}
-        start={timeFrame.start}
-        end={timeFrame.end}
-        mode={timeFrame.mode}
-        resolvedTimeFrame={scope}
+        start={displayedTimeFrame.start}
+        end={displayedTimeFrame.end}
+        mode={displayedTimeFrame.mode}
+        resolvedTimeFrame={scope ?? undefined}
+        dateRangeLabel={t('Widget timeframe')}
+        hideModeToggle
         preserveRangeOnModeChange
         contentPadding={0}
         earliestTransaction={earliestTransaction}
         latestTransaction={latestTransaction}
-        onChangeDates={(start, end, mode) => update({ start, end, mode })}
+        onChangeDates={(start, end, mode) => onChange({ start, end, mode })}
+        inlineContent={
+          timeFrame && (
+            <Button variant="bare" onPress={onClear}>
+              <Trans>Clear</Trans>
+            </Button>
+          )
+        }
       />
     </View>
   );

--- a/packages/desktop-client/src/components/reports/DashboardDateRangeControls.tsx
+++ b/packages/desktop-client/src/components/reports/DashboardDateRangeControls.tsx
@@ -1,0 +1,71 @@
+import { View } from '@actual-app/components/view';
+import * as monthUtils from '@actual-app/core/shared/months';
+import type {
+  DashboardDateScope,
+  DashboardPageEntity,
+  TimeFrame,
+} from '@actual-app/core/types/models';
+
+import { useUpdateDashboardDateRangeMutation } from '#reports/mutations';
+
+import { Header } from './Header';
+
+type DashboardDateRangeControlsProps = {
+  dashboard: DashboardPageEntity;
+  scope: DashboardDateScope | null;
+  allMonths: Array<{ name: string }>;
+  earliestTransaction: string;
+  latestTransaction: string;
+};
+
+export function DashboardDateRangeControls({
+  dashboard,
+  scope,
+  allMonths,
+  earliestTransaction,
+  latestTransaction,
+}: DashboardDateRangeControlsProps) {
+  const updateDateRange = useUpdateDashboardDateRangeMutation();
+  const timeFrame: TimeFrame = dashboard.time_frame ?? {
+    start: monthUtils.subMonths(monthUtils.currentMonth(), 5),
+    end: monthUtils.currentMonth(),
+    mode: 'sliding-window',
+  };
+
+  function update(time_frame: TimeFrame) {
+    updateDateRange.mutate({
+      id: dashboard.id,
+      date_range_enabled: true,
+      time_frame,
+    });
+  }
+
+  if (!dashboard.date_range_enabled || !scope) {
+    return null;
+  }
+
+  return (
+    <View
+      data-testid="dashboard-date-range-controls"
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 5,
+      }}
+    >
+      <Header
+        allMonths={allMonths}
+        start={timeFrame.start}
+        end={timeFrame.end}
+        mode={timeFrame.mode}
+        resolvedTimeFrame={scope}
+        preserveRangeOnModeChange
+        contentPadding={0}
+        earliestTransaction={earliestTransaction}
+        latestTransaction={latestTransaction}
+        onChangeDates={(start, end, mode) => update({ start, end, mode })}
+      />
+    </View>
+  );
+}

--- a/packages/desktop-client/src/components/reports/DashboardDateScope.test.ts
+++ b/packages/desktop-client/src/components/reports/DashboardDateScope.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest';
+
+import { addDashboardDateScopeToUrl } from './DashboardDateScope';
+
+it('serializes the resolved dashboard editing snapshot', () => {
+  expect(
+    addDashboardDateScopeToUrl(
+      '/reports/net-worth?id=report',
+      { start: '2026-03', end: '2026-08', mode: 'sliding-window' },
+      'widget-id',
+    ),
+  ).toBe(
+    '/reports/net-worth?id=report&dashboardStart=2026-03&dashboardEnd=2026-08&dashboardMode=sliding-window&dashboardWidget=widget-id',
+  );
+});

--- a/packages/desktop-client/src/components/reports/DashboardDateScope.tsx
+++ b/packages/desktop-client/src/components/reports/DashboardDateScope.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+import type { DashboardDateScope } from '@actual-app/core/types/models';
+
+const DashboardDateScopeContext = createContext<DashboardDateScope | null>(
+  null,
+);
+
+export function DashboardDateScopeProvider({
+  scope,
+  children,
+}: {
+  scope: DashboardDateScope | null;
+  children: ReactNode;
+}) {
+  return (
+    <DashboardDateScopeContext.Provider value={scope}>
+      {children}
+    </DashboardDateScopeContext.Provider>
+  );
+}
+
+export function useDashboardDateScope() {
+  return useContext(DashboardDateScopeContext);
+}
+
+export function addDashboardDateScopeToUrl(
+  destination: string,
+  scope: DashboardDateScope,
+  widgetId: string,
+) {
+  const [path, query = ''] = destination.split('?');
+  const params = new URLSearchParams(query);
+  params.set('dashboardStart', scope.start);
+  params.set('dashboardEnd', scope.end);
+  params.set('dashboardMode', scope.mode);
+  params.set('dashboardWidget', widgetId);
+  return `${path}?${params}`;
+}

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -27,7 +27,7 @@ import { getFirstDayOfWeek } from '#components/select/getFirstDayOfWeek';
 import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useDateFormat } from '#hooks/useDateFormat';
-import { useLanguage } from '#hooks/useLocale';
+import { useLanguage, useLocale } from '#hooks/useLocale';
 import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
 import { getLiveRange } from './getLiveRange';
@@ -117,6 +117,7 @@ export function Header({
   const { t } = useTranslation();
   const { isNarrowWidth } = useResponsive();
   const language = useLanguage();
+  const locale = useLocale();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
   const [searchParams] = useSearchParams();
   const routeParams = useParams();
@@ -143,6 +144,13 @@ export function Header({
             dashboardScope!.end,
           )
         : [start, end, mode];
+  const liveReferenceDate =
+    hasDashboardContext && !useDashboardDateRange && displayMode !== 'static'
+      ? dashboardScope!.end
+      : undefined;
+  const liveReferenceMonth = liveReferenceDate
+    ? monthUtils.getMonth(liveReferenceDate)
+    : undefined;
   const commitDates = (
     newStart: string,
     newEnd: string,
@@ -165,6 +173,7 @@ export function Header({
       latestTransaction,
       includeCurrentInterval,
       firstDayOfWeekIdx,
+      liveReferenceDate,
     );
     return [
       monthUtils.getMonth(rangeStart),
@@ -217,17 +226,19 @@ export function Header({
         ...(show1Month
           ? [
               makePreset('1-month', <Trans>1 month</Trans>, () =>
-                getLatestRange(0),
+                getLatestRange(0, liveReferenceDate),
               ),
             ]
           : []),
         makePreset('3-months', <Trans>3 months</Trans>, () =>
-          getLatestRange(2),
+          getLatestRange(2, liveReferenceDate),
         ),
         makePreset('6-months', <Trans>6 months</Trans>, () =>
-          getLatestRange(5),
+          getLatestRange(5, liveReferenceDate),
         ),
-        makePreset('1-year', <Trans>1 year</Trans>, () => getLatestRange(11)),
+        makePreset('1-year', <Trans>1 year</Trans>, () =>
+          getLatestRange(11, liveReferenceDate),
+        ),
         makePreset('year-to-date', <Trans>Year to date</Trans>, () =>
           liveRangeAsMonths('Year to date', true, 'yearToDate'),
         ),
@@ -317,6 +328,18 @@ export function Header({
           <DateRangePicker
             start={displayStart}
             end={displayEnd}
+            referenceMonth={liveReferenceMonth}
+            referenceHint={
+              liveReferenceMonth
+                ? t('Live ranges use {{month}} as the reference month.', {
+                    month: monthUtils.format(
+                      liveReferenceMonth,
+                      'MMMM yyyy',
+                      locale,
+                    ),
+                  })
+                : undefined
+            }
             isDisabled={useDashboardDateRange}
             granularities={granularities}
             // allMonths is newest-first and may be empty before reports load.
@@ -328,9 +351,13 @@ export function Header({
             maxDate={
               showFutureRange
                 ? undefined
-                : allMonths.length
-                  ? allMonths[0].name
-                  : monthUtils.currentMonth()
+                : liveReferenceMonth &&
+                    (!allMonths.length ||
+                      liveReferenceMonth > allMonths[0].name)
+                  ? liveReferenceMonth
+                  : allMonths.length
+                    ? allMonths[0].name
+                    : monthUtils.currentMonth()
             }
             firstDayOfWeek={getFirstDayOfWeek(firstDayOfWeekIdx)}
             locale={language}

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -10,7 +10,6 @@ import type {
 } from '@actual-app/components/date-range-picker';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SpaceBetween } from '@actual-app/components/space-between';
-import { Toggle } from '@actual-app/components/toggle';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
@@ -49,6 +48,7 @@ type HeaderProps = {
   preserveRangeOnModeChange?: boolean;
   contentPadding?: number;
   resolvedTimeFrame?: DashboardDateScope;
+  dateRangeLabel?: string;
   allMonths: Array<{ name: string }>;
   earliestTransaction: string;
   latestTransaction: string;
@@ -97,6 +97,7 @@ export function Header({
   preserveRangeOnModeChange,
   contentPadding,
   resolvedTimeFrame,
+  dateRangeLabel,
   allMonths,
   earliestTransaction,
   latestTransaction,
@@ -132,6 +133,12 @@ export function Header({
     isUsingDashboardRange: useDashboardDateRange,
   } = useDashboardReportTimeRange(dashboardChild);
   const updateWidget = useUpdateDashboardWidgetMutation();
+  const canUseDashboardDateRange = Boolean(
+    !resolvedTimeFrame &&
+    hasDashboardContext &&
+    dashboardChild &&
+    dashboardChild.type !== 'formula-card',
+  );
   const [displayStart, displayEnd, displayMode] = resolvedTimeFrame
     ? [resolvedTimeFrame.start, resolvedTimeFrame.end, resolvedTimeFrame.mode]
     : useDashboardDateRange
@@ -156,10 +163,29 @@ export function Header({
     newEnd: string,
     newMode: TimeFrame['mode'],
   ) => {
-    if (resolvedTimeFrame || !useDashboardDateRange) {
+    if (
+      resolvedTimeFrame ||
+      !useDashboardDateRange ||
+      canUseDashboardDateRange
+    ) {
       onChangeDates(newStart, newEnd, newMode);
     }
   };
+  const selectWidgetTimeframe = () => {
+    if (useDashboardDateRange && dashboardChild) {
+      updateWidget.mutate({
+        widget: {
+          id: dashboardChild.id,
+          use_dashboard_date_range: false,
+        },
+      });
+    }
+  };
+  const modeLabel = useDashboardDateRange
+    ? t('Dashboard')
+    : displayMode === 'static'
+      ? t('Static')
+      : t('Live');
 
   // Live-range presets return day-shaped bounds; collapse them to months.
   function liveRangeAsMonths(
@@ -284,32 +310,30 @@ export function Header({
         }}
       >
         <SpaceBetween gap={isNarrowWidth ? 5 : undefined}>
-          {!resolvedTimeFrame &&
-            hasDashboardContext &&
-            dashboardChild?.type !== 'formula-card' && (
-              <View
-                style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
-              >
-                <Toggle
-                  id={`use-dashboard-date-range-${dashboardChild?.id}`}
-                  isOn={useDashboardDateRange}
-                  onToggle={value =>
-                    updateWidget.mutate({
-                      widget: {
-                        id: dashboardChild!.id,
-                        use_dashboard_date_range: value,
-                      },
-                    })
-                  }
-                />
-                <Trans>Use dashboard date range</Trans>
-              </View>
-            )}
           {displayMode && !hideModeToggle && (
             <Button
-              variant={displayMode === 'static' ? 'normal' : 'primary'}
-              isDisabled={useDashboardDateRange}
+              variant={
+                useDashboardDateRange || displayMode !== 'static'
+                  ? 'primary'
+                  : 'normal'
+              }
               onPress={() => {
+                if (useDashboardDateRange) {
+                  selectWidgetTimeframe();
+                  return;
+                }
+
+                if (mode === 'static' && canUseDashboardDateRange) {
+                  updateWidget.mutate({
+                    widget: {
+                      id: dashboardChild!.id,
+                      use_dashboard_date_range: true,
+                    },
+                  });
+                  return;
+                }
+
+                selectWidgetTimeframe();
                 const newMode = mode === 'static' ? 'sliding-window' : 'static';
                 const [newStart, newEnd] =
                   newMode === 'static'
@@ -321,7 +345,7 @@ export function Header({
                 commitDates(newStart, newEnd, newMode);
               }}
             >
-              {displayMode === 'static' ? t('Static') : t('Live')}
+              {modeLabel}
             </Button>
           )}
 
@@ -372,7 +396,7 @@ export function Header({
               previousMonth: t('Previous month'),
               nextMonth: t('Next month'),
               year: t('Year'),
-              dateRange: t('Date range'),
+              dateRange: dateRangeLabel ?? t('Date range'),
             }}
             presets={presets}
             onChangeDates={(newStart, newEnd) =>

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, ReactNode } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+import { useParams, useSearchParams } from 'react-router';
 
 import { Button } from '@actual-app/components/button';
 import { DateRangePicker } from '@actual-app/components/date-range-picker';
@@ -9,9 +10,12 @@ import type {
 } from '@actual-app/components/date-range-picker';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
 import { SpaceBetween } from '@actual-app/components/space-between';
+import { Toggle } from '@actual-app/components/toggle';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type {
+  DashboardDateScope,
+  DashboardWidgetEntity,
   RuleConditionEntity,
   TimeFrame,
 } from '@actual-app/core/types/models';
@@ -20,8 +24,11 @@ import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 import { AppliedFilters } from '#components/filters/AppliedFilters';
 import { FilterButton } from '#components/filters/FiltersMenu';
 import { getFirstDayOfWeek } from '#components/select/getFirstDayOfWeek';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
+import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useDateFormat } from '#hooks/useDateFormat';
 import { useLanguage } from '#hooks/useLocale';
+import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
 import { getLiveRange } from './getLiveRange';
 import {
@@ -39,6 +46,9 @@ type HeaderProps = {
   show1Month?: boolean;
   showFutureRange?: boolean;
   hideModeToggle?: boolean;
+  preserveRangeOnModeChange?: boolean;
+  contentPadding?: number;
+  resolvedTimeFrame?: DashboardDateScope;
   allMonths: Array<{ name: string }>;
   earliestTransaction: string;
   latestTransaction: string;
@@ -84,6 +94,9 @@ export function Header({
   show1Month,
   showFutureRange,
   hideModeToggle,
+  preserveRangeOnModeChange,
+  contentPadding,
+  resolvedTimeFrame,
   allMonths,
   earliestTransaction,
   latestTransaction,
@@ -105,6 +118,40 @@ export function Header({
   const { isNarrowWidth } = useResponsive();
   const language = useLanguage();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
+  const [searchParams] = useSearchParams();
+  const routeParams = useParams();
+  const dashboardWidgetId =
+    searchParams.get('dashboardWidget') ?? routeParams.id;
+  const { data: dashboardChild } = useDashboardWidget<DashboardWidgetEntity>({
+    id: resolvedTimeFrame ? undefined : (dashboardWidgetId ?? undefined),
+  });
+  const {
+    dashboardScope,
+    hasDashboardContext,
+    isUsingDashboardRange: useDashboardDateRange,
+  } = useDashboardReportTimeRange(dashboardChild);
+  const updateWidget = useUpdateDashboardWidgetMutation();
+  const [displayStart, displayEnd, displayMode] = resolvedTimeFrame
+    ? [resolvedTimeFrame.start, resolvedTimeFrame.end, resolvedTimeFrame.mode]
+    : useDashboardDateRange
+      ? [dashboardScope!.start, dashboardScope!.end, dashboardScope!.mode]
+      : hasDashboardContext && mode !== 'static'
+        ? calculateTimeRange(
+            { start, end, mode },
+            undefined,
+            latestTransaction,
+            dashboardScope!.end,
+          )
+        : [start, end, mode];
+  const commitDates = (
+    newStart: string,
+    newEnd: string,
+    newMode: TimeFrame['mode'],
+  ) => {
+    if (resolvedTimeFrame || !useDashboardDateRange) {
+      onChangeDates(newStart, newEnd, newMode);
+    }
+  };
 
   // Live-range presets return day-shaped bounds; collapse them to months.
   function liveRangeAsMonths(
@@ -140,7 +187,7 @@ export function Header({
         const [rangeStart, rangeEnd] = getFullRange();
         return [rangeStart, rangeEnd];
       },
-      onSelect: () => onChangeDates(...getFullRange()),
+      onSelect: () => commitDates(...getFullRange()),
     };
   }
 
@@ -213,8 +260,9 @@ export function Header({
   return (
     <View
       style={{
-        padding: 20,
-        paddingTop: 15,
+        padding: contentPadding ?? 20,
+        paddingTop: contentPadding == null ? 15 : 4,
+        paddingBottom: contentPadding == null ? 20 : 4,
         flexShrink: 0,
       }}
     >
@@ -225,27 +273,51 @@ export function Header({
         }}
       >
         <SpaceBetween gap={isNarrowWidth ? 5 : undefined}>
-          {mode && !hideModeToggle && (
+          {!resolvedTimeFrame &&
+            hasDashboardContext &&
+            dashboardChild?.type !== 'formula-card' && (
+              <View
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
+              >
+                <Toggle
+                  id={`use-dashboard-date-range-${dashboardChild?.id}`}
+                  isOn={useDashboardDateRange}
+                  onToggle={value =>
+                    updateWidget.mutate({
+                      widget: {
+                        id: dashboardChild!.id,
+                        use_dashboard_date_range: value,
+                      },
+                    })
+                  }
+                />
+                <Trans>Use dashboard date range</Trans>
+              </View>
+            )}
+          {displayMode && !hideModeToggle && (
             <Button
-              variant={mode === 'static' ? 'normal' : 'primary'}
+              variant={displayMode === 'static' ? 'normal' : 'primary'}
+              isDisabled={useDashboardDateRange}
               onPress={() => {
                 const newMode = mode === 'static' ? 'sliding-window' : 'static';
-                const [newStart, newEnd] = calculateTimeRange({
-                  start,
-                  end,
-                  mode: newMode,
-                });
+                const [newStart, newEnd] =
+                  newMode === 'static'
+                    ? [displayStart, displayEnd]
+                    : preserveRangeOnModeChange
+                      ? [start, end]
+                      : calculateTimeRange({ start, end, mode: newMode });
 
-                onChangeDates(newStart, newEnd, newMode);
+                commitDates(newStart, newEnd, newMode);
               }}
             >
-              {mode === 'static' ? t('Static') : t('Live')}
+              {displayMode === 'static' ? t('Static') : t('Live')}
             </Button>
           )}
 
           <DateRangePicker
-            start={start}
-            end={end}
+            start={displayStart}
+            end={displayEnd}
+            isDisabled={useDashboardDateRange}
             granularities={granularities}
             // allMonths is newest-first and may be empty before reports load.
             minDate={
@@ -277,7 +349,7 @@ export function Header({
             }}
             presets={presets}
             onChangeDates={(newStart, newEnd) =>
-              onChangeDates(newStart, newEnd, 'static')
+              commitDates(newStart, newEnd, 'static')
             }
           />
           {filters && (

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -425,7 +425,9 @@ export function Overview({ dashboard }: OverviewProps) {
         height: type === 'sankey-card' ? 3 : 2,
         meta,
         dashboard_page_id: dashboard.id,
-        use_dashboard_date_range: true,
+        use_dashboard_date_range: !(
+          type === 'calendar-card' && dashboard.date_range_enabled
+        ),
       },
     });
   };

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -5,7 +5,7 @@ import ReactGridLayout from 'react-grid-layout';
 import type { Layout } from 'react-grid-layout';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { Trans, useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router';
+import { useLocation, useSearchParams } from 'react-router';
 
 import { Button } from '@actual-app/components/button';
 import { useResponsive } from '@actual-app/components/hooks/useResponsive';
@@ -23,6 +23,7 @@ import type {
   DashboardWidgetEntity,
   ExportImportDashboard,
   MarkdownWidget,
+  TimeFrame,
 } from '@actual-app/core/types/models';
 
 import { MOBILE_NAV_HEIGHT } from '#components/mobile/MobileNavTabs';
@@ -48,7 +49,6 @@ import {
   useDeleteDashboardPageMutation,
   useImportDashboardPageMutation,
   useResetDashboardPageMutation,
-  useUpdateDashboardDateRangeMutation,
   useUpdateDashboardWidgetMutation,
   useUpdateDashboardWidgetsMutation,
 } from '#reports/mutations';
@@ -112,6 +112,24 @@ function getWidgetMinWidth(widget: DashboardWidgetEntity) {
   }
 
   return 3;
+}
+
+const DASHBOARD_TIME_FRAME_MODES = new Set<TimeFrame['mode']>([
+  'sliding-window',
+  'static',
+  'full',
+  'lastMonth',
+  'lastYear',
+  'yearToDate',
+  'priorYearToDate',
+]);
+
+function isDashboardDate(value: string | null) {
+  return Boolean(
+    value &&
+    (monthUtils.isValidYearMonth(value) ||
+      monthUtils.isValidYearMonthDay(value)),
+  );
 }
 
 function getDashboardMeta<T extends DashboardWidgetEntity>(
@@ -216,6 +234,42 @@ export function Overview({ dashboard }: OverviewProps) {
     monthUtils.currentDay(),
   );
   const [allMonths, setAllMonths] = useState<Array<{ name: string }>>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dashboardTimeFrame = useMemo<TimeFrame | null>(() => {
+    const start = searchParams.get('dashboardStart');
+    const end = searchParams.get('dashboardEnd');
+    const mode = searchParams.get('dashboardMode') as TimeFrame['mode'] | null;
+
+    if (
+      !isDashboardDate(start) ||
+      !isDashboardDate(end) ||
+      start! > end! ||
+      !mode ||
+      !DASHBOARD_TIME_FRAME_MODES.has(mode)
+    ) {
+      return null;
+    }
+
+    return { start: start!, end: end!, mode };
+  }, [searchParams]);
+  const setDashboardTimeFrameInHistory = useCallback(
+    (timeFrame: TimeFrame | null) => {
+      setSearchParams(params => {
+        if (timeFrame) {
+          params.set('dashboardStart', timeFrame.start);
+          params.set('dashboardEnd', timeFrame.end);
+          params.set('dashboardMode', timeFrame.mode);
+        } else {
+          params.delete('dashboardStart');
+          params.delete('dashboardEnd');
+          params.delete('dashboardMode');
+        }
+        params.delete('dashboardWidget');
+        return params;
+      });
+    },
+    [setSearchParams],
+  );
 
   useEffect(() => {
     async function loadTransactionRange() {
@@ -241,16 +295,16 @@ export function Overview({ dashboard }: OverviewProps) {
   }, []);
 
   const dashboardScope = useMemo<DashboardDateScope | null>(() => {
-    if (!dashboard.date_range_enabled || !dashboard.time_frame) {
+    if (!dashboardTimeFrame) {
       return null;
     }
     const [start, end, mode] = calculateTimeRange(
-      dashboard.time_frame,
+      dashboardTimeFrame,
       undefined,
       latestTransaction,
     );
     return { start, end, mode };
-  }, [dashboard, latestTransaction]);
+  }, [dashboardTimeFrame, latestTransaction]);
 
   const isLoading =
     isCustomReportsLoading || isWidgetsLoading || isDashboardPageLoading;
@@ -357,20 +411,6 @@ export function Overview({ dashboard }: OverviewProps) {
   };
 
   const resetDashboardPageMutation = useResetDashboardPageMutation();
-  const updateDashboardDateRangeMutation =
-    useUpdateDashboardDateRangeMutation();
-
-  const onToggleDashboardDateRange = () => {
-    updateDashboardDateRangeMutation.mutate({
-      id: dashboard.id,
-      date_range_enabled: !dashboard.date_range_enabled,
-      time_frame: dashboard.time_frame ?? {
-        start: monthUtils.subMonths(monthUtils.currentMonth(), 5),
-        end: monthUtils.currentMonth(),
-        mode: 'sliding-window',
-      },
-    });
-  };
 
   const onResetDashboard = async () => {
     setIsImporting(true);
@@ -425,18 +465,14 @@ export function Overview({ dashboard }: OverviewProps) {
         height: type === 'sankey-card' ? 3 : 2,
         meta,
         dashboard_page_id: dashboard.id,
-        use_dashboard_date_range: !(
-          type === 'calendar-card' && dashboard.date_range_enabled
-        ),
+        use_dashboard_date_range: type !== 'calendar-card',
       },
     });
   };
 
   const onExport = () => {
     const data = {
-      version: 2,
-      date_range_enabled: dashboard.date_range_enabled,
-      time_frame: dashboard.time_frame,
+      version: 1,
       widgets: widgets.map(widget => {
         if (isCustomReportWidget(widget)) {
           const customReport = customReportMap.get(widget.meta.id);
@@ -787,8 +823,10 @@ export function Overview({ dashboard }: OverviewProps) {
                 currentDashboard={dashboard}
               />
               <DashboardDateRangeControls
-                dashboard={dashboard}
+                timeFrame={dashboardTimeFrame}
                 scope={dashboardScope}
+                onChange={setDashboardTimeFrameInHistory}
+                onClear={() => setDashboardTimeFrameInHistory(null)}
                 allMonths={allMonths}
                 earliestTransaction={earliestTransaction}
                 latestTransaction={latestTransaction}
@@ -817,8 +855,10 @@ export function Overview({ dashboard }: OverviewProps) {
               {currentBreakpoint === 'desktop' && (
                 <>
                   <DashboardDateRangeControls
-                    dashboard={dashboard}
+                    timeFrame={dashboardTimeFrame}
                     scope={dashboardScope}
+                    onChange={setDashboardTimeFrameInHistory}
+                    onClear={() => setDashboardTimeFrameInHistory(null)}
                     allMonths={allMonths}
                     earliestTransaction={earliestTransaction}
                     latestTransaction={latestTransaction}
@@ -999,9 +1039,6 @@ export function Overview({ dashboard }: OverviewProps) {
                           slot="close"
                           onMenuSelect={item => {
                             switch (item) {
-                              case 'date-ranges':
-                                onToggleDashboardDateRange();
-                                break;
                               case 'reset':
                                 void onResetDashboard();
                                 break;
@@ -1021,13 +1058,6 @@ export function Overview({ dashboard }: OverviewProps) {
                             }
                           }}
                           items={[
-                            {
-                              name: 'date-ranges',
-                              text: dashboard.date_range_enabled
-                                ? t('Disable date ranges')
-                                : t('Enable date ranges'),
-                            },
-                            Menu.line,
                             {
                               name: 'reset',
                               text: t('Reset to default'),

--- a/packages/desktop-client/src/components/reports/Overview.tsx
+++ b/packages/desktop-client/src/components/reports/Overview.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Dialog, DialogTrigger } from 'react-aria-components';
 import { ErrorBoundary } from 'react-error-boundary';
 import ReactGridLayout from 'react-grid-layout';
@@ -14,8 +14,11 @@ import { Menu } from '@actual-app/components/menu';
 import { Popover } from '@actual-app/components/popover';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
+import * as monthUtils from '@actual-app/core/shared/months';
 import type {
   CustomReportWidget,
+  DashboardDateScope,
   DashboardPageEntity,
   DashboardWidgetEntity,
   ExportImportDashboard,
@@ -45,15 +48,22 @@ import {
   useDeleteDashboardPageMutation,
   useImportDashboardPageMutation,
   useResetDashboardPageMutation,
+  useUpdateDashboardDateRangeMutation,
   useUpdateDashboardWidgetMutation,
   useUpdateDashboardWidgetsMutation,
 } from '#reports/mutations';
 
 import { NON_DRAGGABLE_AREA_CLASS_NAME } from './constants';
-import { DashboardHeader } from './DashboardHeader';
 import './overview.scss';
+import { DashboardDateRangeControls } from './DashboardDateRangeControls';
+import { DashboardDateScopeProvider } from './DashboardDateScope';
+import { DashboardHeader } from './DashboardHeader';
 import { DashboardSelector } from './DashboardSelector';
 import { LoadingIndicator } from './LoadingIndicator';
+import {
+  calculateSpendingReportTimeRange,
+  calculateTimeRange,
+} from './reportRanges';
 import { AgeOfMoneyCard } from './reports/AgeOfMoneyCard';
 import { BalanceForecastCard } from './reports/BalanceForecastCard';
 import { BudgetAnalysisCard } from './reports/BudgetAnalysisCard';
@@ -104,6 +114,65 @@ function getWidgetMinWidth(widget: DashboardWidgetEntity) {
   return 3;
 }
 
+function getDashboardMeta<T extends DashboardWidgetEntity>(
+  widget: T,
+  dashboardScope?: DashboardDateScope | null,
+): T['meta'] {
+  if (!dashboardScope || widget.type === 'formula-card') {
+    return widget.meta;
+  }
+  const usesTimeFrame = [
+    'net-worth-card',
+    'cash-flow-card',
+    'crossover-card',
+    'budget-analysis-card',
+    'summary-card',
+    'calendar-card',
+    'sankey-card',
+    'balance-forecast-card',
+    'age-of-money-card',
+  ].includes(widget.type);
+  let timeFrame =
+    widget.meta && 'timeFrame' in widget.meta
+      ? widget.meta.timeFrame
+      : undefined;
+  let spendingRange: {
+    compare: string;
+    compareTo: string;
+    isLive: false;
+  } | null = null;
+  if (widget.type === 'spending-card') {
+    const [compare, compareTo] =
+      (widget.use_dashboard_date_range ?? true)
+        ? [dashboardScope.start, dashboardScope.end]
+        : calculateSpendingReportTimeRange(
+            widget.meta ?? {},
+            dashboardScope.end,
+          );
+    spendingRange = { compare, compareTo, isLive: false };
+  }
+  if (usesTimeFrame && (widget.use_dashboard_date_range ?? true)) {
+    timeFrame = {
+      start: dashboardScope.start,
+      end: dashboardScope.end,
+      mode: 'static',
+    };
+  } else if (usesTimeFrame && timeFrame && timeFrame.mode !== 'static') {
+    const [start, end] = calculateTimeRange(
+      timeFrame,
+      undefined,
+      undefined,
+      dashboardScope.end,
+    );
+    timeFrame = { start, end, mode: 'static' };
+  }
+  return {
+    ...widget.meta,
+    ...(timeFrame ? { timeFrame } : null),
+    ...spendingRange,
+  } as T['meta'];
+}
+
 type OverviewProps = {
   dashboard: DashboardPageEntity;
 };
@@ -140,6 +209,48 @@ export function Overview({ dashboard }: OverviewProps) {
 
   const { data: widgets = [], isPending: isWidgetsLoading } =
     useDashboardPageWidgets(dashboard.id);
+  const [earliestTransaction, setEarliestTransaction] = useState(
+    monthUtils.currentDay(),
+  );
+  const [latestTransaction, setLatestTransaction] = useState(
+    monthUtils.currentDay(),
+  );
+  const [allMonths, setAllMonths] = useState<Array<{ name: string }>>([]);
+
+  useEffect(() => {
+    async function loadTransactionRange() {
+      const [earliest, latest] = await Promise.all([
+        send('get-earliest-transaction'),
+        send('get-latest-transaction'),
+      ]);
+      const first = earliest?.date ?? monthUtils.currentDay();
+      const last = latest?.date ?? monthUtils.currentDay();
+      setEarliestTransaction(first);
+      setLatestTransaction(last);
+      setAllMonths(
+        monthUtils
+          .rangeInclusive(
+            monthUtils.monthFromDate(first),
+            monthUtils.monthFromDate(last),
+          )
+          .map(name => ({ name }))
+          .reverse(),
+      );
+    }
+    void loadTransactionRange();
+  }, []);
+
+  const dashboardScope = useMemo<DashboardDateScope | null>(() => {
+    if (!dashboard.date_range_enabled || !dashboard.time_frame) {
+      return null;
+    }
+    const [start, end, mode] = calculateTimeRange(
+      dashboard.time_frame,
+      undefined,
+      latestTransaction,
+    );
+    return { start, end, mode };
+  }, [dashboard, latestTransaction]);
 
   const isLoading =
     isCustomReportsLoading || isWidgetsLoading || isDashboardPageLoading;
@@ -157,7 +268,7 @@ export function Overview({ dashboard }: OverviewProps) {
   const isMounted = containerWidth > 0;
 
   const mobileLayout = useMemo(() => {
-    if (!widgets || widgets.length === 0) {
+    if (widgets.length === 0) {
       return [];
     }
 
@@ -188,7 +299,6 @@ export function Overview({ dashboard }: OverviewProps) {
   }, [widgets]);
 
   const desktopLayout = useMemo(() => {
-    if (!widgets) return [];
     return widgets.map(widget => ({
       i: widget.id,
       x: widget.x,
@@ -247,6 +357,20 @@ export function Overview({ dashboard }: OverviewProps) {
   };
 
   const resetDashboardPageMutation = useResetDashboardPageMutation();
+  const updateDashboardDateRangeMutation =
+    useUpdateDashboardDateRangeMutation();
+
+  const onToggleDashboardDateRange = () => {
+    updateDashboardDateRangeMutation.mutate({
+      id: dashboard.id,
+      date_range_enabled: !dashboard.date_range_enabled,
+      time_frame: dashboard.time_frame ?? {
+        start: monthUtils.subMonths(monthUtils.currentMonth(), 5),
+        end: monthUtils.currentMonth(),
+        mode: 'sliding-window',
+      },
+    });
+  };
 
   const onResetDashboard = async () => {
     setIsImporting(true);
@@ -301,36 +425,43 @@ export function Overview({ dashboard }: OverviewProps) {
         height: type === 'sankey-card' ? 3 : 2,
         meta,
         dashboard_page_id: dashboard.id,
+        use_dashboard_date_range: true,
       },
     });
   };
 
   const onExport = () => {
     const data = {
-      version: 1,
-      widgets: desktopLayout.map(item => {
-        const widget = widgetMap.get(item.i);
-
-        if (!widget) {
-          throw new Error(`Unable to query widget: ${item.i}`);
-        }
-
+      version: 2,
+      date_range_enabled: dashboard.date_range_enabled,
+      time_frame: dashboard.time_frame,
+      widgets: widgets.map(widget => {
         if (isCustomReportWidget(widget)) {
           const customReport = customReportMap.get(widget.meta.id);
 
           if (!customReport) {
-            throw new Error(`Custom report not found for widget: ${item.i}`);
+            throw new Error(`Custom report not found for widget: ${widget.id}`);
           }
+          const {
+            id: _id,
+            dashboard_page_id: _dashboardPageId,
+            tombstone: _tombstone,
+            ...exportWidget
+          } = widget;
 
           return {
-            ...widget,
+            ...exportWidget,
             meta: customReport,
-            id: undefined,
-            tombstone: undefined,
           };
         }
 
-        return { ...widget, id: undefined, tombstone: undefined };
+        const {
+          id: _id,
+          dashboard_page_id: _dashboardPageId,
+          tombstone: _tombstone,
+          ...exportWidget
+        } = widget;
+        return exportWidget;
       }),
     } satisfies ExportImportDashboard;
 
@@ -468,6 +599,157 @@ export function Overview({ dashboard }: OverviewProps) {
 
   const { data: accounts = [] } = useAccounts();
 
+  function renderWidget(
+    widget: DashboardWidgetEntity,
+    activeDashboardScope?: DashboardDateScope | null,
+  ) {
+    const common = {
+      widgetId: widget.id,
+      isEditing,
+    };
+    const changeMeta = (meta: DashboardWidgetEntity['meta']) => {
+      if (!activeDashboardScope || !meta) {
+        onMetaChange({ i: widget.id }, meta);
+        return;
+      }
+      const dateKeys = ['timeFrame', 'compare', 'compareTo', 'isLive'];
+      const originalMeta = (widget.meta ?? {}) as Record<string, unknown>;
+      const persistedMeta = Object.fromEntries(
+        Object.entries(meta).filter(([key]) => !dateKeys.includes(key)),
+      );
+      dateKeys.forEach(key => {
+        if (Object.hasOwn(originalMeta, key)) {
+          persistedMeta[key] = originalMeta[key];
+        }
+      });
+      onMetaChange(
+        { i: widget.id },
+        persistedMeta as DashboardWidgetEntity['meta'],
+      );
+    };
+
+    switch (widget.type) {
+      case 'net-worth-card':
+        return (
+          <NetWorthCard
+            {...common}
+            accounts={accounts}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'crossover-card':
+        return (
+          <CrossoverCard
+            {...common}
+            accounts={accounts}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'age-of-money-card':
+        return (
+          <AgeOfMoneyCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'cash-flow-card':
+        return (
+          <CashFlowCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'spending-card':
+        return (
+          <SpendingCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'budget-analysis-card':
+        return budgetAnalysisReportEnabled ? (
+          <BudgetAnalysisCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        ) : null;
+      case 'balance-forecast-card':
+        return balanceForecastReportEnabled ? (
+          <BalanceForecastCard
+            {...common}
+            accounts={accounts}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        ) : null;
+      case 'markdown-card':
+        return (
+          <MarkdownCard
+            {...common}
+            meta={widget.meta}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'custom-report':
+        return (
+          <CustomReportListCards
+            {...common}
+            report={customReportMap.get(widget.meta.id)}
+            useDashboardDateRange={widget.use_dashboard_date_range}
+          />
+        );
+      case 'summary-card':
+        return (
+          <SummaryCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'calendar-card':
+        return (
+          <CalendarCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            firstDayOfWeekIdx={firstDayOfWeekIdx}
+            onMetaChange={changeMeta}
+          />
+        );
+      case 'formula-card':
+        return formulaMode ? (
+          <FormulaCard
+            {...common}
+            meta={widget.meta}
+            onMetaChange={changeMeta}
+          />
+        ) : null;
+      case 'sankey-card':
+        return sankeyFeatureFlag ? (
+          <SankeyCard
+            {...common}
+            meta={getDashboardMeta(widget, activeDashboardScope)}
+            onMetaChange={changeMeta}
+          />
+        ) : null;
+      case 'monte-carlo-card':
+        return monteCarloReportEnabled ? (
+          <MonteCarloCard
+            {...common}
+            meta={widget.meta}
+            onMetaChange={changeMeta}
+          />
+        ) : null;
+      default:
+        return null;
+    }
+  }
+
   if (isLoading) {
     return <LoadingIndicator message={t('Loading reports...')} />;
   }
@@ -495,11 +777,19 @@ export function Overview({ dashboard }: OverviewProps) {
                 padding: '5px',
                 borderBottom: '1px solid ' + theme.pillBorder,
                 backgroundColor: theme.mobilePageBackground,
+                gap: 10,
               }}
             >
               <DashboardSelector
                 dashboards={dashboardPages}
                 currentDashboard={dashboard}
+              />
+              <DashboardDateRangeControls
+                dashboard={dashboard}
+                scope={dashboardScope}
+                allMonths={allMonths}
+                earliestTransaction={earliestTransaction}
+                latestTransaction={latestTransaction}
               />
             </View>
           </View>
@@ -518,12 +808,20 @@ export function Overview({ dashboard }: OverviewProps) {
               style={{
                 flexDirection: 'row',
                 justifyContent: 'space-between',
-                gap: 5,
+                gap: 10,
                 alignItems: 'stretch',
               }}
             >
               {currentBreakpoint === 'desktop' && (
                 <>
+                  <DashboardDateRangeControls
+                    dashboard={dashboard}
+                    scope={dashboardScope}
+                    allMonths={allMonths}
+                    earliestTransaction={earliestTransaction}
+                    latestTransaction={latestTransaction}
+                  />
+
                   {/* Dashboard Selector */}
                   <DashboardSelector
                     dashboards={dashboardPages}
@@ -699,6 +997,9 @@ export function Overview({ dashboard }: OverviewProps) {
                           slot="close"
                           onMenuSelect={item => {
                             switch (item) {
+                              case 'date-ranges':
+                                onToggleDashboardDateRange();
+                                break;
                               case 'reset':
                                 void onResetDashboard();
                                 break;
@@ -718,6 +1019,13 @@ export function Overview({ dashboard }: OverviewProps) {
                             }
                           }}
                           items={[
+                            {
+                              name: 'date-ranges',
+                              text: dashboard.date_range_enabled
+                                ? t('Disable date ranges')
+                                : t('Enable date ranges'),
+                            },
+                            Menu.line,
                             {
                               name: 'reset',
                               text: t('Reset to default'),
@@ -764,180 +1072,51 @@ export function Overview({ dashboard }: OverviewProps) {
             style={{ userSelect: 'none', paddingBottom: MOBILE_NAV_HEIGHT }}
           >
             {isMounted && (
-              <ReactGridLayout
-                width={containerWidth}
-                layout={currentLayout}
-                gridConfig={{
-                  cols: currentBreakpoint === 'desktop' ? 12 : 1,
-                  rowHeight: 100,
-                }}
-                dragConfig={{
-                  enabled: currentBreakpoint === 'desktop' && isEditing,
-                  cancel: `.${NON_DRAGGABLE_AREA_CLASS_NAME}`,
-                }}
-                resizeConfig={{
-                  enabled: currentBreakpoint === 'desktop' && isEditing,
-                }}
-                onLayoutChange={
-                  currentBreakpoint === 'desktop' ? onLayoutChange : undefined
-                }
-              >
-                {currentLayout.map(item => {
-                  const widget = widgetMap.get(item.i);
-
-                  if (!widget) {
-                    return null;
+              <DashboardDateScopeProvider scope={dashboardScope}>
+                <ReactGridLayout
+                  width={containerWidth}
+                  layout={currentLayout}
+                  gridConfig={{
+                    cols: currentBreakpoint === 'desktop' ? 12 : 1,
+                    rowHeight: 100,
+                  }}
+                  dragConfig={{
+                    enabled: currentBreakpoint === 'desktop' && isEditing,
+                    cancel: `.${NON_DRAGGABLE_AREA_CLASS_NAME}`,
+                  }}
+                  resizeConfig={{
+                    enabled: currentBreakpoint === 'desktop' && isEditing,
+                  }}
+                  onLayoutChange={
+                    currentBreakpoint === 'desktop' ? onLayoutChange : undefined
                   }
+                >
+                  {currentLayout.map(item => {
+                    const widget = widgetMap.get(item.i);
 
-                  return (
-                    <div key={item.i}>
-                      <ErrorBoundary
-                        fallbackRender={() => (
-                          <MissingReportCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                          >
-                            <Trans>This widget has failed to load.</Trans>
-                          </MissingReportCard>
-                        )}
-                      >
-                        {widget.type === 'net-worth-card' ? (
-                          <NetWorthCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            accounts={accounts}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'crossover-card' ? (
-                          <CrossoverCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            accounts={accounts}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'age-of-money-card' ? (
-                          <AgeOfMoneyCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'cash-flow-card' ? (
-                          <CashFlowCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'spending-card' ? (
-                          <SpendingCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'budget-analysis-card' &&
-                          budgetAnalysisReportEnabled ? (
-                          <BudgetAnalysisCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'balance-forecast-card' &&
-                          balanceForecastReportEnabled ? (
-                          <BalanceForecastCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            accounts={accounts}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'markdown-card' ? (
-                          <MarkdownCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'custom-report' ? (
-                          <CustomReportListCards
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            report={customReportMap.get(widget.meta.id)}
-                          />
-                        ) : widget.type === 'summary-card' ? (
-                          <SummaryCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'calendar-card' ? (
-                          <CalendarCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            firstDayOfWeekIdx={firstDayOfWeekIdx}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'formula-card' && formulaMode ? (
-                          <FormulaCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'sankey-card' &&
-                          sankeyFeatureFlag ? (
-                          <SankeyCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : widget.type === 'monte-carlo-card' &&
-                          monteCarloReportEnabled ? (
-                          <MonteCarloCard
-                            widgetId={item.i}
-                            isEditing={isEditing}
-                            meta={widget.meta}
-                            onMetaChange={newMeta =>
-                              onMetaChange(item, newMeta)
-                            }
-                          />
-                        ) : null}
-                      </ErrorBoundary>
-                    </div>
-                  );
-                })}
-              </ReactGridLayout>
+                    if (!widget) {
+                      return null;
+                    }
+
+                    return (
+                      <div key={item.i}>
+                        <ErrorBoundary
+                          fallbackRender={() => (
+                            <MissingReportCard
+                              widgetId={item.i}
+                              isEditing={isEditing}
+                            >
+                              <Trans>This widget has failed to load.</Trans>
+                            </MissingReportCard>
+                          )}
+                        >
+                          {renderWidget(widget, dashboardScope)}
+                        </ErrorBoundary>
+                      </div>
+                    );
+                  })}
+                </ReactGridLayout>
+              </DashboardDateScopeProvider>
             )}
           </View>
         </div>

--- a/packages/desktop-client/src/components/reports/ReportCard.tsx
+++ b/packages/desktop-client/src/components/reports/ReportCard.tsx
@@ -19,6 +19,10 @@ import {
 } from '#reports/mutations';
 
 import { NON_DRAGGABLE_AREA_CLASS_NAME } from './constants';
+import {
+  addDashboardDateScopeToUrl,
+  useDashboardDateScope,
+} from './DashboardDateScope';
 
 type ReportCardProps = {
   widgetId: string;
@@ -47,6 +51,7 @@ export function ReportCard({
   const isInViewport = useIsInViewport(ref);
   const [hasRendered, setHasRendered] = useState(false);
   const navigate = useNavigate();
+  const dashboardScope = useDashboardDateScope();
   const { isNarrowWidth } = useResponsive();
   const containerProps = {
     flex: isNarrowWidth ? '1 1' : `0 0 calc(${size * 100}% / 3 - 20px)`,
@@ -110,7 +115,14 @@ export function ReportCard({
       <Layout {...layoutProps}>
         <Button
           variant="bare"
-          onPress={() => navigate(to, { state: { goBack: true } })}
+          onPress={() =>
+            navigate(
+              dashboardScope
+                ? addDashboardDateScopeToUrl(to, dashboardScope, widgetId)
+                : to,
+              { state: { goBack: true } },
+            )
+          }
           style={{
             height: '100%',
             width: '100%',

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -11,6 +11,7 @@ import { SpaceBetween } from '@actual-app/components/space-between';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Toggle } from '@actual-app/components/toggle';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
@@ -76,6 +77,8 @@ type ReportSidebarProps = {
   latestTransaction: TransactionEntity['date'];
   firstDayOfWeekIdx: SyncedPrefs['firstDayOfWeekIdx'];
   isComplexCategoryCondition?: boolean;
+  useDashboardDateRange?: boolean;
+  onUseDashboardDateRangeChange?: (value: boolean) => void;
 };
 
 export function ReportSidebar({
@@ -109,6 +112,8 @@ export function ReportSidebar({
   latestTransaction,
   firstDayOfWeekIdx,
   isComplexCategoryCondition = false,
+  useDashboardDateRange,
+  onUseDashboardDateRangeChange,
 }: ReportSidebarProps) {
   const { t } = useTranslation();
   const locale = useLocale();
@@ -544,9 +549,24 @@ export function ReportSidebar({
               <Trans>Date filters</Trans>
             </strong>
           </Text>
+          {onUseDashboardDateRangeChange && (
+            <View
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
+            >
+              <Toggle
+                id="custom-report-use-dashboard-date-range"
+                isOn={Boolean(useDashboardDateRange)}
+                onToggle={onUseDashboardDateRangeChange}
+              />
+              <Text>
+                <Trans>Use dashboard date range</Trans>
+              </Text>
+            </View>
+          )}
           <View style={{ flex: 1 }} />
           <ModeButton
             selected={!customReportItems.isDateStatic}
+            isDisabled={useDashboardDateRange}
             onSelect={() => {
               setSessionReport('isDateStatic', false);
               setIsDateStatic(false);
@@ -557,6 +577,7 @@ export function ReportSidebar({
           </ModeButton>
           <ModeButton
             selected={customReportItems.isDateStatic}
+            isDisabled={useDashboardDateRange}
             onSelect={() => {
               setSessionReport('isDateStatic', true);
               setIsDateStatic(true);
@@ -584,6 +605,7 @@ export function ReportSidebar({
             <Select
               value={customReportItems.dateRange}
               onChange={onSelectRange}
+              disabled={useDashboardDateRange}
               options={rangeOptions}
             />
             {!disabledList.currentInterval.get(customReportItems.dateRange) &&
@@ -632,6 +654,7 @@ export function ReportSidebar({
                   )
                 }
                 value={customReportItems.startDate}
+                disabled={useDashboardDateRange}
                 defaultLabel={monthUtils.format(
                   customReportItems.startDate,
                   ReportOptions.intervalFormat.get(
@@ -666,6 +689,7 @@ export function ReportSidebar({
                   )
                 }
                 value={customReportItems.endDate}
+                disabled={useDashboardDateRange}
                 defaultLabel={monthUtils.format(
                   customReportItems.endDate,
                   ReportOptions.intervalFormat.get(

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -11,7 +11,6 @@ import { SpaceBetween } from '@actual-app/components/space-between';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
-import { Toggle } from '@actual-app/components/toggle';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import * as monthUtils from '@actual-app/core/shared/months';
@@ -549,25 +548,19 @@ export function ReportSidebar({
               <Trans>Date filters</Trans>
             </strong>
           </Text>
-          {onUseDashboardDateRangeChange && (
-            <View
-              style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
-            >
-              <Toggle
-                id="custom-report-use-dashboard-date-range"
-                isOn={Boolean(useDashboardDateRange)}
-                onToggle={onUseDashboardDateRangeChange}
-              />
-              <Text>
-                <Trans>Use dashboard date range</Trans>
-              </Text>
-            </View>
-          )}
           <View style={{ flex: 1 }} />
+          {onUseDashboardDateRangeChange && (
+            <ModeButton
+              selected={Boolean(useDashboardDateRange)}
+              onSelect={() => onUseDashboardDateRangeChange(true)}
+            >
+              <Trans>Dashboard</Trans>
+            </ModeButton>
+          )}
           <ModeButton
-            selected={!customReportItems.isDateStatic}
-            isDisabled={useDashboardDateRange}
+            selected={!useDashboardDateRange && !customReportItems.isDateStatic}
             onSelect={() => {
+              onUseDashboardDateRangeChange?.(false);
               setSessionReport('isDateStatic', false);
               setIsDateStatic(false);
               onSelectRange(customReportItems.dateRange);
@@ -576,9 +569,9 @@ export function ReportSidebar({
             <Trans>Live</Trans>
           </ModeButton>
           <ModeButton
-            selected={customReportItems.isDateStatic}
-            isDisabled={useDashboardDateRange}
+            selected={!useDashboardDateRange && customReportItems.isDateStatic}
             onSelect={() => {
+              onUseDashboardDateRangeChange?.(false);
               setSessionReport('isDateStatic', true);
               setIsDateStatic(true);
               onChangeDates(

--- a/packages/desktop-client/src/components/reports/getLiveRange.test.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.test.ts
@@ -76,4 +76,17 @@ describe('getLiveRange', () => {
       expect(end).toBe('2017-01-01');
     });
   });
+
+  it('uses an explicit reference date for live ranges', () => {
+    expect(
+      getLiveRange(
+        'Last 30 days',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2026-08-31',
+      ).slice(0, 2),
+    ).toEqual(['2026-08-02', '2026-08-31']);
+  });
 });

--- a/packages/desktop-client/src/components/reports/getLiveRange.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.ts
@@ -11,6 +11,7 @@ export function getLiveRange(
   latestTransaction: string,
   includeCurrentInterval: boolean,
   firstDayOfWeekIdx?: SyncedPrefs['firstDayOfWeekIdx'],
+  referenceDate = monthUtils.currentDay(),
 ): [string, string, TimeFrame['mode']] {
   let dateStart = earliestTransaction;
   let dateEnd = latestTransaction;
@@ -19,13 +20,13 @@ export function getLiveRange(
     case 'yearToDate': {
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
-        monthUtils.getYearStart(monthUtils.currentMonth()) + '-01',
-        monthUtils.currentDay(),
+        monthUtils.getYearStart(referenceDate) + '-01',
+        referenceDate,
       );
       break;
     }
     case 'lastMonth': {
-      const prevMonth = monthUtils.subMonths(monthUtils.currentMonth(), 1);
+      const prevMonth = monthUtils.subMonths(referenceDate, 1);
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
         monthUtils.firstDayOfMonth(prevMonth),
@@ -36,29 +37,24 @@ export function getLiveRange(
     case 'lastYear': {
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
-        monthUtils.getYearStart(
-          monthUtils.prevYear(monthUtils.currentMonth()),
-        ) + '-01',
-        monthUtils.getYearEnd(monthUtils.prevYear(monthUtils.currentDate())) +
-          '-31',
+        monthUtils.getYearStart(monthUtils.prevYear(referenceDate)) + '-01',
+        monthUtils.getYearEnd(monthUtils.prevYear(referenceDate)) + '-31',
       );
       break;
     }
     case 'priorYearToDate': {
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
-        monthUtils.getYearStart(
-          monthUtils.prevYear(monthUtils.currentMonth()),
-        ) + '-01',
-        monthUtils.prevYear(monthUtils.currentDate(), 'yyyy-MM-dd'),
+        monthUtils.getYearStart(monthUtils.prevYear(referenceDate)) + '-01',
+        monthUtils.prevYear(referenceDate, 'yyyy-MM-dd'),
       );
       break;
     }
     case 'last30Days': {
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
-        monthUtils.subDays(monthUtils.currentDay(), 29),
-        monthUtils.currentDay(),
+        monthUtils.subDays(referenceDate, 29),
+        referenceDate,
       );
       break;
     }
@@ -76,6 +72,7 @@ export function getLiveRange(
             : rangeName - (includeCurrentInterval ? 0 : 1),
           ReportOptions.dateRangeType.get(cond),
           firstDayOfWeekIdx,
+          referenceDate,
         );
       } else {
         break;

--- a/packages/desktop-client/src/components/reports/reportRanges.test.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.test.ts
@@ -60,6 +60,25 @@ describe('calculateTimeRange', () => {
     expect(start).toBe('2016-12-18'); // width of 14 days preserved
     expect(mode).toBe('sliding-window');
   });
+
+  it('anchors live month and preset ranges to an explicit date', () => {
+    expect(
+      calculateTimeRange(
+        { start: '2025-01', end: '2025-06', mode: 'sliding-window' },
+        undefined,
+        undefined,
+        '2026-08-31',
+      ),
+    ).toEqual(['2026-03', '2026-08', 'sliding-window']);
+    expect(
+      calculateTimeRange(
+        { start: '', end: '', mode: 'yearToDate' },
+        undefined,
+        undefined,
+        '2026-08-31',
+      ),
+    ).toEqual(['2026-01', '2026-08', 'yearToDate']);
+  });
 });
 
 // In test mode, monthUtils.currentMonth() returns '2017-01'
@@ -113,6 +132,15 @@ describe('calculateSpendingReportTimeRange', () => {
 
     expect(compare).toBe('2017-01');
     expect(compareTo).toBe('2017-01');
+  });
+
+  it('uses an explicit reference month for a live report without saved dates', () => {
+    expect(
+      calculateSpendingReportTimeRange(
+        { isLive: true, mode: 'single-month' },
+        '2026-08-31',
+      ),
+    ).toEqual(['2026-08', '2026-07']);
   });
 });
 

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -139,9 +139,10 @@ export function getSpecificRange(
   addNumber: number | null,
   type?: string,
   firstDayOfWeekIdx?: SyncedPrefs['firstDayOfWeekIdx'],
+  referenceDate = monthUtils.currentDay(),
 ) {
-  const currentDay = monthUtils.currentDay();
-  const currentWeek = monthUtils.currentWeek(firstDayOfWeekIdx);
+  const currentDay = referenceDate;
+  const currentWeek = monthUtils.weekFromDate(referenceDate, firstDayOfWeekIdx);
 
   let dateStart = monthUtils.subMonths(currentDay, offset) + '-01';
   let dateEnd = monthUtils.getMonthEnd(
@@ -164,8 +165,10 @@ export function getFullRange(start: string, end: string) {
   return [start, end, 'full'] as const;
 }
 
-export function getLatestRange(offset: number) {
-  const end = monthUtils.currentMonth();
+export function getLatestRange(offset: number, referenceDate?: string) {
+  const end = referenceDate
+    ? monthUtils.getMonth(referenceDate)
+    : monthUtils.currentMonth();
   const start = monthUtils.subMonths(end, offset);
 
   return [start, end, 'sliding-window'] as const;
@@ -209,7 +212,12 @@ export function calculateTimeRange(
   timeFrame?: Partial<TimeFrame>,
   defaultTimeFrame?: TimeFrame,
   latestTransaction?: string,
+  referenceDate?: string,
 ) {
+  const referenceDay = referenceDate ?? monthUtils.currentDay();
+  const referenceMonth = referenceDate
+    ? monthUtils.getMonth(referenceDate)
+    : monthUtils.currentMonth();
   const start =
     timeFrame?.start ??
     defaultTimeFrame?.start ??
@@ -222,7 +230,7 @@ export function calculateTimeRange(
     const latestTransactionMonth = latestTransaction
       ? monthUtils.monthFromDate(latestTransaction)
       : null;
-    const currentMonth = monthUtils.currentMonth();
+    const currentMonth = referenceMonth;
     const fullEnd =
       latestTransactionMonth &&
       monthUtils.isAfter(latestTransactionMonth, currentMonth)
@@ -237,7 +245,7 @@ export function calculateTimeRange(
       monthUtils.isValidYearMonthDay(end)
     ) {
       const dayOffset = monthUtils.differenceInCalendarDays(end, start);
-      const today = monthUtils.currentDay();
+      const today = referenceDay;
       return [
         monthUtils.subDays(today, Math.max(dayOffset, 0)),
         today,
@@ -249,36 +257,36 @@ export function calculateTimeRange(
 
     if (start > end) {
       return [
-        monthUtils.currentMonth(),
-        monthUtils.subMonths(monthUtils.currentMonth(), -offset),
+        referenceMonth,
+        monthUtils.subMonths(referenceMonth, -offset),
         'sliding-window',
       ] as const;
     }
 
-    return getLatestRange(offset);
+    return getLatestRange(offset, referenceDate);
   }
   if (mode === 'lastMonth') {
-    const lastMonth = monthUtils.subMonths(monthUtils.currentMonth(), 1);
+    const lastMonth = monthUtils.subMonths(referenceMonth, 1);
     return [lastMonth, lastMonth, 'lastMonth'] as const;
   }
   if (mode === 'lastYear') {
     return [
-      monthUtils.getYearStart(monthUtils.prevYear(monthUtils.currentMonth())),
-      monthUtils.getYearEnd(monthUtils.prevYear(monthUtils.currentDate())),
+      monthUtils.getYearStart(monthUtils.prevYear(referenceMonth)),
+      monthUtils.getYearEnd(monthUtils.prevYear(referenceMonth)),
       'lastYear',
     ] as const;
   }
   if (mode === 'yearToDate') {
     return [
-      monthUtils.currentYear() + '-01',
-      monthUtils.currentMonth(),
+      monthUtils.getYearStart(referenceMonth),
+      referenceMonth,
       'yearToDate',
     ] as const;
   }
   if (mode === 'priorYearToDate') {
     return [
-      monthUtils.getYearStart(monthUtils.prevYear(monthUtils.currentMonth())),
-      monthUtils.prevYear(monthUtils.currentDate(), 'yyyy-MM-dd'),
+      monthUtils.getYearStart(monthUtils.prevYear(referenceMonth)),
+      monthUtils.prevYear(referenceDay, 'yyyy-MM-dd'),
       'priorYearToDate',
     ] as const;
   }
@@ -286,19 +294,25 @@ export function calculateTimeRange(
   return [start, end, 'static'] as const;
 }
 
-export function calculateSpendingReportTimeRange({
-  compare,
-  compareTo,
-  isLive = true,
-  mode = 'single-month',
-}: {
-  compare?: string;
-  compareTo?: string;
-  isLive?: boolean;
-  mode?: 'budget' | 'average' | 'single-month';
-}): [string, string] {
+export function calculateSpendingReportTimeRange(
+  {
+    compare,
+    compareTo,
+    isLive = true,
+    mode = 'single-month',
+  }: {
+    compare?: string;
+    compareTo?: string;
+    isLive?: boolean;
+    mode?: 'budget' | 'average' | 'single-month';
+  },
+  referenceDate?: string,
+): [string, string] {
+  const referenceMonth = referenceDate
+    ? monthUtils.getMonth(referenceDate)
+    : monthUtils.currentMonth();
   if (['budget', 'average'].includes(mode) && isLive) {
-    const month = compare ?? monthUtils.currentMonth();
+    const month = compare ?? referenceMonth;
     return [month, month];
   }
 
@@ -313,10 +327,12 @@ export function calculateSpendingReportTimeRange({
       mode: (isLive ?? true) ? 'sliding-window' : 'static',
     },
     {
-      start: monthUtils.currentMonth(),
-      end: monthUtils.subMonths(monthUtils.currentMonth(), 1),
+      start: referenceMonth,
+      end: monthUtils.subMonths(referenceMonth, 1),
       mode: 'sliding-window',
     },
+    undefined,
+    referenceDate,
   );
   return [start, end];
 }

--- a/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
+++ b/packages/desktop-client/src/components/reports/reports/AgeOfMoney.tsx
@@ -33,10 +33,10 @@ import { PrivacyFilter } from '#components/PrivacyFilter';
 import { AgeOfMoneyGraph } from '#components/reports/graphs/AgeOfMoneyGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { createAgeOfMoneySpreadsheet } from '#components/reports/spreadsheets/age-of-money-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useLocale } from '#hooks/useLocale';
 import { useNavigate } from '#hooks/useNavigate';
@@ -67,6 +67,8 @@ type AgeOfMoneyInnerProps = {
 };
 
 function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -100,7 +102,6 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
 
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
-
   const reportParams = useMemo(
     () =>
       createAgeOfMoneySpreadsheet({
@@ -159,7 +160,7 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
 
   useEffect(() => {
     if (latestTransaction) {
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         undefined,
         latestTransaction,
@@ -168,7 +169,7 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
       setEnd(initialEnd);
       setMode(initialMode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame]);
+  }, [latestTransaction, widget?.meta?.timeFrame, resolveTimeRange]);
 
   function onChangeDates(
     newStart: string,
@@ -194,11 +195,13 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
           ...(widget.meta ?? {}),
           conditions,
           conditionsOp,
-          timeFrame: {
-            start,
-            end,
-            mode,
-          },
+          timeFrame: isUsingDashboardRange
+            ? widget.meta?.timeFrame
+            : {
+                start,
+                end,
+                mode,
+              },
           granularity,
         },
       },
@@ -220,6 +223,7 @@ function AgeOfMoneyInner({ widget }: AgeOfMoneyInnerProps) {
     end,
     mode,
     granularity,
+    isUsingDashboardRange,
     dispatch,
     t,
   ]);

--- a/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BalanceForecast.tsx
@@ -37,6 +37,7 @@ import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
 import { useAccounts } from '#hooks/useAccounts';
 import { useBalanceForecast } from '#hooks/useBalanceForecast';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -101,17 +102,32 @@ function BalanceForecastInner({ widget }: BalanceForecastInnerProps) {
   }> | null>(null);
 
   const currentMonth = monthUtils.currentMonth();
-  const [start, setStart] = useState(
-    widget?.meta?.timeFrame?.start ?? widget?.meta?.startDate ?? currentMonth,
+  const { resolve, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
+  const defaultTimeFrame = useMemo(
+    () => ({
+      start: widget?.meta?.startDate ?? currentMonth,
+      end: widget?.meta?.endDate ?? monthUtils.addMonths(currentMonth, 11),
+      mode: 'static' as const,
+    }),
+    [currentMonth, widget?.meta?.endDate, widget?.meta?.startDate],
   );
-  const [end, setEnd] = useState(
-    widget?.meta?.timeFrame?.end ??
-      widget?.meta?.endDate ??
-      monthUtils.addMonths(currentMonth, 11),
+  const [initialStart, initialEnd, initialMode] = resolve(
+    widget?.meta?.timeFrame,
+    defaultTimeFrame,
   );
-  const [mode, setMode] = useState<TimeFrame['mode']>(
-    widget?.meta?.timeFrame?.mode ?? 'static',
-  );
+  const [start, setStart] = useState(initialStart);
+  const [end, setEnd] = useState(initialEnd);
+  const [mode, setMode] = useState<TimeFrame['mode']>(initialMode);
+  useEffect(() => {
+    const [nextStart, nextEnd, nextMode] = resolve(
+      widget?.meta?.timeFrame,
+      defaultTimeFrame,
+    );
+    setStart(nextStart);
+    setEnd(nextEnd);
+    setMode(nextMode);
+  }, [defaultTimeFrame, resolve, widget?.meta?.timeFrame]);
   const [granularity, setGranularity] = useState<'Daily' | 'Monthly'>(
     widget?.meta?.granularity ?? 'Monthly',
   );
@@ -121,7 +137,6 @@ function BalanceForecastInner({ widget }: BalanceForecastInnerProps) {
       : 'schedules',
   );
   const isTrackingBudgetForecast = source === 'tracking-budget';
-
   useEffect(() => {
     if (budgetType !== 'tracking' && source === 'tracking-budget') {
       setSource('schedules');
@@ -179,15 +194,13 @@ function BalanceForecastInner({ widget }: BalanceForecastInnerProps) {
         ...widget.meta,
         conditions,
         conditionsOp,
-        startDate: start,
-        endDate: end,
+        startDate: isUsingDashboardRange ? widget.meta?.startDate : start,
+        endDate: isUsingDashboardRange ? widget.meta?.endDate : end,
         granularity: isTrackingBudgetForecast ? 'Monthly' : granularity,
         source,
-        timeFrame: {
-          start,
-          end,
-          mode,
-        },
+        timeFrame: isUsingDashboardRange
+          ? widget.meta?.timeFrame
+          : { start, end, mode },
       },
     });
     dispatch(

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -31,11 +31,11 @@ import { Change } from '#components/reports/Change';
 import { BudgetAnalysisGraph } from '#components/reports/graphs/BudgetAnalysisGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { buildBudgetAnalysisCsv } from '#components/reports/spreadsheets/budget-analysis-export';
 import { createBudgetAnalysisSpreadsheet } from '#components/reports/spreadsheets/budget-analysis-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -140,6 +140,8 @@ type BudgetAnalysisInternalProps = {
 };
 
 function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -234,7 +236,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
       setAllMonths(allMonthsData);
 
       if (widget?.meta?.timeFrame) {
-        const [calculatedStart, calculatedEnd] = calculateTimeRange(
+        const [calculatedStart, calculatedEnd] = resolveTimeRange(
           widget.meta.timeFrame,
           undefined,
           latestTransDate,
@@ -245,7 +247,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
 
         setIsConcise(calculateIsConcise(calculatedStart, calculatedEnd));
       } else {
-        const [liveStart, liveEnd] = calculateTimeRange({
+        const [liveStart, liveEnd] = resolveTimeRange({
           start: monthUtils.subMonths(currentMonth, 5),
           end: currentMonth,
           mode: 'sliding-window',
@@ -257,7 +259,7 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
       }
     }
     void run();
-  }, [locale, widget?.meta?.timeFrame]);
+  }, [locale, widget?.meta?.timeFrame, resolveTimeRange]);
 
   // `start`/`end` may be `yyyy-MM` or `yyyy-MM-dd`; collapse to months first.
   const startDate = `${monthUtils.getMonth(start)}-01`;
@@ -306,11 +308,13 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
             ...(widget.meta ?? {}),
             conditions,
             conditionsOp,
-            timeFrame: {
-              start,
-              end,
-              mode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode,
+                },
             graphType,
             showBalance,
             balanceOnly: !showCategories,

--- a/packages/desktop-client/src/components/reports/reports/Calendar.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Calendar.tsx
@@ -40,7 +40,6 @@ import { DateRange } from '#components/reports/DateRange';
 import { CalendarGraph } from '#components/reports/graphs/CalendarGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { calendarSpreadsheet } from '#components/reports/spreadsheets/calendar-spreadsheet';
 import type { CalendarDataType } from '#components/reports/spreadsheets/calendar-spreadsheet';
 import { useReport } from '#components/reports/useReport';
@@ -50,6 +49,7 @@ import { TransactionList } from '#components/transactions/TransactionList';
 import { useAccounts } from '#hooks/useAccounts';
 import { SchedulesProvider } from '#hooks/useCachedSchedules';
 import { useCategories } from '#hooks/useCategories';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useDateFormat } from '#hooks/useDateFormat';
 import { DisplayPayeeProvider } from '#hooks/useDisplayPayee';
@@ -93,6 +93,8 @@ type CalendarInnerProps = {
 };
 
 function CalendarInner({ widget, parameters }: CalendarInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const { t } = useTranslation();
   const format = useFormat();
@@ -134,7 +136,6 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
     widget?.meta?.conditions,
     widget?.meta?.conditionsOp,
   );
-
   useEffect(() => {
     const day = parameters.get('day');
     const month = parameters.get('month');
@@ -301,7 +302,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
 
   useEffect(() => {
     if (latestTransaction) {
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         {
           start: monthUtils.dayFromDate(monthUtils.currentMonth()),
@@ -314,7 +315,7 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
       setEnd(initialEnd);
       setMode(initialMode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame]);
+  }, [latestTransaction, widget?.meta?.timeFrame, resolveTimeRange]);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -360,11 +361,13 @@ function CalendarInner({ widget, parameters }: CalendarInnerProps) {
             ...(widget.meta ?? {}),
             conditions,
             conditionsOp,
-            timeFrame: {
-              start,
-              end,
-              mode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode,
+                },
           },
         },
       },

--- a/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CashFlow.tsx
@@ -28,9 +28,9 @@ import { Change } from '#components/reports/Change';
 import { CashFlowGraph } from '#components/reports/graphs/CashFlowGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { cashFlowByDate } from '#components/reports/spreadsheets/cash-flow-spreadsheet';
 import { useReport } from '#components/reports/useReport';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -68,6 +68,8 @@ type CashFlowInnerProps = {
 };
 
 function CashFlowInner({ widget }: CashFlowInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -99,7 +101,6 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
   const [latestTransaction, setLatestTransaction] = useState('');
 
   const [isConcise, setIsConcise] = useState(false);
-
   useEffect(() => {
     const numDays = d.differenceInCalendarDays(
       d.parseISO(end),
@@ -165,7 +166,7 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
 
   useEffect(() => {
     if (latestTransaction) {
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         defaultTimeFrame,
         latestTransaction,
@@ -174,7 +175,7 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
       setEnd(initialEnd);
       setMode(initialMode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame]);
+  }, [latestTransaction, widget?.meta?.timeFrame, resolveTimeRange]);
 
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     setStart(start);
@@ -199,11 +200,13 @@ function CashFlowInner({ widget }: CashFlowInnerProps) {
             ...(widget.meta ?? {}),
             conditions,
             conditionsOp,
-            timeFrame: {
-              start,
-              end,
-              mode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode,
+                },
             showBalance,
           },
         },

--- a/packages/desktop-client/src/components/reports/reports/Crossover.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Crossover.tsx
@@ -34,12 +34,12 @@ import { CategorySelector } from '#components/reports/CategorySelector';
 import { CrossoverGraph } from '#components/reports/graphs/CrossoverGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { createCrossoverSpreadsheet } from '#components/reports/spreadsheets/crossover-spreadsheet';
 import type { CrossoverData } from '#components/reports/spreadsheets/crossover-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategories } from '#hooks/useCategories';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -72,6 +72,11 @@ export function Crossover() {
 type CrossoverInnerProps = { widget?: CrossoverWidget };
 
 function CrossoverInner({ widget }: CrossoverInnerProps) {
+  const {
+    resolve: resolveTimeRange,
+    hasDashboardContext,
+    isUsingDashboardRange,
+  } = useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -199,7 +204,7 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
 
   useEffect(() => {
     if (latestTransaction && allMonths?.length) {
-      const [initialStart, initialEnd, mode] = calculateTimeRange(
+      const [initialStart, initialEnd, mode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         defaultTimeFrame,
         latestTransaction,
@@ -208,6 +213,13 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
       const latestMonth = allMonths[0].name;
       let start = initialStart;
       let end = initialEnd;
+
+      if (hasDashboardContext) {
+        setStart(start);
+        setEnd(end);
+        setMode(mode);
+        return;
+      }
 
       const clampMonth = (m: string) => {
         if (monthUtils.isBefore(m, earliestMonth)) return earliestMonth;
@@ -234,7 +246,13 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
       setEnd(end);
       setMode(mode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame, allMonths]);
+  }, [
+    latestTransaction,
+    widget?.meta?.timeFrame,
+    allMonths,
+    resolveTimeRange,
+    hasDashboardContext,
+  ]);
 
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     if (!allMonths?.length) {
@@ -300,7 +318,9 @@ function CrossoverInner({ widget }: CrossoverInnerProps) {
             projectionType,
             expenseAdjustmentFactor,
             showHiddenCategories,
-            timeFrame: { start, end, mode },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : { start, end, mode },
           },
         },
       },

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -54,9 +54,14 @@ import { setSessionReport } from '#components/reports/setSessionReport';
 import { createCustomSpreadsheet } from '#components/reports/spreadsheets/custom-spreadsheet';
 import { createGroupedSpreadsheet } from '#components/reports/spreadsheets/grouped-spreadsheet';
 import { useReport } from '#components/reports/useReport';
-import { calculateHasWarning, fromDateRepr } from '#components/reports/util';
+import {
+  calculateHasWarning,
+  fromDateRepr,
+  normalizeCustomReportDateRange,
+} from '#components/reports/util';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategories } from '#hooks/useCategories';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
 import { useLocalPref } from '#hooks/useLocalPref';
@@ -65,6 +70,7 @@ import { usePayees } from '#hooks/usePayees';
 import { useReport as useCustomReport } from '#hooks/useReport';
 import { useRuleConditionFilters } from '#hooks/useRuleConditionFilters';
 import { useSyncedPref } from '#hooks/useSyncedPref';
+import { useUpdateDashboardWidgetMutation } from '#reports/mutations';
 
 /**
  * Transform `selectedCategories` into `conditions`.
@@ -187,6 +193,13 @@ function CustomReportInner({
     ...combine,
     ...session,
   };
+  const {
+    dashboardWidget,
+    dashboardScope,
+    hasDashboardContext,
+    isUsingDashboardRange,
+  } = useDashboardReportTimeRange();
+  const updateDashboardWidget = useUpdateDashboardWidgetMutation();
 
   const [allIntervals, setAllIntervals] = useState<
     Array<{
@@ -311,6 +324,51 @@ function CustomReportInner({
         ? 'saved'
         : 'new',
   );
+
+  useEffect(() => {
+    if (!dashboardScope) {
+      return;
+    }
+    if (isUsingDashboardRange) {
+      const [nextStart, nextEnd] = normalizeCustomReportDateRange(
+        interval,
+        dashboardScope.start,
+        dashboardScope.end,
+      );
+      setStartDate(nextStart);
+      setEndDate(nextEnd);
+      setIsDateStatic(true);
+      return;
+    }
+    setIsDateStatic(loadReport.isDateStatic);
+    if (!loadReport.isDateStatic) {
+      const [nextStart, nextEnd] = getLiveRange(
+        loadReport.dateRange,
+        earliestTransactionDate || monthUtils.currentDay(),
+        latestTransactionDate || monthUtils.currentDay(),
+        loadReport.includeCurrentInterval,
+        firstDayOfWeekIdx,
+        dashboardScope.end,
+      );
+      setStartDate(nextStart);
+      setEndDate(nextEnd);
+    } else {
+      setStartDate(loadReport.startDate);
+      setEndDate(loadReport.endDate);
+    }
+  }, [
+    dashboardScope,
+    earliestTransactionDate,
+    firstDayOfWeekIdx,
+    interval,
+    isUsingDashboardRange,
+    latestTransactionDate,
+    loadReport.dateRange,
+    loadReport.endDate,
+    loadReport.includeCurrentInterval,
+    loadReport.isDateStatic,
+    loadReport.startDate,
+  ]);
 
   const onApplyFilterConditions = useEffectEvent(
     (
@@ -501,7 +559,6 @@ function CustomReportInner({
     payees,
     accounts,
   });
-
   useEffect(() => {
     if (balanceTypeOp !== 'totalBudgeted') {
       return;
@@ -631,6 +688,16 @@ function CustomReportInner({
     conditions,
     conditionsOp,
   };
+  const savedCustomReportItems = isUsingDashboardRange
+    ? {
+        ...customReportItems,
+        startDate: loadReport.startDate,
+        endDate: loadReport.endDate,
+        isDateStatic: loadReport.isDateStatic,
+        dateRange: loadReport.dateRange,
+        includeCurrentInterval: loadReport.includeCurrentInterval,
+      }
+    : customReportItems;
 
   const navigate = useNavigate();
   const [, setScrollWidth] = useState(0);
@@ -929,6 +996,18 @@ function CustomReportInner({
             latestTransaction={latestTransactionDate}
             firstDayOfWeekIdx={firstDayOfWeekIdx}
             isComplexCategoryCondition={isComplexCategoryCondition}
+            useDashboardDateRange={isUsingDashboardRange}
+            onUseDashboardDateRangeChange={
+              hasDashboardContext && dashboardWidget
+                ? use_dashboard_date_range =>
+                    updateDashboardWidget.mutate({
+                      widget: {
+                        id: dashboardWidget.id,
+                        use_dashboard_date_range,
+                      },
+                    })
+                : undefined
+            }
           />
         )}
         <View
@@ -938,7 +1017,7 @@ function CustomReportInner({
         >
           {!isNarrowWidth && (
             <ReportTopbar
-              customReportItems={customReportItems}
+              customReportItems={savedCustomReportItems}
               report={report}
               savedStatus={savedStatus}
               setGraphType={setGraphType}

--- a/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReportListCards.tsx
@@ -11,10 +11,15 @@ import { send } from '@actual-app/core/platform/client/connection';
 import * as monthUtils from '@actual-app/core/shared/months';
 import type { CustomReportEntity } from '@actual-app/core/types/models';
 
+import { useDashboardDateScope } from '#components/reports/DashboardDateScope';
 import { DateRange } from '#components/reports/DateRange';
+import { getLiveRange } from '#components/reports/getLiveRange';
 import { ReportCard } from '#components/reports/ReportCard';
 import { ReportCardName } from '#components/reports/ReportCardName';
-import { calculateHasWarning } from '#components/reports/util';
+import {
+  calculateHasWarning,
+  normalizeCustomReportDateRange,
+} from '#components/reports/util';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategories } from '#hooks/useCategories';
 import { usePayees } from '#hooks/usePayees';
@@ -30,12 +35,14 @@ type CustomReportListCardsProps = {
   widgetId: string;
   isEditing?: boolean;
   report?: CustomReportEntity;
+  useDashboardDateRange?: boolean;
 };
 
 export function CustomReportListCards({
   widgetId,
   isEditing,
   report,
+  useDashboardDateRange,
 }: CustomReportListCardsProps) {
   // It's possible for a dashboard to reference a non-existing
   // custom report
@@ -52,6 +59,7 @@ export function CustomReportListCards({
       widgetId={widgetId}
       isEditing={isEditing}
       report={report}
+      useDashboardDateRange={useDashboardDateRange}
     />
   );
 }
@@ -60,10 +68,12 @@ function CustomReportListCardsInner({
   widgetId,
   isEditing,
   report,
+  useDashboardDateRange,
 }: CustomReportListCardsProps & {
   report: CustomReportEntity;
 }) {
   const { t } = useTranslation();
+  const dashboardScope = useDashboardDateScope();
 
   const dispatch = useDispatch();
 
@@ -99,6 +109,33 @@ function CustomReportListCardsInner({
   }, []);
 
   const updateReportMutation = useUpdateReportMutation();
+  let effectiveReport = report;
+  if (dashboardScope) {
+    let startDate = report.startDate;
+    let endDate = report.endDate;
+    if (useDashboardDateRange ?? true) {
+      [startDate, endDate] = normalizeCustomReportDateRange(
+        report.interval,
+        dashboardScope.start,
+        dashboardScope.end,
+      );
+    } else if (!report.isDateStatic) {
+      [startDate, endDate] = getLiveRange(
+        report.dateRange,
+        earliestTransaction,
+        latestTransaction,
+        report.includeCurrentInterval,
+        firstDayOfWeekIdx,
+        dashboardScope.end,
+      );
+    }
+    effectiveReport = {
+      ...report,
+      startDate,
+      endDate,
+      isDateStatic: true,
+    };
+  }
 
   const onSaveName = async (name: string) => {
     const updatedReport = {
@@ -151,8 +188,11 @@ function CustomReportListCardsInner({
               onChange={onSaveName}
               onClose={() => setNameMenuOpen(false)}
             />
-            {report.isDateStatic ? (
-              <DateRange start={report.startDate} end={report.endDate} />
+            {effectiveReport.isDateStatic ? (
+              <DateRange
+                start={effectiveReport.startDate}
+                end={effectiveReport.endDate}
+              />
             ) : (
               <Text style={{ color: theme.pageTextSubdued }}>
                 {t(report.dateRange)}
@@ -161,7 +201,7 @@ function CustomReportListCardsInner({
           </View>
         </View>
         <GetCardData
-          report={report}
+          report={effectiveReport}
           payees={payees}
           accounts={accounts}
           categories={categories}

--- a/packages/desktop-client/src/components/reports/reports/Formula.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Formula.tsx
@@ -11,7 +11,10 @@ import { styles } from '@actual-app/components/styles';
 import { theme } from '@actual-app/components/theme';
 import { Toggle } from '@actual-app/components/toggle';
 import { View } from '@actual-app/components/view';
-import type { FormulaWidget } from '@actual-app/core/types/models';
+import type {
+  DashboardDateScope,
+  FormulaWidget,
+} from '@actual-app/core/types/models';
 
 import { EditablePageHeaderTitle } from '#components/EditablePageHeaderTitle';
 import { QueryManager } from '#components/formula/QueryManager';
@@ -20,6 +23,7 @@ import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { FormulaResult } from '#components/reports/FormulaResult';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
 import { useCategories } from '#hooks/useCategories';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormulaExecution } from '#hooks/useFormulaExecution';
 import { useNavigate } from '#hooks/useNavigate';
@@ -40,19 +44,21 @@ export function Formula() {
     id: params.id,
     type: 'formula-card',
   });
+  const { dashboardScope } = useDashboardReportTimeRange(widget);
 
   if (isPending) {
     return <LoadingIndicator />;
   }
 
-  return <FormulaInner widget={widget} />;
+  return <FormulaInner widget={widget} dashboardScope={dashboardScope} />;
 }
 
 type FormulaInnerProps = {
   widget?: FormulaWidget;
+  dashboardScope: DashboardDateScope | null;
 };
 
-function FormulaInner({ widget }: FormulaInnerProps) {
+function FormulaInner({ widget, dashboardScope }: FormulaInnerProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -89,7 +95,13 @@ function FormulaInner({ widget }: FormulaInnerProps) {
     result,
     isLoading: isExecuting,
     error,
-  } = useFormulaExecution(formula, queriesRef.current, queriesVersion);
+  } = useFormulaExecution(
+    formula,
+    queriesRef.current,
+    queriesVersion,
+    undefined,
+    dashboardScope,
+  );
 
   const colorVariables = useMemo(
     () => ({
@@ -126,6 +138,7 @@ function FormulaInner({ widget }: FormulaInnerProps) {
     queriesRef.current,
     queriesVersion,
     colorVariables,
+    dashboardScope,
   );
 
   const handleQueriesChange = useCallback(
@@ -477,6 +490,7 @@ function FormulaInner({ widget }: FormulaInnerProps) {
           <QueryManager
             queries={queriesRef.current}
             onQueriesChange={handleQueriesChange}
+            dashboardScope={dashboardScope}
           />
         </View>
       </View>

--- a/packages/desktop-client/src/components/reports/reports/FormulaCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/FormulaCard.tsx
@@ -4,11 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { View } from '@actual-app/components/view';
 import type { FormulaWidget } from '@actual-app/core/types/models';
 
+import { useDashboardDateScope } from '#components/reports/DashboardDateScope';
 import { FormulaResult } from '#components/reports/FormulaResult';
 import { ReportCard } from '#components/reports/ReportCard';
 import { ReportCardName } from '#components/reports/ReportCardName';
 import { useFormulaExecution } from '#hooks/useFormulaExecution';
 import { useThemeColors } from '#hooks/useThemeColors';
+
+const EMPTY_QUERIES = {};
 
 type FormulaCardProps = {
   widgetId: string;
@@ -27,6 +30,7 @@ export function FormulaCard({
   const [nameMenuOpen, setNameMenuOpen] = useState(false);
   const themeColors = useThemeColors();
   const containerRef = useRef<HTMLDivElement>(null);
+  const dashboardScope = useDashboardDateScope();
 
   const formula = meta?.formula || '=SUM(1, 2, 3)';
   const fontSize = meta?.fontSize;
@@ -34,11 +38,14 @@ export function FormulaCard({
   const staticFontSize = meta?.staticFontSize || 32;
   const showTitle = meta?.showTitle ?? true;
   const colorFormula = meta?.colorFormula || '';
+  const queries = meta?.queries ?? EMPTY_QUERIES;
 
   const { result, isLoading, error } = useFormulaExecution(
     formula,
-    meta?.queries || {},
+    queries,
     meta?.queriesVersion,
+    undefined,
+    dashboardScope,
   );
 
   const colorVariables = useMemo(
@@ -56,9 +63,10 @@ export function FormulaCard({
   );
   const { result: colorResult, error: colorError } = useFormulaExecution(
     colorFormula,
-    meta?.queries || {},
+    queries,
     meta?.queriesVersion,
     colorVariables,
+    dashboardScope,
   );
 
   // Determine the custom color from color formula result

--- a/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
+++ b/packages/desktop-client/src/components/reports/reports/NetWorth.tsx
@@ -32,11 +32,11 @@ import { NetWorthGraph } from '#components/reports/graphs/NetWorthGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
 import { ReportOptions } from '#components/reports/ReportOptions';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { createSpreadsheet as netWorthSpreadsheet } from '#components/reports/spreadsheets/net-worth-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { useAccounts } from '#hooks/useAccounts';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -66,6 +66,8 @@ type NetWorthInnerProps = {
 };
 
 function NetWorthInner({ widget }: NetWorthInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const dispatch = useDispatch();
   const { t } = useTranslation();
@@ -120,7 +122,6 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
   );
 
   const [latestTransaction, setLatestTransaction] = useState('');
-
   const [_firstDayOfWeekIdx] = useSyncedPref('firstDayOfWeekIdx');
   const firstDayOfWeekIdx = _firstDayOfWeekIdx || '0';
 
@@ -204,7 +205,7 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
 
   useEffect(() => {
     if (latestTransaction) {
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         undefined,
         latestTransaction,
@@ -213,7 +214,12 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
       setEnd(initialEnd);
       setModeAndInterval(initialMode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame, setModeAndInterval]);
+  }, [
+    latestTransaction,
+    widget?.meta?.timeFrame,
+    setModeAndInterval,
+    resolveTimeRange,
+  ]);
 
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     setStart(start);
@@ -238,11 +244,13 @@ function NetWorthInner({ widget }: NetWorthInnerProps) {
             conditionsOp,
             interval,
             mode: graphMode,
-            timeFrame: {
-              start,
-              end,
-              mode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode,
+                },
           },
         },
       },

--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -37,7 +37,6 @@ import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { SankeyGraph } from '#components/reports/graphs/SankeyGraph';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import {
   buildSankeyData,
   createBaseGraphSpreadsheet,
@@ -48,6 +47,7 @@ import type { Graph } from '#components/reports/spreadsheets/sankey-spreadsheet'
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { useCategories } from '#hooks/useCategories';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormatList } from '#hooks/useFormatList';
 import { useLocale } from '#hooks/useLocale';
@@ -424,6 +424,8 @@ type SankeyInnerProps = {
   widget?: SankeyWidget;
 };
 function SankeyInner({ widget }: SankeyInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const dispatch = useDispatch();
   const { t, i18n } = useTranslation();
@@ -441,7 +443,6 @@ function SankeyInner({ widget }: SankeyInnerProps) {
     widget?.meta?.conditions,
     widget?.meta?.conditionsOp,
   );
-
   const currentMonth = monthUtils.currentMonth();
   const [allMonths, setAllMonths] = useState([
     {
@@ -639,7 +640,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
         : monthUtils.currentDay();
       setLatestTransaction(latestTransactionDate);
 
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         undefined,
         latestTransactionDate,
@@ -685,7 +686,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
       setAllMonths(allMonths);
     }
     void run();
-  }, [locale, widget?.meta?.timeFrame]);
+  }, [locale, widget?.meta?.timeFrame, resolveTimeRange]);
   function onChangeDates(start: string, end: string, mode: TimeFrame['mode']) {
     setStart(start);
     setEnd(end);
@@ -712,11 +713,13 @@ function SankeyInner({ widget }: SankeyInnerProps) {
             showPercentages,
             layerFrom,
             layerTo,
-            timeFrame: {
-              start,
-              end,
-              mode: timeFrameMode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode: timeFrameMode,
+                },
             groupAccounts,
           },
         },

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -13,6 +13,7 @@ import { SpaceBetween } from '@actual-app/components/space-between';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
+import { Toggle } from '@actual-app/components/toggle';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
@@ -44,6 +45,7 @@ import {
 import { createSpendingSpreadsheet } from '#components/reports/spreadsheets/spending-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -97,9 +99,15 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const [allIntervals, setAllIntervals] = useState(emptyIntervals);
 
   const initialReportMode = widget?.meta?.mode ?? 'single-month';
-  const [initialCompare, initialCompareTo] = calculateSpendingReportTimeRange(
-    widget?.meta ?? {},
-  );
+  const { dashboardScope, hasDashboardContext, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
+  const [initialCompare, initialCompareTo] =
+    isUsingDashboardRange && dashboardScope
+      ? [dashboardScope.start, dashboardScope.end]
+      : calculateSpendingReportTimeRange(
+          widget?.meta ?? {},
+          dashboardScope?.end,
+        );
   const [compare, setCompare] = useState(initialCompare);
   const [compareTo, setCompareTo] = useState(initialCompareTo);
   const [averageRange, setAverageRange] = useState(
@@ -108,6 +116,17 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
   const [isLive, setIsLive] = useState(widget?.meta?.isLive ?? true);
 
   const [reportMode, setReportMode] = useState(initialReportMode);
+  useEffect(() => {
+    const [nextCompare, nextCompareTo] =
+      isUsingDashboardRange && dashboardScope
+        ? [dashboardScope.start, dashboardScope.end]
+        : calculateSpendingReportTimeRange(
+            widget?.meta ?? {},
+            dashboardScope?.end,
+          );
+    setCompare(nextCompare);
+    setCompareTo(nextCompareTo);
+  }, [dashboardScope, isUsingDashboardRange, widget?.meta]);
 
   useEffect(() => {
     async function run() {
@@ -180,10 +199,12 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
             ...(widget.meta ?? {}),
             conditions,
             conditionsOp,
-            compare,
-            compareTo,
+            compare: isUsingDashboardRange ? widget.meta?.compare : compare,
+            compareTo: isUsingDashboardRange
+              ? widget.meta?.compareTo
+              : compareTo,
             averageRange,
-            isLive,
+            isLive: isUsingDashboardRange ? widget.meta?.isLive : isLive,
             mode: reportMode,
           },
         },
@@ -302,8 +323,26 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
       >
         {!isNarrowWidth && (
           <SpaceBetween gap={0}>
+            {hasDashboardContext && (
+              <View
+                style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
+              >
+                <Toggle
+                  id={`use-dashboard-date-range-${widget?.id}`}
+                  isOn={isUsingDashboardRange}
+                  onToggle={use_dashboard_date_range =>
+                    widget &&
+                    updateDashboardWidgetMutation.mutate({
+                      widget: { id: widget.id, use_dashboard_date_range },
+                    })
+                  }
+                />
+                <Trans>Use dashboard date range</Trans>
+              </View>
+            )}
             <Button
               variant={isLive ? 'primary' : 'normal'}
+              isDisabled={isUsingDashboardRange}
               onPress={() => setIsLive(state => !state)}
             >
               {isLive ? t('Live') : t('Static')}
@@ -326,6 +365,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               <Select
                 value={compare}
                 onChange={setCompare}
+                disabled={isUsingDashboardRange}
                 options={allIntervals.map(
                   ({ name, pretty }) => [name, pretty] as const,
                 )}
@@ -339,7 +379,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
                 value={comparisonValue}
                 onChange={onComparisonChange}
                 options={comparisonOptions}
-                disabled={reportMode === 'budget'}
+                disabled={reportMode === 'budget' || isUsingDashboardRange}
                 style={{ width: 150 }}
                 popoverStyle={{ width: 150 }}
               />
@@ -358,6 +398,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
             <SpaceBetween gap={5}>
               <ModeButton
                 selected={reportMode === 'single-month'}
+                isDisabled={isUsingDashboardRange}
                 style={{
                   backgroundColor: 'inherit',
                 }}
@@ -369,6 +410,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               </ModeButton>
               <ModeButton
                 selected={reportMode === 'budget'}
+                isDisabled={isUsingDashboardRange}
                 onSelect={() => {
                   setReportMode('budget');
                 }}
@@ -380,6 +422,7 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
               </ModeButton>
               <ModeButton
                 selected={reportMode === 'average'}
+                isDisabled={isUsingDashboardRange}
                 onSelect={() => {
                   setReportMode('average');
                 }}

--- a/packages/desktop-client/src/components/reports/reports/Spending.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Spending.tsx
@@ -13,7 +13,6 @@ import { SpaceBetween } from '@actual-app/components/space-between';
 import { styles } from '@actual-app/components/styles';
 import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
-import { Toggle } from '@actual-app/components/toggle';
 import { Tooltip } from '@actual-app/components/tooltip';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
@@ -324,29 +323,44 @@ function SpendingInternal({ widget }: SpendingInternalProps) {
         {!isNarrowWidth && (
           <SpaceBetween gap={0}>
             {hasDashboardContext && (
-              <View
-                style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}
+              <ModeButton
+                selected={isUsingDashboardRange}
+                onSelect={() =>
+                  widget &&
+                  updateDashboardWidgetMutation.mutate({
+                    widget: { id: widget.id, use_dashboard_date_range: true },
+                  })
+                }
               >
-                <Toggle
-                  id={`use-dashboard-date-range-${widget?.id}`}
-                  isOn={isUsingDashboardRange}
-                  onToggle={use_dashboard_date_range =>
-                    widget &&
-                    updateDashboardWidgetMutation.mutate({
-                      widget: { id: widget.id, use_dashboard_date_range },
-                    })
-                  }
-                />
-                <Trans>Use dashboard date range</Trans>
-              </View>
+                <Trans>Dashboard</Trans>
+              </ModeButton>
             )}
-            <Button
-              variant={isLive ? 'primary' : 'normal'}
-              isDisabled={isUsingDashboardRange}
-              onPress={() => setIsLive(state => !state)}
+            <ModeButton
+              selected={!isUsingDashboardRange && isLive}
+              onSelect={() => {
+                if (widget) {
+                  updateDashboardWidgetMutation.mutate({
+                    widget: { id: widget.id, use_dashboard_date_range: false },
+                  });
+                }
+                setIsLive(true);
+              }}
             >
-              {isLive ? t('Live') : t('Static')}
-            </Button>
+              <Trans>Live</Trans>
+            </ModeButton>
+            <ModeButton
+              selected={!isUsingDashboardRange && !isLive}
+              onSelect={() => {
+                if (widget) {
+                  updateDashboardWidgetMutation.mutate({
+                    widget: { id: widget.id, use_dashboard_date_range: false },
+                  });
+                }
+                setIsLive(false);
+              }}
+            >
+              <Trans>Static</Trans>
+            </ModeButton>
 
             <View
               style={{

--- a/packages/desktop-client/src/components/reports/reports/Summary.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Summary.tsx
@@ -33,11 +33,11 @@ import { MobilePageHeader, Page, PageHeader } from '#components/Page';
 import { PrivacyFilter } from '#components/PrivacyFilter';
 import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
-import { calculateTimeRange } from '#components/reports/reportRanges';
 import { summarySpreadsheet } from '#components/reports/spreadsheets/summary-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { FieldSelect } from '#components/rules/RuleEditor';
+import { useDashboardReportTimeRange } from '#hooks/useDashboardReportTimeRange';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 import { useFormat } from '#hooks/useFormat';
 import { useLocale } from '#hooks/useLocale';
@@ -69,6 +69,8 @@ type SummaryInnerProps = {
 type FilterObject = ReturnType<typeof useRuleConditionFilters>;
 
 function SummaryInner({ widget }: SummaryInnerProps) {
+  const { resolve: resolveTimeRange, isUsingDashboardRange } =
+    useDashboardReportTimeRange(widget);
   const locale = useLocale();
   const { t } = useTranslation();
   const format = useFormat();
@@ -112,7 +114,6 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       ? (content?.divisorConditionsOp ?? 'and')
       : 'and',
   );
-
   const params = useMemo(
     () =>
       summarySpreadsheet(
@@ -123,14 +124,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
         content,
         locale,
       ),
-    [
-      start,
-      end,
-      dividendFilters.conditions,
-      dividendFilters.conditionsOp,
-      content,
-      locale,
-    ],
+    [start, end, dividendFilters, content, locale],
   );
 
   const data = useReport('summary', params);
@@ -209,7 +203,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
 
   useEffect(() => {
     if (latestTransaction) {
-      const [initialStart, initialEnd, initialMode] = calculateTimeRange(
+      const [initialStart, initialEnd, initialMode] = resolveTimeRange(
         widget?.meta?.timeFrame,
         {
           start: monthUtils.dayFromDate(monthUtils.currentMonth()),
@@ -222,7 +216,7 @@ function SummaryInner({ widget }: SummaryInnerProps) {
       setEnd(initialEnd);
       setMode(initialMode);
     }
-  }, [latestTransaction, widget?.meta?.timeFrame]);
+  }, [latestTransaction, widget?.meta?.timeFrame, resolveTimeRange]);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -284,11 +278,13 @@ function SummaryInner({ widget }: SummaryInnerProps) {
             ...(widget.meta ?? {}),
             conditions: dividendFilters.conditions,
             conditionsOp: dividendFilters.conditionsOp,
-            timeFrame: {
-              start,
-              end,
-              mode,
-            },
+            timeFrame: isUsingDashboardRange
+              ? widget.meta?.timeFrame
+              : {
+                  start,
+                  end,
+                  mode,
+                },
             content: JSON.stringify(content),
           },
         },

--- a/packages/desktop-client/src/components/reports/util.test.ts
+++ b/packages/desktop-client/src/components/reports/util.test.ts
@@ -1,0 +1,14 @@
+import { normalizeCustomReportDateRange } from './util';
+
+describe('normalizeCustomReportDateRange', () => {
+  it.each<[string, [string, string]]>([
+    ['Daily', ['2026-03-01', '2026-08-31']],
+    ['Weekly', ['2026-03-01', '2026-08-31']],
+    ['Monthly', ['2026-03', '2026-08']],
+    ['Yearly', ['2026', '2026']],
+  ])('normalizes %s report boundaries', (interval, expected) => {
+    expect(
+      normalizeCustomReportDateRange(interval, '2026-03', '2026-08'),
+    ).toEqual(expected);
+  });
+});

--- a/packages/desktop-client/src/components/reports/util.ts
+++ b/packages/desktop-client/src/components/reports/util.ts
@@ -1,3 +1,4 @@
+import * as monthUtils from '@actual-app/core/shared/months';
 // @ts-strict-ignore
 import type { Query } from '@actual-app/core/shared/query';
 import type {
@@ -11,6 +12,20 @@ import { aqlQuery } from '#queries/aqlQuery';
 
 export function fromDateRepr(date: string): string {
   return date.slice(0, 7);
+}
+
+export function normalizeCustomReportDateRange(
+  interval: string,
+  start: string,
+  end: string,
+): [string, string] {
+  if (interval === 'Monthly') {
+    return [monthUtils.monthFromDate(start), monthUtils.monthFromDate(end)];
+  }
+  if (interval === 'Yearly') {
+    return [monthUtils.yearFromDate(start), monthUtils.yearFromDate(end)];
+  }
+  return [monthUtils.firstDayOfMonth(start), monthUtils.lastDayOfMonth(end)];
 }
 
 export async function runAll(

--- a/packages/desktop-client/src/hooks/useDashboardReportTimeRange.test.ts
+++ b/packages/desktop-client/src/hooks/useDashboardReportTimeRange.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDashboardTimeRange } from './useDashboardReportTimeRange';
+
+const dashboardScope = {
+  start: '2026-03',
+  end: '2026-08',
+  mode: 'sliding-window' as const,
+};
+
+describe('resolveDashboardTimeRange', () => {
+  it('inherits dashboard dates or anchors an independent LIVE range to its end', () => {
+    expect(
+      resolveDashboardTimeRange(dashboardScope, true, {
+        start: '2025-01',
+        end: '2025-03',
+        mode: 'sliding-window',
+      }),
+    ).toEqual(['2026-03', '2026-08', 'sliding-window']);
+
+    expect(
+      resolveDashboardTimeRange(dashboardScope, false, {
+        start: '2025-01',
+        end: '2025-03',
+        mode: 'sliding-window',
+      }),
+    ).toEqual(['2026-06', '2026-08', 'sliding-window']);
+
+    expect(
+      resolveDashboardTimeRange(dashboardScope, false, {
+        start: '2025-01',
+        end: '2025-03',
+        mode: 'static',
+      }),
+    ).toEqual(['2025-01', '2025-03', 'static']);
+  });
+});

--- a/packages/desktop-client/src/hooks/useDashboardReportTimeRange.ts
+++ b/packages/desktop-client/src/hooks/useDashboardReportTimeRange.ts
@@ -9,7 +9,6 @@ import type {
 } from '@actual-app/core/types/models';
 
 import { calculateTimeRange } from '#components/reports/reportRanges';
-import { useDashboardPages } from '#hooks/useDashboardPages';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
 
 const MODES = new Set<TimeFrame['mode']>([
@@ -51,10 +50,6 @@ export function useDashboardReportTimeRange(widget?: DashboardWidgetEntity) {
     id: widget ? undefined : (contextualWidgetId ?? undefined),
   });
   const dashboardWidget = widget ?? contextualWidget;
-  const { data: dashboards = [] } = useDashboardPages();
-  const dashboard = dashboards.find(
-    page => page.id === dashboardWidget?.dashboard_page_id,
-  );
   const start = params.get('dashboardStart');
   const end = params.get('dashboardEnd');
   const mode = params.get('dashboardMode') as TimeFrame['mode'] | null;
@@ -74,16 +69,15 @@ export function useDashboardReportTimeRange(widget?: DashboardWidgetEntity) {
     MODES.has(mode),
   );
   const dashboardScope = useMemo<DashboardDateScope | null>(() => {
-    if (!dashboard?.date_range_enabled || !dashboard.time_frame) {
+    if (!hasValidSnapshot) {
       return null;
     }
-    const persistedScope = calculateTimeRange(dashboard.time_frame);
     return {
-      start: hasValidSnapshot ? start! : persistedScope[0],
-      end: hasValidSnapshot ? end! : persistedScope[1],
-      mode: hasValidSnapshot ? mode! : persistedScope[2],
+      start: start!,
+      end: end!,
+      mode: mode!,
     };
-  }, [dashboard, end, hasValidSnapshot, mode, start]);
+  }, [end, hasValidSnapshot, mode, start]);
   const hasDashboardContext = dashboardScope !== null;
   const isUsingDashboardRange =
     hasDashboardContext && (dashboardWidget?.use_dashboard_date_range ?? true);

--- a/packages/desktop-client/src/hooks/useDashboardReportTimeRange.ts
+++ b/packages/desktop-client/src/hooks/useDashboardReportTimeRange.ts
@@ -1,0 +1,115 @@
+import { useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router';
+
+import * as monthUtils from '@actual-app/core/shared/months';
+import type {
+  DashboardDateScope,
+  DashboardWidgetEntity,
+  TimeFrame,
+} from '@actual-app/core/types/models';
+
+import { calculateTimeRange } from '#components/reports/reportRanges';
+import { useDashboardPages } from '#hooks/useDashboardPages';
+import { useDashboardWidget } from '#hooks/useDashboardWidget';
+
+const MODES = new Set<TimeFrame['mode']>([
+  'sliding-window',
+  'static',
+  'full',
+  'lastMonth',
+  'lastYear',
+  'yearToDate',
+  'priorYearToDate',
+]);
+
+export function resolveDashboardTimeRange(
+  dashboardScope: DashboardDateScope | null,
+  useDashboardDateRange: boolean,
+  timeFrame?: Partial<TimeFrame>,
+  defaultTimeFrame?: TimeFrame,
+  latestTransaction?: string,
+) {
+  if (dashboardScope && useDashboardDateRange) {
+    return [
+      dashboardScope.start,
+      dashboardScope.end,
+      dashboardScope.mode,
+    ] as const;
+  }
+  return calculateTimeRange(
+    timeFrame,
+    defaultTimeFrame,
+    latestTransaction,
+    dashboardScope?.end,
+  );
+}
+
+export function useDashboardReportTimeRange(widget?: DashboardWidgetEntity) {
+  const [params] = useSearchParams();
+  const contextualWidgetId = params.get('dashboardWidget');
+  const { data: contextualWidget } = useDashboardWidget<DashboardWidgetEntity>({
+    id: widget ? undefined : (contextualWidgetId ?? undefined),
+  });
+  const dashboardWidget = widget ?? contextualWidget;
+  const { data: dashboards = [] } = useDashboardPages();
+  const dashboard = dashboards.find(
+    page => page.id === dashboardWidget?.dashboard_page_id,
+  );
+  const start = params.get('dashboardStart');
+  const end = params.get('dashboardEnd');
+  const mode = params.get('dashboardMode') as TimeFrame['mode'] | null;
+  const isValidDate = (value: string | null) =>
+    Boolean(
+      value &&
+      (monthUtils.isValidYearMonth(value) ||
+        monthUtils.isValidYearMonthDay(value)),
+    );
+  const hasValidSnapshot = Boolean(
+    dashboardWidget &&
+    (!contextualWidgetId || contextualWidgetId === dashboardWidget.id) &&
+    isValidDate(start) &&
+    isValidDate(end) &&
+    start! <= end! &&
+    mode &&
+    MODES.has(mode),
+  );
+  const dashboardScope = useMemo<DashboardDateScope | null>(() => {
+    if (!dashboard?.date_range_enabled || !dashboard.time_frame) {
+      return null;
+    }
+    const persistedScope = calculateTimeRange(dashboard.time_frame);
+    return {
+      start: hasValidSnapshot ? start! : persistedScope[0],
+      end: hasValidSnapshot ? end! : persistedScope[1],
+      mode: hasValidSnapshot ? mode! : persistedScope[2],
+    };
+  }, [dashboard, end, hasValidSnapshot, mode, start]);
+  const hasDashboardContext = dashboardScope !== null;
+  const isUsingDashboardRange =
+    hasDashboardContext && (dashboardWidget?.use_dashboard_date_range ?? true);
+
+  const resolve = useCallback(
+    (
+      timeFrame?: Partial<TimeFrame>,
+      defaultTimeFrame?: TimeFrame,
+      latestTransaction?: string,
+    ) => {
+      return resolveDashboardTimeRange(
+        dashboardScope,
+        isUsingDashboardRange,
+        timeFrame,
+        defaultTimeFrame,
+        latestTransaction,
+      );
+    },
+    [dashboardScope, isUsingDashboardRange],
+  );
+
+  return {
+    resolve,
+    dashboardScope,
+    dashboardWidget,
+    hasDashboardContext,
+    isUsingDashboardRange,
+  };
+}

--- a/packages/desktop-client/src/hooks/useDashboardWidget.ts
+++ b/packages/desktop-client/src/hooks/useDashboardWidget.ts
@@ -13,7 +13,8 @@ export function useDashboardWidget<W extends DashboardWidgetEntity>({
 }: UseDashboardWidgetProps<W>) {
   return useQuery({
     ...dashboardQueries.listDashboardWidgets<W>(),
-    select: widgets => widgets.find(w => w.id === id && w.type === type),
-    enabled: !!id && !!type,
+    select: widgets =>
+      widgets.find(w => w.id === id && (!type || w.type === type)),
+    enabled: !!id,
   });
 }

--- a/packages/desktop-client/src/hooks/useFormulaExecution.test.ts
+++ b/packages/desktop-client/src/hooks/useFormulaExecution.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestProviders } from '#mocks';
 
 import {
+  applyDashboardScopeToFormulaQueries,
   buildFilteredTransactionsQuery,
   useFormulaExecution,
 } from './useFormulaExecution';
@@ -221,5 +222,43 @@ describe('formula query timeframes', () => {
       '2026-07-01',
       '2026-07-31',
     );
+  });
+
+  it('applies dashboard dates independently to formula queries', () => {
+    const queries = applyDashboardScopeToFormulaQueries(
+      {
+        inherited: {
+          timeFrame: {
+            start: '2025-01',
+            end: '2025-03',
+            mode: 'sliding-window',
+          },
+        },
+        independent: {
+          useDashboardDateRange: false,
+          timeFrame: {
+            start: '2025-01',
+            end: '2025-03',
+            mode: 'sliding-window',
+          },
+        },
+      },
+      {
+        start: '2026-03',
+        end: '2026-08',
+        mode: 'sliding-window',
+      },
+    );
+
+    expect(queries.inherited.timeFrame).toEqual({
+      start: '2026-03',
+      end: '2026-08',
+      mode: 'static',
+    });
+    expect(queries.independent.timeFrame).toEqual({
+      start: '2026-06',
+      end: '2026-08',
+      mode: 'static',
+    });
   });
 });

--- a/packages/desktop-client/src/hooks/useFormulaExecution.ts
+++ b/packages/desktop-client/src/hooks/useFormulaExecution.ts
@@ -12,8 +12,9 @@ import type { Query } from '@actual-app/core/shared/query';
 import { integerToAmount } from '@actual-app/core/shared/util';
 import type {
   CategoryEntity,
+  DashboardDateScope,
+  FormulaQueryConfig,
   RuleConditionEntity,
-  TimeFrame,
 } from '@actual-app/core/types/models';
 import { HyperFormula } from 'hyperformula';
 
@@ -32,11 +33,7 @@ import { useLocale } from './useLocale';
 
 bootstrapHyperFormula();
 
-type QueryConfig = {
-  conditions?: RuleConditionEntity[];
-  conditionsOp?: 'and' | 'or';
-  timeFrame?: Partial<TimeFrame>;
-};
+type QueryConfig = FormulaQueryConfig;
 
 type QueriesMap = Record<string, QueryConfig>;
 
@@ -136,6 +133,7 @@ export function useFormulaExecution(
   queries: QueriesMap,
   queriesVersion?: number,
   namedExpressions?: Record<string, number | string>,
+  dashboardScope?: DashboardDateScope | null,
 ) {
   const locale = useLocale();
   const [language] = useGlobalPref('language');
@@ -182,7 +180,11 @@ export function useFormulaExecution(
           throwOnCellError: false,
         });
 
-        await prefetchFormulaQueries(formulaQueryContext, queries);
+        const effectiveQueries = applyDashboardScopeToFormulaQueries(
+          queries,
+          dashboardScope,
+        );
+        await prefetchFormulaQueries(formulaQueryContext, effectiveQueries);
 
         formulaQueryContext.budgetQueryRequests.clear();
         evaluateFormulaWithContext({
@@ -223,9 +225,53 @@ export function useFormulaExecution(
     return () => {
       cancelled = true;
     };
-  }, [formula, queriesVersion, locale, language, queries, namedExpressions]);
+  }, [
+    formula,
+    queriesVersion,
+    locale,
+    language,
+    queries,
+    namedExpressions,
+    dashboardScope,
+  ]);
 
   return { result, isLoading, error };
+}
+
+export function applyDashboardScopeToFormulaQueries(
+  queries: QueriesMap,
+  dashboardScope?: DashboardDateScope | null,
+): QueriesMap {
+  if (!dashboardScope) {
+    return queries;
+  }
+  return Object.fromEntries(
+    Object.entries(queries).map(([name, query]) => {
+      let timeFrame = query.timeFrame;
+      if (query.useDashboardDateRange ?? true) {
+        timeFrame = {
+          start: dashboardScope.start,
+          end: dashboardScope.end,
+          mode: 'static',
+        };
+      } else if (timeFrame && timeFrame.mode !== 'static') {
+        const [start, end] = calculateTimeRange(
+          asMonthSlidingTimeFrame(timeFrame),
+          undefined,
+          undefined,
+          dashboardScope.end,
+        );
+        timeFrame = { start, end, mode: 'static' };
+      }
+      return [
+        name,
+        {
+          ...query,
+          timeFrame,
+        },
+      ];
+    }),
+  );
 }
 
 async function prefetchFormulaQueries(
@@ -326,7 +372,6 @@ export async function buildFilteredTransactionsQuery(
   });
 
   const conditionsOpKey = conditionsOp === 'or' ? '$or' : '$and';
-
   // Start building the query
   let transQuery = q('transactions');
 

--- a/packages/desktop-client/src/reports/mutations.ts
+++ b/packages/desktop-client/src/reports/mutations.ts
@@ -215,31 +215,6 @@ export function useRenameDashboardPageMutation() {
   });
 }
 
-type UpdateDashboardDateRangeMutationPayload = Pick<
-  DashboardPageEntity,
-  'id' | 'date_range_enabled' | 'time_frame'
->;
-
-export function useUpdateDashboardDateRangeMutation() {
-  const queryClient = useQueryClient();
-  const dispatch = useDispatch();
-  const { t } = useTranslation();
-
-  return useMutation({
-    mutationFn: async (dashboard: UpdateDashboardDateRangeMutationPayload) =>
-      await sendThrow('dashboard-update-date-range', dashboard),
-    onSuccess: () => invalidateDashboardQueries(queryClient),
-    onError: error => {
-      console.error('Error updating dashboard date range:', error);
-      dispatchErrorNotification(
-        dispatch,
-        t('There was an error updating the dashboard date range.'),
-        error,
-      );
-    },
-  });
-}
-
 type UpdateDashboardWidgetsMutationPayload = {
   widgets: EverythingButIdOptional<Omit<DashboardWidgetEntity, 'tombstone'>>[];
 };

--- a/packages/desktop-client/src/reports/mutations.ts
+++ b/packages/desktop-client/src/reports/mutations.ts
@@ -215,6 +215,31 @@ export function useRenameDashboardPageMutation() {
   });
 }
 
+type UpdateDashboardDateRangeMutationPayload = Pick<
+  DashboardPageEntity,
+  'id' | 'date_range_enabled' | 'time_frame'
+>;
+
+export function useUpdateDashboardDateRangeMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async (dashboard: UpdateDashboardDateRangeMutationPayload) =>
+      await sendThrow('dashboard-update-date-range', dashboard),
+    onSuccess: () => invalidateDashboardQueries(queryClient),
+    onError: error => {
+      console.error('Error updating dashboard date range:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error updating the dashboard date range.'),
+        error,
+      );
+    },
+  });
+}
+
 type UpdateDashboardWidgetsMutationPayload = {
   widgets: EverythingButIdOptional<Omit<DashboardWidgetEntity, 'tombstone'>>[];
 };

--- a/packages/desktop-client/src/reports/queries.ts
+++ b/packages/desktop-client/src/reports/queries.ts
@@ -50,12 +50,7 @@ export const dashboardQueries = {
         const { data }: { data: DashboardPageEntity[] } = await aqlQuery(
           q('dashboard_pages').select('*'),
         );
-        return data.map(page => ({
-          ...page,
-          name: page.name ?? '',
-          date_range_enabled: page.date_range_enabled ?? false,
-          time_frame: page.time_frame ?? null,
-        }));
+        return data.map(page => ({ ...page, name: page.name ?? '' }));
       },
     }),
 };

--- a/packages/desktop-client/src/reports/queries.ts
+++ b/packages/desktop-client/src/reports/queries.ts
@@ -50,7 +50,12 @@ export const dashboardQueries = {
         const { data }: { data: DashboardPageEntity[] } = await aqlQuery(
           q('dashboard_pages').select('*'),
         );
-        return data.map(page => ({ ...page, name: page.name ?? '' }));
+        return data.map(page => ({
+          ...page,
+          name: page.name ?? '',
+          date_range_enabled: page.date_range_enabled ?? false,
+          time_frame: page.time_frame ?? null,
+        }));
       },
     }),
 };

--- a/packages/loot-core/migrations/1786024326001_add_dashboard_date_ranges.sql
+++ b/packages/loot-core/migrations/1786024326001_add_dashboard_date_ranges.sql
@@ -1,0 +1,3 @@
+ALTER TABLE dashboard_pages ADD COLUMN date_range_enabled INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE dashboard_pages ADD COLUMN time_frame TEXT;
+ALTER TABLE dashboard ADD COLUMN use_dashboard_date_range INTEGER NOT NULL DEFAULT 0;

--- a/packages/loot-core/migrations/1786024326001_add_dashboard_date_ranges.sql
+++ b/packages/loot-core/migrations/1786024326001_add_dashboard_date_ranges.sql
@@ -1,3 +1,0 @@
-ALTER TABLE dashboard_pages ADD COLUMN date_range_enabled INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE dashboard_pages ADD COLUMN time_frame TEXT;
-ALTER TABLE dashboard ADD COLUMN use_dashboard_date_range INTEGER NOT NULL DEFAULT 0;

--- a/packages/loot-core/migrations/1786024326001_add_dashboard_widget_date_range_mode.sql
+++ b/packages/loot-core/migrations/1786024326001_add_dashboard_widget_date_range_mode.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dashboard ADD COLUMN use_dashboard_date_range INTEGER NOT NULL DEFAULT 1;
+UPDATE dashboard SET use_dashboard_date_range = 0 WHERE type = 'calendar-card';

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -195,11 +195,14 @@ export const schema = {
   dashboard_pages: {
     id: f('id'),
     name: f('string'),
+    date_range_enabled: f('boolean'),
+    time_frame: f('json'),
     tombstone: f('boolean'),
   },
   dashboard: {
     id: f('id'),
     dashboard_page_id: f('id', { ref: 'dashboard_pages' }),
+    use_dashboard_date_range: f('boolean'),
     type: f('string', { required: true }),
     width: f('integer', { required: true }),
     height: f('integer', { required: true }),

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -195,8 +195,6 @@ export const schema = {
   dashboard_pages: {
     id: f('id'),
     name: f('string'),
-    date_range_enabled: f('boolean'),
-    time_frame: f('json'),
     tombstone: f('boolean'),
   },
   dashboard: {

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -13,10 +13,8 @@ import { reportModel } from '#server/reports/app';
 import { batchMessages } from '#server/sync';
 import { undoable } from '#server/undo';
 import { DEFAULT_DASHBOARD_STATE } from '#shared/dashboard';
-import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
 import type {
-  DashboardPageEntity,
   DashboardWidgetEntity,
   ExportImportCustomReportWidget,
   ExportImportDashboard,
@@ -60,7 +58,7 @@ const exportModel = {
         'Invalid dashboard.widgets data type: it must be an array of widgets.',
       );
     }
-    if (![1, 2].includes(dashboard.version)) {
+    if (dashboard.version !== 1) {
       throw new ValidationError('Unsupported dashboard export version.');
     }
 
@@ -107,45 +105,6 @@ const exportModel = {
         reportModel.validate(widget.meta);
       }
     });
-
-    if (dashboard.version === 2) {
-      requiredFields('Dashboard', dashboard, ['date_range_enabled']);
-      if (typeof dashboard.date_range_enabled !== 'boolean') {
-        throw new ValidationError(
-          'Invalid dashboard.date_range_enabled data type.',
-        );
-      }
-      if (!Object.hasOwn(dashboard, 'time_frame')) {
-        throw new ValidationError('Dashboard is missing field time_frame.');
-      }
-      if (dashboard.date_range_enabled && !dashboard.time_frame) {
-        throw new ValidationError(
-          'Dashboard is missing a timeframe for enabled date ranges.',
-        );
-      }
-      if (dashboard.time_frame) {
-        const { start, end, mode } = dashboard.time_frame;
-        const isDate = (value: unknown) =>
-          typeof value === 'string' &&
-          (monthUtils.isValidYearMonth(value) ||
-            monthUtils.isValidYearMonthDay(value));
-        if (
-          !isDate(start) ||
-          !isDate(end) ||
-          ![
-            'sliding-window',
-            'static',
-            'full',
-            'lastMonth',
-            'lastYear',
-            'yearToDate',
-            'priorYearToDate',
-          ].includes(mode)
-        ) {
-          throw new ValidationError('Invalid dashboard timeframe.');
-        }
-      }
-    }
   },
 };
 
@@ -181,18 +140,6 @@ async function deleteDashboardPage(id: string) {
 
 async function renameDashboardPage({ id, name }: { id: string; name: string }) {
   await db.updateWithSchema('dashboard_pages', { id, name });
-}
-
-async function updateDashboardPageDateRange({
-  id,
-  date_range_enabled,
-  time_frame,
-}: Pick<DashboardPageEntity, 'id' | 'date_range_enabled' | 'time_frame'>) {
-  await db.updateWithSchema('dashboard_pages', {
-    id,
-    date_range_enabled,
-    time_frame,
-  });
 }
 
 async function updateDashboard(
@@ -237,11 +184,6 @@ async function resetDashboard(id: string) {
       ...DEFAULT_DASHBOARD_STATE.map(widget =>
         db.insertWithSchema('dashboard', { ...widget, dashboard_page_id: id }),
       ),
-      db.updateWithSchema('dashboard_pages', {
-        id,
-        date_range_enabled: false,
-        time_frame: null,
-      }),
     ]);
   });
 }
@@ -355,15 +297,6 @@ async function importDashboard({
 
     await batchMessages(async () => {
       await Promise.all([
-        db.updateWithSchema('dashboard_pages', {
-          id: dashboardPageId,
-          date_range_enabled:
-            parsedContent.version === 2
-              ? parsedContent.date_range_enabled
-              : false,
-          time_frame:
-            parsedContent.version === 2 ? parsedContent.time_frame : null,
-        }),
         // Delete all widgets
         ...existingWidgets.map(({ id }) => db.delete_('dashboard', id)),
 
@@ -433,7 +366,6 @@ export type DashboardHandlers = {
   'dashboard-create': typeof createDashboardPage;
   'dashboard-delete': typeof deleteDashboardPage;
   'dashboard-rename': typeof renameDashboardPage;
-  'dashboard-update-date-range': typeof updateDashboardPageDateRange;
   'dashboard-update': typeof updateDashboard;
   'dashboard-update-widget': typeof updateDashboardWidget;
   'dashboard-reset': typeof resetDashboard;
@@ -448,10 +380,6 @@ export const app = createApp<DashboardHandlers>();
 app.method('dashboard-create', mutator(undoable(createDashboardPage)));
 app.method('dashboard-delete', mutator(undoable(deleteDashboardPage)));
 app.method('dashboard-rename', mutator(undoable(renameDashboardPage)));
-app.method(
-  'dashboard-update-date-range',
-  mutator(undoable(updateDashboardPageDateRange)),
-);
 app.method('dashboard-update', mutator(undoable(updateDashboard)));
 app.method('dashboard-update-widget', mutator(undoable(updateDashboardWidget)));
 app.method('dashboard-reset', mutator(undoable(resetDashboard)));

--- a/packages/loot-core/src/server/dashboard/app.ts
+++ b/packages/loot-core/src/server/dashboard/app.ts
@@ -13,8 +13,10 @@ import { reportModel } from '#server/reports/app';
 import { batchMessages } from '#server/sync';
 import { undoable } from '#server/undo';
 import { DEFAULT_DASHBOARD_STATE } from '#shared/dashboard';
+import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
 import type {
+  DashboardPageEntity,
   DashboardWidgetEntity,
   ExportImportCustomReportWidget,
   ExportImportDashboard,
@@ -58,6 +60,9 @@ const exportModel = {
         'Invalid dashboard.widgets data type: it must be an array of widgets.',
       );
     }
+    if (![1, 2].includes(dashboard.version)) {
+      throw new ValidationError('Unsupported dashboard export version.');
+    }
 
     dashboard.widgets.forEach((widget, idx) => {
       requiredFields(`Dashboard widget #${idx}`, widget, [
@@ -68,7 +73,6 @@ const exportModel = {
         'height',
         ...(isExportedCustomReportWidget(widget) ? ['meta' as const] : []),
       ]);
-
       if (!Number.isInteger(widget.x)) {
         throw new ValidationError(
           `Invalid widget.${idx}.x data-type for value ${widget.x}.`,
@@ -103,6 +107,45 @@ const exportModel = {
         reportModel.validate(widget.meta);
       }
     });
+
+    if (dashboard.version === 2) {
+      requiredFields('Dashboard', dashboard, ['date_range_enabled']);
+      if (typeof dashboard.date_range_enabled !== 'boolean') {
+        throw new ValidationError(
+          'Invalid dashboard.date_range_enabled data type.',
+        );
+      }
+      if (!Object.hasOwn(dashboard, 'time_frame')) {
+        throw new ValidationError('Dashboard is missing field time_frame.');
+      }
+      if (dashboard.date_range_enabled && !dashboard.time_frame) {
+        throw new ValidationError(
+          'Dashboard is missing a timeframe for enabled date ranges.',
+        );
+      }
+      if (dashboard.time_frame) {
+        const { start, end, mode } = dashboard.time_frame;
+        const isDate = (value: unknown) =>
+          typeof value === 'string' &&
+          (monthUtils.isValidYearMonth(value) ||
+            monthUtils.isValidYearMonthDay(value));
+        if (
+          !isDate(start) ||
+          !isDate(end) ||
+          ![
+            'sliding-window',
+            'static',
+            'full',
+            'lastMonth',
+            'lastYear',
+            'yearToDate',
+            'priorYearToDate',
+          ].includes(mode)
+        ) {
+          throw new ValidationError('Invalid dashboard timeframe.');
+        }
+      }
+    }
   },
 };
 
@@ -138,6 +181,18 @@ async function deleteDashboardPage(id: string) {
 
 async function renameDashboardPage({ id, name }: { id: string; name: string }) {
   await db.updateWithSchema('dashboard_pages', { id, name });
+}
+
+async function updateDashboardPageDateRange({
+  id,
+  date_range_enabled,
+  time_frame,
+}: Pick<DashboardPageEntity, 'id' | 'date_range_enabled' | 'time_frame'>) {
+  await db.updateWithSchema('dashboard_pages', {
+    id,
+    date_range_enabled,
+    time_frame,
+  });
 }
 
 async function updateDashboard(
@@ -182,6 +237,11 @@ async function resetDashboard(id: string) {
       ...DEFAULT_DASHBOARD_STATE.map(widget =>
         db.insertWithSchema('dashboard', { ...widget, dashboard_page_id: id }),
       ),
+      db.updateWithSchema('dashboard_pages', {
+        id,
+        date_range_enabled: false,
+        time_frame: null,
+      }),
     ]);
   });
 }
@@ -214,7 +274,7 @@ async function addDashboardWidget(
 
   const { dashboard_page_id, ...widgetWithoutDashboardPageId } = widget;
 
-  await db.insertWithSchema('dashboard', {
+  return await db.insertWithSchema('dashboard', {
     ...widgetWithoutDashboardPageId,
     dashboard_page_id,
   });
@@ -251,7 +311,12 @@ async function copyDashboardWidget({
         meta: widget.meta ? JSON.parse(widget.meta) : {},
         dashboard_page_id: targetDashboardPageId,
       };
-      await addDashboardWidget(newWidget);
+      await addDashboardWidget({
+        ...newWidget,
+        use_dashboard_date_range: Boolean(
+          widget.use_dashboard_date_range ?? true,
+        ),
+      });
     } else {
       throw new Error(`Unsupported widget type: ${widget.type}`);
     }
@@ -274,6 +339,8 @@ async function importDashboard({
     const parsedContent: ExportImportDashboard = JSON.parse(content);
 
     exportModel.validate(parsedContent);
+    const importedWidgets: ExportImportDashboardWidget[] =
+      parsedContent.widgets;
 
     const customReportIds = await db.all<Pick<db.DbCustomReport, 'id'>>(
       'SELECT id from custom_reports',
@@ -288,11 +355,20 @@ async function importDashboard({
 
     await batchMessages(async () => {
       await Promise.all([
+        db.updateWithSchema('dashboard_pages', {
+          id: dashboardPageId,
+          date_range_enabled:
+            parsedContent.version === 2
+              ? parsedContent.date_range_enabled
+              : false,
+          time_frame:
+            parsedContent.version === 2 ? parsedContent.time_frame : null,
+        }),
         // Delete all widgets
         ...existingWidgets.map(({ id }) => db.delete_('dashboard', id)),
 
         // Insert new widgets
-        ...parsedContent.widgets.map(widget =>
+        ...importedWidgets.map(widget =>
           db.insertWithSchema('dashboard', {
             type: widget.type,
             width: widget.width,
@@ -300,6 +376,7 @@ async function importDashboard({
             x: widget.x,
             y: widget.y,
             dashboard_page_id: dashboardPageId,
+            use_dashboard_date_range: widget.use_dashboard_date_range ?? true,
             meta: isExportedCustomReportWidget(widget)
               ? { id: widget.meta.id }
               : widget.meta,
@@ -307,7 +384,7 @@ async function importDashboard({
         ),
 
         // Insert new custom reports
-        ...parsedContent.widgets
+        ...importedWidgets
           .filter(isExportedCustomReportWidget)
           .filter(({ meta }) => !customReportIdSet.has(meta.id))
           .map(({ meta }) =>
@@ -315,7 +392,7 @@ async function importDashboard({
           ),
 
         // Update existing reports
-        ...parsedContent.widgets
+        ...importedWidgets
           .filter(isExportedCustomReportWidget)
           .filter(({ meta }) => customReportIdSet.has(meta.id))
           .map(({ meta }) =>
@@ -356,6 +433,7 @@ export type DashboardHandlers = {
   'dashboard-create': typeof createDashboardPage;
   'dashboard-delete': typeof deleteDashboardPage;
   'dashboard-rename': typeof renameDashboardPage;
+  'dashboard-update-date-range': typeof updateDashboardPageDateRange;
   'dashboard-update': typeof updateDashboard;
   'dashboard-update-widget': typeof updateDashboardWidget;
   'dashboard-reset': typeof resetDashboard;
@@ -370,6 +448,10 @@ export const app = createApp<DashboardHandlers>();
 app.method('dashboard-create', mutator(undoable(createDashboardPage)));
 app.method('dashboard-delete', mutator(undoable(deleteDashboardPage)));
 app.method('dashboard-rename', mutator(undoable(renameDashboardPage)));
+app.method(
+  'dashboard-update-date-range',
+  mutator(undoable(updateDashboardPageDateRange)),
+);
 app.method('dashboard-update', mutator(undoable(updateDashboard)));
 app.method('dashboard-update-widget', mutator(undoable(updateDashboardWidget)));
 app.method('dashboard-reset', mutator(undoable(resetDashboard)));

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -263,8 +263,6 @@ export type DbCustomReport = {
 export type DbDashboardPage = {
   id: string;
   name: string;
-  date_range_enabled: 0 | 1;
-  time_frame: JsonString | null;
   tombstone: 1 | 0;
 };
 

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -263,12 +263,15 @@ export type DbCustomReport = {
 export type DbDashboardPage = {
   id: string;
   name: string;
+  date_range_enabled: 0 | 1;
+  time_frame: JsonString | null;
   tombstone: 1 | 0;
 };
 
 export type DbDashboard = {
   id: string;
   dashboard_page_id: string;
+  use_dashboard_date_range: 1 | 0;
   type: string;
   width: number;
   height: number;

--- a/packages/loot-core/src/shared/dashboard.ts
+++ b/packages/loot-core/src/shared/dashboard.ts
@@ -208,6 +208,7 @@ export const DEFAULT_DASHBOARD_STATE: NewDashboardWidgetEntity[] = [
     height: 4,
     x: 0,
     y: 8,
+    use_dashboard_date_range: false,
     meta: {
       name: 'Transaction Calendar',
       timeFrame: {

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -5,8 +5,6 @@ import type { RuleConditionEntity } from './rule';
 export type DashboardPageEntity = {
   id: string;
   name: string;
-  date_range_enabled: boolean;
-  time_frame: TimeFrame | null;
   tombstone: boolean;
 };
 
@@ -315,16 +313,7 @@ export type ExportImportDashboardV1 = {
   widgets: ExportImportDashboardWidget[];
 };
 
-export type ExportImportDashboardV2 = {
-  version: 2;
-  date_range_enabled: boolean;
-  time_frame: TimeFrame | null;
-  widgets: ExportImportDashboardWidget[];
-};
-
-export type ExportImportDashboard =
-  | ExportImportDashboardV1
-  | ExportImportDashboardV2;
+export type ExportImportDashboard = ExportImportDashboardV1;
 
 export type SummaryWidget = AbstractWidget<
   'summary-card',

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -5,7 +5,15 @@ import type { RuleConditionEntity } from './rule';
 export type DashboardPageEntity = {
   id: string;
   name: string;
+  date_range_enabled: boolean;
+  time_frame: TimeFrame | null;
   tombstone: boolean;
+};
+
+export type DashboardDateScope = {
+  start: string;
+  end: string;
+  mode: TimeFrame['mode'];
 };
 
 export type TimeFrame = {
@@ -27,6 +35,7 @@ type AbstractWidget<
 > = {
   id: string;
   dashboard_page_id: string;
+  use_dashboard_date_range?: boolean;
   type: T;
   x: number;
   y: number;
@@ -287,22 +296,35 @@ export type NewDashboardWidgetEntity = Omit<
 // Exported/imported (json) widget definition
 export type ExportImportCustomReportWidget = Omit<
   CustomReportWidget,
-  'id' | 'meta' | 'tombstone'
+  'id' | 'dashboard_page_id' | 'meta' | 'tombstone'
 > & {
   meta: Omit<CustomReportEntity, 'tombstone'>;
 };
-export type ExportImportDashboardWidget = Omit<
-  ExportImportCustomReportWidget | SpecializedWidget,
-  'tombstone'
->;
+type ExportImportSpecializedWidget<T> = T extends SpecializedWidget
+  ? Omit<T, 'id' | 'dashboard_page_id' | 'tombstone'>
+  : never;
+export type ExportImportDashboardWidget =
+  | ExportImportCustomReportWidget
+  | ExportImportSpecializedWidget<SpecializedWidget>;
 
-export type ExportImportDashboard = {
+export type ExportImportDashboardV1 = {
   // Dashboard exports can be versioned; currently we support
   // only a single version, but lets account for multiple
   // future versions
   version: 1;
   widgets: ExportImportDashboardWidget[];
 };
+
+export type ExportImportDashboardV2 = {
+  version: 2;
+  date_range_enabled: boolean;
+  time_frame: TimeFrame | null;
+  widgets: ExportImportDashboardWidget[];
+};
+
+export type ExportImportDashboard =
+  | ExportImportDashboardV1
+  | ExportImportDashboardV2;
 
 export type SummaryWidget = AbstractWidget<
   'summary-card',
@@ -351,16 +373,16 @@ export type FormulaWidget = AbstractWidget<
     showTitle?: boolean;
     colorFormula?: string;
     queriesVersion?: number;
-    queries?: Record<
-      string,
-      {
-        conditions?: RuleConditionEntity[];
-        conditionsOp?: 'and' | 'or';
-        timeFrame?: TimeFrame;
-      }
-    >;
+    queries?: Record<string, FormulaQueryConfig>;
   } | null
 >;
+
+export type FormulaQueryConfig = {
+  conditions?: RuleConditionEntity[];
+  conditionsOp?: 'and' | 'or';
+  timeFrame?: Partial<TimeFrame>;
+  useDashboardDateRange?: boolean;
+};
 
 export type SankeyWidget = AbstractWidget<
   'sankey-card',

--- a/upcoming-release-notes/add-dashboard-date-ranges.md
+++ b/upcoming-release-notes/add-dashboard-date-ranges.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [leandro-menezes]
+---
+
+Add optional shared date ranges to report dashboards


### PR DESCRIPTION
This PR enables having a dashboard date range picker.

<img width="716" height="267" alt="image" src="https://github.com/user-attachments/assets/4cad495b-1811-474c-afc4-e602b73a5c30" />

How does it works:
Once you toggle the date ranges, it allows you to set the report to use that range as the report range:
<img width="628" height="130" alt="image" src="https://github.com/user-attachments/assets/7358388d-3037-4ab7-a324-8f7be577984a" />

So, all dates there are linked to the dashboard range

But we have more options:
- If the user doesn't use `Use dashboard date range`, but use LIVE dates, it will use the **END of the dashboard date range** as  the date of the card.
Example:
My dashboard is using this range:
<img width="471" height="388" alt="image" src="https://github.com/user-attachments/assets/b0991153-fdb1-4941-8d0a-fe376e71b1dd" />

So, for every card that with LIVE dates, it will consider JUNE as the reference month:
<img width="673" height="525" alt="image" src="https://github.com/user-attachments/assets/c4cfa8b1-16e0-4d4f-a86a-e31102134b64" />
In this case, the last month from JUNE is May

- And STATIC keeps working as is


For formula card, the toogle is per query:
<img width="403" height="523" alt="image" src="https://github.com/user-attachments/assets/4773c976-a937-4f36-9b82-05d0a636af6a" />
