### PR TITLE
Add option to show transfers in Sankey chart Spent view

### DIFF
--- a/packages/desktop-client/src/components/reports/reports/Sankey.tsx
+++ b/packages/desktop-client/src/components/reports/reports/Sankey.tsx
@@ -375,6 +375,8 @@ type OptionsButtonProps = {
   onTogglePercentages: () => void;
   groupAccounts: boolean;
   onToggleGroupAccounts: () => void;
+  showTransfers: boolean;
+  onToggleShowTransfers: () => void;
 };
 
 function OptionsButton({
@@ -382,6 +384,8 @@ function OptionsButton({
   onTogglePercentages,
   groupAccounts,
   onToggleGroupAccounts,
+  showTransfers,
+  onToggleShowTransfers,
 }: OptionsButtonProps) {
   const { t } = useTranslation();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -401,6 +405,7 @@ function OptionsButton({
           onMenuSelect={item => {
             if (item === 'show-percentages') onTogglePercentages();
             if (item === 'group-accounts') onToggleGroupAccounts();
+            if (item === 'show-transfers') onToggleShowTransfers();
           }}
           items={[
             {
@@ -412,6 +417,11 @@ function OptionsButton({
               name: 'group-accounts',
               text: t('Group accounts in Spent view'),
               toggle: groupAccounts,
+            },
+            {
+              name: 'show-transfers',
+              text: t('Show transfers in Spent view'),
+              toggle: showTransfers,
             },
           ]}
         />
@@ -505,6 +515,9 @@ function SankeyInner({ widget }: SankeyInnerProps) {
   const [groupAccounts, setGroupAccounts] = useState(
     widget?.meta?.groupAccounts ?? false,
   );
+  const [showTransfers, setShowTransfers] = useState(
+    widget?.meta?.showTransfers ?? false,
+  );
 
   const [layerRange, setLayerRange] = useState<LayerRange>(() =>
     normalizeLayerRange(widget?.meta?.mode ?? 'spent', {
@@ -576,6 +589,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
       conditionsOp,
       graphMode,
       groupAccounts,
+      showTransfers,
     );
   }, [
     datesInitialized,
@@ -586,6 +600,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
     conditionsOp,
     graphMode,
     groupAccounts,
+    showTransfers,
   ]);
 
   const defaultGetBaseGraph = async (
@@ -710,6 +725,7 @@ function SankeyInner({ widget }: SankeyInnerProps) {
             topNcategories,
             categorySort,
             showPercentages,
+            showTransfers,
             layerFrom,
             layerTo,
             timeFrame: {
@@ -883,6 +899,8 @@ function SankeyInner({ widget }: SankeyInnerProps) {
             onTogglePercentages={() => setShowPercentages(v => !v)}
             groupAccounts={groupAccounts}
             onToggleGroupAccounts={() => setGroupAccounts(v => !v)}
+            showTransfers={showTransfers}
+            onToggleShowTransfers={() => setShowTransfers(v => !v)}
           />
         </View>
         {widget && (

--- a/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
+++ b/packages/desktop-client/src/components/reports/reports/SankeyCard.tsx
@@ -103,6 +103,7 @@ export function SankeyCard({
         meta?.conditionsOp ?? 'and',
         mode,
         groupAccounts,
+        meta?.showTransfers ?? false,
       ),
     [
       start,
@@ -112,6 +113,7 @@ export function SankeyCard({
       meta?.conditionsOp,
       mode,
       groupAccounts,
+      meta?.showTransfers,
     ],
   );
   const defaultGetBaseGraph = async (

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -751,6 +751,8 @@ describe('sankey-spreadsheet', () => {
         );
       }
 
+      expect(percentagesByLayer.size).toBeGreaterThan(0);
+
       for (const total of percentagesByLayer.values()) {
         expect(total).toBeCloseTo(100, 1);
       }

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -135,6 +135,19 @@ describe('sankey-spreadsheet', () => {
       expect(getLayer(graph, 'child')).toBe(1);
       expect(getLayer(graph, 'grandchild')).toBe(2);
     });
+
+    it('does not recurse infinitely when links form a cycle', () => {
+      const graph: Graph = new Map();
+      addNode(graph, 'account-a', GraphLayers.Account, 'Account A');
+      addNode(graph, 'account-b', GraphLayers.Account, 'Account B');
+      addValueToLink(graph, 'account-a', 'account-b', 100);
+      addValueToLink(graph, 'account-b', 'account-a', 80);
+
+      expect(() => getLayer(graph, 'account-a')).not.toThrow();
+      expect(() => getLayer(graph, 'account-b')).not.toThrow();
+      expect(Number.isFinite(getLayer(graph, 'account-a'))).toBe(true);
+      expect(Number.isFinite(getLayer(graph, 'account-b'))).toBe(true);
+    });
   });
 
   describe('nodesInLayer', () => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -2,6 +2,7 @@ import type { RuleConditionEntity } from '@actual-app/core/types/models';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  addHiddenNodes,
   addNode,
   addPercentageLabels,
   addValueToLink,
@@ -719,24 +720,40 @@ describe('sankey-spreadsheet', () => {
       expect(node2?.percentageLabel).toBe('75.0%');
     });
 
-    it('normalizes percentages per GraphLayer, not computed depth', () => {
+    it('normalizes percentages per computed graph layer', () => {
       const graph: Graph = new Map();
 
-      addNode(graph, 'payee', GraphLayers.IncomePayee, 'Payee');
-      addNode(graph, 'income-cat', GraphLayers.IncomeCategory, 'Income Cat');
-      addNode(graph, 'account-incoming', GraphLayers.Account, 'Account A');
-
-      addNode(graph, 'account-root', GraphLayers.Account, 'Account B');
+      addNode(graph, 'account-root', GraphLayers.Account, 'Account A');
+      addNode(graph, 'account-transfer', GraphLayers.Account, 'Account B');
       addNode(graph, 'group', GraphLayers.CategoryGroup, 'Group');
+      addNode(graph, 'category', GraphLayers.Category, 'Category');
 
-      addValueToLink(graph, 'payee', 'income-cat', 300);
-      addValueToLink(graph, 'income-cat', 'account-incoming', 300);
+      addValueToLink(graph, 'account-root', 'account-transfer', 300);
       addValueToLink(graph, 'account-root', 'group', 100);
+      addValueToLink(graph, 'group', 'category', 100);
+
+      addHiddenNodes(graph);
 
       addPercentageLabels(graph);
 
-      expect(graph.get('account-root')?.percentageLabel).toBe('25.0%');
-      expect(graph.get('account-incoming')?.percentageLabel).toBe('75.0%');
+      const percentagesByLayer = new Map<number, number>();
+
+      for (const [key, node] of graph) {
+        if (key.endsWith('__HIDDEN') || !node.percentageLabel) {
+          continue;
+        }
+
+        const layer = getLayer(graph, key);
+        const percentage = Number.parseFloat(node.percentageLabel);
+        percentagesByLayer.set(
+          layer,
+          (percentagesByLayer.get(layer) ?? 0) + percentage,
+        );
+      }
+
+      for (const total of percentagesByLayer.values()) {
+        expect(total).toBeCloseTo(100, 1);
+      }
     });
   });
 
@@ -839,6 +856,31 @@ describe('sankey-spreadsheet', () => {
       const nodeKeys = sankeyData.nodes.map(node => node.key);
       expect(nodeKeys).toContain('group-no-child_category__HIDDEN');
       expect(nodeKeys).not.toContain('group-no-child_category_group__HIDDEN');
+    });
+
+    it('keeps category groups after all account sublayers when transfers exist', () => {
+      const graph: Graph = new Map();
+
+      addNode(graph, 'account-root', GraphLayers.Account, 'Account A');
+      addNode(graph, 'account-transfer', GraphLayers.Account, 'Account B');
+      addNode(graph, 'group', GraphLayers.CategoryGroup, 'Group');
+      addNode(graph, 'category', GraphLayers.Category, 'Category');
+
+      addValueToLink(graph, 'account-root', 'account-transfer', 300);
+      addValueToLink(graph, 'account-root', 'group', 100);
+      addValueToLink(graph, 'group', 'category', 100);
+
+      const sankeyData = buildSankeyData(
+        graph,
+        100,
+        [],
+        'global',
+        GraphLayers.Account,
+        GraphLayers.Category,
+      );
+
+      const nodeKeys = sankeyData.nodes.map(node => node.key);
+      expect(nodeKeys).toContain('group_account_1__HIDDEN');
     });
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -148,6 +148,26 @@ describe('sankey-spreadsheet', () => {
       expect(Number.isFinite(getLayer(graph, 'account-a'))).toBe(true);
       expect(Number.isFinite(getLayer(graph, 'account-b'))).toBe(true);
     });
+
+    it('uses a shared cache consistently across query orders for cyclic nodes', () => {
+      const graph: Graph = new Map();
+      addNode(graph, 'account-a', GraphLayers.Account, 'Account A');
+      addNode(graph, 'account-b', GraphLayers.Account, 'Account B');
+      addValueToLink(graph, 'account-a', 'account-b', 100);
+      addValueToLink(graph, 'account-b', 'account-a', 80);
+
+      const cacheFromAB = new Map<string, number>();
+      getLayer(graph, 'account-a', cacheFromAB);
+      getLayer(graph, 'account-b', cacheFromAB);
+
+      const cacheFromBA = new Map<string, number>();
+      getLayer(graph, 'account-b', cacheFromBA);
+      getLayer(graph, 'account-a', cacheFromBA);
+
+      expect(cacheFromAB.get('account-a')).toBe(cacheFromBA.get('account-a'));
+      expect(cacheFromAB.get('account-b')).toBe(cacheFromBA.get('account-b'));
+      expect(cacheFromAB.get('account-a')).toBe(cacheFromAB.get('account-b'));
+    });
   });
 
   describe('nodesInLayer', () => {

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.test.ts
@@ -5,6 +5,7 @@ import {
   addNode,
   addPercentageLabels,
   addValueToLink,
+  aggregateTransferPairs,
   buildSankeyData,
   cleanUpNodes,
   convertToSankeyData,
@@ -569,6 +570,72 @@ describe('sankey-spreadsheet', () => {
       expect(graph.has('c_groceries')).toBe(true);
       expect(graph.has('c_salary')).toBe(true);
       expect(graph.has('p_employer')).toBe(true);
+    });
+  });
+
+  describe('aggregateTransferPairs', () => {
+    it('keeps transfer direction when source account id sorts after destination', () => {
+      const transferPairs = aggregateTransferPairs([
+        {
+          id: 'tx-1',
+          transfer_id: 'tx-2',
+          accountId: 'z-account',
+          accountName: 'Z Account',
+          amount: -125,
+        },
+        {
+          id: 'tx-2',
+          transfer_id: 'tx-1',
+          accountId: 'a-account',
+          accountName: 'A Account',
+          amount: 125,
+        },
+      ]);
+
+      expect(transferPairs).toEqual([
+        {
+          fromAccountId: 'z-account',
+          fromAccountName: 'Z Account',
+          toAccountId: 'a-account',
+          toAccountName: 'A Account',
+          amount: 125,
+        },
+      ]);
+    });
+
+    it('nets reciprocal transfers and omits zero-value pairs', () => {
+      const transferPairs = aggregateTransferPairs([
+        {
+          id: 'tx-1',
+          transfer_id: 'tx-2',
+          accountId: 'a-account',
+          accountName: 'A Account',
+          amount: -100,
+        },
+        {
+          id: 'tx-2',
+          transfer_id: 'tx-1',
+          accountId: 'z-account',
+          accountName: 'Z Account',
+          amount: 100,
+        },
+        {
+          id: 'tx-3',
+          transfer_id: 'tx-4',
+          accountId: 'z-account',
+          accountName: 'Z Account',
+          amount: -100,
+        },
+        {
+          id: 'tx-4',
+          transfer_id: 'tx-3',
+          accountId: 'a-account',
+          accountName: 'A Account',
+          amount: 100,
+        },
+      ]);
+
+      expect(transferPairs).toEqual([]);
     });
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -89,6 +89,14 @@ type TransferEntry = {
   transfer_id: string;
 };
 
+type TransferPair = {
+  fromAccountId: string;
+  fromAccountName: string;
+  toAccountId: string;
+  toAccountName: string;
+  amount: number;
+};
+
 type SortMode = 'per-group' | 'global' | 'budget-order';
 
 type NodeKey = string;
@@ -192,7 +200,7 @@ async function createBaseGraph(
 ): Promise<Graph> {
   let data: CategoryEntry[] = [];
   let aggregated: AggregatedBudget | undefined;
-  let transferData: TransferEntry[] | undefined;
+  let transferData: TransferPair[] | undefined;
 
   if (mode === 'budgeted') {
     ({ data, aggregated } = await createBudgetSpreadsheet(
@@ -385,7 +393,7 @@ export function createTransactionsSpreadsheet(
       groupAccounts,
     );
 
-    let transferData: TransferEntry[] = [];
+    let transferData: TransferPair[] = [];
     if (showTransfers) {
       transferData = await fetchTransferData(
         conditionsOpKey,
@@ -598,7 +606,7 @@ async function fetchTransferData(
   filters: unknown[] = [],
   start: string,
   end: string,
-): Promise<TransferEntry[]> {
+): Promise<TransferPair[]> {
   const results = await aqlQuery(
     q('transactions')
       .filter({ [conditionsOpKey]: filters })
@@ -618,7 +626,7 @@ async function fetchTransferData(
       ]),
   );
 
-  return results.data.map(
+  const raw_results: TransferEntry[] = results.data.map(
     (row: {
       id?: string;
       amount?: number;
@@ -634,6 +642,53 @@ async function fetchTransferData(
         transfer_id: row.transfer_id ?? '',
       }) satisfies TransferEntry,
   );
+
+  const byId = new Map<string, TransferEntry>();
+  const byAccountId = new Map<string, string>();
+  
+  raw_results.forEach((t: TransferEntry) => {
+    byId.set(String(t.id), t);
+    byAccountId.set(String(t.accountId), t.accountName);
+  });
+
+  const result_pairs = new Map<string, number>();
+
+  raw_results.forEach((from: TransferEntry) => {
+    let to = byId.get(String(from.transfer_id));
+    if (!to) return; // counterpart not present
+
+    if (from.accountId > to.accountId) return; // only process one direction to avoid duplicates
+
+    // Swap order if the "from" amount is positive, so that we always have the negative amount first
+    if (from.amount > 0) {
+      [from, to] = [to, from];
+    }
+    const sortedKey = [from.accountId, to.accountId].sort().join('|');
+    const toFromKey = [to.accountId, from.accountId].join('|');
+
+    const existingValue = result_pairs.get(sortedKey) ?? 0;
+
+    if (result_pairs.has(sortedKey)) {
+      if (toFromKey === sortedKey) {
+        result_pairs.set(sortedKey, existingValue - from.amount);
+      } else {
+        result_pairs.set(sortedKey, existingValue + from.amount);
+      }
+    } else {
+      result_pairs.set(sortedKey, -from.amount);
+    }
+  });
+
+  return Array.from(result_pairs.entries()).map(([key, value]) => {
+    const [accountId1, accountId2] = key.split('|');
+    return {
+      fromAccountId: accountId1,
+      fromAccountName: byAccountId.get(accountId1) || '',
+      toAccountId: accountId2,
+      toAccountName: byAccountId.get(accountId2) || '',
+      amount: Math.abs(value),
+    };
+  }) satisfies TransferPair[];
 }
 
 export function createBudgetGraph(
@@ -801,7 +856,7 @@ export function createBudgetGraph(
 
 export function createTransactionsGraph(
   categoryData: CategoryEntry[],
-  transferData?: TransferEntry[],
+  transferData?: TransferPair[],
   groupAccounts?: boolean,
 ): Graph {
   function addAccountNode(accountId: string, accountName: string): void {
@@ -911,25 +966,10 @@ export function createTransactionsGraph(
   // If transfer data is provided, add links between accounts representing transfers.
   // Pair transactions strictly by transfer_id === id.
   if (transferData && transferData.length > 0 && !groupAccounts) {
-    const byId = new Map<string, TransferEntry>();
-    transferData.forEach((t: TransferEntry) => byId.set(String(t.id), t));
-
-    transferData.forEach((from: TransferEntry) => {
-      const to = byId.get(String(from.transfer_id));
-      if (!to) return; // counterpart not present
-
-      // Ensure a single link per transfer pair by only processing the pair in one direction (from -> to)
-      // Amounts transferred are registered as negative (leaving the account)
-      if (String(from.amount) >= String(to.amount)) return;
-
-      addAccountNode(to.accountId, to.accountName);
-      addAccountNode(from.accountId, from.accountName);
-      addValueToLink(
-        graph,
-        from.accountId,
-        to.accountId,
-        Math.abs(from.amount),
-      );
+    transferData.forEach((pair: TransferPair) => {
+      addAccountNode(pair.fromAccountId, pair.fromAccountName);
+      addAccountNode(pair.toAccountId, pair.toAccountName);
+      addValueToLink(graph, pair.fromAccountId, pair.toAccountId, pair.amount);
     });
   }
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -113,6 +113,7 @@ export type NodeData = {
   color?: string;
 };
 export type Graph = Map<NodeKey, NodeData>;
+type VisualLayerIndex = number;
 
 type TooltipInfoMap = Map<
   NodeKey,
@@ -244,10 +245,10 @@ export function buildSankeyData(
     categorySort,
   );
   const sortedGraph = sortGraph(graph, categorySort, categories);
-  addPercentageLabels(sortedGraph);
-  addColors(sortedGraph);
   cleanUpNodes(sortedGraph);
   addHiddenNodes(sortedGraph);
+  addPercentageLabels(sortedGraph);
+  addColors(sortedGraph);
   filterGraphByLayers(sortedGraph, layerFrom, layerTo);
 
   return convertToSankeyData(sortedGraph, toolTipInfoMap);
@@ -1022,7 +1023,18 @@ export function addValueToLink(
   }
 }
 
-export function getLayer(graph: Graph, key: NodeKey): number {
+export function getLayer(
+  graph: Graph,
+  key: NodeKey,
+  layerCache?: Map<NodeKey, VisualLayerIndex>,
+): number {
+  const resolvedLayerCache = layerCache ?? new Map<NodeKey, VisualLayerIndex>();
+
+  const cachedLayer = resolvedLayerCache.get(key);
+  if (cachedLayer !== undefined) {
+    return cachedLayer;
+  }
+
   // Find parent nodes for the given key
   const parents: NodeKey[] = [];
   for (const [parentKey, data] of graph) {
@@ -1030,12 +1042,37 @@ export function getLayer(graph: Graph, key: NodeKey): number {
       parents.push(parentKey);
     }
   }
+
   if (parents.length === 0) {
     // No parents: this is a root node, layer 0
+    resolvedLayerCache.set(key, 0);
     return 0;
   }
+
   // Otherwise, 1 + max parent's layer
-  return 1 + Math.max(...parents.map(parentKey => getLayer(graph, parentKey)));
+  const layer =
+    1 +
+    Math.max(
+      ...parents.map(parentKey =>
+        getLayer(graph, parentKey, resolvedLayerCache),
+      ),
+    );
+  resolvedLayerCache.set(key, layer);
+  return layer;
+}
+
+function getComputedNodeLayers(graph: Graph): Map<NodeKey, VisualLayerIndex> {
+  const layerCache = new Map<NodeKey, VisualLayerIndex>();
+
+  for (const key of graph.keys()) {
+    getLayer(graph, key, layerCache);
+  }
+
+  return layerCache;
+}
+
+function isHiddenNodeKey(key: NodeKey): boolean {
+  return key.endsWith(SpecialNodeKeys.HiddenSuffix);
 }
 
 function groupOtherCategories(
@@ -1392,19 +1429,31 @@ export function moveNodeToStart(
   }
 }
 
-export function getNodeValue(graph: Graph, key: NodeKey): number {
+export function getNodeValue(
+  graph: Graph,
+  key: NodeKey,
+  computedLayersByNode?: Map<NodeKey, VisualLayerIndex>,
+): number {
+  const resolvedLayersByNode =
+    computedLayersByNode ?? getComputedNodeLayers(graph);
   let nodeValue: number = 0;
 
-  if (getLayer(graph, key) === 0) {
+  if ((resolvedLayersByNode.get(key) ?? 0) === 0) {
     // Look at outgoing links for root nodes
     const node = graph.get(key);
     if (node) {
-      node.to.forEach(value => {
+      node.to.forEach((value, targetKey) => {
+        if (isHiddenNodeKey(targetKey)) {
+          return;
+        }
         nodeValue += value ?? 0;
       });
     }
   } else {
-    graph.forEach(data => {
+    graph.forEach((data, sourceKey) => {
+      if (isHiddenNodeKey(sourceKey)) {
+        return;
+      }
       nodeValue += data.to.get(key) ?? 0;
     });
 
@@ -1413,7 +1462,10 @@ export function getNodeValue(graph: Graph, key: NodeKey): number {
       nodeValue = 0;
       const node = graph.get(key);
       if (node) {
-        node.to.forEach(value => {
+        node.to.forEach((value, targetKey) => {
+          if (isHiddenNodeKey(targetKey)) {
+            return;
+          }
           nodeValue += value;
         });
       }
@@ -1423,22 +1475,38 @@ export function getNodeValue(graph: Graph, key: NodeKey): number {
 }
 
 export function addPercentageLabels(graph: Graph): void {
-  const layerSums = new Map<GraphLayers, number>();
+  const layerSums = new Map<VisualLayerIndex, number>();
+  const computedLayersByNode = getComputedNodeLayers(graph);
 
-  // First pass: calculate GraphLayer sums
+  // First pass: calculate visual-layer sums
   graph.forEach((_: NodeData, key: NodeKey) => {
-    const layer = graph.get(key)?.type;
-    if (!layer) {
+    if (isHiddenNodeKey(key)) {
       return;
     }
-    const nodeValue = getNodeValue(graph, key);
+
+    const layer = computedLayersByNode.get(key);
+    if (layer === undefined) {
+      return;
+    }
+
+    const nodeValue = getNodeValue(graph, key, computedLayersByNode);
     layerSums.set(layer, (layerSums.get(layer) ?? 0) + nodeValue);
   });
 
   // Second pass: assign percentage label to each node
   graph.forEach((data: NodeData, key: NodeKey) => {
-    const layer = data.type;
-    const nodeValue = getNodeValue(graph, key);
+    if (isHiddenNodeKey(key)) {
+      data.percentageLabel = undefined;
+      return;
+    }
+
+    const layer = computedLayersByNode.get(key);
+    if (layer === undefined) {
+      data.percentageLabel = undefined;
+      return;
+    }
+
+    const nodeValue = getNodeValue(graph, key, computedLayersByNode);
     const layerTotal = layerSums.get(layer) ?? 1;
     const percentage = layerTotal ? (nodeValue / layerTotal) * 100 : 0;
     data.percentageLabel = `${percentage.toFixed(1)}%`;
@@ -1483,7 +1551,7 @@ function setColor(graph: Graph, key: NodeKey, color: string) {
   }
 }
 
-function addHiddenNodes(graph: Graph) {
+export function addHiddenNodes(graph: Graph) {
   // Nodes with parents/children different than other nodes in the same layer might end up
   // in the wrong place in the graph. This fixes that, by adding extra, hidden nodes.
 
@@ -1570,6 +1638,88 @@ function addHiddenNodes(graph: Graph) {
       }
     }
   }
+
+  ensureCategoryGroupsFollowAccountLayers(graph);
+}
+
+function ensureCategoryGroupsFollowAccountLayers(graph: Graph) {
+  let computedLayersByNode = getComputedNodeLayers(graph);
+
+  let maxVisibleAccountLayer = -1;
+  for (const [key, node] of graph) {
+    if (node.type !== GraphLayers.Account || isHiddenNodeKey(key)) {
+      continue;
+    }
+
+    const nodeLayer = computedLayersByNode.get(key);
+    if (nodeLayer !== undefined && nodeLayer > maxVisibleAccountLayer) {
+      maxVisibleAccountLayer = nodeLayer;
+    }
+  }
+
+  if (maxVisibleAccountLayer < 0) {
+    return;
+  }
+
+  const categoryGroupsToPush: NodeKey[] = [];
+  for (const [key, node] of graph) {
+    if (node.type !== GraphLayers.CategoryGroup) {
+      continue;
+    }
+
+    const nodeLayer = computedLayersByNode.get(key);
+    if (nodeLayer !== undefined && nodeLayer <= maxVisibleAccountLayer) {
+      categoryGroupsToPush.push(key);
+    }
+  }
+
+  for (const key of categoryGroupsToPush) {
+    let currentLayer = computedLayersByNode.get(key);
+    while (
+      currentLayer !== undefined &&
+      currentLayer <= maxVisibleAccountLayer
+    ) {
+      const deepestParent = getDeepestParentKey(
+        graph,
+        key,
+        computedLayersByNode,
+      );
+      if (!deepestParent) {
+        break;
+      }
+
+      const hiddenParentKey = `${key}_${GraphLayers.Account}_${currentLayer}${SpecialNodeKeys.HiddenSuffix}`;
+      addNode(graph, hiddenParentKey, GraphLayers.Account, '');
+      addValueToLink(graph, deepestParent, hiddenParentKey, -1);
+      addValueToLink(graph, hiddenParentKey, key, -1);
+
+      computedLayersByNode = getComputedNodeLayers(graph);
+      currentLayer = computedLayersByNode.get(key);
+    }
+  }
+}
+
+function getDeepestParentKey(
+  graph: Graph,
+  nodeKey: NodeKey,
+  computedLayersByNode: Map<NodeKey, VisualLayerIndex>,
+): NodeKey | undefined {
+  let deepestParent: NodeKey | undefined;
+  let deepestLayer = -Infinity;
+
+  for (const [parentKey, data] of graph) {
+    if (!data.to.has(nodeKey)) {
+      continue;
+    }
+
+    const parentLayer = computedLayersByNode.get(parentKey);
+    if (parentLayer !== undefined && parentLayer > deepestLayer) {
+      deepestLayer = parentLayer;
+      deepestParent = parentKey;
+    }
+  }
+
+  return deepestParent;
 }
 
 function buildTypeConnectivity(

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -608,7 +608,7 @@ async function fetchTransferData(
           { date: { $lte: monthUtils.lastDayOfMonth(end) } },
         ],
       })
-      .filter({ transfer_id: { $ne: null } })
+      .filter({ transfer_id: { $ne: null }, 'account.offbudget': false})
       .select([
         { id: 'id' },
         { amount: 'amount' },
@@ -932,8 +932,6 @@ export function createTransactionsGraph(
       );
     });
   }
-
-  console.log(graph);
 
   return graph;
 }

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -1030,52 +1030,146 @@ export function getLayer(
 ): number {
   const resolvedLayerCache = layerCache ?? new Map<NodeKey, VisualLayerIndex>();
 
-  return getLayerWithCycleGuard(graph, key, resolvedLayerCache, new Set());
-}
-
-function getLayerWithCycleGuard(
-  graph: Graph,
-  key: NodeKey,
-  layerCache: Map<NodeKey, VisualLayerIndex>,
-  visitedInPath: Set<NodeKey>,
-): number {
-  if (visitedInPath.has(key)) {
-    return 0;
-  }
-
-  const cachedLayer = layerCache.get(key);
+  const cachedLayer = resolvedLayerCache.get(key);
   if (cachedLayer !== undefined) {
     return cachedLayer;
   }
 
-  visitedInPath.add(key);
-
-  // Find parent nodes for the given key
-  const parents: NodeKey[] = [];
-  for (const [parentKey, data] of graph) {
-    if (data.to.has(key)) {
-      parents.push(parentKey);
-    }
-  }
-
-  if (parents.length === 0) {
-    // No parents: this is a root node, layer 0
-    layerCache.set(key, 0);
-    visitedInPath.delete(key);
+  if (!graph.has(key)) {
+    resolvedLayerCache.set(key, 0);
     return 0;
   }
 
-  // Otherwise, 1 + max parent's layer
-  const layer =
-    1 +
-    Math.max(
-      ...parents.map(parentKey =>
-        getLayerWithCycleGuard(graph, parentKey, layerCache, visitedInPath),
-      ),
-    );
-  layerCache.set(key, layer);
-  visitedInPath.delete(key);
-  return layer;
+  const computedLayers = getLayersByStronglyConnectedComponents(graph);
+  computedLayers.forEach((layer, nodeKey) => {
+    resolvedLayerCache.set(nodeKey, layer);
+  });
+
+  return resolvedLayerCache.get(key) ?? 0;
+}
+
+function getLayersByStronglyConnectedComponents(
+  graph: Graph,
+): Map<NodeKey, VisualLayerIndex> {
+  const visitedIndex = new Map<NodeKey, number>();
+  const lowlink = new Map<NodeKey, number>();
+  const stack: NodeKey[] = [];
+  const activeStack = new Set<NodeKey>();
+  const componentByNode = new Map<NodeKey, number>();
+  const components: NodeKey[][] = [];
+  let index = 0;
+
+  function strongConnect(nodeKey: NodeKey) {
+    visitedIndex.set(nodeKey, index);
+    lowlink.set(nodeKey, index);
+    index += 1;
+    stack.push(nodeKey);
+    activeStack.add(nodeKey);
+
+    const node = graph.get(nodeKey);
+    if (node) {
+      for (const childKey of node.to.keys()) {
+        if (!graph.has(childKey)) {
+          continue;
+        }
+
+        if (!visitedIndex.has(childKey)) {
+          strongConnect(childKey);
+          lowlink.set(
+            nodeKey,
+            Math.min(lowlink.get(nodeKey) ?? 0, lowlink.get(childKey) ?? 0),
+          );
+        } else if (activeStack.has(childKey)) {
+          lowlink.set(
+            nodeKey,
+            Math.min(
+              lowlink.get(nodeKey) ?? 0,
+              visitedIndex.get(childKey) ?? 0,
+            ),
+          );
+        }
+      }
+    }
+
+    if (lowlink.get(nodeKey) === visitedIndex.get(nodeKey)) {
+      const componentIndex = components.length;
+      const componentNodes: NodeKey[] = [];
+
+      let poppedNode: NodeKey | undefined;
+      do {
+        poppedNode = stack.pop();
+        if (!poppedNode) {
+          break;
+        }
+
+        activeStack.delete(poppedNode);
+        componentByNode.set(poppedNode, componentIndex);
+        componentNodes.push(poppedNode);
+      } while (poppedNode !== nodeKey);
+
+      components.push(componentNodes);
+    }
+  }
+
+  for (const nodeKey of graph.keys()) {
+    if (!visitedIndex.has(nodeKey)) {
+      strongConnect(nodeKey);
+    }
+  }
+
+  const parentsByComponent = new Map<number, Set<number>>();
+  for (
+    let componentIndex = 0;
+    componentIndex < components.length;
+    componentIndex += 1
+  ) {
+    parentsByComponent.set(componentIndex, new Set());
+  }
+
+  for (const [sourceKey, sourceNode] of graph) {
+    const sourceComponent = componentByNode.get(sourceKey);
+    if (sourceComponent === undefined) {
+      continue;
+    }
+
+    for (const targetKey of sourceNode.to.keys()) {
+      const targetComponent = componentByNode.get(targetKey);
+      if (
+        targetComponent === undefined ||
+        targetComponent === sourceComponent
+      ) {
+        continue;
+      }
+
+      parentsByComponent.get(targetComponent)?.add(sourceComponent);
+    }
+  }
+
+  const layerByComponent = new Map<number, VisualLayerIndex>();
+  function resolveComponentLayer(componentIndex: number): VisualLayerIndex {
+    const cachedComponentLayer = layerByComponent.get(componentIndex);
+    if (cachedComponentLayer !== undefined) {
+      return cachedComponentLayer;
+    }
+
+    const parents = parentsByComponent.get(componentIndex);
+    if (!parents || parents.size === 0) {
+      layerByComponent.set(componentIndex, 0);
+      return 0;
+    }
+
+    const layer =
+      1 + Math.max(...Array.from(parents).map(resolveComponentLayer));
+    layerByComponent.set(componentIndex, layer);
+    return layer;
+  }
+
+  const layerByNode = new Map<NodeKey, VisualLayerIndex>();
+  for (const [nodeKey, componentIndex] of componentByNode) {
+    layerByNode.set(nodeKey, resolveComponentLayer(componentIndex));
+  }
+
+  return layerByNode;
 }
 
 function getComputedNodeLayers(graph: Graph): Map<NodeKey, VisualLayerIndex> {

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -81,6 +81,14 @@ type CategoryEntry = {
   payeeId?: string;
 };
 
+type TransferEntry = {
+  accountId: string;
+  accountName: string;
+  amount: number;
+  id: string;
+  transfer_id: string;
+};
+
 type SortMode = 'per-group' | 'global' | 'budget-order';
 
 type NodeKey = string;
@@ -151,6 +159,7 @@ export function createBaseGraphSpreadsheet(
   conditionsOp: 'and' | 'or' = 'and',
   mode: 'budgeted' | 'spent' = 'spent',
   groupAccounts: boolean = false,
+  showTransfers: boolean = false,
 ) {
   return async (
     _spreadsheet: ReturnType<typeof useSpreadsheet>,
@@ -164,6 +173,7 @@ export function createBaseGraphSpreadsheet(
       conditionsOp,
       mode,
       groupAccounts,
+      showTransfers,
     );
 
     setData(baseGraph);
@@ -178,9 +188,11 @@ async function createBaseGraph(
   conditionsOp: 'and' | 'or' = 'and',
   mode: 'budgeted' | 'spent' = 'spent',
   groupAccounts: boolean = false,
+  showTransfers: boolean = false,
 ): Promise<Graph> {
   let data: CategoryEntry[] = [];
   let aggregated: AggregatedBudget | undefined;
+  let transferData: TransferEntry[] | undefined;
 
   if (mode === 'budgeted') {
     ({ data, aggregated } = await createBudgetSpreadsheet(
@@ -190,19 +202,22 @@ async function createBaseGraph(
       conditionsOp,
     )());
   } else if (mode === 'spent') {
-    data = await createTransactionsSpreadsheet(
+    const res = await createTransactionsSpreadsheet(
       start,
       end,
       categories,
       conditions,
       conditionsOp,
       groupAccounts,
+      showTransfers,
     )();
+    data = res.data;
+    transferData = res.transferData;
   }
 
   return aggregated
     ? createBudgetGraph(data, aggregated)
-    : createTransactionsGraph(data);
+    : createTransactionsGraph(data, transferData, groupAccounts);
 }
 
 export function buildSankeyData(
@@ -352,6 +367,7 @@ export function createTransactionsSpreadsheet(
   conditions: RuleConditionEntity[] = [],
   conditionsOp: 'and' | 'or' = 'and',
   groupAccounts: boolean,
+  showTransfers: boolean,
 ) {
   return async () => {
     // gather filters user has set
@@ -369,7 +385,17 @@ export function createTransactionsSpreadsheet(
       groupAccounts,
     );
 
-    return categoryData;
+    let transferData: TransferEntry[] = [];
+    if (showTransfers) {
+      transferData = await fetchTransferData(
+        conditionsOpKey,
+        filters,
+        start,
+        end,
+      );
+    }
+
+    return { data: categoryData, transferData };
   };
 }
 
@@ -566,6 +592,50 @@ async function fetchCategoryData(
   return allCategoryData;
 }
 
+// Fetch transactions that are transfers within the provided month range
+async function fetchTransferData(
+  conditionsOpKey: string = '$and',
+  filters: unknown[] = [],
+  start: string,
+  end: string,
+): Promise<TransferEntry[]> {
+  const results = await aqlQuery(
+    q('transactions')
+      .filter({ [conditionsOpKey]: filters })
+      .filter({
+        $and: [
+          { date: { $gte: monthUtils.firstDayOfMonth(start) } },
+          { date: { $lte: monthUtils.lastDayOfMonth(end) } },
+        ],
+      })
+      .filter({ transfer_id: { $ne: null } })
+      .select([
+        { id: 'id' },
+        { amount: 'amount' },
+        { accountId: { $id: '$account.id' } },
+        { accountName: { $id: '$account.name' } },
+        { transfer_id: 'transfer_id' },
+      ]),
+  );
+
+  return results.data.map(
+    (row: {
+      id?: string;
+      amount?: number;
+      accountId?: string;
+      accountName?: string;
+      transfer_id?: string;
+    }) =>
+      ({
+        id: row.id ?? '',
+        amount: row.amount ?? 0,
+        accountId: row.accountId ?? '',
+        accountName: row.accountName ?? '',
+        transfer_id: row.transfer_id ?? '',
+      }) satisfies TransferEntry,
+  );
+}
+
 export function createBudgetGraph(
   categoryData: CategoryEntry[],
   aggregated: AggregatedBudget,
@@ -729,7 +799,11 @@ export function createBudgetGraph(
   return graph;
 }
 
-export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
+export function createTransactionsGraph(
+  categoryData: CategoryEntry[],
+  transferData?: TransferEntry[],
+  groupAccounts?: boolean,
+): Graph {
   function addAccountNode(accountId: string, accountName: string): void {
     if (accountId === SpecialNodeKeys.AllAccounts) {
       addNodeWithLabel(
@@ -833,6 +907,34 @@ export function createTransactionsGraph(categoryData: CategoryEntry[]): Graph {
       }
     }
   });
+
+  // If transfer data is provided, add links between accounts representing transfers.
+  // Pair transactions strictly by transfer_id === id.
+  if (transferData && transferData.length > 0 && !groupAccounts) {
+    const byId = new Map<string, TransferEntry>();
+    transferData.forEach((t: TransferEntry) => byId.set(String(t.id), t));
+
+    transferData.forEach((from: TransferEntry) => {
+      const to = byId.get(String(from.transfer_id));
+      if (!to) return; // counterpart not present
+
+      // Ensure a single link per transfer pair by only processing the pair in one direction (from -> to)
+      // Amounts transferred are registered as negative (leaving the account)
+      if (String(from.amount) >= String(to.amount)) return;
+
+      addAccountNode(to.accountId, to.accountName);
+      addAccountNode(from.accountId, from.accountName);
+      addValueToLink(
+        graph,
+        from.accountId,
+        to.accountId,
+        Math.abs(from.amount),
+      );
+    });
+  }
+
+  console.log(graph);
+
   return graph;
 }
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -645,7 +645,7 @@ async function fetchTransferData(
 
   const byId = new Map<string, TransferEntry>();
   const byAccountId = new Map<string, string>();
-  
+
   raw_results.forEach((t: TransferEntry) => {
     byId.set(String(t.id), t);
     byAccountId.set(String(t.accountId), t.accountName);

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -1103,28 +1103,35 @@ function moveToOther(
   fromNodes.forEach(([fromKey, fromData]) => {
     const linkValue = fromData.to.get(key);
     if (linkValue !== undefined) {
-      addValueToLink(graph, fromKey, otherKey, linkValue);
-      newAddTooltipInfo(
-        toolTipInfoMap,
-        fromKey,
-        otherKey,
-        graph.get(key)?.name ?? key,
-        linkValue,
-      );
+      // Avoid creating self-links (otherKey -> otherKey) which produce
+      // immediate cycles and can break recursive layer computation.
+      if (fromKey !== otherKey) {
+        addValueToLink(graph, fromKey, otherKey, linkValue);
+        newAddTooltipInfo(
+          toolTipInfoMap,
+          fromKey,
+          otherKey,
+          graph.get(key)?.name ?? key,
+          linkValue,
+        );
+      }
     }
   });
   toNodes.forEach(toKey => {
     const fromData = graph.get(key);
     const linkValue = fromData?.to.get(toKey);
     if (linkValue !== undefined) {
-      addValueToLink(graph, otherKey, toKey, linkValue);
-      newAddTooltipInfo(
-        toolTipInfoMap,
-        otherKey,
-        toKey,
-        graph.get(key)?.name ?? key,
-        linkValue,
-      );
+      // Avoid creating self-links (otherKey -> otherKey)
+      if (otherKey !== toKey) {
+        addValueToLink(graph, otherKey, toKey, linkValue);
+        newAddTooltipInfo(
+          toolTipInfoMap,
+          otherKey,
+          toKey,
+          graph.get(key)?.name ?? key,
+          linkValue,
+        );
+      }
     }
   });
 

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -608,7 +608,7 @@ async function fetchTransferData(
           { date: { $lte: monthUtils.lastDayOfMonth(end) } },
         ],
       })
-      .filter({ transfer_id: { $ne: null }, 'account.offbudget': false})
+      .filter({ transfer_id: { $ne: null }, 'account.offbudget': false })
       .select([
         { id: 'id' },
         { amount: 'amount' },

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -643,52 +643,52 @@ async function fetchTransferData(
       }) satisfies TransferEntry,
   );
 
+  return aggregateTransferPairs(raw_results);
+}
+
+export function aggregateTransferPairs(
+  rawResults: TransferEntry[],
+): TransferPair[] {
   const byId = new Map<string, TransferEntry>();
   const byAccountId = new Map<string, string>();
 
-  raw_results.forEach((t: TransferEntry) => {
-    byId.set(String(t.id), t);
-    byAccountId.set(String(t.accountId), t.accountName);
+  rawResults.forEach((transfer: TransferEntry) => {
+    byId.set(String(transfer.id), transfer);
+    byAccountId.set(String(transfer.accountId), transfer.accountName);
   });
 
-  const result_pairs = new Map<string, number>();
+  const resultPairs = new Map<string, number>();
 
-  raw_results.forEach((from: TransferEntry) => {
-    let to = byId.get(String(from.transfer_id));
-    if (!to) return; // counterpart not present
+  rawResults.forEach((from: TransferEntry) => {
+    const to = byId.get(String(from.transfer_id));
+    if (!to) return;
 
-    if (from.accountId > to.accountId) return; // only process one direction to avoid duplicates
+    if (from.accountId > to.accountId) return;
 
-    // Swap order if the "from" amount is positive, so that we always have the negative amount first
-    if (from.amount > 0) {
-      [from, to] = [to, from];
-    }
-    const sortedKey = [from.accountId, to.accountId].sort().join('|');
-    const toFromKey = [to.accountId, from.accountId].join('|');
+    const [accountId1, accountId2] = [from.accountId, to.accountId].sort();
+    const pairKey = `${accountId1}|${accountId2}`;
+    const sourceAccountId = from.amount < 0 ? from.accountId : to.accountId;
+    const sign = sourceAccountId === accountId1 ? 1 : -1;
+    const existingValue = resultPairs.get(pairKey) ?? 0;
 
-    const existingValue = result_pairs.get(sortedKey) ?? 0;
-
-    if (result_pairs.has(sortedKey)) {
-      if (toFromKey === sortedKey) {
-        result_pairs.set(sortedKey, existingValue - from.amount);
-      } else {
-        result_pairs.set(sortedKey, existingValue + from.amount);
-      }
-    } else {
-      result_pairs.set(sortedKey, -from.amount);
-    }
+    resultPairs.set(pairKey, existingValue + sign * Math.abs(from.amount));
   });
 
-  return Array.from(result_pairs.entries()).map(([key, value]) => {
-    const [accountId1, accountId2] = key.split('|');
-    return {
-      fromAccountId: accountId1,
-      fromAccountName: byAccountId.get(accountId1) || '',
-      toAccountId: accountId2,
-      toAccountName: byAccountId.get(accountId2) || '',
-      amount: Math.abs(value),
-    };
-  }) satisfies TransferPair[];
+  return Array.from(resultPairs.entries())
+    .filter(([, value]) => value !== 0)
+    .map(([key, value]) => {
+      const [accountId1, accountId2] = key.split('|');
+      const fromAccountId = value > 0 ? accountId1 : accountId2;
+      const toAccountId = value > 0 ? accountId2 : accountId1;
+
+      return {
+        fromAccountId,
+        fromAccountName: byAccountId.get(fromAccountId) || '',
+        toAccountId,
+        toAccountName: byAccountId.get(toAccountId) || '',
+        amount: Math.abs(value),
+      };
+    }) satisfies TransferPair[];
 }
 
 export function createBudgetGraph(

--- a/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
+++ b/packages/desktop-client/src/components/reports/spreadsheets/sankey-spreadsheet.ts
@@ -1030,10 +1030,25 @@ export function getLayer(
 ): number {
   const resolvedLayerCache = layerCache ?? new Map<NodeKey, VisualLayerIndex>();
 
-  const cachedLayer = resolvedLayerCache.get(key);
+  return getLayerWithCycleGuard(graph, key, resolvedLayerCache, new Set());
+}
+
+function getLayerWithCycleGuard(
+  graph: Graph,
+  key: NodeKey,
+  layerCache: Map<NodeKey, VisualLayerIndex>,
+  visitedInPath: Set<NodeKey>,
+): number {
+  if (visitedInPath.has(key)) {
+    return 0;
+  }
+
+  const cachedLayer = layerCache.get(key);
   if (cachedLayer !== undefined) {
     return cachedLayer;
   }
+
+  visitedInPath.add(key);
 
   // Find parent nodes for the given key
   const parents: NodeKey[] = [];
@@ -1045,7 +1060,8 @@ export function getLayer(
 
   if (parents.length === 0) {
     // No parents: this is a root node, layer 0
-    resolvedLayerCache.set(key, 0);
+    layerCache.set(key, 0);
+    visitedInPath.delete(key);
     return 0;
   }
 
@@ -1054,10 +1070,11 @@ export function getLayer(
     1 +
     Math.max(
       ...parents.map(parentKey =>
-        getLayer(graph, parentKey, resolvedLayerCache),
+        getLayerWithCycleGuard(graph, parentKey, layerCache, visitedInPath),
       ),
     );
-  resolvedLayerCache.set(key, layer);
+  layerCache.set(key, layer);
+  visitedInPath.delete(key);
   return layer;
 }
 

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -394,6 +394,7 @@ export type SankeyWidget = AbstractWidget<
     categorySort?: 'per-group' | 'global' | 'budget-order';
     showPercentages?: boolean;
     groupAccounts?: boolean;
+    showTransfers?: boolean;
     layerFrom?: string;
     layerTo?: string;
   } | null

--- a/upcoming-release-notes/sankey-add-transfers.md
+++ b/upcoming-release-notes/sankey-add-transfers.md
@@ -1,0 +1,6 @@
+---
+category: Features
+authors: [emiltb]
+---
+
+Add option to show transfers in Sankey spent view


### PR DESCRIPTION
## Description

Adds an optional toggle in the Sankey chart to show transfers. This can better represent the flow of money, e.g. if the user receives money in one account, but have most of their spending from credit cards, which would previously resulted in a disconnected graph.

With option off:
<img width="949" height="285" alt="2026-08-23T21:18:18,811583869+02:00" src="https://github.com/user-attachments/assets/7d3b5af2-8586-40f6-9075-8d94f2070a04" />

With option on: 
<img width="1565" height="410" alt="2026-08-24T15:29:32,159381810+02:00" src="https://github.com/user-attachments/assets/ef639886-5a24-4bc3-8ab5-6d968967dd8e" />


Development aided by OpenCode / GPT-5 Mini. 

## Related issue(s)

Relates to #1919, where it has been requested multiple times. 

## Testing

Manual testing with a specifically crafted tested budget and the full history of my own budget.

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.5 MB → 13.51 MB (+12.67 kB) | +0.09%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.5 MB → 13.51 MB (+12.67 kB) | +0.09%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/mobile/accounts/AllAccountTransactions.tsx` | 📈 +1.54 kB (+33.21%) | 4.65 kB → 6.19 kB
`src/components/reports/spreadsheets/sankey-spreadsheet.ts` | 📈 +8.4 kB (+28.53%) | 29.44 kB → 37.83 kB
`src/components/mobile/transactions/TransactionListWithBalances.tsx` | 📈 +1.49 kB (+23.04%) | 6.46 kB → 7.94 kB
`src/components/reports/reports/Sankey.tsx` | 📈 +800 B (+2.46%) | 31.76 kB → 32.54 kB
`src/components/mobile/accounts/AccountsPage.tsx` | 📈 +258 B (+1.46%) | 17.23 kB → 17.49 kB
`src/components/reports/reports/SankeyCard.tsx` | 📈 +53 B (+1.19%) | 4.36 kB → 4.41 kB
`locale/en.json` | 📈 +156 B (+0.06%) | 245.7 kB → 245.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.42 MB → 1.43 MB (+9.23 kB) | +0.63%
static/js/narrow.js | 287.24 kB → 290.52 kB (+3.28 kB) | +1.14%
static/js/en.js | 245.7 kB → 245.85 kB (+156 B) | +0.06%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->