### PR TITLE
[AI] Add mobile e2e coverage for the transaction calendar report

### DIFF
--- a/packages/desktop-client/e2e/page-models/reports-page.ts
+++ b/packages/desktop-client/e2e/page-models/reports-page.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
 import { CustomReportPage } from './custom-report-page';
@@ -23,6 +24,42 @@ export class ReportsPage {
   async goToCashFlowPage() {
     await this.pageContent.getByRole('button', { name: /^Cash/ }).click();
     return new ReportsPage(this.page);
+  }
+
+  async goToCalendarPage() {
+    const card = await this.scrollDashboardCardIntoView(/^Calendar$/);
+
+    await Promise.all([
+      this.page.waitForURL(/\/reports\/calendar\/.+/),
+      card.click(),
+    ]);
+
+    return new ReportsPage(this.page);
+  }
+
+  /**
+   * Locates the dashboard card whose title matches `name` and scrolls it into
+   * view, returning its clickable button.
+   *
+   * `ReportCard` renders its children only once the card enters the viewport,
+   * so an off-screen card has no title to match on — and a card added during
+   * the test may not be in the DOM yet at all. Both are handled by re-scrolling
+   * to the bottom of the dashboard (where new widgets land) until the card
+   * shows up.
+   */
+  private async scrollDashboardCardIntoView(name: RegExp) {
+    const card = this.pageContent
+      .getByRole('button')
+      .filter({ has: this.page.getByRole('heading', { name }) });
+
+    await expect(async () => {
+      await this.page.evaluate(() => {
+        window.scrollTo(0, document.documentElement.scrollHeight);
+      });
+      await expect(card).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 20_000 });
+
+    return card;
   }
 
   async goToBalanceForecastPage() {

--- a/packages/desktop-client/e2e/page-models/reports-page.ts
+++ b/packages/desktop-client/e2e/page-models/reports-page.ts
@@ -43,9 +43,12 @@ export class ReportsPage {
    *
    * `ReportCard` renders its children only once the card enters the viewport,
    * so an off-screen card has no title to match on — and a card added during
-   * the test may not be in the DOM yet at all. Both are handled by re-scrolling
-   * to the bottom of the dashboard (where new widgets land) until the card
-   * shows up.
+   * the test may not be in the DOM yet at all.
+   *
+   * The dashboard scrolls inside `Page`'s own `overflowY: auto` container
+   * rather than the document, so scrolling the window is a no-op here. Walk
+   * the grid items instead and bring each into view until the card renders;
+   * `ReportCard` latches `hasRendered`, so a card stays rendered once seen.
    */
   private async scrollDashboardCardIntoView(name: RegExp) {
     const card = this.pageContent
@@ -53,9 +56,17 @@ export class ReportsPage {
       .filter({ has: this.page.getByRole('heading', { name }) });
 
     await expect(async () => {
-      await this.page.evaluate(() => {
-        window.scrollTo(0, document.documentElement.scrollHeight);
-      });
+      const gridItems = this.pageContent.locator('.react-grid-item');
+      const count = await gridItems.count();
+
+      for (let i = count - 1; i >= 0; i--) {
+        await gridItems.nth(i).scrollIntoViewIfNeeded();
+
+        if (await card.isVisible()) {
+          break;
+        }
+      }
+
       await expect(card).toBeVisible({ timeout: 1000 });
     }).toPass({ timeout: 20_000 });
 

--- a/packages/desktop-client/e2e/reports.mobile.test.ts
+++ b/packages/desktop-client/e2e/reports.mobile.test.ts
@@ -1,0 +1,64 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from './fixtures';
+import { ConfigurationPage } from './page-models/configuration-page';
+import { Navigation } from './page-models/navigation';
+
+test.describe('Mobile Reports', () => {
+  let page: Page;
+  let navigation: Navigation;
+  let configurationPage: ConfigurationPage;
+
+  test.beforeEach(async ({ browser }) => {
+    page = await browser.newPage();
+    navigation = new Navigation(page);
+    configurationPage = new ConfigurationPage(page);
+
+    await page.goto('/');
+    await configurationPage.createTestFile();
+  });
+
+  test.afterEach(async () => {
+    await page?.close();
+  });
+
+  // The narrow-width branch of the calendar report renders the mobile
+  // `TransactionList`, whose rows call `useDisplayPayee`. That hook throws when
+  // it renders outside a `DisplayPayeeProvider`, which took the whole report
+  // down to `FeatureErrorFallback`. The wide-width branch never hit it because
+  // it renders `TransactionTable`, which mounts its own provider internally.
+  //
+  // This starts at desktop width on purpose, mirroring the original report: the
+  // calendar widget is not on the default dashboard and "Add new widget" is
+  // desktop-only, so the widget is added wide and then viewed narrow.
+  test('transaction calendar renders its transaction list on a narrow viewport', async () => {
+    const reportsPage = await navigation.goToReportsPage();
+    await reportsPage.waitToLoad();
+    await reportsPage.addWidget('Calendar card');
+    await reportsPage.goToCalendarPage();
+
+    await page.setViewportSize({ width: 350, height: 600 });
+
+    const showTransactions = page.getByRole('button', {
+      name: 'Show transactions',
+    });
+    const errorFallback = page.getByText(
+      'Something went wrong loading this section.',
+    );
+
+    // Settle on whichever renders first so a crash reports as a visible error
+    // boundary rather than as a timeout waiting for the button.
+    await expect(showTransactions.or(errorFallback).first()).toBeVisible();
+    await expect(errorFallback).not.toBeVisible();
+
+    await showTransactions.click();
+
+    const transactionList = page.getByLabel('Transaction list');
+    await expect(transactionList).toBeVisible();
+
+    // Rendering a row at all is the assertion that matters — a row is what
+    // invokes `useDisplayPayee`.
+    await expect(transactionList.getByRole('option').first()).toBeVisible();
+    await expect(errorFallback).not.toBeVisible();
+  });
+});

--- a/upcoming-release-notes/8783.md
+++ b/upcoming-release-notes/8783.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [zannis]
+---
+
+Add mobile e2e coverage for the transaction calendar report


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds mobile (narrow-viewport) e2e coverage for the transaction calendar report.
<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

Written using Claude Code.

## Related issue(s)

Relates to #7108
<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

Ran the new test locally and confirmed it passes.

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.51 MB | 0%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.51 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185.95 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->