### PR TITLE
docs(api): fix rule `stage` docs — `default` is rejected, `null` is the default

### DIFF
--- a/packages/docs/docs/api/types.jsx
+++ b/packages/docs/docs/api/types.jsx
@@ -440,8 +440,8 @@ export const objects = {
       required: true,
       description: (
         <span>
-          Must be one of <code>pre</code>, <code>default</code>, or{' '}
-          <code>post</code>.
+          Must be one of <code>pre</code>, <code>post</code>, or{' '}
+          <code>null</code> (the default stage when none is chosen).
         </span>
       ),
     },


### PR DESCRIPTION
Closes #8682

The rules API reference documents `stage` as `pre`/`default`/`post`, but the implementation rejects `default` and requires `null` for the default stage (verified against a stock 26.8.0 server). This is the docs-only fix suggested in the issue (option 1): update the description to `pre`, `post`, or `null`, noting `null` is the default stage.

Scoped to the `rule` entry as suggested; `payeeRule` describes a read shape and was left untouched.