### PR TITLE
[WIP][AI] Speed up the transaction list and scheduled transaction previews

### DIFF
--- a/.claude/skills/writing-release-notes/SKILL.md
+++ b/.claude/skills/writing-release-notes/SKILL.md
@@ -11,6 +11,8 @@ Release notes are the user-facing changelog. Each code change adds one Markdown 
 
 Create `upcoming-release-notes/<slug>.md`, where `<slug>` is a **short, descriptive kebab-case slug** naming the change (e.g. `add-payee-autocomplete.md`, `fix-mobile-category-delete.md`). Do **not** use a PR number, since the PR link is resolved automatically at release time. (Numeric filenames like `1234.md` still work, but a slug is preferred.)
 
+**One file per PR.** Each pull request ships exactly one release note. If work spanning several changes lands as a single PR, combine them into one file with one sentence covering the overall change — do not create a file per change. If you already created several files during a work session that will ship as one PR, merge them into a single file before the PR is cut.
+
 ```markdown
 ---
 category: Features

--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -58,6 +58,20 @@ const worker = startBrowserBackend({
     isOpenIdCallback,
 });
 
+// Ask the browser to exclude this origin's storage (the local budget database
+// in IndexedDB) from automatic eviction under storage pressure. Without this,
+// the browser is allowed to silently delete all local data, forcing a full
+// re-download of the budget and losing any changes not yet synced.
+if (navigator.storage?.persist) {
+  void navigator.storage.persist().then(persisted => {
+    if (!persisted) {
+      console.warn(
+        'Persistent storage was not granted; the browser may evict local budget data under storage pressure.',
+      );
+    }
+  });
+}
+
 let isUpdateReadyForDownload = false;
 let markUpdateReadyForDownload;
 const isUpdateReadyForDownloadPromise = new Promise(resolve => {

--- a/packages/desktop-client/src/browser-preload.js
+++ b/packages/desktop-client/src/browser-preload.js
@@ -58,20 +58,6 @@ const worker = startBrowserBackend({
     isOpenIdCallback,
 });
 
-// Ask the browser to exclude this origin's storage (the local budget database
-// in IndexedDB) from automatic eviction under storage pressure. Without this,
-// the browser is allowed to silently delete all local data, forcing a full
-// re-download of the budget and losing any changes not yet synced.
-if (navigator.storage?.persist) {
-  void navigator.storage.persist().then(persisted => {
-    if (!persisted) {
-      console.warn(
-        'Persistent storage was not granted; the browser may evict local budget data under storage pressure.',
-      );
-    }
-  });
-}
-
 let isUpdateReadyForDownload = false;
 let markUpdateReadyForDownload;
 const isUpdateReadyForDownloadPromise = new Promise(resolve => {

--- a/packages/desktop-client/src/components/accounts/Account.tsx
+++ b/packages/desktop-client/src/components/accounts/Account.tsx
@@ -4,6 +4,7 @@ import React, {
   startTransition,
   useEffect,
   useMemo,
+  useState,
 } from 'react';
 import type { ReactElement, RefObject } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -105,29 +106,51 @@ function isTransactionFilterEntity(
 }
 
 type AllTransactionsProps = {
-  account?: AccountEntity | undefined;
+  accountId?: string | undefined;
   transactions: TransactionEntity[];
   balances: Record<TransactionEntity['id'], IntegerAmount> | null;
   showBalances?: boolean | undefined;
   filtered?: boolean | undefined;
+  transactionsStale?: boolean | undefined;
   children: (
     transactions: TransactionEntity[],
     balances: Record<TransactionEntity['id'], IntegerAmount> | null,
+    isWaitingForPreviews: boolean,
   ) => ReactElement;
 };
 
+type SettledView = {
+  transactions: TransactionEntity[];
+  balances: Record<TransactionEntity['id'], IntegerAmount> | null;
+};
+
 function AllTransactions({
-  account,
+  accountId,
   transactions,
   balances,
   showBalances,
   filtered,
+  transactionsStale,
   children,
 }: AllTransactionsProps) {
-  const accountId = account?.id;
   const { dispatch: splitsExpandedDispatch } = useSplitsExpanded();
   const { previewTransactions, isLoading: isPreviewTransactionsLoading } =
     useAccountPreviewTransactions({ accountId });
+
+  // On an account switch, keep showing the previous account's complete view
+  // (rows + previews) until the new account's transactions AND its
+  // scheduled-transaction previews have both resolved, then swap everything in
+  // a single paint — no blank state and no table shift when previews arrive.
+  // Later preview refreshes (e.g. after an edit) keep showing the current
+  // rows, so this only affects account switches.
+  const previewKey = accountId ?? 'all';
+  const [loadedPreviewKey, setLoadedPreviewKey] = useState<string | null>(null);
+  if (!isPreviewTransactionsLoading && loadedPreviewKey !== previewKey) {
+    // Adjust-state-during-render, same pattern as settledView below
+    setLoadedPreviewKey(previewKey);
+  }
+  const isWaitingForPreviews =
+    loadedPreviewKey !== previewKey && isPreviewTransactionsLoading;
 
   useEffect(() => {
     if (!isPreviewTransactionsLoading) {
@@ -184,10 +207,31 @@ function AllTransactions({
     return balances;
   }, [filtered, prependBalances, balances]);
 
-  if (!previewTransactions?.length || filtered) {
-    return children(transactions, balances);
+  // allTransactions/allBalances already fall back to the plain
+  // transactions/balances when filtering or when there are no previews
+  const currentView: SettledView = useMemo(
+    () => ({ transactions: allTransactions, balances: allBalances }),
+    [allTransactions, allBalances],
+  );
+
+  const isSettled = !isWaitingForPreviews && !transactionsStale;
+
+  // Remember the last fully-settled view so it can keep being shown while the
+  // next account's data loads (adjust-state-during-render pattern)
+  const [settledView, setSettledView] = useState<SettledView>({
+    transactions: [],
+    balances: null,
+  });
+  if (isSettled && settledView !== currentView) {
+    setSettledView(currentView);
   }
-  return children(allTransactions, allBalances);
+
+  if (filtered) {
+    return children(transactions, balances, false);
+  }
+
+  const shownView = isSettled ? currentView : settledView;
+  return children(shownView.transactions, shownView.balances, !isSettled);
 }
 
 function getField(field?: string) {
@@ -275,6 +319,10 @@ type AccountInternalState = {
   reconcileAmount: null | number;
   transactions: TransactionEntity[];
   transactionsFiltered?: boolean;
+  // True between an account switch and the arrival of the new account's
+  // transactions; the previous account's rows stay in state so the table can
+  // keep showing them until the new view is ready to swap in
+  isTransactionsStale?: boolean;
   showBalances?: boolean | undefined;
   balances: Record<TransactionEntity['id'], IntegerAmount> | null;
   showCleared?: boolean | undefined;
@@ -534,29 +582,67 @@ class AccountInternal extends PureComponent<
           }
         }
 
-        const balances = this.state.showBalances
-          ? await this.calculateBalances()
-          : null;
-        const filteredAmount = await this.getFilteredAmount();
-        this.setState(
-          {
-            transactions: data,
-            transactionsFiltered: isFiltered,
-            loading: false,
-            workingHard: false,
-            balances,
-            filteredAmount,
-          },
-          () => {
-            if (firstLoad) {
-              this.table.current?.scrollToTop();
-            }
+        const paged = this.paged;
+        const aggregatesPromise = Promise.all([
+          this.state.showBalances ? this.calculateBalances() : null,
+          // The filtered total is only shown when a filter/search is active
+          isFiltered ? this.getFilteredAmount() : null,
+        ]);
 
-            setTimeout(() => {
-              this.table.current?.setRowAnimation(true);
-            }, 0);
-          },
-        );
+        const onRendered = () => {
+          if (firstLoad) {
+            this.table.current?.scrollToTop();
+          }
+
+          setTimeout(() => {
+            this.table.current?.setRowAnimation(true);
+          }, 0);
+        };
+
+        if (firstLoad) {
+          // Render the rows immediately; the aggregate queries (running
+          // balances, filtered total) fill in when they resolve
+          this.setState(
+            {
+              transactions: data,
+              transactionsFiltered: isFiltered,
+              isTransactionsStale: false,
+              loading: false,
+              workingHard: false,
+              balances: null,
+              filteredAmount: null,
+            },
+            onRendered,
+          );
+
+          const [balances, filteredAmount] = await aggregatesPromise;
+          // Bail if the query changed while the aggregates were computing
+          // (e.g. the user switched to another account)
+          if (this.paged === paged) {
+            this.setState({ balances, filteredAmount });
+          }
+        } else {
+          // On live updates (sync, pagination) render rows and aggregates
+          // together to avoid a second full-table render
+          const [balances, filteredAmount] = await aggregatesPromise;
+          // Bail if the query changed while the aggregates were computing
+          // (e.g. the user switched to another account)
+          if (this.paged !== paged) {
+            return;
+          }
+          this.setState(
+            {
+              transactions: data,
+              transactionsFiltered: isFiltered,
+              isTransactionsStale: false,
+              loading: false,
+              workingHard: false,
+              balances,
+              filteredAmount,
+            },
+            onRendered,
+          );
+        }
       },
       options: {
         pageCount: 150,
@@ -572,8 +658,14 @@ class AccountInternal extends PureComponent<
         {
           loading: true,
           search: '',
+          // Keep the previous account's rows in state but mark them stale;
+          // AllTransactions keeps showing the old view until the new
+          // account's transactions and previews are both ready
+          isTransactionsStale: true,
+          transactionsFiltered: false,
           showBalances: nextProps.showBalances,
           balances: null,
+          filteredAmount: null,
           showCleared: nextProps.showCleared,
           showReconciled: nextProps.showReconciled,
           reconcileAmount: null,
@@ -1817,13 +1909,14 @@ class AccountInternal extends PureComponent<
 
     return (
       <AllTransactions
-        account={account}
+        accountId={accountId}
         transactions={transactions}
         balances={balances}
         showBalances={showBalances}
         filtered={transactionsFiltered}
+        transactionsStale={this.state.isTransactionsStale}
       >
-        {(allTransactions, allBalances) => (
+        {(allTransactions, allBalances, isWaitingForPreviews) => (
           <SelectedProviderWithItems
             name="transactions"
             // When reconciled transactions are hidden they are still
@@ -1944,7 +2037,7 @@ class AccountInternal extends PureComponent<
                           )
                         }
                       />
-                    ) : !loading ? (
+                    ) : !loading && !isWaitingForPreviews ? (
                       <View
                         style={{
                           color: theme.tableText,
@@ -2066,10 +2159,12 @@ export function Account() {
 
   const savedFiters = useTransactionFilters();
 
-  const schedulesQuery = useMemo(
-    () => getSchedulesQuery(params.id),
-    [params.id],
-  );
+  // Subscribe to the full schedules list rather than a per-view query:
+  // previews are filtered per account/view client-side (see
+  // useAccountPreviewTransactions), and a query identity that never changes
+  // keeps the schedules/statuses subscriptions alive across account switches
+  // so previews resolve without waiting on fresh round-trips.
+  const schedulesQuery = useMemo(() => getSchedulesQuery(), []);
 
   const { mutate: reopenAccount } = useReopenAccountMutation();
   const onReopenAccount = (id: AccountEntity['id']) => reopenAccount({ id });

--- a/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
+++ b/packages/desktop-client/src/components/transactions/SelectedTransactionsButton.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import { Menu } from '@actual-app/components/menu';
 import { validForMerge } from '@actual-app/core/shared/merge';
-import { q } from '@actual-app/core/shared/query';
 import {
   extractScheduleConds,
   scheduleIsRecurring,
@@ -14,7 +13,7 @@ import { validForTransfer } from '@actual-app/core/shared/transfer';
 import type { TransactionEntity } from '@actual-app/core/types/models';
 
 import { SelectedItemsButton } from '#components/table';
-import { useSchedules } from '#hooks/useSchedules';
+import { useSelectedPreviewSchedules } from '#hooks/useSchedules';
 import { useSelectedItems } from '#hooks/useSelected';
 import { pushModal } from '#modals/modalsSlice';
 import { useDispatch } from '#redux';
@@ -72,21 +71,8 @@ export function SelectedTransactionsButton({
   const selectedItems = useSelectedItems();
   const selectedIds = useMemo(() => [...selectedItems], [selectedItems]);
 
-  const scheduleIds = useMemo(() => {
-    return selectedIds
-      .filter(id => isPreviewId(id))
-      .map(id => id.split('/')[1]);
-  }, [selectedIds]);
-
-  const scheduleQuery = useMemo(() => {
-    return q('schedules')
-      .filter({ id: { $oneof: scheduleIds } })
-      .select('*');
-  }, [scheduleIds]);
-
-  const { schedules: selectedSchedules } = useSchedules({
-    query: scheduleQuery,
-  });
+  const { schedules: selectedSchedules } =
+    useSelectedPreviewSchedules(selectedIds);
 
   const types = useMemo(() => {
     const items = selectedIds;

--- a/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
+++ b/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import type { RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { q } from '@actual-app/core/shared/query';
 import {
   extractScheduleConds,
   scheduleIsRecurring,
@@ -12,7 +11,7 @@ import type { TransactionEntity } from '@actual-app/core/types/models';
 
 import type { ContextMenuItem } from '#contextmenu/types';
 import { useContextMenu } from '#hooks/useContextMenu';
-import { useSchedules } from '#hooks/useSchedules';
+import { useSelectedPreviewSchedules } from '#hooks/useSchedules';
 import { useSelectedItems } from '#hooks/useSelected';
 import { pushModal } from '#modals/modalsSlice';
 import { useDispatch } from '#redux';
@@ -49,29 +48,15 @@ export function useTransactionRowContextActions({
   const dispatch = useDispatch();
   const selectedItems = useSelectedItems();
 
+  const transactionId = transaction.id;
   const selectedIds = useMemo(() => {
     const ids =
-      selectedItems && selectedItems.size > 0
-        ? selectedItems
-        : [transaction.id];
+      selectedItems && selectedItems.size > 0 ? selectedItems : [transactionId];
     return Array.from(new Set(ids));
-  }, [transaction, selectedItems]);
+  }, [transactionId, selectedItems]);
 
-  const scheduleIds = useMemo(() => {
-    return selectedIds
-      .filter(id => isPreviewId(id))
-      .map(id => id.split('/')[1]);
-  }, [selectedIds]);
-
-  const scheduleQuery = useMemo(() => {
-    return q('schedules')
-      .filter({ id: { $oneof: scheduleIds } })
-      .select('*');
-  }, [scheduleIds]);
-
-  const { schedules: selectedSchedules } = useSchedules({
-    query: scheduleQuery,
-  });
+  const { schedules: selectedSchedules } =
+    useSelectedPreviewSchedules(selectedIds);
 
   const types = useMemo(() => {
     const items = selectedIds;

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -9,6 +9,7 @@ import type {
   TransactionEntity,
 } from '@actual-app/core/types/models';
 
+import { PSEUDO_ACCOUNT_VIEWS } from '#queries';
 import * as bindings from '#spreadsheet/bindings';
 
 import { useAccounts } from './useAccounts';
@@ -19,6 +20,10 @@ import { useSyncedPref } from './useSyncedPref';
 import { calculateRunningBalancesBottomUp } from './useTransactions';
 
 type UseAccountPreviewTransactionsProps = {
+  /**
+   * A concrete account id, one of the pseudo views ('onbudget', 'offbudget',
+   * 'closed', 'uncategorized'), or undefined for all accounts.
+   */
   accountId?: AccountEntity['id'] | undefined;
 };
 
@@ -27,13 +32,18 @@ type UseAccountPreviewTransactionsResult = ReturnType<
 >;
 
 /**
- * Preview transactions for a given account or all accounts if no `accountId` is provided.
- * This will invert the payees, accounts, and amounts accordingly depending on which account
- * the preview transactions are being viewed from.
+ * Preview transactions for a given account (or pseudo account view), or all
+ * accounts if no `accountId` is provided. This will invert the payees,
+ * accounts, and amounts accordingly depending on which account the preview
+ * transactions are being viewed from.
  */
 export function useAccountPreviewTransactions({
   accountId,
 }: UseAccountPreviewTransactionsProps): UseAccountPreviewTransactionsResult {
+  const concreteAccountId =
+    accountId != null && PSEUDO_ACCOUNT_VIEWS.includes(accountId)
+      ? undefined
+      : accountId;
   const { data: accounts = [] } = useAccounts();
   const accountsById = useMemo(() => groupById(accounts), [accounts]);
   const { data: payees = [] } = usePayees();
@@ -61,19 +71,43 @@ export function useAccountPreviewTransactions({
   );
 
   const accountSchedulesFilter = useCallback(
-    (schedule: ScheduleEntity) =>
-      !accountId ||
-      schedule._account === accountId ||
-      getTransferAccountByPayee(schedule._payee)?.id === accountId,
-    [accountId, getTransferAccountByPayee],
+    (schedule: ScheduleEntity) => {
+      if (!accountId) {
+        return true;
+      }
+
+      if (accountId === 'uncategorized' || accountId === 'closed') {
+        // These views never show schedule previews
+        return false;
+      }
+
+      if (accountId === 'onbudget' || accountId === 'offbudget') {
+        const wantOffbudget = accountId === 'offbudget';
+        return [
+          accountsById[schedule._account],
+          getTransferAccountByPayee(schedule._payee),
+        ].some(
+          account =>
+            account != null &&
+            !account.closed &&
+            Boolean(account.offbudget) === wantOffbudget,
+        );
+      }
+
+      return (
+        schedule._account === accountId ||
+        getTransferAccountByPayee(schedule._payee)?.id === accountId
+      );
+    },
+    [accountId, accountsById, getTransferAccountByPayee],
   );
 
   const accountBalanceValue = useSheetValue<
     'account',
     'balance' | 'accounts-balance'
   >(
-    accountId
-      ? bindings.accountBalance(accountId)
+    concreteAccountId
+      ? bindings.accountBalance(concreteAccountId)
       : bindings.allAccountBalance(),
   );
 
@@ -93,7 +127,7 @@ export function useAccountPreviewTransactions({
   });
 
   return useMemo(() => {
-    if (!accountId) {
+    if (!concreteAccountId) {
       return {
         previewTransactions: allPreviewTransactions,
         runningBalances: allRunningBalances,
@@ -106,7 +140,7 @@ export function useAccountPreviewTransactions({
       transactions: previewTransactions,
       runningBalances: previewRunningBalances,
     } = inverseBasedOnAccount({
-      accountId,
+      accountId: concreteAccountId,
       transactions: allPreviewTransactions,
       runningBalances: allRunningBalances,
       startingBalance: accountBalanceValue ?? 0,
@@ -128,7 +162,7 @@ export function useAccountPreviewTransactions({
       error,
     };
   }, [
-    accountId,
+    concreteAccountId,
     allPreviewTransactions,
     accountBalanceValue,
     allRunningBalances,

--- a/packages/desktop-client/src/hooks/usePreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/usePreviewTransactions.ts
@@ -59,16 +59,20 @@ export function usePreviewTransactions({
   filter,
   options,
 }: UsePreviewTransactionsProps = {}): UsePreviewTransactionsResult {
-  const [previewTransactions, setPreviewTransactions] = useState<
-    TransactionEntity[]
-  >([]);
+  // The rules-applied transactions, where `key` tags which
+  // `scheduleTransactions` value they were computed from: `key !==
+  // scheduleTransactions` means a refresh is in flight (reported as
+  // `isLoading`, with no stale-`false` windows during account switches).
+  const [resolved, setResolved] = useState<{
+    key: TransactionEntity[] | null;
+    transactions: TransactionEntity[];
+  }>({ key: null, transactions: [] });
   const {
     isLoading: isSchedulesLoading,
     error: scheduleQueryError,
     schedules,
     statuses,
   } = useCachedSchedules();
