### PR TITLE
[AI] fix(sync): receive only the latest timestamp to stop counter overflow

### DIFF
--- a/packages/loot-core/src/server/sync/index.ts
+++ b/packages/loot-core/src/server/sync/index.ts
@@ -446,9 +446,31 @@ export const applyMessages = sequential(async (messages: Message[]) => {
 
 export function receiveMessages(messages: Message[]): Promise<Message[]> {
   try {
-    messages.forEach(msg => {
-      Timestamp.recv(msg.timestamp);
-    });
+    // Receive only the latest timestamp. The clock lands in the same place and
+    // the drift check still sees the furthest-ahead message, but the 16-bit
+    // counter advances once per batch instead of once per message. Per-message
+    // `recv` overflows that counter on a large sync when `Date.now()` is coarse
+    // (Firefox rounds it to 100ms under resistFingerprinting, which LibreWolf
+    // enables by default).
+    //
+    // Rank on millis and counter, the fields `recv` reads. The serialized form
+    // sorts a year-10000 timestamp below every other one, which would let it
+    // skip the drift check: `toISOString` writes it `+010000-…`, and `+` sorts
+    // under the digits.
+    let latest = null;
+    for (const { timestamp } of messages) {
+      if (
+        latest === null ||
+        timestamp.millis() > latest.millis() ||
+        (timestamp.millis() === latest.millis() &&
+          timestamp.counter() > latest.counter())
+      ) {
+        latest = timestamp;
+      }
+    }
+    if (latest !== null) {
+      Timestamp.recv(latest);
+    }
   } catch (e) {
     if (e instanceof Timestamp.ClockDriftError) {
       throw new SyncError('clock-drift');

--- a/packages/loot-core/src/server/sync/sync.test.ts
+++ b/packages/loot-core/src/server/sync/sync.test.ts
@@ -9,7 +9,13 @@ import * as mockSyncServer from '#server/tests/mockSyncServer';
 import * as encoder from './encoder';
 import { isError } from './utils';
 
-import { applyMessages, fullSync, sendMessages, setSyncingMode } from './index';
+import {
+  applyMessages,
+  fullSync,
+  receiveMessages,
+  sendMessages,
+  setSyncingMode,
+} from './index';
 
 beforeEach(() => {
   mockSyncServer.reset();
@@ -149,6 +155,58 @@ describe('Sync', () => {
     if (isError(result)) throw result.error;
     expect(result.messages.length).toBe(2);
     expect(mockSyncServer.getMessages().length).toBe(3);
+  });
+
+  it('should advance the clock once per received batch', async () => {
+    // `Date.now()` is frozen here, standing in for the 100ms rounding Firefox
+    // applies under resistFingerprinting. The counter only resets when
+    // `Date.now()` advances, so one tick per message overflowed its 16 bits
+    // once a sync carried more than 65535 of them.
+    const node = '0000testinguuid2';
+    const base = Date.parse('1970-01-02T00:00:00.000Z');
+
+    const messages = [];
+    for (let i = 0; i < 100; i++) {
+      messages.push({
+        dataset: 'transactions',
+        row: 'foo',
+        column: 'amount',
+        value: 'N:1',
+        timestamp: Timestamp.parse(
+          `${new Date(base + i).toISOString()}-0000-${node}`,
+        ),
+      });
+    }
+
+    await receiveMessages(messages);
+
+    expect(getClock().timestamp.counter()).toBeLessThanOrEqual(1);
+
+    // The clock must still sort above every timestamp it received.
+    const latest = messages[messages.length - 1].timestamp.toString();
+    expect(getClock().timestamp.toString() > latest).toBe(true);
+  });
+
+  it('should reject a batch holding a far-future timestamp', () => {
+    // `toISOString` writes years above 9999 as `+010000-…`, which sorts below
+    // every normal timestamp. The batch maximum must not rank it last, which
+    // would let it skip the clock drift check.
+    const message = (millis: number) => ({
+      dataset: 'transactions',
+      row: 'foo',
+      column: 'amount',
+      value: 'N:1',
+      timestamp: Timestamp.parse(
+        `${new Date(millis).toISOString()}-0000-0000testinguuid2`,
+      ),
+    });
+
+    expect(() =>
+      receiveMessages([
+        message(Date.parse('1970-01-02T00:00:00.000Z')),
+        message(253402300800000),
+      ]),
+    ).toThrow(expect.objectContaining({ reason: 'clock-drift' }));
   });
 });
 

--- a/upcoming-release-notes/sync-timestamp-counter-overflow.md
+++ b/upcoming-release-notes/sync-timestamp-counter-overflow.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [StephenBrown2]
+---
+
+Fix "timestamp counter overflow" when a large sync is downloaded in a browser that reduces `Date.now()` precision, such as LibreWolf or Firefox with `privacy.resistFingerprinting` enabled


### PR DESCRIPTION

## Description

Loading a large budget fails with `Error: timestamp counter overflow` in LibreWolf, and in any Firefox with `privacy.resistFingerprinting` turned on. The sync downloads its messages, then throws before it applies them, so the budget never opens. This makes those browsers usable again. Some technical details were discovered by Opus, so I've asked for a brief technical explanation which follows below. I also left some of the explanitory comments in the code since this isn't a directly obvious issue.

### How it works

`receiveMessages` called `Timestamp.recv` once per message. Each call adds 1 to the clock counter when the logical clock does not move, and the counter only resets when `Date.now()` moves forward. The counter is 16 bits, so a sync of more than 65,537 messages inside one clock tick overflows it.

That loop only calls `recv`, so it runs millions of times per second. Normal browsers report `Date.now()` in 1ms steps, which is too short for the loop to reach 65,537. Fingerprint resistance rounds `Date.now()` down to 100ms steps, which gives the loop enough time to run out the counter. This is why the error needs both a hardened browser and a large budget.

Receiving only the highest incoming timestamp leaves the clock in the same state, because the new clock time is a maximum over all of them. The clock drift check still sees the message that is furthest ahead, so it keeps working. The counter now moves once per batch instead of once per message.

### AI usage disclosure

Written with Claude Code (Opus 5).

## Related issue(s)

Reported on Discord: <https://discord.com/channels/937901803608096828/1536312945687138314>

## Testing

You need a budget with more than about 65,000 sync messages and a browser that rounds `Date.now()`. In Firefox, open `about:config` and set `privacy.resistFingerprinting` to `true`. Reset the client with a fresh browser profile, then load the budget from the server: on `master` it stops with `timestamp counter overflow` after the download, and with this change it opens.

Two tests in `sync.test.ts` cover it. `Date.now()` is already frozen in the test environment, which is the condition the bug needs.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.7 MB → 13.78 MB (+87.88 kB) | +0.63%
loot-core | 1 | 4.65 MB → 4.65 MB (+203 B) | +0.00%
api | 2 | 3.86 MB → 3.86 MB (+203 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.7 MB → 13.78 MB (+87.88 kB) | +0.63%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/pl.json` | 📈 +128 B (+0.09%) | 136.39 kB → 136.51 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 166.98 kB (+87.76 kB) | +110.78%
static/js/pl.js | 136.39 kB → 136.51 kB (+128 B) | +0.09%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.68 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.38 MB | 0%
static/js/FormulaEditor.js | 767.24 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.48 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 258.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 178.66 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.79 kB | 0%
static/js/months.js | 575.1 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pt-BR.js | 178.74 kB | 0%
static/js/ru.js | 212.44 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 211.2 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.65 MB → 4.65 MB (+203 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +203 B (+1.31%) | 15.18 kB → 15.38 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.wB5aOoKO.js | 0 B → 4.65 MB (+4.65 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BASOiwtr.js | 4.65 MB → 0 B (-4.65 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.86 MB → 3.86 MB (+203 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +203 B (+1.35%) | 14.72 kB → 14.92 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.86 MB → 3.86 MB (+203 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->