### PR TITLE
[AI] Long note values will show a full tooltip on hover in the transactions table

### DIFF
--- a/packages/desktop-client/e2e/transactions.test.ts
+++ b/packages/desktop-client/e2e/transactions.test.ts
@@ -290,6 +290,41 @@ test.describe('Transactions', () => {
     await expect(page).toMatchThemeScreenshots();
   });
 
+  test.describe('notes tooltip', () => {
+    test('shows the full note and its tags only when the note is truncated', async () => {
+      const longNote =
+        'This is a deliberately long note about a grocery run that should overflow the notes column and get truncated with an ellipsis #groceries at the very end of the note text.';
+
+      await accountPage.createSingleTransaction({
+        payee: 'Home Depot',
+        notes: longNote,
+      });
+      await accountPage.createSingleTransaction({
+        payee: 'Kroger',
+        notes: 'short note',
+      });
+
+      const truncatedNotes = accountPage.getNthTransaction(1).notes;
+      const shortNotes = accountPage.getNthTransaction(0).notes;
+
+      // A short note that fits in the column never shows a tooltip, even
+      // after waiting past the tooltip's hover delay.
+      await shortNotes.hover();
+      await page.waitForTimeout(700);
+      await expect(page.getByRole('tooltip')).not.toBeVisible();
+
+      // A truncated note shows the full text, with tags rendered as pills,
+      // in a tooltip.
+      await truncatedNotes.hover();
+      const tooltip = page.getByRole('tooltip');
+      await expect(tooltip).toBeVisible();
+      await expect(tooltip).toContainText(longNote);
+      await expect(
+        tooltip.getByRole('button', { name: '#groceries' }),
+      ).toBeVisible();
+    });
+  });
+
   test.describe('column manager', () => {
     test('hides and reorders columns', async () => {
       const header = page.getByTestId('transaction-table-header');

--- a/packages/desktop-client/src/components/table.tsx
+++ b/packages/desktop-client/src/components/table.tsx
@@ -125,14 +125,13 @@ export const Field = forwardRef<HTMLDivElement, FieldProps>(function Field(
   );
 });
 
-export function UnexposedCellContent({
-  value,
-  formatter,
-  style,
-  ...props
-}: Pick<CellProps, 'value' | 'formatter' | 'style'>) {
+export const UnexposedCellContent = forwardRef<
+  HTMLSpanElement,
+  Pick<CellProps, 'value' | 'formatter' | 'style'>
+>(function UnexposedCellContent({ value, formatter, style, ...props }, ref) {
   return (
     <Text
+      innerRef={ref}
       style={{
         flexGrow: 1,
         whiteSpace: 'nowrap',
@@ -145,7 +144,7 @@ export function UnexposedCellContent({
       {formatter ? formatter(value) : value}
     </Text>
   );
-}
+});
 
 type CellProps = Omit<ComponentProps<typeof View>, 'children' | 'value'> & {
   formatter?: (value: string, type?: unknown) => string | JSX.Element;

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.test.tsx
@@ -23,6 +23,7 @@ import type {
   TransactionEntity,
 } from '@actual-app/core/types/models';
 import {
+  act,
   fireEvent,
   render,
   renderHook,
@@ -1570,6 +1571,85 @@ describe('Transactions', () => {
 
       // Verify the tag was added to the note correctly
       expect(getTransactions()[2].notes).toBe('spending on #coffee');
+    });
+  });
+
+  describe('Notes tooltip', () => {
+    // jsdom doesn't lay out elements, so scrollWidth/clientWidth are always
+    // 0. Stub them so the truncation check has something meaningful to read.
+    let isOverflowing = false;
+    const originalScrollWidth = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'scrollWidth',
+    )!;
+    const originalClientWidth = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'clientWidth',
+    )!;
+
+    beforeAll(() => {
+      Object.defineProperty(Element.prototype, 'scrollWidth', {
+        configurable: true,
+        get() {
+          return isOverflowing ? 200 : 100;
+        },
+      });
+      Object.defineProperty(Element.prototype, 'clientWidth', {
+        configurable: true,
+        get() {
+          return 100;
+        },
+      });
+    });
+
+    afterAll(() => {
+      Object.defineProperty(
+        Element.prototype,
+        'scrollWidth',
+        originalScrollWidth,
+      );
+      Object.defineProperty(
+        Element.prototype,
+        'clientWidth',
+        originalClientWidth,
+      );
+    });
+
+    test('shows the full note and renders tags when the note is truncated', async () => {
+      isOverflowing = true;
+      const transactions = generateTransactions(1);
+      transactions[0].notes =
+        'a very long note about weekend spending #groceries that overflows the column';
+
+      const { container } = renderTransactions({ transactions });
+      const notesText = queryField(container, 'notes', 'span', 0);
+
+      await userEvent.hover(notesText);
+
+      const tooltip = await screen.findByRole('tooltip', {}, { timeout: 1000 });
+      expect(tooltip.textContent).toContain(
+        'a very long note about weekend spending',
+      );
+      expect(
+        within(tooltip).getByRole('button', { name: '#groceries' }),
+      ).toBeInTheDocument();
+    });
+
+    test('does not show a tooltip when the note fits without truncation', async () => {
+      isOverflowing = false;
+      const transactions = generateTransactions(1);
+      transactions[0].notes = 'short note';
+
+      const { container } = renderTransactions({ transactions });
+      const notesText = queryField(container, 'notes', 'span', 0);
+
+      await userEvent.hover(notesText);
+
+      // Wait past the tooltip's hover delay to make sure it never opens
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 700));
+      });
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -5,6 +5,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -126,6 +127,7 @@ import { useLocalPref } from '#hooks/useLocalPref';
 import { useMergedRefs } from '#hooks/useMergedRefs';
 import { usePrevious } from '#hooks/usePrevious';
 import { useProperFocus } from '#hooks/useProperFocus';
+import { useResizeObserver } from '#hooks/useResizeObserver';
 import { useSelectedDispatch, useSelectedItems } from '#hooks/useSelected';
 import { SheetNameProvider } from '#hooks/useSheetName';
 import { useSplitsExpanded } from '#hooks/useSplitsExpanded';
@@ -2229,11 +2231,25 @@ function NotesCell({
   onClickTag,
   onExpose,
 }: NotesCellProps) {
-  const cellRef = useRef<HTMLDivElement | null>(null);
   const [inputValue, setInputValue] = useState(note);
   useEffect(() => {
     setInputValue(note);
   }, [note, setInputValue]);
+
+  const textRef = useRef<HTMLSpanElement | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+  const checkTruncated = useCallback(() => {
+    const el = textRef.current;
+    setIsTruncated(el != null && el.scrollWidth > el.clientWidth);
+  }, []);
+  const resizeRef = useResizeObserver<HTMLSpanElement>(checkTruncated);
+  const setTextRef = useCallback(
+    (el: HTMLSpanElement | null) => {
+      textRef.current = el;
+      resizeRef(el as HTMLSpanElement);
+    },
+    [resizeRef],
+  );
 
   function onKeyDown(e: KeyboardEvent) {
     if (e.key === 'Enter' || e.key === 'Tab') {
@@ -2245,9 +2261,12 @@ function NotesCell({
 
   const displayedNote = note || scheduleNote || '';
 
+  useLayoutEffect(() => {
+    checkTruncated();
+  }, [displayedNote, checkTruncated]);
+
   return (
     <CustomCell
-      innerRef={cellRef}
       width="flex"
       name="notes"
       value={displayedNote}
@@ -2261,6 +2280,25 @@ function NotesCell({
       onUpdate={onUpdate}
       onKeyDown={onKeyDown}
       onBlur={() => onUpdate(inputValue)}
+      unexposedContent={props => (
+        <Tooltip
+          content={
+            <View style={{ padding: 10, maxWidth: 400 }}>
+              <Text style={{ whiteSpace: 'pre-wrap' }}>
+                <NotesTagFormatter
+                  notes={displayedNote}
+                  onNotesTagClick={onClickTag}
+                />
+              </Text>
+            </View>
+          }
+          style={{ ...styles.tooltip }}
+          placement="bottom start"
+          triggerProps={{ delay: 500, isDisabled: !isTruncated }}
+        >
+          <UnexposedCellContent {...props} ref={setTextRef} />
+        </Tooltip>
+      )}
     >
       {({ inputStyle, onKeyDown, onBlur }) => (
         <TagAutocomplete

--- a/packages/desktop-client/src/setupTests.ts
+++ b/packages/desktop-client/src/setupTests.ts
@@ -6,6 +6,21 @@ import { resetTestProviders } from './mocks';
 global.IS_TESTING = true;
 global.Actual = {} as typeof global.Actual;
 
+// jsdom doesn't implement ResizeObserver. Components that only use it to
+// react to layout changes (rather than asserting on it) can run against a
+// no-op stub.
+global.ResizeObserver = class {
+  observe() {
+    // no-op
+  }
+  unobserve() {
+    // no-op
+  }
+  disconnect() {
+    // no-op
+  }
+};
+
 type Size = { height: number; width: number };
 
 type AutoSizerProps = {

--- a/upcoming-release-notes/tx-notes-tooltip.md
+++ b/upcoming-release-notes/tx-notes-tooltip.md
@@ -3,4 +3,4 @@ category: Enhancements
 authors: [DavidGrinberg]
 ---
 
-Notes which are long enough to be truncated in the transcation table can now be hovered over to show a tooltip with the full contents of the note.
+Notes which are long enough to be truncated in the transaction table can now be hovered over to show a tooltip with the full contents of the note.

--- a/upcoming-release-notes/tx-notes-tooltip.md
+++ b/upcoming-release-notes/tx-notes-tooltip.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [DavidGrinberg]
+---
+
+Notes which are long enough to be truncated in the transcation table can now be hovered over to show a tooltip with the full contents of the note.


### PR DESCRIPTION
## Description

Transactions with long notes fields are truncated in the transaction table. This makes viewing the full contents of the notes annoying from a UX standpoint. This change allows you to just hover over a long note field to have a tooltip popover with the full note text

  <img width="1600" height="636" alt="image" src="https://github.com/user-attachments/assets/34ab394a-b330-44c4-8aa9-ac3ed1c205bc" />
  <sub style="text-align: center;">An example from the demo budget</sub>

<p>

AI was used to help with the code, but was not used in this PR.

## Testing
Unit & e2e tests were added. Manual testing (see screenshot above) as well.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed


<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.53 MB → 13.53 MB (+2.79 kB) | +0.02%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.53 MB → 13.53 MB (+2.79 kB) | +0.02%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/TransactionsTable.tsx` | 📈 +1.95 kB (+2.21%) | 88.05 kB → 90 kB
`locale/ru.json` | 📈 +750 B (+0.35%) | 209.49 kB → 210.22 kB
`src/components/table.tsx` | 📈 +113 B (+0.31%) | 36.12 kB → 36.23 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.93 MB → 1.94 MB (+2.46 kB) | +0.12%
static/js/ru.js | 209.49 kB → 210.22 kB (+750 B) | +0.35%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/LoadingIndicator.js | 669.76 kB → 669.36 kB (-412 B) | -0.06%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/AppliedFilters.js | 35.51 kB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/FormulaEditor.js | 766.28 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 76.54 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.94 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 171.68 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/de.js | 183.43 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.47 kB | 0%
static/js/es.js | 165.11 kB | 0%
static/js/fr.js | 180.13 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 152.73 kB | 0%
static/js/months.js | 574.49 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 136.51 kB | 0%
static/js/nl.js | 152.45 kB | 0%
static/js/pl.js | 137.04 kB | 0%
static/js/pt-BR.js | 179.25 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 200.72 kB | 0%
static/js/useDateFormat.js | 2.37 MB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/useTransactionBatchActions.js | 11.03 kB | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 107.54 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DOLEluIG.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->