### PR TITLE
[AI] fix(api): translate default rule stage at API boundary

### DIFF
--- a/packages/api/methods.ts
+++ b/packages/api/methods.ts
@@ -5,6 +5,7 @@ import type {
   APICategoryGroupEntity,
   APIFileEntity,
   APIPayeeEntity,
+  APIRuleEntity,
   APIScheduleEntity,
   APITagEntity,
 } from '@actual-app/core/server/api-models';
@@ -362,11 +363,11 @@ export function getPayeeRules(id: RuleEntity['id']) {
   return send('api/payee-rules-get', { id });
 }
 
-export function createRule(rule: Omit<RuleEntity, 'id'>) {
+export function createRule(rule: Omit<APIRuleEntity, 'id'>) {
   return send('api/rule-create', { rule });
 }
 
-export function updateRule(rule: RuleEntity) {
+export function updateRule(rule: APIRuleEntity) {
   return send('api/rule-update', { rule });
 }
 

--- a/packages/loot-core/src/server/api-models.ts
+++ b/packages/loot-core/src/server/api-models.ts
@@ -3,7 +3,9 @@ import type {
   AccountEntity,
   CategoryEntity,
   CategoryGroupEntity,
+  NewRuleEntity,
   PayeeEntity,
+  RuleEntity,
   ScheduleEntity,
   TagEntity,
 } from '#types/models';
@@ -121,6 +123,23 @@ export const payeeModel = {
     // No translation is needed
     return payee as PayeeEntity;
   },
+};
+
+export type APIRuleEntity = Omit<RuleEntity, 'stage'> & {
+  stage: RuleEntity['stage'] | 'default';
+};
+
+function fromExternalRule(rule: APIRuleEntity): RuleEntity;
+function fromExternalRule(rule: Omit<APIRuleEntity, 'id'>): NewRuleEntity;
+function fromExternalRule(rule: Omit<APIRuleEntity, 'id'> | APIRuleEntity) {
+  return {
+    ...rule,
+    stage: rule.stage === 'default' ? null : rule.stage,
+  };
+}
+
+export const ruleModel = {
+  fromExternal: fromExternalRule,
 };
 
 export type APITagEntity = Pick<

--- a/packages/loot-core/src/server/api.test.ts
+++ b/packages/loot-core/src/server/api.test.ts
@@ -138,4 +138,65 @@ describe('API handlers', () => {
       expect(group?.categories?.[0]).toHaveProperty('carryover', false);
     });
   });
+
+  describe('api/rule-create', () => {
+    beforeEach(global.emptyDatabase());
+
+    beforeEach(async () => {
+      await prefs.loadPrefs();
+    });
+
+    test.each(['default', null, 'pre', 'post'] as const)(
+      'normalizes %s input at the API boundary',
+      async stage => {
+        const rule = {
+          stage,
+          conditionsOp: 'and' as const,
+          conditions: [],
+          actions: [],
+        };
+        const internalRule = {
+          id: 'rule-id',
+          ...rule,
+          stage: stage === 'default' ? null : stage,
+        };
+
+        handlers['rule-add'] = vi.fn().mockResolvedValue(internalRule);
+
+        await expect(handlers['api/rule-create']({ rule })).resolves.toEqual(
+          internalRule,
+        );
+        expect(handlers['rule-add']).toHaveBeenCalledWith({
+          ...rule,
+          stage: internalRule.stage,
+        });
+      },
+    );
+  });
+
+  describe('api/rule-update', () => {
+    beforeEach(global.emptyDatabase());
+
+    beforeEach(async () => {
+      await prefs.loadPrefs();
+    });
+
+    test('normalizes default input at the API boundary', async () => {
+      const rule = {
+        id: 'rule-id',
+        stage: 'default' as const,
+        conditionsOp: 'and' as const,
+        conditions: [],
+        actions: [],
+      };
+      const internalRule = { ...rule, stage: null };
+
+      handlers['rule-update'] = vi.fn().mockResolvedValue(internalRule);
+
+      await expect(handlers['api/rule-update']({ rule })).resolves.toEqual(
+        internalRule,
+      );
+      expect(handlers['rule-update']).toHaveBeenCalledWith(internalRule);
+    });
+  });
 });

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -33,6 +33,7 @@ import {
   categoryModel,
   payeeModel,
   remoteFileModel,
+  ruleModel,
   scheduleModel,
   tagModel,
 } from './api-models';
