### PR TITLE
[WIP] [AI] Fix schedules failing to save when the name starts with $ or :

### DIFF
--- a/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
+++ b/packages/desktop-client/src/components/mobile/schedules/MobileScheduleEditPage.tsx
@@ -74,7 +74,9 @@ export function MobileScheduleEditPage() {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: state.fields.name }).select('id'),
+        q('schedules')
+          .filter({ name: { $eq: { $literal: state.fields.name } } })
+          .select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
+++ b/packages/desktop-client/src/components/schedules/ScheduleEditModal.tsx
@@ -100,7 +100,9 @@ export function ScheduleEditModal({ id, transaction }: ScheduleEditModalProps) {
 
     if (state.fields.name) {
       const { data: sameName } = await aqlQuery(
-        q('schedules').filter({ name: state.fields.name }).select('id'),
+        q('schedules')
+          .filter({ name: { $eq: { $literal: state.fields.name } } })
+          .select('id'),
       );
       if (sameName.length > 0 && sameName[0].id !== state.schedule.id) {
         dispatch({

--- a/packages/loot-core/src/server/api.ts
+++ b/packages/loot-core/src/server/api.ts
@@ -936,7 +936,9 @@ handlers['api/schedule-update'] = withMutation(async function ({
       case 'name': {
         const newName = String(value);
         const { data: existing } = await aqlQuery(
-          q('schedules').filter({ name: newName }).select('*'),
+          q('schedules')
+            .filter({ name: { $eq: { $literal: newName } } })
+            .select('*'),
         );
         if (!existing || existing.length === 0 || existing[0].id === sched.id) {
           sched.name = newName;
@@ -1065,7 +1067,11 @@ handlers['api/get-id-by-name'] = async function ({ type, name }) {
     throw APIError('Provide a valid type');
   }
 
-  const { data } = await aqlQuery(q(type).filter({ name }).select('*'));
+  const { data } = await aqlQuery(
+    q(type)
+      .filter({ name: { $eq: { $literal: name } } })
+      .select('*'),
+  );
 
   if (!data || data.length === 0) {
     throw APIError(`Not found: ${type} with name ${name}`);

--- a/packages/loot-core/src/server/aql/compiler.test.ts
+++ b/packages/loot-core/src/server/aql/compiler.test.ts
@@ -263,6 +263,50 @@ describe('sheet language', () => {
     expect(result.sql).not.toMatch('payees.id AS id');
   });
 
+  it('`$literal` treats its argument as a raw value', () => {
+    // A leading `$` would otherwise be parsed as a field reference and a
+    // leading `:` as a named parameter
+    for (const name of ['$foo', ':foo', '$', 'plain']) {
+      const result = generateSQLWithState(
+        q('payees')
+          .filter({ name: { $eq: { $literal: name } } })
+          .select('name')
+          .serialize(),
+        schemaWithRefs,
+      );
+      expect(result.sql).toMatch(`WHERE (payees.name = '${name}')`);
+      expect(result.state.namedParameters).toEqual([]);
+    }
+  });
+
+  it('`$literal` does not unescape backslashes', () => {
+    const result = generateSQLWithState(
+      q('payees')
+        .filter({ name: { $eq: { $literal: 'a\\$b' } } })
+        .select('name')
+        .serialize(),
+      schemaWithRefs,
+    );
+    expect(result.sql).toMatch(`WHERE (payees.name = 'a\\$b')`);
+  });
+
+  it('unwrapped strings still parse as field references and parameters', () => {
+    let result = generateSQLWithState(
+      q('transactions').filter({ amount: '$amount2' }).select('id').serialize(),
+      basicSchema,
+    );
+    expect(result.sql).toMatch(
+      'WHERE (transactions.amount = transactions.amount2)',
+    );
+
+    result = generateSQLWithState(
+      q('transactions').filter({ amount: ':foo' }).select('id').serialize(),
+      basicSchema,
+    );
+    expect(result.sql).toMatch('transactions.amount = ?');
+    expect(result.state.namedParameters.map(p => p.paramName)).toContain('foo');
+  });
+
   it('automatically joins tables if referenced by path', () => {
     // Join a simple table
     let result = generateSQLWithState(

--- a/packages/loot-core/src/server/aql/compiler.ts
+++ b/packages/loot-core/src/server/aql/compiler.ts
@@ -457,7 +457,7 @@ function getCompileError(error, stack) {
 
 //// Compiler
 
-function compileLiteral(value) {
+function compileLiteral(value, { unescape = true } = {}) {
   if (value === undefined) {
     throw new CompileError('`undefined` is not a valid query value');
   } else if (value === null) {
@@ -466,8 +466,11 @@ function compileLiteral(value) {
     return typed(nativeDateToInt(value), 'date', { literal: true });
   } else if (typeof value === 'string') {
     // Allow user to escape $, and quote the string to make it a
-    // string literal in the output
-    value = value.replace(/\\\$/g, '$');
+    // string literal in the output. Values coming from `$literal` are
+    // already raw, so they must not be unescaped again.
+    if (unescape) {
+      value = value.replace(/\\\$/g, '$');
+    }
     return typed(value, 'string', { literal: true });
   } else if (typeof value === 'boolean') {
     return typed(value ? 1 : 0, 'boolean', { literal: true });
@@ -534,8 +537,10 @@ const compileFunction = saveStack('function', (state, func) => {
   }
 
   let args = argExprs;
-  // `$condition` is a special-case where it will be evaluated later
-  if (name !== '$condition') {
+  // `$condition` is a special-case where it will be evaluated later, and
+  // `$literal` takes its argument raw so that it is never parsed as a
+  // field reference or a named parameter
+  if (name !== '$condition' && name !== '$literal') {
     args = argExprs.map(arg => compileExpr(state, arg));
   }
 
@@ -633,11 +638,8 @@ const compileFunction = saveStack('function', (state, func) => {
       return typed(`${arg1} COLLATE NOCASE`, args[0].type);
 
     case '$literal': {
-      validateArgLength(args, 1);
-      if (!args[0].literal) {
-        throw new CompileError('Literal not passed to $literal');
-      }
-      return args[0];
+      validateArgLength(argExprs, 1);
+      return compileLiteral(argExprs[0], { unescape: false });
     }
     default:
       throw new CompileError(`Unknown function: ${name}`);

--- a/upcoming-release-notes/fix-schedule-name-starting-with-dollar-sign.md
+++ b/upcoming-release-notes/fix-schedule-name-starting-with-dollar-sign.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [NoiceHax]
+---
+
+Fix schedules failing to save when the name starts with a dollar sign or a colon


### PR DESCRIPTION
## Description

Saving a schedule failed with the red "Something went wrong" message whenever the name started with a dollar sign. AQL reads a bare string starting with `$` as a field reference, and one starting with `:` as a named parameter. The duplicate name check passes the schedule name straight into `filter({ name })`, so a name like `$rent` was compiled as a field reference and threw "Invalid field reference: $".

AQL already had a `$literal` function meant for exactly this, but it could never work. `compileFunction` ran every argument through `compileExpr` before the `$literal` branch saw it, so the string had already been misread as a field reference by the time its guard ran. I made `$literal` skip that pre-compilation, the same way `$condition` already does, and compile the raw value directly without the backslash unescaping that normal literals get.

The four places that look a record up by name now wrap the name in `$literal`. Nothing needs escaping at the call sites, and `$` and `:` keep their meaning for real field references and named parameters. Two of those sites are the desktop and mobile schedule editors. The other two are in the API, where `api/get-id-by-name` hit the same problem for a payee, category or account whose name starts with `$`.

Drafted with Claude Code; I reviewed the diff line by line and tested it locally.

## Related issue(s)

Fixes #7358

## Testing

Added tests in `compiler.test.ts` covering `$literal` with `$foo`, `:foo`, a bare `$` and a plain name, and one checking a backslash is left alone. There is also a test that unwrapped strings still resolve as field references and named parameters, so that behaviour is not lost.

I checked the new tests really catch the bug: with the compiler change reverted, the two `$literal` tests fail, and they pass with it. The file is green at 32 of 32.

The other AQL test files in that folder need the better-sqlite3 native build, which does not compile on my machine. They fail the same way without my changes, so I could not run those.

To reproduce the original bug, add a schedule named `$rent` and save it.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 → 41 | 13.39 MB → 13.32 MB (-71.91 kB) | -0.52%
loot-core | 1 | 4.63 MB → 4.63 MB (+2.16 kB) | +0.05%
api | 2 | 3.84 MB → 3.84 MB (+2.64 kB) | +0.07%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 → 41 | 13.39 MB → 13.32 MB (-71.91 kB) | -0.52%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/react-joyride/dist/index.mjs` | 🆕 +81.59 kB | 0 B → 81.59 kB
`node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs` | 🆕 +17.94 kB | 0 B → 17.94 kB
`node_modules/@floating-ui/core/dist/floating-ui.core.mjs` | 🆕 +16.68 kB | 0 B → 16.68 kB
`src/components/reports/reports/monte-carlo/MonteCarloContributions.tsx` | 🆕 +10.49 kB | 0 B → 10.49 kB
`src/components/tour/steps.tsx` | 🆕 +6.81 kB | 0 B → 6.81 kB
`node_modules/@floating-ui/react-dom/dist/floating-ui.react-dom.mjs` | 🆕 +6.53 kB | 0 B → 6.53 kB
`node_modules/is-lite/dist/index.mjs` | 🆕 +6.28 kB | 0 B → 6.28 kB
`src/components/tour/TourHost.ts` | 🆕 +4.8 kB | 0 B → 4.8 kB
`node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs` | 🆕 +4.67 kB | 0 B → 4.67 kB
`node_modules/@fastify/deepmerge/index.js` | 🆕 +4.49 kB | 0 B → 4.49 kB
`node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs` | 🆕 +4.16 kB | 0 B → 4.16 kB
`src/components/tour/TourTooltip.tsx` | 🆕 +4.01 kB | 0 B → 4.01 kB
`node_modules/@gilbarbara/hooks/dist/index.mjs` | 🆕 +3.97 kB | 0 B → 3.97 kB
`node_modules/@gilbarbara/deep-equal/dist/index.mjs` | 🆕 +3.87 kB | 0 B → 3.87 kB
`src/components/tour/TourProvider.tsx` | 🆕 +1.54 kB | 0 B → 1.54 kB
`src/components/tour/TourAutoOffer.ts` | 🆕 +1.52 kB | 0 B → 1.52 kB
`node_modules/scroll/index.js` | 🆕 +1.29 kB | 0 B → 1.29 kB
`node_modules/scrollparent/scrollparent.js` | 🆕 +950 B | 0 B → 950 B
`node_modules/react-innertext/index.js` | 🆕 +839 B | 0 B → 839 B
`src/components/tour/Tour.tsx` | 🆕 +668 B | 0 B → 668 B
`src/components/tour/TourTooltipButton.tsx` | 🆕 +374 B | 0 B → 374 B
`src/hooks/useDaysOfWeek.ts` | 📈 +913 B (+352.51%) | 259 B → 1.14 kB
`src/hooks/usePayee.ts` | 📈 +373 B (+192.27%) | 194 B → 567 B
`src/hooks/useAccounts.ts` | 📈 +213 B (+183.62%) | 116 B → 329 B
`src/hooks/useCategory.ts` | 📈 +373 B (+182.84%) | 204 B → 577 B
`src/hooks/useReport.ts` | 📈 +373 B (+180.19%) | 207 B → 580 B
`src/hooks/useCategoryGroup.ts` | 📈 +373 B (+173.49%) | 215 B → 588 B
`src/hooks/useNearbyPayees.ts` | 📈 +269 B (+166.05%) | 162 B → 431 B
`src/hooks/useDashboardWidget.ts` | 📈 +421 B (+154.21%) | 273 B → 694 B
`src/components/transactions/useTransactionRowContextActions.ts` | 📈 +7 kB (+147.19%) | 4.76 kB → 11.76 kB
`src/hooks/useCategoryPreviewTransactions.ts` | 📈 +2.21 kB (+147.17%) | 1.5 kB → 3.71 kB
`src/hooks/usePayees.ts` | 📈 +347 B (+146.41%) | 237 B → 584 B
`src/hooks/useMetadataPref.ts` | 📈 +512 B (+145.45%) | 352 B → 864 B
`src/hooks/useReports.ts` | 📈 +155 B (+134.78%) | 115 B → 270 B
`src/hooks/useDashboardPages.ts` | 📈 +370 B (+134.06%) | 276 B → 646 B
`src/hooks/useAccount.ts` | 📈 +243 B (+132.07%) | 184 B → 427 B
`src/hooks/useCommonPayees.ts` | 📈 +155 B (+119.23%) | 130 B → 285 B
`src/hooks/useClosedAccounts.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/usePayeeRuleCounts.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/useOrphanedPayees.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/useOnBudgetAccounts.ts` | 📈 +155 B (+110.71%) | 140 B → 295 B
`src/hooks/useServerPref.ts` | 📈 +376 B (+109.62%) | 343 B → 719 B
`src/hooks/useSyncedPref.ts` | 📈 +376 B (+109.62%) | 343 B → 719 B
`src/hooks/useCategoryScheduleGoalTemplates.ts` | 📈 +1.66 kB (+109.03%) | 1.52 kB → 3.19 kB
`src/hooks/useOffBudgetAccounts.ts` | 📈 +155 B (+108.39%) | 143 B → 298 B
`home/runner/work/actual/actual/packages/component-library/src/hooks/useResponsive.ts` | 📈 +510 B (+105.59%) | 483 B → 993 B
`src/hooks/useGlobalPref.ts` | 📈 +445 B (+103.25%) | 431 B → 876 B
`src/hooks/useTags.ts` | 📈 +1.04 kB (+101.24%) | 1.03 kB → 2.07 kB
`src/components/reports/reports/monte-carlo/useResolvedMonteCarloConfig.ts` | 📈 +572 B (+101.06%) | 566 B → 1.11 kB
`src/hooks/useCurrentAccess.ts` | 📈 +719 B (+100.84%) | 713 B → 1.4 kB
`src/hooks/useCategories.ts` | 📈 +326 B (+100.62%) | 324 B → 650 B
`src/hooks/useSyncedPrefs.ts` | 📈 +291 B (+94.17%) | 309 B → 600 B
`src/hooks/useFormatList.ts` | 📈 +619 B (+92.53%) | 669 B → 1.26 kB
`src/util/router-tools.ts` | 📈 +198 B (+91.24%) | 217 B → 415 B
`src/hooks/useInputRefValue.ts` | 📈 +558 B (+90.88%) | 614 B → 1.14 kB
`src/hooks/useCleanupGroups.ts` | 📈 +751 B (+90.48%) | 830 B → 1.54 kB
`src/components/reports/reports/FormulaCard.tsx` | 📈 +2.27 kB (+88.52%) | 2.57 kB → 4.84 kB
`src/hooks/useSendPlatformRequest.ts` | 📈 +398 B (+82.57%) | 482 B → 880 B
`src/hooks/useTransactionTableColumns.ts` | 📈 +1.68 kB (+79.53%) | 2.11 kB → 3.79 kB
`src/components/banksync/useBankSyncAccountSettings.ts` | 📈 +2.44 kB (+78.69%) | 3.1 kB → 5.54 kB
`src/hooks/useModalState.ts` | 📈 +514 B (+76.83%) | 669 B → 1.16 kB
`src/hooks/usePluggyAiStatus.ts` | 📈 +483 B (+76.67%) | 630 B → 1.09 kB
`src/tags/mutations.ts` | 📈 +2.46 kB (+76.61%) | 3.21 kB → 5.68 kB
`src/hooks/useUrlParam.ts` | 📈 +399 B (+75.28%) | 530 B → 929 B
`src/reports/mutations.ts` | 📈 +5.35 kB (+70.55%) | 7.59 kB → 12.94 kB
`src/hooks/useAkahuStatus.ts` | 📈 +442 B (+70.38%) | 628 B → 1.04 kB
`src/hooks/useBudgetAutomations.ts` | 📈 +547 B (+69.59%) | 786 B → 1.3 kB
`src/hooks/usePreviewTransactions.ts` | 📈 +1.85 kB (+64.02%) | 2.88 kB → 4.73 kB
`src/hooks/useLocale.ts` | 📈 +147 B (+63.91%) | 230 B → 377 B
`src/hooks/useLocalPref.ts` | 📈 +158 B (+62.95%) | 251 B → 409 B
`src/hooks/useSimpleFinStatus.ts` | 📈 +379 B (+62.23%) | 609 B → 988 B
`src/hooks/useGoCardlessStatus.ts` | 📈 +381 B (+61.85%) | 616 B → 997 B
`node_modules/date-fns/isSameWeek.js` | 📈 +181 B (+61.56%) | 294 B → 475 B
`src/hooks/useCursorPosition.ts` | 📈 +540 B (+61.29%) | 881 B → 1.39 kB
`src/hooks/useIsInViewport.ts` | 📈 +300 B (+59.17%) | 507 B → 807 B
`src/payees/mutations.ts` | 📈 +1.21 kB (+57.89%) | 2.08 kB → 3.29 kB
`src/hooks/useNotes.ts` | 📈 +143 B (+57.66%) | 248 B → 391 B
`src/hooks/useCategoryCleanup.ts` | 📈 +554 B (+57.29%) | 967 B → 1.49 kB
`src/hooks/useUndo.ts` | 📈 +501 B (+57.13%) | 877 B → 1.35 kB
`src/hooks/useDragRef.ts` | 📈 +98 B (+56.65%) | 173 B → 271 B
`src/components/reports/useReport.ts` | 📈 +253 B (+54.64%) | 463 B → 716 B
`src/components/transactions/table/columns.ts` | 📈 +1.24 kB (+54.55%) | 2.28 kB → 3.52 kB
`src/hooks/useCategoryScheduleGoalTemplateIndicator.ts` | 📈 +1.46 kB (+54.34%) | 2.69 kB → 4.15 kB
`src/hooks/useAccountBalances.ts` | 📈 +474 B (+53.32%) | 889 B → 1.33 kB
`src/hooks/useFailedAccounts.ts` | 📈 +140 B (+52.83%) | 265 B → 405 B
`src/hooks/useTransactionFilters.ts` | 📈 +273 B (+48.15%) | 567 B → 840 B
`src/hooks/useMergedRefs.ts` | 📈 +117 B (+41.94%) | 279 B → 396 B
`src/components/manager/subscribe/OpenIdCallback.ts` | 📈 +149 B (+39.84%) | 374 B → 523 B
`src/components/GlobalKeys.ts` | 📈 +238 B (+37.25%) | 639 B → 877 B
`src/hooks/useSchedules.ts` | 📈 +926 B (+37.14%) | 2.43 kB → 3.34 kB
`src/components/reports/getLiveRange.ts` | 📈 +588 B (+36.66%) | 1.57 kB → 2.14 kB
`src/accounts/mutations.ts` | 📈 +5.16 kB (+36.50%) | 14.14 kB → 19.31 kB
`src/hooks/useLocationPermission.ts` | 📈 +513 B (+34.50%) | 1.45 kB → 1.95 kB
`src/hooks/useMetaThemeColor.ts` | 📈 +706 B (+32.64%) | 2.11 kB → 2.8 kB
`src/budget/mutations.ts` | 📈 +4.59 kB (+30.89%) | 14.85 kB → 19.44 kB
`src/hooks/useRuleConditionFilters.ts` | 📈 +466 B (+30.56%) | 1.49 kB → 1.94 kB
`src/hooks/useAccountPreviewTransactions.ts` | 📈 +1.07 kB (+30.26%) | 3.54 kB → 4.62 kB
`src/hooks/useFormat.ts` | 📈 +1.41 kB (+27.42%) | 5.15 kB → 6.56 kB
`src/components/reports/chart-theme.ts` | 📈 +205 B (+24.88%) | 824 B → 1 kB
`src/hooks/useUpdatedAccounts.ts` | 📈 +36 B (+23.68%) | 152 B → 188 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/LoadingIndicator.js | 0 B → 669.76 kB (+669.76 kB) | -
static/js/months.js | 0 B → 574.39 kB (+574.39 kB) | -
static/js/TourHost.js | 0 B → 169.22 kB (+169.22 kB) | -
static/js/useLocalPref.js | 0 B → 97.2 kB (+97.2 kB) | -
static/js/TourProvider.js | 0 B → 1.54 kB (+1.54 kB) | -
static/js/useReducedMotion.js | 0 B → 594 B (+594 B) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/chart-theme.js | 670.14 kB → 0 B (-670.14 kB) | -100%
static/js/th.js | 165.36 kB → 0 B (-165.36 kB) | -100%
static/js/ru.js | 142.56 kB → 0 B (-142.56 kB) | -100%
static/js/da.js | 95.87 kB → 0 B (-95.87 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 209.56 kB → 245.23 kB (+35.67 kB) | +17.02%
static/js/ReportRouter.js | 1.39 MB → 1.42 MB (+33.61 kB) | +2.37%
static/js/index.js | 1.56 MB → 1.57 MB (+12.18 kB) | +0.76%
static/js/fr.js | 168.15 kB → 180.13 kB (+11.98 kB) | +7.13%
static/js/nl.js | 144.82 kB → 152.45 kB (+7.63 kB) | +5.27%
static/js/FormulaEditor.js | 762.13 kB → 766.28 kB (+4.16 kB) | +0.55%
static/js/de.js | 179.29 kB → 183.43 kB (+4.14 kB) | +2.31%
static/js/ScheduleEditForm.js | 73.39 kB → 76.54 kB (+3.15 kB) | +4.29%
static/js/PayeeRuleCountLabel.js | 9.8 kB → 12.81 kB (+3.01 kB) | +30.75%
static/js/ManageRules.js | 69.17 kB → 71.66 kB (+2.49 kB) | +3.59%
static/js/narrow.js | 284.96 kB → 287.26 kB (+2.31 kB) | +0.81%
static/js/wide.js | 272.21 kB → 274.04 kB (+1.83 kB) | +0.67%
static/js/useTransactionBatchActions.js | 9.77 kB → 11.03 kB (+1.26 kB) | +12.86%
static/js/useFormatList.js | 9.31 kB → 10.22 kB (+931 B) | +9.77%
static/js/TransactionEdit.js | 219.25 kB → 219.94 kB (+714 B) | +0.32%
static/js/SchedulesTable.js | 171.06 kB → 171.25 kB (+194 B) | +0.11%
static/js/it.js | 152.57 kB → 152.73 kB (+163 B) | +0.10%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useDateFormat.js | 2.92 MB → 2.37 MB (-565.71 kB) | -18.93%
static/js/Value.js | 2 MB → 1.93 MB (-69.92 kB) | -3.41%
static/js/pt-BR.js | 179.66 kB → 179.25 kB (-417 B) | -0.23%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+2.16 kB) | +0.05%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +289 B (+4.13%) | 6.84 kB → 7.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +835 B (+3.79%) | 21.54 kB → 22.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +172 B (+3.74%) | 4.49 kB → 4.66 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +216 B (+2.14%) | 9.87 kB → 10.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +229 B (+1.96%) | 11.4 kB → 11.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +373 B (+1.47%) | 24.71 kB → 25.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +86 B (+1.47%) | 5.73 kB → 5.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.70%) | 6.24 kB → 6.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +52 B (+0.21%) | 23.73 kB → 23.78 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -88 B (-0.93%) | 9.23 kB → 9.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.7m91TP23.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DMvmLzbd.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+2.64 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +1.33 kB (+6.30%) | 21.11 kB → 22.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +273 B (+4.13%) | 6.46 kB → 6.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +169 B (+3.80%) | 4.34 kB → 4.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +214 B (+2.18%) | 9.58 kB → 9.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +225 B (+1.98%) | 11.12 kB → 11.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +364 B (+1.48%) | 24.07 kB → 24.42 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +84 B (+1.29%) | 6.36 kB → 6.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.72%) | 6.14 kB → 6.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +52 B (+0.22%) | 23.11 kB → 23.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -81 B (-0.88%) | 8.95 kB → 8.88 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+2.64 kB) | +0.07%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->