### PR TITLE
[WIP][AI][Enhancement] Add WebAuthn single user support

### DIFF
--- a/packages/desktop-client/package.json
+++ b/packages/desktop-client/package.json
@@ -134,6 +134,9 @@
     "playwright": "playwright",
     "typecheck": "tsgo -b && tsc-strict"
   },
+  "dependencies": {
+    "@simplewebauthn/browser": "^13.3.0"
+  },
   "devDependencies": {
     "@actual-app/components": "workspace:*",
     "@actual-app/core": "workspace:*",

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.test.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.test.tsx
@@ -1,0 +1,141 @@
+import { initServer } from '@actual-app/core/platform/client/connection';
+import {
+  browserSupportsWebAuthn,
+  startRegistration,
+} from '@simplewebauthn/browser';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Bootstrap } from './Bootstrap';
+import type * as CommonModule from './common';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: vi.fn(),
+  browserSupportsWebAuthn: vi.fn(() => true),
+}));
+
+const mockDispatch = vi.fn();
+vi.mock('#redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('#hooks/useNavigate', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockRefreshLoginMethods = vi.fn();
+vi.mock('#components/ServerContext', () => ({
+  useRefreshLoginMethods: () => mockRefreshLoginMethods,
+}));
+
+vi.mock('./common', async importOriginal => {
+  const actual = await importOriginal<typeof CommonModule>();
+  return {
+    ...actual,
+    useBootstrapped: () => ({ checked: true }),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(browserSupportsWebAuthn).mockReturnValue(true);
+  initServer({});
+});
+
+describe('Bootstrap - method choice', () => {
+  it('shows password and passkey options before a method is chosen', () => {
+    render(<Bootstrap />);
+
+    expect(
+      screen.getByRole('button', { name: 'Use a password' }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Register a passkey' }),
+    ).toBeVisible();
+    expect(screen.queryByPlaceholderText('Password')).not.toBeInTheDocument();
+  });
+
+  it('shows the password form after choosing "Use a password"', async () => {
+    const user = userEvent.setup();
+    render(<Bootstrap />);
+
+    await user.click(screen.getByRole('button', { name: 'Use a password' }));
+
+    expect(screen.getByPlaceholderText('Password')).toBeVisible();
+  });
+
+  it('disables the passkey option when the browser does not support WebAuthn', async () => {
+    vi.mocked(browserSupportsWebAuthn).mockReturnValue(false);
+
+    render(<Bootstrap />);
+
+    expect(
+      await screen.findByRole('button', { name: 'Register a passkey' }),
+    ).toBeDisabled();
+  });
+
+  it('registers a passkey and navigates to /login on success', async () => {
+    const user = userEvent.setup();
+    initServer({
+      'webauthn-get-registration-options': vi.fn().mockResolvedValue({
+        options: { challenge: 'reg-challenge' },
+      }),
+      'webauthn-verify-registration': vi.fn().mockResolvedValue({}),
+    });
+    vi.mocked(startRegistration).mockResolvedValue({
+      id: 'cred',
+      response: {},
+    } as never);
+
+    render(<Bootstrap />);
+    await user.click(
+      screen.getByRole('button', { name: 'Register a passkey' }),
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'Register a passkey' }),
+    );
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+    expect(mockRefreshLoginMethods).toHaveBeenCalled();
+  });
+
+  it('shows an error when passkey registration verification fails', async () => {
+    const user = userEvent.setup();
+    initServer({
+      'webauthn-get-registration-options': vi.fn().mockResolvedValue({
+        options: { challenge: 'reg-challenge' },
+      }),
+      'webauthn-verify-registration': vi.fn().mockResolvedValue({
+        error: 'verification-failed',
+      }),
+    });
+    vi.mocked(startRegistration).mockResolvedValue({
+      id: 'cred',
+      response: {},
+    } as never);
+
+    render(<Bootstrap />);
+    await user.click(
+      screen.getByRole('button', { name: 'Register a passkey' }),
+    );
+    await user.click(
+      screen.getByRole('button', { name: 'Register a passkey' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'Your passkey could not be registered. Please try again',
+      ),
+    ).toBeVisible();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Bootstrap.tsx
@@ -1,5 +1,5 @@
 // @ts-strict-ignore
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Button } from '@actual-app/components/button';
@@ -8,6 +8,7 @@ import { Text } from '@actual-app/components/text';
 import { theme } from '@actual-app/components/theme';
 import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
+import { browserSupportsWebAuthn } from '@simplewebauthn/browser';
 
 import { createBudget } from '#budgetfiles/budgetfilesSlice';
 import { Link } from '#components/common/Link';
@@ -17,15 +18,22 @@ import { useDispatch } from '#redux';
 
 import { Title, useBootstrapped } from './common';
 import { ConfirmPasswordForm } from './ConfirmPasswordForm';
+import { WebAuthnRegistration } from './WebAuthnRegistration';
 
 export function Bootstrap() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const [error, setError] = useState(null);
+  const [method, setMethod] = useState<'password' | 'webauthn' | null>(null);
+  const [webauthnSupported, setWebauthnSupported] = useState(false);
   const refreshLoginMethods = useRefreshLoginMethods();
 
   const { checked } = useBootstrapped();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    setWebauthnSupported(browserSupportsWebAuthn());
+  }, []);
 
   function getErrorMessage(error) {
     switch (error) {
@@ -41,6 +49,15 @@ export function Bootstrap() {
         return t('Client ID cannot be empty');
       case 'missing-client-secret':
         return t('Client secret cannot be empty');
+      case 'already-bootstrapped':
+        return t('This server has already been set up');
+      case 'webauthn-not-supported':
+        return t('Passkeys are not supported in this browser');
+      case 'webauthn-ceremony-failed':
+      case 'verification-failed':
+      case 'invalid-or-expired-challenge':
+      case 'invalid-response':
+        return t('Your passkey could not be registered. Please try again');
       default:
         return t(`An unknown error occurred: {{error}}`, { error });
     }
@@ -58,6 +75,11 @@ export function Bootstrap() {
     }
   }
 
+  async function onWebAuthnRegistered() {
+    await refreshLoginMethods();
+    void navigate('/login');
+  }
+
   async function onDemo() {
     await dispatch(createBudget({ demoMode: true }));
   }
@@ -66,13 +88,28 @@ export function Bootstrap() {
     return null;
   }
 
+  const demoButton = (
+    <Button
+      variant="bare"
+      style={{
+        fontSize: 15,
+        color: theme.pageTextLink,
+        marginRight: 15,
+      }}
+      onPress={onDemo}
+    >
+      {t('Try Demo')}
+    </Button>
+  );
+
   return (
     <View style={{ maxWidth: 450 }}>
       <Title text={t('Welcome to Actual!')} />
       <Paragraph style={{ fontSize: 16, color: theme.pageTextDark }}>
         <Trans>
           Actual is a super fast privacy-focused app for managing your finances.
-          To secure your data, you'll need to set a password for your server.
+          To secure your data, you'll need to set a password or register a
+          passkey for your server.
         </Trans>
       </Paragraph>
 
@@ -82,8 +119,8 @@ export function Bootstrap() {
           <Link variant="external" to="https://actualbudget.org/docs/tour/">
             our tour
           </Link>{' '}
-          in a new tab for some guidance on what to do when you've set your
-          password.
+          in a new tab for some guidance on what to do when you've set up your
+          login.
         </Trans>
       </Paragraph>
 
@@ -100,23 +137,45 @@ export function Bootstrap() {
         </Text>
       )}
 
-      <ConfirmPasswordForm
-        buttons={
-          <Button
-            variant="bare"
-            style={{
-              fontSize: 15,
-              color: theme.pageTextLink,
-              marginRight: 15,
-            }}
-            onPress={onDemo}
-          >
-            {t('Try Demo')}
+      {method === null && (
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+            marginTop: 30,
+            gap: '1rem',
+          }}
+        >
+          {demoButton}
+          <Button variant="normal" onPress={() => setMethod('password')}>
+            <Trans>Use a password</Trans>
           </Button>
-        }
-        onSetPassword={onSetPassword}
-        onError={setError}
-      />
+          <Button
+            variant="primary"
+            isDisabled={!webauthnSupported}
+            onPress={() => setMethod('webauthn')}
+          >
+            <Trans>Register a passkey</Trans>
+          </Button>
+        </View>
+      )}
+
+      {method === 'password' && (
+        <ConfirmPasswordForm
+          buttons={demoButton}
+          onSetPassword={onSetPassword}
+          onError={setError}
+        />
+      )}
+
+      {method === 'webauthn' && (
+        <WebAuthnRegistration
+          buttons={demoButton}
+          onRegistered={onWebAuthnRegistered}
+          onError={setError}
+        />
+      )}
     </View>
   );
 }

--- a/packages/desktop-client/src/components/manager/subscribe/Login.test.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.test.tsx
@@ -1,0 +1,156 @@
+import { initServer } from '@actual-app/core/platform/client/connection';
+import { startAuthentication } from '@simplewebauthn/browser';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as CommonModule from './common';
+import { Login } from './Login';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+const mockDispatch = vi.fn();
+vi.mock('#redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+vi.mock('#components/ServerContext', () => ({
+  useLoginMethod: () => 'webauthn',
+  useAvailableLoginMethods: () => [
+    { method: 'webauthn', displayName: 'Passkey', active: true },
+  ],
+}));
+
+vi.mock('./common', async importOriginal => {
+  const actual = await importOriginal<typeof CommonModule>();
+  return {
+    ...actual,
+    useBootstrapped: () => ({ checked: true }),
+  };
+});
+
+vi.mock('react-router', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  initServer({});
+});
+
+describe('Login - WebAuthn method', () => {
+  it('renders a passkey sign-in button', () => {
+    render(<Login />);
+
+    expect(
+      screen.getByRole('button', { name: 'Sign in with passkey' }),
+    ).toBeVisible();
+  });
+
+  it('signs in successfully via the passkey ceremony', async () => {
+    const user = userEvent.setup();
+    const options = { challenge: 'auth-challenge' };
+    const assertion = { id: 'cred', response: {} };
+
+    initServer({
+      'webauthn-get-authentication-options': vi.fn().mockResolvedValue({
+        options,
+      }),
+      'webauthn-verify-authentication': vi.fn().mockResolvedValue({}),
+    });
+    vi.mocked(startAuthentication).mockResolvedValue(assertion as never);
+
+    render(<Login />);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with passkey' }),
+    );
+
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+    expect(startAuthentication).toHaveBeenCalledWith({ optionsJSON: options });
+  });
+
+  it('shows an error when no passkey is registered', async () => {
+    const user = userEvent.setup();
+    initServer({
+      'webauthn-get-authentication-options': vi.fn().mockResolvedValue({
+        error: 'webauthn-not-configured',
+      }),
+    });
+
+    render(<Login />);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with passkey' }),
+    );
+
+    expect(
+      await screen.findByText('No passkey has been registered for this server'),
+    ).toBeVisible();
+    expect(startAuthentication).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the browser ceremony is cancelled', async () => {
+    const user = userEvent.setup();
+    initServer({
+      'webauthn-get-authentication-options': vi.fn().mockResolvedValue({
+        options: { challenge: 'auth-challenge' },
+      }),
+    });
+    vi.mocked(startAuthentication).mockRejectedValue(
+      new Error('NotAllowedError'),
+    );
+
+    render(<Login />);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with passkey' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'Your passkey could not be verified. Please try again',
+      ),
+    ).toBeVisible();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when the server rejects the assertion', async () => {
+    const user = userEvent.setup();
+    initServer({
+      'webauthn-get-authentication-options': vi.fn().mockResolvedValue({
+        options: { challenge: 'auth-challenge' },
+      }),
+      'webauthn-verify-authentication': vi.fn().mockResolvedValue({
+        error: 'verification-failed',
+      }),
+    });
+    vi.mocked(startAuthentication).mockResolvedValue({
+      id: 'cred',
+      response: {},
+    } as never);
+
+    render(<Login />);
+    await user.click(
+      screen.getByRole('button', { name: 'Sign in with passkey' }),
+    );
+
+    expect(
+      await screen.findByText(
+        'Your passkey could not be verified. Please try again',
+      ),
+    ).toBeVisible();
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -128,6 +128,8 @@ function WebAuthnLogin({ setError, dispatch }) {
       } else {
         dispatch(loggedIn());
       }
