### PR TITLE
[AI] Fix scheduled split transfer previews

### DIFF
--- a/packages/desktop-client/e2e/schedules.test.ts
+++ b/packages/desktop-client/e2e/schedules.test.ts
@@ -173,6 +173,7 @@ test.describe('Schedules', () => {
     });
 
     await expect(previewTransfer).toHaveCount(1);
+    await expect(previewTransfer.getByTestId('category')).toContainText('Due');
     await expect(previewTransfer.getByTestId('debit')).toHaveText('');
     await expect(previewTransfer.getByTestId('credit')).toHaveText('50.00');
   });

--- a/packages/desktop-client/e2e/schedules.test.ts
+++ b/packages/desktop-client/e2e/schedules.test.ts
@@ -85,6 +85,98 @@ test.describe('Schedules', () => {
     await expect(page).toMatchThemeScreenshots();
   });
 
+  test('shows a scheduled split transfer in its destination account', async () => {
+    await page.evaluate(async () => {
+      const $send = (
+        window as unknown as {
+          $send: <T>(type: string, args?: unknown) => Promise<T>;
+        }
+      ).$send;
+      const query = <T>(
+        table: string,
+        filterExpressions: unknown[],
+        selectExpressions: string[],
+      ) =>
+        $send<{ data: T[] }>('query', {
+          table,
+          tableOptions: {},
+          filterExpressions,
+          selectExpressions,
+          groupExpressions: [],
+          orderExpressions: [],
+          calculation: false,
+          rawMode: false,
+          withDead: false,
+          validateRefs: true,
+          limit: null,
+          offset: null,
+        });
+
+      const {
+        data: [destinationAccount],
+      } = await query<{ id: string }>(
+        'accounts',
+        [{ name: 'Ally Savings' }],
+        ['id'],
+      );
+      const {
+        data: [destinationPayee],
+      } = await query<{ id: string }>(
+        'payees',
+        [{ transfer_acct: destinationAccount.id }],
+        ['id'],
+      );
+      const {
+        data: [schedule],
+      } = await query<{ rule: string }>(
+        'schedules',
+        [{ name: 'Phone bills' }],
+        ['rule'],
+      );
+      const rule = await $send<{
+        actions: unknown[];
+        conditions: unknown[];
+        conditionsOp: 'and' | 'or';
+        id: string;
+        stage: 'pre' | 'post' | null;
+      }>('rule-get', { id: schedule.rule });
+
+      await $send('rule-update', {
+        ...rule,
+        actions: [
+          ...rule.actions,
+          {
+            op: 'set-split-amount',
+            value: -7_000,
+            options: { splitIndex: 1, method: 'fixed-amount' },
+          },
+          {
+            op: 'set-split-amount',
+            value: null,
+            options: { splitIndex: 2, method: 'remainder' },
+          },
+          {
+            op: 'set',
+            field: 'payee',
+            value: destinationPayee.id,
+            options: { splitIndex: 2 },
+          },
+        ],
+      });
+    });
+
+    const destinationAccountPage =
+      await navigation.goToAccountPage('Ally Savings');
+    const previewTransfer = destinationAccountPage.transactionTableRow.filter({
+      has: page.getByTestId('schedule-icon'),
+      hasText: 'Bank of America',
+    });
+
+    await expect(previewTransfer).toHaveCount(1);
+    await expect(previewTransfer.getByTestId('debit')).toHaveText('');
+    await expect(previewTransfer.getByTestId('credit')).toHaveText('50.00');
+  });
+
   test('creates two new schedules, posts both transactions and later completes one', async () => {
     // Adding two schedules with the same payee and account and amount, mimicking two different subscriptions
     let scheduleEditModal = await schedulesPage.addNewSchedule();

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.test.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.test.ts
@@ -117,6 +117,7 @@ describe('inverseBasedOnAccount', () => {
       amount: -100_000,
       date: '2026-08-15',
       payee: 'employer',
+      category: 'upcoming',
       is_parent: true,
       schedule: 'paycheck',
     },
@@ -159,10 +160,10 @@ describe('inverseBasedOnAccount', () => {
         account: savings.id,
         amount: 40_000,
         payee: 'to-checking',
+        category: 'upcoming',
         inversed: true,
       }),
     ]);
-    expect(result.transactions[0]).not.toHaveProperty('category');
     expect(result.transactions[0]).not.toHaveProperty('is_child');
     expect(result.transactions[0]).not.toHaveProperty('parent_id');
     expect(result.runningBalances.get('preview/savings-transfer')).toBe(

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.test.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.test.ts
@@ -1,0 +1,194 @@
+import type {
+  AccountEntity,
+  PayeeEntity,
+  ScheduleEntity,
+  TransactionEntity,
+} from '@actual-app/core/types/models';
+import { describe, expect, test } from 'vitest';
+
+import {
+  inverseBasedOnAccount,
+  isScheduleRelevantToAccount,
+} from './useAccountPreviewTransactions';
+
+function makeAccount(id: string): AccountEntity {
+  return {
+    id,
+    name: id,
+    offbudget: 0,
+    closed: 0,
+    sort_order: 0,
+    last_reconciled: null,
+    tombstone: 0,
+    account_id: null,
+    bank: null,
+    bankName: null,
+    bankId: null,
+    mask: null,
+    official_name: null,
+    balance_current: null,
+    balance_available: null,
+    balance_limit: null,
+    account_sync_source: null,
+    last_sync: null,
+    bank_sync_status: null,
+  };
+}
+
+const checking = makeAccount('checking');
+const savings = makeAccount('savings');
+const unrelated = makeAccount('unrelated');
+
+const payees: PayeeEntity[] = [
+  { id: 'employer', name: 'Employer' },
+  { id: 'insurance', name: 'Insurance' },
+  { id: 'to-checking', name: 'Transfer: checking', transfer_acct: checking.id },
+  { id: 'to-savings', name: 'Transfer: savings', transfer_acct: savings.id },
+];
+
+function getPayeeByTransferAccount(accountId?: string | null) {
+  return payees.find(payee => payee.transfer_acct === accountId) || null;
+}
+
+function getTransferAccountByPayee(payeeId?: string | null) {
+  const transferAccountId = payees.find(
+    payee => payee.id === payeeId,
+  )?.transfer_acct;
+  return (
+    [checking, savings, unrelated].find(
+      account => account.id === transferAccountId,
+    ) || null
+  );
+}
+
+function makeSplitSchedule(): ScheduleEntity {
+  return {
+    id: 'paycheck',
+    rule: 'paycheck-rule',
+    next_date: '2026-08-15',
+    completed: false,
+    posts_transaction: true,
+    tombstone: false,
+    _payee: 'employer',
+    _account: checking.id,
+    _amount: -100_000,
+    _amountOp: 'is',
+    _date: '2026-08-15',
+    _conditions: [],
+    _actions: [
+      {
+        op: 'set',
+        field: 'description',
+        value: 'to-savings',
+        options: { splitIndex: 2 },
+      },
+    ],
+  };
+}
+
+describe('isScheduleRelevantToAccount', () => {
+  test('includes a split schedule for its transfer destination', () => {
+    expect(
+      isScheduleRelevantToAccount({
+        accountId: savings.id,
+        schedule: makeSplitSchedule(),
+        getTransferAccountByPayee,
+      }),
+    ).toBe(true);
+  });
+
+  test('excludes a split schedule from unrelated accounts', () => {
+    expect(
+      isScheduleRelevantToAccount({
+        accountId: unrelated.id,
+        schedule: makeSplitSchedule(),
+        getTransferAccountByPayee,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('inverseBasedOnAccount', () => {
+  const parentId = 'preview/paycheck/2026-08-15';
+  const transactions: TransactionEntity[] = [
+    {
+      id: parentId,
+      account: checking.id,
+      amount: -100_000,
+      date: '2026-08-15',
+      payee: 'employer',
+      is_parent: true,
+      schedule: 'paycheck',
+    },
+    {
+      id: 'preview/deduction',
+      account: checking.id,
+      amount: -60_000,
+      date: '2026-08-15',
+      payee: 'insurance',
+      is_child: true,
+      parent_id: parentId,
+      schedule: 'paycheck',
+    },
+    {
+      id: 'preview/savings-transfer',
+      account: checking.id,
+      amount: -40_000,
+      date: '2026-08-15',
+      payee: 'to-savings',
+      category: 'old-category',
+      is_child: true,
+      parent_id: parentId,
+      schedule: 'paycheck',
+    },
+  ];
+
+  test('projects only the transfer child as a destination-account deposit', () => {
+    const result = inverseBasedOnAccount({
+      accountId: savings.id,
+      transactions,
+      startingBalance: 500_000,
+      runningBalances: new Map(),
+      getPayeeByTransferAccount,
+      getTransferAccountByPayee,
+    });
+
+    expect(result.transactions).toEqual([
+      expect.objectContaining({
+        id: 'preview/savings-transfer',
+        account: savings.id,
+        amount: 40_000,
+        payee: 'to-checking',
+        inversed: true,
+      }),
+    ]);
+    expect(result.transactions[0]).not.toHaveProperty('category');
+    expect(result.transactions[0]).not.toHaveProperty('is_child');
+    expect(result.transactions[0]).not.toHaveProperty('parent_id');
+    expect(result.runningBalances.get('preview/savings-transfer')).toBe(
+      540_000,
+    );
+  });
+
+  test('preserves the complete split in its source account', () => {
+    const runningBalances = new Map([[parentId, 400_000]]);
+    const result = inverseBasedOnAccount({
+      accountId: checking.id,
+      transactions,
+      startingBalance: 500_000,
+      runningBalances,
+      getPayeeByTransferAccount,
+      getTransferAccountByPayee,
+    });
+
+    expect(result.transactions.map(transaction => transaction.id)).toEqual(
+      transactions.map(transaction => transaction.id),
+    );
+    expect(result.transactions[2]).toMatchObject({
+      amount: -40_000,
+      is_child: true,
+      parent_id: parentId,
+    });
+    expect(result.runningBalances).toBe(runningBalances);
+  });
+});

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -204,12 +204,14 @@ export function isScheduleRelevantToAccount({
 
 function inverseTransferForAccount({
   accountId,
+  previewStatus,
   transaction,
   getPayeeByTransferAccount,
 }: Pick<
   InverseBasedOnAccountProps,
   'accountId' | 'getPayeeByTransferAccount'
 > & {
+  previewStatus?: TransactionEntity['category'];
   transaction: TransactionEntity;
 }): AccountPreviewTransaction {
   const {
@@ -227,6 +229,7 @@ function inverseTransferForAccount({
     amount: -transaction.amount,
     payee: getPayeeByTransferAccount(transaction.account)?.id || '',
     account: accountId || '',
+    ...(previewStatus != null && { category: previewStatus }),
   };
 }
 
@@ -241,6 +244,11 @@ export function inverseBasedOnAccount({
   transactions: TransactionEntity[];
   runningBalances: Map<TransactionEntity['id'], IntegerAmount>;
 } {
+  const parentPreviewStatuses = new Map(
+    transactions
+      .filter(transaction => transaction.is_parent)
+      .map(transaction => [transaction.id, transaction.category]),
+  );
   const mappedTransactions: AccountPreviewTransaction[] = transactions.flatMap(
     transaction => {
       if (transaction.account === accountId) {
@@ -261,6 +269,9 @@ export function inverseBasedOnAccount({
         .map(candidate =>
           inverseTransferForAccount({
             accountId,
+            previewStatus: candidate.parent_id
+              ? parentPreviewStatuses.get(candidate.parent_id)
+              : candidate.category,
             transaction: candidate,
             getPayeeByTransferAccount,
           }),

--- a/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
+++ b/packages/desktop-client/src/hooks/useAccountPreviewTransactions.ts
@@ -62,9 +62,11 @@ export function useAccountPreviewTransactions({
 
   const accountSchedulesFilter = useCallback(
     (schedule: ScheduleEntity) =>
-      !accountId ||
-      schedule._account === accountId ||
-      getTransferAccountByPayee(schedule._payee)?.id === accountId,
+      isScheduleRelevantToAccount({
+        accountId,
+        schedule,
+        getTransferAccountByPayee,
+      }),
     [accountId, getTransferAccountByPayee],
   );
 
@@ -152,7 +154,83 @@ type InverseBasedOnAccountProps = {
   ) => AccountEntity | null;
 };
 
-function inverseBasedOnAccount({
+type AccountPreviewTransaction = TransactionEntity & {
+  inversed: boolean;
+};
+
+type ScheduleRelevantToAccountProps = Pick<
+  InverseBasedOnAccountProps,
+  'accountId' | 'getTransferAccountByPayee'
+> & {
+  schedule: ScheduleEntity;
+};
+
+export function isScheduleRelevantToAccount({
+  accountId,
+  schedule,
+  getTransferAccountByPayee,
+}: ScheduleRelevantToAccountProps): boolean {
+  if (!accountId) {
+    return true;
+  }
+
+  if (
+    schedule._account === accountId ||
+    getTransferAccountByPayee(schedule._payee)?.id === accountId
+  ) {
+    return true;
+  }
+
+  return schedule._actions.some(action => {
+    if (
+      action.op !== 'set' ||
+      (action.field !== 'payee' && action.field !== 'description') ||
+      !action.options?.splitIndex
+    ) {
+      return false;
+    }
+
+    if (
+      action.options.formula != null ||
+      action.options.template != null ||
+      typeof action.value !== 'string'
+    ) {
+      return true;
+    }
+
+    return getTransferAccountByPayee(action.value)?.id === accountId;
+  });
+}
+
+function inverseTransferForAccount({
+  accountId,
+  transaction,
+  getPayeeByTransferAccount,
+}: Pick<
+  InverseBasedOnAccountProps,
+  'accountId' | 'getPayeeByTransferAccount'
+> & {
+  transaction: TransactionEntity;
+}): AccountPreviewTransaction {
+  const {
+    category: _category,
+    is_child: _isChild,
+    is_parent: _isParent,
+    parent_id: _parentId,
+    subtransactions: _subtransactions,
+    ...standaloneTransaction
+  } = transaction;
+
+  return {
+    ...standaloneTransaction,
+    inversed: true,
+    amount: -transaction.amount,
+    payee: getPayeeByTransferAccount(transaction.account)?.id || '',
+    account: accountId || '',
+  };
+}
+
+export function inverseBasedOnAccount({
   accountId,
   transactions,
   runningBalances,
@@ -163,31 +241,32 @@ function inverseBasedOnAccount({
   transactions: TransactionEntity[];
   runningBalances: Map<TransactionEntity['id'], IntegerAmount>;
 } {
-  const mappedTransactions = transactions.map(transaction => {
-    const inverse = transaction.account !== accountId;
-    const subtransactions = transaction.subtransactions?.map(st => ({
-      ...st,
-      amount: inverse ? -st.amount : st.amount,
-      payee:
-        (inverse ? getPayeeByTransferAccount(st.account)?.id : st.payee) || '',
-      account: inverse
-        ? getTransferAccountByPayee(st.payee)?.id || ''
-        : st.account,
-    }));
-    return {
-      inversed: inverse,
-      ...transaction,
-      amount: inverse ? -transaction.amount : transaction.amount,
-      payee:
-        (inverse
-          ? getPayeeByTransferAccount(transaction.account)?.id
-          : transaction.payee) || '',
-      account: inverse
-        ? getTransferAccountByPayee(transaction.payee)?.id || ''
-        : transaction.account,
-      ...(subtransactions && { subtransactions }),
-    };
-  });
+  const mappedTransactions: AccountPreviewTransaction[] = transactions.flatMap(
+    transaction => {
+      if (transaction.account === accountId) {
+        return [{ inversed: false, ...transaction }];
+      }
+
+      const candidates = transaction.subtransactions
+        ? transaction.subtransactions
+        : transaction.is_parent
+          ? []
+          : [transaction];
+
+      return candidates
+        .filter(
+          candidate =>
+            getTransferAccountByPayee(candidate.payee)?.id === accountId,
+        )
+        .map(candidate =>
+          inverseTransferForAccount({
+            accountId,
+            transaction: candidate,
+            getPayeeByTransferAccount,
+          }),
+        );
+    },
+  );
 
   // Recalculate running balances if any transaction was inversed.
   // This is necessary because the running balances are calculated based on the

--- a/packages/desktop-client/src/hooks/useSchedules.test.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { liveQuery } from '#queries/liveQuery';
 import type { LiveQuery } from '#queries/liveQuery';
 
-import { useSchedules } from './useSchedules';
+import { getSchedulesQuery, useSchedules } from './useSchedules';
 
 vi.mock('#queries/liveQuery', () => ({
   liveQuery: vi.fn(),
@@ -78,5 +78,19 @@ describe('useSchedules', () => {
 
     expect(calls[0].unsubscribe).toHaveBeenCalled();
     expect(calls[1].unsubscribe).toHaveBeenCalled();
+  });
+});
+
+describe('getSchedulesQuery', () => {
+  it('loads split schedules for concrete account views', () => {
+    const query = getSchedulesQuery('savings');
+
+    expect(query.state.filterExpressions).toContainEqual({
+      $or: [
+        { _account: 'savings' },
+        { '_payee.transfer_acct': 'savings' },
+        { _has_splits: true },
+      ],
+    });
   });
 });

--- a/packages/desktop-client/src/hooks/useSchedules.ts
+++ b/packages/desktop-client/src/hooks/useSchedules.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { q } from '@actual-app/core/shared/query';
-import type { Query } from '@actual-app/core/shared/query';
+import type { ObjectExpression, Query } from '@actual-app/core/shared/query';
 import {
   getHasTransactionsQuery,
   getStatus,
@@ -164,8 +164,19 @@ export function getSchedulesQuery(
     if (view === 'uncategorized') {
       query = query.filter({ next_date: null });
     } else {
+      const scheduleFilters: ObjectExpression[] = [
+        filterByAccount,
+        filterByPayee,
+      ].filter(filter => filter !== null);
+
+      if (view !== 'onbudget' && view !== 'offbudget') {
+        scheduleFilters.push({
+          _has_splits: true,
+        });
+      }
+
       query = query.filter({
-        $or: [filterByAccount, filterByPayee],
+        $or: scheduleFilters,
       });
     }
   }

--- a/packages/loot-core/src/server/aql/schema/index.ts
+++ b/packages/loot-core/src/server/aql/schema/index.ts
@@ -124,6 +124,7 @@ export const schema = {
     _date: f('json/fallback'),
     _conditions: f('json'),
     _actions: f('json'),
+    _has_splits: f('boolean'),
   },
   rules: {
     id: f('id'),
@@ -344,6 +345,11 @@ export const schemaConfig: SchemaConfig = {
           _date: `json_extract(_rules.conditions, _paths.date || '.value')`,
           _conditions: '_rules.conditions',
           _actions: '_rules.actions',
+          _has_splits: `EXISTS (
+            SELECT 1
+            FROM json_each(_rules.actions) action
+            WHERE json_extract(action.value, '$.options.splitIndex') > 0
+          )`,
         });
 
         return `

--- a/packages/loot-core/src/server/db/types/index.ts
+++ b/packages/loot-core/src/server/db/types/index.ts
@@ -353,6 +353,7 @@ export type DbViewSchedule = {
   _date: JsonString;
   _conditions: JsonString;
   _actions: JsonString;
+  _has_splits: 0 | 1;
 };
 
 export type DbTag = {

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -162,6 +162,52 @@ describe('schedule app', () => {
       ).rejects.toThrow(/date condition is required/);
     });
 
+    it('identifies schedules with split actions', async () => {
+      const id = await createSchedule({
+        conditions: [{ op: 'is', field: 'date', value: '2020-12-20' }],
+      });
+      const { data: ruleId } = await aqlQuery(
+        q('schedules').filter({ id }).calculate('rule'),
+      );
+
+      await updateRule({
+        id: ruleId,
+        actions: [
+          {
+            op: 'set',
+            field: 'payee',
+            value: 'destination-payee',
+            options: { splitIndex: 0 },
+          },
+          { op: 'link-schedule', value: id },
+        ],
+      });
+
+      const { data: parentActionMatches } = await aqlQuery(
+        q('schedules').filter({ _has_splits: true }).select(['id']),
+      );
+      expect(parentActionMatches).toEqual([]);
+
+      await updateRule({
+        id: ruleId,
+        actions: [
+          {
+            op: 'set',
+            field: 'payee',
+            value: 'destination-payee',
+            options: { splitIndex: 1 },
+          },
+          { op: 'link-schedule', value: id },
+        ],
+      });
+
+      const { data: splitActionMatches } = await aqlQuery(
+        q('schedules').filter({ _has_splits: true }).select(['id']),
+      );
+
+      expect(splitActionMatches).toEqual([{ id }]);
+    });
+
     it('trims schedule names when creating and updating schedules', async () => {
       const id = await createSchedule({
         schedule: { name: '  Rent  ' },

--- a/packages/loot-core/src/types/models/schedule.ts
+++ b/packages/loot-core/src/types/models/schedule.ts
@@ -1,6 +1,6 @@
 import type { AccountEntity } from './account';
 import type { PayeeEntity } from './payee';
-import type { RuleConditionEntity, RuleEntity } from './rule';
+import type { RuleActionEntity, RuleConditionEntity, RuleEntity } from './rule';
 
 export type RecurPattern = {
   value: number;
@@ -38,7 +38,8 @@ export type ScheduleEntity = {
   _amountOp: string;
   _date: RecurConfig | string;
   _conditions: RuleConditionEntity[];
-  _actions: Array<{ op: unknown }>;
+  _actions: RuleActionEntity[];
+  _has_splits?: boolean;
 };
 
 export type DiscoverScheduleEntity = {

--- a/upcoming-release-notes/fix-scheduled-split-transfer-previews.md
+++ b/upcoming-release-notes/fix-scheduled-split-transfer-previews.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [JerryNee]
+---
+
+Show upcoming split transfers as deposits in their destination accounts


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

This PR fixes scheduled split transfers not appearing as upcoming transactions in their destination accounts.

Account-scoped schedule queries previously considered only the schedule’s source account and direct transfer payee. Because split transfer destinations are stored in rule actions, those schedules were excluded before their preview transactions were generated.

This change:

- Adds a queryable flag for identifying schedules with split actions.
- Loads split schedules as candidates for concrete account views.
- Filters candidates against the actual split transfer destination.
- Projects the matching transfer child as a standalone deposit in the destination account.
- Preserves the preview status and recalculates the running balance correctly.
- Adds unit, database integration, and Playwright coverage for the complete workflow.

**AI disclosure:** OpenAI Codex assisted with the implementation and test development for this PR. The resulting change was verified with local unit, integration, and Playwright tests, as well as the full GitHub CI suite.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->
Fixes #7822

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->
- Added unit tests for split schedule filtering and destination-account projection.
- Added an AQL integration test for detecting split actions.
- Added a Playwright test verifying a $50 scheduled deposit in the destination account.
- Ran yarn typecheck and yarn lint:fix locally.
- All GitHub CI checks passed.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 36 | 13.1 MB → 13.11 MB (+5.38 kB) | +0.04%
loot-core | 1 | 4.63 MB → 4.63 MB (+216 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+214 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
36 | 13.1 MB → 13.11 MB (+5.38 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useAccountPreviewTransactions.ts` | 📈 +1.07 kB (+30.04%) | 3.55 kB → 4.62 kB
`src/hooks/useSchedules.ts` | 📈 +182 B (+5.62%) | 3.16 kB → 3.34 kB
`locale/de.json` | 📈 +4.14 kB (+2.31%) | 179.29 kB → 183.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/de.js | 179.29 kB → 183.43 kB (+4.14 kB) | +2.31%
static/js/PayeeRuleCountLabel.js | 11.74 kB → 12.81 kB (+1.07 kB) | +9.08%
static/js/Value.js | 2.03 MB → 2.03 MB (+182 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 762.13 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/ReportRouter.js | 1.4 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.15 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/chart-theme.js | 670.28 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 236.63 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 171.84 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.57 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.66 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.93 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+216 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +216 B (+2.14%) | 9.87 kB → 10.08 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.88PhXbQ3.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.7rV9_5dh.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+214 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +214 B (+2.18%) | 9.58 kB → 9.79 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+214 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->