@@ -862,7 +863,7 @@ handlers['api/payee-rules-get'] = async function ({ id }) {
 
 handlers['api/rule-create'] = withMutation(async function ({ rule }) {
   checkFileOpen();
-  const addedRule = await handlers['rule-add'](rule);
+  const addedRule = await handlers['rule-add'](ruleModel.fromExternal(rule));
 
   if ('error' in addedRule) {
     throw APIError('Failed creating a new rule', addedRule.error);
@@ -873,7 +874,9 @@ handlers['api/rule-create'] = withMutation(async function ({ rule }) {
 
 handlers['api/rule-update'] = withMutation(async function ({ rule }) {
   checkFileOpen();
-  const updatedRule = await handlers['rule-update'](rule);
+  const updatedRule = await handlers['rule-update'](
+    ruleModel.fromExternal(rule),
+  );
 
   if ('error' in updatedRule) {
     throw APIError('Failed updating the rule', updatedRule.error);

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -6,6 +6,7 @@ import type {
   APICategoryGroupEntity,
   APIFileEntity,
   APIPayeeEntity,
+  APIRuleEntity,
   APIScheduleEntity,
   APITagEntity,
 } from '#server/api-models';
@@ -18,7 +19,6 @@ import type {
   CategoryGroupEntity,
   ImportTransactionEntity,
   NearbyPayeeEntity,
-  NewRuleEntity,
   NoteEntity,
   PayeeEntity,
   PayeeLocationEntity,
@@ -261,9 +261,11 @@ export type ApiHandlers = {
     id: APIPayeeEntity['id'];
   }) => Promise<RuleEntity[]>;
 
-  'api/rule-create': (arg: { rule: NewRuleEntity }) => Promise<RuleEntity>;
+  'api/rule-create': (arg: {
+    rule: Omit<APIRuleEntity, 'id'>;
+  }) => Promise<RuleEntity>;
 
-  'api/rule-update': (arg: { rule: RuleEntity }) => Promise<RuleEntity>;
+  'api/rule-update': (arg: { rule: APIRuleEntity }) => Promise<RuleEntity>;
 
   'api/rule-delete': (id: RuleEntity['id']) => Promise<boolean>;
 

--- a/upcoming-release-notes/8689.md
+++ b/upcoming-release-notes/8689.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [cakeni]
+---
+
+Fix the Rule API default stage handling.


### PR DESCRIPTION
## Description

Fix the Rule API stage handling so the implementation matches the documented API contract.

The public Rule API documents `stage` as `pre`, `default`, or `post`, while the internal Rule model represents the default stage as `null`. The API was exposing the internal representation directly, causing `stage: 'default'` to be rejected on input and default-stage rules to serialize as `null`.

This change:

- translates API `stage: 'default'` to internal `null`;
- translates internal `null` back to API `stage: 'default'`;
- leaves `pre` and `post` unchanged;
- keeps the internal Rule model, validation, database representation, and ranking semantics unchanged;
- restores the Rule API documentation to its original `pre` / `default` / `post` contract.

`stage` remains required. Runtime `null` input is not newly rejected in this patch to avoid introducing an unrelated compatibility break, but the public API type now exposes the documented values.

AI usage: OpenAI Codex/ChatGPT assisted with tracing the Rule API call chain, implementing the boundary translation, and adding regression tests. The resulting diff and CI results were reviewed before updating this PR.

## Related issue(s)

- Fixes #8682

## Testing

- `yarn lint`: passed
- `yarn typecheck`: passed
- `yarn test`: passed
- `packages/api/rules-stage.test.ts`: 3 regression tests passed
- API Browser Test: passed
- Build: passed
- Release notes check: passed
- CodeQL: passed

## Checklist

- [x] Added a Bugfix release note
- [x] Added regression coverage for the Rule API stage contract
- [x] Restored the documentation to its original semantics
- [x] Kept the implementation change scoped to the API boundary

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.36 MB | 0%
loot-core | 1 | 4.63 MB → 4.63 MB (+238 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+231 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.36 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.67 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.33 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+238 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +174 B (+4.61%) | 3.69 kB → 3.86 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +48 B (+0.20%) | 23.73 kB → 23.78 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +12 B (+0.05%) | 22.35 kB → 22.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +2 B (+0.01%) | 15.72 kB → 15.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +2 B (+0.01%) | 24.83 kB → 24.83 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dab0t8iz.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Byat_jru.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+231 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +167 B (+4.63%) | 3.52 kB → 3.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +48 B (+0.20%) | 23.11 kB → 23.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +12 B (+0.05%) | 22.44 kB → 22.45 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +2 B (+0.01%) | 15.4 kB → 15.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/importers/ynab5.ts` | 📈 +2 B (+0.01%) | 24.23 kB → 24.23 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+231 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->