### PR TITLE
26.8.1 cherry picks

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/api",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "An API for Actual",
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/cli",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "CLI for Actual Budget",
   "license": "MIT",
   "repository": {

--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/web",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
+++ b/packages/desktop-client/src/components/schedules/SchedulesTable.tsx
@@ -198,6 +198,11 @@ function ScheduleRow({
             onClick: () => onAction('complete', schedule.id),
             hidden: status === 'completed',
           },
+          {
+            name: 'delete',
+            text: t('Delete'),
+            onClick: () => onAction('delete', schedule.id),
+          },
         ]
       : [],
   });

--- a/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
+++ b/packages/desktop-client/src/components/transactions/useTransactionRowContextActions.ts
@@ -64,6 +64,9 @@ export function useTransactionRowContextActions({
   }, [selectedIds]);
 
   const scheduleQuery = useMemo(() => {
+    if (scheduleIds.length === 0) {
+      return undefined;
+    }
     return q('schedules')
       .filter({ id: { $oneof: scheduleIds } })
       .select('*');

--- a/packages/desktop-client/src/hooks/useContextMenu.ts
+++ b/packages/desktop-client/src/hooks/useContextMenu.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import type { RefObject } from 'react';
 
 import type { Falsy } from '@actual-app/core/types/util';
@@ -23,10 +23,6 @@ export function useContextMenu({
   items,
 }: UseContextMenuProps) {
   const dispatch = useDispatch();
-
-  // Store actions in a ref to avoid re-binding the event listener on every render
-  const actionsRef = useRef(items);
-  actionsRef.current = items;
 
   const processedItems = items.filter(
     item => item && (typeof item === 'symbol' || !item.hidden),

--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -1,0 +1,97 @@
+import type { RefObject } from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRefEventListener } from './useRefEventListener';
+
+describe('useRefEventListener', () => {
+  function makeMockElement() {
+    return {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+  }
+
+  it('registers the listener once on mount', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    renderHook(() => useRefEventListener(ref, 'click', vi.fn()));
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+  });
+
+  it('does not re-bind the native listener when only the callback identity changes', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(
+      ({ callback }) => useRefEventListener(ref, 'click', callback),
+      { initialProps: { callback: vi.fn() } },
+    );
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.removeEventListener).not.toHaveBeenCalled();
+
+    // Simulate a caller passing a brand-new inline function every render.
+    rerender({ callback: vi.fn() });
+    rerender({ callback: vi.fn() });
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el.removeEventListener).not.toHaveBeenCalled();
+  });
+
+  it('always invokes the latest callback, even after a re-render', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ callback }) => useRefEventListener(ref, 'click', callback),
+      { initialProps: { callback: firstCallback } },
+    );
+
+    rerender({ callback: secondCallback });
+
+    const registeredListener = el.addEventListener.mock.calls[0][1];
+    const event = { type: 'click' };
+    registeredListener(event);
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledWith(event);
+  });
+
+  it('rebinds when the event name changes', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook<void, { event: 'click' | 'keyup' }>(
+      ({ event }) => useRefEventListener(ref, event, vi.fn()),
+      { initialProps: { event: 'click' } },
+    );
+
+    rerender({ event: 'keyup' });
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(2);
+    expect(el.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const el = makeMockElement();
+    const ref = { current: el } as unknown as RefObject<HTMLElement | null>;
+
+    const { unmount } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    unmount();
+
+    expect(el.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 
 export function useRefEventListener<
@@ -10,16 +10,26 @@ export function useRefEventListener<
   // oxlint-disable-next-line typescript/no-explicit-any
   callback: (this: ElementType, ev: HTMLElementEventMap[EventType]) => any,
 ) {
-  // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
+  // Keep the latest callback in a ref so the effect below doesn't need to
+  // depend on it. Callers routinely pass a new inline function every render,
+  // which would otherwise tear down and re-add the native listener on every
+  // render instead of only when `ref`/`event` change.
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
   useEffect(() => {
     const el =
       ref instanceof Document || ref instanceof Window ? ref : ref.current;
     if (!el) return;
 
-    const callbackRef = callback as EventListener; // closure?
-    el.addEventListener(event, callbackRef);
+    const listener: EventListener = e =>
+      callbackRef.current.call(
+        el as ElementType,
+        e as HTMLElementEventMap[EventType],
+      );
+    el.addEventListener(event, listener);
     return () => {
-      el.removeEventListener(event, callbackRef);
+      el.removeEventListener(event, listener);
     };
-  }, [ref, event, callback]);
+  }, [ref, event]);
 }

