### PR TITLE
[AI] Omit empty WHERE clauses from AQL instead of emitting WHERE 1

### DIFF
--- a/packages/loot-core/src/server/aql/compiler.test.ts
+++ b/packages/loot-core/src/server/aql/compiler.test.ts
@@ -118,7 +118,6 @@ describe('sheet language', () => {
         SELECT transactions1.id AS trans1, transactions2.id AS trans2, accounts.id AS id FROM accounts
         LEFT JOIN transactions transactions1 ON transactions1.id = accounts.trans1
         LEFT JOIN transactions transactions2 ON transactions2.id = accounts.trans2
-        WHERE 1
       `),
     );
   });
@@ -172,7 +171,6 @@ describe('sheet language', () => {
         LEFT JOIN transactions transactions1 ON transactions1.id = accounts.trans1
         LEFT JOIN transactions transactions2 ON transactions2.id = accounts.trans2
         LEFT JOIN transactions transactions3 ON transactions3.id = accounts.trans3
-        WHERE 1
       `),
     );
 
@@ -188,7 +186,6 @@ describe('sheet language', () => {
         LEFT JOIN transactions transactions2 ON transactions2.id = accounts.trans2
         LEFT JOIN transactions transactions3 ON transactions3.id = accounts.trans3
         LEFT JOIN payees payees4 ON payees4.id = transactions1.payee
-        WHERE 1
      `),
     );
   });
@@ -210,7 +207,7 @@ describe('sheet language', () => {
     expect(sqlLines(result.sql)).toEqual(
       sqlLines(`
         SELECT transactions.amount AS amount, transactions.id AS id FROM transactions
-        WHERE 1 AND transactions.tombstone = 0
+        WHERE transactions.tombstone = 0
       `),
     );
 
@@ -222,7 +219,6 @@ describe('sheet language', () => {
     expect(sqlLines(result.sql)).toEqual(
       sqlLines(`
         SELECT transactions.amount AS amount, transactions.id AS id FROM transactions
-        WHERE 1
       `),
     );
 
@@ -236,7 +232,6 @@ describe('sheet language', () => {
         SELECT transactions1.amount AS "trans.amount", payees2.name AS "trans.payee.name", accounts.id AS id FROM accounts
         LEFT JOIN transactions transactions1 ON transactions1.id = accounts.trans AND transactions1.tombstone = 0
         LEFT JOIN payees payees2 ON payees2.id = transactions1.payee AND payees2.tombstone = 0
-        WHERE 1
       `),
     );
 