+    } catch {
+      setError('network-failure');
     } finally {
       setLoading(false);
     }

--- a/packages/desktop-client/src/components/manager/subscribe/Login.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/Login.tsx
@@ -17,6 +17,7 @@ import { View } from '@actual-app/components/view';
 import { send } from '@actual-app/core/platform/client/connection';
 import { isElectron } from '@actual-app/core/shared/environment';
 import type { OpenIdConfig } from '@actual-app/core/types/models';
+import { startAuthentication } from '@simplewebauthn/browser';
 
 import { Link } from '#components/common/Link';
 import {
@@ -83,6 +84,74 @@ function PasswordLogin({ setError, dispatch }) {
         onPress={onSubmitPassword}
       >
         <Trans>Sign in</Trans>
+      </ButtonWithLoading>
+    </View>
+  );
+}
+
+function WebAuthnLogin({ setError, dispatch }) {
+  const [loading, setLoading] = useState(false);
+  const { isNarrowWidth } = useResponsive();
+
+  async function onSignInWithPasskey() {
+    if (loading) {
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const { options, error: optionsError } = await send(
+        'webauthn-get-authentication-options',
+      );
+
+      if (optionsError) {
+        setError(optionsError);
+        return;
+      }
+
+      let assertion;
+      try {
+        assertion = await startAuthentication({ optionsJSON: options });
+      } catch {
+        setError('webauthn-ceremony-failed');
+        return;
+      }
+
+      const { error } = await send('webauthn-verify-authentication', {
+        response: assertion,
+      });
+
+      if (error) {
+        setError(error);
+      } else {
+        dispatch(loggedIn());
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        justifyContent: 'center',
+        marginTop: 15,
+      }}
+    >
+      <ButtonWithLoading
+        variant="primary"
+        isLoading={loading}
+        onPress={onSignInWithPasskey}
+        style={{
+          fontSize: 15,
+          width: isNarrowWidth ? '100%' : 220,
+          ...(isNarrowWidth ? { padding: 10 } : null),
+        }}
+      >
+        <Trans>Sign in with passkey</Trans>
       </ButtonWithLoading>
     </View>
   );
@@ -345,6 +414,15 @@ export function Login() {
         return t('Unable to contact the server');
       case 'internal-error':
         return t('Internal error');
+      case 'webauthn-not-configured':
+        return t('No passkey has been registered for this server');
+      case 'webauthn-ceremony-failed':
+        return t('Your passkey could not be verified. Please try again');
+      case 'verification-failed':
+      case 'invalid-or-expired-challenge':
+      case 'rp-id-mismatch':
+      case 'invalid-response':
+        return t('Your passkey could not be verified. Please try again');
       default:
         return t(`An unknown error occurred: {{error}}`, { error });
     }
@@ -379,6 +457,10 @@ export function Login() {
       )}
 
       {method === 'openid' && <OpenIdLogin setError={setError} />}
+
+      {method === 'webauthn' && (
+        <WebAuthnLogin setError={setError} dispatch={dispatch} />
+      )}
 
       {method === 'header' && <HeaderLogin error={error} />}
 

--- a/packages/desktop-client/src/components/manager/subscribe/WebAuthnRegistration.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/WebAuthnRegistration.tsx
@@ -55,6 +55,8 @@ export function WebAuthnRegistration({
       } else {
         onRegistered();
       }
+    } catch {
+      onError('network-failure');
     } finally {
       setLoading(false);
     }

--- a/packages/desktop-client/src/components/manager/subscribe/WebAuthnRegistration.tsx
+++ b/packages/desktop-client/src/components/manager/subscribe/WebAuthnRegistration.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import type { ReactNode } from 'react';
+import { Trans } from 'react-i18next';
+
+import { ButtonWithLoading } from '@actual-app/components/button';
+import { View } from '@actual-app/components/view';
+import { send } from '@actual-app/core/platform/client/connection';
+import { startRegistration } from '@simplewebauthn/browser';
+
+type WebAuthnRegistrationProps = {
+  buttons: ReactNode;
+  onRegistered: () => void;
+  onError: (error: string | null) => void;
+};
+
+export function WebAuthnRegistration({
+  buttons,
+  onRegistered,
+  onError,
+}: WebAuthnRegistrationProps) {
+  const [loading, setLoading] = useState(false);
+
+  async function onRegister() {
+    if (loading) {
+      return;
+    }
+
+    onError(null);
+    setLoading(true);
+
+    try {
+      const { options, error: optionsError } = await send(
+        'webauthn-get-registration-options',
+      );
+
+      if (optionsError) {
+        onError(optionsError);
+        return;
+      }
+
+      let attestation;
+      try {
+        attestation = await startRegistration({ optionsJSON: options });
+      } catch {
+        onError('webauthn-ceremony-failed');
+        return;
+      }
+
+      const { error } = await send('webauthn-verify-registration', {
+        response: attestation,
+      });
+
+      if (error) {
+        onError(error);
+      } else {
+        onRegistered();
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        fontSize: 15,
+        marginTop: 30,
+      }}
+    >
+      <View style={{ flex: 1 }} />
+      {buttons}
+      <ButtonWithLoading
+        variant="primary"
+        isLoading={loading}
+        onPress={onRegister}
+      >
+        <Trans>Register a passkey</Trans>
+      </ButtonWithLoading>
+    </View>
+  );
+}

