### PR TITLE
add cleared to rule conditions

### DIFF
--- a/packages/desktop-client/src/components/rules/RuleEditor.tsx
+++ b/packages/desktop-client/src/components/rules/RuleEditor.tsx
@@ -1015,6 +1015,7 @@ const conditionFields = [
   .concat([
     ['amount-inflow', mapField('amount', { inflow: true })],
     ['amount-outflow', mapField('amount', { outflow: true })],
+    ['cleared', mapField('cleared')],
   ]);
 
 type RuleEditorProps = {

--- a/packages/docs/docs/budgeting/rules/index.md
+++ b/packages/docs/docs/budgeting/rules/index.md
@@ -42,10 +42,13 @@ Conditions can use the following fields:
 - amount
 - amount (inflow)
 - amount (outflow)
+- cleared
 
 `imported payee` is different from `payee` in that it is _always_ the original text of the payee or description field when the transaction was imported. `payee` references a payee in Actual. This matters because it allows you to rename a payee before it is created in Actual. You can have several rules that all check `imported payee` and set the payee to something without worrying about them stepping on each other. (Conditions can't reliably check `payee` if previous rules changed it)
 
 The `inflow` and `outflow` versions of `amount` make it easier to work with amounts. If you only want to match expenses between 5 and 10 dollars, use `amount (outflow)` because that money is leaving the account. If you use `amount`, you'd have to use negative numbers and it's simply less convenient.
+
+The `cleared` field matches whether a transaction is marked as cleared. For transactions coming from bank sync, this lets a rule treat pending and booked transactions differently.
 
 All strings are matched case-insensitive. An `imported payee` of "PuBlix" will match a condition that is "contains 'publix'".
 

--- a/packages/loot-core/src/server/rules/index.test.ts
+++ b/packages/loot-core/src/server/rules/index.test.ts
@@ -296,6 +296,29 @@ describe('Condition', () => {
     expect(cond.eval({ amount: 1.67 })).toBe(false);
     expect(cond.eval({ amount: 1.5 })).toBe(true);
   });
+
+  test('boolean validates value', () => {
+    new Condition('is', 'cleared', true, null);
+
+    expect(() => {
+      new Condition('is', 'cleared', 'true', null);
+    }).toThrow('Value must be a boolean');
+
+    expect(() => {
+      new Condition('is', 'cleared', null, null);
+    }).toThrow('Field cannot be empty');
+  });
+
+  test('boolean works with `is` operator', () => {
+    let cond = new Condition('is', 'cleared', true, null);
+    expect(cond.eval({ cleared: true })).toBe(true);
+    expect(cond.eval({ cleared: false })).toBe(false);
+    expect(cond.eval({})).toBe(false);
+
+    cond = new Condition('is', 'cleared', false, null);
+    expect(cond.eval({ cleared: false })).toBe(true);
+    expect(cond.eval({ cleared: true })).toBe(false);
+  });
 });
 
 describe('Action', () => {
@@ -560,6 +583,18 @@ describe('Rule', () => {
     });
     expect(rule.exec({ notes: 'James2' })).toEqual(null);
     expect(rule.apply({ notes: 'James2' })).toEqual({ notes: 'James2' });
+  });
+
+  test('rule with a cleared condition matches on cleared status', () => {
+    const rule = new Rule({
+      conditionsOp: 'and',
+      conditions: [{ op: 'is', field: 'cleared', value: true }],
+      actions: [{ op: 'set', field: 'notes', value: 'Sarah' }],
+    });
+
+    expect(rule.exec({ cleared: true })).toEqual({ notes: 'Sarah' });
+    expect(rule.exec({ cleared: false })).toEqual(null);
+    expect(rule.exec({})).toEqual(null);
   });
 
   test('rule with `and` conditionsOp evaluates conditions as AND', () => {

--- a/upcoming-release-notes/add-cleared-rule-condition.md
+++ b/upcoming-release-notes/add-cleared-rule-condition.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [matt-fidd]
+---
+
+Allow rules to match transactions by cleared status


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

As above, I can't find any reason we didn't add this, and it's been requested, so here it is

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Tested locally, wasn't able to test with bank sync but the logic should work as other rules do

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.33 MB → 13.33 MB (+39 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.33 MB → 13.33 MB (+39 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/rules/RuleEditor.tsx` | 📈 +39 B (+0.08%) | 45.54 kB → 45.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.93 MB → 1.93 MB (+39 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.39 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->