### PR TITLE
[AI] Block AI agents from creating GitHub issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,15 @@
         ]
       },
       {
+        "matcher": "mcp__github__issue_write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/agent-hooks/no-issue-create.sh\""
+          }
+        ]
+      },
+      {
         "matcher": "mcp__github__(add_issue_comment|add_comment_to_pending_review|add_reply_to_pull_request_comment|pull_request_review_write|issue_write|sub_issue_write)",
         "hooks": [
           {

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -31,8 +31,8 @@
 [features]
 lifecycle_hooks = true
 
-# Block unsafe git/workspace commands ([AI] prefix, --no-verify, force-push,
-# push-to-main, git config writes, yarn-from-a-workspace).
+# Block unsafe git/gh/workspace commands ([AI] prefix, --no-verify, force-push,
+# push-to-main, git config writes, gh issue create, yarn-from-a-workspace).
 [[hooks.PreToolUse]]
 matcher = "^Bash$"
 [[hooks.PreToolUse.hooks]]
@@ -57,6 +57,17 @@ command = '"$(git rev-parse --show-toplevel)/scripts/agent-hooks/format-edited-f
 [[hooks.PostToolUse.hooks]]
 type = "command"
 command = '"$(git rev-parse --show-toplevel)/scripts/agent-hooks/prefer-one-component.sh"'
+
+# Block creating GitHub issues — filing an issue is a human decision. The guard
+# reads tool_input.method and only lets issue_write calls whose method is
+# "update" through (exit 2 blocks everything else). `gh issue create` from the
+# shell is blocked by the git guard above.
+[[hooks.PreToolUse]]
+matcher = "^mcp__github__issue_write$"
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = '"$(git rev-parse --show-toplevel)/scripts/agent-hooks/no-issue-create.sh"'
+statusMessage = "Checking GitHub issue call is not a create"
 
 # Require GitHub comments, reviews and issues to be prefixed with the robot emoji
 # 🤖. Matches the github MCP comment/review/issue writers below (add_issue_comment,

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -31,8 +31,8 @@
 [features]
 lifecycle_hooks = true
 
-# Block unsafe git/gh/workspace commands ([AI] prefix, --no-verify, force-push,
-# push-to-main, git config writes, gh issue create, yarn-from-a-workspace).
+# Enforce the repo's shell-command policy (git safety, gh, yarn-from-a-workspace)
+# — the header of scripts/agent-hooks/git-guard.sh is the single list of rules.
 [[hooks.PreToolUse]]
 matcher = "^Bash$"
 [[hooks.PreToolUse.hooks]]

--- a/.cursor/hooks/before-mcp-github.sh
+++ b/.cursor/hooks/before-mcp-github.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 # Cursor `beforeMCPExecution` adapter.
 #
-# Dispatches github MCP calls to the matching shared guard in
+# Dispatches github MCP calls to the matching shared guard(s) in
 # scripts/agent-hooks/: comment/review/issue writers must be 🤖-prefixed
-# (github-comment-style.sh), and create_pull_request must leave the PR template
+# (github-comment-style.sh), issue_write must not create issues
+# (no-issue-create.sh), and create_pull_request must leave the PR template
 # blank (pr-template-blank.sh).
 # Cursor input on stdin: { tool_name, tool_input, ... }. Output on stdout:
 # { permission: "allow" | "deny", userMessage, agentMessage }.
@@ -31,34 +32,38 @@ deny() {
   exit 0
 }
 
-# Pick the guard for this tool; wave known non-GitHub tools by. Fail closed on a
-# malformed payload (jq parse failure / missing .tool_name), matching
+# Pick the guard(s) for this tool; wave known non-GitHub tools by. Fail closed
+# on a malformed payload (jq parse failure / missing .tool_name), matching
 # guard-shell.sh — a payload we can't read must not bypass the GitHub guards.
 tool=$(printf '%s' "$input" | jq -re '.tool_name' 2>/dev/null) ||
   deny "Invalid Cursor hook payload: could not read .tool_name."
 case "$tool" in
+  mcp__github__issue_write)
+    guards="no-issue-create.sh github-comment-style.sh" ;;
   mcp__github__add_issue_comment | \
     mcp__github__add_comment_to_pending_review | \
     mcp__github__add_reply_to_pull_request_comment | \
     mcp__github__pull_request_review_write | \
-    mcp__github__issue_write | \
     mcp__github__sub_issue_write)
-    guard=github-comment-style.sh ;;
+    guards=github-comment-style.sh ;;
   mcp__github__create_pull_request)
-    guard=pr-template-blank.sh ;;
+    guards=pr-template-blank.sh ;;
   *) allow ;;
 esac
 
 # Each guard reads the same `.tool_input.*` payload Cursor passes, so forward it