-  const [isLoading, setIsLoading] = useState(isSchedulesLoading);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   const [upcomingLength] = useSyncedPref('upcomingScheduledTransactionLength');
@@ -92,19 +96,12 @@ export function usePreviewTransactions({
     setError(undefined);
 
     if (scheduleTransactions.length === 0) {
-      setIsLoading(false);
-      setPreviewTransactions([]);
+      setResolved({ key: scheduleTransactions, transactions: [] });
       return;
     }
 
-    setIsLoading(true);
-
-    Promise.all(
-      scheduleTransactions.map(transaction =>
-        // Kick off an async rules application
-        send('rules-run', { transaction }),
-      ),
-    )
+    // Apply rules to all preview transactions in a single round-trip
+    send('rules-run-batch', { transactions: scheduleTransactions })
       .then(newTrans => {
         if (!isUnmounted) {
           const scheduleById = new Map(schedules.map(s => [s.id, s]));
@@ -129,15 +126,16 @@ export function usePreviewTransactions({
           withDefaults.sort(comparePreviewTransactions);
 
           const ungroupedTransactions = ungroupTransactions(withDefaults);
-          setPreviewTransactions(ungroupedTransactions);
-
-          setIsLoading(false);
+          setResolved({
+            key: scheduleTransactions,
+            transactions: ungroupedTransactions,
+          });
         }
       })
       .catch(error => {
         if (!isUnmounted) {
           setError(error);
-          setIsLoading(false);
+          setResolved({ key: scheduleTransactions, transactions: [] });
         }
       });
 
@@ -145,6 +143,8 @@ export function usePreviewTransactions({
       isUnmounted = true;
     };
   }, [scheduleTransactions, schedules, statuses, upcomingLength]);
+
+  const previewTransactions = resolved.transactions;
 
   const runningBalances = useMemo(() => {
     if (!options?.calculateRunningBalances) {
@@ -168,7 +168,7 @@ export function usePreviewTransactions({
   return {
     previewTransactions,
     runningBalances,
-    isLoading: isLoading || isSchedulesLoading,
+    isLoading: isSchedulesLoading || resolved.key !== scheduleTransactions,
     ...(returnError && { error: returnError }),
   };
 }

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { q } from '@actual-app/core/shared/query';
 import type { Query } from '@actual-app/core/shared/query';
@@ -7,6 +7,7 @@ import {
   getStatus,
 } from '@actual-app/core/shared/schedules';
 import type { ScheduleStatuses } from '@actual-app/core/shared/schedules';
+import { isPreviewId } from '@actual-app/core/shared/transactions';
 import type {
   AccountEntity,
   ScheduleEntity,
@@ -86,7 +87,14 @@ export function useSchedules({
     setError(undefined);
 
     if (!query) {
-      // This usually means query is not yet set on this render cycle.
+      // No query yet (or the caller disabled the subscription) — clear any
+      // data left over from a previous query
+      setData({
+        schedules: [],
+        statuses: new Map(),
+        statusLabels: new Map(),
+      });
+      setIsLoading(false);
       return;
     }
 
@@ -167,4 +175,32 @@ export function getSchedulesQuery(
   }
 
   return query.orderBy({ next_date: 'desc' });
+}
+
+/**
+ * Schedules behind the preview (scheduled) transactions among the given
+ * selected ids. Only subscribes to the schedules query when preview
+ * transactions are actually selected — this is used for every transaction
+ * row's context menu, and an unconditional subscription per row floods the
+ * backend on every table change.
+ */
+export function useSelectedPreviewSchedules(
+  selectedIds: string[],
+): UseSchedulesResult {
+  const scheduleIds = useMemo(
+    () => selectedIds.filter(id => isPreviewId(id)).map(id => id.split('/')[1]),
+    [selectedIds],
+  );
+
+  const scheduleQuery = useMemo(
+    () =>
+      scheduleIds.length > 0
+        ? q('schedules')
+            .filter({ id: { $oneof: scheduleIds } })
+            .select('*')
+        : undefined,
+    [scheduleIds],
+  );
+
+  return useSchedules({ query: scheduleQuery });
 }

--- a/packages/desktop-client/src/queries/index.ts
+++ b/packages/desktop-client/src/queries/index.ts
@@ -16,6 +16,15 @@ import type { SyncedPrefs } from '@actual-app/core/types/prefs';
 // @ts-strict-ignore
 import { isValid as isDateValid, parse as parseDate } from 'date-fns';
 
+// The pseudo account views that can appear in place of a concrete account id
+// (see accountFilter below for their semantics)
+export const PSEUDO_ACCOUNT_VIEWS: readonly string[] = [
+  'onbudget',
+  'offbudget',
+  'closed',
+  'uncategorized',
+];
+
 export function accountFilter(
   accountId?:
     | AccountEntity['id']

--- a/packages/loot-core/src/server/rules/app.ts
+++ b/packages/loot-core/src/server/rules/app.ts
@@ -79,6 +79,7 @@ export type RulesHandlers = {
   'rules-get': typeof getRules;
   'rule-get': typeof getRule;
   'rules-run': typeof runRules;
+  'rules-run-batch': typeof runRulesBatch;
 };
 
 // Expose functions to the client
@@ -94,6 +95,7 @@ app.method('rule-add-payee-rename', mutator(addRulePayeeRename));
 app.method('rules-get', getRules);
 app.method('rule-get', getRule);
 app.method('rules-run', runRules);
+app.method('rules-run-batch', runRulesBatch);
 
 async function ruleValidate(
   rule: Partial<RuleEntity>,
@@ -190,4 +192,12 @@ async function runRules({
   transaction: TransactionEntity;
 }): Promise<TransactionEntity> {
   return rules.runRules(transaction);
+}
+
+async function runRulesBatch({
+  transactions,
+}: {
+  transactions: TransactionEntity[];
+}): Promise<TransactionEntity[]> {
+  return rules.runRulesBatch(transactions);
 }

--- a/packages/loot-core/src/server/transactions/transaction-rules.ts
+++ b/packages/loot-core/src/server/transactions/transaction-rules.ts
@@ -321,6 +321,9 @@ export async function getAllRuleIdsFromSchedules(
 export async function runRules(
   trans,
   accounts: Map<string, db.DbAccount> | null = null,
+  // Optional schedule id -> rule id map so batch callers can share one
+  // schedules lookup across many transactions
+  scheduleRules: Map<string, string | null> | null = null,
 ) {
   await ensureFormulaPreferencesLoaded();
 
@@ -338,14 +341,19 @@ export async function runRules(
   let scheduleRuleID = '';
   // Check if a schedule is attached to this transaction and if so get the rule ID attached to that schedule.
   if (trans.schedule != null) {
-    const ruleId = await getRuleIdFromScheduleId(trans.schedule);
+    const ruleId = scheduleRules
+      ? scheduleRules.get(trans.schedule) || null
+      : await getRuleIdFromScheduleId(trans.schedule);
     if (ruleId != null) {
       scheduleRuleID = ruleId;
     }
   }
 
-  const RuleIdsLinkedToSchedules =
-    await getAllRuleIdsFromSchedules(scheduleRuleID);
+  const RuleIdsLinkedToSchedules = scheduleRules
+    ? [...scheduleRules.values()]
+        .filter((rule): rule is string => !!rule)
+        .filter(ruleId => ruleId !== scheduleRuleID)
+    : await getAllRuleIdsFromSchedules(scheduleRuleID);
 
   const rules = rankRules(
     fastSetMerge(
@@ -387,6 +395,22 @@ export async function runRules(
   }
 
   return await finalizeTransactionForRules(finalTrans);
+}
+
+// Run rules over many transactions sharing one accounts and one schedules
+// lookup, instead of the per-transaction queries runRules does on its own
+export async function runRulesBatch(trans: unknown[]) {
+  const accounts = new Map(
+    (await db.getAccounts()).map(account => [account.id, account]),
+  );
+  const scheduleRules = new Map(
+    (
+      await db.all<Pick<db.DbSchedule, 'id' | 'rule'>>(
+        'SELECT id, rule FROM schedules',
+      )
+    ).map(row => [row.id, row.rule]),
+  );
+  return Promise.all(trans.map(t => runRules(t, accounts, scheduleRules)));
 }
 
 function conditionSpecialCases(cond: Condition | null): Condition | null {

--- a/upcoming-release-notes/speed-up-transaction-list-and-schedules.md
+++ b/upcoming-release-notes/speed-up-transaction-list-and-schedules.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [MatissJanis]
+---
+
+Speed up the transaction list and upcoming scheduled transactions, keep the table steady when switching accounts, and protect local budget data from browser storage cleanup

--- a/upcoming-release-notes/speed-up-transaction-list-and-schedules.md
+++ b/upcoming-release-notes/speed-up-transaction-list-and-schedules.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [MatissJanis]
 ---
 
-Speed up the transaction list and upcoming scheduled transactions, keep the table steady when switching accounts, and protect local budget data from browser storage cleanup
+Speed up the transaction list and upcoming scheduled transactions, and keep the table steady when switching accounts


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

Waiting on https://github.com/actualbudget/actual/pull/8663 to be merged first; this PR might significantly change afterwards.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.1 MB (+1.9 kB) | +0.01%
loot-core | 1 | 4.63 MB → 4.63 MB (+671 B) | +0.01%
api | 2 | 3.84 MB → 3.84 MB (+662 B) | +0.02%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.1 MB (+1.9 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useSchedules.ts` | 📈 +925 B (+28.58%) | 3.16 kB → 4.06 kB
`src/hooks/useAccountPreviewTransactions.ts` | 📈 +604 B (+16.62%) | 3.55 kB → 4.14 kB
`src/components/accounts/Account.tsx` | 📈 +1.56 kB (+3.84%) | 40.61 kB → 42.17 kB
`src/queries/index.ts` | 📈 +87 B (+3.83%) | 2.22 kB → 2.31 kB
`src/hooks/usePreviewTransactions.ts` | 📈 +36 B (+0.74%) | 4.73 kB → 4.76 kB
`src/components/PrivacyFilter.tsx` | 📈 +2 B (+0.03%) | 5.86 kB → 5.86 kB
`src/budget/mutations.ts` | 📉 -4 B (-0.02%) | 19.44 kB → 19.43 kB
`src/components/transactions/SelectedTransactionsButton.tsx` | 📉 -622 B (-3.45%) | 17.62 kB → 17.01 kB
`src/components/transactions/useTransactionRowContextActions.ts` | 📉 -674 B (-5.60%) | 11.76 kB → 11.1 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 274.04 kB → 274.99 kB (+974 B) | +0.35%
static/js/PayeeRuleCountLabel.js | 11.74 kB → 12.37 kB (+640 B) | +5.32%
static/js/Value.js | 2.03 MB → 2.03 MB (+336 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 171.84 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+671 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/app.ts` | 📈 +142 B (+4.76%) | 2.91 kB → 3.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +529 B (+2.40%) | 21.54 kB → 22.05 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.ClKW5gYV.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bcf_a9eI.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+662 B) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/app.ts` | 📈 +138 B (+4.73%) | 2.85 kB → 2.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +524 B (+2.42%) | 21.11 kB → 21.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+662 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->