### PR TITLE
Fix API password login when OpenID is configured alongside password auth

### DIFF
--- a/packages/sync-server/src/account-db.js
+++ b/packages/sync-server/src/account-db.js
@@ -64,11 +64,7 @@ export function getLoginMethod(req) {
     (req.body || { loginMethod: null }).loginMethod &&
     config.get('allowedLoginMethods').includes(req.body.loginMethod)
   ) {
-    const accountDb = getAccountDb();
-    const row = accountDb.first('SELECT method FROM auth WHERE method = ?', [
-      req.body.loginMethod,
-    ]);
-    if (row) return req.body.loginMethod;
+    return req.body.loginMethod;
   }
 
   //BY-PASS ANY OTHER CONFIGURATION TO ENSURE HEADER AUTH

--- a/packages/sync-server/src/app-account.test.js
+++ b/packages/sync-server/src/app-account.test.js
@@ -206,10 +206,10 @@ describe('getLoginMethod()', () => {
     expect(getLoginMethod(req)).toBe('password');
   });
 
-  it('ignores a client-requested method that is not in DB', () => {
+  it('honors a client-requested allowed method even when it has no auth row', () => {
     insertAuthRow('openid', 1);
     const req = { body: { loginMethod: 'password' } };
-    expect(getLoginMethod(req)).toBe('openid');
+    expect(getLoginMethod(req)).toBe('password');
   });
 
   it('falls back to config default when auth table is empty and no req', () => {
@@ -253,6 +253,32 @@ describe('/login', () => {
 
     expect(res.statusCode).toEqual(400);
     expect(res.body).toHaveProperty('reason', 'invalid-password');
+  });
+
+  it('should route an explicit password login to the password handler when OpenID is the only configured method', async () => {
+    // Simulate an OpenID-only env bootstrap (app.ts run()): only an openid row exists.
+    insertAuthRow('openid', 1);
+
+    const res = await request(app)
+      .post('/login')
+      .send({ loginMethod: 'password', password: 'whatever' });
+
+    // The request must NOT be diverted into the OpenID redirect flow.
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.reason).not.toEqual('Invalid redirect URL');
+    expect(res.body.reason).toEqual('invalid-password');
+  });
+
+  it('should not silently fall back to password when openid is explicitly requested but not configured', async () => {
+    await bootstrapPassword('testpassword');
+    // only a password row exists; no openid row
+
+    const res = await request(app)
+      .post('/login')
+      .send({ loginMethod: 'openid', returnUrl: 'http://localhost/callback' });
+
+    expect(res.statusCode).toEqual(400);
+    expect(res.body.reason).toEqual('Invalid redirect URL');
   });
 });
 

--- a/upcoming-release-notes/fix-password-login-openid.md
+++ b/upcoming-release-notes/fix-password-login-openid.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lorenzozanee]
+---
+
+Route an explicit password login request to the password handler instead of the OpenID redirect flow when OpenID is configured via environment variables.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Password login via the Node.js API fails with `Invalid redirect URL` on servers configured with OpenID through environment variables, even when password auth is allowed. The request is sent with an explicit `loginMethod: 'password'`, but the server's login-method routing discards it when no password auth row exists, falling through to the OpenID flow, which requires a `returnUrl` that a password request never supplies.

This change makes routing honor an explicitly requested method whenever it is allowed by the server configuration. Each method validates its own readiness: password login reports `invalid-password` when no password hash is configured, and the OpenID handler keeps validating the redirect URL and provider configuration.

## Related issue(s)

Fixes #7241

## Testing

Added regression tests covering an explicit password login on a server where OpenID is the only configured method, and explicit OpenID requests on a password-only server.

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->