### PR TITLE
Skip overspent sources when a named cleanup pool collects funds

### DIFF
--- a/packages/loot-core/src/server/budget/cleanup-template.test.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.test.ts
@@ -1,0 +1,167 @@
+import { vi } from 'vitest';
+
+import * as db from '#server/db';
+import type { CleanupTemplate } from '#types/models/cleanup-templates';
+
+import * as actions from './actions';
+import { cleanupTemplate } from './cleanup-template';
+
+vi.mock('./actions', () => ({
+  getSheetValue: vi.fn(),
+  setBudget: vi.fn(),
+  setGoal: vi.fn(),
+}));
+
+vi.mock('#server/db', () => ({
+  all: vi.fn(),
+  first: vi.fn(),
+}));
+
+vi.mock('./cleanup-template-notes', () => ({
+  storeNoteCleanups: vi.fn(),
+}));
+
+const MONTH = '2026-08';
+const GROUP_ID = 'pool-1';
+
+type TestCategory = {
+  id: string;
+  name: string;
+  cleanup_def: CleanupTemplate[];
+};
+
+function setup({
+  categories,
+  sheetValues,
+}: {
+  categories: TestCategory[];
+  sheetValues: Record<string, number>;
+}) {
+  vi.mocked(db.all).mockImplementation(async (sql: string) => {
+    if (sql.includes('cleanup_groups')) {
+      return [{ id: GROUP_ID, name: 'Something' }];
+    }
+    return categories.map(c => ({
+      id: c.id,
+      name: c.name,
+      is_income: 0,
+      cleanup_def: JSON.stringify(c.cleanup_def),
+    }));
+  });
+  // No carryover rows, so overspending never rolls over in these tests.
+  vi.mocked(db.first).mockResolvedValue(null);
+  vi.mocked(actions.getSheetValue).mockImplementation(
+    async (_sheet: string, key: string) => sheetValues[key] ?? 0,
+  );
+}
+
+function budgetedFor(categoryId: string) {
+  return vi
+    .mocked(actions.setBudget)
+    .mock.calls.map(([args]) => args)
+    .filter(args => args.category === categoryId);
+}
+
+describe('cleanupTemplate - named pool sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not drain a source whose balance is negative', async () => {
+    setup({
+      categories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          cleanup_def: [{ role: 'sink', groupId: GROUP_ID, weight: 1 }],
+        },
+        {
+          id: 'cat-2',
+          name: 'Category 2',
+          cleanup_def: [{ role: 'source', groupId: GROUP_ID }],
+        },
+      ],
+      sheetValues: {
+        'leftover-cat-1': -1500,
+        'budget-cat-1': 6000,
+        // Category 2 overspent, so it has nothing to send to the pool.
+        'leftover-cat-2': -1000,
+        'budget-cat-2': 5000,
+        'to-budget': 0,
+      },
+    });
+
+    await cleanupTemplate({ month: MONTH });
+
+    // Draining the source budgets `budgeted - balance`, which for a negative
+    // balance credits the category instead of taking from it (5000 - -1000).
+    expect(budgetedFor('cat-2')).not.toContainEqual(
+      expect.objectContaining({ amount: 6000 }),
+    );
+  });
+
+  test('warns that the overspent source has no available funds', async () => {
+    setup({
+      categories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          cleanup_def: [{ role: 'sink', groupId: GROUP_ID, weight: 1 }],
+        },
+        {
+          id: 'cat-2',
+          name: 'Category 2',
+          cleanup_def: [{ role: 'source', groupId: GROUP_ID }],
+        },
+      ],
+      sheetValues: {
+        'leftover-cat-1': -1500,
+        'budget-cat-1': 6000,
+        'leftover-cat-2': -1000,
+        'budget-cat-2': 5000,
+        'to-budget': 0,
+      },
+    });
+
+    const result = await cleanupTemplate({ month: MONTH });
+
+    expect(result.message).toBe('cleanup-no-funds');
+    expect(result.pre ?? '').toContain(
+      'Category 2 does not have available funds.',
+    );
+  });
+
+  test('still drains a source that has positive leftover funds', async () => {
+    setup({
+      categories: [
+        {
+          id: 'cat-1',
+          name: 'Category 1',
+          cleanup_def: [{ role: 'sink', groupId: GROUP_ID, weight: 1 }],
+        },
+        {
+          id: 'cat-2',
+          name: 'Category 2',
+          cleanup_def: [{ role: 'source', groupId: GROUP_ID }],
+        },
+      ],
+      sheetValues: {
+        'leftover-cat-1': 0,
+        'budget-cat-1': 6000,
+        'leftover-cat-2': 1000,
+        'budget-cat-2': 5000,
+        'to-budget': 0,
+      },
+    });
+
+    const result = await cleanupTemplate({ month: MONTH });
+
+    // The source gives up its leftover: 5000 - 1000.
+    expect(budgetedFor('cat-2')).toContainEqual(
+      expect.objectContaining({ amount: 4000 }),
+    );
+    expect(result.pre ?? '').not.toContain(
+      'Category 2 does not have available funds.',
+    );
+  });
+});

