### PR TITLE
[WIP] Fix budget name menu not reopening after renaming the budget file

### DIFF
--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -83,24 +83,27 @@ describe('useRefEventListener', () => {
   });
 
   it('rebinds when the ref target element changes without the ref object changing', () => {
-    const elA = makeMockElement();
-    const elB = makeMockElement();
-    const ref = { current: elA } as unknown as RefObject<HTMLElement | null>;
+    const elA = document.createElement('button');
+    const elB = document.createElement('button');
+    const addListenerA = vi.spyOn(elA, 'addEventListener');
+    const removeListenerA = vi.spyOn(elA, 'removeEventListener');
+    const addListenerB = vi.spyOn(elB, 'addEventListener');
+    const ref = { current: elA } satisfies RefObject<HTMLElement | null>;
 
     const { rerender } = renderHook(() =>
       useRefEventListener(ref, 'click', vi.fn()),
     );
 
-    expect(elA.addEventListener).toHaveBeenCalledTimes(1);
+    expect(addListenerA).toHaveBeenCalledTimes(1);
 
     // Simulate a caller that conditionally unmounts the element the ref is
     // attached to and mounts a different one in its place, reusing the same
     // RefObject (e.g. swapping a button for an input while editing).
-    ref.current = elB as unknown as HTMLElement;
+    ref.current = elB;
     rerender();
 
-    expect(elA.removeEventListener).toHaveBeenCalledTimes(1);
-    expect(elB.addEventListener).toHaveBeenCalledTimes(1);
+    expect(removeListenerA).toHaveBeenCalledTimes(1);
+    expect(addListenerB).toHaveBeenCalledTimes(1);
   });
 
   it('removes the listener on unmount', () => {

--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -82,6 +82,27 @@ describe('useRefEventListener', () => {
     expect(el.removeEventListener).toHaveBeenCalledTimes(1);
   });
 
+  it('rebinds when the ref target element changes without the ref object changing', () => {
+    const elA = makeMockElement();
+    const elB = makeMockElement();
+    const ref = { current: elA } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    expect(elA.addEventListener).toHaveBeenCalledTimes(1);
+
+    // Simulate a caller that conditionally unmounts the element the ref is
+    // attached to and mounts a different one in its place, reusing the same
+    // RefObject (e.g. swapping a button for an input while editing).
+    ref.current = elB as unknown as HTMLElement;
+    rerender();
+
+    expect(elA.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(elB.addEventListener).toHaveBeenCalledTimes(1);
+  });
+
   it('removes the listener on unmount', () => {
     const el = makeMockElement();
     const ref = { current: el } as unknown as RefObject<HTMLElement | null>;

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 
 export function useRefEventListener<
@@ -17,9 +17,27 @@ export function useRefEventListener<
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
+  const isStaticTarget = ref instanceof Document || ref instanceof Window;
+
+  // `ref.current` can change without a re-render of this hook (e.g. a
+  // caller conditionally unmounts the element the ref is attached to and
+  // mounts a different one in its place, reusing the same RefObject). The
+  // effect below needs to know when that happens so it can rebind to the
+  // new element instead of staying attached to the detached one.
+  const [target, setTarget] = useState<ElementType | null>(
+    isStaticTarget ? null : ref.current,
+  );
+  // Deliberately runs every render (no deps) to notice when `ref.current`
+  // points at a different element than last time, since ref mutations don't
+  // themselves trigger a re-render. React bails out of the update when
+  // `setTarget` is called with the same value, so this doesn't loop.
+  // oxlint-disable-next-line react-hooks/exhaustive-deps -- must run every render, see comment above
   useEffect(() => {
-    const el =
-      ref instanceof Document || ref instanceof Window ? ref : ref.current;
+    if (!isStaticTarget) setTarget(ref.current);
+  });
+
+  useEffect(() => {
+    const el = isStaticTarget ? ref : target;
     if (!el) return;
 
     const listener: EventListener = e =>
@@ -31,5 +49,5 @@ export function useRefEventListener<
     return () => {
       el.removeEventListener(event, listener);
     };
-  }, [ref, event]);
+  }, [isStaticTarget, ref, event, target]);
 }

--- a/upcoming-release-notes/fix-rename-budget-menu-reopen.md
+++ b/upcoming-release-notes/fix-rename-budget-menu-reopen.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [YatoVoid]
+---
+
+Fix budget name menu not reopening after renaming the budget file


### PR DESCRIPTION
## Description

`useRefEventListener`'s effect was keyed on `[ref, event]`. Since `ref` is a
`useRef` object, its identity never changes, so the effect that binds the
native event listener only ever ran once. `BudgetName` swaps its `Button`
for an `Input` while renaming (reusing the same ref but mounting a new DOM
node), so after a rename the listener stays attached to the detached old
node and the context menu stops opening.

Track the current ref target in state so the effect notices when it
changes and rebinds to the new element.

This PR was drafted with AI assistance (Claude Code): I reviewed the root
cause, the fix, and the test, and verified everything above.

## Related issue(s)

Fixes #8793

## Testing

Added a unit test for `useRefEventListener` that swaps the ref's target
element mid-test and asserts the listener unbinds from the old element and
rebinds to the new one. Ran the full `useRefEventListener` and
`useContextMenu` suites, `yarn typecheck` (web), and `yarn oxlint`/`oxfmt`
on the changed files — all pass.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+253 B) | +0.00%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+253 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useRefEventListener.ts` | 📈 +253 B (+48.28%) | 524 B → 777 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.79 MB → 1.79 MB (+253 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.85 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->