### PR TITLE
[AI] Rename tags from the Tags page

### DIFF
--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -938,7 +938,7 @@ export type TableProps<T extends TableItem = TableItem> = {
     item: T;
     editing: boolean;
     focusedField: string | null;
-    onEdit: (id: T['id'] | null, field?: string) => void;
+    onEdit: TableNavigator<T>['onEdit'];
     index: number;
     position: number;
   }) => ReactNode;

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -938,7 +938,7 @@ export type TableProps<T extends TableItem = TableItem> = {
     item: T;
     editing: boolean;
     focusedField: string | null;
-    onEdit: (id: T['id'], field: string) => void;
+    onEdit: (id: T['id'] | null, field?: string) => void;
     index: number;
     position: number;
   }) => ReactNode;

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -85,10 +85,14 @@ describe('ManageTags', () => {
     await userEvent.clear(input);
     await userEvent.type(input, 'ToBeReimbursed{Enter}');
 
+    expect(renameTag).toHaveBeenCalledTimes(1);
     expect(renameTag).toHaveBeenCalledWith({
       id: 'tag-1',
       tag: 'ToBeReimbursed',
     });
+    expect(
+      screen.queryByDisplayValue('ToBeReimbursed'),
+    ).not.toBeInTheDocument();
   });
 
   it('does not rename when the name is unchanged', async () => {
@@ -97,5 +101,6 @@ describe('ManageTags', () => {
     await userEvent.type(screen.getByDisplayValue('Reimbursable'), '{Enter}');
 
     expect(renameTag).not.toHaveBeenCalled();
+    expect(screen.queryByDisplayValue('Reimbursable')).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { initServer } from '@actual-app/core/platform/client/connection';
+import type { TagEntity } from '@actual-app/core/types/models';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {
+  configureTestAppStore,
+  createTestQueryClient,
+  TestProviders,
+} from '#mocks';
+import { tagQueries } from '#tags';
+
+import { ManageTags } from './ManageTags';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+const tags: TagEntity[] = [
+  { id: 'tag-1', tag: 'Reimbursable', color: null, description: null },
+  { id: 'tag-2', tag: 'Work', color: null, description: null },
+];
+
+const createRenameTagMock = () =>
+  vi.fn(async ({ id }: { id: string; tag: string }) => id);
+
+describe('ManageTags', () => {
+  let store: ReturnType<typeof configureTestAppStore>;
+  let renameTag: ReturnType<typeof createRenameTagMock>;
+
+  beforeEach(async () => {
+    renameTag = createRenameTagMock();
+    initServer({ 'tags-get': async () => tags, 'tags-rename': renameTag });
+
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(tagQueries.list().queryKey, tags);
+    store = configureTestAppStore({ queryClient });
+
+    render(
+      <TestProviders store={store} queryClient={queryClient}>
+        <MemoryRouter>
+          <ManageTags />
+        </MemoryRouter>
+      </TestProviders>,
+    );
+    await act(() => Promise.resolve());
+  });
+
+  function contextMenuItem(name: string) {
+    const item = store
+      .getState()
+      .contextMenu.items.find(
+        item => typeof item === 'object' && item.name === name,
+      );
+    return typeof item === 'object' ? item : undefined;
+  }
+
+  async function startRenaming(tagName: string) {
+    await userEvent.pointer({
+      target: screen.getByText(`#${tagName}`),
+      keys: '[MouseRight]',
+    });
+
+    const rename = contextMenuItem('rename');
+    expect(rename).toBeDefined();
+    await act(async () => rename!.onClick?.());
+  }
+
+  it('offers renaming from the row context menu', async () => {
+    await startRenaming('Reimbursable');
+
+    expect(screen.getByDisplayValue('Reimbursable')).toBeInTheDocument();
+  });
+
+  it('renames the tag on submit', async () => {
+    await startRenaming('Reimbursable');
+
+    const input = screen.getByDisplayValue('Reimbursable');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'ToBeReimbursed{Enter}');
+
+    expect(renameTag).toHaveBeenCalledWith({
+      id: 'tag-1',
+      tag: 'ToBeReimbursed',
+    });
+  });
+
+  it('does not rename when the name is unchanged', async () => {
+    await startRenaming('Reimbursable');
+
+    await userEvent.type(screen.getByDisplayValue('Reimbursable'), '{Enter}');
+
+    expect(renameTag).not.toHaveBeenCalled();
+  });
+});

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -66,8 +66,10 @@ describe('ManageTags', () => {
     });
 
     const rename = contextMenuItem('rename');
-    expect(rename).toBeDefined();
-    await act(async () => rename!.onClick?.());
+    if (!rename) {
+      throw new Error('Rename context menu item not found');
+    }
+    await act(async () => rename.onClick?.());
   }
 
   it('offers renaming from the row context menu', async () => {

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router';
 
 import { initServer } from '@actual-app/core/platform/client/connection';
 import type { TagEntity } from '@actual-app/core/types/models';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -71,6 +71,45 @@ describe('ManageTags', () => {
     }
     await act(async () => rename.onClick?.());
   }
+
+  async function selectTag(tagName: string) {
+    const row = screen
+      .getByText(`#${tagName}`)
+      .closest<HTMLElement>('[data-testid="row"]');
+    if (!row) {
+      throw new Error(`Row for #${tagName} not found`);
+    }
+    await userEvent.click(within(row).getByTestId('select'));
+  }
+
+  async function openSelectionMenu() {
+    await userEvent.click(screen.getByTestId('selected-tags-select-button'));
+    return screen.getByTestId('selected-tags-select-tooltip');
+  }
+
+  it('offers renaming from the selection menu for a single tag', async () => {
+    await selectTag('Reimbursable');
+
+    const menu = await openSelectionMenu();
+    await userEvent.click(within(menu).getByText('Rename'));
+
+    expect(await screen.findByDisplayValue('Reimbursable')).toBeInTheDocument();
+    // The selection is cleared so the closing menu cannot pull focus back
+    // out of the input, which would leave the delete/hide hotkeys live
+    expect(
+      screen.queryByTestId('selected-tags-select-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not offer renaming when several tags are selected', async () => {
+    await selectTag('Reimbursable');
+    await selectTag('Work');
+
+    const menu = await openSelectionMenu();
+
+    expect(within(menu).queryByText('Rename')).not.toBeInTheDocument();
+    expect(within(menu).getByText('Delete')).toBeInTheDocument();
+  });
 
   it('renames the tag on submit', async () => {
     await startRenaming('Reimbursable');

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -101,7 +101,29 @@ describe('ManageTags', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not offer renaming when several tags are selected', async () => {
+  it('drops renaming from the row context menu for a multi-selection', async () => {
+    await selectTag('Reimbursable');
+    await selectTag('Work');
+    await userEvent.pointer({
+      target: screen.getByText('#Reimbursable'),
+      keys: '[MouseRight]',
+    });
+
+    expect(contextMenuItem('rename')).toBeUndefined();
+    expect(contextMenuItem('delete')).toBeDefined();
+  });
+
+  it('keeps renaming in the row context menu for one selected tag', async () => {
+    await selectTag('Reimbursable');
+    await userEvent.pointer({
+      target: screen.getByText('#Reimbursable'),
+      keys: '[MouseRight]',
+    });
+
+    expect(contextMenuItem('rename')).toBeDefined();
+  });
+
+  it('drops renaming from the selection menu for a multi-selection', async () => {
     await selectTag('Reimbursable');
     await selectTag('Work');
 

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -72,12 +72,6 @@ describe('ManageTags', () => {
     await act(async () => rename.onClick?.());
   }
 
-  it('offers renaming from the row context menu', async () => {
-    await startRenaming('Reimbursable');
-
-    expect(screen.getByDisplayValue('Reimbursable')).toBeInTheDocument();
-  });
-
   it('renames the tag on submit', async () => {
     await startRenaming('Reimbursable');
 
@@ -93,14 +87,5 @@ describe('ManageTags', () => {
     expect(
       screen.queryByDisplayValue('ToBeReimbursed'),
     ).not.toBeInTheDocument();
-  });
-
-  it('does not rename when the name is unchanged', async () => {
-    await startRenaming('Reimbursable');
-
-    await userEvent.type(screen.getByDisplayValue('Reimbursable'), '{Enter}');
-
-    expect(renameTag).not.toHaveBeenCalled();
-    expect(screen.queryByDisplayValue('Reimbursable')).not.toBeInTheDocument();
   });
 });

--- a/packages/desktop-client/src/components/tags/ManageTags.test.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.test.tsx
@@ -123,8 +123,8 @@ describe('ManageTags', () => {
       id: 'tag-1',
       tag: 'ToBeReimbursed',
     });
-    expect(
-      screen.queryByDisplayValue('ToBeReimbursed'),
-    ).not.toBeInTheDocument();
+    // No editor is left open anywhere: the navigator would otherwise carry
+    // editing on to the next row's tag field
+    expect(screen.queryAllByTestId('tag')).toHaveLength(0);
   });
 });

--- a/packages/desktop-client/src/components/tags/ManageTags.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.tsx
@@ -42,6 +42,7 @@ export function ManageTags() {
   const selectedInst = useSelected('manage-tags', filteredTags, []);
   const tableNavigator = useTableNavigator(filteredTags, [
     'select',
+    'tag',
     'color',
     'description',
   ]);

--- a/packages/desktop-client/src/components/tags/ManageTags.tsx
+++ b/packages/desktop-client/src/components/tags/ManageTags.tsx
@@ -12,6 +12,7 @@ import { listen } from '@actual-app/core/platform/client/connection';
 import { getNormalisedString } from '@actual-app/core/shared/normalisation';
 
 import { Search } from '#components/common/Search';
+import { useTableNavigator } from '#components/table';
 import { SelectedProvider, useSelected } from '#hooks/useSelected';
 import { useTags } from '#hooks/useTags';
 
@@ -39,6 +40,11 @@ export function ManageTags() {
   }, [filter, tags]);
 
   const selectedInst = useSelected('manage-tags', filteredTags, []);
+  const tableNavigator = useTableNavigator(filteredTags, [
+    'select',
+    'color',
+    'description',
+  ]);
 
   return (
     <SelectedProvider instance={selectedInst}>
@@ -73,7 +79,9 @@ export function ManageTags() {
             value={filter}
             onChange={setFilter}
           />
-          <SelectedTagsButton />
+          <SelectedTagsButton
+            onRename={id => tableNavigator.onEdit(id, 'tag')}
+          />
           <TagsMenuButton />
         </SpaceBetween>
         <View style={{ marginTop: 12, ...styles.tableContainer }}>
@@ -83,6 +91,7 @@ export function ManageTags() {
           )}
           {tags.length ? (
             <TagsList
+              navigator={tableNavigator}
               tags={filteredTags}
               hoveredTag={hoveredTag}
               onHover={id => setHoveredTag(id ?? undefined)}

--- a/packages/desktop-client/src/components/tags/SelectedTagsButton.tsx
+++ b/packages/desktop-client/src/components/tags/SelectedTagsButton.tsx
@@ -1,6 +1,7 @@
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
+import type { MenuItemObject } from '@actual-app/components/menu';
 import type { TagEntity } from '@actual-app/core/types/models';
 
 import { SelectedItemsButton } from '#components/table';
@@ -69,7 +70,13 @@ export function SelectedTagsButton({ onRename }: SelectedTagsButtonProps) {
       name={c => `${c} Tags`}
       items={[
         ...(isSingleSelection
-          ? [{ name: 'rename-tag' as const, text: t('Rename'), key: 'R' }]
+          ? [
+              {
+                name: 'rename-tag',
+                text: t('Rename'),
+                key: 'R',
+              } satisfies MenuItemObject<Actions>,
+            ]
           : []),
         { name: 'delete-tags', text: t('Delete'), key: 'D' },
         { name: 'hide-tags', text: t('Hide'), key: 'H' },

--- a/packages/desktop-client/src/components/tags/SelectedTagsButton.tsx
+++ b/packages/desktop-client/src/components/tags/SelectedTagsButton.tsx
@@ -1,6 +1,8 @@
 import { useHotkeys } from 'react-hotkeys-hook';
 import { useTranslation } from 'react-i18next';
 
+import type { TagEntity } from '@actual-app/core/types/models';
+
 import { SelectedItemsButton } from '#components/table';
 import { useSelectedDispatch, useSelectedItems } from '#hooks/useSelected';
 import {
@@ -9,9 +11,13 @@ import {
   useUnhideTagsMutation,
 } from '#tags';
 
-type Actions = 'delete-tags' | 'hide-tags' | 'unhide-tags';
+type Actions = 'rename-tag' | 'delete-tags' | 'hide-tags' | 'unhide-tags';
 
-export function SelectedTagsButton() {
+type SelectedTagsButtonProps = {
+  onRename: (id: TagEntity['id']) => void;
+};
+
+export function SelectedTagsButton({ onRename }: SelectedTagsButtonProps) {
   const dispatch = useSelectedDispatch();
   const { t } = useTranslation();
   const selectedItems = useSelectedItems();
@@ -26,8 +32,17 @@ export function SelectedTagsButton() {
     );
   }
 
+  // The closing menu restores focus to its trigger, so clear the selection
+  // (which unmounts this button) and open the editor once that has settled
+  function startRename(id: TagEntity['id']) {
+    dispatch({ type: 'select-none' });
+    requestAnimationFrame(() => onRename(id));
+  }
+
   function handleSelect(name: Actions, tagIds: string[]) {
-    if (name === 'delete-tags') {
+    if (name === 'rename-tag') {
+      startRename(tagIds[0]);
+    } else if (name === 'delete-tags') {
       void handleDelete(tagIds);
     } else if (name === 'hide-tags') {
       hideTags({ ids: [...tagIds] });
@@ -39,6 +54,11 @@ export function SelectedTagsButton() {
   }
 
   const enabled = !!selectedItems.size;
+  // Renaming edits a single row, so it is only offered for one selected tag
+  const isSingleSelection = selectedItems.size === 1;
+  useHotkeys('r', () => startRename([...selectedItems][0]), {
+    enabled: isSingleSelection,
+  });
   useHotkeys('d', () => handleDelete([...selectedItems]), { enabled });
   useHotkeys('h', () => hideTags({ ids: [...selectedItems] }), { enabled });
   useHotkeys('u', () => unhideTags({ ids: [...selectedItems] }), { enabled });
@@ -48,6 +68,9 @@ export function SelectedTagsButton() {
       id="selected-tags"
       name={c => `${c} Tags`}
       items={[
+        ...(isSingleSelection
+          ? [{ name: 'rename-tag' as const, text: t('Rename'), key: 'R' }]
+          : []),
         { name: 'delete-tags', text: t('Delete'), key: 'D' },
         { name: 'hide-tags', text: t('Hide'), key: 'H' },
         { name: 'unhide-tags', text: t('Unhide'), key: 'U' },

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -1,4 +1,5 @@
 import React, { memo, useRef } from 'react';
+import type { KeyboardEvent } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { SvgArrowThinRight } from '@actual-app/components/icons/v1';
@@ -32,7 +33,7 @@ type TagRowProps = {
   hovered?: boolean;
   onHover: (id?: string) => void;
   focusedField: string | null;
-  onEdit: (id: string, field: string) => void;
+  onEdit: (id: string | null, field?: string) => void;
 };
 
 export const TagRow = memo(
@@ -66,6 +67,17 @@ export const TagRow = memo(
         return;
       }
       renameTag({ id: tag.id, tag: trimmed });
+    };
+
+    // The 'tag' field is not part of the table navigator, so Enter must be
+    // handled here or the navigator reopens the input via flashInput
+    const onRenameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        onRename(e.currentTarget.value);
+        onEdit(null);
+      }
     };
 
     const onShowActivity = () => {
@@ -150,7 +162,10 @@ export const TagRow = memo(
             textAlign="flex"
             exposed
             value={tag.tag}
-            inputProps={{ onUpdate: onRename }}
+            inputProps={{
+              onUpdate: onRename,
+              onKeyDownCapture: onRenameKeyDown,
+            }}
           />
         ) : (
           <Cell width={250} plain style={{ padding: '5px', display: 'block' }}>

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -69,8 +69,9 @@ export const TagRow = memo(
       renameTag({ id: tag.id, tag: trimmed });
     };
 
-    // The 'tag' field is not part of the table navigator, so Enter must be
-    // handled here or the navigator reopens the input via flashInput
+    // Enter must be handled here: the navigator would otherwise move editing
+    // to the next row's tag field, which after the list re-sorts is an
+    // unrelated tag
     const onRenameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter') {
         e.preventDefault();

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -99,11 +99,14 @@ export const TagRow = memo(
     };
 
     const contextActionIds = selected ? Array.from(selectedIds) : [tag.id];
+    // The other actions apply to every id above, so renaming — which edits a
+    // single row — is only offered when that is the one tag
+    const isSingleTagAction = contextActionIds.length === 1;
 
     useContextMenu({
       triggerRef,
       items: [
-        {
+        isSingleTagAction && {
           name: 'rename',
           text: t('Rename'),
           onClick: () => onEdit(tag.id, 'tag'),

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -20,6 +20,7 @@ import { useSelectedDispatch, useSelectedItems } from '#hooks/useSelected';
 import {
   useDeleteTagsMutation,
   useHideTagsMutation,
+  useRenameTagMutation,
   useUnhideTagsMutation,
   useUpdateTagMutation,
 } from '#tags';
@@ -50,12 +51,21 @@ export const TagRow = memo(
     const triggerRef = useRef(null);
     const navigate = useNavigate();
     const { mutate: updateTag } = useUpdateTagMutation();
+    const { mutate: renameTag } = useRenameTagMutation();
     const { mutate: deleteTags } = useDeleteTagsMutation();
     const { mutate: hideTags } = useHideTagsMutation();
     const { mutate: unhideTags } = useUnhideTagsMutation();
 
     const onUpdate = (description: string) => {
       updateTag({ tag: { ...tag, description } });
+    };
+
+    const onRename = (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed || trimmed === tag.tag) {
+        return;
+      }
+      renameTag({ id: tag.id, tag: trimmed });
     };
 
     const onShowActivity = () => {
@@ -80,6 +90,11 @@ export const TagRow = memo(
     useContextMenu({
       triggerRef,
       items: [
+        {
+          name: 'rename',
+          text: t('Rename'),
+          onClick: () => onEdit(tag.id, 'tag'),
+        },
         {
           name: 'delete',
           text: t('Delete'),
@@ -128,9 +143,24 @@ export const TagRow = memo(
           selected={selected}
         />
 
-        <Cell width={250} plain style={{ padding: '5px', display: 'block' }}>
-          <TagEditor tag={tag} ref={colorButtonRef} />
-        </Cell>
+        {focusedField === 'tag' ? (
+          <InputCell
+            width={250}
+            name="tag"
+            textAlign="flex"
+            exposed
+            onExpose={name => onEdit(tag.id, name)}
+            value={tag.tag}
+            inputProps={{
+              value: tag.tag,
+              onUpdate: onRename,
+            }}
+          />
+        ) : (
+          <Cell width={250} plain style={{ padding: '5px', display: 'block' }}>
+            <TagEditor tag={tag} ref={colorButtonRef} />
+          </Cell>
+        )}
 
         <InputCell
           width="flex"

--- a/packages/desktop-client/src/components/tags/TagRow.tsx
+++ b/packages/desktop-client/src/components/tags/TagRow.tsx
@@ -149,12 +149,8 @@ export const TagRow = memo(
             name="tag"
             textAlign="flex"
             exposed
-            onExpose={name => onEdit(tag.id, name)}
             value={tag.tag}
-            inputProps={{
-              value: tag.tag,
-              onUpdate: onRename,
-            }}
+            inputProps={{ onUpdate: onRename }}
           />
         ) : (
           <Cell width={250} plain style={{ padding: '5px', display: 'block' }}>

--- a/packages/desktop-client/src/components/tags/TagsList.tsx
+++ b/packages/desktop-client/src/components/tags/TagsList.tsx
@@ -3,26 +3,27 @@ import React from 'react';
 import { theme } from '@actual-app/components/theme';
 import type { TagEntity } from '@actual-app/core/types/models';
 
-import { Table, useTableNavigator } from '#components/table';
+import { Table } from '#components/table';
+import type { TableNavigator } from '#components/table';
 
 import { TagRow } from './TagRow';
 
 type TagsListProps = {
+  navigator: TableNavigator<TagEntity>;
   tags: TagEntity[];
   hoveredTag?: string;
   onHover: (id?: string) => void;
 };
 
-export function TagsList({ tags, hoveredTag, onHover }: TagsListProps) {
-  const tableNavigator = useTableNavigator(tags, [
-    'select',
-    'color',
-    'description',
-  ]);
-
+export function TagsList({
+  navigator,
+  tags,
+  hoveredTag,
+  onHover,
+}: TagsListProps) {
   return (
     <Table
-      navigator={tableNavigator}
+      navigator={navigator}
       items={tags}
       backgroundColor={theme.tableBackground}
       renderItem={({ item: tag, focusedField, onEdit }) => {

--- a/packages/desktop-client/src/tags/mutations.ts
+++ b/packages/desktop-client/src/tags/mutations.ts
@@ -85,6 +85,32 @@ export function useUpdateTagMutation() {
   });
 }
 
+type RenameTagPayload = {
+  id: TagEntity['id'];
+  tag: TagEntity['tag'];
+};
+
+export function useRenameTagMutation() {
+  const queryClient = useQueryClient();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: async ({ id, tag }: RenameTagPayload) => {
+      return await send('tags-rename', { id, tag });
+    },
+    onSuccess: () => invalidateQueries(queryClient),
+    onError: error => {
+      console.error('Error renaming tag:', error);
+      dispatchErrorNotification(
+        dispatch,
+        t('There was an error renaming the tag. Please try again.'),
+        error,
+      );
+    },
+  });
+}
+
 type DeleteTagPayload = {
   id: TagEntity['id'];
 };

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -36,5 +36,5 @@ The Tag management page can be found in the sidebar under _More_. Here you can p
 - **Find Existing Tags** searches for tags already used within transactions and adds them to the list of managed tags.
 - Add a description by clicking in the description field.
 - **View Transactions** which use a given tag.
-- **Rename** a tag from the context menu (right-click menu). Renaming also rewrites the hashtag in every transaction note that uses it, so `#Reimbursable` becomes `#ToBeReimbursed` everywhere. Tag names cannot contain spaces or `#`, and cannot match an existing tag.
+- **Rename** a tag from the context menu (right-click menu), or from the selection menu when exactly one tag is selected. Renaming also rewrites the hashtag in every transaction note that uses it, so `#Reimbursable` becomes `#ToBeReimbursed` everywhere. Tag names cannot contain spaces or `#`, and cannot match an existing tag.
 - Use the context menu (right-click menu) to delete a tag from this page. It will **not** delete the tag from the transaction notes.

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -36,4 +36,5 @@ The Tag management page can be found in the sidebar under _More_. Here you can p
 - **Find Existing Tags** searches for tags already used within transactions and adds them to the list of managed tags.
 - Add a description by clicking in the description field.
 - **View Transactions** which use a given tag.
+- **Rename** a tag from the context menu (right-click menu). Renaming also rewrites the hashtag in every transaction note that uses it, so `#Reimbursable` becomes `#ToBeReimbursed` everywhere. Tag names cannot contain spaces or `#`, and cannot match an existing tag.
 - Use the context menu (right-click menu) to delete a tag from this page. It will **not** delete the tag from the transaction notes.

--- a/packages/docs/docs/transactions/tags.md
+++ b/packages/docs/docs/transactions/tags.md
@@ -36,5 +36,5 @@ The Tag management page can be found in the sidebar under _More_. Here you can p
 - **Find Existing Tags** searches for tags already used within transactions and adds them to the list of managed tags.
 - Add a description by clicking in the description field.
 - **View Transactions** which use a given tag.
-- **Rename** a tag from the context menu (right-click menu), or from the selection menu when exactly one tag is selected. Renaming also rewrites the hashtag in every transaction note that uses it, so `#Reimbursable` becomes `#ToBeReimbursed` everywhere. Tag names cannot contain spaces or `#`, and cannot match an existing tag.
+- **Rename** a tag from the context menu (right-click menu), or from the selection menu when exactly one tag is selected. Renaming also rewrites the hashtag in every transaction note that uses it. Tag names cannot contain spaces or `#`, and cannot match an existing tag.
 - Use the context menu (right-click menu) to delete a tag from this page. It will **not** delete the tag from the transaction notes.

--- a/packages/loot-core/src/server/db/index.ts
+++ b/packages/loot-core/src/server/db/index.ts
@@ -1026,9 +1026,9 @@ export function updateTag(tag: Partial<DbTag> & Pick<DbTag, 'id'>) {
 }
 
 export function findTags() {
-  return all<{ notes: string }>(
+  return all<{ id: DbTransaction['id']; notes: string }>(
     `
-      SELECT notes
+      SELECT id, notes
       FROM transactions
       WHERE tombstone = 0 AND notes LIKE ?
     `,

--- a/packages/loot-core/src/server/tags/app.test.ts
+++ b/packages/loot-core/src/server/tags/app.test.ts
@@ -38,45 +38,17 @@ describe('tags app', () => {
       });
       const matching = await insertTransaction('Lunch #Reimbursable');
       const partial = await insertTransaction('Dinner #ReimbursableLater');
-      const untagged = await insertTransaction('Coffee');
 
-      await app.handlers['tags-rename']({ id, tag: 'ToBeReimbursed' });
+      await app.handlers['tags-rename']({ id, tag: '  ToBeReimbursed  ' });
 
       expect(await db.getTags()).toEqual([
         expect.objectContaining({ id, tag: 'ToBeReimbursed' }),
       ]);
       expect(await getNotes(matching)).toBe('Lunch #ToBeReimbursed');
       expect(await getNotes(partial)).toBe('Dinner #ReimbursableLater');
-      expect(await getNotes(untagged)).toBe('Coffee');
     });
 
-    it('trims the new name', async () => {
-      const id = await db.insertTag({
-        tag: 'Food',
-        color: null,
-        description: null,
-      });
-      const transaction = await insertTransaction('Lunch #Food today');
-
-      await app.handlers['tags-rename']({ id, tag: '  Groceries  ' });
-
-      expect(await getNotes(transaction)).toBe('Lunch #Groceries today');
-    });
-
-    it('is a no-op when the name is unchanged', async () => {
-      const id = await db.insertTag({
-        tag: 'Food',
-        color: null,
-        description: null,
-      });
-      const transaction = await insertTransaction('Lunch #Food');
-
-      await app.handlers['tags-rename']({ id, tag: 'Food' });
-
-      expect(await getNotes(transaction)).toBe('Lunch #Food');
-    });
-
-    it('rejects names containing whitespace or "#"', async () => {
+    it('rejects an invalid name', async () => {
       const id = await db.insertTag({
         tag: 'Food',
         color: null,
@@ -85,12 +57,6 @@ describe('tags app', () => {
 
       await expect(
         app.handlers['tags-rename']({ id, tag: 'two words' }),
-      ).rejects.toThrow('Invalid tag name');
-      await expect(
-        app.handlers['tags-rename']({ id, tag: '#Food' }),
-      ).rejects.toThrow('Invalid tag name');
-      await expect(
-        app.handlers['tags-rename']({ id, tag: '' }),
       ).rejects.toThrow('Invalid tag name');
     });
 

--- a/packages/loot-core/src/server/tags/app.test.ts
+++ b/packages/loot-core/src/server/tags/app.test.ts
@@ -77,6 +77,24 @@ describe('tags app', () => {
       ).rejects.toThrow('A tag with that name already exists');
     });
 
+    it('rejects renaming onto a deleted tag', async () => {
+      const id = await db.insertTag({
+        tag: 'Food',
+        color: null,
+        description: null,
+      });
+      const deletedId = await db.insertTag({
+        tag: 'Groceries',
+        color: null,
+        description: null,
+      });
+      await app.handlers['tags-delete']({ id: deletedId });
+
+      await expect(
+        app.handlers['tags-rename']({ id, tag: 'Groceries' }),
+      ).rejects.toThrow('A tag with that name already exists');
+    });
+
     it('rejects an unknown tag', async () => {
       await expect(
         app.handlers['tags-rename']({ id: 'missing', tag: 'Food' }),

--- a/packages/loot-core/src/server/tags/app.test.ts
+++ b/packages/loot-core/src/server/tags/app.test.ts
@@ -1,0 +1,120 @@
+import * as db from '#server/db';
+import { loadMappings } from '#server/db/mappings';
+import { app } from '#server/tags/app';
+
+beforeEach(async () => {
+  await global.emptyDatabase()();
+  await loadMappings();
+});
+
+async function insertTransaction(notes: string) {
+  return await db.insertTransaction({
+    account: 'account-1',
+    date: '2024-01-01',
+    amount: -1000,
+    notes,
+  });
+}
+
+async function getNotes(id: string) {
+  const transaction = await db.first<{ notes: string }>(
+    'SELECT notes FROM transactions WHERE id = ?',
+    [id],
+  );
+  return transaction?.notes;
+}
+
+describe('tags app', () => {
+  describe('tags-rename', () => {
+    beforeEach(async () => {
+      await db.insertAccount({ id: 'account-1', name: 'Account 1' });
+    });
+
+    it('renames the tag and rewrites it in transaction notes', async () => {
+      const id = await db.insertTag({
+        tag: 'Reimbursable',
+        color: null,
+        description: null,
+      });
+      const matching = await insertTransaction('Lunch #Reimbursable');
+      const partial = await insertTransaction('Dinner #ReimbursableLater');
+      const untagged = await insertTransaction('Coffee');
+
+      await app.handlers['tags-rename']({ id, tag: 'ToBeReimbursed' });
+
+      expect(await db.getTags()).toEqual([
+        expect.objectContaining({ id, tag: 'ToBeReimbursed' }),
+      ]);
+      expect(await getNotes(matching)).toBe('Lunch #ToBeReimbursed');
+      expect(await getNotes(partial)).toBe('Dinner #ReimbursableLater');
+      expect(await getNotes(untagged)).toBe('Coffee');
+    });
+
+    it('trims the new name', async () => {
+      const id = await db.insertTag({
+        tag: 'Food',
+        color: null,
+        description: null,
+      });
+      const transaction = await insertTransaction('Lunch #Food today');
+
+      await app.handlers['tags-rename']({ id, tag: '  Groceries  ' });
+
+      expect(await getNotes(transaction)).toBe('Lunch #Groceries today');
+    });
+
+    it('is a no-op when the name is unchanged', async () => {
+      const id = await db.insertTag({
+        tag: 'Food',
+        color: null,
+        description: null,
+      });
+      const transaction = await insertTransaction('Lunch #Food');
+
+      await app.handlers['tags-rename']({ id, tag: 'Food' });
+
+      expect(await getNotes(transaction)).toBe('Lunch #Food');
+    });
+
+    it('rejects names containing whitespace or "#"', async () => {
+      const id = await db.insertTag({
+        tag: 'Food',
+        color: null,
+        description: null,
+      });
+
+      await expect(
+        app.handlers['tags-rename']({ id, tag: 'two words' }),
+      ).rejects.toThrow('Invalid tag name');
+      await expect(
+        app.handlers['tags-rename']({ id, tag: '#Food' }),
+      ).rejects.toThrow('Invalid tag name');
+      await expect(
+        app.handlers['tags-rename']({ id, tag: '' }),
+      ).rejects.toThrow('Invalid tag name');
+    });
+
+    it('rejects renaming onto an existing tag', async () => {
+      const id = await db.insertTag({
+        tag: 'Food',
+        color: null,
+        description: null,
+      });
+      await db.insertTag({
+        tag: 'Groceries',
+        color: null,
+        description: null,
+      });
+
+      await expect(
+        app.handlers['tags-rename']({ id, tag: 'Groceries' }),
+      ).rejects.toThrow('A tag with that name already exists');
+    });
+
+    it('rejects an unknown tag', async () => {
+      await expect(
+        app.handlers['tags-rename']({ id: 'missing', tag: 'Food' }),
+      ).rejects.toThrow('Tag not found');
+    });
+  });
+});

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -122,7 +122,7 @@ async function renameTag({
     throw new Error('Invalid tag name');
   }
 
-  const tags = await getTags();
+  const tags = await db.getTags();
   const existing = tags.find(t => t.id === id);
   if (!existing) {
     throw new Error('Tag not found');

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -3,6 +3,7 @@ import * as db from '#server/db';
 import { mutator } from '#server/mutators';
 import { batchMessages } from '#server/sync';
 import { undoable } from '#server/undo';
+import { renameTagInNotes } from '#shared/tags';
 import type { TagEntity } from '#types/models';
 
 export type TagsHandlers = {
@@ -13,6 +14,7 @@ export type TagsHandlers = {
   'tags-hide-all': typeof hideAllTags;
   'tags-unhide-all': typeof unhideAllTags;
   'tags-update': typeof updateTag;
+  'tags-rename': typeof renameTag;
   'tags-discover': typeof discoverTags;
 };
 
@@ -24,6 +26,7 @@ app.method('tags-delete-all', mutator(undoable(deleteAllTags)));
 app.method('tags-hide-all', mutator(undoable(hideAllTags)));
 app.method('tags-unhide-all', mutator(undoable(unhideAllTags)));
 app.method('tags-update', mutator(undoable(updateTag)));
+app.method('tags-rename', mutator(undoable(renameTag)));
 app.method('tags-discover', mutator(discoverTags));
 
 const collator = new Intl.Collator(undefined, {
@@ -107,6 +110,42 @@ async function updateTag(
     ...(hidden !== undefined ? { hidden: hidden ? 1 : 0 } : {}),
   });
   return tag;
+}
+
+async function renameTag({
+  id,
+  tag: newTag,
+}: Pick<TagEntity, 'id' | 'tag'>): Promise<TagEntity['id']> {
+  const name = newTag.trim();
+  // accept any char except whitespaces and '#', same as tag creation
+  if (!/^[^#\s]+$/.test(name)) {
+    throw new Error('Invalid tag name');
+  }
+
+  const tags = await getTags();
+  const existing = tags.find(t => t.id === id);
+  if (!existing) {
+    throw new Error('Tag not found');
+  }
+  if (existing.tag === name) {
+    return id;
+  }
+  if (tags.some(t => t.id !== id && t.tag === name)) {
+    throw new Error('A tag with that name already exists');
+  }
+
+  await batchMessages(async () => {
+    await db.updateTag({ id, tag: name });
+
+    for (const { id: transactionId, notes } of await db.findTags()) {
+      const renamed = renameTagInNotes(notes, existing.tag, name);
+      if (renamed !== notes) {
+        await db.updateTransaction({ id: transactionId, notes: renamed });
+      }
+    }
+  });
+
+  return id;
 }
 
 async function discoverTags(): Promise<TagEntity[]> {

--- a/packages/loot-core/src/server/tags/app.ts
+++ b/packages/loot-core/src/server/tags/app.ts
@@ -123,6 +123,7 @@ async function renameTag({
   }
 
   const tags = await db.getTags();
+  const allTags = await db.getAllTags();
   const existing = tags.find(t => t.id === id);
   if (!existing) {
     throw new Error('Tag not found');
@@ -130,7 +131,7 @@ async function renameTag({
   if (existing.tag === name) {
     return id;
   }
-  if (tags.some(t => t.id !== id && t.tag === name)) {
+  if (allTags.some(t => t.id !== id && t.tag === name)) {
     throw new Error('A tag with that name already exists');
   }
 

--- a/packages/loot-core/src/shared/tags.test.ts
+++ b/packages/loot-core/src/shared/tags.test.ts
@@ -48,6 +48,11 @@ describe('renameTagInNotes', () => {
     expect(renameTagInNotes('#a+b', 'a+b', 'c')).toBe('#c');
   });
 
+  test('treats replacement tokens in the new name literally', () => {
+    expect(renameTagInNotes('#Food', 'Food', '$&')).toBe('#$&');
+    expect(renameTagInNotes('#Food', 'Food', "$'x$`")).toBe("#$'x$`");
+  });
+
   test('leaves notes without the tag untouched', () => {
     expect(renameTagInNotes('nothing to see here', 'Food', 'Groceries')).toBe(
       'nothing to see here',

--- a/packages/loot-core/src/shared/tags.test.ts
+++ b/packages/loot-core/src/shared/tags.test.ts
@@ -1,0 +1,56 @@
+import { renameTagInNotes } from './tags';
+
+describe('renameTagInNotes', () => {
+  test('renames a tag wherever it appears as a whole tag', () => {
+    expect(
+      renameTagInNotes(
+        'Lunch #Reimbursable with #Work',
+        'Reimbursable',
+        'ToBeReimbursed',
+      ),
+    ).toBe('Lunch #ToBeReimbursed with #Work');
+  });
+
+  test('renames a tag at the start and end of the notes', () => {
+    expect(renameTagInNotes('#Food', 'Food', 'Groceries')).toBe('#Groceries');
+    expect(renameTagInNotes('#Food lunch #Food', 'Food', 'Groceries')).toBe(
+      '#Groceries lunch #Groceries',
+    );
+  });
+
+  test('does not rename tags that merely start with the same text', () => {
+    expect(renameTagInNotes('#FoodCourt #Food', 'Food', 'Groceries')).toBe(
+      '#FoodCourt #Groceries',
+    );
+  });
+
+  test('renames tags adjacent to other tags', () => {
+    expect(renameTagInNotes('#Food#Work', 'Food', 'Groceries')).toBe(
+      '#Groceries#Work',
+    );
+    expect(renameTagInNotes('#Work#Food', 'Food', 'Groceries')).toBe(
+      '#Work#Groceries',
+    );
+  });
+
+  test('ignores escaped tags', () => {
+    expect(renameTagInNotes('##Food', 'Food', 'Groceries')).toBe('##Food');
+  });
+
+  test('is case sensitive', () => {
+    expect(renameTagInNotes('#food #Food', 'Food', 'Groceries')).toBe(
+      '#food #Groceries',
+    );
+  });
+
+  test('treats regex characters in the tag name literally', () => {
+    expect(renameTagInNotes('#a.b #axb', 'a.b', 'c')).toBe('#c #axb');
+    expect(renameTagInNotes('#a+b', 'a+b', 'c')).toBe('#c');
+  });
+
+  test('leaves notes without the tag untouched', () => {
+    expect(renameTagInNotes('nothing to see here', 'Food', 'Groceries')).toBe(
+      'nothing to see here',
+    );
+  });
+});

--- a/packages/loot-core/src/shared/tags.test.ts
+++ b/packages/loot-core/src/shared/tags.test.ts
@@ -1,61 +1,17 @@
 import { renameTagInNotes } from './tags';
 
 describe('renameTagInNotes', () => {
-  test('renames a tag wherever it appears as a whole tag', () => {
+  test('renames only whole, unescaped, case-sensitive tags', () => {
     expect(
       renameTagInNotes(
-        'Lunch #Reimbursable with #Work',
-        'Reimbursable',
-        'ToBeReimbursed',
+        '##Food #FoodCourt #food #Food#Work #Work#Food',
+        'Food',
+        'Groceries',
       ),
-    ).toBe('Lunch #ToBeReimbursed with #Work');
+    ).toBe('##Food #FoodCourt #food #Groceries#Work #Work#Groceries');
   });
 
-  test('renames a tag at the start and end of the notes', () => {
-    expect(renameTagInNotes('#Food', 'Food', 'Groceries')).toBe('#Groceries');
-    expect(renameTagInNotes('#Food lunch #Food', 'Food', 'Groceries')).toBe(
-      '#Groceries lunch #Groceries',
-    );
-  });
-
-  test('does not rename tags that merely start with the same text', () => {
-    expect(renameTagInNotes('#FoodCourt #Food', 'Food', 'Groceries')).toBe(
-      '#FoodCourt #Groceries',
-    );
-  });
-
-  test('renames tags adjacent to other tags', () => {
-    expect(renameTagInNotes('#Food#Work', 'Food', 'Groceries')).toBe(
-      '#Groceries#Work',
-    );
-    expect(renameTagInNotes('#Work#Food', 'Food', 'Groceries')).toBe(
-      '#Work#Groceries',
-    );
-  });
-
-  test('ignores escaped tags', () => {
-    expect(renameTagInNotes('##Food', 'Food', 'Groceries')).toBe('##Food');
-  });
-
-  test('is case sensitive', () => {
-    expect(renameTagInNotes('#food #Food', 'Food', 'Groceries')).toBe(
-      '#food #Groceries',
-    );
-  });
-
-  test('treats regex characters in the tag name literally', () => {
-    expect(renameTagInNotes('#a.b #axb', 'a.b', 'c')).toBe('#c #axb');
-    expect(renameTagInNotes('#a+b', 'a+b', 'c')).toBe('#c');
-  });
-
-  test('treats replacement tokens in the new name literally', () => {
-    expect(renameTagInNotes('#Food', 'Food', '$&')).toBe('#$&');
-    expect(renameTagInNotes('#Food', 'Food', "$'x$`")).toBe("#$'x$`");
-  });
-
-  test('leaves notes without the tag untouched', () => {
-    expect(renameTagInNotes('nothing to see here', 'Food', 'Groceries')).toBe(
-      'nothing to see here',
-    );
+  test('treats regex and replacement characters literally', () => {
+    expect(renameTagInNotes('#a.b #axb', 'a.b', '$&')).toBe('#$& #axb');
   });
 });

--- a/packages/loot-core/src/shared/tags.ts
+++ b/packages/loot-core/src/shared/tags.ts
@@ -15,3 +15,16 @@ export function extractTagsForFilter(value: string) {
   }
   return tagValues;
 }
+
+// Tags in notes are delimited by whitespace or another '#', and a doubled
+// '#' escapes the tag (see `parseNotes`). Matching is case sensitive because
+// tag identity elsewhere (colors, discovery) is case sensitive too.
+export function renameTagInNotes(
+  notes: string,
+  oldTag: string,
+  newTag: string,
+) {
+  const escaped = oldTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`(?<!#)#${escaped}(?=[\\s#]|$)`, 'g');
+  return notes.replace(pattern, `#${newTag}`);
+}

--- a/packages/loot-core/src/shared/tags.ts
+++ b/packages/loot-core/src/shared/tags.ts
@@ -26,5 +26,5 @@ export function renameTagInNotes(
 ) {
   const escaped = oldTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`(?<!#)#${escaped}(?=[\\s#]|$)`, 'g');
-  return notes.replace(pattern, `#${newTag}`);
+  return notes.replace(pattern, () => `#${newTag}`);
 }

--- a/upcoming-release-notes/rename-tags-from-tags-page.md
+++ b/upcoming-release-notes/rename-tags-from-tags-page.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [tim-smart]
+---
+
+Rename a tag from the Tags page, updating the hashtag in every transaction note that uses it


### PR DESCRIPTION
## Description

Allows renaming tags, and ensures notes using the renamed tag are kept updated.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 | 13.46 MB → 13.46 MB (+3.48 kB) | +0.03%
loot-core | 1 | 4.63 MB → 4.63 MB (+1.11 kB) | +0.02%
api | 2 | 3.84 MB → 3.84 MB (+1.08 kB) | +0.03%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 | 13.46 MB → 13.46 MB (+3.48 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/tags/SelectedTagsButton.tsx` | 📈 +1.11 kB (+32.53%) | 3.42 kB → 4.53 kB
`src/components/tags/TagRow.tsx` | 📈 +1.46 kB (+17.33%) | 8.4 kB → 9.86 kB
`src/tags/mutations.ts` | 📈 +922 B (+15.86%) | 5.68 kB → 6.58 kB
`src/components/tags/ManageTags.tsx` | 📈 +236 B (+7.30%) | 3.16 kB → 3.39 kB
`src/components/admin/UserAccess/UserAccess.tsx` | 📈 +2 B (+0.02%) | 9.98 kB → 9.98 kB
`src/components/tags/TagsList.tsx` | 📉 -222 B (-20.40%) | 1.06 kB → 866 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB → 1.58 MB (+3.48 kB) | +0.22%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 164.69 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/ru.js | 210.22 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+1.11 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 📈 +241 B (+57.93%) | 416 B → 657 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +887 B (+35.61%) | 2.43 kB → 3.3 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +4 B (+0.02%) | 20.07 kB → 20.07 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.oYX50zoz.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.qaixuUi8.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+1.08 kB) | +0.03%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/shared/tags.ts` | 📈 +236 B (+58.56%) | 403 B → 639 B
`home/runner/work/actual/actual/packages/loot-core/src/server/tags/app.ts` | 📈 +862 B (+35.68%) | 2.36 kB → 3.2 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/db/index.ts` | 📈 +4 B (+0.02%) | 20.76 kB → 20.77 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+1.08 kB) | +0.03%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->