--- a/packages/desktop-client/src/hooks/useSchedules.test.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.test.ts
@@ -1,0 +1,82 @@
+import { q } from '@actual-app/core/shared/query';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { liveQuery } from '#queries/liveQuery';
+import type { LiveQuery } from '#queries/liveQuery';
+
+import { useSchedules } from './useSchedules';
+
+vi.mock('#queries/liveQuery', () => ({
+  liveQuery: vi.fn(),
+}));
+
+vi.mock('./useSyncedPref', () => ({
+  useSyncedPref: () => ['7', vi.fn()],
+}));
+
+type LiveQueryCall = {
+  onData: (data: unknown[], previousData: unknown[]) => void;
+  unsubscribe: ReturnType<typeof vi.fn>;
+};
+
+describe('useSchedules', () => {
+  let calls: LiveQueryCall[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calls = [];
+
+    // `vi.mocked` keeps the mock bound to the real `liveQuery` signature, so a
+    // change to how the hook calls it still fails typecheck.
+    vi.mocked(liveQuery).mockImplementation((_query, { onData }) => {
+      const handle = {
+        onData: onData ?? vi.fn(),
+        unsubscribe: vi.fn(),
+      };
+      calls.push(handle);
+      // `LiveQuery` is a class with private state; only the subscription
+      // surface used by the hook is faked here.
+      return handle as unknown as LiveQuery<unknown>;
+    });
+  });
+
+  it('does not open any live query when no query is given', () => {
+    renderHook(() => useSchedules({}));
+
+    expect(liveQuery).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes the previous status query when schedules refresh', () => {
+    renderHook(() => useSchedules({ query: q('schedules').select('*') }));
+
+    // The schedules query is opened first; its onData opens the status query.
+    expect(calls).toHaveLength(1);
+    const schedulesQuery = calls[0];
+
+    schedulesQuery.onData([], []);
+    expect(calls).toHaveLength(2);
+    const firstStatusQuery = calls[1];
+    expect(firstStatusQuery.unsubscribe).not.toHaveBeenCalled();
+
+    // A refresh must tear down the previous status query rather than orphaning
+    // it — an orphan stays subscribed to sync events and keeps re-running.
+    schedulesQuery.onData([], []);
+    expect(firstStatusQuery.unsubscribe).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('unsubscribes both queries on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useSchedules({ query: q('schedules').select('*') }),
+    );
+
+    calls[0].onData([], []);
+    expect(calls).toHaveLength(2);
+
+    unmount();
+
+    expect(calls[0].unsubscribe).toHaveBeenCalled();
+    expect(calls[1].unsubscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -106,6 +106,10 @@ export function useSchedules({
 
     scheduleQueryRef.current = liveQuery<ScheduleEntity>(query, {
       onData: async schedules => {
+        // `onData` fires again whenever the schedules change, so tear down the
+        // previous status query first. Otherwise each refresh orphans a live
+        // query that stays subscribed to sync events and keeps re-running.
+        statusQueryRef.current?.unsubscribe();
         statusQueryRef.current = loadStatuses(
           schedules,
           (statuses: ScheduleStatuses) => {

--- a/packages/desktop-client/src/queries/liveQuery.ts
+++ b/packages/desktop-client/src/queries/liveQuery.ts
@@ -215,11 +215,15 @@ export class LiveQuery<TResponse = unknown> {
         }
 
         this.onData(this.data, previousData);
-        this.inflightRequestId = null;
       }
     } catch (e) {
       console.log('Error fetching data', e);
       this.onError(e);
+    } finally {
+      // always clear the request id, to prevent an infinite loop
+      if (this.inflightRequestId === reqId) {
+        this.inflightRequestId = null;
+      }
     }
   };
 }

--- a/packages/desktop-client/src/queries/pagedQuery.test.ts
+++ b/packages/desktop-client/src/queries/pagedQuery.test.ts
@@ -618,4 +618,101 @@ describe('pagedQuery', () => {
 
     await wait(1000);
   });
+
+  it('does not spin forever when unsubscribed during a refetch', async () => {
+    // Regression test: unsubscribing while a refetch was in flight (e.g.
+    // switching accounts while a scroll-triggered `fetchNext` was pending)
+    // used to leave `inflightRequestId` set forever, making `fetchNext` spin
+    // in an infinite microtask loop that froze the app at 100% CPU.
+    const data = [];
+    for (let i = 0; i < 400; i++) {
+      data.push({ id: i });
+    }
+
+    // Server that blocks every page query until we release it, so the test
+    // controls exactly when each in-flight request resolves.
+    const pending = [];
+    mockServer({
+      send: async (name, args) => {
+        switch (name) {
+          case 'query': {
+            const query = args;
+            if (isCountQuery(query)) {
+              return { data: data.length, dependencies: ['transactions'] };
+            }
+            await new Promise(resolve => pending.push(resolve));
+            return {
+              data: limitOffset(
+                data.map(row => select(row, query.selectExpressions)),
+                query.limit,
+                query.offset,
+              ),
+              dependencies: ['transactions'],
+            };
+          }
+          default:
+            throw new Error(`Command not implemented: ${name}`);
+        }
+      },
+    });
+
+    const query = q('transactions').select('id');
+    const paged = pagedQuery(query, {
+      options: { onlySync: true, pageCount: 150 },
+    });
+
+    await wait(1);
+    pending.shift()();
+    await wait(1);
+    expect(paged.data.length).toBe(150);
+
+    // A scroll near the bottom starts fetching the next page...
+    let fetchNextSettled = false;
+    const fetchNextPromise = paged.fetchNext().then(() => {
+      fetchNextSettled = true;
+    });
+    await wait(1);
+
+    // ...a database change triggers a refetch while that page is loading...
+    mockPublishEvent('sync-event', {
+      type: 'success',
+      tables: ['transactions'],
+    });
+    await wait(1);
+
+    // ...and the account switch unsubscribes before either request finishes.
+    paged.unsubscribe();
+    while (pending.length) {
+      pending.shift()();
+    }
+
+    // Pump the microtask queue a bounded number of times. Timers never fire
+    // while `fetchNext` spins, so this must not wait on a timer.
+    for (let i = 0; i < 2000; i++) {
+      await Promise.resolve();
+    }
+
+    // The cancelled refetch must not leave a stale in-flight request id
+    // behind — `fetchNext` loops on it until it clears.
+    const internals = paged as unknown as {
+      _inflightRequestId: number | null;
+    };
+    const staleRequestId = internals._inflightRequestId;
+    // Break the loop if it is spinning, so a regression fails cleanly here
+    // instead of hanging the test worker.
+    internals._inflightRequestId = null;
+    expect(staleRequestId).toBeNull();
+
+    // fetchNext recovers: release the page request it retries and let it
+    // finish.
+    for (let i = 0; i < 20 && !fetchNextSettled; i++) {
+      while (pending.length) {
+        pending.shift()();
+      }
+      await wait(1);
+    }
+    await fetchNextPromise;
+    expect(fetchNextSettled).toBe(true);
+    expect(paged.data.length).toBe(300);
+  });
 });

--- a/packages/desktop-electron/package.json
+++ b/packages/desktop-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "desktop-electron",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "A simple and powerful personal finance system",
   "author": "Actual",
   "main": "build/desktop-electron/index.js",

--- a/packages/loot-core/package.json
+++ b/packages/loot-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/core",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "",
   "license": "ISC",
   "repository": {

--- a/packages/loot-core/src/shared/schedules.test.ts
+++ b/packages/loot-core/src/shared/schedules.test.ts
@@ -5,6 +5,7 @@ import type { RuleConditionEntity, ScheduleEntity } from '#types/models';
 import * as monthUtils from './months';
 import {
   computeSchedulePreviewTransactions,
+  getHasTransactionsQuery,
   getNextDate,
   getScheduleOccurrenceMatchStartDate,
   getStatus,
@@ -266,6 +267,35 @@ describe('schedules', () => {
 
       // Should not crash; schedule with past end date produces its next_date entry only
       expect(result).toBeDefined();
+    });
+  });
+
+  describe('getHasTransactionsQuery', () => {
+    it('matches nothing when there are no schedules', () => {
+      // An empty `$or` compiles away to no constraint at all, which would make
+      // this scan every transaction in the budget. It must never do that.
+      const filters = getHasTransactionsQuery([]).serialize().filterExpressions;
+
+      expect(filters).toEqual([{ id: null }]);
+      expect(filters[0]).not.toHaveProperty('$or');
+    });
+
+    it('filters by schedule and date when schedules are given', () => {
+      const filters = getHasTransactionsQuery([
+        {
+          id: 'schedule-1',
+          next_date: '2024-03-10',
+          _conditions: [{ op: 'is', field: 'date', value: '2024-03-10' }],
+        },
+      ]).serialize().filterExpressions;
+
+      expect(filters).toEqual([
+        {
+          $or: [
+            { $and: { schedule: 'schedule-1', date: { $gte: '2024-03-10' } } },
+          ],
+        },
+      ]);
     });
   });
 

--- a/packages/loot-core/src/shared/schedules.ts
+++ b/packages/loot-core/src/shared/schedules.ts
@@ -136,11 +136,19 @@ export function getHasTransactionsQuery(schedules) {
     };
   });
 
-  return q('transactions')
+  const query = q('transactions')
     .options({ splits: 'all' })
-    .filter({ $or: filters })
     .orderBy({ date: 'desc' })
     .select(['schedule', 'date']);
+
+  // An empty `$or` compiles away to no constraint at all (`WHERE 1`), which
+  // would scan every transaction in the budget to answer a question about zero
+  // schedules. Match nothing instead — `id` is a primary key and never null.
+  if (filters.length === 0) {
+    return query.filter({ id: null });
+  }
+
+  return query.filter({ $or: filters });
 }
 
 type ScheduleRuleOptions = IRuleOptions & {

--- a/packages/mobile-client/package.json
+++ b/packages/mobile-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobile-client",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "license": "MIT",
   "files": [
     "build"

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actual-app/sync-server",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "actual syncing server",
   "license": "MIT",
   "repository": {

--- a/upcoming-release-notes/7829.md
+++ b/upcoming-release-notes/7829.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Switch from bcrypt to argon2id hashing algorithm

--- a/upcoming-release-notes/7952.md
+++ b/upcoming-release-notes/7952.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [clintharris]
----
-
-Restore budget table scroll position when navigating back from the spent transactions view.

--- a/upcoming-release-notes/8032.md
+++ b/upcoming-release-notes/8032.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [Nustinua]
----
-
-Skip Enable Banking PSU headers when the detected client IP is local or private.

--- a/upcoming-release-notes/8100.md
+++ b/upcoming-release-notes/8100.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [BIGSUS24]
----
-
-Add scoped error boundaries around the mobile budget, account, and transaction edit pages so a rendering error in one of them no longer crashes the entire app.

--- a/upcoming-release-notes/8244.md
+++ b/upcoming-release-notes/8244.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [lelemm]
----
-
-Fix Formula card query sliding-window timeframes to use the same live range calculation as reports.

--- a/upcoming-release-notes/8245.md
+++ b/upcoming-release-notes/8245.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Improve formula editors with visual badges and context-aware completions for queries, variables, budget fields, categories, and timeframes

--- a/upcoming-release-notes/8316.md
+++ b/upcoming-release-notes/8316.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Allow bank sync credentials to be stored globally or for a specific budget file.

--- a/upcoming-release-notes/8351.md
+++ b/upcoming-release-notes/8351.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [lucasboebel]
----
-
-avoid the full-page reset and scroll jump when editing crossover report filters

--- a/upcoming-release-notes/8369.md
+++ b/upcoming-release-notes/8369.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [lelemm]
----
-
-Refactor formula autocomplete metadata to share a single catalog for report and rule formula suggestions.

--- a/upcoming-release-notes/8380.md
+++ b/upcoming-release-notes/8380.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Add corrected installment dates for Pluggy credit card transactions, available as a mappable date field in bank sync settings.

--- a/upcoming-release-notes/8505.md
+++ b/upcoming-release-notes/8505.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [MikesGlitch]
----
-
-Fix OIDC login on iPad and harden the OIDC callback on all browsers

--- a/upcoming-release-notes/8526.md
+++ b/upcoming-release-notes/8526.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [MikesGlitch]
----
-
-Fix login issue that happens after signing out of a server with OIDC on Electron.

--- a/upcoming-release-notes/8545.md
+++ b/upcoming-release-notes/8545.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [shahidsarker]
----
-
-Migrate api/app/query to TypeScript

--- a/upcoming-release-notes/README.md
+++ b/upcoming-release-notes/README.md
@@ -1,1 +1,0 @@
-See the [Writing Good Release Notes](https://actualbudget.org/docs/contributing/#writing-good-release-notes) section of the README for the documentation repo for more information on how to create a release notes file here.

--- a/upcoming-release-notes/add-4rules-blurple-dark-theme.md
+++ b/upcoming-release-notes/add-4rules-blurple-dark-theme.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [distantvapor]
----
-
-Added "4Rules Blurple - Dark" to the custom theme catalog; renamed "You Need A Dark Mode" to "4Rules Cyan - Dark".

--- a/upcoming-release-notes/add-alucard-theme.md
+++ b/upcoming-release-notes/add-alucard-theme.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Add Dracula and Alucard to the custom theme catalog.

--- a/upcoming-release-notes/add-api-import-export-budget.md
+++ b/upcoming-release-notes/add-api-import-export-budget.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [MatissJanis]
----
-
-Add importBudget and exportBudget functions to the API for importing and exporting budget files directly

--- a/upcoming-release-notes/add-cleared-column-tooltip.md
+++ b/upcoming-release-notes/add-cleared-column-tooltip.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [rtwfroody]
----
-
-Add a tooltip to the cleared column header explaining the transaction status icons

--- a/upcoming-release-notes/add-mobile-reconciliation.md
+++ b/upcoming-release-notes/add-mobile-reconciliation.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Add ability to reconcile accounts on mobile

--- a/upcoming-release-notes/add-release-notes-skill.md
+++ b/upcoming-release-notes/add-release-notes-skill.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Add a Claude skill for writing release notes

--- a/upcoming-release-notes/add-tag-button-mobile.md
+++ b/upcoming-release-notes/add-tag-button-mobile.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [alecbakholdin]
----
-
-Added button to mobile transaction edit to allow easier access to # in mobile, and added tags to demo budget

--- a/upcoming-release-notes/add-thyrium-theme.md
+++ b/upcoming-release-notes/add-thyrium-theme.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [Carlisle96]
----
-
-Add Thyrium to the custom theme catalog.

--- a/upcoming-release-notes/add-vrt-skill.md
+++ b/upcoming-release-notes/add-vrt-skill.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Add an agent skill documenting how to run and update visual regression tests

--- a/upcoming-release-notes/add-zero-dark-theme.md
+++ b/upcoming-release-notes/add-zero-dark-theme.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [Deathblade666]
----
-
-Add Zero Dark to the custom theme catalog.

--- a/upcoming-release-notes/adding-tooltip-to-title-icons.md
+++ b/upcoming-release-notes/adding-tooltip-to-title-icons.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [tabedzki]
----
-
-Add tooltips to the theme, privacy, and server status icons in the top bar

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-export-csv-feature.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-export-csv-feature.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [tabedzki]
----
-
-Budget Analysis reports can now be exported as CSV

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-show-hidden-categories.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [tabedzki]
----
-
-Budget analysis report: add "show hidden categories" option, group options into dropdown

--- a/upcoming-release-notes/allow-null-sql-query-params.md
+++ b/upcoming-release-notes/allow-null-sql-query-params.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Allow `null` in database query parameter types via a shared `SqlParam` type

--- a/upcoming-release-notes/api-browser-custom-data-dir.md
+++ b/upcoming-release-notes/api-browser-custom-data-dir.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [MatissJanis]
----
-
-Fix using a custom data directory in the browser version of the API, and show the real error message when something goes wrong in the background

--- a/upcoming-release-notes/api-browser-self-contained.md
+++ b/upcoming-release-notes/api-browser-self-contained.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [MatissJanis]
----
-
-api: the browser version of the API now works out of the box in any web app, with no extra setup.

--- a/upcoming-release-notes/api-get-preferences.md
+++ b/upcoming-release-notes/api-get-preferences.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [MatissJanis]
----
-
-The API can now read a budget's formatting preferences, such as its number and currency format.

--- a/upcoming-release-notes/automation-month-picker.md
+++ b/upcoming-release-notes/automation-month-picker.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Use a month picker instead of a full date picker when choosing months in budget automations

--- a/upcoming-release-notes/automations-ui-prep.md
+++ b/upcoming-release-notes/automations-ui-prep.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Tweak testing framework for templates/automations

--- a/upcoming-release-notes/chatgpt-desktop-agent-hooks.md
+++ b/upcoming-release-notes/chatgpt-desktop-agent-hooks.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Make Codex-based agent harnesses (ChatGPT desktop app, Codex CLI/IDE) run the repo agent hooks and discover the shared skills

--- a/upcoming-release-notes/ci-e2e-shard-guard.md
+++ b/upcoming-release-notes/ci-e2e-shard-guard.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [StephenBrown2]
----
-
-E2E test fixes for easier local runs

--- a/upcoming-release-notes/count-points-fix.md
+++ b/upcoming-release-notes/count-points-fix.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Fix maintainer points counting script PR categorisation

--- a/upcoming-release-notes/deps-mid-month.md
+++ b/upcoming-release-notes/deps-mid-month.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Bump various dependencies

--- a/upcoming-release-notes/deps-playwright.md
+++ b/upcoming-release-notes/deps-playwright.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Bump playwright

--- a/upcoming-release-notes/disable-shared-worker-on-android.md
+++ b/upcoming-release-notes/disable-shared-worker-on-android.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [martin-lukas]
----
-
-Fix app becoming unresponsive on Android when reopening after being in the background for a while.

--- a/upcoming-release-notes/electron-ci-matrix.md
+++ b/upcoming-release-notes/electron-ci-matrix.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Speed up desktop app builds in CI

--- a/upcoming-release-notes/enforce-append-only-migrations-ci.md
+++ b/upcoming-release-notes/enforce-append-only-migrations-ci.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Enforce in CI that shipped database migration files are never edited or deleted, and warn on migrations that look destructive

--- a/upcoming-release-notes/first-account-setup.md
+++ b/upcoming-release-notes/first-account-setup.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Improve the process to add a first account

--- a/upcoming-release-notes/fix-account-switch-freeze.md
+++ b/upcoming-release-notes/fix-account-switch-freeze.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [matt-fidd]
+---
+
+Fix intermittent app freezes with 100% CPU usage

--- a/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
+++ b/upcoming-release-notes/fix-age-of-money-filtered-transfers.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [saahiljaffer]
----
-
-Fix Age of Money account filters so transfers between included and filtered-out on-budget accounts count as money entering or leaving the filtered accounts.

--- a/upcoming-release-notes/fix-api-update-transaction-split.md
+++ b/upcoming-release-notes/fix-api-update-transaction-split.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [aturzone]
----
-
-Fixed a crash when converting a regular transaction into a split via the API.

--- a/upcoming-release-notes/fix-bank-sync-relink-stale-accounts.md
+++ b/upcoming-release-notes/fix-bank-sync-relink-stale-accounts.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [mooons]
----
-
-Allow previously linked bank-sync accounts to be selected again when reconnecting the same provider.

--- a/upcoming-release-notes/fix-custom-theme-css-cache.md
+++ b/upcoming-release-notes/fix-custom-theme-css-cache.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [lelemm]
----
-
-Fetch the latest custom theme CSS when installing themes from the catalog.

--- a/upcoming-release-notes/fix-desktop-gocardless-linking.md
+++ b/upcoming-release-notes/fix-desktop-gocardless-linking.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [matt-fidd]
----
-
-Fix GoCardless account linking in the desktop app

--- a/upcoming-release-notes/fix-duplicate-draft-releases.md
+++ b/upcoming-release-notes/fix-duplicate-draft-releases.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Prevent duplicate draft releases being created by the Electron release job

--- a/upcoming-release-notes/fix-mobile-category-delete-confirmation.md
+++ b/upcoming-release-notes/fix-mobile-category-delete-confirmation.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [edwei06]
----
-
-Fix deleting categories and category groups with transactions on mobile

--- a/upcoming-release-notes/fix-mobile-swipe-to-delete.md
+++ b/upcoming-release-notes/fix-mobile-swipe-to-delete.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [youngcw]
----
-
-Fix mobile swipe-to-delete gesture not working on payees, rules, and schedules

--- a/upcoming-release-notes/fix-per-row-schedule-fullscan.md
+++ b/upcoming-release-notes/fix-per-row-schedule-fullscan.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix the transaction list getting slower as a budget grows, especially when adding, clearing, or deleting transactions and when reconciling

--- a/upcoming-release-notes/fix-relink-account-picker.md
+++ b/upcoming-release-notes/fix-relink-account-picker.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [youngcw]
----
-
-Fix relinking a bank account that had been unlinked.

--- a/upcoming-release-notes/fix-simplefin-token-claim.md
+++ b/upcoming-release-notes/fix-simplefin-token-claim.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [matt-fidd]
----
-
-Fix some SimpleFIN setup tokens failing to claim and link accounts

--- a/upcoming-release-notes/fix-slow-transaction-context-menu-listener.md
+++ b/upcoming-release-notes/fix-slow-transaction-context-menu-listener.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [youngcw]
+---
+
+Prevent context menu listeners from rebinding every render

--- a/upcoming-release-notes/fix-split-error-popover-collapse.md
+++ b/upcoming-release-notes/fix-split-error-popover-collapse.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [matt-fidd]
----
-
-Fix the split transaction popover sometimes not rendering at full height

--- a/upcoming-release-notes/fix-stacked-bar-tooltip.md
+++ b/upcoming-release-notes/fix-stacked-bar-tooltip.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [dsmaugy]
----
-
-Shows label name of hovered stacked bar chart group even if the label would have been hidden in compact mode

--- a/upcoming-release-notes/fix-tracking-budget-template-priority.md
+++ b/upcoming-release-notes/fix-tracking-budget-template-priority.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [youngcw]
----
-
-Fix budget templates/automations with a priority not allocating funds properly in tracking budgets

--- a/upcoming-release-notes/formula-hint-usage-fix.md
+++ b/upcoming-release-notes/formula-hint-usage-fix.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [lelemm]
----
-
-Fix Query Manager hints for QUERY and QUERY_COUNT to show double-quoted query names, matching the syntax formulas actually require.

--- a/upcoming-release-notes/friendly-onboarding.md
+++ b/upcoming-release-notes/friendly-onboarding.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Redesign onboarding screens

--- a/upcoming-release-notes/github-comment-robot-emoji-prefix.md
+++ b/upcoming-release-notes/github-comment-robot-emoji-prefix.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Prefix agent-authored GitHub comments, reviews and issues with the robot emoji 🤖.

--- a/upcoming-release-notes/gocardless-eua-expired-reauth.md
+++ b/upcoming-release-notes/gocardless-eua-expired-reauth.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [matt-fidd]
----
-
-Recognise GoCardless responses advising that the EUA has expired as relink requests

--- a/upcoming-release-notes/improved-context-menu.md
+++ b/upcoming-release-notes/improved-context-menu.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [alecbakholdin]
----
-
-Improved context menu ergonomics under the hood

--- a/upcoming-release-notes/match-mobile-app-branding.md
+++ b/upcoming-release-notes/match-mobile-app-branding.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [jfdoming]
----
-
-Update the iOS and Android app icons and launch screens to match the PWA

--- a/upcoming-release-notes/mobile-app-build.md
+++ b/upcoming-release-notes/mobile-app-build.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [jfdoming]
----
-
-Update build configuration to support mobile app

--- a/upcoming-release-notes/mobile-app-foundations.md
+++ b/upcoming-release-notes/mobile-app-foundations.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [jfdoming]
----
-
-Check in basic structure for mobile app PWA wrapper

--- a/upcoming-release-notes/mobile-bank-sync-setup.md
+++ b/upcoming-release-notes/mobile-bank-sync-setup.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Allow setting up bank sync providers and linking accounts from the mobile Bank Sync page

--- a/upcoming-release-notes/mobile-error-boundaries-schedules-payees-banksync.md
+++ b/upcoming-release-notes/mobile-error-boundaries-schedules-payees-banksync.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [BasilTh]
----
-
-Wrap the mobile schedules, payees, and bank sync pages in scoped error boundaries, so a rendering error in one of these sections shows a recoverable fallback instead of crashing the whole app.

--- a/upcoming-release-notes/month-range-picker-a11y-labels.md
+++ b/upcoming-release-notes/month-range-picker-a11y-labels.md
@@ -1,6 +1,0 @@
----
-category: Enhancement
-authors: [tabedzki, rznn7, MatissJanis]
----
-
-Add day-level date range selection to reports: the new date range picker lets you switch between picking whole months or exact days, and works the same in every browser

--- a/upcoming-release-notes/no-bug-label.md
+++ b/upcoming-release-notes/no-bug-label.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [youngcw]
----
-
-Dont add duplicate labels to bug and feature issues when there is already a type set

--- a/upcoming-release-notes/nynab-export-docs.md
+++ b/upcoming-release-notes/nynab-export-docs.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [archit-goyal]
----
-
-Clarify nYNAB export options when the third-party web exporter is unavailable.

--- a/upcoming-release-notes/pluggy-drop-category.md
+++ b/upcoming-release-notes/pluggy-drop-category.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [lelemm]
----
-
-Prevent Pluggy bank sync from repeatedly rewriting uncategorized and transfer transactions

--- a/upcoming-release-notes/pluggy-per-budget-credentials-ui.md
+++ b/upcoming-release-notes/pluggy-per-budget-credentials-ui.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Add Pluggy.ai settings support for configuring credentials on a specific budget file.

--- a/upcoming-release-notes/pluggy-per-budget-credentials.md
+++ b/upcoming-release-notes/pluggy-per-budget-credentials.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [lelemm]
----
-
-Use per-budget-file credentials for Pluggy.ai bank sync.

--- a/upcoming-release-notes/promote-age-of-money-report.md
+++ b/upcoming-release-notes/promote-age-of-money-report.md
@@ -1,6 +1,0 @@
----
-category: Features
-authors: [youngcw]
----
-
-Promote the Age of Money report to a stable feature

--- a/upcoming-release-notes/promote-payee-locations.md
+++ b/upcoming-release-notes/promote-payee-locations.md
@@ -1,6 +1,0 @@
----
-category: Features
-authors: [MatissJanis]
----
-
-Promote Payee Locations to a stable feature.

--- a/upcoming-release-notes/react-compiler-monorepo.md
+++ b/upcoming-release-notes/react-compiler-monorepo.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [MatissJanis]
----
-
-Enable React Compiler for all monorepo packages with React code instead of only desktop-client

--- a/upcoming-release-notes/refresh-running-balance.md
+++ b/upcoming-release-notes/refresh-running-balance.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [tianrking]
----
-
-Refresh running balances after editing a transaction

--- a/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
+++ b/upcoming-release-notes/release-notes-resolve-pr-link-from-master.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Fix release note generation script to resolve links in cherry-picked changes

--- a/upcoming-release-notes/replace-adm-zip-with-fflate.md
+++ b/upcoming-release-notes/replace-adm-zip-with-fflate.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [StephenBrown2]
----
-
-Replace adm-zip with fflate and safe wrappers for zip handling.

--- a/upcoming-release-notes/report-group-clickthrough.md
+++ b/upcoming-release-notes/report-group-clickthrough.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [matt-fidd]
----
-
-Support clicking on category groups in reports to see the filtered transactions

--- a/upcoming-release-notes/resolve-payee-name-eagerly.md
+++ b/upcoming-release-notes/resolve-payee-name-eagerly.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [julienvincent]
----
-
-When a rule action sets payee_name, resolve it to the actual payee ID immediately during rule execution instead of waiting until finalization.

--- a/upcoming-release-notes/restore-schedule-delete-menu-option.md
+++ b/upcoming-release-notes/restore-schedule-delete-menu-option.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [bzupnick]
+---
+
+Restore the "Delete" option in the schedule row menu on the Schedules page

--- a/upcoming-release-notes/simplefin-secrets-tweak.md
+++ b/upcoming-release-notes/simplefin-secrets-tweak.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [matt-fidd]
----
-
-Reorganise the SimpleFIN key saving logic

--- a/upcoming-release-notes/simplify-categories-get-api.md
+++ b/upcoming-release-notes/simplify-categories-get-api.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [MatissJanis]
----
-
-Simplify the getCategories API to always return a flat list of categories.

--- a/upcoming-release-notes/skip-ynab-transfer-payees.md
+++ b/upcoming-release-notes/skip-ynab-transfer-payees.md
@@ -1,6 +1,0 @@
----
-category: Bugfixes
-authors: [claude]
----
-
-Stop the nYNAB importer from creating an unused duplicate payee for each linked transfer account.

--- a/upcoming-release-notes/stable-api-error-codes.md
+++ b/upcoming-release-notes/stable-api-error-codes.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [MatissJanis]
----
-
-Common API failures now include a stable code so apps built on the API can show their own clear message for each kind of failure.

--- a/upcoming-release-notes/translate-budget-template-notifications.md
+++ b/upcoming-release-notes/translate-budget-template-notifications.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [DarthAmk97]
----
-
-Translate budget template action notifications.

--- a/upcoming-release-notes/welcome-animation-fill.md
+++ b/upcoming-release-notes/welcome-animation-fill.md
@@ -1,6 +1,0 @@
----
-category: Bugfix
-authors: [matt-fidd]
----
-
-Respect reduced motion settings in the new onboarding screen

--- a/upcoming-release-notes/wip-ai-add-performance-indexes-for-transactions-table.md
+++ b/upcoming-release-notes/wip-ai-add-performance-indexes-for-transactions-table.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [alecbakholdin]
----
-
-Add performance indices for transactions table

--- a/upcoming-release-notes/wip-chore-api-migrate-node-version-validation-to-typescript.md
+++ b/upcoming-release-notes/wip-chore-api-migrate-node-version-validation-to-typescript.md
@@ -1,6 +1,0 @@
----
-category: Maintenance
-authors: [Ehtasham-Yasin]
----
-
-Migrate node version validation to TypeScript


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

To be merged AFTER https://github.com/actualbudget/actual/pull/8672

- 7a67eff1e026e4651503b92c14783cd1c272ddeb (fix context menu rebinding)
- 17a72d3c3b54b3cf094517326e830fab04926cc4 (fixes hang when switching while queries are running)
- 87e33e49eb4d666c33e0c0f172faf340d1b7aa0a (main fix to schedule queries)
- 492525089ad11f2807c43bbb0aa711e62f599107 (adds delete back to the schedule context menu)

Aimed at fixing performance regressions, and adding delete back to the context menus while we're patching

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 37 → 36 | 14.02 MB → 12.83 MB (-1.19 MB) | -8.46%
loot-core | 1 | 5.34 MB → 4.62 MB (-734.96 kB) | -13.44%
api | 2 | 3.96 MB → 3.84 MB (-128.62 kB) | -3.17%
cli | 1 | 7.97 MB → 8.02 MB (+53.67 kB) | +0.66%
crdt | 1 | 11.12 kB → 11.16 kB (+34 B) | +0.30%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
37 → 36 | 14.02 MB → 12.83 MB (-1.19 MB) | -8.46%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 🆕 +137.04 kB | 0 B → 137.04 kB
`node_modules/csv-stringify/dist/esm/sync.js` | 🆕 +58.66 kB | 0 B → 58.66 kB
`src/components/formula/formulaCatalog.ts` | 🆕 +38.6 kB | 0 B → 38.6 kB
`node_modules/react-aria/dist/private/focus/FocusScope.mjs` | 🆕 +24.17 kB | 0 B → 24.17 kB
`src/components/modals/BudgetAutomationsModal/BudgetAutomationsBodyMobile.tsx` | 🆕 +20.02 kB | 0 B → 20.02 kB
`node_modules/react-stately/dist/private/color/Color.mjs` | 🆕 +19.91 kB | 0 B → 19.91 kB
`node_modules/react-stately/dist/private/layout/ListLayout.mjs` | 🆕 +19.83 kB | 0 B → 19.83 kB
`node_modules/react-router/dist/production/lib/dom/lib.js` | 🆕 +17.79 kB | 0 B → 17.79 kB
`node_modules/react-aria/dist/private/overlays/calculatePosition.mjs` | 🆕 +17.75 kB | 0 B → 17.75 kB
`node_modules/react-aria/dist/private/interactions/usePress.mjs` | 🆕 +17.07 kB | 0 B → 17.07 kB
`node_modules/react-aria/dist/private/dnd/useDroppableCollection.mjs` | 🆕 +16.64 kB | 0 B → 16.64 kB
`node_modules/react-aria-components/dist/private/GridList.mjs` | 🆕 +16.32 kB | 0 B → 16.32 kB
`node_modules/react-router/dist/production/lib/hooks.js` | 🆕 +16.13 kB | 0 B → 16.13 kB
`node_modules/react-aria/dist/private/dnd/DragManager.mjs` | 🆕 +15.71 kB | 0 B → 15.71 kB
`node_modules/react-aria-components/dist/private/ListBox.mjs` | 🆕 +14.96 kB | 0 B → 14.96 kB
`node_modules/react-router/dist/production/lib/router/utils.js` | 🆕 +13.82 kB | 0 B → 13.82 kB
`src/components/common/CalculatorButtons.tsx` | 🆕 +13.59 kB | 0 B → 13.59 kB
`node_modules/react-aria-components/dist/private/Calendar.mjs` | 🆕 +12.83 kB | 0 B → 12.83 kB
`node_modules/react-stately/dist/private/calendar/useCalendarState.mjs` | 🆕 +12.53 kB | 0 B → 12.53 kB
`node_modules/react-aria/dist/private/selection/useSelectableCollection.mjs` | 🆕 +12.46 kB | 0 B → 12.46 kB
`node_modules/@internationalized/date/dist/private/manipulation.mjs` | 🆕 +12.24 kB | 0 B → 12.24 kB
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +11.15 kB | 0 B → 11.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.04 kB | 0 B → 11.04 kB
`src/components/formula/formulaBadgeRanges.ts` | 🆕 +10.59 kB | 0 B → 10.59 kB
`node_modules/@internationalized/number/dist/private/NumberParser.mjs` | 🆕 +10.27 kB | 0 B → 10.27 kB
`node_modules/react-aria/dist/private/collections/Document.mjs` | 🆕 +10.25 kB | 0 B → 10.25 kB
`node_modules/react-aria/dist/private/gridlist/useGridListItem.mjs` | 🆕 +10.17 kB | 0 B → 10.17 kB
`node_modules/react-aria/dist/private/interactions/useFocusVisible.mjs` | 🆕 +9.54 kB | 0 B → 9.54 kB
`node_modules/react-aria/dist/private/numberfield/useNumberField.mjs` | 🆕 +9.46 kB | 0 B → 9.46 kB
`node_modules/react-aria/dist/private/dnd/useDrop.mjs` | 🆕 +9.45 kB | 0 B → 9.45 kB
`node_modules/react-hotkeys-hook/packages/react-hotkeys-hook/dist/index.js` | 🆕 +9.35 kB | 0 B → 9.35 kB
`node_modules/react-aria/dist/private/intl/dnd/ru-RU.mjs` | 🆕 +9.28 kB | 0 B → 9.28 kB
`node_modules/react-aria/dist/private/intl/dnd/el-GR.mjs` | 🆕 +9.04 kB | 0 B → 9.04 kB
`node_modules/react-aria/dist/private/intl/dnd/uk-UA.mjs` | 🆕 +9.02 kB | 0 B → 9.02 kB
`node_modules/react-stately/dist/private/selection/SelectionManager.mjs` | 🆕 +8.79 kB | 0 B → 8.79 kB
`node_modules/react-aria/dist/private/selection/ListKeyboardDelegate.mjs` | 🆕 +8.4 kB | 0 B → 8.4 kB
`node_modules/react-aria/dist/private/intl/dnd/bg-BG.mjs` | 🆕 +8.3 kB | 0 B → 8.3 kB
`node_modules/react-aria/dist/private/calendar/useCalendarCell.mjs` | 🆕 +8.18 kB | 0 B → 8.18 kB
`node_modules/react-aria/dist/private/dnd/useDrag.mjs` | 🆕 +7.94 kB | 0 B → 7.94 kB
`node_modules/react-aria/dist/private/selection/useSelectableItem.mjs` | 🆕 +7.72 kB | 0 B → 7.72 kB
`node_modules/react-stately/dist/private/virtualizer/Virtualizer.mjs` | 🆕 +7.45 kB | 0 B → 7.45 kB
`node_modules/react-aria/dist/private/dnd/utils.mjs` | 🆕 +7.38 kB | 0 B → 7.38 kB
`node_modules/react-aria/dist/private/virtualizer/ScrollView.mjs` | 🆕 +7.31 kB | 0 B → 7.31 kB
`node_modules/react-router/dist/production/lib/dom/ssr/components.js` | 🆕 +7.28 kB | 0 B → 7.28 kB
`node_modules/@internationalized/date/dist/private/conversion.mjs` | 🆕 +7.18 kB | 0 B → 7.18 kB
`node_modules/react-aria/dist/private/collections/CollectionBuilder.mjs` | 🆕 +7.12 kB | 0 B → 7.12 kB
`node_modules/react-stately/dist/private/numberfield/useNumberFieldState.mjs` | 🆕 +7.07 kB | 0 B → 7.07 kB
`node_modules/react-aria/dist/private/collections/BaseCollection.mjs` | 🆕 +7.04 kB | 0 B → 7.04 kB
`home/runner/work/actual/actual/packages/component-library/src/date-range-picker/DayRangeCalendar.tsx` | 🆕 +6.89 kB | 0 B → 6.89 kB
`node_modules/@internationalized/date/dist/private/calendars/IslamicCalendar.mjs` | 🆕 +6.87 kB | 0 B → 6.87 kB
`src/util/error.ts` | 🆕 +6.85 kB | 0 B → 6.85 kB
`node_modules/react-aria/dist/private/dnd/DropTargetKeyboardNavigation.mjs` | 🆕 +6.58 kB | 0 B → 6.58 kB
`node_modules/react-aria/dist/private/spinbutton/useSpinButton.mjs` | 🆕 +6.31 kB | 0 B → 6.31 kB
`node_modules/react-aria/dist/private/overlays/ariaHideOutside.mjs` | 🆕 +6.24 kB | 0 B → 6.24 kB
`node_modules/react-router/dist/production/lib/components.js` | 🆕 +6.24 kB | 0 B → 6.24 kB
`node_modules/react-aria/dist/private/overlays/usePreventScroll.mjs` | 🆕 +6.16 kB | 0 B → 6.16 kB
`src/components/modals/BudgetAutomationsModal/useBudgetAutomationsEditor.ts` | 🆕 +6.11 kB | 0 B → 6.11 kB
`node_modules/react-aria/dist/private/intl/dnd/ja-JP.mjs` | 🆕 +6.11 kB | 0 B → 6.11 kB
`node_modules/react-aria-components/dist/private/Popover.mjs` | 🆕 +6.04 kB | 0 B → 6.04 kB
`node_modules/react-aria/dist/private/intl/dnd/he-IL.mjs` | 🆕 +6.04 kB | 0 B → 6.04 kB
`node_modules/react-stately/dist/private/calendar/useRangeCalendarState.mjs` | 🆕 +6.03 kB | 0 B → 6.03 kB
`src/components/mobile/transactions/CalculatorAmountInput.tsx` | 🆕 +6.03 kB | 0 B → 6.03 kB
`node_modules/recharts/es6/cartesian/AreaRevealShape.js` | 🆕 +5.92 kB | 0 B → 5.92 kB
`node_modules/react-aria-components/dist/private/Modal.mjs` | 🆕 +5.89 kB | 0 B → 5.89 kB
`node_modules/react-stately/dist/private/collections/CollectionBuilder.mjs` | 🆕 +5.75 kB | 0 B → 5.75 kB
`node_modules/react-aria/dist/private/overlays/useOverlayPosition.mjs` | 🆕 +5.73 kB | 0 B → 5.73 kB
`node_modules/react-aria/dist/private/utils/scrollIntoView.mjs` | 🆕 +5.72 kB | 0 B → 5.72 kB
`node_modules/react-aria/dist/private/intl/dnd/ar-AE.mjs` | 🆕 +5.72 kB | 0 B → 5.72 kB
`src/components/mobile/transactions/CalculatorKeyboard.tsx` | 🆕 +5.68 kB | 0 B → 5.68 kB
`node_modules/react-router/dist/production/lib/router/history.js` | 🆕 +5.62 kB | 0 B → 5.62 kB
`node_modules/@internationalized/date/dist/private/queries.mjs` | 🆕 +5.62 kB | 0 B → 5.62 kB
`home/runner/work/actual/actual/packages/component-library/src/DateRangePicker.tsx` | 🆕 +5.6 kB | 0 B → 5.6 kB
`src/components/modals/AccountReconcileModal.tsx` | 🆕 +5.39 kB | 0 B → 5.39 kB
`node_modules/es-toolkit/dist/object/cloneDeepWith.mjs` | 🆕 +5.36 kB | 0 B → 5.36 kB
`node_modules/@internationalized/date/dist/private/CalendarDate.mjs` | 🆕 +5.35 kB | 0 B → 5.35 kB
`node_modules/react-stately/dist/private/form/useFormValidationState.mjs` | 🆕 +5.32 kB | 0 B → 5.32 kB
`node_modules/react-aria/dist/private/utils/shadowdom/ShadowTreeWalker.mjs` | 🆕 +5.13 kB | 0 B → 5.13 kB
`node_modules/react-aria/dist/private/intl/dnd/ko-KR.mjs` | 🆕 +5.09 kB | 0 B → 5.09 kB
`node_modules/react-aria-components/dist/private/utils.mjs` | 🆕 +5.06 kB | 0 B → 5.06 kB
`home/runner/work/actual/actual/packages/component-library/src/MonthPicker.tsx` | 🆕 +4.82 kB | 0 B → 4.82 kB
`node_modules/react-aria/dist/private/calendar/utils.mjs` | 🆕 +4.82 kB | 0 B → 4.82 kB
`node_modules/@internationalized/number/dist/private/NumberFormatter.mjs` | 🆕 +4.8 kB | 0 B → 4.8 kB
`src/components/transactions/useTransactionRowContextActions.ts` | 🆕 +4.8 kB | 0 B → 4.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/browser-preload/worker-bridge.ts` | 🆕 +4.65 kB | 0 B → 4.65 kB
`node_modules/react-stately/dist/private/dnd/useDroppableCollectionState.mjs` | 🆕 +4.61 kB | 0 B → 4.61 kB
`src/components/modals/AkahuInitialiseModal.tsx` | 🆕 +4.57 kB | 0 B → 4.57 kB
`node_modules/react-aria-components/dist/private/Virtualizer.mjs` | 🆕 +4.44 kB | 0 B → 4.44 kB
`src/components/autocomplete/TagMultiAutocomplete.tsx` | 🆕 +4.4 kB | 0 B → 4.4 kB
`node_modules/@internationalized/date/dist/private/DateFormatter.mjs` | 🆕 +4.34 kB | 0 B → 4.34 kB
`node_modules/react-aria-components/dist/private/ColorField.mjs` | 🆕 +4.32 kB | 0 B → 4.32 kB
`node_modules/react-aria/dist/private/dnd/ListDropTargetDelegate.mjs` | 🆕 +4.25 kB | 0 B → 4.25 kB
`node_modules/react-aria/dist/private/interactions/utils.mjs` | 🆕 +4.21 kB | 0 B → 4.21 kB
`src/util/schedule.ts` | 🆕 +4.19 kB | 0 B → 4.19 kB
`node_modules/react-aria/dist/private/intl/dnd/zh-TW.mjs` | 🆕 +4.15 kB | 0 B → 4.15 kB
`node_modules/recharts/es6/animation/AnimatedItems.js` | 🆕 +4.01 kB | 0 B → 4.01 kB
`node_modules/@internationalized/date/dist/private/calendars/JapaneseCalendar.mjs` | 🆕 +3.99 kB | 0 B → 3.99 kB
`node_modules/es-toolkit/dist/predicate/isEqualWith.mjs` | 🆕 +3.9 kB | 0 B → 3.9 kB
`node_modules/react-router/dist/production/lib/dom/dom.js` | 🆕 +3.9 kB | 0 B → 3.9 kB
`node_modules/react-aria/dist/private/interactions/useHover.mjs` | 🆕 +3.87 kB | 0 B → 3.87 kB
`node_modules/@internationalized/date/dist/private/calendars/HebrewCalendar.mjs` | 🆕 +3.84 kB | 0 B → 3.84 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useDateFormat.js | 0 B → 2.91 MB (+2.91 MB) | -
static/js/chart-theme.js | 0 B → 670.14 kB (+670.14 kB) | -
static/js/pl.js | 0 B → 137.04 kB (+137.04 kB) | -
static/js/AppliedFilters.js | 0 B → 35.51 kB (+35.51 kB) | -
static/js/bootstrapHyperFormula.js | 0 B → 302 B (+302 B) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/toString.js | 705.14 kB → 0 B (-705.14 kB) | -100%
static/js/extends.js | 500.57 kB → 0 B (-500.57 kB) | -100%
static/js/th.js | 174.48 kB → 0 B (-174.48 kB) | -100%
static/js/da.js | 101.17 kB → 0 B (-101.17 kB) | -100%
static/js/_baseIsEqual.js | 98.02 kB → 0 B (-98.02 kB) | -100%
static/js/resize-observer.js | 18.06 kB → 0 B (-18.06 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/nl.js | 106.24 kB → 152.45 kB (+46.21 kB) | +43.49%
static/js/en.js | 198.13 kB → 236.36 kB (+38.23 kB) | +19.30%
static/js/ManageRules.js | 46.98 kB → 68.85 kB (+21.87 kB) | +46.55%
static/js/TransactionEdit.js | 89.65 kB → 107.62 kB (+17.97 kB) | +20.04%
static/js/de.js | 170.79 kB → 179.29 kB (+8.5 kB) | +4.98%
static/js/index.js | 1.54 MB → 1.55 MB (+8.24 kB) | +0.52%
static/js/useFormatList.js | 2.52 kB → 9.31 kB (+6.79 kB) | +269.68%
static/js/PayeeRuleCountLabel.js | 7.33 kB → 9.41 kB (+2.08 kB) | +28.32%
static/js/en-GB.js | 9.25 kB → 11.1 kB (+1.85 kB) | +19.95%
static/js/client.js | 451.37 kB → 452.05 kB (+696 B) | +0.15%
static/js/useTransactionBatchActions.js | 9.71 kB → 9.77 kB (+64 B) | +0.64%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 5.07 MB → 2 MB (-3.07 MB) | -60.55%
static/js/FormulaEditor.js | 962.55 kB → 762.13 kB (-200.43 kB) | -20.82%
static/js/ReportRouter.js | 1.26 MB → 1.2 MB (-58.55 kB) | -4.55%
static/js/narrow.js | 364.2 kB → 330.95 kB (-33.25 kB) | -9.13%
static/js/SchedulesTable.js | 202.7 kB → 171.06 kB (-31.64 kB) | -15.61%
static/js/wide.js | 296.1 kB → 269.73 kB (-26.37 kB) | -8.91%
static/js/ca.js | 186.78 kB → 171.68 kB (-15.1 kB) | -8.08%
static/js/es.js | 178.71 kB → 165.11 kB (-13.61 kB) | -7.61%
static/js/it.js | 165.02 kB → 152.57 kB (-12.45 kB) | -7.54%
static/js/nb-NO.js | 148.08 kB → 136.51 kB (-11.57 kB) | -7.81%
static/js/zh-Hans.js | 116.92 kB → 107.54 kB (-9.38 kB) | -8.02%
static/js/pt-BR.js | 188.46 kB → 179.66 kB (-8.79 kB) | -4.67%
static/js/fr.js | 178.61 kB → 171.84 kB (-6.77 kB) | -3.79%
static/js/uk.js | 207.49 kB → 200.72 kB (-6.77 kB) | -3.26%
static/js/TransactionList.js | 85.81 kB → 79.07 kB (-6.74 kB) | -7.86%
static/js/ScheduleEditForm.js | 146.45 kB → 140.4 kB (-6.04 kB) | -4.13%
static/js/theme.js | 31.77 kB → 31.1 kB (-679 B) | -2.09%
static/js/workbox-window.prod.es5.js | 7.33 kB → 7.21 kB (-117 B) | -1.56%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 5.34 MB → 4.62 MB (-734.96 kB) | -13.44%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/fflate/esm/browser.js` | 🆕 +22.81 kB | 0 B → 22.81 kB
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +11.43 kB | 0 B → 11.43 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.4 kB | 0 B → 11.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/customFunctionsPreferences.ts` | 🆕 +4.36 kB | 0 B → 4.36 kB
`node_modules/hyperformula/es/interpreter/plugin/PercentilePlugin.mjs` | 🆕 +3.56 kB | 0 B → 3.56 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatchWith.mjs` | 🆕 +3.33 kB | 0 B → 3.33 kB
`node_modules/hyperformula/es/interpreter/plugin/SequencePlugin.mjs` | 🆕 +3.29 kB | 0 B → 3.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/zip.ts` | 🆕 +2.3 kB | 0 B → 2.3 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-tracking-budget.ts` | 🆕 +1.82 kB | 0 B → 1.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/errors.ts` | 🆕 +1.54 kB | 0 B → 1.54 kB
`node_modules/csv-parse/lib/utils/delimiter_discover.js` | 🆕 +1.51 kB | 0 B → 1.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/shared.ts` | 🆕 +1.34 kB | 0 B → 1.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/bootstrap.ts` | 🆕 +648 B | 0 B → 648 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/sort-categories.ts` | 🆕 +577 B | 0 B → 577 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/memoize.ts` | 🆕 +548 B | 0 B → 548 B
`@oxc-project+runtime@0.139.0/helpers/esm/toPrimitive.js` | 🆕 +418 B | 0 B → 418 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 🆕 +416 B | 0 B → 416 B
`@oxc-project+runtime@0.139.0/helpers/esm/typeof.js` | 🆕 +409 B | 0 B → 409 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/environment.browser.ts` | 🆕 +309 B | 0 B → 309 B
`@oxc-project+runtime@0.139.0/helpers/esm/assertClassBrand.js` | 🆕 +288 B | 0 B → 288 B
`@oxc-project+runtime@0.139.0/helpers/esm/defineProperty.js` | 🆕 +282 B | 0 B → 282 B
`@oxc-project+runtime@0.139.0/helpers/esm/checkPrivateRedeclaration.js` | 🆕 +246 B | 0 B → 246 B
`node_modules/es-toolkit/dist/_internal/isEqualsSameValueZero.mjs` | 🆕 +217 B | 0 B → 217 B
`node_modules/es-toolkit/dist/compat/predicate/isObject.mjs` | 🆕 +206 B | 0 B → 206 B
`node_modules/es-toolkit/dist/predicate/isPrimitive.mjs` | 🆕 +202 B | 0 B → 202 B
`@oxc-project+runtime@0.139.0/helpers/esm/toPropertyKey.js` | 🆕 +197 B | 0 B → 197 B
`@oxc-project+runtime@0.139.0/helpers/esm/classPrivateFieldInitSpec.js` | 🆕 +195 B | 0 B → 195 B
`@oxc-project+runtime@0.139.0/helpers/esm/classPrivateMethodInitSpec.js` | 🆕 +191 B | 0 B → 191 B
`@oxc-project+runtime@0.139.0/helpers/esm/classPrivateFieldSet2.js` | 🆕 +185 B | 0 B → 185 B
`node_modules/es-toolkit/dist/compat/predicate/isMatch.mjs` | 🆕 +178 B | 0 B → 178 B
`@oxc-project+runtime@0.139.0/helpers/esm/classPrivateFieldGet2.js` | 🆕 +176 B | 0 B → 176 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/app.ts` | 🆕 +169 B | 0 B → 169 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/memory/index.ts` | 🆕 +123 B | 0 B → 123 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +2.1 kB (+82.44%) | 2.55 kB → 4.66 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/platform.ts` | 📈 +281 B (+67.55%) | 416 B → 697 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +644 B (+34.87%) | 1.8 kB → 2.43 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +744 B (+30.27%) | 2.4 kB → 3.13 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +3.1 kB (+24.88%) | 12.46 kB → 15.56 kB
`node_modules/hyperformula/es/LazilyTransformingAstService.mjs` | 📈 +426 B (+23.05%) | 1.8 kB → 2.22 kB
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📈 +4.33 kB (+21.29%) | 20.35 kB → 24.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +1.43 kB (+20.15%) | 7.11 kB → 8.54 kB
`node_modules/csv-parse/lib/api/init_state.js` | 📈 +301 B (+16.90%) | 1.74 kB → 2.03 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.64 kB (+13.53%) | 26.9 kB → 30.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +1.42 kB (+11.97%) | 11.82 kB → 13.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/fs/index.ts` | 📈 +905 B (+11.14%) | 7.93 kB → 8.82 kB
`node_modules/csv-parse/lib/api/normalize_options.js` | 📈 +1.72 kB (+10.65%) | 16.13 kB → 17.84 kB
`node_modules/uuid/dist/rng.js` | 📈 +16 B (+10.46%) | 153 B → 169 B
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📈 +755 B (+8.68%) | 8.49 kB → 9.23 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📈 +1.59 kB (+8.31%) | 19.11 kB → 20.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +493 B (+7.96%) | 6.05 kB → 6.53 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +437 B (+7.92%) | 5.39 kB → 5.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +662 B (+7.84%) | 8.25 kB → 8.89 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/backups.ts` | 📈 +346 B (+7.11%) | 4.75 kB → 5.09 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/custom-sync-mapping.ts` | 📈 +48 B (+6.61%) | 726 B → 774 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +142 B (+6.59%) | 2.1 kB → 2.24 kB
`rolldown/runtime.js` | 📈 +108 B (+6.58%) | 1.6 kB → 1.71 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +422 B (+6.56%) | 6.29 kB → 6.7 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +124 B (+6.49%) | 1.87 kB → 1.99 kB
`node_modules/hyperformula/es/interpreter/plugin/index.mjs` | 📈 +124 B (+6.44%) | 1.88 kB → 2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +312 B (+6.06%) | 5.03 kB → 5.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +1.24 kB (+5.23%) | 23.74 kB → 24.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +536 B (+4.76%) | 10.99 kB → 11.51 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📈 +418 B (+4.47%) | 9.13 kB → 9.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +42 B (+4.36%) | 963 B → 1005 B
`node_modules/csv-parse/lib/api/index.js` | 📈 +873 B (+4.15%) | 20.52 kB → 21.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +242 B (+3.88%) | 6.08 kB → 6.32 kB
`node_modules/csv-stringify/lib/api/index.js` | 📈 +260 B (+3.49%) | 7.28 kB → 7.53 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/actual.ts` | 📈 +25 B (+3.47%) | 720 B → 745 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +277 B (+3.26%) | 8.31 kB → 8.58 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/sqlite/index.ts` | 📈 +106 B (+3.23%) | 3.21 kB → 3.31 kB
`node_modules/csv-parse/lib/sync.js` | 📈 +17 B (+3.14%) | 541 B → 558 B
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +149 B (+3.14%) | 4.64 kB → 4.78 kB
`node_modules/date-fns/locale/cs/_lib/formatRelative.js` | 📈 +20 B (+3.11%) | 643 B → 663 B
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +142 B (+2.34%) | 5.92 kB → 6.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +461 B (+2.13%) | 21.09 kB → 21.54 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📈 +178 B (+2.11%) | 8.24 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/util.ts` | 📈 +16 B (+2.09%) | 767 B → 783 B
`node_modules/lru-cache/dist/esm/browser/index.min.js` | 📈 +768 B (+1.94%) | 38.7 kB → 39.45 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +78 B (+1.72%) | 4.42 kB → 4.49 kB
`node_modules/date-fns/locale/hu/_lib/formatDistance.js` | 📈 +29 B (+1.69%) | 1.67 kB → 1.7 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/months.ts` | 📈 +84 B (+1.56%) | 5.25 kB → 5.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/title/lower-case.ts` | 📈 +16 B (+1.46%) | 1.07 kB → 1.08 kB
`node_modules/des.js/lib/des/ede.js` | 📈 +22 B (+1.44%) | 1.49 kB → 1.51 kB
`node_modules/des.js/lib/des/cbc.js` | 📈 +22 B (+1.42%) | 1.51 kB → 1.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +30 B (+1.41%) | 2.08 kB → 2.11 kB
`node_modules/date-fns/locale/pl/_lib/formatRelative.js` | 📈 +19 B (+1.37%) | 1.35 kB → 1.37 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +283 B (+1.32%) | 20.95 kB → 21.22 kB
`node_modules/date-fns/locale/zh-TW/_lib/match.js` | 📈 +34 B (+1.15%) | 2.88 kB → 2.91 kB
`node_modules/date-fns/locale/zh-HK/_lib/match.js` | 📈 +34 B (+1.13%) | 2.93 kB → 2.96 kB
`node_modules/date-fns/locale/zh-CN/_lib/match.js` | 📈 +34 B (+1.13%) | 2.93 kB → 2.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab4.ts` | 📈 +101 B (+1.05%) | 9.4 kB → 9.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +252 B (+1.05%) | 23.49 kB → 23.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/reports/app.ts` | 📈 +36 B (+0.96%) | 3.64 kB → 3.68 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/spreadsheet/spreadsheet.ts` | 📈 +79 B (+0.89%) | 8.68 kB → 8.75 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/title/index.ts` | 📈 +27 B (+0.88%) | 2.99 kB → 3.02 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +85 B (+0.85%) | 9.76 kB → 9.85 kB
`node_modules/date-fns/locale/lt/_lib/formatDistance.js` | 📈 +29 B (+0.81%) | 3.49 kB → 3.52 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +66 B (+0.81%) | 8 kB → 8.06 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/app.ts` | 📈 +70 B (+0.74%) | 9.24 kB → 9.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/encryption/encryption-internals.ts` | 📈 +16 B (+0.71%) | 2.19 kB → 2.21 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CL1XOrfD.js | 0 B → 4.62 MB (+4.62 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C_UHYSJL.js | 5.34 MB → 0 B (-5.34 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.96 MB → 3.84 MB (-128.62 kB) | -3.17%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/fflate/esm/browser.js` | 🆕 +23.19 kB | 0 B → 23.19 kB
`node_modules/hyperformula/es/interpreter/plugin/DatabasePlugin.mjs` | 🆕 +15.79 kB | 0 B → 15.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 🆕 +11.12 kB | 0 B → 11.12 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatchWith.mjs` | 🆕 +6.2 kB | 0 B → 6.2 kB
`node_modules/hyperformula/es/interpreter/plugin/PercentilePlugin.mjs` | 🆕 +6.03 kB | 0 B → 6.03 kB
`node_modules/hyperformula/es/interpreter/plugin/SequencePlugin.mjs` | 🆕 +5.08 kB | 0 B → 5.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/customFunctionsPreferences.ts` | 🆕 +4.28 kB | 0 B → 4.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/zip.ts` | 🆕 +2.21 kB | 0 B → 2.21 kB
`app/query.ts` | 🆕 +2.12 kB | 0 B → 2.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-tracking-budget.ts` | 🆕 +1.78 kB | 0 B → 1.78 kB
`node_modules/csv-parse/lib/utils/delimiter_discover.js` | 🆕 +1.46 kB | 0 B → 1.46 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/retry.ts` | 🆕 +1.13 kB | 0 B → 1.13 kB
`node_modules/es-toolkit/dist/compat/predicate/isObject.mjs` | 🆕 +1 kB | 0 B → 1 kB
`node_modules/es-toolkit/dist/compat/predicate/isMatch.mjs` | 🆕 +1023 B | 0 B → 1023 B
`node_modules/es-toolkit/dist/predicate/isPrimitive.mjs` | 🆕 +861 B | 0 B → 861 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/memoize.ts` | 🆕 +778 B | 0 B → 778 B
`node_modules/es-toolkit/dist/_internal/isEqualsSameValueZero.mjs` | 🆕 +606 B | 0 B → 606 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/bootstrap.ts` | 🆕 +605 B | 0 B → 605 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/sort-categories.ts` | 🆕 +569 B | 0 B → 569 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 🆕 +403 B | 0 B → 403 B
`validateNodeVersion.ts` | 🆕 +377 B | 0 B → 377 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/client/connection/index.api.ts` | 🆕 +326 B | 0 B → 326 B
`home/runner/work/actual/actual/packages/loot-core/src/server/formulas/app.ts` | 🆕 +167 B | 0 B → 167 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/memory/index.api.ts` | 🆕 +121 B | 0 B → 121 B
`node_modules/hyperformula/es/DependencyGraph/index.mjs` | 🆕 +157 B | 0 B → 157 B
`node_modules/hyperformula/es/statistics/index.mjs` | 🆕 +152 B | 0 B → 152 B
`node_modules/hyperformula/es/parser/index.mjs` | 🆕 +148 B | 0 B → 148 B
`node_modules/hyperformula/es/LazilyTransformingAstService.mjs` | 📈 +2.79 kB (+158.80%) | 1.75 kB → 4.54 kB
`node_modules/date-fns/addDays.js` | 📈 +1.21 kB (+105.70%) | 1.15 kB → 2.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts` | 📈 +1.17 kB (+103.11%) | 1.13 kB → 2.29 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/scalar.js` | 📈 +967 B (+85.12%) | 1.11 kB → 2.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +2.08 kB (+82.33%) | 2.52 kB → 4.6 kB
`node_modules/hyperformula/es/Lookup/ColumnBinarySearch.mjs` | 📈 +392 B (+53.85%) | 728 B → 1.09 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +617 B (+34.30%) | 1.76 kB → 2.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +441 B (+30.84%) | 1.4 kB → 1.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/app.ts` | 📈 +725 B (+30.21%) | 2.34 kB → 3.05 kB
`node_modules/hyperformula/es/UndoRedo.mjs` | 📈 +4.94 kB (+26.62%) | 18.55 kB → 23.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +3.04 kB (+24.94%) | 12.19 kB → 15.24 kB
`node_modules/hyperformula/es/i18n/languages/enUS.mjs` | 📈 +59 B (+24.38%) | 242 B → 301 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +1.18 kB (+22.42%) | 5.26 kB → 6.44 kB
`methods.ts` | 📈 +1.23 kB (+21.57%) | 5.72 kB → 6.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/mocks/budget.ts` | 📈 +4.2 kB (+21.28%) | 19.71 kB → 23.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/base.ts` | 📈 +1.41 kB (+20.26%) | 6.95 kB → 8.36 kB
`node_modules/hyperformula/es/interpreter/plugin/TextPlugin.mjs` | 📈 +2.2 kB (+20.12%) | 10.95 kB → 13.15 kB
`node_modules/csv-parse/lib/api/init_state.js` | 📈 +293 B (+17.26%) | 1.66 kB → 1.94 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +3.76 kB (+14.33%) | 26.23 kB → 29.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/actions.ts` | 📈 +1.37 kB (+11.96%) | 11.49 kB → 12.87 kB
`node_modules/uuid/dist/rng.js` | 📈 +16 B (+10.74%) | 149 B → 165 B
`node_modules/csv-parse/lib/api/normalize_options.js` | 📈 +1.68 kB (+10.61%) | 15.87 kB → 17.55 kB
`node_modules/hyperformula/es/interpreter/plugin/index.mjs` | 📈 +194 B (+10.32%) | 1.84 kB → 2.03 kB
`node_modules/hyperformula/es/Emitter.mjs` | 📈 +73 B (+10.25%) | 712 B → 785 B
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📈 +734 B (+8.70%) | 8.24 kB → 8.95 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/condition.ts` | 📈 +649 B (+8.16%) | 7.77 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/transactions.ts` | 📈 +476 B (+7.95%) | 5.85 kB → 6.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/backups.ts` | 📈 +337 B (+7.12%) | 4.62 kB → 4.95 kB
`rolldown/runtime.js` | 📈 +101 B (+7.00%) | 1.41 kB → 1.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/rules.ts` | 📈 +141 B (+6.89%) | 2 kB → 2.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/util/custom-sync-mapping.ts` | 📈 +48 B (+6.79%) | 707 B → 755 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +398 B (+6.55%) | 5.94 kB → 6.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +301 B (+5.97%) | 4.93 kB → 5.22 kB
`node_modules/hyperformula/es/Lookup/ColumnIndex.mjs` | 📈 +479 B (+5.80%) | 8.07 kB → 8.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/forecast/forecast-schedules.ts` | 📈 +341 B (+5.60%) | 5.95 kB → 6.28 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +1.28 kB (+5.51%) | 23.21 kB → 24.49 kB
`node_modules/hyperformula/es/interpreter/plugin/FunctionPlugin.mjs` | 📈 +684 B (+5.48%) | 12.2 kB → 12.86 kB
`node_modules/hyperformula/es/parser/parser-consts.mjs` | 📈 +73 B (+5.44%) | 1.31 kB → 1.38 kB
`node_modules/hyperformula/es/i18n/languages/enGB.mjs` | 📈 +474 B (+5.31%) | 8.72 kB → 9.19 kB
`node_modules/handlebars/dist/cjs/handlebars/base.js` | 📈 +153 B (+5.04%) | 2.97 kB → 3.12 kB
`node_modules/date-fns/locale/ca/_lib/localize.js` | 📈 +324 B (+4.86%) | 6.52 kB → 6.83 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +525 B (+4.83%) | 10.63 kB → 11.14 kB
`node_modules/@bufbuild/protobuf/dist/esm/from-binary.js` | 📈 +253 B (+4.62%) | 5.35 kB → 5.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/server-config.ts` | 📈 +41 B (+4.41%) | 929 B → 970 B
`node_modules/csv-parse/lib/api/index.js` | 📈 +853 B (+4.16%) | 20.01 kB → 20.84 kB
`node_modules/csv-stringify/lib/api/index.js` | 📈 +265 B (+3.65%) | 7.08 kB → 7.34 kB
`node_modules/hyperformula/es/Config.mjs` | 📈 +303 B (+3.61%) | 8.21 kB → 8.5 kB
`node_modules/csv-parse/lib/sync.js` | 📈 +17 B (+3.32%) | 512 B → 529 B
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +273 B (+3.27%) | 8.14 kB → 8.41 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +113 B (+3.21%) | 3.44 kB → 3.55 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/actual.ts` | 📈 +22 B (+3.14%) | 700 B → 722 B
`node_modules/date-fns/locale/cs/_lib/formatRelative.js` | 📈 +19 B (+3.07%) | 619 B → 638 B
`node_modules/@bufbuild/protobuf/dist/esm/wire/binary-encoding.js` | 📈 +346 B (+2.83%) | 11.93 kB → 12.27 kB
`node_modules/hyperformula/es/helpers/licenseKeyValidator.mjs` | 📈 +58 B (+2.68%) | 2.11 kB → 2.17 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +551 B (+2.62%) | 20.57 kB → 21.11 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/payees/app.ts` | 📈 +140 B (+2.34%) | 5.84 kB → 5.98 kB
`node_modules/hyperformula/es/parser/Cache.mjs` | 📈 +59 B (+2.34%) | 2.46 kB → 2.52 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/util.ts` | 📈 +16 B (+2.14%) | 749 B → 765 B
`node_modules/lru-cache/dist/esm/index.min.js` | 📈 +498 B (+2.12%) | 22.99 kB → 23.48 kB
`node_modules/hyperformula/es/interpreter/plugin/AddressPlugin.mjs` | 📈 +50 B (+1.82%) | 2.68 kB → 2.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +79 B (+1.81%) | 4.27 kB → 4.34 kB
`node_modules/hyperformula/es/error-message.mjs` | 📈 +75 B (+1.72%) | 4.26 kB → 4.34 kB
`node_modules/hyperformula/es/interpreter/plugin/VersionPlugin.mjs` | 📈 +16 B (+1.70%) | 942 B → 958 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/title/lower-case.ts` | 📈 +16 B (+1.59%) | 1004 B → 1020 B
`node_modules/date-fns/locale/hu/_lib/formatDistance.js` | 📈 +26 B (+1.58%) | 1.61 kB → 1.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +31 B (+1.55%) | 1.95 kB → 1.98 kB
`node_modules/date-fns/locale/pl/_lib/formatRelative.js` | 📈 +18 B (+1.34%) | 1.31 kB → 1.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/category-template-context.ts` | 📈 +251 B (+1.23%) | 19.95 kB → 20.2 kB
`node_modules/hyperformula/es/parser/CellAddress.mjs` | 📈 +76 B (+1.22%) | 6.09 kB → 6.16 kB
`node_modules/@bufbuild/protobuf/dist/esm/reflect/names.js` | 📈 +16 B (+1.21%) | 1.3 kB → 1.31 kB
`node_modules/date-fns/locale/zh-TW/_lib/match.js` | 📈 +34 B (+1.20%) | 2.76 kB → 2.8 kB
`node_modules/date-fns/locale/zh-HK/_lib/match.js` | 📈 +34 B (+1.18%) | 2.81 kB → 2.85 kB
`node_modules/date-fns/locale/zh-CN/_lib/match.js` | 📈 +34 B (+1.18%) | 2.81 kB → 2.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.96 MB → 3.84 MB (-128.62 kB) | -3.17%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 7.97 MB → 8.02 MB (+53.67 kB) | +0.66%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/cosmiconfig/dist/merge.js` | 📈 +87 B (+6.72%) | 1.26 kB → 1.35 kB
`node_modules/proper-lockfile/index.js` | 📈 +54 B (+4.95%) | 1.06 kB → 1.12 kB
`node_modules/cosmiconfig/dist/util.js` | 📈 +125 B (+4.40%) | 2.77 kB → 2.89 kB
`node_modules/cosmiconfig/dist/Explorer.js` | 📈 +112 B (+2.04%) | 5.37 kB → 5.48 kB
`node_modules/cosmiconfig/dist/ExplorerSync.js` | 📈 +112 B (+2.01%) | 5.45 kB → 5.56 kB
`node_modules/import-fresh/index.js` | 📈 +19 B (+1.99%) | 957 B → 976 B
`rolldown/runtime.js` | 📈 +23 B (+1.96%) | 1.15 kB → 1.17 kB
`node_modules/js-yaml/lib/type/timestamp.js` | 📈 +32 B (+1.65%) | 1.89 kB → 1.93 kB
`src/config.ts` | 📈 +40 B (+1.11%) | 3.52 kB → 3.56 kB
`node_modules/typescript/lib/typescript.js` | 📈 +59.48 kB (+0.78%) | 7.48 MB → 7.53 MB
`node_modules/js-yaml/lib/type/float.js` | 📈 +16 B (+0.77%) | 2.03 kB → 2.04 kB
`node_modules/@babel/code-frame/lib/index.js` | 📈 +48 B (+0.72%) | 6.51 kB → 6.56 kB
`src/output.ts` | 📈 +16 B (+0.65%) | 2.41 kB → 2.43 kB
`node_modules/graceful-fs/graceful-fs.js` | 📈 +48 B (+0.46%) | 10.29 kB → 10.34 kB
`node_modules/picocolors/picocolors.js` | 📈 +10 B (+0.35%) | 2.81 kB → 2.82 kB
`node_modules/js-yaml/lib/dumper.js` | 📈 +25 B (+0.12%) | 20.54 kB → 20.56 kB
`node_modules/proper-lockfile/lib/lockfile.js` | 📈 +4 B (+0.06%) | 6.56 kB → 6.56 kB
`node_modules/emoji-regex/index.js` | 📉 -26 B (-0.25%) | 10.17 kB → 10.15 kB
`node_modules/cosmiconfig/dist/ExplorerBase.js` | 📉 -34 B (-0.81%) | 4.08 kB → 4.05 kB
`node_modules/cosmiconfig/dist/defaults.js` | 📉 -70 B (-2.35%) | 2.91 kB → 2.85 kB
`node_modules/is-fullwidth-code-point/index.js` | 📉 -26 B (-2.36%) | 1.08 kB → 1.05 kB
`node_modules/commander/lib/command.js` | 📉 -2.21 kB (-3.14%) | 70.2 kB → 67.99 kB
`node_modules/commander/lib/help.js` | 📉 -891 B (-5.23%) | 16.64 kB → 15.77 kB
`node_modules/commander/lib/option.js` | 📉 -473 B (-5.28%) | 8.75 kB → 8.29 kB
`node_modules/strip-ansi/index.js` | 📉 -26 B (-8.33%) | 312 B → 286 B
`node_modules/commander/lib/suggestSimilar.js` | 📉 -176 B (-8.35%) | 2.06 kB → 1.89 kB
`node_modules/commander/lib/argument.js` | 📉 -325 B (-10.46%) | 3.04 kB → 2.72 kB
`node_modules/commander/lib/error.js` | 📉 -200 B (-16.50%) | 1.18 kB → 1012 B
`node_modules/cosmiconfig/dist/index.js` | 📉 -1.06 kB (-18.17%) | 5.84 kB → 4.78 kB
`node_modules/commander/index.js` | 📉 -794 B (-89.62%) | 886 B → 92 B
`node_modules/commander/esm.mjs` | 🔥 -331 B (-100%) | 331 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 7.97 MB → 8.02 MB (+53.67 kB) | +0.66%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.12 kB → 11.16 kB (+34 B) | +0.30%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/uuid/dist-node/rng.js` | 📈 +16 B (+10.39%) | 154 B → 170 B
`src/crdt/merkle.ts` | 📈 +18 B (+0.68%) | 2.6 kB → 2.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.12 kB → 11.16 kB (+34 B) | +0.30%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->