### PR TITLE
[AI] Fix duplicate payees in rules after merging payees (#6486)

### DIFF
--- a/packages/loot-core/src/server/rules/rule-utils.test.ts
+++ b/packages/loot-core/src/server/rules/rule-utils.test.ts
@@ -1,0 +1,52 @@
+import { Rule } from './rule';
+import { migrateIds } from './rule-utils';
+
+describe('migrateIds', () => {
+  it('deduplicates mapped IDs in oneOf and notOneOf conditions', () => {
+    const rule = new Rule({
+      conditionsOp: 'and',
+      conditions: [
+        {
+          op: 'oneOf',
+          field: 'payee',
+          value: ['payee-a', 'payee-b', 'payee-c'],
+          options: null,
+        },
+        {
+          op: 'notOneOf',
+          field: 'payee',
+          value: ['payee-a', 'payee-b', 'payee-c'],
+          options: null,
+        },
+      ],
+      actions: [],
+    });
+    const mappings = new Map([
+      ['payee-a', 'payee-merged'],
+      ['payee-b', 'payee-merged'],
+    ]);
+
+    migrateIds(rule, mappings);
+
+    expect(rule.conditions[0].rawValue).toEqual([
+      'payee-a',
+      'payee-b',
+      'payee-c',
+    ]);
+    expect(rule.conditions[0].value).toEqual(['payee-merged', 'payee-c']);
+    expect(rule.conditions[0].unparsedValue).toEqual([
+      'payee-merged',
+      'payee-c',
+    ]);
+    expect(rule.conditions[1].rawValue).toEqual([
+      'payee-a',
+      'payee-b',
+      'payee-c',
+    ]);
+    expect(rule.conditions[1].value).toEqual(['payee-merged', 'payee-c']);
+    expect(rule.conditions[1].unparsedValue).toEqual([
+      'payee-merged',
+      'payee-c',
+    ]);
+  });
+});

--- a/packages/loot-core/src/server/rules/rule-utils.ts
+++ b/packages/loot-core/src/server/rules/rule-utils.ts
@@ -138,13 +138,12 @@ export function migrateIds(rule: Rule, mappings: Map<string, string>): void {
           cond.unparsedValue = cond.value;
           break;
         case 'oneOf':
-          cond.value = cond.rawValue.map(v => mappings.get(v) || v);
+        case 'notOneOf': {
+          const mappedValues = cond.rawValue.map(v => mappings.get(v) || v);
+          cond.value = [...new Set(mappedValues)];
           cond.unparsedValue = [...cond.value];
           break;
-        case 'notOneOf':
-          cond.value = cond.rawValue.map(v => mappings.get(v) || v);
-          cond.unparsedValue = [...cond.value];
-          break;
+        }
         default:
       }
     }

--- a/upcoming-release-notes/deduplicate-merged-payees-in-rules.md
+++ b/upcoming-release-notes/deduplicate-merged-payees-in-rules.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [SomSamantray]
+---
+
+Remove duplicate payees from rules after merging payees


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

Fixes #6486 

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.32 MB → 13.32 MB (+43 B) | +0.00%
loot-core | 1 | 4.63 MB → 4.63 MB (-59 B) | -0.00%
api | 2 | 3.84 MB → 3.84 MB (-58 B) | -0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.32 MB → 13.32 MB (+43 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/fr.json` | 📈 +43 B (+0.02%) | 180.08 kB → 180.13 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/fr.js | 180.08 kB → 180.13 kB (+43 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.19 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.25 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (-59 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📉 -59 B (-1.24%) | 4.66 kB → 4.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DzUXTGv0.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DhWCE92C.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (-58 B) | -0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule-utils.ts` | 📉 -58 B (-1.26%) | 4.49 kB → 4.43 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (-58 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->