### PR TITLE
Don't send a starting balance of 0 when only the starting date is set

### DIFF
--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   computeInitialLinkState,
+  getDefaultStartingSettings,
   getSelectableAccountOptions,
+  resolveStartingSettings,
 } from './SelectLinkedAccountsModal';
 
 function makeLocalAccount(
@@ -156,5 +158,49 @@ describe('getSelectableAccountOptions', () => {
       'Create new account',
       'Create new account (off budget)',
     ]);
+  });
+});
+
+describe('resolveStartingSettings', () => {
+  it('sends no starting balance when the user only changed the date', () => {
+    // A row starts with a default date and no balance. Editing the date keeps
+    // the rest of the settings, which must not introduce a balance of 0.
+    const settings = { ...getDefaultStartingSettings(), date: '2026-01-15' };
+
+    expect(resolveStartingSettings(settings)).toEqual({
+      startingDate: '2026-01-15',
+      startingBalance: undefined,
+    });
+  });
+
+  it('sends no starting balance when nothing was touched', () => {
+    expect(resolveStartingSettings(undefined)).toEqual({
+      startingDate: undefined,
+      startingBalance: undefined,
+    });
+  });
+
+  it('sends the balance once the user enters one', () => {
+    const settings = { ...getDefaultStartingSettings(), amount: 12345 };
+
+    expect(resolveStartingSettings(settings).startingBalance).toBe(12345);
+  });
+
+  it('sends a balance the user deliberately set to zero', () => {
+    const settings = { ...getDefaultStartingSettings(), amount: 0 };
+
+    expect(resolveStartingSettings(settings).startingBalance).toBe(0);
+  });
+
+  it('ignores a blank date', () => {
+    expect(
+      resolveStartingSettings({ date: '   ' }).startingDate,
+    ).toBeUndefined();
+  });
+});
+
+describe('getDefaultStartingSettings', () => {
+  it('does not include a starting balance', () => {
+    expect(getDefaultStartingSettings().amount).toBeUndefined();
   });
 });

