### PR TITLE
[AI] Use noble Playwright image for the desktop VRT job to compile against Electron 43 headers

### DIFF
--- a/.github/workflows/vrt-update-generate.yml
+++ b/.github/workflows/vrt-update-generate.yml
@@ -170,7 +170,9 @@ jobs:
     runs-on: depot-ubuntu-latest
     needs: get-pr
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-jammy
+      # noble (gcc 13) is required to compile native modules against Electron 43+ headers;
+      # jammy's gcc 11/12 cannot parse them. Keep in sync with the functional-desktop-app job in e2e-test.yml.
+      image: mcr.microsoft.com/playwright:v1.61.1-noble
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/upcoming-release-notes/fix-desktop-vrt-container.md
+++ b/upcoming-release-notes/fix-desktop-vrt-container.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [MikesGlitch]
+---
+
+Fix the desktop VRT update workflow failing to build native modules against Electron 43


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Prerequisite to updating Electron. This shouldn't impact any of the other tests. 

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

https://github.com/actualbudget/actual/pull/8769

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
