### PR TITLE
[AI] feat(budget analysis report): allow selecting future months in date range

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -223,8 +223,13 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
         earliestMonth = yearAgo;
       }
 
+      // Extend the selectable range to December of next year so users can
+      // plan ahead (e.g. June 2026 → December 2027).
+      const futureYear = String(Number(currentMonth.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
       const allMonthsData = monthUtils
-        .rangeInclusive(earliestMonth, latestMonth)
+        .rangeInclusive(earliestMonth, futureMonth)
         .map(month => ({
           name: month,
           pretty: monthUtils.format(month, 'MMMM, yyyy', locale),

--- a/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
+++ b/packages/desktop-client/src/components/reports/reports/BudgetAnalysis.tsx
@@ -33,7 +33,10 @@ import { Header } from '#components/reports/Header';
 import { LoadingIndicator } from '#components/reports/LoadingIndicator';
 import { calculateTimeRange } from '#components/reports/reportRanges';
 import { buildBudgetAnalysisCsv } from '#components/reports/spreadsheets/budget-analysis-export';
-import { createBudgetAnalysisSpreadsheet } from '#components/reports/spreadsheets/budget-analysis-spreadsheet';
+import {
+  createBudgetAnalysisSpreadsheet,
+  getLastSelectableMonth,
+} from '#components/reports/spreadsheets/budget-analysis-spreadsheet';
 import { useReport } from '#components/reports/useReport';
 import { fromDateRepr } from '#components/reports/util';
 import { useDashboardWidget } from '#hooks/useDashboardWidget';
@@ -224,12 +227,12 @@ function BudgetAnalysisInternal({ widget }: BudgetAnalysisInternalProps) {
       }
 
       // Extend the selectable range to December of next year so users can
-      // plan ahead (e.g. June 2026 → December 2027).
-      const futureYear = String(Number(currentMonth.slice(0, 4)) + 1);
-      const futureMonth = `${futureYear}-12`;
+      // plan ahead (e.g. June 2026 → December 2027), without hiding
+      // transactions dated beyond that.
+      const lastMonth = getLastSelectableMonth(currentMonth, latestMonth);
 
       const allMonthsData = monthUtils
-        .rangeInclusive(earliestMonth, futureMonth)
+        .rangeInclusive(earliestMonth, lastMonth)
         .map(month => ({
           name: month,
           pretty: monthUtils.format(month, 'MMMM, yyyy', locale),

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,7 +1,13 @@
 import { rangeInclusive } from '@actual-app/core/shared/months';
 import type { CategoryEntity } from '@actual-app/core/types/models';
 
-import { isBaseCategory } from './budget-analysis-spreadsheet';
+import {
+  getLastSelectableMonth,
+  getNextRunningBalance,
+  isBaseCategory,
+  summarizeMonthCategories,
+} from './budget-analysis-spreadsheet';
+import type { BudgetMonthCell } from './budgetMonthCell';
 
 const makeCategory = (
   overrides: Partial<CategoryEntity> & Pick<CategoryEntity, 'id' | 'name'>,
@@ -76,44 +82,196 @@ describe('createBudgetAnalysisSpreadsheet', () => {
     });
   });
 
-  describe('future month range', () => {
-    it('future month is December of next year', () => {
-      const current = '2026-06';
-      const futureYear = String(Number(current.slice(0, 4)) + 1);
-      const futureMonth = `${futureYear}-12`;
-
-      expect(futureMonth).toBe('2027-12');
+  describe('getLastSelectableMonth', () => {
+    it('extends the range to December of next year', () => {
+      expect(getLastSelectableMonth('2026-06', '2026-06')).toBe('2027-12');
     });
 
-    it('rangeInclusive from a mid-year month to December next year ends at December', () => {
-      const current = '2026-06';
-      const futureYear = String(Number(current.slice(0, 4)) + 1);
-      const futureMonth = `${futureYear}-12`;
-      const range = rangeInclusive(current, futureMonth);
+    it('ends in December regardless of the current month', () => {
+      for (const month of ['2024-01', '2024-06', '2024-12']) {
+        expect(getLastSelectableMonth(month, month)).toBe('2025-12');
+      }
+    });
+
+    it('keeps a later transaction month selectable', () => {
+      // A transaction dated past December of next year must not be cut off.
+      expect(getLastSelectableMonth('2026-08', '2028-03')).toBe('2028-03');
+    });
+
+    it('prefers December of next year when the latest transaction is earlier', () => {
+      expect(getLastSelectableMonth('2026-08', '2026-11')).toBe('2027-12');
+    });
+
+    it('keeps the boundary month itself', () => {
+      expect(getLastSelectableMonth('2026-08', '2027-12')).toBe('2027-12');
+    });
+
+    it('produces a range that spans from the earliest month to the endpoint', () => {
+      const range = rangeInclusive(
+        '2026-06',
+        getLastSelectableMonth('2026-06', '2026-06'),
+      );
 
       expect(range[0]).toBe('2026-06');
       expect(range[range.length - 1]).toBe('2027-12');
     });
 
-    it('future month is always in December regardless of current month', () => {
-      for (const month of ['2024-01', '2024-06', '2024-12']) {
-        const futureYear = String(Number(month.slice(0, 4)) + 1);
-        const futureMonth = `${futureYear}-12`;
-        expect(futureMonth.endsWith('-12')).toBe(true);
-      }
+    it('lists future months before the current month once reversed', () => {
+      const last = getLastSelectableMonth('2026-06', '2026-06');
+      const allMonths = rangeInclusive('2026-06', last).reverse();
+
+      expect(allMonths[0]).toBe(last);
+      expect(allMonths[allMonths.length - 1]).toBe('2026-06');
+    });
+  });
+
+  describe('summarizeMonthCategories', () => {
+    const cells = (
+      values: Record<string, number | boolean>,
+    ): BudgetMonthCell[] =>
+      Object.entries(values).map(([name, value]) => ({
+        name: `budget202601!${name}`,
+        value,
+      })) as BudgetMonthCell[];
+
+    it('reports no budget data when every cell is empty', () => {
+      const result = summarizeMonthCategories([], [visibleExpense]);
+
+      expect(result).toEqual({
+        budgeted: 0,
+        spent: 0,
+        carryoverToNextMonth: 0,
+        overspendingThisMonth: 0,
+        hasBudgetData: false,
+      });
     });
 
-    it('future months appear before current month in the reversed picker list', () => {
-      const current = '2026-06';
-      const futureYear = String(Number(current.slice(0, 4)) + 1);
-      const futureMonth = `${futureYear}-12`;
+    it('carries a positive balance to the next month', () => {
+      const result = summarizeMonthCategories(
+        cells({
+          'budget-c1': 10000,
+          'sum-amount-c1': -4000,
+          'leftover-c1': 6000,
+          'carryover-c1': false,
+        }),
+        [visibleExpense],
+      );
 
-      const allMonths = rangeInclusive(current, futureMonth)
-        .map(month => ({ name: month }))
-        .reverse();
+      expect(result.carryoverToNextMonth).toBe(6000);
+      expect(result.overspendingThisMonth).toBe(0);
+      expect(result.hasBudgetData).toBe(true);
+    });
 
-      expect(allMonths[0].name).toBe(futureMonth);
-      expect(allMonths[allMonths.length - 1].name).toBe(current);
+    it('treats an overspend without carryover as an overspending adjustment', () => {
+      const result = summarizeMonthCategories(
+        cells({
+          'budget-c1': 0,
+          'sum-amount-c1': -10000,
+          'leftover-c1': -10000,
+          'carryover-c1': false,
+        }),
+        [visibleExpense],
+      );
+
+      expect(result.carryoverToNextMonth).toBe(0);
+      expect(result.overspendingThisMonth).toBe(-10000);
+      expect(result.hasBudgetData).toBe(true);
+    });
+
+    it('carries a negative balance forward when carryover is enabled', () => {
+      const result = summarizeMonthCategories(
+        cells({
+          'budget-c1': 0,
+          'sum-amount-c1': -10000,
+          'leftover-c1': -10000,
+          'carryover-c1': true,
+        }),
+        [visibleExpense],
+      );
+
+      expect(result.carryoverToNextMonth).toBe(-10000);
+      expect(result.overspendingThisMonth).toBe(0);
+    });
+
+    it('only counts the categories it is given', () => {
+      const result = summarizeMonthCategories(
+        cells({
+          'budget-c1': 10000,
+          'leftover-c1': 10000,
+          'budget-c2': 5000,
+          'leftover-c2': 5000,
+        }),
+        [visibleExpense],
+      );
+
+      expect(result.budgeted).toBe(10000);
+      expect(result.carryoverToNextMonth).toBe(10000);
+    });
+  });
+
+  describe('getNextRunningBalance', () => {
+    it('hands off only what carries over when the month has data', () => {
+      expect(
+        getNextRunningBalance({
+          hasBudgetData: true,
+          carryoverToNextMonth: 6000,
+          runningBalance: 20000,
+        }),
+      ).toBe(6000);
+    });
+
+    it('resets a non-carryover overspend instead of dragging it forward', () => {
+      // The overspend surfaces as next month's overspending adjustment, so it
+      // must not also reduce the running balance.
+      expect(
+        getNextRunningBalance({
+          hasBudgetData: true,
+          carryoverToNextMonth: 0,
+          runningBalance: 20000,
+        }),
+      ).toBe(0);
+    });
+
+    it('passes the running balance through months with no budget data', () => {
+      expect(
+        getNextRunningBalance({
+          hasBudgetData: false,
+          carryoverToNextMonth: 0,
+          runningBalance: 20000,
+        }),
+      ).toBe(20000);
+    });
+
+    it('preserves a balance across a run of empty future months', () => {
+      let runningBalance = 15000;
+      for (let i = 0; i < 6; i++) {
+        runningBalance = getNextRunningBalance({
+          hasBudgetData: false,
+          carryoverToNextMonth: 0,
+          runningBalance,
+        });
+      }
+
+      expect(runningBalance).toBe(15000);
+    });
+
+    it('does not carry a non-carryover overspend into later empty months', () => {
+      // Overspend of -10000 in a category without carryover enabled.
+      let runningBalance = getNextRunningBalance({
+        hasBudgetData: true,
+        carryoverToNextMonth: 0,
+        runningBalance: 0,
+      });
+
+      for (let i = 0; i < 3; i++) {
+        runningBalance = getNextRunningBalance({
+          hasBudgetData: false,
+          carryoverToNextMonth: 0,
+          runningBalance,
+        });
+      }
+
+      expect(runningBalance).toBe(0);
     });
   });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,4 +1,5 @@
 import type { CategoryEntity } from '@actual-app/core/types/models';
+import { rangeInclusive } from 'loot-core/shared/months';
 
 import { isBaseCategory } from './budget-analysis-spreadsheet';
 
@@ -72,6 +73,47 @@ describe('createBudgetAnalysisSpreadsheet', () => {
       expect(result).toHaveLength(2);
       expect(result).toContain(visibleExpense);
       expect(result).toContain(hiddenExpense);
+    });
+  });
+
+  describe('future month range', () => {
+    it('future month is December of next year', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
+      expect(futureMonth).toBe('2027-12');
+    });
+
+    it('rangeInclusive from a mid-year month to December next year ends at December', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+      const range = rangeInclusive(current, futureMonth);
+
+      expect(range[0]).toBe('2026-06');
+      expect(range[range.length - 1]).toBe('2027-12');
+    });
+
+    it('future month is always in December regardless of current month', () => {
+      for (const month of ['2024-01', '2024-06', '2024-12']) {
+        const futureYear = String(Number(month.slice(0, 4)) + 1);
+        const futureMonth = `${futureYear}-12`;
+        expect(futureMonth.endsWith('-12')).toBe(true);
+      }
+    });
+
+    it('future months appear before current month in the reversed picker list', () => {
+      const current = '2026-06';
+      const futureYear = String(Number(current.slice(0, 4)) + 1);
+      const futureMonth = `${futureYear}-12`;
+
+      const allMonths = rangeInclusive(current, futureMonth)
+        .map(month => ({ name: month }))
+        .reverse();
+
+      expect(allMonths[0].name).toBe(futureMonth);
+      expect(allMonths[allMonths.length - 1].name).toBe(current);
     });
   });
 });

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -146,6 +146,24 @@ describe('createBudgetAnalysisSpreadsheet', () => {
       });
     });
 
+    it('reports no budget data for a never-budgeted month', () => {
+      // `envelope-budget-month` emits a cell for every category in every
+      // month, so an untouched future month arrives as present-but-zero
+      // cells rather than as missing ones. Presence alone cannot distinguish
+      // it from a real month.
+      const result = summarizeMonthCategories(
+        cells({
+          'budget-c1': 0,
+          'sum-amount-c1': 0,
+          'leftover-c1': 0,
+          'carryover-c1': false,
+        }),
+        [visibleExpense],
+      );
+
+      expect(result.hasBudgetData).toBe(false);
+    });
+
     it('carries a positive balance to the next month', () => {
       const result = summarizeMonthCategories(
         cells({

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.test.ts
@@ -1,5 +1,5 @@
+import { rangeInclusive } from '@actual-app/core/shared/months';
 import type { CategoryEntity } from '@actual-app/core/types/models';
-import { rangeInclusive } from 'loot-core/shared/months';
 
 import { isBaseCategory } from './budget-analysis-spreadsheet';
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -277,10 +277,14 @@ export function createBudgetAnalysisSpreadsheet({
         overspendingAdjustment: Math.abs(overspendingAdjustment), // Display as positive
       });
 
-      // Update running balance for next month
-      runningBalance = carryoverToNextMonth;
-      // Save this month's overspending to apply in next month
-      overspendingFromPrevMonth = overspendingThisMonth;
+      // Only update running balance if this month had budget data.
+      // Future months with no budget entries return no cells; carrying
+      // carryoverToNextMonth=0 would silently wipe the accumulated balance.
+      const monthHasData = monthData.length > 0;
+      if (monthHasData) {
+        runningBalance = carryoverToNextMonth;
+        overspendingFromPrevMonth = overspendingThisMonth;
+      }
     }
 
     setData({

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -115,6 +115,13 @@ export function summarizeMonthCategories(
     const catBalance = (balanceCell?.value as number) || 0;
     const hasCarryover = Boolean(carryoverCell?.value);
 
+    // Detect by value, not by cell presence: `envelope-budget-month` builds
+    // its response from the category list, so it emits a cell for every
+    // category in every month and fills missing sheet values with 0. Every
+    // month therefore has all its cells, and presence tells us nothing.
+    // A zero here is unambiguous: `leftover` already folds in the previous
+    // month's balance, so a month with a real balance carrying in cannot
+    // report zero across all three.
     if (catBudgeted !== 0 || catSpent !== 0 || catBalance !== 0) {
       hasBudgetData = true;
     }

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -272,19 +272,18 @@ export function createBudgetAnalysisSpreadsheet({
       intervalData.push({
         date: month,
         budgeted,
-        spent, // Display as positive
+        spent,
         balance: monthBalance,
-        overspendingAdjustment: Math.abs(overspendingAdjustment), // Display as positive
+        overspendingAdjustment: Math.abs(overspendingAdjustment),
       });
 
-      // Only update running balance if this month had budget data.
-      // Future months with no budget entries return no cells; carrying
-      // carryoverToNextMonth=0 would silently wipe the accumulated balance.
-      const monthHasData = monthData.length > 0;
-      if (monthHasData) {
-        runningBalance = carryoverToNextMonth;
-        overspendingFromPrevMonth = overspendingThisMonth;
-      }
+      // For future months with no budget or transactions, category balances are
+      // all zero so carryoverToNextMonth=0, which would wipe the running balance.
+      // Use the computed monthBalance as the next month's starting balance instead,
+      // which correctly preserves the cumulative balance regardless of whether
+      // category cells have data.
+      runningBalance = monthBalance;
+      overspendingFromPrevMonth = overspendingThisMonth;
     }
 
     setData({

--- a/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts
@@ -43,6 +43,127 @@ export function isBaseCategory(
   return !cat.is_income && (showHiddenCategories || !cat.hidden);
 }
 
+/**
+ * Last month the date pickers offer.
+ *
+ * The range runs through December of next year so the report can be used for
+ * planning ahead, but it never cuts off existing data: if a transaction is
+ * dated even further out, that month stays selectable.
+ */
+export function getLastSelectableMonth(
+  currentMonth: string,
+  latestMonth: string,
+): string {
+  const futureMonth = `${Number(currentMonth.slice(0, 4)) + 1}-12`;
+  return latestMonth > futureMonth ? latestMonth : futureMonth;
+}
+
+export type MonthCategoryTotals = {
+  budgeted: number;
+  spent: number;
+  /**
+   * Sum of category balances that roll into the next month: positive balances
+   * always roll over, negative ones only when the category has carryover
+   * ("rollover overspending") enabled.
+   */
+  carryoverToNextMonth: number;
+  /**
+   * Sum of negative balances for categories without carryover enabled. These
+   * are zeroed out at the month boundary and surface as next month's
+   * overspending adjustment instead of reducing the running balance.
+   */
+  overspendingThisMonth: number;
+  /**
+   * Whether the month returned any budget data at all. Months in the future
+   * that have never been budgeted come back with every cell empty; there is
+   * nothing to carry over from them, so the running balance must pass through
+   * untouched rather than being reset to zero.
+   */
+  hasBudgetData: boolean;
+};
+
+/**
+ * Reduce a month's raw budget cells down to the totals the report needs.
+ */
+export function summarizeMonthCategories(
+  monthData: BudgetMonthCell[],
+  categoriesToInclude: CategoryEntity[],
+): MonthCategoryTotals {
+  let budgeted = 0;
+  let spent = 0;
+  let carryoverToNextMonth = 0;
+  let overspendingThisMonth = 0;
+  let hasBudgetData = false;
+
+  for (const cat of categoriesToInclude) {
+    // Find the budget, spent, balance, and carryover flag for this category
+    const budgetCell = monthData.find((cell: BudgetMonthCell) =>
+      cell.name.endsWith(`budget-${cat.id}`),
+    );
+    const spentCell = monthData.find((cell: BudgetMonthCell) =>
+      cell.name.endsWith(`sum-amount-${cat.id}`),
+    );
+    const balanceCell = monthData.find((cell: BudgetMonthCell) =>
+      cell.name.endsWith(`leftover-${cat.id}`),
+    );
+    const carryoverCell = monthData.find((cell: BudgetMonthCell) =>
+      cell.name.endsWith(`carryover-${cat.id}`),
+    );
+
+    const catBudgeted = (budgetCell?.value as number) || 0;
+    const catSpent = (spentCell?.value as number) || 0;
+    const catBalance = (balanceCell?.value as number) || 0;
+    const hasCarryover = Boolean(carryoverCell?.value);
+
+    if (catBudgeted !== 0 || catSpent !== 0 || catBalance !== 0) {
+      hasBudgetData = true;
+    }
+
+    budgeted += catBudgeted;
+    spent += catSpent;
+
+    // Add to next month's carryover if:
+    // - Balance is positive (always carries over), OR
+    // - Balance is negative AND carryover is enabled
+    if (catBalance > 0 || (catBalance < 0 && hasCarryover)) {
+      carryoverToNextMonth += catBalance;
+    } else if (catBalance < 0 && !hasCarryover) {
+      // If balance is negative and carryover is NOT enabled,
+      // this will be zeroed out and becomes next month's overspending adjustment
+      overspendingThisMonth += catBalance; // Keep as negative
+    }
+  }
+
+  return {
+    budgeted,
+    spent,
+    carryoverToNextMonth,
+    overspendingThisMonth,
+    hasBudgetData,
+  };
+}
+
+/**
+ * The balance that seeds the following month.
+ *
+ * Months with budget data hand off only what actually carries over, so
+ * overspending in a category without carryover enabled is reset rather than
+ * dragged forward. Months with no data at all (typically future months that
+ * have never been budgeted) have nothing to carry over and must leave the
+ * running balance untouched.
+ */
+export function getNextRunningBalance({
+  hasBudgetData,
+  carryoverToNextMonth,
+  runningBalance,
+}: {
+  hasBudgetData: boolean;
+  carryoverToNextMonth: number;
+  runningBalance: number;
+}): number {
+  return hasBudgetData ? carryoverToNextMonth : runningBalance;
+}
+
 export function createBudgetAnalysisSpreadsheet({
   conditions = [],
   conditionsOp = 'and',
@@ -174,7 +295,6 @@ export function createBudgetAnalysisSpreadsheet({
 
     // Track running balance that respects carryover flags
     // Get the balance from the month before the start period to initialize properly
-    let runningBalance = 0;
     const monthBeforeStart = monthUtils.subMonths(
       monthUtils.getMonth(startDate),
       1,
@@ -184,22 +304,10 @@ export function createBudgetAnalysisSpreadsheet({
     });
 
     // Calculate the carryover from the previous month
-    for (const cat of categoriesToInclude) {
-      const balanceCell = prevMonthData.find((cell: BudgetMonthCell) =>
-        cell.name.endsWith(`leftover-${cat.id}`),
-      );
-      const carryoverCell = prevMonthData.find((cell: BudgetMonthCell) =>
-        cell.name.endsWith(`carryover-${cat.id}`),
-      );
-
-      const catBalance = (balanceCell?.value as number) || 0;
-      const hasCarryover = Boolean(carryoverCell?.value);
-
-      // Add to running balance if it would carry over
-      if (catBalance > 0 || (catBalance < 0 && hasCarryover)) {
-        runningBalance += catBalance;
-      }
-    }
+    let runningBalance = summarizeMonthCategories(
+      prevMonthData,
+      categoriesToInclude,
+    ).carryoverToNextMonth;
 
     // Track totals across all months
     let totalBudgeted = 0;
@@ -215,48 +323,13 @@ export function createBudgetAnalysisSpreadsheet({
       // This uses the same calculations as the budget page
       const monthData = await send('envelope-budget-month', { month });
 
-      let budgeted = 0;
-      let spent = 0;
-      let overspendingThisMonth = 0;
-
-      // Track what will carry over to next month
-      let carryoverToNextMonth = 0;
-
-      // Sum up values for categories we're interested in
-      for (const cat of categoriesToInclude) {
-        // Find the budget, spent, balance, and carryover flag for this category
-        const budgetCell = monthData.find((cell: BudgetMonthCell) =>
-          cell.name.endsWith(`budget-${cat.id}`),
-        );
-        const spentCell = monthData.find((cell: BudgetMonthCell) =>
-          cell.name.endsWith(`sum-amount-${cat.id}`),
-        );
-        const balanceCell = monthData.find((cell: BudgetMonthCell) =>
-          cell.name.endsWith(`leftover-${cat.id}`),
-        );
-        const carryoverCell = monthData.find((cell: BudgetMonthCell) =>
-          cell.name.endsWith(`carryover-${cat.id}`),
-        );
-
-        const catBudgeted = (budgetCell?.value as number) || 0;
-        const catSpent = (spentCell?.value as number) || 0;
-        const catBalance = (balanceCell?.value as number) || 0;
-        const hasCarryover = Boolean(carryoverCell?.value);
-
-        budgeted += catBudgeted;
-        spent += catSpent;
-
-        // Add to next month's carryover if:
-        // - Balance is positive (always carries over), OR
-        // - Balance is negative AND carryover is enabled
-        if (catBalance > 0 || (catBalance < 0 && hasCarryover)) {
-          carryoverToNextMonth += catBalance;
-        } else if (catBalance < 0 && !hasCarryover) {
-          // If balance is negative and carryover is NOT enabled,
-          // this will be zeroed out and becomes next month's overspending adjustment
-          overspendingThisMonth += catBalance; // Keep as negative
-        }
-      }
+      const {
+        budgeted,
+        spent,
+        carryoverToNextMonth,
+        overspendingThisMonth,
+        hasBudgetData,
+      } = summarizeMonthCategories(monthData, categoriesToInclude);
 
       // Apply overspending adjustment from previous month (negative value)
       const overspendingAdjustment = overspendingFromPrevMonth;
@@ -277,12 +350,12 @@ export function createBudgetAnalysisSpreadsheet({
         overspendingAdjustment: Math.abs(overspendingAdjustment),
       });
 
-      // For future months with no budget or transactions, category balances are
-      // all zero so carryoverToNextMonth=0, which would wipe the running balance.
-      // Use the computed monthBalance as the next month's starting balance instead,
-      // which correctly preserves the cumulative balance regardless of whether
-      // category cells have data.
-      runningBalance = monthBalance;
+      runningBalance = getNextRunningBalance({
+        hasBudgetData,
+        carryoverToNextMonth,
+        runningBalance,
+      });
+      // Save this month's overspending to apply in next month
       overspendingFromPrevMonth = overspendingThisMonth;
     }
 

--- a/upcoming-release-notes/ai-feat-budget-analysis-report-allow-selecting-future-months-in-date-range.md
+++ b/upcoming-release-notes/ai-feat-budget-analysis-report-allow-selecting-future-months-in-date-range.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [tabedzki]
+---
+
+Allow selecting future months in the Budget Analysis report date range, so you can plan ahead.


### PR DESCRIPTION
Extend the Budget Analysis month picker to December of the next year so users can select future months for long-term goal planning.

<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds future months to the Budget Analysis report's date range picker, so you can plan ahead instead of being capped at the latest month with transactions.

Two changes:

1. `BudgetAnalysis.tsx` — the `allMonths` list is built out to December of the next year rather than stopping at `latestMonth`. Since `allMonths` is reversed to newest-first and the reports DateRangePicker derives its upper bound from `allMonths[0]`, extending the list is what makes future months selectable.
2. `budget-analysis-spreadsheet.t`s — carry the running balance forward as `monthBalance` instead of `carryoverToNextMonth`. For future months there are no budgets or transactions, so every category balance is zero and `carryoverToNextMonth` collapses to 0, which wiped the accumulated balance the moment the range crossed into the future. Using `monthBalance` preserves the cumulative balance whether or not the month has data.

Claude was used to write the code and tests.

## Related issue(s)

Addresses @A5308Y's [comment](https://github.com/actualbudget/actual/issues/6742#issuecomment-4181817155). Original PR was #8165

## Testing

Used the dropdown feature itself, and confirmed the balance line stays continuous when the range extends past the latest transaction.

Added unit tests in budget-analysis-spreadsheet.test.ts covering the future-month range construction and picker ordering. Full @actual-app/web suite passes (913 passed, 1 skipped), along with yarn typecheck and yarn lint.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.32 MB → 13.33 MB (+471 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.32 MB → 13.33 MB (+471 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/spreadsheets/budget-analysis-spreadsheet.ts` | 📈 +397 B (+7.41%) | 5.23 kB → 5.62 kB
`src/components/reports/reports/BudgetAnalysis.tsx` | 📈 +74 B (+0.28%) | 25.41 kB → 25.48 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.42 MB → 1.42 MB (+471 B) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.19 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.39 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->