--- a/packages/docs/docs/config/index.md
+++ b/packages/docs/docs/config/index.md
@@ -96,10 +96,11 @@ Change the default authentication method for Actual (environment variable: `ACTU
 - `"password"` (default) - This is standard password authentication
 - `"header"` - Use the HTTP header `x-actual-password` to automatically login. This is for advanced use and if not done correctly could have security implications.
 - `"openid"` - OpenId auth (in preview)
+- `"webauthn"` - Sign in with a [passkey](./webauthn-auth.md) instead of a password
 
 ## `allowedLoginMethods`
 
-The list of login methods that are permitted for auth. This defaults to `['password','header','openid']` (environment variable: `ACTUAL_ALLOWED_LOGIN_METHODS`, comma separated string).
+The list of login methods that are permitted for auth. This defaults to `['password','header','openid','webauthn']` (environment variable: `ACTUAL_ALLOWED_LOGIN_METHODS`, comma separated string).
 
 If you wish to restrict the server from accepting certain login methods, you should update this setting.
 

--- a/packages/docs/docs/config/webauthn-auth.md
+++ b/packages/docs/docs/config/webauthn-auth.md
@@ -1,0 +1,36 @@
+# Authenticating With a Passkey (WebAuthn)
+
+:::info
+This feature requires use of [Actual Server](./index.md)
+:::
+
+Instead of protecting your server with a password, you can register a passkey using your device's built-in authenticator (such as Windows Hello, Touch ID, or a hardware security key) or a password manager that supports passkeys. Passkeys use the [WebAuthn](https://webauthn.io/) standard, so no password is ever sent to or stored on the server.
+
+Unlike [OpenID authentication](./oauth-auth.md), a passkey doesn't require any external provider or configuration file — you set it up entirely from the Actual web UI.
+
+:::caution
+Only one passkey is supported per server at this time, shared by whoever signs in (the same way a server password is shared today). There isn't yet a way for individual users to register their own passkeys.
+:::
+
+## Requirements
+
+Passkeys rely on a browser feature that only works in a secure context, so your server must be served over HTTPS, or accessed at `localhost`. See [Activating HTTPS](./https.md) if your server isn't already using it.
+
+If your browser or device doesn't support passkeys, or your server isn't served over a secure context, the option to register a passkey won't appear during setup.
+
+## Setting Up a Passkey
+
+The first time you open a freshly installed server, you'll be asked to choose a login method:
+
+- **Use a password** sets a traditional server password.
+- **Register a passkey** starts the passkey registration ceremony, prompting you to use your device's authenticator or password manager.
+
+Once registration finishes, you'll be sent to the login page, where you can sign in with the passkey you just registered.
+
+## Signing In
+
+On the login page, select **Sign in with passkey** and follow your browser's prompt to complete the passkey ceremony.
+
+## Losing Access to Your Passkey
+
+There isn't yet an in-app way to switch back to a password or register a replacement passkey after setup. If you lose access to your passkey, follow the [reset password](../troubleshooting/reset_password.md) instructions — running the reset command on a server using a passkey clears it instead of prompting for a new password, and sends you back to the setup screen to register a new passkey or set a password. Your budget files and users are not affected.

--- a/packages/docs/docs/troubleshooting/reset_password.md
+++ b/packages/docs/docs/troubleshooting/reset_password.md
@@ -4,6 +4,10 @@ If you have forgotten your actual-server login password - not all is lost, as th
 
 A password reset feature is available from version 23.4.2.
 
+:::note
+If your server is set up to sign in with a [passkey](../config/webauthn-auth.md) instead of a password, the same commands below also work to recover access — they clear the passkey rather than prompting for a new password. See [Losing Access to Your Passkey](../config/webauthn-auth.md#losing-access-to-your-passkey) for details.
+:::
+
 ## If `actual-server` is installed on the host
 
 The deployed server environment may not have Yarn available, so the existing npm script
@@ -40,5 +44,7 @@ kubectl exec --stdin --tty <actual_pod_name> -- /bin/sh
 node /app/src/scripts/reset-password.js
 ```
 
-Both commands will prompt for a new password and ask you to confirm it. Once the reset
-completes, you can sign in with the new password.
+If your server currently uses a password, both commands will prompt for a new password and
+ask you to confirm it; once the reset completes, you can sign in with the new password. If
+your server currently uses a passkey instead, the commands clear it without prompting for
+anything — open Actual in your browser afterward to register a new passkey or set a password.

--- a/packages/loot-core/src/server/auth/app.test.ts
+++ b/packages/loot-core/src/server/auth/app.test.ts
@@ -1,0 +1,133 @@
+import * as asyncStorage from '#platform/server/asyncStorage';
+import { PostError } from '#server/errors';
+import { post } from '#server/post';
+import { setServer } from '#server/server-config';
+
+import { app } from './app';
+
+vi.mock('#server/post', () => ({ post: vi.fn() }));
+
+beforeEach(() => {
+  setServer('https://example.com');
+  vi.mocked(post).mockReset();
+  vi.mocked(asyncStorage.setItem).mockReset();
+});
+
+describe('webauthn-get-registration-options', () => {
+  it('fetches options from the server', async () => {
+    const options = { challenge: 'reg-challenge' };
+    vi.mocked(post).mockResolvedValueOnce(options);
+
+    const result = await app.handlers['webauthn-get-registration-options']();
+
+    expect(post).toHaveBeenCalledWith(
+      'https://example.com/webauthn/registration-options',
+      {},
+    );
+    expect(result).toEqual({ options });
+  });
+
+  it('translates a PostError into an error result', async () => {
+    vi.mocked(post).mockRejectedValueOnce(
+      new PostError('already-bootstrapped'),
+    );
+
+    const result = await app.handlers['webauthn-get-registration-options']();
+
+    expect(result).toEqual({ error: 'already-bootstrapped' });
+  });
+});
+
+describe('webauthn-verify-registration', () => {
+  it('posts the response and resolves with no error on success', async () => {
+    vi.mocked(post).mockResolvedValueOnce({});
+
+    const response = { id: 'cred' };
+    const result = await app.handlers['webauthn-verify-registration']({
+      response,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      'https://example.com/webauthn/registration-verify',
+      { response },
+    );
+    expect(result).toEqual({});
+  });
+
+  it('translates a PostError into an error result', async () => {
+    vi.mocked(post).mockRejectedValueOnce(new PostError('verification-failed'));
+
+    const result = await app.handlers['webauthn-verify-registration']({
+      response: { id: 'cred' },
+    });
+
+    expect(result).toEqual({ error: 'verification-failed' });
+  });
+});
+
+describe('webauthn-get-authentication-options', () => {
+  it('fetches options from the server', async () => {
+    const options = { challenge: 'auth-challenge' };
+    vi.mocked(post).mockResolvedValueOnce(options);
+
+    const result = await app.handlers['webauthn-get-authentication-options']();
+
+    expect(post).toHaveBeenCalledWith(
+      'https://example.com/webauthn/authentication-options',
+      {},
+    );
+    expect(result).toEqual({ options });
+  });
+
+  it('translates a PostError into an error result', async () => {
+    vi.mocked(post).mockRejectedValueOnce(
+      new PostError('webauthn-not-configured'),
+    );
+
+    const result = await app.handlers['webauthn-get-authentication-options']();
+
+    expect(result).toEqual({ error: 'webauthn-not-configured' });
+  });
+});
+
+describe('webauthn-verify-authentication', () => {
+  it('stores the returned token exactly like signIn does', async () => {
+    vi.mocked(post).mockResolvedValueOnce({ token: 'session-token' });
+
+    const response = { id: 'cred' };
+    const result = await app.handlers['webauthn-verify-authentication']({
+      response,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      'https://example.com/webauthn/authentication-verify',
+      { response },
+    );
+    expect(asyncStorage.setItem).toHaveBeenCalledWith(
+      'user-token',
+      'session-token',
+    );
+    expect(result).toEqual({});
+  });
+
+  it('translates a PostError into an error result without storing a token', async () => {
+    vi.mocked(post).mockRejectedValueOnce(new PostError('verification-failed'));
+
+    const result = await app.handlers['webauthn-verify-authentication']({
+      response: { id: 'cred' },
+    });
+
+    expect(result).toEqual({ error: 'verification-failed' });
+    expect(asyncStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('throws when the server responds without a token', async () => {
+    vi.mocked(post).mockResolvedValueOnce({});
+
+    await expect(
+      app.handlers['webauthn-verify-authentication']({
+        response: { id: 'cred' },
+      }),
+    ).rejects.toThrow('User token not set');
+  });
+});

--- a/packages/loot-core/src/server/auth/app.ts
+++ b/packages/loot-core/src/server/auth/app.ts
@@ -20,6 +20,10 @@ export type AuthHandlers = {
   'enable-openid': typeof enableOpenId;
   'get-openid-config': typeof getOpenIdConfig;
   'enable-password': typeof enablePassword;
+  'webauthn-get-registration-options': typeof webauthnGetRegistrationOptions;
+  'webauthn-verify-registration': typeof webauthnVerifyRegistration;
+  'webauthn-get-authentication-options': typeof webauthnGetAuthenticationOptions;
+  'webauthn-verify-authentication': typeof webauthnVerifyAuthentication;
 };
 
 export const app = createApp<AuthHandlers>();
@@ -35,6 +39,13 @@ app.method('subscribe-set-token', setToken);
 app.method('enable-openid', enableOpenId);
 app.method('get-openid-config', getOpenIdConfig);
 app.method('enable-password', enablePassword);
+app.method('webauthn-get-registration-options', webauthnGetRegistrationOptions);
+app.method('webauthn-verify-registration', webauthnVerifyRegistration);
+app.method(
+  'webauthn-get-authentication-options',
+  webauthnGetAuthenticationOptions,
+);
+app.method('webauthn-verify-authentication', webauthnVerifyAuthentication);
 
 async function didBootstrap() {
   return Boolean(await asyncStorage.getItem('did-bootstrap'));
@@ -383,5 +394,112 @@ async function enablePassword(passwordConfig: { password: string }) {
 
     throw err;
   }
+  return {};
+}
+
+async function webauthnGetRegistrationOptions() {
+  try {
+    const serverConfig = getServer();
+    if (!serverConfig) {
+      throw new Error('No sync server configured.');
+    }
+
+    const options = await post(
+      serverConfig.BASE_SERVER + '/webauthn/registration-options',
+      {},
+    );
+
+    return { options };
+  } catch (err) {
+    if (err instanceof PostError) {
+      return {
+        error: err.reason || 'network-failure',
+      };
+    }
+
+    throw err;
+  }
+}
+
+async function webauthnVerifyRegistration({ response }: { response: unknown }) {
+  try {
+    const serverConfig = getServer();
+    if (!serverConfig) {
+      throw new Error('No sync server configured.');
+    }
+
+    await post(serverConfig.BASE_SERVER + '/webauthn/registration-verify', {
+      response,
+    });
+  } catch (err) {
+    if (err instanceof PostError) {
+      return {
+        error: err.reason || 'network-failure',
+      };
+    }
+
+    throw err;
+  }
+  return {};
+}
+
+async function webauthnGetAuthenticationOptions() {
+  try {
+    const serverConfig = getServer();
+    if (!serverConfig) {
+      throw new Error('No sync server configured.');
+    }
+
+    const options = await post(
+      serverConfig.BASE_SERVER + '/webauthn/authentication-options',
+      {},
+    );
+
+    return { options };
+  } catch (err) {
+    if (err instanceof PostError) {
+      return {
+        error: err.reason || 'network-failure',
+      };
+    }
+
+    throw err;
+  }
+}
+
+async function webauthnVerifyAuthentication({
+  response,
+}: {
+  response: unknown;
+}) {
+  let res: { token?: string };
+
+  try {
+    const serverConfig = getServer();
+    if (!serverConfig) {
+      throw new Error('No sync server configured.');
+    }
+
+    res = await post(
+      serverConfig.BASE_SERVER + '/webauthn/authentication-verify',
+      {
+        response,
+      },
+    );
+  } catch (err) {
+    if (err instanceof PostError) {
+      return {
+        error: err.reason || 'network-failure',
+      };
+    }
+
+    throw err;
+  }
+
+  if (!res.token) {
+    throw new Error('webauthn login: User token not set');
+  }
+
+  await asyncStorage.setItem('user-token', res.token);
   return {};
 }

--- a/packages/sync-server/migrations/1786300000000-webauthn.js
+++ b/packages/sync-server/migrations/1786300000000-webauthn.js
@@ -1,0 +1,22 @@
+import { getAccountDb } from '../src/account-db';
+
+export const up = async function () {
+  await getAccountDb().exec(
+    `
+    BEGIN TRANSACTION;
+    CREATE TABLE pending_webauthn_challenges
+      (challenge TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      expiry_time INTEGER NOT NULL);
+    COMMIT;`,
+  );
+};
+
+export const down = async function () {
+  await getAccountDb().exec(
+    `
+    BEGIN TRANSACTION;
+    DROP TABLE pending_webauthn_challenges;
+    COMMIT;`,
+  );
+};

--- a/packages/sync-server/package.json
+++ b/packages/sync-server/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@actual-app/crdt": "workspace:*",
     "@actual-app/web": "workspace:*",
+    "@simplewebauthn/server": "^13.3.2",
     "akahu": "^2.5.1",
     "argon2": "^0.44.0",
     "bcrypt": "^6.0.0",

--- a/packages/sync-server/src/accounts/webauthn.test.ts
+++ b/packages/sync-server/src/accounts/webauthn.test.ts
@@ -1,0 +1,377 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import type { Request } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAccountDb } from '#account-db';
+
+import {
+  getAuthenticationOptions,
+  getRegistrationOptions,
+  resetWebAuthnCredential,
+  verifyAuthentication,
+  verifyRegistration,
+} from './webauthn';
+
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: vi.fn(),
+  verifyRegistrationResponse: vi.fn(),
+  generateAuthenticationOptions: vi.fn(),
+  verifyAuthenticationResponse: vi.fn(),
+}));
+
+const FALLBACK_OWNER_ID = 'webauthn-test-owner';
+
+function fakeRequest(host = 'localhost:3000'): Request {
+  return {
+    hostname: host.split(':')[0],
+    protocol: 'http',
+    get: (header: string) =>
+      header.toLowerCase() === 'host' ? host : undefined,
+  } as unknown as Request;
+}
+
+function encodeClientData(
+  challenge: string,
+  type: 'webauthn.create' | 'webauthn.get',
+  origin = 'http://localhost:3000',
+) {
+  return Buffer.from(
+    JSON.stringify({ type, challenge, origin, crossOrigin: false }),
+  ).toString('base64url');
+}
+
+function ensureOwner() {
+  const db = getAccountDb();
+  const owner = db.first("SELECT id FROM users WHERE user_name = ''");
+  if (!owner) {
+    db.mutate(
+      'INSERT INTO users (id, user_name, display_name, enabled, owner, role) VALUES (?, ?, ?, 1, 1, ?)',
+      [FALLBACK_OWNER_ID, '', '', 'ADMIN'],
+    );
+  }
+}
+
+function insertWebauthnCredential(overrides = {}) {
+  const credential = {
+    credentialID: 'stored-credential-id',
+    credentialPublicKey: Buffer.from([1, 2, 3, 4]).toString('base64url'),
+    counter: 0,
+    transports: ['internal'],
+    rpID: 'localhost',
+    deviceType: 'singleDevice',
+    backedUp: false,
+    ...overrides,
+  };
+  getAccountDb().mutate(
+    "INSERT INTO auth (method, display_name, extra_data, active) VALUES ('webauthn', 'Passkey', ?, 1)",
+    [JSON.stringify(credential)],
+  );
+  return credential;
+}
+
+beforeEach(() => {
+  const db = getAccountDb();
+  db.mutate('DELETE FROM auth');
+  db.mutate("DELETE FROM sessions WHERE auth_method = 'webauthn'");
+  db.mutate('DELETE FROM pending_webauthn_challenges');
+  ensureOwner();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  const db = getAccountDb();
+  db.mutate('DELETE FROM auth');
+  db.mutate("DELETE FROM sessions WHERE auth_method = 'webauthn'");
+  db.mutate('DELETE FROM pending_webauthn_challenges');
+  db.mutate('DELETE FROM users WHERE id = ?', [FALLBACK_OWNER_ID]);
+});
+
+describe('getRegistrationOptions', () => {
+  it('generates options and stores the challenge for later verification', async () => {
+    vi.mocked(generateRegistrationOptions).mockResolvedValue({
+      challenge: 'registration-challenge-1',
+      rp: { name: 'Actual Budget', id: 'localhost' },
+      user: { id: 'admin', name: 'admin', displayName: 'admin' },
+      pubKeyCredParams: [],
+    } as never);
+
+    const result = await getRegistrationOptions(fakeRequest());
+
+    expect('error' in result).toBe(false);
+    expect(generateRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ rpID: 'localhost' }),
+    );
+
+    const pending = getAccountDb().first(
+      'SELECT * FROM pending_webauthn_challenges WHERE challenge = ?',
+      ['registration-challenge-1'],
+    );
+    expect(pending).toBeTruthy();
+    expect(pending.type).toBe('registration');
+  });
+});
+
+describe('verifyRegistration', () => {
+  it('rejects a challenge that was never issued', async () => {
+    const response = {
+      response: {
+        clientDataJSON: encodeClientData('unknown', 'webauthn.create'),
+      },
+    } as never;
+
+    const result = await verifyRegistration(fakeRequest(), response);
+
+    expect(result).toEqual({ error: 'invalid-or-expired-challenge' });
+  });
+
+  it('stores the credential and activates the webauthn method on success', async () => {
+    getAccountDb().mutate(
+      'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+      ['registration-challenge-2', 'registration', Date.now() + 60_000],
+    );
+
+    vi.mocked(verifyRegistrationResponse).mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: 'new-credential-id',
+          publicKey: Uint8Array.from([9, 9, 9]),
+          counter: 0,
+          transports: ['internal'],
+        },
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+      },
+    } as never);
+
+    const response = {
+      response: {
+        clientDataJSON: encodeClientData(
+          'registration-challenge-2',
+          'webauthn.create',
+        ),
+      },
+    } as never;
+
+    const result = await verifyRegistration(fakeRequest(), response);
+
+    expect(result).toEqual({});
+
+    const authRow = getAccountDb().first(
+      "SELECT * FROM auth WHERE method = 'webauthn'",
+    );
+    expect(authRow.active).toBe(1);
+    const stored = JSON.parse(authRow.extra_data);
+    expect(stored.credentialID).toBe('new-credential-id');
+    expect(stored.rpID).toBe('localhost');
+
+    // The challenge is single-use.
+    const pending = getAccountDb().first(
+      'SELECT * FROM pending_webauthn_challenges WHERE challenge = ?',
+      ['registration-challenge-2'],
+    );
+    expect(pending).toBeFalsy();
+  });
+
+  it('deactivates any other active method when a passkey is registered', async () => {
+    getAccountDb().mutate(
+      "INSERT INTO auth (method, display_name, extra_data, active) VALUES ('password', 'Password', 'hash', 1)",
+    );
+    getAccountDb().mutate(
+      'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+      ['registration-challenge-3', 'registration', Date.now() + 60_000],
+    );
+    vi.mocked(verifyRegistrationResponse).mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: 'cred',
+          publicKey: Uint8Array.from([1]),
+          counter: 0,
+          transports: [],
+        },
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+      },
+    } as never);
+
+    await verifyRegistration(fakeRequest(), {
+      response: {
+        clientDataJSON: encodeClientData(
+          'registration-challenge-3',
+          'webauthn.create',
+        ),
+      },
+    } as never);
+
+    const passwordRow = getAccountDb().first(
+      "SELECT active FROM auth WHERE method = 'password'",
+    );
+    expect(passwordRow.active).toBe(0);
+  });
+
+  it('returns verification-failed when the library rejects the response', async () => {
+    getAccountDb().mutate(
+      'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+      ['registration-challenge-4', 'registration', Date.now() + 60_000],
+    );
+    vi.mocked(verifyRegistrationResponse).mockResolvedValue({
+      verified: false,
+    } as never);
+
+    const result = await verifyRegistration(fakeRequest(), {
+      response: {
+        clientDataJSON: encodeClientData(
+          'registration-challenge-4',
+          'webauthn.create',
+        ),
+      },
+    } as never);
+
+    expect(result).toEqual({ error: 'verification-failed' });
+  });
+});
+
+describe('getAuthenticationOptions', () => {
+  it('errors when no credential has been registered', async () => {
+    const result = await getAuthenticationOptions(fakeRequest());
+    expect(result).toEqual({ error: 'webauthn-not-configured' });
+  });
+
+  it('generates options scoped to the stored credential', async () => {
+    insertWebauthnCredential();
+    vi.mocked(generateAuthenticationOptions).mockResolvedValue({
+      challenge: 'authentication-challenge-1',
+      rpId: 'localhost',
+    } as never);
+
+    const result = await getAuthenticationOptions(fakeRequest());
+
+    expect('error' in result).toBe(false);
+    expect(generateAuthenticationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpID: 'localhost',
+        allowCredentials: [
+          { id: 'stored-credential-id', transports: ['internal'] },
+        ],
+      }),
+    );
+  });
+});
+
+describe('verifyAuthentication', () => {
+  it('errors when no credential has been registered', async () => {
+    const result = await verifyAuthentication(fakeRequest(), {
+      response: { clientDataJSON: encodeClientData('x', 'webauthn.get') },
+    } as never);
+
+    expect(result).toEqual({ error: 'webauthn-not-configured' });
+  });
+
+  it('rejects when the request rpID does not match the stored credential', async () => {
+    insertWebauthnCredential({ rpID: 'someotherhost' });
+
+    const result = await verifyAuthentication(fakeRequest(), {
+      response: { clientDataJSON: encodeClientData('x', 'webauthn.get') },
+    } as never);
+
+    expect(result).toEqual({ error: 'rp-id-mismatch' });
+  });
+
+  it('rejects an expired or unknown challenge', async () => {
+    insertWebauthnCredential();
+
+    const result = await verifyAuthentication(fakeRequest(), {
+      response: { clientDataJSON: encodeClientData('unknown', 'webauthn.get') },
+    } as never);
+
+    expect(result).toEqual({ error: 'invalid-or-expired-challenge' });
+  });
+
+  it('issues a token, updates the counter, and reuses the implicit admin user on success', async () => {
+    insertWebauthnCredential({ counter: 5 });
+    getAccountDb().mutate(
+      'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+      ['authentication-challenge-2', 'authentication', Date.now() + 60_000],
+    );
+    vi.mocked(verifyAuthenticationResponse).mockResolvedValue({
+      verified: true,
+      authenticationInfo: { newCounter: 6 },
+    } as never);
+
+    const result = await verifyAuthentication(fakeRequest(), {
+      response: {
+        clientDataJSON: encodeClientData(
+          'authentication-challenge-2',
+          'webauthn.get',
+        ),
+      },
+    } as never);
+
+    expect(result).toHaveProperty('token');
+
+    const authRow = getAccountDb().first(
+      "SELECT extra_data FROM auth WHERE method = 'webauthn'",
+    );
+    expect(JSON.parse(authRow.extra_data).counter).toBe(6);
+
+    const session = getAccountDb().first(
+      "SELECT * FROM sessions WHERE auth_method = 'webauthn'",
+    );
+    expect(session).toBeTruthy();
+    expect(session.token).toBe((result as { token: string }).token);
+  });
+
+  it('reuses the same session token on a second login', async () => {
+    insertWebauthnCredential();
+
+    async function login(challenge: string) {
+      getAccountDb().mutate(
+        'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+        [challenge, 'authentication', Date.now() + 60_000],
+      );
+      vi.mocked(verifyAuthenticationResponse).mockResolvedValue({
+        verified: true,
+        authenticationInfo: { newCounter: 1 },
+      } as never);
+      return verifyAuthentication(fakeRequest(), {
+        response: {
+          clientDataJSON: encodeClientData(challenge, 'webauthn.get'),
+        },
+      } as never);
+    }
+
+    const first = await login('authentication-challenge-3');
+    const second = await login('authentication-challenge-4');
+
+    expect((first as { token: string }).token).toBe(
+      (second as { token: string }).token,
+    );
+  });
+});
+
+describe('resetWebAuthnCredential', () => {
+  it('clears the stored credential and any webauthn sessions', () => {
+    insertWebauthnCredential();
+    getAccountDb().mutate(
+      'INSERT INTO sessions (token, expires_at, user_id, auth_method) VALUES (?, ?, ?, ?)',
+      ['some-token', -1, FALLBACK_OWNER_ID, 'webauthn'],
+    );
+
+    resetWebAuthnCredential();
+
+    expect(
+      getAccountDb().first("SELECT * FROM auth WHERE method = 'webauthn'"),
+    ).toBeFalsy();
+    expect(
+      getAccountDb().first(
+        "SELECT * FROM sessions WHERE auth_method = 'webauthn'",
+      ),
+    ).toBeFalsy();
+  });
+});