@@ -373,7 +368,6 @@ describe('sheet language', () => {
       sqlLines(`
         SELECT transactions.id AS id FROM transactions
         LEFT JOIN payees payees1 ON payees1.id = transactions.payee
-        WHERE 1
         GROUP BY payees1.name
       `),
     );
@@ -398,7 +392,6 @@ describe('sheet language', () => {
       sqlLines(`
         SELECT transactions.id AS id FROM transactions
         LEFT JOIN payees payees1 ON payees1.id = transactions.payee
-        WHERE 1
         ORDER BY payees1.name
       `),
     );
@@ -558,6 +551,30 @@ describe('sheet language', () => {
     );
   });
 
+  it('ignores an empty $or filter', () => {
+    const result = generateSQLWithState(
+      q('transactions').filter({ $or: [] }).select(['id']).serialize(),
+      basicSchema,
+    );
+    expect(sqlLines(result.sql)).toEqual(
+      sqlLines(`
+        SELECT transactions.id AS id FROM transactions
+      `),
+    );
+  });
+
+  it('ignores a null $or filter', () => {
+    const result = generateSQLWithState(
+      q('transactions').filter({ $or: null }).select(['id']).serialize(),
+      basicSchema,
+    );
+    expect(sqlLines(result.sql)).toEqual(
+      sqlLines(`
+        SELECT transactions.id AS id FROM transactions
+      `),
+    );
+  });
+
   it('allows functions in `filter`', () => {
     // Allows transforming the input
     let result = generateSQLWithState(
@@ -675,7 +692,7 @@ describe('sheet language', () => {
     expect(sqlLines(result.sql)).toEqual(
       sqlLines(`
         SELECT v_transactions.amount AS amount, v_transactions.id AS id FROM v_transactions
-        WHERE 1 AND (v_transactions.amount > 0)
+        WHERE (v_transactions.amount > 0)
       `),
     );
 
@@ -699,7 +716,6 @@ describe('sheet language', () => {
       sqlLines(`
         SELECT transactions1.amount AS "trans1.amount", accounts.id AS id FROM accounts
         LEFT JOIN v_transactions transactions1 ON transactions1.id = accounts.trans1 AND (transactions1.amount > 0)
-        WHERE 1
       `),
     );
 
@@ -730,7 +746,6 @@ describe('sheet language', () => {
     expect(sqlLines(result.sql)).toEqual(
       sqlLines(`
         SELECT v_transactions.amount AS amount, v_transactions.id AS id FROM v_transactions
-        WHERE 1
       `),
     );
   });

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -25,7 +25,16 @@ function dateToInt(date) {
 
 function addTombstone(schema, tableName, tableId, whereStr) {
   const hasTombstone = schema[tableName].tombstone != null;
-  return hasTombstone ? `${whereStr} AND ${tableId}.tombstone = 0` : whereStr;
+  if (!hasTombstone) {
+    return whereStr;
+  }
+  return whereStr
+    ? `${whereStr} AND ${tableId}.tombstone = 0`
+    : `WHERE ${tableId}.tombstone = 0`;
+}
+
+export function appendWhere(whereStr: string, condition: string) {
+  return whereStr ? `${whereStr} AND ${condition}` : `WHERE ${condition}`;
 }
 
 function popPath(path) {
@@ -811,7 +820,16 @@ function compileAnd(state, conds) {
 }
 
 const compileWhere = saveStack('filter', (state, conds) => {
-  return compileAnd(state, conds);
+  // Unlike compileAnd, an empty top-level filter omits the WHERE clause
+  // entirely instead of emitting the always-true `1` placeholder.
+  if (!conds) {
+    return null;
+  }
+  const res = compileConditions(state, conds);
+  if (res.length === 0) {
+    return null;
+  }
+  return '(' + res.join('\n  AND ') + ')';
 });
 
 function compileJoins(state, tableRef, internalTableFilters) {
@@ -1132,17 +1150,18 @@ export function compileQuery(
       orderExpressions,
     );
 
+    where = '';
     if (filterExpressions.length > 0) {
       const result = compileWhere(state, filterExpressions);
-      where = 'WHERE ' + result;
-    } else {
-      where = 'WHERE 1';
+      if (result) {
+        where = 'WHERE ' + result;
+      }
     }
 
     if (!rawMode) {
       const filters = internalTableFilters(tableName);
       if (filters.length > 0) {
-        where += ' AND ' + compileAnd(state, filters);
+        where = appendWhere(where, compileAnd(state, filters));
       }
     }
 

--- a/packages/loot-core/src/server/aql/schema/executors.ts
+++ b/packages/loot-core/src/server/aql/schema/executors.ts
@@ -1,6 +1,6 @@
 // @ts-strict-ignore
 
-import { isAggregateQuery } from '#server/aql/compiler';
+import { appendWhere, isAggregateQuery } from '#server/aql/compiler';
 import type {
   CompilerState,
   OutputTypes,
@@ -113,7 +113,7 @@ async function execTransactionsGrouped(
     const s = { ...sqlPieces };
 
     // Modify the where to only include non-parents
-    s.where = `${s.where} AND ${s.from}.is_parent = 0`;
+    s.where = appendWhere(s.where, `${s.from}.is_parent = 0`);
 
     // We also want to exclude deleted transactions. Normally we
     // handle this manually down below, but now that we are doing a
@@ -138,7 +138,7 @@ async function execTransactionsGrouped(
       SELECT ${sqlPieces.from}.id as group_id
       FROM ${sqlPieces.from}
       ${sqlPieces.joins}
-      ${sqlPieces.where} AND is_child = 0 ${whereDead}
+      ${appendWhere(sqlPieces.where, `is_child = 0 ${whereDead}`)}
       ${sqlPieces.orderBy}
       ${sqlPieces.limit != null ? `LIMIT ${sqlPieces.limit}` : ''}
       ${sqlPieces.offset != null ? `OFFSET ${sqlPieces.offset}` : ''}
@@ -156,7 +156,7 @@ async function execTransactionsGrouped(
             FROM ${sqlPieces.from}
             LEFT JOIN transactions _t2 ON ${sqlPieces.from}.is_child = 1 AND _t2.id = ${sqlPieces.from}.parent_id
             ${sqlPieces.joins}
-            ${sqlPieces.where} AND ${sqlPieces.from}.tombstone = 0 AND IFNULL(_t2.tombstone, 0) = 0
+            ${appendWhere(sqlPieces.where, `${sqlPieces.from}.tombstone = 0 AND IFNULL(_t2.tombstone, 0) = 0`)}
           )
         GROUP BY group_id
       )
@@ -237,9 +237,9 @@ async function execTransactionsBasic(
 
   if (splitType !== 'all') {
     if (splitType === 'none') {
-      s.where = `${s.where} AND ${s.from}.parent_id IS NULL`;
+      s.where = appendWhere(s.where, `${s.from}.parent_id IS NULL`);
     } else {
-      s.where = `${s.where} AND ${s.from}.is_parent = 0`;
+      s.where = appendWhere(s.where, `${s.from}.is_parent = 0`);
     }
   }
 

--- a/upcoming-release-notes/aql-omit-empty-where.md
+++ b/upcoming-release-notes/aql-omit-empty-where.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Omit empty WHERE clauses from AQL instead of emitting a tautology placeholder


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixing unsanitary `WHERE` conditions in AQL. `WHERE 1` should never happen.

## Related issue(s)

Follow-up from https://github.com/actualbudget/actual/pull/8663#discussion_r3731937349

Not exactly what we discussed there, but I have actually changed my mind.. so just cleaning up the WHERE expressions we make.

## Testing

Unit test cases added/updated

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB | 0%
loot-core | 1 | 4.63 MB → 4.63 MB (+394 B) | +0.01%
api | 2 | 3.84 MB → 3.84 MB (+384 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.39 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2.03 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.36 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 171.84 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+394 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +349 B (+1.38%) | 24.71 kB → 25.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.70%) | 6.24 kB → 6.29 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.7rV9_5dh.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Bcf_a9eI.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+384 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +339 B (+1.38%) | 24.07 kB → 24.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.72%) | 6.14 kB → 6.18 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+384 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->