### PR TITLE
[WIP] [AI] Rebind ref event listeners when the target element is swapped

### DIFF
--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -82,6 +82,31 @@ describe('useRefEventListener', () => {
     expect(el.removeEventListener).toHaveBeenCalledTimes(1);
   });
 
+  it('rebinds when the element under the ref is swapped out for a new one', () => {
+    const el1 = makeMockElement() as unknown as HTMLElement;
+    const el2 = makeMockElement() as unknown as HTMLElement;
+    const ref = { current: el1 } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    expect(el1.addEventListener).toHaveBeenCalledTimes(1);
+
+    // Simulate React replacing the DOM node while keeping the same ref
+    // object (e.g. a cell that switches between its unexposed and exposed
+    // representations renders a brand-new trigger element).
+    ref.current = el2;
+    rerender();
+
+    expect(el1.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(el2.addEventListener).toHaveBeenCalledTimes(1);
+    expect(el2.addEventListener).toHaveBeenCalledWith(
+      'click',
+      expect.any(Function),
+    );
+  });
+
   it('removes the listener on unmount', () => {
     const el = makeMockElement();
     const ref = { current: el } as unknown as RefObject<HTMLElement | null>;

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -17,6 +17,16 @@ export function useRefEventListener<
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
+  // Track which element is currently under the ref. Components such as
+  // table cells swap out their DOM node while keeping the same ref object
+  // (e.g. switching between an unexposed label and an exposed input), so
+  // the effect below must re-run when the target element itself changes,
+  // not just when the ref object or event name changes. Reading ref.current
+  // during render is safe here because the value is only consumed at
+  // effect time, after React has committed any ref updates.
+  const currentTarget =
+    ref instanceof Document || ref instanceof Window ? ref : ref.current;
+
   useEffect(() => {
     const el =
       ref instanceof Document || ref instanceof Window ? ref : ref.current;
@@ -31,5 +41,5 @@ export function useRefEventListener<
     return () => {
       el.removeEventListener(event, listener);
     };
-  }, [ref, event]);
+  }, [ref, event, currentTarget]);
 }

--- a/upcoming-release-notes/8782.md
+++ b/upcoming-release-notes/8782.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [ryanduguid]
+---
+
+Fix dropdown menus on budget categories and groups not opening after a rename until the page was refreshed


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.5 MB → 13.58 MB (+87.95 kB) | +0.64%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.5 MB → 13.58 MB (+87.95 kB) | +0.64%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useRefEventListener.ts` | 📈 +79 B (+15.08%) | 524 B → 603 B
`locale/en.json` | 📈 +117 B (+0.05%) | 245.7 kB → 245.81 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 166.98 kB (+87.76 kB) | +110.78%
static/js/en.js | 245.7 kB → 245.81 kB (+117 B) | +0.05%
static/js/Value.js | 1.79 MB → 1.79 MB (+79 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 287.24 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->