### PR TITLE
[AI] Fix selected balance counting unselected split children

### DIFF
--- a/packages/desktop-client/src/components/accounts/Balance.test.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type { ScheduleEntity } from '@actual-app/core/types/models';
 import { render, screen } from '@testing-library/react';
+import type { Mock } from 'vitest';
 
 import { useCachedSchedules } from '#hooks/useCachedSchedules';
 import { useSelectedItems } from '#hooks/useSelected';
@@ -84,6 +85,56 @@ describe('SelectedBalance – normal transactions', () => {
     );
 
     expect(screen.getByText('Selected balance:')).toBeInTheDocument();
+  });
+});
+
+describe('SelectedBalance – split transactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCachedSchedules).mockReturnValue(mockedSchedules([]));
+  });
+
+  // The rows query returns objects while the sum query returns a number, which
+  // the typed overload can't express in a single mock.
+  const mockSheetValues = vi.mocked(useSheetValue) as unknown as Mock;
+
+  function summedIds() {
+    // The second useSheetValue call is the one that sums the amounts.
+    const binding = vi.mocked(useSheetValue).mock.calls[1][0];
+    if (typeof binding === 'string' || !binding.query) {
+      throw new Error('expected the balance binding to carry a query');
+    }
+    const [filter] = binding.query.serialize().filterExpressions as Array<{
+      id: { $oneof: string[] };
+    }>;
+    return filter.id.$oneof;
+  }
+
+  test('sums only the selected children when a parent is partially selected', () => {
+    mockSheetValues
+      .mockReturnValueOnce([{ id: 'child-1', parent_id: 'parent-1' }])
+      .mockReturnValueOnce(-5951);
+
+    render(
+      <TestProviders>
+        <SelectedBalance selectedItems={new Set(['parent-1', 'child-1'])} />
+      </TestProviders>,
+    );
+
+    // The parent is dropped, so the unselected sibling is not counted.
+    expect(summedIds()).toEqual(['child-1']);
+  });
+
+  test('sums the whole split when only the parent is selected', () => {
+    mockSheetValues.mockReturnValueOnce([]).mockReturnValueOnce(-7239);
+
+    render(
+      <TestProviders>
+        <SelectedBalance selectedItems={new Set(['parent-1'])} />
+      </TestProviders>,
+    );
+
+    expect(summedIds()).toEqual(['parent-1']);
   });
 });
 

--- a/packages/desktop-client/src/components/accounts/Balance.tsx
+++ b/packages/desktop-client/src/components/accounts/Balance.tsx
@@ -75,11 +75,21 @@ export function SelectedBalance({
         id: { $oneof: [...selectedItems] },
         parent_id: { $oneof: [...selectedItems] },
       })
-      .select('id'),
+      .select(['id', 'parent_id']),
   });
-  const ids = new Set((rows || []).map((r: { id: string }) => r.id));
 
-  const finalIds = [...selectedItems].filter(id => !ids.has(id));
+  // When a split parent is selected together with some of its children, summing
+  // the parent would count every child of the split - including the ones that
+  // were never selected. Drop the parent instead and keep the selected
+  // children, so only what the user actually selected is counted. A parent
+  // selected on its own is left alone and still contributes the whole split.
+  const parentIdsWithSelectedChildren = new Set(
+    (rows || []).map(r => r.parent_id),
+  );
+
+  const finalIds = [...selectedItems].filter(
+    id => !parentIdsWithSelectedChildren.has(id),
+  );
   let balance = useSheetValue<'balance', `selected-balance-${string}`>({
     name: (name + '-sum') as `selected-balance-${string}`,
     query: q('transactions')

--- a/packages/desktop-client/src/spreadsheet/index.ts
+++ b/packages/desktop-client/src/spreadsheet/index.ts
@@ -83,7 +83,10 @@ export type Spreadsheets = {
 
     // Balance fields
     [key: `balance-query-${string}`]: number;
-    [key: `selected-transactions-${string}`]: Array<{ id: string }>;
+    [key: `selected-transactions-${string}`]: Array<{
+      id: string;
+      parent_id: string | null;
+    }>;
     [key: `selected-balance-${string}`]: number;
   };
 };

--- a/upcoming-release-notes/fix-selected-balance-partial-splits.md
+++ b/upcoming-release-notes/fix-selected-balance-partial-splits.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Islinger19]
+---
+
+Fix the selected balance counting unselected split children when a split parent and only some of its children are selected


### PR DESCRIPTION
## Description

When a split parent is selected together with only some of its children, the
"Selected balance" pill shows the total of the whole split instead of just what
was picked.

The cause is in `SelectedBalance`. It queries for selected children whose parent
is also selected, then removes those children from the sum and keeps the parent.
Because summing the parent pulls in every child of the split, the children you
did not select get added anyway.

I flipped it around: when a parent has selected children, drop the parent and
keep the children. Selecting a parent on its own is untouched and still counts
the whole split.

Using the numbers from the issue — a split of 72.39 made up of 59.51 and 12.88 —
selecting the parent plus the 59.51 child now shows 59.51 instead of 72.39.

The rows query needed `parent_id` as well as `id`, so the binding type in
`spreadsheet/index.ts` picks up `parent_id` too.

Note on AI use: I used Claude to help track down the root cause and draft the
patch. I reproduced the bug myself, read through the change, and ran the tests
locally before opening this.

## Related issue(s)

Closes #5525

## Testing

Tested in the demo budget in the browser. Made a split with two children,
selected the parent and one child, and checked the pill before and after.

I also walked through every selection combination against a local database to
confirm only the broken case changed:

| selection | before | after |
| --- | --- | --- |
| one child | -5951 | -5951 |
| both children | -7239 | -7239 |
| parent only | -7239 | -7239 |
| parent + both children | -7239 | -7239 |
| parent + one child | -7239 | **-5951** |
| one child + a normal txn | -6951 | -6951 |
| parent + a normal txn | -8239 | -8239 |

Added two tests in `Balance.test.tsx` covering the partial selection and the
parent-only case. The first fails on master with
`expected [ 'parent-1' ] to deeply equal [ 'child-1' ]`.

`yarn typecheck` and `yarn lint:fix` are clean, and the desktop-client suite
passes (937 tests).

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.53 MB (+74 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.53 MB (+74 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/accounts/Balance.tsx` | 📈 +74 B (+0.95%) | 7.6 kB → 7.67 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/wide.js | 274.04 kB → 274.11 kB (+74 B) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/ru.js | 209.49 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->