### PR TITLE
[AI] Fix schedule service shutdown race

### DIFF
--- a/packages/loot-core/src/server/main.test.ts
+++ b/packages/loot-core/src/server/main.test.ts
@@ -443,3 +443,118 @@ describe('Categories', () => {
     expect(sheet.getCellValue(nextSheetName, 'to-budget')).toBe(toBudget);
   });
 });
+
+describe('Mutator shutdown', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function deferred() {
+    let resolve;
+    const promise = new Promise(resolvePromise => {
+      resolve = resolvePromise;
+    });
+    return { promise, resolve };
+  }
+
+  function startCloseBudget() {
+    return runHandler(handlers['close-budget'], undefined, {
+      name: 'close-budget',
+    });
+  }
+
+  test('waits for a running mutator before closing the database', async () => {
+    vi.useFakeTimers();
+    const gate = deferred();
+    const mutatorPromise = runMutator(async () => {
+      await gate.promise;
+      await db.first('SELECT 1');
+    });
+    const closePromise = startCloseBudget();
+
+    try {
+      await vi.advanceTimersByTimeAsync(200);
+      expect(db.getDatabase()).not.toBeNull();
+
+      gate.resolve();
+      await expect(mutatorPromise).resolves.toBeUndefined();
+      await vi.runAllTimersAsync();
+      await expect(closePromise).resolves.toBe('ok');
+    } finally {
+      gate.resolve();
+      await vi.runAllTimersAsync();
+      await Promise.allSettled([mutatorPromise, closePromise]);
+    }
+  });
+
+  test('waits for queued mutators before closing the database', async () => {
+    vi.useFakeTimers();
+    const gate = deferred();
+    const events = [];
+    const firstPromise = runMutator(async () => {
+      events.push('first-start');
+      await gate.promise;
+      events.push('first-finish');
+    });
+    const secondPromise = runMutator(async () => {
+      events.push('second-start');
+      await db.first('SELECT 1');
+      events.push('second-finish');
+    });
+    const closePromise = startCloseBudget();
+
+    try {
+      await vi.advanceTimersByTimeAsync(200);
+      expect(db.getDatabase()).not.toBeNull();
+      expect(events).toEqual(['first-start']);
+
+      gate.resolve();
+      await expect(firstPromise).resolves.toBeUndefined();
+      await expect(secondPromise).resolves.toBeUndefined();
+      await vi.runAllTimersAsync();
+      await expect(closePromise).resolves.toBe('ok');
+      expect(events).toEqual([
+        'first-start',
+        'first-finish',
+        'second-start',
+        'second-finish',
+      ]);
+    } finally {
+      gate.resolve();
+      await vi.runAllTimersAsync();
+      await Promise.allSettled([firstPromise, secondPromise, closePromise]);
+    }
+  });
+
+  test('continues closing when a mutator rejects', async () => {
+    vi.useFakeTimers();
+    const gate = deferred();
+    const rejectingPromise = runMutator(async () => {
+      await gate.promise;
+      throw new Error('mutator failed');
+    });
+    const succeedingPromise = runMutator(async () => {
+      await db.first('SELECT 1');
+    });
+    const closePromise = startCloseBudget();
+
+    try {
+      await vi.advanceTimersByTimeAsync(200);
+      expect(db.getDatabase()).not.toBeNull();
+
+      gate.resolve();
+      await expect(rejectingPromise).rejects.toThrow('mutator failed');
+      await expect(succeedingPromise).resolves.toBeUndefined();
+      await vi.runAllTimersAsync();
+      await expect(closePromise).resolves.toBe('ok');
+    } finally {
+      gate.resolve();
+      await vi.runAllTimersAsync();
+      await Promise.allSettled([
+        rejectingPromise,
+        succeedingPromise,
+        closePromise,
+      ]);
+    }
+  });
+});

--- a/packages/loot-core/src/server/mutators.ts
+++ b/packages/loot-core/src/server/mutators.ts
@@ -4,6 +4,7 @@ import { sequential } from '#shared/async';
 import type { HandlerFunctions, Handlers } from '#types/handlers';
 
 const runningMethods = new Set();
+const runningMutators = new Set<Promise<unknown>>();
 
 let currentContext = null;
 const mutatingMethods = new WeakMap();