--- a/packages/sync-server/src/accounts/webauthn.ts
+++ b/packages/sync-server/src/accounts/webauthn.ts
@@ -63,16 +63,18 @@ function consumePendingChallenge(
   type: PendingChallengeType,
 ): boolean {
   const accountDb = getAccountDb();
-  const row = accountDb.first(
-    'SELECT challenge FROM pending_webauthn_challenges WHERE challenge = ? AND type = ? AND expiry_time > ?',
-    [challenge, type, Date.now()],
-  );
-  if (!row) return false;
-  accountDb.mutate(
-    'DELETE FROM pending_webauthn_challenges WHERE challenge = ?',
-    [challenge],
-  );
-  return true;
+  return accountDb.transaction(() => {
+    const row = accountDb.first(
+      'SELECT challenge FROM pending_webauthn_challenges WHERE challenge = ? AND type = ? AND expiry_time > ?',
+      [challenge, type, Date.now()],
+    );
+    if (!row) return false;
+    accountDb.mutate(
+      'DELETE FROM pending_webauthn_challenges WHERE challenge = ?',
+      [challenge],
+    );
+    return true;
+  });
 }
 
 function getStoredCredential(): StoredWebAuthnCredential | null {

--- a/packages/sync-server/src/accounts/webauthn.ts
+++ b/packages/sync-server/src/accounts/webauthn.ts
@@ -1,0 +1,343 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import type {
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from '@simplewebauthn/server';
+import {
+  decodeClientDataJSON,
+  isoBase64URL,
+} from '@simplewebauthn/server/helpers';
+import type { Request } from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+import { clearExpiredSessions, getAccountDb } from '#account-db';
+import { config } from '#load-config';
+import { TOKEN_EXPIRATION_NEVER } from '#util/validate-user';
+
+const RP_NAME = 'Actual Budget';
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+const PENDING_CHALLENGE_TYPE = {
+  registration: 'registration',
+  authentication: 'authentication',
+} as const;
+type PendingChallengeType =
+  (typeof PENDING_CHALLENGE_TYPE)[keyof typeof PENDING_CHALLENGE_TYPE];
+
+type StoredWebAuthnCredential = {
+  credentialID: string;
+  credentialPublicKey: string;
+  counter: number;
+  transports?: AuthenticatorTransportFuture[];
+  rpID: string;
+  deviceType: string;
+  backedUp: boolean;
+};
+
+function getRpIdAndOrigin(req: Request): { rpID: string; origin: string } {
+  return { rpID: req.hostname, origin: `${req.protocol}://${req.get('host')}` };
+}
+
+function storePendingChallenge(challenge: string, type: PendingChallengeType) {
+  const accountDb = getAccountDb();
+  const now = Date.now();
+  accountDb.mutate(
+    'DELETE FROM pending_webauthn_challenges WHERE expiry_time < ?',
+    [now],
+  );
+  accountDb.mutate(
+    'INSERT INTO pending_webauthn_challenges (challenge, type, expiry_time) VALUES (?, ?, ?)',
+    [challenge, type, now + CHALLENGE_TTL_MS],
+  );
+}
+
+function consumePendingChallenge(
+  challenge: string,
+  type: PendingChallengeType,
+): boolean {
+  const accountDb = getAccountDb();
+  const row = accountDb.first(
+    'SELECT challenge FROM pending_webauthn_challenges WHERE challenge = ? AND type = ? AND expiry_time > ?',
+    [challenge, type, Date.now()],
+  );
+  if (!row) return false;
+  accountDb.mutate(
+    'DELETE FROM pending_webauthn_challenges WHERE challenge = ?',
+    [challenge],
+  );
+  return true;
+}
+
+function getStoredCredential(): StoredWebAuthnCredential | null {
+  const accountDb = getAccountDb();
+  const row = accountDb.first(
+    "SELECT extra_data FROM auth WHERE method = 'webauthn'",
+  );
+  if (!row || !row.extra_data) return null;
+  try {
+    return JSON.parse(row.extra_data);
+  } catch (err) {
+    console.error('Error parsing WebAuthn credential:', err);
+    return null;
+  }
+}
+
+function setStoredCredential(credential: StoredWebAuthnCredential) {
+  const accountDb = getAccountDb();
+  accountDb.transaction(() => {
+    accountDb.mutate('DELETE FROM auth WHERE method = ?', ['webauthn']);
+    accountDb.mutate('UPDATE auth SET active = 0');
+    accountDb.mutate(
+      "INSERT INTO auth (method, display_name, extra_data, active) VALUES ('webauthn', 'Passkey', ?, 1)",
+      [JSON.stringify(credential)],
+    );
+  });
+}
+
+function decodeChallenge(clientDataJSON: string): string | null {
+  try {
+    return decodeClientDataJSON(clientDataJSON).challenge;
+  } catch (err) {
+    console.error('Error decoding WebAuthn clientDataJSON:', err);
+    return null;
+  }
+}
+
+export async function getRegistrationOptions(
+  req: Request,
+): Promise<
+  { error: string } | { options: PublicKeyCredentialCreationOptionsJSON }
+> {
+  const { rpID } = getRpIdAndOrigin(req);
+
+  const options = await generateRegistrationOptions({
+    rpName: RP_NAME,
+    rpID,
+    userName: 'admin',
+    attestationType: 'none',
+    authenticatorSelection: {
+      residentKey: 'preferred',
+      userVerification: 'preferred',
+    },
+  });
+
+  storePendingChallenge(options.challenge, PENDING_CHALLENGE_TYPE.registration);
+
+  return { options };
+}
+
+export async function verifyRegistration(
+  req: Request,
+  response: RegistrationResponseJSON,
+): Promise<{ error: string } | Record<string, never>> {
+  if (!response?.response?.clientDataJSON) {
+    return { error: 'invalid-response' };
+  }
+
+  const { rpID, origin } = getRpIdAndOrigin(req);
+
+  const challenge = decodeChallenge(response.response.clientDataJSON);
+  if (!challenge) {
+    return { error: 'invalid-response' };
+  }
+
+  if (
+    !consumePendingChallenge(challenge, PENDING_CHALLENGE_TYPE.registration)
+  ) {
+    return { error: 'invalid-or-expired-challenge' };
+  }
+
+  let verification;
+  try {
+    verification = await verifyRegistrationResponse({
+      response,
+      expectedChallenge: challenge,
+      expectedOrigin: origin,
+      expectedRPID: rpID,
+    });
+  } catch (err) {
+    console.error('Error verifying WebAuthn registration:', err);
+    return { error: 'verification-failed' };
+  }
+
+  if (!verification.verified || !verification.registrationInfo) {
+    return { error: 'verification-failed' };
+  }
+
+  const { credential, credentialDeviceType, credentialBackedUp } =
+    verification.registrationInfo;
+
+  setStoredCredential({
+    credentialID: credential.id,
+    credentialPublicKey: isoBase64URL.fromBuffer(credential.publicKey),
+    counter: credential.counter,
+    transports: credential.transports,
+    rpID,
+    deviceType: credentialDeviceType,
+    backedUp: credentialBackedUp,
+  });
+
+  return {};
+}
+
+export async function getAuthenticationOptions(
+  req: Request,
+): Promise<
+  { error: string } | { options: PublicKeyCredentialRequestOptionsJSON }
+> {
+  const credential = getStoredCredential();
+  if (!credential) {
+    return { error: 'webauthn-not-configured' };
+  }
+
+  const { rpID } = getRpIdAndOrigin(req);
+
+  const options = await generateAuthenticationOptions({
+    rpID,
+    allowCredentials: [
+      { id: credential.credentialID, transports: credential.transports },
+    ],
+    userVerification: 'preferred',
+  });
+
+  storePendingChallenge(
+    options.challenge,
+    PENDING_CHALLENGE_TYPE.authentication,
+  );
+
+  return { options };
+}
+
+export async function verifyAuthentication(
+  req: Request,
+  response: AuthenticationResponseJSON,
+): Promise<{ error: string } | { token: string }> {
+  if (!response?.response?.clientDataJSON) {
+    return { error: 'invalid-response' };
+  }
+
+  const credential = getStoredCredential();
+  if (!credential) {
+    return { error: 'webauthn-not-configured' };
+  }
+
+  const { rpID, origin } = getRpIdAndOrigin(req);
+
+  if (credential.rpID !== rpID) {
+    return { error: 'rp-id-mismatch' };
+  }
+
+  const challenge = decodeChallenge(response.response.clientDataJSON);
+  if (!challenge) {
+    return { error: 'invalid-response' };
+  }
+
+  if (
+    !consumePendingChallenge(challenge, PENDING_CHALLENGE_TYPE.authentication)
+  ) {
+    return { error: 'invalid-or-expired-challenge' };
+  }
+
+  let verification;
+  try {
+    verification = await verifyAuthenticationResponse({
+      response,
+      expectedChallenge: challenge,
+      expectedOrigin: origin,
+      expectedRPID: rpID,
+      credential: {
+        id: credential.credentialID,
+        publicKey: isoBase64URL.toBuffer(credential.credentialPublicKey),
+        counter: credential.counter,
+        transports: credential.transports,
+      },
+    });
+  } catch (err) {
+    console.error('Error verifying WebAuthn authentication:', err);
+    return { error: 'verification-failed' };
+  }
+
+  if (!verification.verified) {
+    return { error: 'verification-failed' };
+  }
+
+  const accountDb = getAccountDb();
+
+  accountDb.mutate("UPDATE auth SET extra_data = ? WHERE method = 'webauthn'", [
+    JSON.stringify({
+      ...credential,
+      counter: verification.authenticationInfo.newCounter,
+    }),
+  ]);
+
+  // Mint/reuse a session exactly like loginWithPassword does.
+  const sessionRow = accountDb.first(
+    'SELECT * FROM sessions WHERE auth_method = ?',
+    ['webauthn'],
+  );
+
+  const token = sessionRow ? sessionRow.token : uuidv4();
+
+  const { totalOfUsers } = accountDb.first(
+    'SELECT count(*) as totalOfUsers FROM users',
+  );
+
+  let userId = null;
+  if (totalOfUsers === 0) {
+    userId = uuidv4();
+    accountDb.mutate(
+      'INSERT INTO users (id, user_name, display_name, enabled, owner, role) VALUES (?, ?, ?, 1, 1, ?)',
+      [userId, '', '', 'ADMIN'],
+    );
+  } else {
+    const { id: userIdFromDb } =
+      accountDb.first('SELECT id FROM users WHERE user_name = ?', ['']) || {};
+    userId = userIdFromDb;
+
+    if (!userId) {
+      return { error: 'user-not-found' };
+    }
+  }
+
+  let expiration = TOKEN_EXPIRATION_NEVER;
+  if (
+    config.get('token_expiration') !== 'never' &&
+    config.get('token_expiration') !== 'openid-provider' &&
+    typeof config.get('token_expiration') === 'number'
+  ) {
+    expiration =
+      Math.floor(Date.now() / 1000) +
+      Number(config.get('token_expiration')) * 60;
+  }
+
+  if (!sessionRow) {
+    accountDb.mutate(
+      'INSERT INTO sessions (token, expires_at, user_id, auth_method) VALUES (?, ?, ?, ?)',
+      [token, expiration, userId, 'webauthn'],
+    );
+  } else {
+    accountDb.mutate(
+      'UPDATE sessions SET user_id = ?, expires_at = ? WHERE token = ?',
+      [userId, expiration, token],
+    );
+  }
+
+  clearExpiredSessions();
+
+  return { token };
+}
+
+export function resetWebAuthnCredential() {
+  const accountDb = getAccountDb();
+  accountDb.transaction(() => {
+    accountDb.mutate("DELETE FROM auth WHERE method = 'webauthn'");
+    accountDb.mutate("DELETE FROM sessions WHERE auth_method = 'webauthn'");
+  });
+}

--- a/packages/sync-server/src/app-webauthn.test.ts
+++ b/packages/sync-server/src/app-webauthn.test.ts
@@ -1,0 +1,178 @@
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getAccountDb } from './account-db';
+import { bootstrapPassword } from './accounts/password';
+import * as webauthnAccount from './accounts/webauthn';
+import { handlers as app, webauthnRateLimiter } from './app-webauthn';
+
+vi.mock('./accounts/webauthn', async importOriginal => {
+  const actual = await importOriginal<typeof webauthnAccount>();
+  return {
+    ...actual,
+    getRegistrationOptions: vi.fn(),
+    verifyRegistration: vi.fn(),
+    getAuthenticationOptions: vi.fn(),
+    verifyAuthentication: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  webauthnRateLimiter.resetKey('127.0.0.1');
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  getAccountDb().mutate('DELETE FROM auth');
+});
+
+describe('rate limiting', () => {
+  it('returns 429 after exceeding the rate limit on /authentication-options', async () => {
+    vi.mocked(webauthnAccount.getAuthenticationOptions).mockResolvedValue({
+      error: 'webauthn-not-configured',
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await request(app).post('/authentication-options').send({});
+    }
+
+    const res = await request(app).post('/authentication-options').send({});
+
+    expect(res.statusCode).toEqual(429);
+    expect(res.body).toEqual({ status: 'error', reason: 'too-many-requests' });
+  });
+});
+
+describe('POST /registration-options', () => {
+  it('rejects once the server has already been bootstrapped', async () => {
+    await bootstrapPassword('bootstrap-password');
+
+    const res = await request(app).post('/registration-options').send({});
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({
+      status: 'error',
+      reason: 'already-bootstrapped',
+    });
+    expect(webauthnAccount.getRegistrationOptions).not.toHaveBeenCalled();
+  });
+
+  it('returns options before the server is bootstrapped', async () => {
+    vi.mocked(webauthnAccount.getRegistrationOptions).mockResolvedValue({
+      options: { challenge: 'abc' } as never,
+    });
+
+    const res = await request(app).post('/registration-options').send({});
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({ status: 'ok', data: { challenge: 'abc' } });
+  });
+
+  it('forwards errors from the underlying options generator', async () => {
+    vi.mocked(webauthnAccount.getRegistrationOptions).mockResolvedValue({
+      error: 'some-error',
+    });
+
+    const res = await request(app).post('/registration-options').send({});
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({ status: 'error', reason: 'some-error' });
+  });
+});
+
+describe('POST /registration-verify', () => {
+  it('rejects once the server has already been bootstrapped', async () => {
+    await bootstrapPassword('bootstrap-password');
+
+    const res = await request(app)
+      .post('/registration-verify')
+      .send({ response: {} });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({
+      status: 'error',
+      reason: 'already-bootstrapped',
+    });
+    expect(webauthnAccount.verifyRegistration).not.toHaveBeenCalled();
+  });
+
+  it('verifies the response and reports success before the server is bootstrapped', async () => {
+    vi.mocked(webauthnAccount.verifyRegistration).mockResolvedValue({});
+
+    const res = await request(app)
+      .post('/registration-verify')
+      .send({ response: { id: 'cred' } });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({ status: 'ok', data: {} });
+    expect(webauthnAccount.verifyRegistration).toHaveBeenCalledWith(
+      expect.anything(),
+      { id: 'cred' },
+    );
+  });
+});
+
+describe('POST /authentication-options', () => {
+  it('is reachable regardless of bootstrap state', async () => {
+    await bootstrapPassword('bootstrap-password');
+    vi.mocked(webauthnAccount.getAuthenticationOptions).mockResolvedValue({
+      options: { challenge: 'auth-challenge' } as never,
+    });
+
+    const res = await request(app).post('/authentication-options').send({});
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({
+      status: 'ok',
+      data: { challenge: 'auth-challenge' },
+    });
+  });
+
+  it('forwards errors, e.g. when no passkey has been registered yet', async () => {
+    vi.mocked(webauthnAccount.getAuthenticationOptions).mockResolvedValue({
+      error: 'webauthn-not-configured',
+    });
+
+    const res = await request(app).post('/authentication-options').send({});
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({
+      status: 'error',
+      reason: 'webauthn-not-configured',
+    });
+  });
+});
+
+describe('POST /authentication-verify', () => {
+  it('returns a token on success', async () => {
+    vi.mocked(webauthnAccount.verifyAuthentication).mockResolvedValue({
+      token: 'session-token',
+    });
+
+    const res = await request(app)
+      .post('/authentication-verify')
+      .send({ response: { id: 'cred' } });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({
+      status: 'ok',
+      data: { token: 'session-token' },
+    });
+  });
+
+  it('returns an error when verification fails', async () => {
+    vi.mocked(webauthnAccount.verifyAuthentication).mockResolvedValue({
+      error: 'verification-failed',
+    });
+
+    const res = await request(app)
+      .post('/authentication-verify')
+      .send({ response: { id: 'cred' } });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body).toEqual({
+      status: 'error',
+      reason: 'verification-failed',
+    });
+  });
+});

--- a/packages/sync-server/src/app-webauthn.ts
+++ b/packages/sync-server/src/app-webauthn.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+
+import { needsBootstrap } from './account-db';
+import {
+  getAuthenticationOptions,
+  getRegistrationOptions,
+  verifyAuthentication,
+  verifyRegistration,
+} from './accounts/webauthn';
+import { errorMiddleware, requestLoggerMiddleware } from './util/middlewares';
+
+const app = express();
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(requestLoggerMiddleware);
+
+const webauthnRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 5, // 5 attempts per window
+  legacyHeaders: false,
+  standardHeaders: true,
+  skipSuccessfulRequests: true,
+  message: { status: 'error', reason: 'too-many-requests' },
+});
+
+export { app as handlers, webauthnRateLimiter };
+
+// Registration pair: only usable before the server has been bootstrapped,
+// mirroring POST /account/bootstrap's "special endpoint, can't call again"
+// gate. Post-bootstrap re-registration is deferred to a future change.
+app.post('/registration-options', webauthnRateLimiter, async (req, res) => {
+  if (!needsBootstrap()) {
+    res.status(400).send({ status: 'error', reason: 'already-bootstrapped' });
+    return;
+  }
+
+  const result = await getRegistrationOptions(req);
+  if ('error' in result) {
+    res.status(400).send({ status: 'error', reason: result.error });
+    return;
+  }
+  res.send({ status: 'ok', data: result.options });
+});
+
+app.post('/registration-verify', webauthnRateLimiter, async (req, res) => {
+  if (!needsBootstrap()) {
+    res.status(400).send({ status: 'error', reason: 'already-bootstrapped' });
+    return;
+  }
+
+  const result = await verifyRegistration(req, req.body?.response);
+  if ('error' in result) {
+    res.status(400).send({ status: 'error', reason: result.error });
+    return;
+  }
+  res.send({ status: 'ok', data: {} });
+});
+
+// Authentication pair: pre-auth, used instead of POST /account/login since
+// that endpoint is single-shot and WebAuthn needs a two-step ceremony.
+app.post('/authentication-options', webauthnRateLimiter, async (req, res) => {
+  const result = await getAuthenticationOptions(req);
+  if ('error' in result) {
+    res.status(400).send({ status: 'error', reason: result.error });
+    return;
+  }
+  res.send({ status: 'ok', data: result.options });
+});
+
+app.post('/authentication-verify', webauthnRateLimiter, async (req, res) => {
+  const result = await verifyAuthentication(req, req.body?.response);
+  if ('error' in result) {
+    res.status(400).send({ status: 'error', reason: result.error });
+    return;
+  }
+  res.send({ status: 'ok', data: { token: result.token } });
+});
+
+app.use(errorMiddleware);