--- a/packages/loot-core/src/server/budget/cleanup-template.ts
+++ b/packages/loot-core/src/server/budget/cleanup-template.ts
@@ -22,6 +22,7 @@ async function applyGroupCleanups(
   sinkGroups: GroupSinkRow[],
   overspendGroups: GroupOverspendRow[],
   groupNamesById: Map<string, string>,
+  categoryNamesById: Map<string, string>,
 ) {
   const sheetName = monthUtils.sheetForMonth(month);
   const warnings = [];
@@ -41,16 +42,25 @@ async function applyGroupCleanups(
     if (sinkGroup.length > 0 || overspendGroup.length > 0) {
       //only return group source funds to To Budget if there are corresponding sinking groups or underfunded included groups
       for (let ii = 0; ii < tempSourceGroups.length; ii++) {
+        const categoryId = tempSourceGroups[ii].category;
         const balance = await getSheetValue(
           sheetName,
-          `leftover-${tempSourceGroups[ii].category}`,
+          `leftover-${categoryId}`,
         );
-        const budgeted = await getSheetValue(
-          sheetName,
-          `budget-${tempSourceGroups[ii].category}`,
-        );
+
+        // A source that is overspent has no leftover funds to send to the pool.
+        // Taking its negative balance would move the overspending onto the sink
+        // categories instead, so skip it and warn - the same way global sources
+        // are handled in processCleanup.
+        if (balance < 0) {
+          const categoryName = categoryNamesById.get(categoryId) ?? categoryId;
+          warnings.push(categoryName + ' does not have available funds.');
+          continue;
+        }
+
+        const budgeted = await getSheetValue(sheetName, `budget-${categoryId}`);
         await setBudget({
-          category: tempSourceGroups[ii].category,
+          category: categoryId,
           month,
           amount: budgeted - balance,
         });
@@ -183,6 +193,7 @@ async function processCleanup(month: string): Promise<TemplateNotification> {
     'SELECT id, name FROM cleanup_groups WHERE tombstone = 0',
   );
   const groupNamesById = new Map(groupRows.map(g => [g.id, g.name]));
+  const categoryNamesById = new Map(categories.map(c => [c.id, c.name]));
 
   //run category groups
   const newWarnings = await applyGroupCleanups(
@@ -191,6 +202,7 @@ async function processCleanup(month: string): Promise<TemplateNotification> {
     groupSink,
     groupOverspend,
     groupNamesById,
+    categoryNamesById,
   );
   warnings.splice(1, 0, ...newWarnings);
 

--- a/upcoming-release-notes/fix-cleanup-pool-negative-balances.md
+++ b/upcoming-release-notes/fix-cleanup-pool-negative-balances.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Islinger19]
+---
+
+Skip overspent categories when a named cleanup pool collects leftover funds, instead of moving their negative balance onto the other categories in the pool


### PR DESCRIPTION
## Description

The "End of month cleanup" macro does not check whether a category set to send
its leftover funds to a named pool actually has any. If the category is
overspent, it is processed anyway: `budgeted - balance` credits it instead of
taking from it, and its negative balance is subtracted from the amount
available to the pool. The overspending ends up on the other categories in the
group, or in To Budget when rollover is enabled.

Global sources already handle this - they skip the category and warn that it
has no available funds. I applied the same check to named pool sources and
reused the same warning, so the two paths behave consistently.

The group rows only carry category ids, so processCleanup now passes a map of
category names through for the warning message.

I read through the issue, reproduced the reported behaviour, and verified the
change locally. The initial patch was drafted with AI assistance.

## Related issue(s)

Closes #8739

## Testing

Added `cleanup-template.test.ts`, which did not exist before. Three cases:

- an overspent source is not drained
- the warning reaches the notification
- a source with positive leftover funds is still drained (so the guard does not
  over-correct)

The first two fail on master:

    expected [...] to not deep equally contain ObjectContaining {"amount": 6000}
    expected 'cleanup-up-to-date' to be 'cleanup-no-funds'

`yarn typecheck` and `yarn lint:fix` are clean, and the full loot-core suite
passes (1042 tests).

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 39 → 42 | 13.21 MB → 13.53 MB (+333.99 kB) | +2.47%
loot-core | 1 | 4.62 MB → 4.63 MB (+3.25 kB) | +0.07%
api | 2 | 3.84 MB → 3.84 MB (+3.98 kB) | +0.10%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
39 → 42 | 13.21 MB → 13.53 MB (+333.99 kB) | +2.47%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`node_modules/react-joyride/dist/index.mjs` | 🆕 +81.59 kB | 0 B → 81.59 kB
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 🆕 +31.33 kB | 0 B → 31.33 kB
`src/components/reports/reports/monte-carlo/MonteCarlo.tsx` | 🆕 +29.86 kB | 0 B → 29.86 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunDetailTable.tsx` | 🆕 +26.45 kB | 0 B → 26.45 kB
`src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx` | 🆕 +24.02 kB | 0 B → 24.02 kB
`node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs` | 🆕 +17.94 kB | 0 B → 17.94 kB
`node_modules/@floating-ui/core/dist/floating-ui.core.mjs` | 🆕 +16.68 kB | 0 B → 16.68 kB
`src/components/reports/reports/monte-carlo/MonteCarloWithdrawalRuleConfiguration.tsx` | 🆕 +14.4 kB | 0 B → 14.4 kB
`src/components/reports/reports/monte-carlo/MonteCarloRunsTable.tsx` | 🆕 +13.51 kB | 0 B → 13.51 kB
`src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx` | 🆕 +12.83 kB | 0 B → 12.83 kB
`src/components/reports/reports/monte-carlo/MonteCarloContributions.tsx` | 🆕 +10.49 kB | 0 B → 10.49 kB
`src/components/reports/reports/monte-carlo/MonteCarloSpendingPhases.tsx` | 🆕 +9.25 kB | 0 B → 9.25 kB
`src/components/reports/reports/monte-carlo/MonteCarloTaxConfiguration.tsx` | 🆕 +8.53 kB | 0 B → 8.53 kB
`src/components/tour/steps.tsx` | 🆕 +6.81 kB | 0 B → 6.81 kB
`src/components/reports/reports/monte-carlo/monteCarloHistoricalReturns.ts` | 🆕 +6.64 kB | 0 B → 6.64 kB
`node_modules/@floating-ui/react-dom/dist/floating-ui.react-dom.mjs` | 🆕 +6.53 kB | 0 B → 6.53 kB
`node_modules/is-lite/dist/index.mjs` | 🆕 +6.28 kB | 0 B → 6.28 kB
`src/components/reports/reports/monte-carlo/MonteCarloPotsTableHeader.tsx` | 🆕 +5.76 kB | 0 B → 5.76 kB
`src/components/tour/TourHost.ts` | 🆕 +4.8 kB | 0 B → 4.8 kB
`node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs` | 🆕 +4.67 kB | 0 B → 4.67 kB
`node_modules/@fastify/deepmerge/index.js` | 🆕 +4.49 kB | 0 B → 4.49 kB
`node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs` | 🆕 +4.16 kB | 0 B → 4.16 kB
`src/components/tour/TourTooltip.tsx` | 🆕 +4.01 kB | 0 B → 4.01 kB
`node_modules/@gilbarbara/hooks/dist/index.mjs` | 🆕 +3.97 kB | 0 B → 3.97 kB
`node_modules/@gilbarbara/deep-equal/dist/index.mjs` | 🆕 +3.87 kB | 0 B → 3.87 kB
`src/components/reports/graphs/MonteCarloGraph.tsx` | 🆕 +3.05 kB | 0 B → 3.05 kB
`src/components/reports/reports/monte-carlo/MonteCarloCard.tsx` | 🆕 +2.83 kB | 0 B → 2.83 kB
`src/components/reports/graphs/MonteCarloGraphTooltip.tsx` | 🆕 +2.28 kB | 0 B → 2.28 kB
`src/components/reports/reports/monte-carlo/MonteCarloNumberInput.tsx` | 🆕 +1.87 kB | 0 B → 1.87 kB
`src/components/reports/graphs/MonteCarloHistogram.tsx` | 🆕 +1.68 kB | 0 B → 1.68 kB
`src/components/tour/TourProvider.tsx` | 🆕 +1.54 kB | 0 B → 1.54 kB
`src/components/tour/TourAutoOffer.ts` | 🆕 +1.52 kB | 0 B → 1.52 kB
`src/hooks/useAccountBalances.ts` | 🆕 +1.33 kB | 0 B → 1.33 kB
`node_modules/scroll/index.js` | 🆕 +1.29 kB | 0 B → 1.29 kB
`src/components/reports/graphs/MonteCarloHistogramTooltip.tsx` | 🆕 +1.27 kB | 0 B → 1.27 kB
`src/components/reports/reports/monte-carlo/useResolvedMonteCarloConfig.ts` | 🆕 +1.11 kB | 0 B → 1.11 kB
`src/components/reports/reports/monte-carlo/MonteCarloHelpTooltip.tsx` | 🆕 +963 B | 0 B → 963 B
`node_modules/scrollparent/scrollparent.js` | 🆕 +950 B | 0 B → 950 B
`node_modules/react-innertext/index.js` | 🆕 +839 B | 0 B → 839 B
`src/components/tour/Tour.tsx` | 🆕 +668 B | 0 B → 668 B
`src/components/reports/reports/monte-carlo/monteCarloStyles.ts` | 🆕 +447 B | 0 B → 447 B
`src/components/tour/TourTooltipButton.tsx` | 🆕 +374 B | 0 B → 374 B
`src/hooks/useDaysOfWeek.ts` | 📈 +913 B (+352.51%) | 259 B → 1.14 kB
`src/hooks/usePayee.ts` | 📈 +373 B (+192.27%) | 194 B → 567 B
`src/hooks/useAccounts.ts` | 📈 +213 B (+183.62%) | 116 B → 329 B
`src/hooks/useCategory.ts` | 📈 +373 B (+182.84%) | 204 B → 577 B
`src/hooks/useReport.ts` | 📈 +373 B (+180.19%) | 207 B → 580 B
`src/hooks/useCategoryGroup.ts` | 📈 +373 B (+173.49%) | 215 B → 588 B
`src/hooks/useNearbyPayees.ts` | 📈 +269 B (+166.05%) | 162 B → 431 B
`src/hooks/useDashboardWidget.ts` | 📈 +421 B (+154.21%) | 273 B → 694 B
`src/components/transactions/useTransactionRowContextActions.ts` | 📈 +7 kB (+147.19%) | 4.76 kB → 11.76 kB
`src/hooks/useCategoryPreviewTransactions.ts` | 📈 +2.21 kB (+147.17%) | 1.5 kB → 3.71 kB
`src/hooks/usePayees.ts` | 📈 +347 B (+146.41%) | 237 B → 584 B
`src/hooks/useMetadataPref.ts` | 📈 +512 B (+145.45%) | 352 B → 864 B
`src/hooks/useReports.ts` | 📈 +155 B (+134.78%) | 115 B → 270 B
`src/hooks/useDashboardPages.ts` | 📈 +370 B (+134.06%) | 276 B → 646 B
`src/hooks/useAccount.ts` | 📈 +243 B (+132.07%) | 184 B → 427 B
`src/hooks/useCommonPayees.ts` | 📈 +155 B (+119.23%) | 130 B → 285 B
`src/hooks/useClosedAccounts.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/usePayeeRuleCounts.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/useOrphanedPayees.ts` | 📈 +155 B (+115.67%) | 134 B → 289 B
`src/hooks/useOnBudgetAccounts.ts` | 📈 +155 B (+110.71%) | 140 B → 295 B
`src/hooks/useServerPref.ts` | 📈 +376 B (+109.62%) | 343 B → 719 B
`src/hooks/useSyncedPref.ts` | 📈 +376 B (+109.62%) | 343 B → 719 B
`src/hooks/useCategoryScheduleGoalTemplates.ts` | 📈 +1.66 kB (+109.03%) | 1.52 kB → 3.19 kB
`src/hooks/useOffBudgetAccounts.ts` | 📈 +155 B (+108.39%) | 143 B → 298 B
`home/runner/work/actual/actual/packages/component-library/src/hooks/useResponsive.ts` | 📈 +510 B (+105.59%) | 483 B → 993 B
`src/hooks/useGlobalPref.ts` | 📈 +445 B (+103.25%) | 431 B → 876 B
`src/hooks/useTags.ts` | 📈 +1.04 kB (+101.24%) | 1.03 kB → 2.07 kB
`src/hooks/useCurrentAccess.ts` | 📈 +719 B (+100.84%) | 713 B → 1.4 kB
`src/hooks/useCategories.ts` | 📈 +326 B (+100.62%) | 324 B → 650 B
`src/hooks/useUrlParam.ts` | 📈 +460 B (+98.08%) | 469 B → 929 B
`src/hooks/useSyncedPrefs.ts` | 📈 +291 B (+94.17%) | 309 B → 600 B
`src/hooks/useFormatList.ts` | 📈 +619 B (+92.53%) | 669 B → 1.26 kB
`src/util/router-tools.ts` | 📈 +198 B (+91.24%) | 217 B → 415 B
`src/hooks/useInputRefValue.ts` | 📈 +558 B (+90.88%) | 614 B → 1.14 kB
`src/hooks/useCleanupGroups.ts` | 📈 +751 B (+90.48%) | 830 B → 1.54 kB
`src/hooks/usePreviewTransactions.ts` | 📈 +2.23 kB (+89.44%) | 2.5 kB → 4.73 kB
`src/components/reports/reports/FormulaCard.tsx` | 📈 +2.27 kB (+88.52%) | 2.57 kB → 4.84 kB
`src/hooks/useSendPlatformRequest.ts` | 📈 +398 B (+82.57%) | 482 B → 880 B
`src/hooks/useTransactionTableColumns.ts` | 📈 +1.68 kB (+79.53%) | 2.11 kB → 3.79 kB
`src/components/banksync/useBankSyncAccountSettings.ts` | 📈 +2.44 kB (+78.69%) | 3.1 kB → 5.54 kB
`src/hooks/useModalState.ts` | 📈 +514 B (+76.83%) | 669 B → 1.16 kB
`src/hooks/usePluggyAiStatus.ts` | 📈 +483 B (+76.67%) | 630 B → 1.09 kB
`src/tags/mutations.ts` | 📈 +2.46 kB (+76.61%) | 3.21 kB → 5.68 kB
`src/reports/mutations.ts` | 📈 +5.35 kB (+70.55%) | 7.59 kB → 12.94 kB
`src/hooks/useAkahuStatus.ts` | 📈 +442 B (+70.38%) | 628 B → 1.04 kB
`src/hooks/useBudgetAutomations.ts` | 📈 +547 B (+69.59%) | 786 B → 1.3 kB
`src/hooks/useLocale.ts` | 📈 +147 B (+63.91%) | 230 B → 377 B
`src/hooks/useLocalPref.ts` | 📈 +158 B (+62.95%) | 251 B → 409 B
`src/hooks/useSimpleFinStatus.ts` | 📈 +379 B (+62.23%) | 609 B → 988 B
`src/hooks/useGoCardlessStatus.ts` | 📈 +381 B (+61.85%) | 616 B → 997 B
`node_modules/date-fns/isSameWeek.js` | 📈 +181 B (+61.56%) | 294 B → 475 B
`src/hooks/useCursorPosition.ts` | 📈 +540 B (+61.29%) | 881 B → 1.39 kB
`src/hooks/useIsInViewport.ts` | 📈 +300 B (+59.17%) | 507 B → 807 B
`src/payees/mutations.ts` | 📈 +1.21 kB (+57.89%) | 2.08 kB → 3.29 kB
`src/hooks/useNotes.ts` | 📈 +143 B (+57.66%) | 248 B → 391 B
`src/hooks/useCategoryCleanup.ts` | 📈 +554 B (+57.29%) | 967 B → 1.49 kB
`src/hooks/useUndo.ts` | 📈 +501 B (+57.13%) | 877 B → 1.35 kB
`src/hooks/useDragRef.ts` | 📈 +98 B (+56.65%) | 173 B → 271 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/LoadingIndicator.js | 0 B → 669.76 kB (+669.76 kB) | -
static/js/months.js | 0 B → 574.49 kB (+574.49 kB) | -
static/js/TourHost.js | 0 B → 169.22 kB (+169.22 kB) | -
static/js/useLocalPref.js | 0 B → 97.2 kB (+97.2 kB) | -
static/js/TourProvider.js | 0 B → 1.54 kB (+1.54 kB) | -
static/js/useReducedMotion.js | 0 B → 594 B (+594 B) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/chart-theme.js | 670.14 kB → 0 B (-670.14 kB) | -100%
static/js/th.js | 165.62 kB → 0 B (-165.62 kB) | -100%
static/js/da.js | 95.93 kB → 0 B (-95.93 kB) | -100%

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.2 MB → 1.42 MB (+227.93 kB) | +18.55%
static/js/TransactionEdit.js | 107.62 kB → 219.94 kB (+112.32 kB) | +104.37%
static/js/ru.js | 142.72 kB → 209.49 kB (+66.77 kB) | +46.78%
static/js/en.js | 209.06 kB → 245.47 kB (+36.41 kB) | +17.42%
static/js/index.js | 1.56 MB → 1.57 MB (+13.27 kB) | +0.83%
static/js/fr.js | 168.31 kB → 180.13 kB (+11.82 kB) | +7.02%
static/js/nl.js | 144.95 kB → 152.45 kB (+7.5 kB) | +5.18%
static/js/FormulaEditor.js | 762.13 kB → 766.28 kB (+4.16 kB) | +0.55%
static/js/de.js | 179.43 kB → 183.43 kB (+4 kB) | +2.23%
static/js/PayeeRuleCountLabel.js | 9.41 kB → 12.81 kB (+3.4 kB) | +36.12%
static/js/ManageRules.js | 69.17 kB → 71.66 kB (+2.49 kB) | +3.59%
static/js/narrow.js | 284.96 kB → 287.24 kB (+2.28 kB) | +0.80%
static/js/wide.js | 272.21 kB → 274.04 kB (+1.83 kB) | +0.67%
static/js/useTransactionBatchActions.js | 9.77 kB → 11.03 kB (+1.26 kB) | +12.86%
static/js/useFormatList.js | 9.31 kB → 10.22 kB (+931 B) | +9.77%
static/js/SchedulesTable.js | 170.95 kB → 171.25 kB (+304 B) | +0.17%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/useDateFormat.js | 2.92 MB → 2.37 MB (-565.57 kB) | -18.93%
static/js/ScheduleEditForm.js | 185.01 kB → 76.54 kB (-108.47 kB) | -58.63%
static/js/Value.js | 2 MB → 1.93 MB (-68.38 kB) | -3.34%
static/js/pt-BR.js | 179.81 kB → 179.25 kB (-573 B) | -0.31%
static/js/uk.js | 200.9 kB → 200.72 kB (-182 B) | -0.09%
static/js/ca.js | 171.84 kB → 171.68 kB (-161 B) | -0.09%
static/js/es.js | 165.25 kB → 165.11 kB (-146 B) | -0.09%
static/js/nb-NO.js | 136.65 kB → 136.51 kB (-146 B) | -0.10%
static/js/pl.js | 137.12 kB → 137.04 kB (-75 B) | -0.05%
static/js/zh-Hans.js | 107.6 kB → 107.54 kB (-63 B) | -0.06%
static/js/it.js | 152.74 kB → 152.73 kB (-5 B) | -0.00%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/client.js | 452.05 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.62 MB → 4.63 MB (+3.25 kB) | +0.07%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +435 B (+6.34%) | 6.7 kB → 7.12 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +835 B (+3.79%) | 21.54 kB → 22.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +172 B (+3.74%) | 4.49 kB → 4.66 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +607 B (+3.04%) | 19.48 kB → 20.07 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📈 +227 B (+2.80%) | 7.92 kB → 8.14 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +243 B (+2.41%) | 9.85 kB → 10.08 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +229 B (+1.96%) | 11.4 kB → 11.62 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +86 B (+1.47%) | 5.73 kB → 5.82 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +349 B (+1.38%) | 24.71 kB → 25.05 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +169 B (+1.06%) | 15.56 kB → 15.72 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.70%) | 6.24 kB → 6.29 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +23 B (+0.30%) | 7.47 kB → 7.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -88 B (-0.93%) | 9.23 kB → 9.14 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DOLEluIG.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DyG6YkPb.js | 4.62 MB → 0 B (-4.62 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+3.98 kB) | +0.10%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/currencies.ts` | 📈 +411 B (+6.34%) | 6.33 kB → 6.73 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +1.33 kB (+6.30%) | 21.11 kB → 22.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +872 B (+4.28%) | 19.91 kB → 20.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/post.ts` | 📈 +169 B (+3.80%) | 4.34 kB → 4.51 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/cleanup-template.ts` | 📈 +222 B (+2.81%) | 7.71 kB → 7.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/index.ts` | 📈 +240 B (+2.45%) | 9.56 kB → 9.79 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/formulas/customFunctions.ts` | 📈 +225 B (+1.98%) | 11.12 kB → 11.34 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/compiler.ts` | 📈 +339 B (+1.38%) | 24.07 kB → 24.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +84 B (+1.29%) | 6.36 kB → 6.44 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +164 B (+1.05%) | 15.24 kB → 15.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/aql/schema/executors.ts` | 📈 +45 B (+0.72%) | 6.14 kB → 6.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/dashboard/app.ts` | 📈 +22 B (+0.29%) | 7.31 kB → 7.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/cloud-storage.ts` | 📉 -81 B (-0.88%) | 8.95 kB → 8.88 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+3.98 kB) | +0.10%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->