@@ -24,9 +25,12 @@ async function flushRunningMethods() {
   // Give the client some time to invoke new requests
   await wait(200);
 
-  while (runningMethods.size > 0) {
+  while (runningMethods.size > 0 || runningMutators.size > 0) {
     // Wait for all of them; rejections already went to their callers.
-    await Promise.allSettled([...runningMethods.values()]);
+    await Promise.allSettled([
+      ...runningMethods.values(),
+      ...runningMutators.values(),
+    ]);
 
     // We give clients more time to make other requests. This lets them continue
     // to do an async workflow
@@ -57,9 +61,8 @@ export async function runHandler<T extends Handlers[keyof Handlers]>(
   }
 
   // When closing a file, it clears out all global state for the file. That
-  // means any async workflows currently executed would be cut off. We handle
-  // this by letting all async workflows finish executing before closing the
-  // file
+  // means any async workflows or mutators currently executing would be cut
+  // off. We handle this by letting them finish before closing the file.
   if (name === 'close-budget') {
     await flushRunningMethods();
   }
@@ -95,7 +98,19 @@ function _runMutator<T extends () => Promise<unknown>>(
   }) as Promise<Awaited<ReturnType<T>>>;
 }
 // Type cast needed as TS looses types over nested generic returns
-export const runMutator = sequential(_runMutator) as typeof _runMutator;
+const runMutatorSequential = sequential(_runMutator) as typeof _runMutator;
+
+export function runMutator<T extends () => Promise<unknown>>(
+  func: T,
+  initialContext = {},
+): Promise<Awaited<ReturnType<T>>> {
+  const promise = runMutatorSequential(func, initialContext);
+  runningMutators.add(promise);
+
+  const remove = () => runningMutators.delete(promise);
+  void promise.then(remove, remove);
+  return promise;
+}
 
 export function withMutatorContext<T>(
   context: { undoListening: boolean; undoTag?: unknown },

--- a/packages/loot-core/src/server/schedules/app.test.ts
+++ b/packages/loot-core/src/server/schedules/app.test.ts
@@ -1,10 +1,15 @@
 // @ts-strict-ignore
 import MockDate from 'mockdate';
 
+import * as aql from '#server/aql';
 import { aqlQuery } from '#server/aql';
 import * as db from '#server/db';
 import { loadMappings } from '#server/db/mappings';
+import { handlers } from '#server/main';
+import { runHandler } from '#server/mutators';
+import * as prefs from '#server/prefs';
 import { loadRules, updateRule } from '#server/transactions/transaction-rules';
+import * as monthUtils from '#shared/months';
 import { q } from '#shared/query';
 import { getNextDate } from '#shared/schedules';
 
@@ -917,5 +922,115 @@ describe('schedule app', () => {
         await schedulesApp.stopServices();
       }
     });
+  });
+});
+
+describe('schedule sync listener', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    await prefs.loadPrefs();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    MockDate.reset();
+    prefs.unloadPrefs();
+    vi.restoreAllMocks();
+  });
+
+  function deferred<T>() {
+    let resolve: (value: T | PromiseLike<T>) => void;
+    let reject: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function trackSavedDays() {
+    const savedDays = [];
+    const savePrefs = prefs.savePrefs;
+    vi.spyOn(prefs, 'savePrefs').mockImplementation(async prefsToSet => {
+      savedDays.push(prefsToSet.lastScheduleRun);
+      return savePrefs(prefsToSet);
+    });
+    return savedDays;
+  }
+
+  async function waitForScheduleRuns() {
+    const closePromise = runHandler(handlers['close-budget'], undefined, {
+      name: 'close-budget',
+    });
+    await vi.advanceTimersByTimeAsync(200);
+    await vi.runAllTimersAsync();
+    await closePromise;
+  }
+
+  function mockScheduleQueries() {
+    return vi
+      .spyOn(aql, 'aqlQuery')
+      .mockImplementation(async () => ({ data: [], dependencies: [] }));
+  }
+
+  it('does not run schedules twice for duplicate syncs on the same day', async () => {
+    const runDay = '2024-01-01';
+    vi.spyOn(monthUtils, 'currentDay').mockReturnValue(runDay);
+    const gate = deferred<{ data: unknown; dependencies: string[] }>();
+    const querySpy = mockScheduleQueries();
+    const savedDays = trackSavedDays();
+    querySpy.mockImplementationOnce(() => gate.promise);
+
+    schedulesApp.events.emit('sync', { type: 'success', tables: [] });
+    expect(querySpy).toHaveBeenCalledTimes(1);
+
+    schedulesApp.events.emit('sync', { type: 'success', tables: [] });
+    expect(querySpy).toHaveBeenCalledTimes(1);
+
+    gate.resolve({ data: [], dependencies: [] });
+    await waitForScheduleRuns();
+
+    expect(querySpy).toHaveBeenCalledTimes(3);
+    expect(savedDays).toEqual([runDay]);
+  });
+
+  it('saves the day captured before a run crosses midnight', async () => {
+    const runDay = '2024-01-01';
+    const nextDay = '2024-01-02';
+    const currentDaySpy = vi
+      .spyOn(monthUtils, 'currentDay')
+      .mockReturnValue(runDay);
+    const gate = deferred<{ data: unknown; dependencies: string[] }>();
+    const querySpy = mockScheduleQueries();
+    const savedDays = trackSavedDays();
+    querySpy.mockImplementationOnce(() => gate.promise);
+
+    schedulesApp.events.emit('sync', { type: 'success', tables: [] });
+    expect(querySpy).toHaveBeenCalledTimes(1);
+
+    currentDaySpy.mockReturnValue(nextDay);
+    gate.resolve({ data: [], dependencies: [] });
+    await waitForScheduleRuns();
+
+    expect(savedDays).toEqual([runDay]);
+  });
+
+  it('retries a failed run queued by a later same-day sync', async () => {
+    const runDay = '2024-01-01';
+    vi.spyOn(monthUtils, 'currentDay').mockReturnValue(runDay);
+    const gate = deferred<{ data: unknown; dependencies: string[] }>();
+    const querySpy = mockScheduleQueries();
+    const savedDays = trackSavedDays();
+    querySpy.mockImplementationOnce(() => gate.promise);
+
+    schedulesApp.events.emit('sync', { type: 'success', tables: [] });
+    schedulesApp.events.emit('sync', { type: 'success', tables: [] });
+    expect(querySpy).toHaveBeenCalledTimes(1);
+
+    gate.reject(new Error('schedule run failed'));
+    await waitForScheduleRuns();
+
+    expect(querySpy).toHaveBeenCalledTimes(4);
+    expect(savedDays).toEqual([runDay]);
   });
 });

