### PR TITLE
[WIP] [AI] Fix budget file menu not reopening after renaming the budget file

### DIFF
--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -67,6 +67,33 @@ describe('useRefEventListener', () => {
     expect(secondCallback).toHaveBeenCalledWith(event);
   });
 
+  it('moves the listener when the ref points at a new element', () => {
+    const el1 = makeMockElement();
+    const el2 = makeMockElement();
+    const ref = { current: el1 } as unknown as RefObject<HTMLElement | null>;
+
+    const { rerender } = renderHook(() =>
+      useRefEventListener(ref, 'click', vi.fn()),
+    );
+
+    expect(el1.addEventListener).toHaveBeenCalledTimes(1);
+
+    // Simulate the trigger element unmounting and a new one mounting,
+    // e.g. a trigger button temporarily replaced by a rename input.
+    ref.current = null;
+    rerender();
+
+    expect(el1.removeEventListener).toHaveBeenCalledTimes(1);
+
+    ref.current = el2 as unknown as HTMLElement;
+    rerender();
+
+    expect(el2.addEventListener).toHaveBeenCalledTimes(1);
+
+    const registeredListener = el2.addEventListener.mock.calls[0][1];
+    expect(registeredListener).toEqual(expect.any(Function));
+  });
+
   it('rebinds when the event name changes', () => {
     const el = makeMockElement();
     const ref = { current: el } as unknown as RefObject<HTMLElement | null>;

--- a/packages/desktop-client/src/hooks/useRefEventListener.test.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.test.ts
@@ -68,30 +68,34 @@ describe('useRefEventListener', () => {
   });
 
   it('moves the listener when the ref points at a new element', () => {
-    const el1 = makeMockElement();
-    const el2 = makeMockElement();
-    const ref = { current: el1 } as unknown as RefObject<HTMLElement | null>;
+    const el1 = document.createElement('button');
+    const el2 = document.createElement('button');
+    const callback = vi.fn();
+    const ref: RefObject<HTMLElement | null> = { current: el1 };
 
     const { rerender } = renderHook(() =>
-      useRefEventListener(ref, 'click', vi.fn()),
+      useRefEventListener(ref, 'click', callback),
     );
 
-    expect(el1.addEventListener).toHaveBeenCalledTimes(1);
+    el1.dispatchEvent(new MouseEvent('click'));
+    expect(callback).toHaveBeenCalledTimes(1);
 
     // Simulate the trigger element unmounting and a new one mounting,
     // e.g. a trigger button temporarily replaced by a rename input.
     ref.current = null;
     rerender();
 
-    expect(el1.removeEventListener).toHaveBeenCalledTimes(1);
+    el1.dispatchEvent(new MouseEvent('click'));
+    expect(callback).toHaveBeenCalledTimes(1);
 
-    ref.current = el2 as unknown as HTMLElement;
+    ref.current = el2;
     rerender();
 
-    expect(el2.addEventListener).toHaveBeenCalledTimes(1);
-
-    const registeredListener = el2.addEventListener.mock.calls[0][1];
-    expect(registeredListener).toEqual(expect.any(Function));
+    el1.dispatchEvent(new MouseEvent('click'));
+    el2.dispatchEvent(new MouseEvent('click'));
+    expect(callback).toHaveBeenCalledTimes(2);
+    // The callback is invoked with the current element as `this`.
+    expect(callback.mock.contexts).toEqual([el1, el2]);
   });
 
   it('rebinds when the event name changes', () => {

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -10,26 +10,51 @@ export function useRefEventListener<
   // oxlint-disable-next-line typescript/no-explicit-any
   callback: (this: ElementType, ev: HTMLElementEventMap[EventType]) => any,
 ) {
-  // Keep the latest callback in a ref so the effect below doesn't need to
+  // Keep the latest callback in a ref so the effects below don't need to
   // depend on it. Callers routinely pass a new inline function every render,
   // which would otherwise tear down and re-add the native listener on every
-  // render instead of only when `ref`/`event` change.
+  // render instead of only when the target element or `event` change.
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
 
+  const attachedRef = useRef<{
+    el: EventTarget;
+    event: string;
+    listener: EventListener;
+  } | null>(null);
+
+  // Runs after every render (no dependency array) so the listener follows
+  // `ref.current` when the trigger element unmounts and a new one mounts
+  // (e.g. a trigger button temporarily replaced by an input). The listener is
+  // only re-attached when the target element or event name actually change.
   useEffect(() => {
     const el =
       ref instanceof Document || ref instanceof Window ? ref : ref.current;
-    if (!el) return;
+    const attached = attachedRef.current;
 
-    const listener: EventListener = e =>
-      callbackRef.current.call(
-        el as ElementType,
-        e as HTMLElementEventMap[EventType],
-      );
-    el.addEventListener(event, listener);
+    if (attached && (attached.el !== el || attached.event !== event)) {
+      attached.el.removeEventListener(attached.event, attached.listener);
+      attachedRef.current = null;
+    }
+
+    if (el && !attachedRef.current) {
+      const listener: EventListener = e =>
+        callbackRef.current.call(
+          el as ElementType,
+          e as HTMLElementEventMap[EventType],
+        );
+      el.addEventListener(event, listener);
+      attachedRef.current = { el, event, listener };
+    }
+  });
+
+  useEffect(() => {
     return () => {
-      el.removeEventListener(event, listener);
+      const attached = attachedRef.current;
+      if (attached) {
+        attached.el.removeEventListener(attached.event, attached.listener);
+        attachedRef.current = null;
+      }
     };
-  }, [ref, event]);
+  }, []);
 }

--- a/packages/desktop-client/src/hooks/useRefEventListener.ts
+++ b/packages/desktop-client/src/hooks/useRefEventListener.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useEffectEvent, useRef } from 'react';
 import type { RefObject } from 'react';
 
 export function useRefEventListener<
