### PR TITLE
[AI] Add payeeNameNormalization option to import transactions API

### DIFF
--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -279,7 +279,7 @@ This method has the following optional flags (passed as the `opts` object):
 - `defaultCleared`: whether imported transactions should be marked as cleared (defaults to `true`)
 - `dryRun`: if `true`, returns what would be added/updated without actually modifying the database (defaults to `false`)
 - `reimportDeleted`: if `true`, transactions that were previously imported and then deleted will be reimported; if `false`, they will be skipped (defaults to `true` for backward compatibility — note that the [file import UI](../transactions/importing.md#avoiding-duplicate-transactions) defaults to `false`)
-- `rawPayeeName`: if `true`, `payee_name` is used exactly as given when creating a payee, instead of being title-cased (defaults to `false`)
+- `payeeNameNormalization`: how `payee_name` is processed when creating a payee — `'title-case'` re-capitalizes each word, `'original'` keeps the name as given, apart from trimming surrounding whitespace (defaults to `'title-case'`)
 
 Example using opts:
 

--- a/packages/docs/docs/api/reference.md
+++ b/packages/docs/docs/api/reference.md
@@ -279,6 +279,7 @@ This method has the following optional flags (passed as the `opts` object):
 - `defaultCleared`: whether imported transactions should be marked as cleared (defaults to `true`)
 - `dryRun`: if `true`, returns what would be added/updated without actually modifying the database (defaults to `false`)
 - `reimportDeleted`: if `true`, transactions that were previously imported and then deleted will be reimported; if `false`, they will be skipped (defaults to `true` for backward compatibility — note that the [file import UI](../transactions/importing.md#avoiding-duplicate-transactions) defaults to `false`)
+- `rawPayeeName`: if `true`, `payee_name` is used exactly as given when creating a payee, instead of being title-cased (defaults to `false`)
 
 Example using opts:
 

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1653,6 +1653,7 @@ async function importTransactions({
       opts?.defaultCleared,
       false,
       opts?.reimportDeleted,
+      opts?.rawPayeeName,
     );
     return {
       errors: [],

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1643,16 +1643,14 @@ async function importTransactions({
     throw APIError('transactions-import: accountId must be an id');
   }
 
-  if (
-    opts?.payeeNameNormalization !== undefined &&
-    opts.payeeNameNormalization !== 'original' &&
-    opts.payeeNameNormalization !== 'title-case'
-  ) {
+  const payeeNameNormalization = opts?.payeeNameNormalization ?? 'title-case';
+  if (!bankSync.PAYEE_NAME_NORMALIZATIONS.includes(payeeNameNormalization)) {
     throw APIError(
-      `transactions-import: payeeNameNormalization must be 'original' or 'title-case', got '${String(opts.payeeNameNormalization)}'`,
+      `transactions-import: payeeNameNormalization must be one of ${bankSync.PAYEE_NAME_NORMALIZATIONS.join(
+        ', ',
+      )}, got '${String(payeeNameNormalization)}'`,
     );
   }
-  const payeeNameNormalization = opts?.payeeNameNormalization ?? 'title-case';
 
   try {
     const reconciled = await bankSync.reconcileTransactions(

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1658,13 +1658,12 @@ async function importTransactions({
     const reconciled = await bankSync.reconcileTransactions(
       accountId,
       transactions,
-      false,
-      true,
-      isPreview,
-      opts?.defaultCleared,
-      false,
-      opts?.reimportDeleted,
-      payeeNameNormalization === 'original',
+      {
+        isPreview,
+        defaultCleared: opts?.defaultCleared,
+        reimportDeleted: opts?.reimportDeleted,
+        payeeNameNormalization,
+      },
     );
     return {
       errors: [],

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1643,15 +1643,16 @@ async function importTransactions({
     throw APIError('transactions-import: accountId must be an id');
   }
 
-  const payeeNameNormalization = opts?.payeeNameNormalization ?? 'title-case';
   if (
-    payeeNameNormalization !== 'original' &&
-    payeeNameNormalization !== 'title-case'
+    opts?.payeeNameNormalization !== undefined &&
+    opts.payeeNameNormalization !== 'original' &&
+    opts.payeeNameNormalization !== 'title-case'
   ) {
     throw APIError(
-      `transactions-import: payeeNameNormalization must be 'original' or 'title-case', got '${String(opts?.payeeNameNormalization)}'`,
+      `transactions-import: payeeNameNormalization must be 'original' or 'title-case', got '${String(opts.payeeNameNormalization)}'`,
     );
   }
+  const payeeNameNormalization = opts?.payeeNameNormalization ?? 'title-case';
 
   try {
     const reconciled = await bankSync.reconcileTransactions(

--- a/packages/loot-core/src/server/accounts/app.ts
+++ b/packages/loot-core/src/server/accounts/app.ts
@@ -1643,6 +1643,16 @@ async function importTransactions({
     throw APIError('transactions-import: accountId must be an id');
   }
 
+  const payeeNameNormalization = opts?.payeeNameNormalization ?? 'title-case';
+  if (
+    payeeNameNormalization !== 'original' &&
+    payeeNameNormalization !== 'title-case'
+  ) {
+    throw APIError(
+      `transactions-import: payeeNameNormalization must be 'original' or 'title-case', got '${String(opts?.payeeNameNormalization)}'`,
+    );
+  }
+
   try {
     const reconciled = await bankSync.reconcileTransactions(
       accountId,
@@ -1653,7 +1663,7 @@ async function importTransactions({
       opts?.defaultCleared,
       false,
       opts?.reimportDeleted,
-      opts?.rawPayeeName,
+      payeeNameNormalization === 'original',
     );
     return {
       errors: [],

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -308,12 +308,7 @@ describe('Account sync', () => {
     await reconcileTransactions(
       acctId,
       [{ date: '2020-01-01', imported_id: 'finid-override' }],
-      false,
-      true,
-      false,
-      true,
-      false,
-      false,
+      { reimportDeleted: false },
     );
     const transactions2 = await getAllTransactions();
     expect(transactions2.length).toBe(1);
@@ -334,12 +329,7 @@ describe('Account sync', () => {
     await reconcileTransactions(
       acctId,
       [{ date: '2020-01-01', imported_id: 'finid-override2' }],
-      false,
-      true,
-      false,
-      true,
-      false,
-      true,
+      { reimportDeleted: true },
     );
     const transactions2 = await getAllTransactions();
     expect(transactions2.length).toBe(2);
@@ -364,12 +354,7 @@ describe('Account sync', () => {
     await reconcileTransactions(
       acctId,
       [{ date: '2020-01-01', imported_id: 'finid-precedence' }],
-      false,
-      true,
-      false,
-      true,
-      false,
-      false,
+      { reimportDeleted: false },
     );
     const transactions2 = await getAllTransactions();
     expect(transactions2.length).toBe(1);
@@ -740,8 +725,7 @@ describe('Account sync', () => {
             imported_id: 'something-else-entirely',
           },
         ],
-        false,
-        false,
+        { strictIdChecking: false },
       );
 
       payees = await getAllPayees();

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -142,6 +142,9 @@ describe('Account sync', () => {
     const payees = await getAllPayees();
     expect(payees.length).toBe(1);
     expect(payees[0].name).toBe('Nintendo Store New York Ny');
+
+    const transactions = await getAllTransactions();
+    expect(transactions[0].imported_payee).toBe('Nintendo Store New York Ny');
   });
 
   test("transactions-import keeps the payee name with payeeNameNormalization 'original'", async () => {
@@ -189,6 +192,9 @@ describe('Account sync', () => {
     const payees = await getAllPayees();
     expect(payees.length).toBe(1);
     expect(payees[0].name).toBe('Nintendo Store New York NY');
+
+    const transactions = await getAllTransactions();
+    expect(transactions[0].imported_payee).toBe('Nintendo Store New York NY');
   });
 
   test('transactions-import rejects an unknown payeeNameNormalization', async () => {

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -103,6 +103,44 @@ describe('Account sync', () => {
     );
   });
 
+  test('reconcile title-cases the payee name by default', async () => {
+    const { id } = await prepareDatabase();
+
+    await reconcileTransactions(id, [
+      {
+        date: '2020-01-02',
+        payee_name: 'Nintendo Store New York NY',
+        amount: 4133,
+      },
+    ]);
+
+    const payees = await getAllPayees();
+    expect(payees.length).toBe(1);
+    expect(payees[0].name).toBe('Nintendo Store New York Ny');
+  });
+
+  test('transactions-import passes rawPayeeName from opts', async () => {
+    const { id } = await prepareDatabase();
+
+    await accountsApp.handlers['transactions-import']({
+      accountId: id,
+      transactions: [
+        {
+          account: id,
+          date: '2020-01-02',
+          payee_name: 'Nintendo Store New York NY',
+          amount: 4133,
+        },
+      ],
+      isPreview: false,
+      opts: { rawPayeeName: true },
+    });
+
+    const payees = await getAllPayees();
+    expect(payees.length).toBe(1);
+    expect(payees[0].name).toBe('Nintendo Store New York NY');
+  });
+
   test('reconcile handles transactions with undefined fields', async () => {
     const { id: acctId } = await prepareDatabase();
 

--- a/packages/loot-core/src/server/accounts/sync.test.ts
+++ b/packages/loot-core/src/server/accounts/sync.test.ts
@@ -8,6 +8,7 @@ import { setSyncingMode } from '#server/sync';
 import { handlers } from '#server/tests/mockSyncServer';
 import { insertRule, loadRules } from '#server/transactions/transaction-rules';
 import * as monthUtils from '#shared/months';
+import type { ImportTransactionsOpts } from '#types/api-handlers';
 import type { SyncedPrefs } from '#types/prefs';
 
 import { app as accountsApp } from './app';
@@ -117,9 +118,12 @@ describe('Account sync', () => {
     const payees = await getAllPayees();
     expect(payees.length).toBe(1);
     expect(payees[0].name).toBe('Nintendo Store New York Ny');
+
+    const transactions = await getAllTransactions();
+    expect(transactions[0].imported_payee).toBe('Nintendo Store New York Ny');
   });
 
-  test('transactions-import passes rawPayeeName from opts', async () => {
+  test('transactions-import title-cases the payee name by default', async () => {
     const { id } = await prepareDatabase();
 
     await accountsApp.handlers['transactions-import']({
@@ -133,12 +137,82 @@ describe('Account sync', () => {
         },
       ],
       isPreview: false,
-      opts: { rawPayeeName: true },
+    });
+
+    const payees = await getAllPayees();
+    expect(payees.length).toBe(1);
+    expect(payees[0].name).toBe('Nintendo Store New York Ny');
+  });
+
+  test("transactions-import keeps the payee name with payeeNameNormalization 'original'", async () => {
+    const { id } = await prepareDatabase();
+
+    await accountsApp.handlers['transactions-import']({
+      accountId: id,
+      transactions: [
+        {
+          account: id,
+          date: '2020-01-02',
+          payee_name: 'Nintendo Store New York NY',
+          amount: 4133,
+        },
+      ],
+      isPreview: false,
+      opts: { payeeNameNormalization: 'original' },
     });
 
     const payees = await getAllPayees();
     expect(payees.length).toBe(1);
     expect(payees[0].name).toBe('Nintendo Store New York NY');
+
+    const transactions = await getAllTransactions();
+    expect(transactions[0].imported_payee).toBe('Nintendo Store New York NY');
+  });
+
+  test("transactions-import trims the payee name with payeeNameNormalization 'original'", async () => {
+    const { id } = await prepareDatabase();
+
+    await accountsApp.handlers['transactions-import']({
+      accountId: id,
+      transactions: [
+        {
+          account: id,
+          date: '2020-01-02',
+          payee_name: '  Nintendo Store New York NY  ',
+          amount: 4133,
+        },
+      ],
+      isPreview: false,
+      opts: { payeeNameNormalization: 'original' },
+    });
+
+    const payees = await getAllPayees();
+    expect(payees.length).toBe(1);
+    expect(payees[0].name).toBe('Nintendo Store New York NY');
+  });
+
+  test('transactions-import rejects an unknown payeeNameNormalization', async () => {
+    const { id } = await prepareDatabase();
+
+    await expect(
+      accountsApp.handlers['transactions-import']({
+        accountId: id,
+        transactions: [
+          {
+            account: id,
+            date: '2020-01-02',
+            payee_name: 'Nintendo Store New York NY',
+            amount: 4133,
+          },
+        ],
+        isPreview: false,
+        opts: {
+          payeeNameNormalization: 'titlecase',
+        } as unknown as ImportTransactionsOpts,
+      }),
+    ).rejects.toThrow(/payeeNameNormalization/);
+
+    expect(await getAllPayees()).toEqual([]);
   });
 
   test('reconcile handles transactions with undefined fields', async () => {

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -604,6 +604,7 @@ export async function reconcileTransactions(
   defaultCleared = true,
   updateDates = false,
   reimportDeleted?: boolean,
+  rawPayeeName = false,
 ): Promise<ReconcileTransactionsResult> {
   logger.log('Performing transaction reconciliation');
 
@@ -623,6 +624,7 @@ export async function reconcileTransactions(
     isBankSyncAccount,
     strictIdChecking,
     reimportDeleted,
+    rawPayeeName,
   );
 
   // Finally, generate & commit the changes
@@ -761,6 +763,7 @@ export async function matchTransactions(
   isBankSyncAccount = false,
   strictIdChecking = true,
   reimportDeletedOverride?: boolean,
+  rawPayeeName = false,
 ) {
   logger.log('Performing transaction reconciliation matching');
 
@@ -775,14 +778,9 @@ export async function matchTransactions(
 
   const hasMatched = new Set();
 
-  const transactionNormalization = isBankSyncAccount
-    ? normalizeBankSyncTransactions
-    : normalizeTransactions;
-
-  const { normalized, payeesToCreate } = await transactionNormalization(
-    transactions,
-    acctId,
-  );
+  const { normalized, payeesToCreate } = isBankSyncAccount
+    ? await normalizeBankSyncTransactions(transactions, acctId)
+    : await normalizeTransactions(transactions, acctId, { rawPayeeName });
 
   // The first pass runs the rules, and preps data for fuzzy matching
   const accounts: db.DbAccount[] = await db.getAccounts();

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -413,7 +413,8 @@ async function resolvePayee(trans, payeeName, payeesToCreate) {
   return trans.payee;
 }
 
-export type PayeeNameNormalization = 'original' | 'title-case';
+export const PAYEE_NAME_NORMALIZATIONS = ['original', 'title-case'] as const;
+export type PayeeNameNormalization = (typeof PAYEE_NAME_NORMALIZATIONS)[number];
 
 function normalizePayeeName(
   payeeName: string,
@@ -437,7 +438,9 @@ async function normalizeTransactions(
   acctId,
   {
     payeeNameNormalization = 'title-case',
-  }: { payeeNameNormalization?: PayeeNameNormalization } = {},
+  }: {
+    payeeNameNormalization?: PayeeNameNormalization;
+  } = {},
 ) {
   const payeesToCreate = new Map();
 
@@ -639,7 +642,7 @@ export async function reconcileTransactions(
     defaultCleared = true,
     updateDates = false,
     reimportDeleted,
-    payeeNameNormalization = 'title-case',
+    payeeNameNormalization,
   }: ReconcileTransactionsOptions = {},
 ): Promise<ReconcileTransactionsResult> {
   logger.log('Performing transaction reconciliation');
@@ -798,7 +801,7 @@ export async function matchTransactions(
     isBankSyncAccount = false,
     strictIdChecking = true,
     reimportDeleted: reimportDeletedOverride,
-    payeeNameNormalization = 'title-case',
+    payeeNameNormalization,
   }: MatchTransactionsOptions = {},
 ) {
   logger.log('Performing transaction reconciliation matching');

--- a/packages/loot-core/src/server/accounts/sync.ts
+++ b/packages/loot-core/src/server/accounts/sync.ts
@@ -413,10 +413,31 @@ async function resolvePayee(trans, payeeName, payeesToCreate) {
   return trans.payee;
 }
 
+export type PayeeNameNormalization = 'original' | 'title-case';
+
+function normalizePayeeName(
+  payeeName: string,
+  normalization: PayeeNameNormalization,
+): string {
+  switch (normalization) {
+    case 'original':
+      return payeeName;
+    case 'title-case':
+      return title(payeeName);
+    default:
+      normalization satisfies never;
+      throw new Error(
+        `Unknown payee name normalization: ${String(normalization)}`,
+      );
+  }
+}
+
 async function normalizeTransactions(
   transactions,
   acctId,
-  { rawPayeeName = false } = {},
+  {
+    payeeNameNormalization = 'title-case',
+  }: { payeeNameNormalization?: PayeeNameNormalization } = {},
 ) {
   const payeesToCreate = new Map();
 
@@ -454,7 +475,7 @@ async function normalizeTransactions(
       if (trimmed === '') {
         payee_name = null;
       } else {
-        payee_name = rawPayeeName ? trimmed : title(trimmed);
+        payee_name = normalizePayeeName(trimmed, payeeNameNormalization);
       }
     }
 
@@ -584,6 +605,19 @@ async function createNewPayees(payeesToCreate, addsAndUpdates) {
   });
 }
 
+export type MatchTransactionsOptions = {
+  isBankSyncAccount?: boolean;
+  strictIdChecking?: boolean;
+  reimportDeleted?: boolean;
+  payeeNameNormalization?: PayeeNameNormalization;
+};
+
+export type ReconcileTransactionsOptions = MatchTransactionsOptions & {
+  isPreview?: boolean;
+  defaultCleared?: boolean;
+  updateDates?: boolean;
+};
+
 export type ReconcileTransactionsResult = {
   added: string[];
   updated: string[];
@@ -598,13 +632,15 @@ export type ReconcileTransactionsResult = {
 export async function reconcileTransactions(
   acctId,
   transactions,
-  isBankSyncAccount = false,
-  strictIdChecking = true,
-  isPreview = false,
-  defaultCleared = true,
-  updateDates = false,
-  reimportDeleted?: boolean,
-  rawPayeeName = false,
+  {
+    isBankSyncAccount = false,
+    strictIdChecking = true,
+    isPreview = false,
+    defaultCleared = true,
+    updateDates = false,
+    reimportDeleted,
+    payeeNameNormalization = 'title-case',
+  }: ReconcileTransactionsOptions = {},
 ): Promise<ReconcileTransactionsResult> {
   logger.log('Performing transaction reconciliation');
 
@@ -618,14 +654,12 @@ export async function reconcileTransactions(
     transactionsStep1,
     transactionsStep2,
     transactionsStep3,
-  } = await matchTransactions(
-    acctId,
-    transactions,
+  } = await matchTransactions(acctId, transactions, {
     isBankSyncAccount,
     strictIdChecking,
     reimportDeleted,
-    rawPayeeName,
-  );
+    payeeNameNormalization,
+  });
 
   // Finally, generate & commit the changes
   for (const { trans, subtransactions, match } of transactionsStep3) {
@@ -760,10 +794,12 @@ export async function reconcileTransactions(
 export async function matchTransactions(
   acctId,
   transactions,
-  isBankSyncAccount = false,
-  strictIdChecking = true,
-  reimportDeletedOverride?: boolean,
-  rawPayeeName = false,
+  {
+    isBankSyncAccount = false,
+    strictIdChecking = true,
+    reimportDeleted: reimportDeletedOverride,
+    payeeNameNormalization = 'title-case',
+  }: MatchTransactionsOptions = {},
 ) {
   logger.log('Performing transaction reconciliation matching');
 
@@ -780,7 +816,9 @@ export async function matchTransactions(
 
   const { normalized, payeesToCreate } = isBankSyncAccount
     ? await normalizeBankSyncTransactions(transactions, acctId)
-    : await normalizeTransactions(transactions, acctId, { rawPayeeName });
+    : await normalizeTransactions(transactions, acctId, {
+        payeeNameNormalization,
+      });
 
   // The first pass runs the rules, and preps data for fuzzy matching
   const accounts: db.DbAccount[] = await db.getAccounts();
@@ -966,7 +1004,7 @@ export async function addTransactions(
   const { normalized, payeesToCreate } = await normalizeTransactions(
     transactions,
     acctId,
-    { rawPayeeName: true },
+    { payeeNameNormalization: 'original' },
   );
 
   const accounts: db.DbAccount[] = await db.getAccounts();
@@ -1123,15 +1161,11 @@ async function processBankSyncDownload(
         starting_balance_flag: true,
       });
 
-      const result = await reconcileTransactions(
-        id,
-        transactions,
-        true,
-        useStrictIdChecking,
-        false,
-        true,
+      const result = await reconcileTransactions(id, transactions, {
+        isBankSyncAccount: true,
+        strictIdChecking: useStrictIdChecking,
         updateDates,
-      );
+      });
       return {
         ...result,
         added: [initialId, ...result.added],
@@ -1148,11 +1182,11 @@ async function processBankSyncDownload(
     const result = await reconcileTransactions(
       id,
       importTransactions ? transactions : [],
-      true,
-      useStrictIdChecking,
-      false,
-      true,
-      updateDates,
+      {
+        isBankSyncAccount: true,
+        strictIdChecking: useStrictIdChecking,
+        updateDates,
+      },
     );
 
     if (currentBalance != null) {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -31,7 +31,7 @@ export type ImportTransactionsOpts = {
   defaultCleared?: boolean;
   dryRun?: boolean;
   reimportDeleted?: boolean;
-  rawPayeeName?: boolean;
+  payeeNameNormalization?: 'original' | 'title-case';
 };
 
 export type ApiHandlers = {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -1,5 +1,6 @@
 // @ts-strict-ignore
 import type { ImportTransactionsResult } from '#server/accounts/app';
+import type { PayeeNameNormalization } from '#server/accounts/sync';
 import type {
   APIAccountEntity,
   APICategoryEntity,
@@ -31,7 +32,7 @@ export type ImportTransactionsOpts = {
   defaultCleared?: boolean;
   dryRun?: boolean;
   reimportDeleted?: boolean;
-  payeeNameNormalization?: 'original' | 'title-case';
+  payeeNameNormalization?: PayeeNameNormalization;
 };
 
 export type ApiHandlers = {

--- a/packages/loot-core/src/types/api-handlers.ts
+++ b/packages/loot-core/src/types/api-handlers.ts
@@ -31,6 +31,7 @@ export type ImportTransactionsOpts = {
   defaultCleared?: boolean;
   dryRun?: boolean;
   reimportDeleted?: boolean;
+  rawPayeeName?: boolean;
 };
 
 export type ApiHandlers = {

--- a/upcoming-release-notes/api-import-payee-name-normalization.md
+++ b/upcoming-release-notes/api-import-payee-name-normalization.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [haimgel]
+---
+
+Add a `payeeNameNormalization` option to the API's `importTransactions`, so payee names can be kept as supplied instead of always being title-cased.

--- a/upcoming-release-notes/api-import-raw-payee-name.md
+++ b/upcoming-release-notes/api-import-raw-payee-name.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [haimgel]
+---
+
+Add a `rawPayeeName` option to the API's `importTransactions`, so payee names can be kept exactly as supplied instead of being always title-cased.

--- a/upcoming-release-notes/api-import-raw-payee-name.md
+++ b/upcoming-release-notes/api-import-raw-payee-name.md
@@ -1,6 +1,0 @@
----
-category: Enhancements
-authors: [haimgel]
----
-
-Add a `rawPayeeName` option to the API's `importTransactions`, so payee names can be kept exactly as supplied instead of being always title-cased.


### PR DESCRIPTION
## Description

### What problem does this solve?

`importTransactions` always runs `title()` over `payee_name` when it creates a payee. `title()` lowercases the entire string before re-capitalizing each word, so acronyms that are common in bank strings don't survive:
 
  | bank string                    | payee created                  |
  |--------------------------------|--------------------------------|
  | Nintendo Store New York NY     | Nintendo Store New York Ny     |
  | Amazon* 194zt1283 Vancouver BC | Amazon* 194zt1283 Vancouver Bc |
  | United Supermarket N5Y 2N1 ON  | United Supermarket N5y 2n1 on  |

Custom importers that already supply payee names in final form had no way to opt out.

### Approach

Threads `opts.rawPayeeName` down to the `normalizeTransactions` call that `addTransactions` already makes with the same option. 

**Note: built with the help of Claude Opus 5.**

## Testing

Unit tests added, works fine in my manual testing.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.57 MB → 13.5 MB (-81.56 kB) | -0.59%
loot-core | 1 | 4.63 MB → 4.63 MB (+7.17 kB) | +0.15%
api | 2 | 3.84 MB → 3.85 MB (+7.92 kB) | +0.20%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.57 MB → 13.5 MB (-81.56 kB) | -0.59%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/tags/SelectedTagsButton.tsx` | 📈 +1.11 kB (+32.53%) | 3.42 kB → 4.53 kB
`src/components/tags/TagRow.tsx` | 📈 +1.46 kB (+17.33%) | 8.4 kB → 9.86 kB
`src/tags/mutations.ts` | 📈 +922 B (+15.86%) | 5.68 kB → 6.58 kB
`src/components/tags/ManageTags.tsx` | 📈 +236 B (+7.30%) | 3.16 kB → 3.39 kB
`src/components/transactions/TransactionsTable.tsx` | 📈 +1.95 kB (+2.13%) | 91.61 kB → 93.56 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +131 B (+1.87%) | 6.82 kB → 6.95 kB
`src/components/settings/Currency.tsx` | 📈 +275 B (+1.28%) | 21.01 kB → 21.28 kB
`src/components/table.tsx` | 📈 +113 B (+0.31%) | 36.12 kB → 36.23 kB
`locale/ru.json` | 📈 +235 B (+0.11%) | 209.33 kB → 209.56 kB
`src/components/admin/UserAccess/UserAccess.tsx` | 📈 +2 B (+0.02%) | 9.98 kB → 9.98 kB
`locale/en.json` | 📈 +33 B (+0.01%) | 245.67 kB → 245.7 kB
`src/components/tags/TagsList.tsx` | 📉 -222 B (-20.40%) | 1.06 kB → 866 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB → 1.58 MB (+3.75 kB) | +0.23%
static/js/ru.js | 209.33 kB → 209.56 kB (+235 B) | +0.11%
static/js/months.js | 574.59 kB → 574.72 kB (+131 B) | +0.02%
static/js/Value.js | 1.79 MB → 1.79 MB (+113 B) | +0.01%
static/js/en.js | 245.67 kB → 245.7 kB (+33 B) | +0.01%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 165.03 kB → 79.22 kB (-85.81 kB) | -52.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+7.17 kB) | +0.15%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/account-groups/app.ts` | 🆕 +1007 B | 0 B → 1007 B
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 📈 +241 B (+57.93%) | 416 B → 657 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📈 +171 B (+42.01%) | 407 B → 578 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +887 B (+35.61%) | 2.43 kB → 3.3 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +2.16 kB (+10.76%) | 20.07 kB → 22.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/models.ts` | 📈 +219 B (+7.72%) | 2.77 kB → 2.98 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +242 B (+6.13%) | 3.86 kB → 4.09 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +840 B (+3.45%) | 23.78 kB → 24.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +642 B (+2.51%) | 24.99 kB → 25.61 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +231 B (+2.24%) | 10.08 kB → 10.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +139 B (+1.91%) | 7.12 kB → 7.26 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +499 B (+1.60%) | 30.54 kB → 31.03 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +8 B (+0.16%) | 4.78 kB → 4.79 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dab0t8iz.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.85 MB (+7.92 kB) | +0.20%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/account-groups/app.ts` | 🆕 +997 B | 0 B → 997 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/link.ts` | 📈 +754 B (+190.40%) | 396 B → 1.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 📈 +236 B (+58.56%) | 403 B → 639 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +862 B (+35.68%) | 2.36 kB → 3.2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +2.12 kB (+10.19%) | 20.76 kB → 22.88 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/models.ts` | 📈 +214 B (+7.74%) | 2.7 kB → 2.91 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api-models.ts` | 📈 +229 B (+6.07%) | 3.69 kB → 3.91 kB
`methods.ts` | 📈 +357 B (+5.01%) | 6.96 kB → 7.31 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +819 B (+3.45%) | 23.16 kB → 23.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/sync.ts` | 📈 +621 B (+2.48%) | 24.49 kB → 25.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +223 B (+2.22%) | 9.79 kB → 10.01 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +131 B (+1.90%) | 6.73 kB → 6.86 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +490 B (+1.60%) | 29.99 kB → 30.46 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +8 B (+0.22%) | 3.55 kB → 3.56 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.85 MB (+7.92 kB) | +0.20%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->