--- a/packages/loot-core/src/server/schedules/app.ts
+++ b/packages/loot-core/src/server/schedules/app.ts
@@ -846,15 +846,22 @@ app.events.on('sync', ({ type }) => {
       return;
     }
 
+    const runDay = currentDay();
     const { lastScheduleRun } = prefs.getPrefs();
-    if (lastScheduleRun !== currentDay()) {
-      void runMutator(() => advanceSchedulesService(type === 'success'));
+    if (lastScheduleRun !== runDay) {
+      void runMutator(async () => {
+        if (prefs.getPrefs()?.lastScheduleRun === runDay) {
+          return;
+        }
 
-      // Only mark the day as done when sync succeeded, so that
-      // schedule auto-posting is retried on subsequent successful syncs
-      if (type === 'success') {
-        void prefs.savePrefs({ lastScheduleRun: currentDay() });
-      }
+        await advanceSchedulesService(type === 'success');
+
+        // Only mark the day as done when sync succeeded, so that
+        // schedule auto-posting is retried on subsequent successful syncs
+        if (type === 'success') {
+          await prefs.savePrefs({ lastScheduleRun: runDay });
+        }
+      });
     }
   }
 });

--- a/upcoming-release-notes/8791.md
+++ b/upcoming-release-notes/8791.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [cakeni]
+---
+
+Prevent the schedule service from querying a budget database after it closes during shutdown


### PR DESCRIPTION
## Description

Prevent the schedule service from querying a budget database after `close-budget` closes it during shutdown. Mutator work is drained before global budget state is cleared, while duplicate same-day schedule runs are skipped and failed runs remain retryable.

## Related issue(s)

Fixes #8775

## Testing

- Schedule app tests: 26 passed.
- Mutator shutdown regressions: 3 passed.
- Shared async utility tests: 6 passed.
- API methods: 23 passed.
- Formatting, type-aware lint, and the TypeScript build passed.
- The full package typecheck reaches the existing `typescript-strict-plugin` failure: `TS5023: Unknown option 'showConfig'`.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.5 MB → 13.5 MB (+39 B) | +0.00%
loot-core | 1 | 4.63 MB → 4.64 MB (+465 B) | +0.01%
api | 2 | 3.85 MB → 3.85 MB (+455 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.5 MB → 13.5 MB (+39 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`locale/en.json` | 📈 +39 B (+0.02%) | 245.81 kB → 245.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/en.js | 245.81 kB → 245.85 kB (+39 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.64 MB (+465 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +370 B (+17.11%) | 2.11 kB → 2.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +95 B (+0.59%) | 15.73 kB → 15.82 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.DmsCY-GG.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+455 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/mutators.ts` | 📈 +362 B (+17.88%) | 1.98 kB → 2.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +93 B (+0.59%) | 15.4 kB → 15.49 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+455 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->