@@ -10,12 +10,15 @@ export function useRefEventListener<
   // oxlint-disable-next-line typescript/no-explicit-any
   callback: (this: ElementType, ev: HTMLElementEventMap[EventType]) => any,
 ) {
-  // Keep the latest callback in a ref so the effects below don't need to
-  // depend on it. Callers routinely pass a new inline function every render,
-  // which would otherwise tear down and re-add the native listener on every
-  // render instead of only when the target element or `event` change.
-  const callbackRef = useRef(callback);
-  callbackRef.current = callback;
+  // An Effect Event always sees the latest committed callback, so callers can
+  // pass a new inline function every render without tearing down and
+  // re-adding the native listener. React invokes Effect Events with
+  // `this === undefined`, so the target element is passed explicitly to
+  // preserve the callback's `this: ElementType` contract.
+  const onEvent = useEffectEvent(
+    (el: ElementType, ev: HTMLElementEventMap[EventType]) =>
+      callback.call(el, ev),
+  );
 
   const attachedRef = useRef<{
     el: EventTarget;
@@ -39,10 +42,7 @@ export function useRefEventListener<
 
     if (el && !attachedRef.current) {
       const listener: EventListener = e =>
-        callbackRef.current.call(
-          el as ElementType,
-          e as HTMLElementEventMap[EventType],
-        );
+        onEvent(el as ElementType, e as HTMLElementEventMap[EventType]);
       el.addEventListener(event, listener);
       attachedRef.current = { el, event, listener };
     }

--- a/upcoming-release-notes/fix-switch-file-menu-after-rename.md
+++ b/upcoming-release-notes/fix-switch-file-menu-after-rename.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [kazbekaskarov]
+---
+
+Fix budget file menu not reopening after renaming the budget file


### PR DESCRIPTION
## Description

Fixes a bug where the budget file menu (rename / settings / switch file) could not be reopened after renaming the budget file, until a full page reload.

**Root cause:** `useRefEventListener` attached the native listener to the element captured on first mount and only re-ran its effect when the ref object identity or the event name changed — but a `useRef` object is referentially stable forever, so the effect never re-ran. In `BudgetName.tsx`, entering rename mode unmounts the trigger `<Button>` and replaces it with an `<Input>`; on confirm, a *new* button element mounts, but the `contextmenu` listener stayed bound to the old detached element. `handleContextMenu` then dispatched the synthetic `contextmenu` event on the new button, where no listener existed, so the menu never opened.

**Fix:** the hook now tracks which element the listener is attached to and moves it whenever `ref.current` points at a new element, while still avoiding re-binding when only the callback identity changes (existing tests cover that guarantee and still pass unchanged).

This also fixes the same latent issue for other consumers of the hook whose trigger elements can remount (`useCursorPosition`, `useInputRefValue`, `useContextMenu`).

AI disclosure: this change was developed with the assistance of an AI coding agent (GitHub Copilot CLI); I have reviewed every line of the diff.

## Related issue(s)

Fixes #8793

## Testing

Reproduced the bug per the issue:
1. Open a budget file
2. Click the budget file name → Rename
3. Confirm the new name
4. Click the budget file name again → menu does not open until page reload

After the fix, the menu opens again immediately after renaming.

Added a unit test to `useRefEventListener.test.ts` (`moves the listener when the ref points at a new element`) that simulates the trigger element unmounting and a new one mounting, and verifies the listener is removed from the old element and attached to the new one. Existing tests for callback-identity stability, event-name rebinding, and unmount cleanup pass unchanged.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+984 B) | +0.01%
loot-core | 1 | 4.63 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+984 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useRefEventListener.ts` | 📈 +984 B (+187.79%) | 524 B → 1.47 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/Value.js | 1.79 MB → 1.79 MB (+984 B) | +0.05%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.85 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->