--- a/packages/sync-server/src/app.ts
+++ b/packages/sync-server/src/app.ts
@@ -18,6 +18,7 @@ import * as pluggai from './app-pluggyai/app-pluggyai';
 import * as secretApp from './app-secrets';
 import * as simpleFinApp from './app-simplefin/app-simplefin';
 import * as syncApp from './app-sync';
+import * as webauthnApp from './app-webauthn';
 import { config } from './load-config';
 
 const app = express();
@@ -71,6 +72,7 @@ if (config.get('corsProxy.enabled')) {
 
 app.use('/admin', adminApp.handlers);
 app.use('/openid', openidApp.handlers);
+app.use('/webauthn', webauthnApp.handlers);
 
 app.get('/mode', (req, res) => {
   res.send(config.get('mode'));

--- a/packages/sync-server/src/load-config.js
+++ b/packages/sync-server/src/load-config.js
@@ -120,14 +120,14 @@ const configSchema = convict({
   },
   loginMethod: {
     doc: 'Authentication method.',
-    format: ['password', 'header', 'openid'],
+    format: ['password', 'header', 'openid', 'webauthn'],
     default: 'password',
     env: 'ACTUAL_LOGIN_METHOD',
   },
   allowedLoginMethods: {
     doc: 'Allowed authentication methods.',
     format: Array,
-    default: ['password', 'header', 'openid'],
+    default: ['password', 'header', 'openid', 'webauthn'],
     env: 'ACTUAL_ALLOWED_LOGIN_METHODS',
   },
   trustedProxies: {

--- a/packages/sync-server/src/scripts/reset-password.js
+++ b/packages/sync-server/src/scripts/reset-password.js
@@ -1,5 +1,6 @@
-import { bootstrap, needsBootstrap } from '#account-db';
+import { bootstrap, getActiveLoginMethod, needsBootstrap } from '#account-db';
 import { changePassword } from '#accounts/password';
+import { resetWebAuthnCredential } from '#accounts/webauthn';
 import { promptPassword } from '#util/prompt';
 
 if (needsBootstrap()) {
@@ -18,6 +19,24 @@ if (needsBootstrap()) {
       process.exit(1);
     }
     console.log('Password set!');
+  } catch (err) {
+    console.log('Unexpected error:', err);
+    console.log(
+      'Please report this as an issue: https://github.com/actualbudget/actual-server/issues',
+    );
+    process.exit(1);
+  }
+} else if (getActiveLoginMethod() === 'webauthn') {
+  console.log(
+    "It looks like this server is using a passkey (WebAuthn) to log in. This script can't reset a passkey directly, but it can clear it so you can set up a new login method.",
+  );
+
+  try {
+    resetWebAuthnCredential();
+    console.log('Passkey cleared!');
+    console.log(
+      'Open Actual in your browser to set up a new password or passkey. All of your budget files and users are untouched.',
+    );
   } catch (err) {
     console.log('Unexpected error:', err);
     console.log(

--- a/upcoming-release-notes/webauthn-passkey-login.md
+++ b/upcoming-release-notes/webauthn-passkey-login.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [ildyria]
+---
+
+Add the option to register a passkey instead of a password when setting up a server

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,6 +182,7 @@ __metadata:
   dependencies:
     "@actual-app/crdt": "workspace:*"
     "@actual-app/web": "workspace:*"
+    "@simplewebauthn/server": "npm:^13.3.2"
     "@types/bcrypt": "npm:^6.0.0"
     "@types/better-sqlite3": "npm:^7.6.13"
     "@types/convict": "npm:^6"
@@ -252,6 +253,7 @@ __metadata:
     "@reduxjs/toolkit": "npm:^2.12.0"
     "@rolldown/plugin-babel": "npm:~0.2.3"
     "@rollup/plugin-inject": "npm:^5.0.5"
+    "@simplewebauthn/browser": "npm:^13.3.0"
     "@tanstack/react-query": "npm:^5.101.2"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:^6.9.1"
@@ -4478,6 +4480,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hexagon/base64@npm:^1.1.27":
+  version: 1.1.28
+  resolution: "@hexagon/base64@npm:1.1.28"
+  checksum: 10/e002644dfdcc932dfbfe95ff188e83b24520d179d77019506429ff77be1c76562e7d9eafbbcf539264da34cfd7a8a8b99fb9ba3ab4ae126716af57ccd8e641f7
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -4873,6 +4882,13 @@ __metadata:
   version: 2.0.5
   resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
   checksum: 10/cb98c608392abe59457a14e00134e7dfa57c0c9b459871730cd4e907bb12b834cbd03e08ad8663fea9e486f260da7f1293ccd9af0376bf5524dd8536192f248c
+  languageName: node
+  linkType: hard
+
+"@levischuck/tiny-cbor@npm:^0.2.2":
+  version: 0.2.11
+  resolution: "@levischuck/tiny-cbor@npm:0.2.11"
+  checksum: 10/b278004882fc9153b6337f04591a8c95471369d4a2eed1ef9c715c12ddb1a6a5bc85d7ef1d45a9757eaac9b9da8f98d99a44dfdf7162c901a82f8bc8fb7add82
   languageName: node
   linkType: hard
 
@@ -6306,6 +6322,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@peculiar/asn1-android@npm:^2.6.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-android@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10/3e08034067bdaabc404629cdd46a63c59951ba087fca288df903ed197a2385b19da2958310fb6b887410dfe318458674b6d598f70f8edf0699a83699c0d5c0df
+  languageName: node
+  linkType: hard
+
 "@peculiar/asn1-cms@npm:^2.6.0, @peculiar/asn1-cms@npm:^2.7.0":
   version: 2.7.0
   resolution: "@peculiar/asn1-cms@npm:2.7.0"
@@ -6331,15 +6358,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-ecc@npm:^2.6.0":
-  version: 2.7.0
-  resolution: "@peculiar/asn1-ecc@npm:2.7.0"
+"@peculiar/asn1-ecc@npm:^2.6.0, @peculiar/asn1-ecc@npm:^2.6.1":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-ecc@npm:2.8.0"
   dependencies:
-    "@peculiar/asn1-schema": "npm:^2.7.0"
-    "@peculiar/asn1-x509": "npm:^2.7.0"
-    asn1js: "npm:^3.0.6"
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
     tslib: "npm:^2.8.1"
-  checksum: 10/c30736a867dd6facf7cf5090c9eace582b927c92cbc0dfd8787b3485e3012dc846b608d5d0c3c38df9e621e0c7fbe0bb2b96e7fa34c03b67f4b59fd3d6d4e8f4
+  checksum: 10/a3b3a6b52e31f5b51c02e91bafc2475d065f7e43a2d0edba4d20b60fa765e504d186803bd40bfb145c3496f9ea373f7092321c58077e698e751e521e5f238798
   languageName: node
   linkType: hard
 
@@ -6385,26 +6412,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-rsa@npm:^2.6.0, @peculiar/asn1-rsa@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "@peculiar/asn1-rsa@npm:2.7.0"
+"@peculiar/asn1-rsa@npm:^2.6.0, @peculiar/asn1-rsa@npm:^2.6.1, @peculiar/asn1-rsa@npm:^2.7.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-rsa@npm:2.8.0"
   dependencies:
-    "@peculiar/asn1-schema": "npm:^2.7.0"
-    "@peculiar/asn1-x509": "npm:^2.7.0"
-    asn1js: "npm:^3.0.6"
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
     tslib: "npm:^2.8.1"
-  checksum: 10/b314b77246a7bee0a2a76978ca08983a016afad78c74dc02b5ae6296f8a71f0146c521d431a9d6e9ba7faec42b5a8bba046ee4c9010cbd1b37067398e05e05af
+  checksum: 10/a94ae4e2adb8a578793571ec71cdbfada4a75cbc62f3922fa7034d56f78dd059b857bfbffcb552fc3f763656d09ad1ca2031fb725e90f4b076468aa8959eda64
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-schema@npm:^2.6.0, @peculiar/asn1-schema@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "@peculiar/asn1-schema@npm:2.7.0"
+"@peculiar/asn1-schema@npm:^2.6.0, @peculiar/asn1-schema@npm:^2.7.0, @peculiar/asn1-schema@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-schema@npm:2.8.0"
   dependencies:
     "@peculiar/utils": "npm:^2.0.2"
-    asn1js: "npm:^3.0.6"
+    asn1js: "npm:^3.0.10"
     tslib: "npm:^2.8.1"
-  checksum: 10/2b18ee2f3de2b68a36b964721e5101f589d6a1db765c450ce5a929829bfc8c0819e0b128145f65639952b257b9bdaa6ce7d1a54cd93c7bf6e694fed4c36d6c98
+  checksum: 10/2964a77c290747cce1f989a55c44a205f34ba00a60e5a7a0fcc2e23d924c7b1f3d33bcf9a8aac7cf4356fed5773f03c1f10b0c6dbbb8c3edbc6217f95282cf15
   languageName: node
   linkType: hard
 
@@ -6420,15 +6447,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-x509@npm:^2.6.0, @peculiar/asn1-x509@npm:^2.7.0":
-  version: 2.7.0
-  resolution: "@peculiar/asn1-x509@npm:2.7.0"
+"@peculiar/asn1-x509@npm:^2.6.0, @peculiar/asn1-x509@npm:^2.6.1, @peculiar/asn1-x509@npm:^2.7.0, @peculiar/asn1-x509@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-x509@npm:2.8.0"
   dependencies:
-    "@peculiar/asn1-schema": "npm:^2.7.0"
+    "@peculiar/asn1-schema": "npm:^2.8.0"
     "@peculiar/utils": "npm:^2.0.2"
-    asn1js: "npm:^3.0.6"
+    asn1js: "npm:^3.0.10"
     tslib: "npm:^2.8.1"
-  checksum: 10/6e6b1124076487e46d1b9f7237f173bc7aab92230e3a7a8b3841fdc84009ece0221624bd88fe16a478aec5b4ba21a9393735038ca4e38245d7f0c1be91f00e8c
+  checksum: 10/5af2586236ad9ca1485899ab4883e90987c5cb3863154e6528a7f363cd10a2e56bbd961fae0f61a45c1cbda8d57867e651bec4e0ede3ad9b0c4e4ebe7e7c0463
   languageName: node
   linkType: hard
 
@@ -6441,7 +6468,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/x509@npm:^1.14.2":
+"@peculiar/x509@npm:^1.14.2, @peculiar/x509@npm:^1.14.3":
   version: 1.14.3
   resolution: "@peculiar/x509@npm:1.14.3"
   dependencies:
@@ -7576,6 +7603,29 @@ __metadata:
   version: 2.0.0
   resolution: "@sideway/pinpoint@npm:2.0.0"
   checksum: 10/1ed21800128b2b23280ba4c9db26c8ff6142b97a8683f17639fd7f2128aa09046461574800b30fb407afc5b663c2331795ccf3b654d4b38fa096e41a5c786bf8
+  languageName: node
+  linkType: hard
+
+"@simplewebauthn/browser@npm:^13.3.0":
+  version: 13.3.0
+  resolution: "@simplewebauthn/browser@npm:13.3.0"
+  checksum: 10/1490c566017145f705e06f7f4d08822d19a616ce1ce8a152fcad1e4d88b418df3a4fa5c1f24e4ce142f41079ecbe3f9b77f3f3889e0cc1a4655e6f2ef2756228
+  languageName: node
+  linkType: hard
+
+"@simplewebauthn/server@npm:^13.3.2":
+  version: 13.3.2
+  resolution: "@simplewebauthn/server@npm:13.3.2"
+  dependencies:
+    "@hexagon/base64": "npm:^1.1.27"
+    "@levischuck/tiny-cbor": "npm:^0.2.2"
+    "@peculiar/asn1-android": "npm:^2.6.0"
+    "@peculiar/asn1-ecc": "npm:^2.6.1"
+    "@peculiar/asn1-rsa": "npm:^2.6.1"
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.1"
+    "@peculiar/x509": "npm:^1.14.3"
+  checksum: 10/02b9f40cf8da4601102ddee7c3b4befede164127f080d92f490444342324f6edc67d50e2e840b12b3bdec4c1560b3502c6431cb7d4d71a502b47a91f4147cb98
   languageName: node
   linkType: hard
 
@@ -10302,7 +10352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1js@npm:^3.0.6":
+"asn1js@npm:^3.0.10, asn1js@npm:^3.0.6":
   version: 3.0.10
   resolution: "asn1js@npm:3.0.10"
   dependencies:


### PR DESCRIPTION
## Description

This PR aims to add support of WebAuthn as means of authentication for single users. When used it **replaces** the password auth completely.

This does not support multi WebAuthn tokens and in case of the loss the reset has to be done in similar fashion as of the password by going to command line.

Initial implementation with Claude Code, followed by local review with CodeRabbitAi.

> **CodeRabbitAi**: 
> No issues detected in this review. You're good to go! 🎉

📜 🙋‍♂️ I solemnly swear I have read every line of code produced.

## Related issue(s)

Fixes #4876

## Testing

Added unit tests + local manual testing


## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.12 MB (+20.47 kB) | +0.15%
loot-core | 1 | 4.63 MB → 4.63 MB (+1.99 kB) | +0.04%
api | 2 | 3.84 MB → 3.84 MB (+1.95 kB) | +0.05%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.12 MB (+20.47 kB) | +0.15%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`node_modules/@simplewebauthn/browser/esm/helpers/identifyRegistrationError.js` | 🆕 +3.3 kB | 0 B → 3.3 kB
`node_modules/@simplewebauthn/browser/esm/methods/startRegistration.js` | 🆕 +3.14 kB | 0 B → 3.14 kB
`node_modules/@simplewebauthn/browser/esm/methods/startAuthentication.js` | 🆕 +2.43 kB | 0 B → 2.43 kB
`node_modules/@simplewebauthn/browser/esm/helpers/identifyAuthenticationError.js` | 🆕 +1.41 kB | 0 B → 1.41 kB
`src/components/manager/subscribe/WebAuthnRegistration.tsx` | 🆕 +1.37 kB | 0 B → 1.37 kB
`node_modules/@simplewebauthn/browser/esm/helpers/webAuthnAbortService.js` | 🆕 +954 B | 0 B → 954 B
`node_modules/@simplewebauthn/browser/esm/helpers/browserSupportsWebAuthnAutofill.js` | 🆕 +739 B | 0 B → 739 B
`node_modules/@simplewebauthn/browser/esm/helpers/base64URLStringToBuffer.js` | 🆕 +548 B | 0 B → 548 B
`node_modules/@simplewebauthn/browser/esm/helpers/webAuthnError.js` | 🆕 +399 B | 0 B → 399 B
`node_modules/@simplewebauthn/browser/esm/helpers/browserSupportsWebAuthn.js` | 🆕 +368 B | 0 B → 368 B
`node_modules/@simplewebauthn/browser/esm/helpers/bufferToBase64URLString.js` | 🆕 +350 B | 0 B → 350 B
`node_modules/@simplewebauthn/browser/esm/helpers/toAuthenticatorAttachment.js` | 🆕 +304 B | 0 B → 304 B
`node_modules/@simplewebauthn/browser/esm/helpers/toPublicKeyCredentialDescriptor.js` | 🆕 +300 B | 0 B → 300 B
`node_modules/@simplewebauthn/browser/esm/helpers/isValidDomain.js` | 🆕 +260 B | 0 B → 260 B
`src/components/manager/subscribe/Bootstrap.tsx` | 📈 +2.61 kB (+55.95%) | 4.66 kB → 7.27 kB
`src/components/manager/subscribe/Login.tsx` | 📈 +2.02 kB (+12.07%) | 16.75 kB → 18.77 kB
`package.json` | 📈 +76 B (+0.72%) | 10.34 kB → 10.41 kB
`node_modules/@simplewebauthn/browser/esm/index.js` |   +0 B (0%) | 0 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB → 1.59 MB (+20.47 kB) | +1.27%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 11.74 kB | 0%
static/js/ReportRouter.js | 1.4 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 2.03 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 179.29 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.63 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 171.84 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+1.99 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/auth/app.ts` | 📈 +1.99 kB (+32.19%) | 6.19 kB → 8.19 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CP_ap9nH.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.7rV9_5dh.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+1.95 kB) | +0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/auth/app.ts` | 📈 +1.95 kB (+32.39%) | 6.01 kB → 7.96 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+1.95 kB) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->