--- a/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
+++ b/packages/desktop-client/src/components/modals/SelectLinkedAccountsModal.tsx
@@ -270,7 +270,7 @@ export function SelectLinkedAccountsModal({
     initiallyChosenAccounts,
   );
   const [customStartingDates, setCustomStartingDates] = useState<
-    Record<string, StartingBalanceInfo>
+    Record<string, CustomStartingSettings>
   >({});
   const { addOnBudgetAccountOption, addOffBudgetAccountOption } =
     useAddBudgetAccountOptions();
@@ -308,13 +308,9 @@ export function SelectLinkedAccountsModal({
         }
 
         // Finally link the matched account
-        const customSettings = customStartingDates[chosenExternalAccountId];
-        const startingDate =
-          customSettings?.date && customSettings.date.trim() !== ''
-            ? customSettings.date
-            : undefined;
-        const startingBalance =
-          customSettings?.amount != null ? customSettings.amount : undefined;
+        const { startingDate, startingBalance } = resolveStartingSettings(
+          customStartingDates[chosenExternalAccountId],
+        );
 
         if (propsWithSortedExternalAccounts.syncSource === 'simpleFin') {
           linkAccountSimpleFin.mutate({
@@ -459,11 +455,8 @@ export function SelectLinkedAccountsModal({
   };
 
   // Memoize default starting settings to avoid repeated calculations
-  const defaultStartingSettings = useMemo<StartingBalanceInfo>(
-    () => ({
-      date: subDays(currentDay(), 89),
-      amount: 0,
-    }),
+  const defaultStartingSettings = useMemo<CustomStartingSettings>(
+    () => getDefaultStartingSettings(),
     [],
   );
 
@@ -471,13 +464,12 @@ export function SelectLinkedAccountsModal({
     if (customStartingDates[accountId]) {
       return customStartingDates[accountId];
     }
-    // Default to 89 days ago (90 days inclusive, matches server default)
     return defaultStartingSettings;
   };
 
   const setCustomStartingDate = (
     accountId: string,
-    settings: StartingBalanceInfo,
+    settings: CustomStartingSettings,
   ) => {
     setCustomStartingDates(prev => ({
       ...prev,
@@ -659,6 +651,40 @@ type StartingBalanceInfo = {
   amount: number;
 };
 
+// The starting balance the user typed into the link modal. `amount` stays
+// undefined until they actually edit it, so that only touching the date does
+// not send a starting balance of 0 to the server - which would override the
+// balance the bank reports.
+type CustomStartingSettings = {
+  date: string;
+  amount?: number;
+};
+
+/**
+ * The settings a row starts with. The balance is deliberately absent: the
+ * server derives the opening balance from the bank unless one is supplied, so
+ * defaulting it to 0 here would silently override the real balance for anyone
+ * who only adjusts the date.
+ */
+export function getDefaultStartingSettings(): CustomStartingSettings {
+  // Default to 89 days ago (90 days inclusive, matches server default)
+  return { date: subDays(currentDay(), 89) };
+}
+
+/**
+ * Turn the row's draft settings into the arguments sent when linking. Anything
+ * the user did not fill in stays undefined so the server keeps its own default.
+ */
+export function resolveStartingSettings(
+  settings: CustomStartingSettings | undefined,
+): { startingDate?: string; startingBalance?: number } {
+  return {
+    startingDate:
+      settings?.date && settings.date.trim() !== '' ? settings.date : undefined,
+    startingBalance: settings?.amount != null ? settings.amount : undefined,
+  };
+}
+
 type SharedAccountRowProps = {
   externalAccount: ExternalAccount;
   chosenAccount: { id: string; name: string } | undefined;
@@ -672,10 +698,10 @@ type SharedAccountRowProps = {
 };
 
 type TableRowProps = SharedAccountRowProps & {
-  customStartingDate: StartingBalanceInfo;
+  customStartingDate: CustomStartingSettings;
   onSetCustomStartingDate: (
     accountId: string,
-    settings: StartingBalanceInfo,
+    settings: CustomStartingSettings,
   ) => void;
   showStartingOptions: boolean;
 };
@@ -892,10 +918,10 @@ function getInstitutionName(
 type StartingOptionsFieldsProps = {
   accountId: string;
   externalBalance: number | null | undefined;
-  customStartingDate: StartingBalanceInfo;
+  customStartingDate: CustomStartingSettings;
   onSetCustomStartingDate: (
     accountId: string,
-    settings: StartingBalanceInfo,
+    settings: CustomStartingSettings,
   ) => void;
   layout: 'inline' | 'stacked';
 };
@@ -929,7 +955,7 @@ function StartingOptionsFields({
         {/* Starting Balance */}
         <Field width={120} truncate={false} style={{ textAlign: 'right' }}>
           <AmountInput
-            value={customStartingDate.amount}
+            value={customStartingDate.amount ?? 0}
             zeroSign={zeroSign}
             onUpdate={amount =>
               onSetCustomStartingDate(accountId, {
@@ -987,7 +1013,7 @@ function StartingOptionsFields({
             <Trans>Balance on that date:</Trans>
           </Text>
           <AmountInput
-            value={customStartingDate.amount}
+            value={customStartingDate.amount ?? 0}
             zeroSign={zeroSign}
             onUpdate={amount =>
               onSetCustomStartingDate(accountId, {
@@ -1004,10 +1030,10 @@ function StartingOptionsFields({
 }
 
 type AccountCardProps = SharedAccountRowProps & {
-  customStartingDate: StartingBalanceInfo;
+  customStartingDate: CustomStartingSettings;
   onSetCustomStartingDate: (
     accountId: string,
-    settings: StartingBalanceInfo,
+    settings: CustomStartingSettings,
   ) => void;
 };
 

--- a/upcoming-release-notes/fix-banksync-custom-start-date.md
+++ b/upcoming-release-notes/fix-banksync-custom-start-date.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [Islinger19]
+---
+
+Fix bank sync setting an opening balance of 0 when a custom starting date is chosen without a custom starting balance


### PR DESCRIPTION
## Description

When linking a bank account, each row defaults its custom starting balance to
0. Editing only the starting date carries that default along, so a starting
balance of 0 is sent to the server. The server treats any defined balance as
the real opening balance rather than deriving one from the bank:

    if (customStartingBalance !== undefined) {
      balanceToUse = customStartingBalance;
    } else if (acctRow.account_sync_source === 'simpleFin') {
      // derive from the downloaded transactions
    }

So the account opens out of sync with what the bank reports. Leaving both
fields alone works, because then no settings object exists at all and the
balance is sent as undefined - which matches the two paths described in the
issue.

The fix leaves the balance undefined until the user actually enters one. The
amount input still displays 0, and a balance deliberately set to 0 is still
sent. The submit path needed no change; it already ignored a null amount.

I extracted `getDefaultStartingSettings` and `resolveStartingSettings` so this
could be unit tested, following the pattern of the pure helpers this file
already exports. Happy to shrink that back to the two-line version if you would
rather keep the diff minimal.

I reproduced the issue, verified the fix locally against a bank sync account,
and reviewed the change. The initial patch was drafted with AI assistance.

## Related issue(s)

Closes #8105

## Testing

Six new cases in the existing `SelectLinkedAccountsModal.test.ts`. Two fail on
master:

    × sends no starting balance when the user only changed the date
        expected { startingDate: '2026-01-15', …(1) } to deeply equal …
    × does not include a starting balance
        expected +0 to be undefined

The other four guard against over-correcting: an entered balance is still sent,
a balance deliberately set to 0 is still sent, a blank date is ignored, and
untouched settings send nothing.

Also verified by hand: linked an account with only the starting date changed
and confirmed the opening balance now matches the bank.

`yarn typecheck` and `yarn lint:fix` are clean, and the desktop-client suite
passes (941 tests).

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.53 MB (+76 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.53 MB (+76 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/modals/SelectLinkedAccountsModal.tsx` | 📈 +76 B (+0.19%) | 38.47 kB → 38.54 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB → 1.57 MB (+76 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/ru.js | 209.49 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.dipLZRtD.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->