### PR TITLE
feat: add Palenight to the custom theme catalog

### DIFF
--- a/packages/desktop-client/src/data/customThemeCatalog.json
+++ b/packages/desktop-client/src/data/customThemeCatalog.json
@@ -387,5 +387,18 @@
       "#ffffff"
     ],
     "mode": "dark"
+  },
+  {
+    "name": "Palenight",
+    "repo": "mafsi/palenight-actual",
+    "colors": [
+      "#292d3e",
+      "#31364a",
+      "#697098",
+      "#c792ea",
+      "#82aaff",
+      "#c3e88d"
+    ],
+    "mode": "dark"
   }
 ]

--- a/upcoming-release-notes/8771.md
+++ b/upcoming-release-notes/8771.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [mafsi]
+---
+
+Add the Palenight theme to the custom theme catalog


### PR DESCRIPTION
## Description

Adds **Palenight** to the custom theme catalog.

Repository: https://github.com/mafsi/palenight-actual (MIT)

Palenight is one of the more widely ported dark schemes — it exists for Vim,
Neovim, VS Code, IntelliJ and iTerm2 — but had no Actual port. The catalog
already carries several editor-derived themes (Dracula, Nord, Gruvbox, Rosé Pine,
Catppuccin), so this fills a gap in that family.

**Palette provenance.** Every colour is quoted from `themes/palenight.json` of
[whizkydee/vscode-palenight-theme](https://github.com/whizkydee/vscode-palenight-theme)
(MIT, by Olaolu Olawuyi), and each declaration in `actual.css` carries the VS Code
key it came from, so values can be traced back to their role upstream:

```css
--palenight-background-light: #31364a;    /* editorWidget.bg, tab.inactive  */
--palenight-selection: #2e3250;           /* peekViewResult.selectionBg     */
--palenight-comment-dim: #4c5374;         /* editorLineNumber.foreground    */
```

Two choices had no direct upstream source and are documented in the theme's
README: Palenight has no distinct pink, so the second accent next to purple is
Palenight's blue `#82aaff`; and where the ANSI variant of the palette differs
(`#82b1ff`, `#ff5370`), the theme uses the UI values (`#82aaff`, `#ff5572`).

**Coverage.** All 224 `--color-*` variables of the built-in dark theme are
defined, including the nine `chartQual*` report colours, so the theme does not
fall back to the base theme anywhere.

Preview colours: `#292d3e` `#31364a` `#697098` `#c792ea` `#82aaff` `#c3e88d`

**AI disclosure.** Per https://actualbudget.org/docs/contributing/ai-usage-policy:
the theme CSS and this PR were written with Claude Code (Claude Opus 5), directed
and reviewed by me. The palette values were taken from the upstream theme file
rather than generated, and the mapping onto Actual's variables was checked against
`customThemes.ts` and the built-in dark theme.

## Related issue(s)

None.

## Testing

- Installed the theme in a local instance (v26.8.1) and used it across the budget,
  accounts, reports, schedules, modals and the mobile layout.
- Ran `validateThemeCss` against the CSS as served from
  `raw.githubusercontent.com/mafsi/palenight-actual/refs/heads/main/actual.css`:
  254 declarations, no rejected values. File is 16 KB, well under the 512 KB
  limit enforced by `validate-theme-catalog`.
- Diffed the theme's variable list against `component-library/src/themes/dark.css`:
  224/224 keys covered, none missing.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 41 → 42 | 13.45 MB → 13.57 MB (+131.02 kB) | +0.95%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.84 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
41 → 42 | 13.45 MB → 13.57 MB (+131.02 kB) | +0.95%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/zh-Hant.json` | 🆕 +130.92 kB | 0 B → 130.92 kB
`src/languages.ts` | 📈 +109 B (+7.24%) | 1.47 kB → 1.58 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/zh-Hant.js | 0 B → 130.92 kB (+130.92 kB) | -

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/months.js | 574.49 kB → 574.59 kB (+109 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.57 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 165.03 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.67 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.33 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Dab0t8iz.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.84 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.84 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->