### PR TITLE
[AI] Fix phantom overspending after deleting a category

### DIFF
--- a/packages/loot-core/src/server/budget/envelope.ts
+++ b/packages/loot-core/src/server/budget/envelope.ts
@@ -238,49 +238,61 @@ export function createBudget(meta, categories, months) {
 }
 
 export function handleCategoryChange(months, oldValue, newValue) {
-  function addDeps(sheetName, groupId, catId) {
-    sheet
-      .get()
-      .addDependencies(sheetName, `group-sum-amount-${groupId}`, [
-        `sum-amount-${catId}`,
+  // The cells a category feeds into, and the deps it contributes to each
+  // one. `addDeps` and `removeDeps` must stay mirror images of each other:
+  // anything only ever added keeps counting after the category is deleted.
+  function getDeps(sheetName, prevSheetName, groupId, cat) {
+    const deps: Array<[string, string[]]> = [
+      [`group-sum-amount-${groupId}`, [`sum-amount-${cat.id}`]],
+      [`group-budget-${groupId}`, [`budget-${cat.id}`]],
+      [`group-leftover-${groupId}`, [`leftover-${cat.id}`]],
+    ];
+
+    if (cat.is_income) {
+      deps.push([
+        'buffered-auto',
+        [
+          `${sheetName}!sum-amount-${cat.id}`,
+          `${sheetName}!carryover-${cat.id}`,
+        ],
       ]);
-    sheet
-      .get()
-      .addDependencies(sheetName, `group-budget-${groupId}`, [
-        `budget-${catId}`,
+    } else {
+      deps.push([
+        'last-month-overspent',
+        [
+          `${prevSheetName}!leftover-${cat.id}`,
+          `${prevSheetName}!carryover-${cat.id}`,
+        ],
       ]);
-    sheet
-      .get()
-      .addDependencies(sheetName, `group-leftover-${groupId}`, [
-        `leftover-${catId}`,
-      ]);
+    }
+
+    return deps;
   }
 
-  function removeDeps(sheetName, groupId, catId) {
-    sheet
-      .get()
-      .removeDependencies(sheetName, `group-sum-amount-${groupId}`, [
-        `sum-amount-${catId}`,
-      ]);
-    sheet
-      .get()
-      .removeDependencies(sheetName, `group-budget-${groupId}`, [
-        `budget-${catId}`,
-      ]);
-    sheet
-      .get()
-      .removeDependencies(sheetName, `group-leftover-${groupId}`, [
-        `leftover-${catId}`,
-      ]);
+  function addDeps(sheetName, prevSheetName, groupId, cat) {
+    getDeps(sheetName, prevSheetName, groupId, cat).forEach(
+      ([cellName, deps]) => {
+        sheet.get().addDependencies(sheetName, cellName, deps);
+      },
+    );
+  }
+
+  function removeDeps(sheetName, prevSheetName, groupId, cat) {
+    getDeps(sheetName, prevSheetName, groupId, cat).forEach(
+      ([cellName, deps]) => {
+        sheet.get().removeDependencies(sheetName, cellName, deps);
+      },
+    );
   }
 
   if (oldValue && oldValue.tombstone === 0 && newValue.tombstone === 1) {
-    const id = newValue.id;
-    const groupId = newValue.cat_group;
-
     months.forEach(month => {
+      const prevSheetName = monthUtils.sheetForMonth(
+        monthUtils.prevMonth(month),
+      );
       const sheetName = monthUtils.sheetForMonth(month);
-      removeDeps(sheetName, groupId, id);
+
+      removeDeps(sheetName, prevSheetName, newValue.cat_group, newValue);
     });
   } else if (
     newValue.tombstone === 0 &&
@@ -296,38 +308,18 @@ export function handleCategoryChange(months, oldValue, newValue) {
 
       createCategoryFromBase(newValue, sheetName, prevSheetName, start, end);
 
-      const id = newValue.id;
-      const groupId = newValue.cat_group;
-
-      sheet
-        .get()
-        .addDependencies(sheetName, 'last-month-overspent', [
-          `${prevSheetName}!leftover-${id}`,
-          `${prevSheetName}!carryover-${id}`,
-        ]);
-
-      addDeps(sheetName, groupId, id);
-      if (newValue.is_income) {
-        sheet
-          .get()
-          .addDependencies(
-            sheetName,
-            'buffered-auto',
-            flatten2([
-              `${sheetName}!sum-amount-${id}`,
-              `${sheetName}!carryover-${id}`,
-            ]),
-          );
-      }
+      addDeps(sheetName, prevSheetName, newValue.cat_group, newValue);
     });
   } else if (oldValue && oldValue.cat_group !== newValue.cat_group) {
     // The category moved so we need to update the dependencies
-    const id = newValue.id;
-
     months.forEach(month => {
+      const prevSheetName = monthUtils.sheetForMonth(
+        monthUtils.prevMonth(month),
+      );
       const sheetName = monthUtils.sheetForMonth(month);
-      removeDeps(sheetName, oldValue.cat_group, id);
-      addDeps(sheetName, newValue.cat_group, id);
+
+      removeDeps(sheetName, prevSheetName, oldValue.cat_group, newValue);
+      addDeps(sheetName, prevSheetName, newValue.cat_group, newValue);
     });
   }
 }

--- a/packages/loot-core/src/server/budget/envelope.ts
+++ b/packages/loot-core/src/server/budget/envelope.ts
@@ -238,9 +238,7 @@ export function createBudget(meta, categories, months) {
 }
 
 export function handleCategoryChange(months, oldValue, newValue) {
-  // The cells a category feeds into, and the deps it contributes to each
-  // one. `addDeps` and `removeDeps` must stay mirror images of each other:
-  // anything only ever added keeps counting after the category is deleted.
+  // Build list of cells and dependencies that need updated
   function getDeps(sheetName, prevSheetName, groupId, cat) {
     const deps: Array<[string, string[]]> = [
       [`group-sum-amount-${groupId}`, [`sum-amount-${cat.id}`]],

--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -388,4 +388,58 @@ describe('Categories', () => {
     categories = await db.getCategories();
     expect(categories.find(cat => cat.id === 'income1')).not.toBeDefined();
   });
+
+  test('do not count as overspent when deleted', async () => {
+    await sheet.loadSpreadsheet(db);
+
+    await runMutator(async () => {
+      await db.insertCategoryGroup({ id: 'group1', name: 'group1' });
+      await db.insertCategoryGroup({
+        id: 'group2',
+        name: 'income',
+        is_income: 1,
+      });
+      await db.insertCategory({ id: 'foo', name: 'foo', cat_group: 'group1' });
+      await db.insertCategory({ id: 'bar', name: 'bar', cat_group: 'group1' });
+      await db.insertAccount({ id: 'acct', name: 'acct' });
+
+      // A deposit straight into the category, like a refund
+      await db.insertTransaction({
+        date: '2017-01-01',
+        account: 'acct',
+        amount: 10000,
+        category: 'foo',
+      });
+    });
+
+    await budget.createAllBudgets();
+
+    // Move 1000 from `foo` to `bar`, which leaves `foo` with a negative
+    // budgeted amount
+    await budgetActions.setBudget({
+      category: 'foo',
+      month: '2017-01',
+      amount: -1000,
+    });
+    await budgetActions.setBudget({
+      category: 'bar',
+      month: '2017-01',
+      amount: 1000,
+    });
+    await sheet.waitOnSpreadsheet();
+
+    const nextSheetName = monthUtils.sheetForMonth('2017-02');
+    expect(sheet.getCellValue(nextSheetName, 'last-month-overspent')).toBe(0);
+    const toBudget = sheet.getCellValue(nextSheetName, 'to-budget');
+
+    await runHandler(handlers['category-delete'], {
+      id: 'foo',
+      transferId: 'bar',
+    });
+    await sheet.waitOnSpreadsheet();
+
+    // The deleted category should not leave any overspending behind
+    expect(sheet.getCellValue(nextSheetName, 'last-month-overspent')).toBe(0);
+    expect(sheet.getCellValue(nextSheetName, 'to-budget')).toBe(toBudget);
+  });
 });

--- a/upcoming-release-notes/fix-phantom-overspend-deleted-category.md
+++ b/upcoming-release-notes/fix-phantom-overspend-deleted-category.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [youngcw]
+---
+
+Fix a phantom overspent amount appearing after deleting a category that had money moved out of it


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
The overspending value wasn't having its dependencies updated when a category was deleted.  The process of moving budgets to the new category left the old category with an overspent amount, thus an overspent amount in the next month.
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->
Used Claude Opus 5
## Related issue(s)
fixes #8754
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.53 MB (+750 B) | +0.01%
loot-core | 1 | 4.63 MB → 4.63 MB (+44 B) | +0.00%
api | 2 | 3.84 MB → 3.84 MB (+42 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.53 MB (+750 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/ru.json` | 📈 +750 B (+0.35%) | 209.49 kB → 210.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ru.js | 209.49 kB → 210.22 kB (+750 B) | +0.35%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/LoadingIndicator.js | 669.76 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.93 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.63 MB (+44 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/envelope.ts` | 📈 +44 B (+0.47%) | 9.12 kB → 9.16 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.C71OKAOt.js | 0 B → 4.63 MB (+4.63 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DOLEluIG.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB → 3.84 MB (+42 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/envelope.ts` | 📈 +42 B (+0.46%) | 8.9 kB → 8.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB → 3.84 MB (+42 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->