-# unchanged. Exit 0 allows, exit 2 + stderr is a real policy denial. Fail closed
-# on any other exit (matching guard-shell.sh) so a broken/missing guard can't
-# silently disable enforcement; the message marks it as an execution problem.
-# (Each guard fails closed on an unreadable payload and exit-0s only when there's
-# genuinely nothing to enforce.)
-status=0
-err=$(printf '%s' "$input" | "$ROOT/scripts/agent-hooks/$guard" 2>&1) || status=$?
-case "$status" in
-  0) allow ;;
-  2) deny "$err" ;;
-  *) deny "$guard failed (exit $status): $err" ;;
-esac
+# unchanged; the first guard to object wins. Exit 0 allows, exit 2 + stderr is a
+# real policy denial. Fail closed on any other exit (matching guard-shell.sh) so
+# a broken/missing guard can't silently disable enforcement; the message marks
+# it as an execution problem. (Each guard fails closed on an unreadable payload
+# and exit-0s only when there's genuinely nothing to enforce.)
+for guard in $guards; do
+  status=0
+  err=$(printf '%s' "$input" | "$ROOT/scripts/agent-hooks/$guard" 2>&1) || status=$?
+  case "$status" in
+    0) ;;
+    2) deny "$err" ;;
+    *) deny "$guard failed (exit $status): $err" ;;
+  esac
+done
+allow

--- a/.github/agents/pr-and-commit-rules.md
+++ b/.github/agents/pr-and-commit-rules.md
@@ -24,11 +24,20 @@ yourself.
 - **Exception**: if a human **explicitly asks** you to fill it out, do so **in
   Chinese**, using Chinese characters (简体中文) for all content you add.
 
+## Do not create GitHub issues
+
+**Agents must never create GitHub issues.** Filing an issue is a human
+decision — neither the GitHub MCP tools (`issue_write` with method `create`)
+nor the `gh` CLI (`gh issue create`) may be used to open one; agent hooks
+block both. If you believe an issue should exist, share the proposed title
+and body with the user and let them file it. Updating existing issues (and
+commenting on them) remains allowed.
+
 ## GitHub comment, review and issue prefix
 
 **Prefix everything you post to GitHub with the robot emoji 🤖** — pull-request
 and issue comments, pull-request reviews (including inline review comments), and
-the title and body of issues you create. This keeps agent-authored content
+the title and body of issues you edit. This keeps agent-authored content
 visibly marked. It does **not** change PR titles (still `[AI] …`) or commit
 messages (still `[AI] …`).
 

--- a/scripts/agent-hooks/git-guard.sh
+++ b/scripts/agent-hooks/git-guard.sh
@@ -42,15 +42,13 @@ case "$cmd" in
 esac
 
 # Never create GitHub issues from the shell — filing an issue is a human
-# decision (.github/agents/pr-and-commit-rules.md). Matches the real gh CLI
-# form (`gh [flags] issue create …`); like the git checks below this is
-# best-effort, not evasion-proof (a hand-rolled `gh api` call is out of scope).
+# decision (.github/agents/pr-and-commit-rules.md). Requires `gh` as a whole
+# token followed by "issue create", matching the real CLI form
+# (`gh [flags] issue create …`); like the git checks below this is best-effort,
+# not evasion-proof (a hand-rolled `gh api` call is out of scope).
 case " $cmd " in
-  *" gh "*)
-    case "$cmd" in
-      *"issue create"*)
-        block "Blocked: agents must not create GitHub issues — filing an issue is a human decision (.github/agents/pr-and-commit-rules.md). Share the proposed issue title and body with the user instead." ;;
-    esac ;;
+  *" gh "*"issue create"*)
+    block "Blocked: agents must not create GitHub issues — filing an issue is a human decision (.github/agents/pr-and-commit-rules.md). Share the proposed issue title and body with the user instead." ;;
 esac
 
 # Everything below only applies to actual git invocations. Match `git` as a

--- a/scripts/agent-hooks/git-guard.sh
+++ b/scripts/agent-hooks/git-guard.sh
@@ -2,8 +2,8 @@
 # Shared agent guard for shell/Bash commands (Claude PreToolUse[Bash],
 # Codex PreToolUse[^Bash$], Cursor beforeShellExecution via adapter).
 #
-# Deterministically enforces the project's git-safety and workspace rules that
-# used to live as prose in AGENTS.md / .github/agents/pr-and-commit-rules.md.
+# Deterministically enforces the project's git-safety, gh and workspace rules
+# that used to live as prose in AGENTS.md / .github/agents/pr-and-commit-rules.md.
 # Reads the command from `.tool_input.command` on stdin. Exit code 2 + stderr
 # blocks the call and feeds the reason back to the agent.
 #
@@ -38,6 +38,18 @@ case "$cmd" in
     case "$cmd" in
       *yarn*)
         block "Blocked: run yarn from the repo root, not a child workspace (AGENTS.md). Use 'yarn workspace <name> <cmd>' from the root instead." ;;
