### PR TITLE
Add navigation features and testing for budget cells #8729 

### DIFF
--- a/packages/desktop-client/src/components/budget/BudgetCategories.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetCategories.tsx
@@ -43,6 +43,7 @@ type LocalDragState =
 type BudgetCategoriesProps = {
   categoryGroups: CategoryGroupEntity[];
   editingCell: { id: string; cell: string } | null;
+  focusedCell: { id: string; cell: string } | null;
   onBudgetAction: (month: string, action: string, arg: unknown) => void;
   onShowActivity: (id: CategoryEntity['id'], month?: string) => void;
   onEditName: (id: CategoryEntity['id']) => void;
@@ -64,6 +65,7 @@ export const BudgetCategories = memo<BudgetCategoriesProps>(
   ({
     categoryGroups,
     editingCell,
+    focusedCell,
     onBudgetAction,
     onShowActivity,
     onEditName,
@@ -316,6 +318,7 @@ export const BudgetCategories = memo<BudgetCategoriesProps>(
                   cat={item.value}
                   categoryGroup={item.group}
                   editingCell={editingCell}
+                  focusedCell={focusedCell}
                   dragState={dragState}
                   onEditName={onEditName}
                   onEditMonth={onEditMonth}
@@ -359,6 +362,7 @@ export const BudgetCategories = memo<BudgetCategoriesProps>(
                 <IncomeCategory
                   cat={item.value}
                   editingCell={editingCell}
+                  focusedCell={focusedCell}
                   isLast={idx === items.length - 1}
                   onEditName={onEditName}
                   onEditMonth={onEditMonth}

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -181,6 +181,7 @@ export function BudgetTable(props: BudgetTableProps) {
       const nextCell = findNextBudgetCell(
         categoryGroups,
         collapsedGroupIds,
+        showHiddenCategories ?? false,
         editing,
         type,
         dir,

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -17,9 +17,9 @@ import { useGlobalPref } from '#hooks/useGlobalPref';
 import { useLocalPref } from '#hooks/useLocalPref';
 
 import { BudgetCategories } from './BudgetCategories';
+import { findNextBudgetCell } from './budgetNavigation';
 import { BudgetSummaries } from './BudgetSummaries';
 import { BudgetTotals } from './BudgetTotals';
-import { findNextBudgetCell } from './budgetNavigation';
 import { MonthsProvider } from './MonthsContext';
 import type { MonthBounds } from './MonthsContext';
 import {

--- a/packages/desktop-client/src/components/budget/BudgetTable.tsx
+++ b/packages/desktop-client/src/components/budget/BudgetTable.tsx
@@ -19,6 +19,7 @@ import { useLocalPref } from '#hooks/useLocalPref';
 import { BudgetCategories } from './BudgetCategories';
 import { BudgetSummaries } from './BudgetSummaries';
 import { BudgetTotals } from './BudgetTotals';
+import { findNextBudgetCell } from './budgetNavigation';
 import { MonthsProvider } from './MonthsContext';
 import type { MonthBounds } from './MonthsContext';
 import {
@@ -89,7 +90,12 @@ export function BudgetTable(props: BudgetTableProps) {
   const [editing, setEditing] = useState<{ id: string; cell: string } | null>(
     null,
   );
+  const [focusedCell, setFocusedCell] = useState<{
+    id: string;
+    cell: string;
+  } | null>(null);
 
+  const tableRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -103,11 +109,18 @@ export function BudgetTable(props: BudgetTableProps) {
   }, []);
 
   const onEditMonth = (id: string, month: string) => {
+    setFocusedCell(null);
     setEditing(id ? { id, cell: month } : null);
   };
 
   const onEditName = (id: string) => {
+    setFocusedCell(null);
     setEditing(id ? { id, cell: 'name' } : null);
+  };
+
+  const onFocusMonth = (id: string, month: string) => {
+    setEditing(null);
+    setFocusedCell(id ? { id, cell: month } : null);
   };
 
   const _onReorderCategory = (
@@ -164,40 +177,17 @@ export function BudgetTable(props: BudgetTableProps) {
   };
 
   const moveVertically = (dir: 1 | -1) => {
-    const flattened = categoryGroups.reduce(
-      (all, group) => {
-        if (collapsedGroupIds.includes(group.id)) {
-          return all.concat({ id: group.id, isGroup: true });
-        }
-        return all.concat([
-          { id: group.id, isGroup: true },
-          ...(group?.categories || []),
-        ]);
-      },
-      [] as Array<
-        { id: CategoryGroupEntity['id']; isGroup: boolean } | CategoryEntity
-      >,
-    );
-
     if (editing) {
-      const idx = flattened.findIndex(item => item.id === editing.id);
-      let nextIdx = idx + dir;
+      const nextCell = findNextBudgetCell(
+        categoryGroups,
+        collapsedGroupIds,
+        editing,
+        type,
+        dir,
+      );
 
-      while (nextIdx >= 0 && nextIdx < flattened.length) {
-        const next = flattened[nextIdx];
-
-        if ('isGroup' in next && next.isGroup) {
-          nextIdx += dir;
-          continue;
-        } else if (
-          type === 'tracking' ||
-          ('is_income' in next && !next.is_income)
-        ) {
-          onEditMonth(next.id, editing.cell);
-          return;
-        } else {
-          break;
-        }
+      if (nextCell) {
+        onFocusMonth(nextCell.id, nextCell.cell);
       }
     }
   };
@@ -306,15 +296,29 @@ export function BudgetTable(props: BudgetTableProps) {
           }}
         >
           <View
+            ref={tableRef}
             style={{
               flexShrink: 0,
             }}
             onKeyDown={onKeyDown}
+            onBlur={e => {
+              if (!document.hasFocus()) {
+                return;
+              }
+
+              if (
+                e.relatedTarget == null ||
+                !tableRef.current?.contains(e.relatedTarget as Node)
+              ) {
+                setFocusedCell(null);
+              }
+            }}
           >
             <SchedulesProvider query={schedulesQuery}>
               <BudgetCategories
                 categoryGroups={categoryGroups}
                 editingCell={editing}
+                focusedCell={focusedCell}
                 onEditMonth={onEditMonth}
                 onEditName={onEditName}
                 onSaveCategory={onSaveCategory}

--- a/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
+++ b/packages/desktop-client/src/components/budget/ExpenseCategory.tsx
@@ -27,6 +27,7 @@ type ExpenseCategoryProps = {
   cat: CategoryEntity;
   categoryGroup?: CategoryGroupEntity;
   editingCell: { id: string; cell: string } | null;
+  focusedCell: { id: string; cell: string } | null;
   dragState: DragState<CategoryEntity> | DragState<CategoryGroupEntity> | null;
   onEditName?: ComponentProps<typeof SidebarCategory>['onEditName'];
   onEditMonth?: (id: CategoryEntity['id'], month: string) => void;
@@ -42,6 +43,7 @@ export function ExpenseCategory({
   cat,
   categoryGroup,
   editingCell,
+  focusedCell,
   dragState,
   onEditName,
   onEditMonth,
@@ -110,6 +112,14 @@ export function ExpenseCategory({
                 editingCell &&
                 editingCell.id === cat.id &&
                 editingCell.cell === month
+              }
+              active={
+                (editingCell &&
+                  editingCell.id === cat.id &&
+                  editingCell.cell === month) ||
+                (focusedCell &&
+                  focusedCell.id === cat.id &&
+                  focusedCell.cell === month)
               }
               category={cat}
               onEdit={onEditMonth}

--- a/packages/desktop-client/src/components/budget/IncomeCategory.tsx
+++ b/packages/desktop-client/src/components/budget/IncomeCategory.tsx
@@ -18,6 +18,7 @@ type IncomeCategoryProps = {
   cat: CategoryEntity;
   isLast?: boolean;
   editingCell: { id: CategoryEntity['id']; cell: string } | null;
+  focusedCell: { id: CategoryEntity['id']; cell: string } | null;
   onEditName: ComponentProps<typeof SidebarCategory>['onEditName'];
   onEditMonth?: (id: CategoryEntity['id'], month: string) => void;
   onSave: ComponentProps<typeof SidebarCategory>['onSave'];
@@ -32,6 +33,7 @@ export function IncomeCategory({
   cat,
   isLast,
   editingCell,
+  focusedCell,
   onEditName,
   onEditMonth,
   onSave,
@@ -88,6 +90,14 @@ export function IncomeCategory({
               editingCell &&
               editingCell.id === cat.id &&
               editingCell.cell === month
+            }
+            active={
+              (editingCell &&
+                editingCell.id === cat.id &&
+                editingCell.cell === month) ||
+              (focusedCell &&
+                focusedCell.id === cat.id &&
+                focusedCell.cell === month)
             }
             category={cat}
             isLast={isLast}

--- a/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
@@ -20,12 +20,22 @@ function makeCategory(
 function makeGroup(
   id: string,
   categories: CategoryEntity[],
-): CategoryGroupEntity & { id: string; categories: CategoryEntity[] } {
+  hidden = false,
+): CategoryGroupEntity & {
+  id: string;
+  categories: CategoryEntity[];
+  hidden?: boolean;
+} {
   return {
     id,
     name: id,
     categories,
-  } as CategoryGroupEntity & { id: string; categories: CategoryEntity[] };
+    hidden,
+  } as CategoryGroupEntity & {
+    id: string;
+    categories: CategoryEntity[];
+    hidden?: boolean;
+  };
 }
 
 describe('findNextBudgetCell', () => {
@@ -38,6 +48,7 @@ describe('findNextBudgetCell', () => {
     const nextCell = findNextBudgetCell(
       expenseGroups,
       [],
+      false,
       { id: 'cat-a', cell: '2026-08' },
       'envelope',
       1,
@@ -50,6 +61,7 @@ describe('findNextBudgetCell', () => {
     const nextCell = findNextBudgetCell(
       expenseGroups,
       [],
+      false,
       { id: 'cat-b', cell: '2026-08' },
       'envelope',
       1,
@@ -62,11 +74,52 @@ describe('findNextBudgetCell', () => {
     const nextCell = findNextBudgetCell(
       expenseGroups,
       [],
+      false,
       { id: 'cat-b', cell: '2026-08' },
       'tracking',
       1,
     );
 
     expect(nextCell).toEqual({ id: 'cat-income', cell: '2026-08' });
+  });
+
+  it('skips hidden expense groups when hidden categories are not shown', () => {
+    const nextCell = findNextBudgetCell(
+      [
+        makeGroup('group-a', [makeCategory('cat-a')]),
+        makeGroup('group-hidden', [makeCategory('cat-hidden')], true),
+        makeGroup('group-b', [makeCategory('cat-b')]),
+      ],
+      [],
+      false,
+      { id: 'cat-a', cell: '2026-08' },
+      'envelope',
+      1,
+    );
+
+    expect(nextCell).toEqual({ id: 'cat-b', cell: '2026-08' });
+  });
+
+  it('skips hidden categories while preserving collapsed groups', () => {
+    const nextCell = findNextBudgetCell(
+      [
+        makeGroup('group-a', [
+          makeCategory('cat-a'),
+          Object.assign(makeCategory('cat-hidden'), { hidden: true }),
+        ]),
+        makeGroup('group-b', [
+          makeCategory('cat-b-1'),
+          makeCategory('cat-b-2'),
+        ]),
+        makeGroup('group-c', [makeCategory('cat-c')]),
+      ],
+      ['group-b'],
+      false,
+      { id: 'cat-a', cell: '2026-08' },
+      'envelope',
+      1,
+    );
+
+    expect(nextCell).toEqual({ id: 'cat-c', cell: '2026-08' });
   });
 });

--- a/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
@@ -1,9 +1,8 @@
-import { describe, expect, it } from 'vitest';
-
 import type {
   CategoryEntity,
   CategoryGroupEntity,
 } from '@actual-app/core/types/models';
+import { describe, expect, it } from 'vitest';
 
 import { findNextBudgetCell } from './budgetNavigation';
 

--- a/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  CategoryEntity,
+  CategoryGroupEntity,
+} from '@actual-app/core/types/models';
+
+import { findNextBudgetCell } from './budgetNavigation';
+
+function makeCategory(
+  id: string,
+  is_income = false,
+): CategoryEntity & { id: string; is_income: boolean } {
+  return {
+    id,
+    name: id,
+    is_income,
+  } as CategoryEntity & { id: string; is_income: boolean };
+}
+
+function makeGroup(
+  id: string,
+  categories: CategoryEntity[],
+): CategoryGroupEntity & { id: string; categories: CategoryEntity[] } {
+  return {
+    id,
+    name: id,
+    categories,
+  } as CategoryGroupEntity & { id: string; categories: CategoryEntity[] };
+}
+
+describe('findNextBudgetCell', () => {
+  const expenseGroups = [
+    makeGroup('group-a', [makeCategory('cat-a'), makeCategory('cat-b')]),
+    makeGroup('income-group', [makeCategory('cat-income', true)]),
+  ];
+
+  it('moves to the next expense category without reopening edit mode', () => {
+    const nextCell = findNextBudgetCell(
+      expenseGroups,
+      [],
+      { id: 'cat-a', cell: '2026-08' },
+      'envelope',
+      1,
+    );
+
+    expect(nextCell).toEqual({ id: 'cat-b', cell: '2026-08' });
+  });
+
+  it('skips income categories when navigating envelope budgets', () => {
+    const nextCell = findNextBudgetCell(
+      expenseGroups,
+      [],
+      { id: 'cat-b', cell: '2026-08' },
+      'envelope',
+      1,
+    );
+
+    expect(nextCell).toBeNull();
+  });
+
+  it('allows moving into income categories for tracking budgets', () => {
+    const nextCell = findNextBudgetCell(
+      expenseGroups,
+      [],
+      { id: 'cat-b', cell: '2026-08' },
+      'tracking',
+      1,
+    );
+
+    expect(nextCell).toEqual({ id: 'cat-income', cell: '2026-08' });
+  });
+});

--- a/packages/desktop-client/src/components/budget/budgetNavigation.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.ts
@@ -1,4 +1,7 @@
-import type { CategoryEntity, CategoryGroupEntity } from '@actual-app/core/types/models';
+import type {
+  CategoryEntity,
+  CategoryGroupEntity,
+} from '@actual-app/core/types/models';
 
 type BudgetNavigationRow =
   | { id: CategoryGroupEntity['id']; isGroup: true }

--- a/packages/desktop-client/src/components/budget/budgetNavigation.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.ts
@@ -1,0 +1,55 @@
+import type { CategoryEntity, CategoryGroupEntity } from '@actual-app/core/types/models';
+
+type BudgetNavigationRow =
+  | { id: CategoryGroupEntity['id']; isGroup: true }
+  | CategoryEntity;
+
+function flattenBudgetRows(
+  categoryGroups: CategoryGroupEntity[],
+  collapsedGroupIds: string[],
+) {
+  return categoryGroups.reduce((all, group) => {
+    if (collapsedGroupIds.includes(group.id)) {
+      return all.concat({ id: group.id, isGroup: true });
+    }
+
+    return all.concat([
+      { id: group.id, isGroup: true } as BudgetNavigationRow,
+      ...((group?.categories || []) as BudgetNavigationRow[]),
+    ]);
+  }, [] as BudgetNavigationRow[]);
+}
+
+export function findNextBudgetCell(
+  categoryGroups: CategoryGroupEntity[],
+  collapsedGroupIds: string[],
+  currentCell: { id: string; cell: string },
+  type: string,
+  dir: 1 | -1,
+) {
+  const flattened = flattenBudgetRows(categoryGroups, collapsedGroupIds);
+  const idx = flattened.findIndex(item => item.id === currentCell.id);
+  let nextIdx = idx + dir;
+
+  while (nextIdx >= 0 && nextIdx < flattened.length) {
+    const next = flattened[nextIdx];
+
+    if ('isGroup' in next && next.isGroup) {
+      nextIdx += dir;
+      continue;
+    }
+
+    const nextCategory = next as CategoryEntity;
+
+    if (type === 'tracking' || !nextCategory.is_income) {
+      return {
+        id: nextCategory.id,
+        cell: currentCell.cell,
+      };
+    }
+
+    break;
+  }
+
+  return null;
+}

--- a/packages/desktop-client/src/components/budget/budgetNavigation.ts
+++ b/packages/desktop-client/src/components/budget/budgetNavigation.ts
@@ -10,15 +10,35 @@ type BudgetNavigationRow =
 function flattenBudgetRows(
   categoryGroups: CategoryGroupEntity[],
   collapsedGroupIds: string[],
+  showHiddenCategories: boolean,
 ) {
+  const shouldShowHiddenCategories = Boolean(showHiddenCategories);
+
   return categoryGroups.reduce((all, group) => {
+    if (group.is_income) {
+      return all.concat(
+        { id: group.id, isGroup: true } as BudgetNavigationRow,
+        ...((collapsedGroupIds.includes(group.id)
+          ? []
+          : (group.categories || []).filter(
+              cat => shouldShowHiddenCategories || !cat.hidden,
+            )) as BudgetNavigationRow[]),
+      );
+    }
+
+    if (group.hidden && !shouldShowHiddenCategories) {
+      return all;
+    }
+
     if (collapsedGroupIds.includes(group.id)) {
       return all.concat({ id: group.id, isGroup: true });
     }
 
     return all.concat([
       { id: group.id, isGroup: true } as BudgetNavigationRow,
-      ...((group?.categories || []) as BudgetNavigationRow[]),
+      ...((group?.categories || []).filter(
+        cat => shouldShowHiddenCategories || !cat.hidden,
+      ) as BudgetNavigationRow[]),
     ]);
   }, [] as BudgetNavigationRow[]);
 }
@@ -26,11 +46,16 @@ function flattenBudgetRows(
 export function findNextBudgetCell(
   categoryGroups: CategoryGroupEntity[],
   collapsedGroupIds: string[],
+  showHiddenCategories: boolean,
   currentCell: { id: string; cell: string },
   type: string,
   dir: 1 | -1,
 ) {
-  const flattened = flattenBudgetRows(categoryGroups, collapsedGroupIds);
+  const flattened = flattenBudgetRows(
+    categoryGroups,
+    collapsedGroupIds,
+    showHiddenCategories,
+  );
   const idx = flattened.findIndex(item => item.id === currentCell.id);
   let nextIdx = idx + dir;
 

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.test.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
+
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+
+import { ExpenseCategoryMonth } from './EnvelopeBudgetComponents';
 
 vi.mock('@actual-app/components/popover', () => ({
   Popover: ({ children, isOpen }: { children: ReactNode; isOpen: boolean }) =>
@@ -62,8 +65,6 @@ vi.mock('#hooks/useUndo', () => ({
     showUndoNotification: vi.fn(),
   }),
 }));
-
-import { ExpenseCategoryMonth } from './EnvelopeBudgetComponents';
 
 describe('ExpenseCategoryMonth', () => {
   it('keeps quick actions visible when the cell is active', () => {

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.test.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@actual-app/components/popover', () => ({
+  Popover: ({ children, isOpen }: { children: ReactNode; isOpen: boolean }) =>
+    isOpen ? <div data-testid="popover">{children}</div> : null,
+}));
+
+vi.mock('#components/NotesButton', () => ({
+  NotesButton: () => <button type="button" aria-label="notes" />,
+}));
+
+vi.mock('#components/budget/BalanceWithCarryover', () => ({
+  BalanceWithCarryover: () => <div data-testid="balance" />,
+}));
+
+vi.mock('#components/budget/envelope/BalanceMovementMenu', () => ({
+  BalanceMovementMenu: () => <div data-testid="balance-menu" />,
+}));
+
+vi.mock('#components/budget/envelope/BudgetMenu', () => ({
+  BudgetMenu: () => <div data-testid="budget-menu" />,
+}));
+
+vi.mock('#components/spreadsheet/CellValue', () => ({
+  CellValue: ({ children }: { children?: (props: never) => ReactNode }) =>
+    children ? <>{children({} as never)}</> : null,
+  CellValueText: () => <div data-testid="cell-value" />,
+}));
+
+vi.mock('#components/table', () => ({
+  Field: ({ children, name }: { children: ReactNode; name?: string }) => (
+    <div data-testid={name}>{children}</div>
+  ),
+  Row: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetCell: () => <div data-testid="sheet-cell" />,
+}));
+
+vi.mock('#hooks/useCategoryScheduleGoalTemplateIndicator', () => ({
+  useCategoryScheduleGoalTemplateIndicator: () => ({
+    schedule: null,
+    scheduleStatus: null,
+    isScheduleRecurring: false,
+    description: '',
+  }),
+}));
+
+vi.mock('#hooks/useFormat', () => ({
+  useFormat: () => ({
+    forEdit: (value: unknown) => value,
+    fromEdit: (value: unknown) => value,
+  }),
+}));
+
+vi.mock('#hooks/useNavigate', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('#hooks/useUndo', () => ({
+  useUndo: () => ({
+    showUndoNotification: vi.fn(),
+  }),
+}));
+
+import { ExpenseCategoryMonth } from './EnvelopeBudgetComponents';
+
+describe('ExpenseCategoryMonth', () => {
+  it('keeps quick actions visible when the cell is active', () => {
+    render(
+      <ExpenseCategoryMonth
+        month="2026-08"
+        category={
+          {
+            id: 'cat-1',
+            name: 'Category',
+            is_income: false,
+          } as never
+        }
+        editing={false}
+        active
+        onEdit={() => undefined}
+        onBudgetAction={() => undefined}
+        onShowActivity={() => undefined}
+      />,
+    );
+
+    const actions = screen.getByTestId('budget-month-actions');
+    expect(actions.className).toContain('force-visible');
+    expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -339,11 +339,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
               padding: 3,
             }}
           >
-            <SvgCheveronDown
-              width={14}
-              height={14}
-              className="hover-visible"
-            />
+            <SvgCheveronDown width={14} height={14} className="hover-visible" />
           </Button>
           <Popover
             triggerRef={budgetMenuTriggerRef}

--- a/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/envelope/EnvelopeBudgetComponents.tsx
@@ -196,6 +196,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
   month,
   category,
   editing,
+  active,
   onEdit,
   onBudgetAction,
   onShowActivity,
@@ -257,6 +258,7 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
     });
 
   const showScheduleIndicator = schedule && scheduleStatus;
+  const showBudgetControls = editing || active;
 
   return (
     <View
@@ -296,109 +298,109 @@ export const ExpenseCategoryMonth = memo(function ExpenseCategoryMonth({
           handleBudgetContextMenu(e);
         }}
       >
-        {!editing && (
-          <>
-            <View
-              style={{
-                paddingLeft: 3,
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderTopWidth: 1,
-                borderBottomWidth: 1,
-                borderColor: theme.tableBorder,
+        <View
+          style={{
+            paddingLeft: 3,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderTopWidth: 1,
+            borderBottomWidth: 1,
+            borderColor: theme.tableBorder,
+          }}
+        >
+          <NotesButton
+            id={`${category.id}-${month}`}
+            defaultColor={theme.pageTextLight}
+          />
+        </View>
+        <View
+          data-testid="budget-month-actions"
+          className={`hover-expand ${
+            budgetMenuOpen || showBudgetControls ? 'force-visible' : ''
+          }`}
+          style={{
+            flexDirection: 'row',
+            flexShrink: 0,
+            paddingLeft: 3,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderTopWidth: 1,
+            borderBottomWidth: 1,
+            borderColor: theme.tableBorder,
+          }}
+        >
+          <Button
+            variant="bare"
+            onPress={() => {
+              resetBudgetPosition(2, -4);
+              setBudgetMenuOpen(true);
+            }}
+            style={{
+              padding: 3,
+            }}
+          >
+            <SvgCheveronDown
+              width={14}
+              height={14}
+              className="hover-visible"
+            />
+          </Button>
+          <Popover
+            triggerRef={budgetMenuTriggerRef}
+            placement="bottom left"
+            isOpen={budgetMenuOpen}
+            onOpenChange={() => setBudgetMenuOpen(false)}
+            style={{ width: 200 }}
+            isNonModal
+            {...budgetPosition}
+          >
+            <BudgetMenu
+              onCopyLastMonthAverage={() => {
+                onMenuAction(month, 'copy-single-last', {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(`Budget set to last month's budget.`),
+                });
               }}
-            >
-              <NotesButton
-                id={`${category.id}-${month}`}
-                defaultColor={theme.pageTextLight}
-              />
-            </View>
-            <View
-              className={`hover-expand ${budgetMenuOpen ? 'force-visible' : ''}`}
-              style={{
-                flexDirection: 'row',
-                flexShrink: 1,
-                paddingLeft: 3,
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderTopWidth: 1,
-                borderBottomWidth: 1,
-                borderColor: theme.tableBorder,
-              }}
-            >
-              <Button
-                variant="bare"
-                onPress={() => {
-                  resetBudgetPosition(2, -4);
-                  setBudgetMenuOpen(true);
-                }}
-                style={{
-                  padding: 3,
-                }}
-              >
-                <SvgCheveronDown
-                  width={14}
-                  height={14}
-                  className="hover-visible"
-                />
-              </Button>
-              <Popover
-                triggerRef={budgetMenuTriggerRef}
-                placement="bottom left"
-                isOpen={budgetMenuOpen}
-                onOpenChange={() => setBudgetMenuOpen(false)}
-                style={{ width: 200 }}
-                isNonModal
-                {...budgetPosition}
-              >
-                <BudgetMenu
-                  onCopyLastMonthAverage={() => {
-                    onMenuAction(month, 'copy-single-last', {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(`Budget set to last month's budget.`),
-                    });
-                  }}
-                  onSetMonthsAverage={numberOfMonths => {
-                    if (
-                      numberOfMonths !== 3 &&
-                      numberOfMonths !== 6 &&
-                      numberOfMonths !== 12
-                    ) {
-                      return;
-                    }
+              onSetMonthsAverage={numberOfMonths => {
+                if (
+                  numberOfMonths !== 3 &&
+                  numberOfMonths !== 6 &&
+                  numberOfMonths !== 12
+                ) {
+                  return;
+                }
 
-                    onMenuAction(month, `set-single-${numberOfMonths}-avg`, {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(
-                        'Budget set to {{numberOfMonths}}-month average.',
-                        { numberOfMonths },
-                      ),
-                    });
-                  }}
-                  onApplyBudgetTemplate={() => {
-                    onMenuAction(month, 'apply-single-category-template', {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(`Budget template applied.`),
-                    });
-                  }}
-                />
-              </Popover>
-            </View>
-          </>
-        )}
+                onMenuAction(month, `set-single-${numberOfMonths}-avg`, {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(
+                    'Budget set to {{numberOfMonths}}-month average.',
+                    { numberOfMonths },
+                  ),
+                });
+              }}
+              onApplyBudgetTemplate={() => {
+                onMenuAction(month, 'apply-single-category-template', {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(`Budget template applied.`),
+                });
+              }}
+            />
+          </Popover>
+        </View>
         <EnvelopeSheetCell
           name="budget"
           exposed={editing}
-          focused={editing}
+          focused={editing || active}
           width="flex"
+          tabIndex={!editing && active ? -1 : undefined}
           onExpose={() => onEdit(category.id, month)}
-          style={{ ...(editing && { zIndex: 100 }), ...styles.tnum }}
+          style={styles.tnum}
           textAlign="right"
           valueStyle={{
             cursor: 'default',

--- a/packages/desktop-client/src/components/budget/index.tsx
+++ b/packages/desktop-client/src/components/budget/index.tsx
@@ -270,6 +270,7 @@ export type CategoryMonthProps = {
   month: string;
   category: CategoryEntity;
   editing: boolean;
+  active?: boolean;
   isLast?: boolean;
   onEdit: (id: CategoryEntity['id'] | null, month?: string) => void;
   onBudgetAction: (month: string, action: string, arg: unknown) => void;

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -296,11 +296,7 @@ export const CategoryMonth = memo(function CategoryMonth({
               padding: 3,
             }}
           >
-            <SvgCheveronDown
-              width={14}
-              height={14}
-              className="hover-visible"
-            />
+            <SvgCheveronDown width={14} height={14} className="hover-visible" />
           </Button>
 
           <Popover

--- a/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
+++ b/packages/desktop-client/src/components/budget/tracking/TrackingBudgetComponents.tsx
@@ -195,6 +195,7 @@ export const CategoryMonth = memo(function CategoryMonth({
   month,
   category,
   editing,
+  active,
   onEdit,
   onBudgetAction,
   onShowActivity,
@@ -223,6 +224,7 @@ export const CategoryMonth = memo(function CategoryMonth({
     });
 
   const showScheduleIndicator = schedule && scheduleStatus;
+  const showBudgetControls = editing || active;
 
   return (
     <View
@@ -257,113 +259,111 @@ export const CategoryMonth = memo(function CategoryMonth({
           flexDirection: 'row',
         }}
       >
-        {!editing && (
-          <>
-            <View
-              style={{
-                paddingLeft: 3,
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderTopWidth: 1,
-                borderBottomWidth: 1,
-                borderColor: theme.tableBorder,
-              }}
-            >
-              <NotesButton
-                id={`${category.id}-${month}`}
-                defaultColor={theme.pageTextLight}
-              />
-            </View>
-            <View
-              className={`hover-expand ${menuOpen ? 'force-visible' : ''}`}
-              style={{
-                flexDirection: 'row',
-                flexShrink: 0,
-                paddingLeft: 3,
-                alignItems: 'center',
-                justifyContent: 'center',
-                borderTopWidth: 1,
-                borderBottomWidth: 1,
-                borderColor: theme.tableBorder,
-              }}
-            >
-              <Button
-                ref={triggerRef}
-                variant="bare"
-                onPress={() => setMenuOpen(true)}
-                style={{
-                  padding: 3,
-                }}
-              >
-                <SvgCheveronDown
-                  width={14}
-                  height={14}
-                  className="hover-visible"
-                />
-              </Button>
+        <View
+          style={{
+            paddingLeft: 3,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderTopWidth: 1,
+            borderBottomWidth: 1,
+            borderColor: theme.tableBorder,
+          }}
+        >
+          <NotesButton
+            id={`${category.id}-${month}`}
+            defaultColor={theme.pageTextLight}
+          />
+        </View>
+        <View
+          data-testid="budget-month-actions"
+          className={`hover-expand ${menuOpen || showBudgetControls ? 'force-visible' : ''}`}
+          style={{
+            flexDirection: 'row',
+            flexShrink: 0,
+            paddingLeft: 3,
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderTopWidth: 1,
+            borderBottomWidth: 1,
+            borderColor: theme.tableBorder,
+          }}
+        >
+          <Button
+            ref={triggerRef}
+            variant="bare"
+            onPress={() => setMenuOpen(true)}
+            style={{
+              padding: 3,
+            }}
+          >
+            <SvgCheveronDown
+              width={14}
+              height={14}
+              className="hover-visible"
+            />
+          </Button>
 
-              <Popover
-                triggerRef={triggerRef}
-                isOpen={menuOpen}
-                onOpenChange={() => setMenuOpen(false)}
-                placement="bottom start"
-              >
-                <BudgetMenu
-                  onCopyLastMonthAverage={() => {
-                    onMenuAction(month, 'copy-single-last', {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(`Budget set to last month's budget.`),
-                    });
-                  }}
-                  onSetMonthsAverage={numberOfMonths => {
-                    if (
-                      numberOfMonths !== 3 &&
-                      numberOfMonths !== 6 &&
-                      numberOfMonths !== 12
-                    ) {
-                      return;
-                    }
+          <Popover
+            triggerRef={triggerRef}
+            isOpen={menuOpen}
+            onOpenChange={() => setMenuOpen(false)}
+            placement="bottom start"
+          >
+            <BudgetMenu
+              onCopyLastMonthAverage={() => {
+                onMenuAction(month, 'copy-single-last', {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(`Budget set to last month's budget.`),
+                });
+              }}
+              onSetMonthsAverage={numberOfMonths => {
+                if (
+                  numberOfMonths !== 3 &&
+                  numberOfMonths !== 6 &&
+                  numberOfMonths !== 12
+                ) {
+                  return;
+                }
 
-                    onMenuAction(month, `set-single-${numberOfMonths}-avg`, {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(
-                        'Budget set to {{numberOfMonths}}-month average.',
-                        { numberOfMonths },
-                      ),
-                    });
-                  }}
-                  onApplyBudgetTemplate={() => {
-                    onMenuAction(month, 'apply-single-category-template', {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(`Budget template applied.`),
-                    });
-                  }}
-                  onCopyUntilYearEnd={() => {
-                    onMenuAction(month, 'copy-until-year-end', {
-                      category: category.id,
-                    });
-                    showUndoNotification({
-                      message: t(`Budget copied until year end.`),
-                    });
-                  }}
-                />
-              </Popover>
-            </View>
-          </>
-        )}
+                onMenuAction(month, `set-single-${numberOfMonths}-avg`, {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(
+                    'Budget set to {{numberOfMonths}}-month average.',
+                    { numberOfMonths },
+                  ),
+                });
+              }}
+              onApplyBudgetTemplate={() => {
+                onMenuAction(month, 'apply-single-category-template', {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(`Budget template applied.`),
+                });
+              }}
+              onCopyUntilYearEnd={() => {
+                onMenuAction(month, 'copy-until-year-end', {
+                  category: category.id,
+                });
+                showUndoNotification({
+                  message: t(`Budget copied until year end.`),
+                });
+              }}
+            />
+          </Popover>
+        </View>
         <TrackingSheetCell
           name="budget"
           exposed={editing}
-          focused={editing}
+          focused={editing || active}
           width="flex"
+          tabIndex={!editing && active ? -1 : undefined}
           onExpose={() => onEdit(category.id, month)}
-          style={{ ...(editing && { zIndex: 100 }), ...styles.tnum }}
+          style={styles.tnum}
           textAlign="right"
           valueStyle={{
             cursor: 'default',

--- a/upcoming-release-notes/input-text-box-overlaps-and-covers-quick-budget-options-during-cell-editing-and-input-text-box.md
+++ b/upcoming-release-notes/input-text-box-overlaps-and-covers-quick-budget-options-during-cell-editing-and-input-text-box.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [hmyg52]
+---
+
+Fixes a UI issue in the Budget screen where the active budget input overlaps and obscures the quick budget actions next to the cell.


### PR DESCRIPTION
## Description

Fixes a UI issue in the Budget screen where the active budget input overlaps and obscures the quick budget actions next to the cell.

When editing a budget value, the input currently expands over the area containing the quick budget actions, making options such as previous month / averages difficult or impossible to access.

Additionally, keyboard navigation with Enter or Tab could immediately put the next budget cell into edit mode, causing the same overlap to occur on every subsequent row.

This PR adjusts the budget cell editing and navigation behavior so that:

- Quick budget actions remain visible and accessible while editing.
- The active input no longer unnecessarily covers adjacent controls.
- Moving between budget cells with the keyboard behaves consistently.
- Existing budget editing, saving, and navigation behavior is preserved.

The issue is particularly visible when navigating through multiple budget rows using the keyboard.

<img width="683" height="415" alt="Bildschirmfoto 2026-08-17 um 17 01 32" src="https://github.com/user-attachments/assets/6bd660a8-1a09-47f2-a421-418a45b97645" />

## Related issue(s)

Fixes #8729 

## Testing

Added new tests. Testing the Budget screen with budget line items that have quick budget actions.

Verified:

- Clicking a budget cell and entering edit mode.
- Quick budget actions remain accessible while the cell is being edited.
- Entering a value and pressing Enter to move to the next row.
- Using Tab to navigate between budget cells.
- Navigating through multiple consecutive budget rows.
- Existing budget values can still be edited and saved correctly.
- Quick budget actions remain usable.
- Long category names and different row types do not cause obvious layout issues.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed


<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.54 MB (+3.37 kB) | +0.02%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.54 MB (+3.37 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/budget/budgetNavigation.ts` | 🆕 +1.41 kB | 0 B → 1.41 kB
`src/components/budget/IncomeCategory.tsx` | 📈 +219 B (+6.89%) | 3.1 kB → 3.32 kB
`src/components/budget/ExpenseCategory.tsx` | 📈 +219 B (+5.66%) | 3.78 kB → 3.99 kB
`src/components/budget/tracking/TrackingBudgetComponents.tsx` | 📈 +660 B (+3.37%) | 19.13 kB → 19.77 kB
`src/components/budget/envelope/EnvelopeBudgetComponents.tsx` | 📈 +741 B (+2.47%) | 29.33 kB → 30.05 kB
`src/components/budget/BudgetCategories.tsx` | 📈 +150 B (+1.20%) | 12.19 kB → 12.33 kB
`src/components/budget/BudgetTable.tsx` | 📈 +20 B (+0.32%) | 6.11 kB → 6.13 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 274.04 kB → 276.04 kB (+2 kB) | +0.73%
static/js/Value.js | 1.93 MB → 1.93 MB (+741 B) | +0.04%
static/js/SchedulesTable.js | 171.25 kB → 171.89 kB (+660 B) | +0.38%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/ru.js | 209.49 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->