### PR TITLE
Improve monte carlo contributions tab on mobile

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx
+++ b/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx
@@ -123,8 +123,8 @@ export function MonteCarloConfiguration({
         gap: 15,
       }}
     >
-      {/* Tab bar */}
-      <View style={{ flexDirection: 'row', gap: 5 }}>
+      {/* Tab bar; wraps onto extra lines on narrow screens */}
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 5 }}>
         <ModeButton
           selected={activeTab === 'plan'}
           onSelect={() => setActiveTab('plan')}

--- a/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloContributions.tsx
+++ b/packages/desktop-client/src/components/reports/reports/monte-carlo/MonteCarloContributions.tsx
@@ -94,135 +94,150 @@ export function MonteCarloContributions({
 
   return (
     <View style={{ gap: 10 }}>
-      <View style={{ ...styles.tableContainer, flex: 'unset' }}>
-        <TableHeader>
-          <Field width="flex" style={{ minWidth: 150 }}>
-            <Trans>Contribution name</Trans>
-          </Field>
-          <Field width="flex" style={{ minWidth: 160 }}>
-            <Trans>Into pot</Trans>
-          </Field>
-          <Field width="flex" style={{ minWidth: 100 }}>
-            <Trans>From age</Trans>
-          </Field>
-          <Field width="flex" style={{ minWidth: 100 }}>
-            <Trans>To age</Trans>
-          </Field>
-          <Field width="flex" style={{ minWidth: 140 }}>
-            <Trans>Amount (per year)</Trans>
-          </Field>
-          <Field width="flex" style={{ minWidth: 170 }} />
-          <Field width={36} />
-        </TableHeader>
+      <View
+        style={{
+          ...styles.tableContainer,
+          ...styles.horizontalScrollbar,
+          flex: 'unset',
+          // Scroll sideways when the columns' minimum widths don't fit,
+          // instead of clipping the end of the rows
+          overflowX: 'auto',
+        }}
+      >
+        <View style={{ minWidth: 'fit-content' }}>
+          <TableHeader>
+            <Field width="flex" style={{ minWidth: 150 }}>
+              <Trans>Contribution name</Trans>
+            </Field>
+            <Field width="flex" style={{ minWidth: 160 }}>
+              <Trans>Into pot</Trans>
+            </Field>
+            <Field width="flex" style={{ minWidth: 100 }}>
+              <Trans>From age</Trans>
+            </Field>
+            <Field width="flex" style={{ minWidth: 100 }}>
+              <Trans>To age</Trans>
+            </Field>
+            <Field width="flex" style={{ minWidth: 140 }}>
+              <Trans>Amount (per year)</Trans>
+            </Field>
+            <Field width="flex" style={{ minWidth: 170 }} />
+            <Field width={36} />
+          </TableHeader>
 
-        {contributions.map((contribution, index) => (
-          <Row
-            key={contribution.id}
-            collapsed
-            height={CONTRIBUTION_ROW_HEIGHT}
-            style={{
-              backgroundColor: theme.tableBackground,
-              ':hover': { backgroundColor: theme.tableRowBackgroundHover },
-            }}
-          >
-            <Field width="flex" style={{ minWidth: 150 }} truncate={false}>
-              <Input
-                defaultValue={contribution.name}
-                placeholder={t('Contribution {{number}}', {
-                  number: index + 1,
-                })}
-                aria-label={t('Contribution name')}
-                onUpdate={newName => {
-                  if (newName !== contribution.name) {
-                    updateContribution(contribution.id, { name: newName });
+          {contributions.map((contribution, index) => (
+            <Row
+              key={contribution.id}
+              collapsed
+              height={CONTRIBUTION_ROW_HEIGHT}
+              style={{
+                backgroundColor: theme.tableBackground,
+                ':hover': { backgroundColor: theme.tableRowBackgroundHover },
+              }}
+            >
+              <Field width="flex" style={{ minWidth: 150 }} truncate={false}>
+                <Input
+                  defaultValue={contribution.name}
+                  placeholder={t('Contribution {{number}}', {
+                    number: index + 1,
+                  })}
+                  aria-label={t('Contribution name')}
+                  onUpdate={newName => {
+                    if (newName !== contribution.name) {
+                      updateContribution(contribution.id, { name: newName });
+                    }
+                  }}
+                />
+              </Field>
+
+              <Field width="flex" style={{ minWidth: 160 }} truncate={false}>
+                <Select
+                  value={contribution.potId}
+                  onChange={value =>
+                    updateContribution(contribution.id, { potId: value })
                   }
-                }}
-              />
-            </Field>
+                  options={potOptions}
+                />
+              </Field>
 
-            <Field width="flex" style={{ minWidth: 160 }} truncate={false}>
-              <Select
-                value={contribution.potId}
-                onChange={value =>
-                  updateContribution(contribution.id, { potId: value })
-                }
-                options={potOptions}
-              />
-            </Field>
+              <Field width="flex" style={{ minWidth: 100 }} truncate={false}>
+                <MonteCarloNumberInput
+                  value={contribution.fromAge}
+                  aria-label={t('From age')}
+                  allowEmpty
+                  roundToInteger
+                  min={currentAge}
+                  max={contribution.toAge ?? targetAge}
+                  step={1}
+                  placeholder={t('Now')}
+                  onCommit={newValue =>
+                    updateContribution(contribution.id, { fromAge: newValue })
+                  }
+                />
+              </Field>
 
-            <Field width="flex" style={{ minWidth: 100 }} truncate={false}>
-              <MonteCarloNumberInput
-                value={contribution.fromAge}
-                aria-label={t('From age')}
-                allowEmpty
-                roundToInteger
-                min={currentAge}
-                max={contribution.toAge ?? targetAge}
-                step={1}
-                placeholder={t('Now')}
-                onCommit={newValue =>
-                  updateContribution(contribution.id, { fromAge: newValue })
-                }
-              />
-            </Field>
+              <Field width="flex" style={{ minWidth: 100 }} truncate={false}>
+                <MonteCarloNumberInput
+                  value={contribution.toAge}
+                  aria-label={t('To age')}
+                  allowEmpty
+                  roundToInteger
+                  min={contribution.fromAge ?? currentAge}
+                  max={targetAge}
+                  step={1}
+                  placeholder={t('End of plan')}
+                  onCommit={newValue =>
+                    updateContribution(contribution.id, { toAge: newValue })
+                  }
+                />
+              </Field>
 
-            <Field width="flex" style={{ minWidth: 100 }} truncate={false}>
-              <MonteCarloNumberInput
-                value={contribution.toAge}
-                aria-label={t('To age')}
-                allowEmpty
-                roundToInteger
-                min={contribution.fromAge ?? currentAge}
-                max={targetAge}
-                step={1}
-                placeholder={t('End of plan')}
-                onCommit={newValue =>
-                  updateContribution(contribution.id, { toAge: newValue })
-                }
-              />
-            </Field>
+              <Field width="flex" style={{ minWidth: 140 }} truncate={false}>
+                <FinancialInput
+                  value={contribution.annualAmount}
+                  aria-label={t('Amount (per year)')}
+                  onUpdate={value => {
+                    const newAmount = Math.min(MAX_AMOUNT, Math.max(0, value));
+                    if (newAmount !== contribution.annualAmount) {
+                      updateContribution(contribution.id, {
+                        annualAmount: newAmount,
+                      });
+                    }
+                  }}
+                />
+              </Field>
 
-            <Field width="flex" style={{ minWidth: 140 }} truncate={false}>
-              <FinancialInput
-                value={contribution.annualAmount}
-                aria-label={t('Amount (per year)')}
-                onUpdate={value => {
-                  const newAmount = Math.min(MAX_AMOUNT, Math.max(0, value));
-                  if (newAmount !== contribution.annualAmount) {
+              <Field width="flex" style={{ minWidth: 170 }} truncate={false}>
+                <LabeledCheckbox
+                  id={`contribution-inflation-${contribution.id}`}
+                  checked={contribution.adjustsWithInflation}
+                  onChange={event =>
                     updateContribution(contribution.id, {
-                      annualAmount: newAmount,
-                    });
+                      adjustsWithInflation: event.target.checked,
+                    })
                   }
-                }}
-              />
-            </Field>
+                >
+                  <Trans>Adjust by inflation</Trans>
+                </LabeledCheckbox>
+              </Field>
 
-            <Field width="flex" style={{ minWidth: 170 }} truncate={false}>
-              <LabeledCheckbox
-                id={`contribution-inflation-${contribution.id}`}
-                checked={contribution.adjustsWithInflation}
-                onChange={event =>
-                  updateContribution(contribution.id, {
-                    adjustsWithInflation: event.target.checked,
-                  })
-                }
+              <Field
+                width={36}
+                truncate={false}
+                style={{ alignItems: 'center' }}
               >
-                <Trans>Adjust by inflation</Trans>
-              </LabeledCheckbox>
-            </Field>
-
-            <Field width={36} truncate={false} style={{ alignItems: 'center' }}>
-              <Button
-                variant="bare"
-                aria-label={t('Remove contribution')}
-                onPress={() => removeContribution(contribution.id)}
-                style={{ padding: 6 }}
-              >
-                <SvgDelete width={12} height={12} />
-              </Button>
-            </Field>
-          </Row>
-        ))}
+                <Button
+                  variant="bare"
+                  aria-label={t('Remove contribution')}
+                  onPress={() => removeContribution(contribution.id)}
+                  style={{ padding: 6 }}
+                >
+                  <SvgDelete width={12} height={12} />
+                </Button>
+              </Field>
+            </Row>
+          ))}
+        </View>
       </View>
 
       <View style={{ flexDirection: 'row' }}>

--- a/upcoming-release-notes/monte-carlo-mobile-responsiveness.md
+++ b/upcoming-release-notes/monte-carlo-mobile-responsiveness.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MikesGlitch]
+---
+
+Fix the Monte Carlo analysis configuration tabs and contributions table overflowing on small screens


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

AI helped with this

Making the contributions tab responsive on mobiile

<img width="513" height="500" alt="image" src="https://github.com/user-attachments/assets/9a1dc431-19be-44e5-8538-b4856bd23d64" />


<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Reported here: #8571
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.32 MB → 13.32 MB (+306 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.32 MB → 13.32 MB (+306 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/reports/monte-carlo/MonteCarloContributions.tsx` | 📈 +285 B (+2.73%) | 10.21 kB → 10.49 kB
`src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx` | 📈 +21 B (+0.09%) | 23.99 kB → 24.01 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.42 MB → 1.42 MB (+306 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 241.43 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.08 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.25 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.vX9QgRcL.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->