+    esac ;;
+esac
+
+# Never create GitHub issues from the shell — filing an issue is a human
+# decision (.github/agents/pr-and-commit-rules.md). Matches the real gh CLI
+# form (`gh [flags] issue create …`); like the git checks below this is
+# best-effort, not evasion-proof (a hand-rolled `gh api` call is out of scope).
+case " $cmd " in
+  *" gh "*)
+    case "$cmd" in
+      *"issue create"*)
+        block "Blocked: agents must not create GitHub issues — filing an issue is a human decision (.github/agents/pr-and-commit-rules.md). Share the proposed issue title and body with the user instead." ;;
     esac ;;
 esac
 

--- a/scripts/agent-hooks/no-issue-create.sh
+++ b/scripts/agent-hooks/no-issue-create.sh
@@ -19,14 +19,12 @@ block() {
 . "$(dirname "$0")/common.sh"
 require_jq
 
-input=$(cat)
-
 # Fail closed on a malformed payload — invalid JSON, or a missing/non-object
 # `.tool_input` — matching the other guards, so a payload we can't read can't
-# silently bypass the check.
-fields=$(printf '%s' "$input" | jq -e '.tool_input | objects' 2>/dev/null) ||
+# silently bypass the check. A valid payload with no method yields "" and is
+# caught by the allowlist below.
+method=$(jq -re '.tool_input | objects | .method // ""' 2>/dev/null) ||
   block "Blocked: could not read the hook payload (.tool_input). (scripts/agent-hooks/no-issue-create.sh)"
-method=$(printf '%s' "$fields" | jq -r '.method // empty')
 
 # Allowlist rather than denylist: only updates to existing issues pass, so an
 # unknown or missing method fails closed instead of slipping past as a create
@@ -36,5 +34,5 @@ case "$method" in
   create)
     block "Blocked: agents must not create GitHub issues — filing an issue is a human decision (.github/agents/pr-and-commit-rules.md). Share the proposed issue title and body with the user instead." ;;
   *)
-    block "Blocked: unrecognized issue_write method '${method:-<missing>}' — agents may only update existing issues, never create them (.github/agents/pr-and-commit-rules.md). (scripts/agent-hooks/no-issue-create.sh)" ;;
+    block "Blocked: unrecognized issue_write method '${method:-<missing>}' — agents may only update existing issues, never create them (.github/agents/pr-and-commit-rules.md). If this is a new non-create method, extend the allowlist in scripts/agent-hooks/no-issue-create.sh." ;;
 esac

--- a/scripts/agent-hooks/no-issue-create.sh
+++ b/scripts/agent-hooks/no-issue-create.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Shared agent guard prohibiting GitHub issue creation, wired for Claude
+# (PreToolUse), Codex (PreToolUse) and Cursor (beforeMCPExecution via adapter).
+#
+# Agents must never create GitHub issues — filing an issue is a human decision
+# (.github/agents/pr-and-commit-rules.md). Runs on the github MCP issue writer
+# (issue_write, which multiplexes create/update via `.tool_input.method`) and
+# blocks everything except updates to existing issues (exit 2 + stderr feeds
+# the reason back to the agent). `gh issue create` from the shell is blocked
+# separately by git-guard.sh.
+
+block() {
+  echo "$1" >&2
+  exit 2
+}
+
+# A missing jq gets its own actionable block, distinct from the
+# malformed-payload block below.
+. "$(dirname "$0")/common.sh"
+require_jq
+
+input=$(cat)
+
+# Fail closed on a malformed payload — invalid JSON, or a missing/non-object
+# `.tool_input` — matching the other guards, so a payload we can't read can't
+# silently bypass the check.
+fields=$(printf '%s' "$input" | jq -e '.tool_input | objects' 2>/dev/null) ||
+  block "Blocked: could not read the hook payload (.tool_input). (scripts/agent-hooks/no-issue-create.sh)"
+method=$(printf '%s' "$fields" | jq -r '.method // empty')
+
+# Allowlist rather than denylist: only updates to existing issues pass, so an
+# unknown or missing method fails closed instead of slipping past as a create
+# by another name.
+case "$method" in
+  update) exit 0 ;;
+  create)
+    block "Blocked: agents must not create GitHub issues — filing an issue is a human decision (.github/agents/pr-and-commit-rules.md). Share the proposed issue title and body with the user instead." ;;
+  *)
+    block "Blocked: unrecognized issue_write method '${method:-<missing>}' — agents may only update existing issues, never create them (.github/agents/pr-and-commit-rules.md). (scripts/agent-hooks/no-issue-create.sh)" ;;
+esac

--- a/upcoming-release-notes/prohibit-agent-issue-creation.md
+++ b/upcoming-release-notes/prohibit-agent-issue-creation.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MatissJanis]
+---
+
+Add agent hooks that block AI agents from creating GitHub issues


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Vibe coded. With the purpose to stop bots opening spam github issues.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

n/a

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

n/a

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
