### PR TITLE
[AI] Fix CLI failing to push changes to end-to-end encrypted budgets

### DIFF
--- a/packages/cli/src/connection.test.ts
+++ b/packages/cli/src/connection.test.ts
@@ -146,7 +146,7 @@ describe('withConnection', () => {
     expect(api.sync).toHaveBeenCalledTimes(1);
   });
 
-  it('encrypted budget forces a sync on a read inside the TTL', async () => {
+  it('encrypted budget syncs through downloadBudget on a read inside the TTL', async () => {
     setConfig({ encryptionPassword: 'secret' });
     writeCacheState(metaDirFor('sync-1'), {
       version: 1,
@@ -157,7 +157,44 @@ describe('withConnection', () => {
       lastDownloadedAt: Date.now(),
     });
     await withConnection({}, async () => 'ok', { mutates: false });
+    expect(api.downloadBudget).toHaveBeenCalledWith('sync-1', {
+      password: 'secret',
+    });
+    expect(api.loadBudget).not.toHaveBeenCalled();
+  });
+
+  it('encrypted budget registers the encryption key before a write pushes', async () => {
+    setConfig({ encryptionPassword: 'secret' });
+    writeCacheState(metaDirFor('sync-1'), {
+      version: 1,
+      syncId: 'sync-1',
+      budgetId: 'bud-disk-1',
+      serverUrl: 'http://test',
+      lastSyncedAt: Date.now(),
+      lastDownloadedAt: Date.now(),
+    });
+    await withConnection({}, async () => 'ok', { mutates: true });
+    // `loadBudget` would leave the key unregistered and the push below would
+    // fail with `encrypt-failure`.
+    expect(api.downloadBudget).toHaveBeenCalledWith('sync-1', {
+      password: 'secret',
+    });
+    expect(api.loadBudget).not.toHaveBeenCalled();
     expect(api.sync).toHaveBeenCalledTimes(1);
+  });
+
+  it('unencrypted budget still syncs through loadBudget', async () => {
+    writeCacheState(metaDirFor('sync-1'), {
+      version: 1,
+      syncId: 'sync-1',
+      budgetId: 'bud-disk-1',
+      serverUrl: 'http://test',
+      lastSyncedAt: Date.now(),
+      lastDownloadedAt: Date.now(),
+    });
+    await withConnection({}, async () => 'ok', { mutates: true });
+    expect(api.loadBudget).toHaveBeenCalledWith('bud-disk-1');
+    expect(api.downloadBudget).not.toHaveBeenCalled();
   });
 
   it('invalidates cache when syncId changes', async () => {

--- a/packages/cli/src/connection.ts
+++ b/packages/cli/src/connection.ts
@@ -127,6 +127,19 @@ export async function withConnection<T>(
         info(`Using cached budget (synced ${age}s ago)...`, globalOpts.verbose);
         await api.loadBudget(decision.state.budgetId);
         state = decision.state;
+      } else if (config.encryptionPassword) {
+        info(`Syncing budget ${config.syncId}...`, globalOpts.verbose);
+        // `loadBudget` does not register the end-to-end encryption key, so a
+        // later push fails with `encrypt-failure` / `isMissingKey`. Reads still
+        // work, which makes the failure look like a broken budget file rather
+        // than a missing key. `downloadBudget` registers the key via `key-test`
+        // and, when the budget already exists locally, just loads and syncs it
+        // instead of re-downloading, so this costs nothing extra.
+        await api.downloadBudget(config.syncId, {
+          password: config.encryptionPassword,
+        });
+        state = { ...decision.state, lastSyncedAt: Date.now() };
+        writeCacheState(meta, state);
       } else {
         info(`Syncing budget ${config.syncId}...`, globalOpts.verbose);
         await api.loadBudget(decision.state.budgetId);

--- a/upcoming-release-notes/8800.md
+++ b/upcoming-release-notes/8800.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [ivanovart]
+---
+
+Fix the CLI failing to push changes to end-to-end encrypted budgets


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->
The CLI cannot push changes to an end-to-end encrypted budget. Any mutating command fails on the sync that follows it, and from that point every subsequent CLI command fails to open the budget at all.

`withConnection` in `packages/cli/src/connection.ts` picks one of three ways to open the budget. Only the `download` branch passes the encryption password:

```ts
await api.downloadBudget(config.syncId, { password: config.encryptionPassword });
```

The `skip` and `sync` branches call `api.loadBudget(budgetId)` instead, which has no password parameter and never registers the E2E key. `api/download-budget` is what performs `key-test` and puts the key in place; `api/load-budget` does not.

`decideSyncAction` routes every mutating command to the `sync` branch, so as soon as a budget is cached, a write opens it without a key. The mutation itself is applied to the local database and the command reports success, then the push fails:

```
SyncError: encrypt-failure
  meta: { isMissingKey: true }
```

After that the budget is left in a state where every later command — including reads — fails with:

```
Error: We had an unknown problem opening "<budget-name>".
```

Two things make this hard to diagnose:

- **It only bites after the first run.** On a cold cache `decideSyncAction` returns `download`, the key is registered, and everything works. The failure appears later, once a cache exists.
- **Reads keep working, so the password looks correct — and it is.** Decoding does not need the registered key; only encoding does. The error surfaces on the push, and the follow-up message names the budget file, so it reads like a corrupt or unreadable budget rather than a missing key.

### The fix

Route encrypted budgets through `downloadBudget` on the `sync` branch. When the budget already exists locally, `api/download-budget` runs `key-test` → `load-budget` → `sync-budget` and returns without re-downloading the file (`packages/loot-core/src/server/api.ts`), so this registers the key at no extra bandwidth cost — it is the same work the `sync` branch already did, plus the key.

`lastDownloadedAt` is deliberately left untouched, since nothing is downloaded.

The `skip` branch is left alone on purpose: `decideSyncAction` always returns `sync` when `encrypted` is set, so `skip` is unreachable for encrypted budgets and handling it there would be dead code.

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->
This change was written with Claude Code (Claude Opus 5): the diagnosis, the patch, and the tests.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Reproduction (before the fix), against a sync server with an end-to-end encrypted budget:

1. Configure the CLI with `ACTUAL_SERVER_URL`, `ACTUAL_SYNC_ID`, `ACTUAL_ENCRYPTION_PASSWORD` and either `ACTUAL_PASSWORD` or `ACT
UAL_SESSION_TOKEN`.
2. Run any read command, e.g. `actual accounts list`. It succeeds and populates the cache.
3. Run any mutating command, e.g. `actual transactions update <id> --data '{"notes":"test"}'`. It prints `"success": true`, then f
ails on the push.
4. Run `actual accounts list` again — it now fails with `We had an unknown problem opening "<budget-name>"`.
5. Re-run with `--verbose` to see `SyncError: encrypt-failure` and `meta: { isMissingKey: true }`.
6. `actual sync --clear` restores read access, because the next command takes the `download` branch — and step 3 breaks it again.

After the fix, step 3 pushes successfully and step 4 keeps working.

Automated coverage in `packages/cli/src/connection.test.ts`:

- `encrypted budget syncs through downloadBudget on a read inside the TTL` — replaces a test that asserted the buggy behaviour (it
 expected the key-less `loadBudget` + `sync` path).
- `encrypted budget registers the encryption key before a write pushes` — pins the regression directly: encrypted + existing cache
 + `mutates: true` must open via `downloadBudget` with the password, never `loadBudget`.
- `unencrypted budget still syncs through loadBudget` — guards the unencrypted path against changing.

Both new tests fail without the fix and pass with it. `yarn workspace @actual-app/cli run test`: 178 passed. `typecheck` and `lint
:fix` clean.

## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.7 MB | 0%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB → 8.02 MB (+306 B) | +0.00%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.7 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.64 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.46 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 219.59 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 186.5 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.92 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 212.8 kB | 0%
static/js/theme.js | 31.68 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.53 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.D1rKdvS-.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+306 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/connection.ts` | 📈 +306 B (+9.01%) | 3.32 kB → 3.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+306 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->