### PR TITLE
[AI] docs(api): drop the orphaned Payee Rule type

### DIFF
--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -70,7 +70,6 @@ import APIList from './APIList';
 <APIList title="Rules" sections={[
 "ConditionOrAction",
 "Rule",
-"Payee rule",
 "getRules",
 "getPayeeRules",
 "createRule",
@@ -653,10 +652,6 @@ await updateTag(id, { color: '#00ff00' });
 
 <StructType fields={objects.rule} />
 
-#### Payee Rule
-
-<StructType fields={objects.payeeRule} />
-
 #### Methods
 
 #### `getRules`
@@ -669,7 +664,7 @@ Get all rules.
 
 <Method name="getPayeeRules" args={[{ name: 'payeeId', type: "id" }]} returns="Promise<Rule[]>" />
 
-Get all rules associated with `payeeId`.
+Get all rules associated with `payeeId`. These are ordinary `Rule` objects, in the same shape `getRules` returns. A rule is associated with a payee when one of its conditions or actions has a `payee` field referencing that id, so the returned rules have no `payee_id` property.
 
 #### `createRule`
 

--- a/packages/docs/docs/api/types.jsx
+++ b/packages/docs/docs/api/types.jsx
@@ -458,33 +458,6 @@ export const objects = {
     { name: 'actions', type: 'ConditionOrAction[]' },
   ],
 
-  payeeRule: [
-    { name: 'id', type: types.id },
-    { name: 'payee_id', type: types.id, required: true },
-    {
-      name: 'stage',
-      type: 'string',
-      required: true,
-      description: (
-        <span>
-          Must be one of <code>pre</code>, <code>default</code>, or{' '}
-          <code>post</code>.
-        </span>
-      ),
-    },
-    {
-      name: 'conditionsOp',
-      type: 'string',
-      description: (
-        <span>
-          Must be one of <code>and</code> or <code>or</code>.
-        </span>
-      ),
-    },
-    { name: 'conditions', type: 'ConditionOrAction[]' },
-    { name: 'actions', type: 'ConditionOrAction[]' },
-  ],
-
   budgetFile: [
     {
       name: 'name',


### PR DESCRIPTION
## Description

The API reference documented a `Payee Rule` type with a required `payee_id` field. No API method returns an object with that field, and none accepts a `payeeRule`, so the type was documentation-only.

`getPayeeRules` returns ordinary serialized `Rule` objects: `packages/loot-core/src/server/payees/app.ts` returns `rules.getRulesForPayee(id).map(rule => rule.serialize())` typed as `Promise<RuleEntity[]>`, and `Rule.serialize()` emits exactly `{ id, stage, conditionsOp, conditions, actions }`. The reference already agreed, annotating `getPayeeRules` as `returns="Promise<Rule[]>"` two lines below that struct.

This PR:

- removes the `payeeRule` entry from `types.jsx` and the `#### Payee Rule` section from `reference.md`
- removes `"Payee rule"` from the Rules `APIList`, whose `#payee-rule` anchor would otherwise point at a deleted heading
- explains the association under `getPayeeRules` instead: a rule belongs to a payee when one of its conditions or actions has a `payee` field referencing that id, so there is no `payee_id` on the returned rules

Context on why this matters in practice: I maintain an MCP server on top of `@actual-app/api` and implemented the payee-rules lookup with a `rule.payee_id === payeeId` filter taken from this table. The field does not exist, so the filter matched nothing and the tool returned an empty list for every payee for months.

Researched and drafted with Claude Code; the diff was reviewed and verified by me.

## Related issue(s)

Closes #8697

Related to #8682, which reports the wrong `stage` value list on the sibling `Rule` table. Kept separate deliberately so a one-line wording fix does not wait on this one. The two touch different blocks of `types.jsx` and merge in either order.

## Testing

Docs-only change, verified on this PR's Netlify deploy preview (https://deploy-preview-8698.www.actualbudget.org/docs/api/reference/):

- the `Payee Rule` heading and struct table are gone
- the Rules navigation list no longer offers a dead `#payee-rule` link
- the new `getPayeeRules` paragraph renders correctly

Also confirmed there are no remaining references to `objects.payeeRule` anywhere in the repo, and that `oxfmt --check packages/docs/docs/api/types.jsx` passes against `.oxfmtrc.json`.

## Checklist

- [ ] Release notes added (see link above) — not applicable: every changed file is under `packages/docs/`, which `release-notes.yml` exempts via `only_docs`. `check-release-notes` passes.
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->