### PR TITLE
[WIP] docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Want to say thanks? Click the ⭐ at the top of the page.
 
 ## Installation
 
-There are four ways to deploy Actual:
+There are five ways to deploy Actual:
 
 1. One-click deployment [via PikaPods](https://www.pikapods.com/pods?run=actual) (~2.00 $/month) - recommended for non-technical users
 1. Managed hosting [via Fly.io](https://actualbudget.org/docs/install/fly) (~1.50 $/month)
 1. Self-hosted by using [a Docker image](https://actualbudget.org/docs/install/docker)
 1. Local-only apps - [downloadable Windows, Mac and Linux apps](https://actualbudget.org/download/) you can run on your device
+1. One-click deployment [via RepoCloud](https://repocloud.io/details/Actual%20Budget/) - free credits for new users
 
 Learn more in the [installation instructions docs](https://actualbudget.org/docs/install/).
 


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a one-click deployment option alongside the existing providers (PikaPods, Fly.io, Docker, local apps).

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment and free credits for new users.

- Adds RepoCloud to the Installation section in `README.md`
- Uses the same numbered list format as existing deployment options
- Updates count from "four ways" to "five ways"
- Links to: https://repocloud.io/details/Actual%20Budget/