### PR TITLE
[AI] Fix category and group menus not opening after a rename

### DIFF
--- a/packages/desktop-client/src/components/budget/SidebarCategory.test.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarCategory.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+
+import { generateCategory } from '@actual-app/core/mocks';
+import { initServer } from '@actual-app/core/platform/client/connection';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import {
+  configureTestAppStore,
+  createTestQueryClient,
+  TestProviders,
+} from '#mocks';
+
+import { SidebarCategory } from './SidebarCategory';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+describe('SidebarCategory context menu', () => {
+  let store: ReturnType<typeof configureTestAppStore>;
+
+  const category = generateCategory('Groceries', 'group-id');
+
+  beforeEach(() => {
+    initServer({
+      query: async () => ({ data: [], dependencies: [] }),
+      'get-cell': async () => ({ name: 'test-cell', value: 0 }),
+    });
+
+    store = configureTestAppStore({ queryClient: createTestQueryClient() });
+  });
+
+  async function renderRow(children: ReactNode) {
+    const result = render(
+      <TestProviders store={store}>{children}</TestProviders>,
+    );
+    // Flush the async notes query kicked off on mount
+    await act(() => Promise.resolve());
+    return result;
+  }
+
+  function contextMenuItemNames() {
+    return store
+      .getState()
+      .contextMenu.items.map(item =>
+        typeof item === 'object' ? item.name : null,
+      );
+  }
+
+  it('opens after the category has been renamed', async () => {
+    const onSave = vi.fn();
+
+    const { rerender } = await renderRow(
+      <SidebarCategory
+        innerRef={null}
+        category={category}
+        editing={false}
+        onEditName={vi.fn()}
+        onSave={onSave}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Groceries'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(true);
+    expect(contextMenuItemNames()).toEqual([
+      'rename',
+      'toggle-visibility',
+      'delete',
+    ]);
+
+    store.dispatch({ type: 'contextMenu/closeContextMenu' });
+
+    // Renaming exposes the cell's input, which unmounts the row's display
+    // node, then puts a brand new one back when editing ends.
+    rerender(
+      <TestProviders store={store}>
+        <SidebarCategory
+          innerRef={null}
+          category={category}
+          editing
+          onEditName={vi.fn()}
+          onSave={onSave}
+        />
+      </TestProviders>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Food' } });
+    fireEvent.blur(input);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Food' }),
+    );
+
+    const renamed = { ...category, name: 'Food' };
+    rerender(
+      <TestProviders store={store}>
+        <SidebarCategory
+          innerRef={null}
+          category={renamed}
+          editing={false}
+          onEditName={vi.fn()}
+          onSave={onSave}
+          onDelete={vi.fn()}
+        />
+      </TestProviders>,
+    );
+    await act(() => Promise.resolve());
+
+    fireEvent.contextMenu(screen.getByText('Food'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(true);
+    expect(contextMenuItemNames()).toEqual([
+      'rename',
+      'toggle-visibility',
+      'delete',
+    ]);
+  });
+});

--- a/packages/desktop-client/src/components/budget/SidebarGroup.test.tsx
+++ b/packages/desktop-client/src/components/budget/SidebarGroup.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+
+import { generateCategoryGroup } from '@actual-app/core/mocks';
+import { initServer } from '@actual-app/core/platform/client/connection';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import {
+  configureTestAppStore,
+  createTestQueryClient,
+  TestProviders,
+} from '#mocks';
+
+import { SidebarGroup } from './SidebarGroup';
+
+vi.mock(
+  '@actual-app/core/platform/client/connection',
+  () => import('#mocks/connection'),
+);
+
+describe('SidebarGroup context menu', () => {
+  let store: ReturnType<typeof configureTestAppStore>;
+
+  const group = generateCategoryGroup('Usual Expenses');
+
+  beforeEach(() => {
+    initServer({
+      query: async () => ({ data: [], dependencies: [] }),
+      'get-cell': async () => ({ name: 'test-cell', value: 0 }),
+    });
+
+    store = configureTestAppStore({ queryClient: createTestQueryClient() });
+  });
+
+  async function renderRow(children: ReactNode) {
+    const result = render(
+      <TestProviders store={store}>{children}</TestProviders>,
+    );
+    // Flush the async notes query kicked off on mount
+    await act(() => Promise.resolve());
+    return result;
+  }
+
+  function contextMenuItemNames() {
+    return store
+      .getState()
+      .contextMenu.items.map(item =>
+        typeof item === 'object' ? item.name : null,
+      );
+  }
+
+  it('opens after the group has been renamed', async () => {
+    const onSave = vi.fn();
+
+    const { rerender } = await renderRow(
+      <SidebarGroup
+        group={group}
+        editing={false}
+        collapsed={false}
+        onEdit={vi.fn()}
+        onSave={onSave}
+        onDelete={vi.fn()}
+        onToggleCollapse={vi.fn()}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Usual Expenses'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(true);
+    expect(contextMenuItemNames()).toEqual([
+      'rename',
+      'toggle-visibility',
+      'delete',
+    ]);
+
+    store.dispatch({ type: 'contextMenu/closeContextMenu' });
+
+    // Renaming exposes the cell's input, which unmounts the row's display
+    // node, then puts a brand new one back when editing ends.
+    rerender(
+      <TestProviders store={store}>
+        <SidebarGroup
+          group={group}
+          editing
+          collapsed={false}
+          onEdit={vi.fn()}
+          onSave={onSave}
+          onDelete={vi.fn()}
+          onToggleCollapse={vi.fn()}
+        />
+      </TestProviders>,
+    );
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Renamed Group' } });
+    fireEvent.blur(input);
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Renamed Group' }),
+    );
+
+    const renamed = { ...group, name: 'Renamed Group' };
+    rerender(
+      <TestProviders store={store}>
+        <SidebarGroup
+          group={renamed}
+          editing={false}
+          collapsed={false}
+          onEdit={vi.fn()}
+          onSave={onSave}
+          onDelete={vi.fn()}
+          onToggleCollapse={vi.fn()}
+        />
+      </TestProviders>,
+    );
+    await act(() => Promise.resolve());
+
+    fireEvent.contextMenu(screen.getByText('Renamed Group'));
+
+    expect(store.getState().contextMenu.isOpen).toBe(true);
+    expect(contextMenuItemNames()).toEqual([
+      'rename',
+      'toggle-visibility',
+      'delete',
+    ]);
+  });
+});

--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -1,6 +1,7 @@
+import { createElement, useRef } from 'react';
 import type { RefObject } from 'react';
 
-import { renderHook } from '@testing-library/react';
+import { render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useRefEventListener } from './useRefEventListener';
@@ -93,5 +94,89 @@ describe('useRefEventListener', () => {
     unmount();
 
     expect(el.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebinds when the ref points at a different element', () => {
+    const first = makeMockElement();
+    const second = makeMockElement();
+    const ref = { current: first } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    ref.current = second as unknown as HTMLElement;
+    rerender();
+
+    expect(first.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(second.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unbinds while the ref is empty and rebinds when it fills again', () => {
+    const first = makeMockElement();
+    const second = makeMockElement();
+    const ref = { current: first } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender, unmount } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    ref.current = null;
+    rerender();
+
+    expect(first.removeEventListener).toHaveBeenCalledTimes(1);
+
+    ref.current = second as unknown as HTMLElement;
+    rerender();
+
+    expect(second.addEventListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(second.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds an element that only appears after the first render', () => {
+    const el = makeMockElement();
+    const ref = { current: null } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    expect(el.addEventListener).not.toHaveBeenCalled();
+
+    ref.current = el as unknown as HTMLElement;
+    rerender();
+
+    expect(el.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps delivering events to a conditionally rendered target that remounts', () => {
+    const callback = vi.fn();
+
+    function Trigger({ showTarget }: { showTarget: boolean }) {
+      const ref = useRef<HTMLButtonElement | null>(null);
+      useRefEventListener(ref, 'click', callback);
+
+      return showTarget
+        ? createElement('button', { ref })
+        : createElement('input');
+    }
+
+    const { rerender } = render(createElement(Trigger, { showTarget: true }));
+
+    screen.getByRole('button').click();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // An editable cell swaps its display node out for an input and back again,
+    // so the target that returns is a different DOM node than the original.
+    rerender(createElement(Trigger, { showTarget: false }));
+    rerender(createElement(Trigger, { showTarget: true }));
+
+    screen.getByRole('button').click();
+
+    expect(callback).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 
 export function useRefEventListener<
@@ -17,55 +17,28 @@ export function useRefEventListener<
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
-  const bindingRef = useRef<{
-    el: EventTarget;
-    event: EventType;
-    listener: EventListener;
-  } | null>(null);
-
-  // A ref object keeps its identity for the lifetime of the component and
-  // mutating `current` doesn't re-run effects, so the element can't go in a
-  // dependency array. Re-resolve it after every render instead and only touch
-  // the native listener when it has actually moved. Elements do move: a
-  // conditionally rendered trigger unmounts and remounts as a brand new node,
-  // and a listener left on the detached original stops delivering events.
+  // Mutating `ref.current` doesn't re-run effects, so the element can't go in
+  // a dependency array. Re-resolve it after every render and mirror it into
+  // state; `setTarget` bails out when the element hasn't moved.
+  const [target, setTarget] = useState<EventTarget | null>(null);
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- must run every render; the bail-out stops the update chain
   useEffect(() => {
-    const el =
-      ref instanceof Document || ref instanceof Window ? ref : ref.current;
-    const binding = bindingRef.current;
+    setTarget(
+      ref instanceof Document || ref instanceof Window ? ref : ref.current,
+    );
+  });
 
-    if (binding && binding.el === el && binding.event === event) {
-      return;
-    }
-
-    if (binding) {
-      binding.el.removeEventListener(binding.event, binding.listener);
-      bindingRef.current = null;
-    }
-
-    if (!el) {
-      return;
-    }
+  useEffect(() => {
+    if (!target) return;
 
     const listener: EventListener = e =>
       callbackRef.current.call(
-        el as ElementType,
+        target as ElementType,
         e as HTMLElementEventMap[EventType],
       );
-    el.addEventListener(event, listener);
-    bindingRef.current = { el, event, listener };
-  });
-
-  // The effect above deliberately registers no cleanup, so that re-running it
-  // on every render doesn't unbind and rebind. Unbinding on unmount lives here.
-  useEffect(
-    () => () => {
-      const binding = bindingRef.current;
-      if (binding) {
-        binding.el.removeEventListener(binding.event, binding.listener);
-        bindingRef.current = null;
-      }
-    },
-    [],
-  );
+    target.addEventListener(event, listener);
+    return () => {
+      target.removeEventListener(event, listener);
+    };
+  }, [target, event]);
 }

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -13,14 +13,39 @@ export function useRefEventListener<
   // Keep the latest callback in a ref so the effect below doesn't need to
   // depend on it. Callers routinely pass a new inline function every render,
   // which would otherwise tear down and re-add the native listener on every
-  // render instead of only when `ref`/`event` change.
+  // render instead of only when the target element or `event` change.
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
+  const bindingRef = useRef<{
+    el: EventTarget;
+    event: EventType;
+    listener: EventListener;
+  } | null>(null);
+
+  // A ref object keeps its identity for the lifetime of the component and
+  // mutating `current` doesn't re-run effects, so the element can't go in a
+  // dependency array. Re-resolve it after every render instead and only touch
+  // the native listener when it has actually moved. Elements do move: a
+  // conditionally rendered trigger unmounts and remounts as a brand new node,
+  // and a listener left on the detached original stops delivering events.
   useEffect(() => {
     const el =
       ref instanceof Document || ref instanceof Window ? ref : ref.current;
-    if (!el) return;
+    const binding = bindingRef.current;
+
+    if (binding && binding.el === el && binding.event === event) {
+      return;
+    }
+
+    if (binding) {
+      binding.el.removeEventListener(binding.event, binding.listener);
+      bindingRef.current = null;
+    }
+
+    if (!el) {
+      return;
+    }
 
     const listener: EventListener = e =>
       callbackRef.current.call(
@@ -28,8 +53,19 @@ export function useRefEventListener<
         e as HTMLElementEventMap[EventType],
       );
     el.addEventListener(event, listener);
-    return () => {
-      el.removeEventListener(event, listener);
-    };
-  }, [ref, event]);
+    bindingRef.current = { el, event, listener };
+  });
+
+  // The effect above deliberately registers no cleanup, so that re-running it
+  // on every render doesn't unbind and rebind. Unbinding on unmount lives here.
+  useEffect(
+    () => () => {
+      const binding = bindingRef.current;
+      if (binding) {
+        binding.el.removeEventListener(binding.event, binding.listener);
+        bindingRef.current = null;
+      }
+    },
+    [],
+  );
 }

--- a/upcoming-release-notes/fix-context-menu-after-rename.md
+++ b/upcoming-release-notes/fix-context-menu-after-rename.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [MannXo]
+---
+
+Fix the budget category and group menus not opening after a rename until the page is reloaded


### PR DESCRIPTION
## Description

On the budget screen, renaming a category or a group left its dropdown menu dead. Neither the chevron button nor a right-click would open it again until the page was reloaded or you navigated away and back.

The cause is in `useRefEventListener`. It resolves `ref.current` once on mount and its effect only re-runs when the ref object identity or the event name changes. A ref object never changes identity, and mutating `current` does not re-run effects, so the native listener stays bound to whatever element existed at mount.

Renaming exposes the `InputCell`'s input, which unmounts the row's display node and puts a brand new one back when editing ends. The `contextmenu` listener is left behind on the detached original, so `useContextMenu`'s synthetic event, and a plain right-click too, land on an element with no listener. `addItems` is never dispatched and the menu never opens.

The fix re-resolves the element after every render and rebinds only when it has actually moved, which keeps the existing "bind once, don't churn when only the callback identity changes" behaviour. Unmount cleanup moves into its own effect, because an effect that re-runs on every render cannot skip its own cleanup. The same latent bug existed for `useCursorPosition` and `useInputRefValue`, which are also fixed by this.

The initial implementation was drafted with Claude, then reviewed, tested and edited by me.

## Related issue(s)

Fixes #8760

## Testing

Reproduced and verified in the running app with the demo budget, for both a category and a group: open the menu, pick Rename, save, then reopen the menu via right-click and via the chevron button. Broken before the change, working after.

Added tests, all of which fail with the fix reverted:

- `useRefEventListener.test.ts` covers rebinding when the ref points at a different element, unbinding while the ref is empty and rebinding when it fills again, binding an element that first appears after the initial render, and a real-DOM case where a conditionally rendered target remounts. The five existing cases still pass, including the one asserting no rebind when only the callback identity changes.
- `SidebarCategory.test.tsx` covers the reported flow: open the menu, rename through the exposed input, then assert the menu opens again.
- `SidebarGroup.test.tsx` covers the same flow for a group, which has its own trigger and rename path.

Local runs, all green: `yarn test`, `yarn lint`, `yarn typecheck`, `yarn constraints`, `yarn check:tsconfig-references`, `yarn knip`, and `yarn workspace @actual-app/web playwright test budget.test.ts`.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.51 MB → 13.6 MB (+87.88 kB) | +0.64%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.51 MB → 13.6 MB (+87.88 kB) | +0.64%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useRefEventListener.ts` | 📈 +124 B (+23.66%) | 524 B → 648 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 166.98 kB (+87.76 kB) | +110.78%
static/js/Value.js | 1.79 MB → 1.79 MB (+124 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->