### PR TITLE
[AI] Keep explicitly cleared fields empty when entering new transactions

### DIFF
--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -1917,11 +1917,15 @@ function TransactionEditUnconnected({
             // (see shouldApplyRuleChange).
             // Or update all fields if the payee changes (assists location-based entry by
             // applying rules to prefill category, notes, etc. based on the selected payee)
+            // — except fields the user explicitly cleared, which must stay empty.
             if (
-              updatedField === 'payee' ||
-              shouldApplyRuleChange(field, newTransaction[field], diff[field], [
-                ...clearedFieldNames.current,
-              ])
+              !clearedFieldNames.current.has(field) &&
+              (updatedField === 'payee' ||
+                shouldApplyRuleChange(
+                  field,
+                  newTransaction[field],
+                  diff[field],
+                ))
             ) {
               (newTransaction as Record<string, unknown>)[field] = diff[field];
               changedFields.add(field);

--- a/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
+++ b/packages/desktop-client/src/components/mobile/transactions/TransactionEdit.tsx
@@ -81,7 +81,10 @@ import {
 } from '#components/mobile/MobileForms';
 import { getPrettyPayee } from '#components/mobile/utils';
 import { MobilePageHeader, Page } from '#components/Page';
-import { shouldApplyRuleChange } from '#components/transactions/table/utils';
+import {
+  isEmptyRuleTarget,
+  shouldApplyRuleChange,
+} from '#components/transactions/table/utils';
 import { useAccounts } from '#hooks/useAccounts';
 import { useCategories } from '#hooks/useCategories';
 import { useCurrentWordRange } from '#hooks/useCurrentWordRange';
@@ -1875,6 +1878,11 @@ function TransactionEditUnconnected({
     searchParams,
   ]);
 
+  // Fields the user explicitly emptied while entering the new transaction.
+  // Rules re-run on every field commit, and they may not re-fill these (e.g.
+  // a cleared pre-assigned category must stay cleared).
+  const clearedFieldNames = useRef(new Set<string>());
+
   const onUpdate = useCallback(
     async (
       serializedTransaction: TransactionEntity,
@@ -1891,6 +1899,12 @@ function TransactionEditUnconnected({
       const newTransaction = { ...transaction };
       const changedFields = new Set<keyof TransactionEntity>([updatedField]);
       if (isTemporary(newTransaction)) {
+        if (isEmptyRuleTarget(newTransaction[updatedField])) {
+          clearedFieldNames.current.add(updatedField);
+        } else {
+          clearedFieldNames.current.delete(updatedField);
+        }
+
         const afterRules = await send('rules-run', {
           transaction: newTransaction,
         });
@@ -1905,18 +1919,24 @@ function TransactionEditUnconnected({
             // applying rules to prefill category, notes, etc. based on the selected payee)
             if (
               updatedField === 'payee' ||
-              shouldApplyRuleChange(field, newTransaction[field], diff[field])
+              shouldApplyRuleChange(field, newTransaction[field], diff[field], [
+                ...clearedFieldNames.current,
+              ])
             ) {
               (newTransaction as Record<string, unknown>)[field] = diff[field];
               changedFields.add(field);
             }
           });
 
-          // When a rule updates a parent transaction, overwrite all changes to the current field in subtransactions.
+          // When a rule updates a parent transaction, overwrite all changes to
+          // the current field in subtransactions — unless the user just
+          // cleared that field on the parent, in which case the rule's value
+          // must not leak into the children either.
           if (
             newTransaction.is_parent &&
             diff.subtransactions !== undefined &&
-            updatedField !== null
+            updatedField !== null &&
+            !isEmptyRuleTarget(newTransaction[updatedField])
           ) {
             newTransaction.subtransactions = diff.subtransactions.map(
               (st, idx) => ({

--- a/packages/desktop-client/src/components/transactions/TransactionList.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionList.tsx
@@ -36,7 +36,7 @@ import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 
-import { shouldApplyRuleChange } from './table/utils';
+import { isEmptyRuleTarget, shouldApplyRuleChange } from './table/utils';
 import { TransactionTable } from './TransactionsTable';
 import type { TransactionTableProps } from './TransactionsTable';
 // When data changes, there are two ways to update the UI:
@@ -265,6 +265,7 @@ export function TransactionList({
     async (
       transaction: TransactionEntity,
       updatedFieldName: string | null = null,
+      clearedFieldNames: readonly string[] = [],
     ) => {
       const afterRules = await send('rules-run', { transaction });
 
@@ -287,17 +288,26 @@ export function TransactionList({
       if (diff) {
         Object.keys(diff).forEach(field => {
           if (
-            shouldApplyRuleChange(field, newTransaction[field], diff[field])
+            shouldApplyRuleChange(
+              field,
+              newTransaction[field],
+              diff[field],
+              clearedFieldNames,
+            )
           ) {
             newTransaction[field] = diff[field];
           }
         });
 
-        // When a rule updates a parent transaction, overwrite all changes to the current field in subtransactions.
+        // When a rule updates a parent transaction, overwrite all changes to
+        // the current field in subtransactions — unless the user just cleared
+        // that field on the parent, in which case the rule's value must not
+        // leak into the children either.
         if (
           transaction.is_parent &&
           diff.subtransactions !== undefined &&
-          updatedFieldName !== null
+          updatedFieldName !== null &&
+          !isEmptyRuleTarget(newTransaction[updatedFieldName])
         ) {
           newTransaction.subtransactions = diff.subtransactions.map(
             (st, idx) => ({

--- a/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
+++ b/packages/desktop-client/src/components/transactions/TransactionsTable.tsx
@@ -156,6 +156,7 @@ import {
 import type { TransactionTableColumnId } from './table/columns';
 import {
   deserializeTransaction,
+  isEmptyRuleTarget,
   isLastChild,
   makeTemporaryTransactions,
   selectAscDesc,
@@ -2612,6 +2613,7 @@ type TransactionTableInnerProps = {
   onApplyRules: (
     transaction: TransactionEntity,
     field: string,
+    clearedFieldNames?: readonly string[],
   ) => Promise<TransactionEntity>;
   onSplit: (id: TransactionEntity['id']) => void;
   onAddSplit: (id: TransactionEntity['id']) => void;
@@ -3022,6 +3024,7 @@ export type TransactionTableProps = {
   onApplyRules: (
     transaction: TransactionEntity,
     field: string | null,
+    clearedFieldNames?: readonly string[],
   ) => Promise<TransactionEntity>;
   onSplit: (id: TransactionEntity['id']) => TransactionEntity['id'];
   onAddSplit: (id: TransactionEntity['id']) => TransactionEntity['id'];
@@ -3288,6 +3291,11 @@ export const TransactionTable = forwardRef(
     const afterSaveFunc = useRef<null | (() => void)>(null);
     const [_, forceRerender] = useState({});
     const selectedItems = useSelectedItems();
+    // Fields the user explicitly emptied while entering the new transaction.
+    // Rules re-run on every field commit, and they may not re-fill these (e.g.
+    // a cleared pre-assigned category must stay cleared until the row is
+    // added or reset).
+    const clearedFieldNames = useRef(new Set<string>());
 
     latestState.current = {
       newTransactions: newTransactions ?? [],
@@ -3299,6 +3307,7 @@ export const TransactionTable = forwardRef(
     // Derive new transactions from the `isAdding` prop
     if (prevIsAdding !== props.isAdding) {
       if (!prevIsAdding && props.isAdding) {
+        clearedFieldNames.current.clear();
         setNewTransactions(
           makeTemporaryTransactions(
             props.currentAccountId,
@@ -3329,6 +3338,7 @@ export const TransactionTable = forwardRef(
         } else {
           const lastDate =
             transactions.length > 0 ? transactions[0].date : null;
+          clearedFieldNames.current.clear();
           setNewTransactions(
             makeTemporaryTransactions(
               props.currentAccountId,
@@ -3381,6 +3391,7 @@ export const TransactionTable = forwardRef(
                 }),
               );
               // Reset form like onAddTemporary does
+              clearedFieldNames.current.clear();
               setNewTransactions(
                 makeTemporaryTransactions(
                   props.currentAccountId,
@@ -3647,9 +3658,20 @@ export const TransactionTable = forwardRef(
 
         if (isTemporaryId(transaction.id)) {
           if (onApplyRulesProp) {
+            // Remember fields the user explicitly emptied so later rule runs
+            // (triggered by edits to other fields) can't re-fill them either.
+            if (updatedFieldName !== null) {
+              if (isEmptyRuleTarget(groupedTransaction[updatedFieldName])) {
+                clearedFieldNames.current.add(updatedFieldName);
+              } else {
+                clearedFieldNames.current.delete(updatedFieldName);
+              }
+            }
+
             groupedTransaction = await onApplyRulesProp(
               groupedTransaction,
               updatedFieldName,
+              [...clearedFieldNames.current],
             );
           }
 
@@ -3940,6 +3962,7 @@ export const TransactionTable = forwardRef(
     );
 
     function onCloseAddTransaction() {
+      clearedFieldNames.current.clear();
       setNewTransactions(
         makeTemporaryTransactions(
           props.currentAccountId,

--- a/packages/desktop-client/src/components/transactions/table/utils.test.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.test.ts
@@ -65,6 +65,29 @@ describe('shouldApplyRuleChange', () => {
       false,
     );
   });
+
+  test('keeps a field empty when the user explicitly cleared it', () => {
+    // Clearing a pre-assigned value (e.g. a category learned from the payee)
+    // is manual input too — rules must not re-fill it, neither on the run for
+    // the clear itself nor on later runs triggered by other field edits.
+    expect(shouldApplyRuleChange('category', null, 'food', ['category'])).toBe(
+      false,
+    );
+    expect(shouldApplyRuleChange('notes', '', 'memo', ['notes'])).toBe(false);
+  });
+
+  test('still fills empty fields the user has not explicitly cleared', () => {
+    expect(shouldApplyRuleChange('category', null, 'food', [])).toBe(true);
+    expect(shouldApplyRuleChange('category', null, 'food', ['notes'])).toBe(
+      true,
+    );
+  });
+
+  test('still applies notes append rules while other fields are cleared', () => {
+    expect(
+      shouldApplyRuleChange('notes', 'Coffee', 'Coffee Tip', ['category']),
+    ).toBe(true);
+  });
 });
 
 describe('deserializeTransaction', () => {

--- a/packages/desktop-client/src/components/transactions/table/utils.ts
+++ b/packages/desktop-client/src/components/transactions/table/utils.ts
@@ -118,24 +118,33 @@ export function selectAscDesc(
     : defaultAscDesc;
 }
 
+// An "empty" value from the perspective of rules: rules are only allowed to
+// fill fields the user left empty.
+export function isEmptyRuleTarget(value: unknown) {
+  return value == null || value === '' || value === 0 || value === false;
+}
+
 // Decides whether a rule result should be applied to a field while the user is
 // entering a new transaction. By default rules only fill fields the user left
-// empty, so their manual input isn't overwritten. The exception is the notes
-// field: append/prepend notes rules intentionally preserve the existing note and
-// add text before or after it, so we allow those through. The check stays
-// idempotent — rules are re-run on every keystroke during entry, so we must not
-// re-add text that the previous run already applied.
+// empty, so their manual input isn't overwritten. Fields the user explicitly
+// emptied (`clearedFieldNames`) also stay empty — clearing a pre-assigned
+// value is manual input too, so rules must not re-fill it on this or any later
+// run while the transaction is still being entered. The exception is the notes
+// field: append/prepend notes rules intentionally preserve the existing note
+// and add text before or after it, so we allow those through. The check stays
+// idempotent — rules are re-run on every keystroke during entry, so we must
+// not re-add text that the previous run already applied.
 export function shouldApplyRuleChange(
   field: string,
   currentValue: unknown,
   nextValue: unknown,
+  clearedFieldNames: readonly string[] = [],
 ) {
-  if (
-    currentValue == null ||
-    currentValue === '' ||
-    currentValue === 0 ||
-    currentValue === false
-  ) {
+  if (clearedFieldNames.includes(field)) {
+    return false;
+  }
+
+  if (isEmptyRuleTarget(currentValue)) {
     return true;
   }
 

--- a/upcoming-release-notes/keep-cleared-fields-on-new-transactions.md
+++ b/upcoming-release-notes/keep-cleared-fields-on-new-transactions.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [bsmarsh333]
+---
+
+Keep explicitly cleared fields (e.g. a pre-assigned category) empty while entering a new transaction instead of letting rules immediately re-fill them.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

When adding a new transaction, the category auto-fills based on the payee. That's helpful, but not always right — and if I tab to the category field, clear it, and save, the transaction still gets the auto-filled category instead of staying uncategorized. This happens because rules re-run on every field commit and treat a deliberately cleared field as "empty, free to fill." This PR makes the entry row remember which fields I explicitly cleared and stops rules from re-filling them (including on later runs, e.g. when the amount is entered after clearing the category). Auto-fill for untouched fields and notes append/prepend rules still work.

This change was written by an AI tool (Claude Code) working under my direction; I reproduced the bug and tested the fix myself.

## Related issue(s)

Fixes the desktop register half of [#7390](https://github.com/actualbudget/actual/issues/7390) (the mobile modal was fixed in [#7521](https://github.com/actualbudget/actual/pull/7521), which closed that issue). Supersedes the stale [#7455](https://github.com/actualbudget/actual/pull/7455).

## Testing

Reproduced on master with a payee→category rule: add transaction → select payee (category auto-fills) → clear category → tab → category reverts; saving stores the rule's category. With this fix, the cleared category stays empty through further edits (including entering the amount afterwards) and the transaction saves as uncategorized. New unit tests cover the shouldApplyRuleChange behavior; yarn test (desktop-client transaction suites), yarn typecheck, and yarn lint all pass.
## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.5 MB → 13.59 MB (+88.83 kB) | +0.64%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.5 MB → 13.59 MB (+88.83 kB) | +0.64%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/transactions/table/utils.ts` | 📈 +129 B (+5.21%) | 2.42 kB → 2.54 kB
`src/components/transactions/TransactionList.tsx` | 📈 +99 B (+1.04%) | 9.29 kB → 9.38 kB
`src/components/mobile/transactions/TransactionEdit.tsx` | 📈 +332 B (+0.52%) | 61.82 kB → 62.15 kB
`src/components/transactions/TransactionsTable.tsx` | 📈 +493 B (+0.51%) | 93.56 kB → 94.04 kB
`locale/en.json` | 📈 +39 B (+0.02%) | 245.81 kB → 245.85 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 167.56 kB (+88.34 kB) | +111.51%
static/js/TransactionEdit.js | 221.38 kB → 221.71 kB (+332 B) | +0.15%
static/js/Value.js | 1.79 MB → 1.79 MB (+129 B) | +0.01%
static/js/en.js | 245.81 kB → 245.85 kB (+39 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.42 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 182.32 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->