### PR TITLE
[AI] Add fixed-start live time filter to reports

### DIFF
--- a/packages/component-library/src/DateRangePicker.tsx
+++ b/packages/component-library/src/DateRangePicker.tsx
@@ -45,6 +45,12 @@ type DateRangePickerProps = {
   /** Pass `['month', 'day']` for callers that handle day-shaped values. */
   granularities?: DateRangeGranularity[];
   presets?: DateRangePreset[];
+  /**
+   * A single click completes the selection (`[picked, picked]`) instead of
+   * requiring a second click for the other bound; used by callers that
+   * derive the end bound themselves (e.g. a rolling "fixed start" range).
+   */
+  selectStartOnly?: boolean;
   firstDayOfWeek?: FirstDayOfWeek;
   /** BCP 47 language tag driving all date formatting. */
   locale: string;
@@ -75,6 +81,7 @@ export function DateRangePicker({
   maxDate,
   granularities = ['month'],
   presets,
+  selectStartOnly = false,
   firstDayOfWeek = 'sun',
   locale,
   formatDayLabel,
@@ -160,6 +167,21 @@ export function DateRangePicker({
     }
   }
 
+  // In selectStartOnly mode the first click completes the pick: commit the
+  // single bound immediately and close. The caller resolves the other bound.
+  // A direct pick always wins over any previewed preset.
+  function changeDraft(nextStart: string, nextEnd: string) {
+    setDraft(nextStart, nextEnd);
+    if (!selectStartOnly) {
+      return;
+    }
+    skipCommitRef.current = true;
+    setIsOpen(false);
+    if (nextStart !== start || nextEnd !== end) {
+      onChangeDates(nextStart, nextEnd);
+    }
+  }
+
   const hasSidebar = showGranularityToggle || Boolean(presets?.length);
 
   function setDraft(nextStart: string, nextEnd: string) {
@@ -228,7 +250,7 @@ export function DateRangePicker({
                 firstDayOfWeek={firstDayOfWeek}
                 locale={locale}
                 labels={labels}
-                onChange={setDraft}
+                onChange={changeDraft}
               />
             ) : (
               <RangeSelector
@@ -238,7 +260,7 @@ export function DateRangePicker({
                 max={monthMax}
                 locale={locale}
                 labels={labels}
-                onChange={setDraft}
+                onChange={changeDraft}
               />
             )}
           </View>
@@ -269,18 +291,35 @@ export function DateRangePicker({
                     }}
                   >
                     {presets?.map(preset => {
-                      // Derive the active preset from the shown range instead
-                      // of storing it, so it survives closing and reopening
-                      // without persisting anything.
+                      // While a preset is being previewed, it alone is
+                      // active. Otherwise derive the active preset from the
+                      // shown range so it survives closing and reopening
+                      // without persisting anything; a preset may override
+                      // the check when range equality would be ambiguous.
                       const [presetStart, presetEnd] = preset.getRange();
-                      const isActive =
-                        presetStart === draftStart && presetEnd === draftEnd;
+                      const isActive = draftPreset
+                        ? draftPreset.key === preset.key
+                        : (preset.isActive ??
+                          (presetStart === draftStart &&
+                            presetEnd === draftEnd));
                       return (
                         <Button
                           key={preset.key}
                           variant={isActive ? 'primary' : 'bare'}
                           aria-pressed={isActive}
                           onPress={() => {
+                            if (preset.commitOnSelect) {
+                              // Commit immediately (the parent re-renders
+                              // with the preset's semantics) but keep the
+                              // picker open for the follow-up pick. Clear
+                              // the pending preset so closing later does
+                              // not re-commit it.
+                              setDraftStart(presetStart);
+                              setDraftEnd(presetEnd);
+                              setDraftPreset(null);
+                              preset.onSelect();
+                              return;
+                            }
                             // Preview in the draft; the commit happens on
                             // close, like manual selection.
                             setDraftStart(presetStart);

--- a/packages/component-library/src/date-range-picker/util.ts
+++ b/packages/component-library/src/date-range-picker/util.ts
@@ -21,6 +21,18 @@ export type DateRangePreset = {
   getRange: () => [string, string];
   /** Commits the preset; called on close if it is still the selection. */
   onSelect: () => void;
+  /**
+   * Commits immediately when clicked (keeping the picker open) instead of
+   * waiting for close; for presets that arm a follow-up interaction, e.g.
+   * pinning a start date the user then picks.
+   */
+  commitOnSelect?: boolean;
+  /**
+   * Overrides the default active check (range equality with the current
+   * draft). Provide `false` to keep the preset from ever highlighting, e.g.
+   * when another preset's range could coincide with it.
+   */
+  isActive?: boolean;
 };
 
 /** All user-facing strings, translated by the caller. */

--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -139,7 +139,10 @@ test.describe('Reports', () => {
     // The picked month is the start; the end is the app's current month.
     // The mode button still presents as Live since fixed start lives
     // within it.
-    const formatOptions = { month: 'short', year: 'numeric' } as const;
+    const formatOptions = {
+      month: 'short',
+      year: 'numeric',
+    } satisfies Intl.DateTimeFormatOptions;
     const expectedStart = target.toLocaleDateString('en-US', formatOptions);
     const expectedEnd = new Date(endYear, endMonthIdx, 1).toLocaleDateString(
       'en-US',

--- a/packages/desktop-client/e2e/reports.test.ts
+++ b/packages/desktop-client/e2e/reports.test.ts
@@ -76,6 +76,86 @@ test.describe('Reports', () => {
     await expect(picker).toMatchThemeScreenshots();
   });
 
+  test('pins a fixed start date that keeps tracking the current month', async () => {
+    await reportsPage.goToNetWorthPage();
+
+    const trigger = page.getByTestId('date-range-picker-trigger');
+    const initialLabel = await trigger.innerText();
+    // The test file pins "now" to January 2017, so read the app's current
+    // month from the range end rather than using the real clock.
+    const [, , , endShortMonth, endYearText] =
+      initialLabel.match(/(\w{3}) (\d{4}) – (\w{3}) (\d{4})/) ?? [];
+    const endYear = Number(endYearText);
+    const endMonthIdx = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ].indexOf(endShortMonth);
+    const startYear = Number(initialLabel.match(/(\d{4})/)?.[1]);
+
+    await trigger.click();
+    const picker = page.locator('[data-popover]');
+
+    // Opt into the fixed-start filter; it commits immediately and keeps
+    // the picker open so a single month click pins the start.
+    const fromStartDate = picker.getByRole('button', {
+      name: 'From start date',
+    });
+    await fromStartDate.click();
+    await expect(fromStartDate).toHaveAttribute('aria-pressed', 'true');
+
+    // While fixed start is active, no other preset may highlight even when
+    // its range coincides (Year to date also ends at the current month).
+    await expect(
+      picker.getByRole('button', { name: 'Year to date', exact: true }),
+    ).toHaveAttribute('aria-pressed', 'false');
+
+    // Pin the month before the app's current month (navigate the year grid
+    // there first if the displayed year differs).
+    const target = new Date(endYear, endMonthIdx - 1, 1);
+    const targetYear = target.getFullYear();
+    for (let year = startYear; year < targetYear; year++) {
+      await picker.getByRole('button', { name: 'Next' }).click();
+    }
+    await picker
+      .getByRole('button', {
+        name: target.toLocaleDateString('en-US', {
+          month: 'long',
+          year: 'numeric',
+        }),
+      })
+      .click();
+    await expect(picker).toBeHidden();
+
+    // The picked month is the start; the end is the app's current month.
+    // The mode button still presents as Live since fixed start lives
+    // within it.
+    const formatOptions = { month: 'short', year: 'numeric' } as const;
+    const expectedStart = target.toLocaleDateString('en-US', formatOptions);
+    const expectedEnd = new Date(endYear, endMonthIdx, 1).toLocaleDateString(
+      'en-US',
+      formatOptions,
+    );
+    await expect(trigger).toContainText(`${expectedStart} – ${expectedEnd}`);
+    await expect(page.getByRole('button', { name: 'Live' })).toBeVisible();
+
+    // Persist the widget, reload, and verify the stored fixed-start range
+    // re-resolves: the pinned start is kept while the end snaps back to
+    // the current month.
+    await page.getByRole('button', { name: 'Save widget' }).click();
+    await page.reload();
+    await expect(trigger).toContainText(`${expectedStart} – ${expectedEnd}`);
+  });
+
   test.describe('balance forecast', () => {
     test.beforeEach(async () => {
       const settingsPage = await navigation.goToSettingsPage();

--- a/packages/desktop-client/src/components/formula/QueryManager.tsx
+++ b/packages/desktop-client/src/components/formula/QueryManager.tsx
@@ -385,24 +385,46 @@ function QueryItem({
   ]);
 
   function handleStartDateChange(newStart: string) {
-    setStartDate(normalizeQueryTimeFrameStart(newStart));
+    const normalized = normalizeQueryTimeFrameStart(newStart);
+    if (timeRangeRef.current === 'static-start') {
+      // In fixed-start mode a start pick moves the pinned start and lets
+      // the end keep tracking the current month.
+      const newEnd = monthUtils.currentMonth();
+      setStartDate(normalized);
+      setEndDate(newEnd);
+      sendUpdate(
+        filters.conditions,
+        filters.conditionsOp,
+        normalized,
+        newEnd,
+        'static-start',
+      );
+      return;
+    }
+    setStartDate(normalized);
     sendUpdate(
       filters.conditions,
       filters.conditionsOp,
-      normalizeQueryTimeFrameStart(newStart),
+      normalized,
       endDate,
       timeRangeRef.current as TimeFrame['mode'],
     );
   }
 
   function handleEndDateChange(newEnd: string) {
-    setEndDate(normalizeQueryTimeFrameEnd(newEnd));
+    const normalized = normalizeQueryTimeFrameEnd(newEnd);
+    // Explicitly picking an end bound in fixed-start mode freezes the range.
+    const nextMode =
+      timeRangeRef.current === 'static-start'
+        ? 'static'
+        : (timeRangeRef.current as TimeFrame['mode']);
+    setEndDate(normalized);
     sendUpdate(
       filters.conditions,
       filters.conditionsOp,
       startDate,
-      normalizeQueryTimeFrameEnd(newEnd),
-      timeRangeRef.current as TimeFrame['mode'],
+      normalized,
+      nextMode,
     );
   }
 
@@ -494,9 +516,15 @@ function QueryItem({
 
   const timeRangeMode = timeRangeRef.current as TimeFrame['mode'];
   const isPresetTimeRange = isPresetTimeRangeMode(timeRangeMode);
+  // Fixed start behaves like a preset (read-only summary, locked end) but
+  // keeps the start selectable.
+  const isFixedStartTimeRange = timeRangeMode === 'static-start';
   const timeRangeLabels = {
     'sliding-window': t('Live'),
     static: t('Static'),
+    // Stored internally by the "From start date" quick select; presented
+    // as "Live".
+    'static-start': t('Live'),
     full: t('All time'),
     lastMonth: t('Last month'),
     lastYear: t('Last year'),
@@ -514,6 +542,7 @@ function QueryItem({
     priorYearToDate: t('Prior year to date transactions'),
     currentQuarter: t('Current quarter transactions'),
     previousQuarter: t('Previous quarter transactions'),
+    'static-start': t('From start date'),
   } satisfies Record<PresetTimeRangeMode, string>;
   const presetTimeRangeLabel = isPresetTimeRange
     ? presetTimeRangeLabels[timeRangeMode]
@@ -714,9 +743,11 @@ function QueryItem({
                 let start: string, end: string, mode: TimeFrame['mode'];
                 const currentMode = timeRangeRef.current as TimeFrame['mode'];
                 // For quick selections, use the current toggle state (static vs sliding-window)
-                const quickSelectMode = ['static', 'sliding-window'].includes(
-                  currentMode,
-                )
+                const quickSelectMode = [
+                  'static',
+                  'sliding-window',
+                  'static-start',
+                ].includes(currentMode)
                   ? currentMode
                   : 'sliding-window';
 
@@ -819,6 +850,14 @@ function QueryItem({
                     mode = 'full';
                     break;
                   }
+                  case 'from-start-date': {
+                    // Pin the current start; the end keeps tracking the
+                    // current month.
+                    start = startDate;
+                    end = monthUtils.currentMonth();
+                    mode = 'static-start';
+                    break;
+                  }
                   default:
                     return;
                 }
@@ -850,6 +889,7 @@ function QueryItem({
                 { name: 'current-quarter', text: t('Current quarter') },
                 { name: 'previous-quarter', text: t('Previous quarter') },
                 { name: 'all-time', text: t('All time') },
+                { name: 'from-start-date', text: t('From start date') },
               ]}
             />
           </Popover>
@@ -879,7 +919,7 @@ function QueryItem({
             }}
           >
             <Select
-              disabled={isPresetTimeRange}
+              disabled={isPresetTimeRange && !isFixedStartTimeRange}
               value={fromDateRepr(startDate)}
               defaultLabel={monthUtils.format(
                 fromDateRepr(startDate),

--- a/packages/desktop-client/src/components/reports/Header.tsx
+++ b/packages/desktop-client/src/components/reports/Header.tsx
@@ -106,6 +106,36 @@ export function Header({
   const language = useLanguage();
   const dateFormat = useDateFormat() || 'MM/dd/yyyy';
 
+  // In fixed-start mode a single pick sets the start; the end keeps tracking
+  // the current month. Any other live mode preserves the window width.
+  const isFixedStart = mode === 'static-start';
+
+  function onChangePickedDates(newStart: string, newEnd: string) {
+    if (!mode || mode === 'static') {
+      onChangeDates(newStart, newEnd, 'static');
+      return;
+    }
+    if (isFixedStart) {
+      // Manual picks keep the rolling end instead of demoting to a fully
+      // static range.
+      const [fixedStart, fixedEnd] = calculateTimeRange({
+        start: newStart,
+        end: newEnd,
+        mode: 'static-start',
+      });
+      onChangeDates(fixedStart, fixedEnd, 'static-start');
+      return;
+    }
+    // Default for live modes: keep the picked range relative — it slides
+    // forward preserving its width.
+    const [liveStart, liveEnd] = calculateTimeRange({
+      start: newStart,
+      end: newEnd,
+      mode: 'sliding-window',
+    });
+    onChangeDates(liveStart, liveEnd, 'sliding-window');
+  }
+
   // Live-range presets return day-shaped bounds; collapse them to months.
   function liveRangeAsMonths(
     rangeName: string,
@@ -214,7 +244,31 @@ export function Header({
               ),
             ]
           : []),
+        // Pins the current start and lets the end keep tracking the current
+        // month. Commits immediately and keeps the picker open so a single
+        // month click then moves the pinned start.
+        {
+          key: 'from-start-date',
+          label: <Trans>From start date</Trans>,
+          commitOnSelect: true,
+          getRange: () => [start, monthUtils.currentMonth()],
+          onSelect: () =>
+            onChangeDates(start, monthUtils.currentMonth(), 'static-start'),
+        },
       ];
+
+  // Highlighting defaults to range equality, but a fixed-start window can
+  // coincide with other presets' ranges (e.g. Year to date). While it is
+  // active, only "From start date" may appear highlighted.
+  const presetsWithActiveState = presets.map(preset => ({
+    ...preset,
+    isActive:
+      preset.key === 'from-start-date'
+        ? isFixedStart
+        : isFixedStart
+          ? false
+          : undefined,
+  }));
 
   return (
     <View
@@ -253,6 +307,7 @@ export function Header({
             start={start}
             end={end}
             granularities={granularities}
+            selectStartOnly={isFixedStart}
             // allMonths is newest-first and may be empty before reports load.
             minDate={
               allMonths.length
@@ -281,10 +336,8 @@ export function Header({
               year: t('Year'),
               dateRange: t('Date range'),
             }}
-            presets={presets}
-            onChangeDates={(newStart, newEnd) =>
-              onChangeDates(newStart, newEnd, 'static')
-            }
+            presets={presetsWithActiveState}
+            onChangeDates={onChangePickedDates}
           />
           {filters && (
             <FilterButton

--- a/packages/desktop-client/src/components/reports/ReportOptions.ts
+++ b/packages/desktop-client/src/components/reports/ReportOptions.ts
@@ -227,6 +227,16 @@ const dateRangeOptions: dateRangeProps[] = [
     Monthly: true,
     Yearly: true,
   },
+  {
+    description: t('From start date'),
+    key: 'fromStartDate',
+    name: 'fromStartDate',
+    type: 'Month',
+    Daily: true,
+    Weekly: true,
+    Monthly: true,
+    Yearly: true,
+  },
 ];
 
 type intervalOptionsProps = {

--- a/packages/desktop-client/src/components/reports/ReportSidebar.tsx
+++ b/packages/desktop-client/src/components/reports/ReportSidebar.tsx
@@ -127,6 +127,7 @@ export function ReportSidebar({
         latestTransaction,
         customReportItems.includeCurrentInterval,
         firstDayOfWeekIdx,
+        customReportItems.startDate,
       ),
     );
   };
@@ -571,41 +572,82 @@ export function ReportSidebar({
           </ModeButton>
         </SpaceBetween>
         {!customReportItems.isDateStatic ? (
-          <View
-            style={{
-              flexDirection: 'row',
-              padding: 5,
-              alignItems: 'center',
-            }}
-          >
-            <Text style={{ width: 50, textAlign: 'right', marginRight: 5 }}>
-              <Trans>Range:</Trans>
-            </Text>
-            <Select
-              value={customReportItems.dateRange}
-              onChange={onSelectRange}
-              options={rangeOptions}
-            />
-            {!disabledList.currentInterval.get(customReportItems.dateRange) &&
-              customReportItems.includeCurrentInterval && (
-                <Tooltip
-                  placement="bottom start"
-                  content={
-                    <Text>
-                      <Trans>Current month</Trans>
-                    </Text>
+          <>
+            <View
+              style={{
+                flexDirection: 'row',
+                padding: 5,
+                alignItems: 'center',
+              }}
+            >
+              <Text style={{ width: 50, textAlign: 'right', marginRight: 5 }}>
+                <Trans>Range:</Trans>
+              </Text>
+              <Select
+                value={customReportItems.dateRange}
+                onChange={onSelectRange}
+                options={rangeOptions}
+              />
+              {!disabledList.currentInterval.get(customReportItems.dateRange) &&
+                customReportItems.includeCurrentInterval && (
+                  <Tooltip
+                    placement="bottom start"
+                    content={
+                      <Text>
+                        <Trans>Current month</Trans>
+                      </Text>
+                    }
+                    style={{
+                      ...styles.tooltip,
+                      lineHeight: 1.5,
+                      padding: '6px 10px',
+                      marginTop: 5,
+                    }}
+                  >
+                    <Text style={{ marginLeft: 10 }}>+1</Text>
+                  </Tooltip>
+                )}
+            </View>
+            {customReportItems.dateRange === 'fromStartDate' && (
+              <View
+                style={{
+                  flexDirection: 'row',
+                  padding: 5,
+                  alignItems: 'center',
+                }}
+              >
+                <Text style={{ width: 50, textAlign: 'right', marginRight: 5 }}>
+                  <Trans>From:</Trans>
+                </Text>
+                <Select
+                  value={customReportItems.startDate}
+                  onChange={newValue =>
+                    onChangeDates(
+                      ...getLiveRange(
+                        'fromStartDate',
+                        earliestTransaction,
+                        latestTransaction,
+                        customReportItems.includeCurrentInterval,
+                        firstDayOfWeekIdx,
+                        newValue,
+                      ),
+                    )
                   }
-                  style={{
-                    ...styles.tooltip,
-                    lineHeight: 1.5,
-                    padding: '6px 10px',
-                    marginTop: 5,
-                  }}
-                >
-                  <Text style={{ marginLeft: 10 }}>+1</Text>
-                </Tooltip>
-              )}
-          </View>
+                  defaultLabel={monthUtils.format(
+                    customReportItems.startDate,
+                    ReportOptions.intervalFormat.get(
+                      customReportItems.interval,
+                    ) || '',
+                    locale,
+                  )}
+                  options={allIntervals.map(({ name, pretty }) => [
+                    name,
+                    pretty,
+                  ])}
+                />
+              </View>
+            )}
+          </>
         ) : (
           <>
             <View

--- a/packages/desktop-client/src/components/reports/disabledList.ts
+++ b/packages/desktop-client/src/components/reports/disabledList.ts
@@ -65,6 +65,10 @@ const currentIntervalOptions = [
     description: t('All time'),
     disableInclude: true,
   },
+  {
+    description: t('From start date'),
+    disableInclude: true,
+  },
 ];
 
 type graphOptions = {

--- a/packages/desktop-client/src/components/reports/disabledList.ts
+++ b/packages/desktop-client/src/components/reports/disabledList.ts
@@ -66,7 +66,7 @@ const currentIntervalOptions = [
     disableInclude: true,
   },
   {
-    description: t('From start date'),
+    description: 'fromStartDate',
     disableInclude: true,
   },
 ];

--- a/packages/desktop-client/src/components/reports/disabledList.ts
+++ b/packages/desktop-client/src/components/reports/disabledList.ts
@@ -66,7 +66,8 @@ const currentIntervalOptions = [
     disableInclude: true,
   },
   {
-    description: 'fromStartDate',
+    description: t('From start date'),
+    key: 'fromStartDate',
     disableInclude: true,
   },
 ];
@@ -240,7 +241,10 @@ export const disabledList = {
     modeOptions.map(item => [item.description, item.disabledGraph]),
   ),
   currentInterval: new Map(
-    currentIntervalOptions.map(item => [item.description, item.disableInclude]),
+    currentIntervalOptions.map(item => [
+      (item as { key?: string; description: string }).key ?? item.description,
+      item.disableInclude,
+    ]),
   ),
 };
 

--- a/packages/desktop-client/src/components/reports/getLiveRange.test.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.test.ts
@@ -204,5 +204,38 @@ describe('getLiveRange', () => {
       );
       expect(mode).toBe('static-start');
     });
+
+    it('clamps a persisted future startDate to today to avoid an inverted range', () => {
+      const [start, end, mode] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2017-06-01',
+      );
+
+      // currentDay() in test mode is '2017-01-01'; a saved start beyond
+      // today must not produce start > end.
+      expect(start).toBe('2017-01-01');
+      expect(end).toBe('2017-01-01');
+      expect(start <= end).toBe(true);
+      expect(mode).toBe('static-start');
+    });
+
+    it('clamps a persisted future month-shaped startDate after normalization', () => {
+      const [start, end] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2017-06',
+      );
+
+      // '2017-06' is padded to '2017-06-01' before clamping.
+      expect(start).toBe('2017-01-01');
+      expect(end).toBe('2017-01-01');
+    });
   });
 });

--- a/packages/desktop-client/src/components/reports/getLiveRange.test.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.test.ts
@@ -115,4 +115,94 @@ describe('getLiveRange', () => {
       expect(end).toBe('2016-12-31');
     });
   });
+
+  describe('From start date', () => {
+    it('pins the saved start and ends today', () => {
+      const [start, end] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2016-03-15',
+      );
+
+      expect(start).toBe('2016-03-15');
+      expect(end).toBe('2017-01-01');
+    });
+
+    it('pads a month-shaped saved start to days', () => {
+      const [start, end] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2016-03',
+      );
+
+      expect(start).toBe('2016-03-01');
+      expect(end).toBe('2017-01-01');
+    });
+
+    it('clamps the saved start to earliestTransaction', () => {
+      const [start, end] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2014-06-01',
+      );
+
+      expect(start).toBe(EARLIEST);
+      expect(end).toBe('2017-01-01');
+    });
+
+    it('falls back to earliestTransaction without a saved start', () => {
+      const [start, end] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+      );
+
+      expect(start).toBe(EARLIEST);
+      expect(end).toBe('2017-01-01');
+    });
+
+    it('is not affected by the includeCurrentInterval flag', () => {
+      const [startExclude, endExclude] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2016-03-15',
+      );
+      const [startInclude, endInclude] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        true,
+        undefined,
+        '2016-03-15',
+      );
+
+      expect(startExclude).toBe(startInclude);
+      expect(endExclude).toBe(endInclude);
+    });
+
+    it('returns static-start mode', () => {
+      const [, , mode] = getLiveRange(
+        'fromStartDate',
+        EARLIEST,
+        LATEST,
+        false,
+        undefined,
+        '2016-03-15',
+      );
+      expect(mode).toBe('static-start');
+    });
+  });
 });

--- a/packages/desktop-client/src/components/reports/getLiveRange.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.ts
@@ -101,6 +101,9 @@ export function getLiveRange(
         fixedStart =
           fixedStart.length === 7 ? `${fixedStart}-01` : `${fixedStart}-01-01`;
       }
+      if (fixedStart > monthUtils.currentDay()) {
+        fixedStart = monthUtils.currentDay();
+      }
       [dateStart, dateEnd] = validateRange(
         earliestTransaction,
         fixedStart,

--- a/packages/desktop-client/src/components/reports/getLiveRange.ts
+++ b/packages/desktop-client/src/components/reports/getLiveRange.ts
@@ -11,6 +11,7 @@ export function getLiveRange(
   latestTransaction: string,
   includeCurrentInterval: boolean,
   firstDayOfWeekIdx?: SyncedPrefs['firstDayOfWeekIdx'],
+  startDate?: string,
 ): [string, string, TimeFrame['mode']] {
   let dateStart = earliestTransaction;
   let dateEnd = latestTransaction;
@@ -91,6 +92,21 @@ export function getLiveRange(
       dateStart = earliestTransaction;
       dateEnd = latestTransaction;
       break;
+    }
+    case 'fromStartDate': {
+      // The saved start is pinned; the end always tracks today.
+      let fixedStart = startDate || earliestTransaction;
+      if (!monthUtils.isValidYearMonthDay(fixedStart)) {
+        // Pad month- or year-shaped saved bounds to days.
+        fixedStart =
+          fixedStart.length === 7 ? `${fixedStart}-01` : `${fixedStart}-01-01`;
+      }
+      [dateStart, dateEnd] = validateRange(
+        earliestTransaction,
+        fixedStart,
+        monthUtils.currentDay(),
+      );
+      return [dateStart, dateEnd, 'static-start'];
     }
     default:
       if (typeof rangeName === 'number') {

--- a/packages/desktop-client/src/components/reports/reportRanges.test.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.test.ts
@@ -84,6 +84,44 @@ describe('calculateTimeRange', () => {
     expect(end).toBe('2016-12');
     expect(mode).toBe('previousQuarter');
   });
+
+  it('keeps a static-start window pinned at its start and ends at the current month', () => {
+    // Saved "fixed start" window; only the start is meaningful, the saved
+    // end is ignored in favor of the (then-)current month.
+    const [start, end, mode] = calculateTimeRange({
+      start: '2015-03',
+      end: '2016-08',
+      mode: 'static-start',
+    });
+
+    expect(start).toBe('2015-03');
+    expect(end).toBe('2017-01');
+    expect(mode).toBe('static-start');
+  });
+
+  it('clamps a static-start window whose start is after the current month', () => {
+    const [start, end, mode] = calculateTimeRange({
+      start: '2017-06',
+      end: '2017-08',
+      mode: 'static-start',
+    });
+
+    expect(start).toBe('2017-01');
+    expect(end).toBe('2017-01');
+    expect(mode).toBe('static-start');
+  });
+
+  it('ends a day-shaped static-start window at the end of the current month', () => {
+    const [start, end, mode] = calculateTimeRange({
+      start: '2016-12-15',
+      end: '2016-12-29',
+      mode: 'static-start',
+    });
+
+    expect(start).toBe('2016-12-15');
+    expect(end).toBe('2017-01-31');
+    expect(mode).toBe('static-start');
+  });
 });
 
 // In test mode, monthUtils.currentMonth() returns '2017-01'

--- a/packages/desktop-client/src/components/reports/reportRanges.ts
+++ b/packages/desktop-client/src/components/reports/reportRanges.ts
@@ -171,6 +171,16 @@ export function getLatestRange(offset: number) {
   return [start, end, 'sliding-window'] as const;
 }
 
+export function getStaticStartRange(start: string) {
+  const currentMonth = monthUtils.currentMonth();
+  // Match the start's granularity so day-granular reports keep day bounds.
+  const end = monthUtils.isValidYearMonthDay(start)
+    ? monthUtils.getMonthEnd(currentMonth)
+    : currentMonth;
+
+  return [start > end ? end : start, end, 'static-start'] as const;
+}
+
 export function getNextRange(offset: number) {
   const start = monthUtils.currentMonth();
   const end = monthUtils.addMonths(start, offset);
@@ -195,7 +205,11 @@ export function asMonthSlidingTimeFrame(
   timeFrame: Partial<TimeFrame>,
 ): Partial<TimeFrame> {
   const { start, end, mode } = timeFrame;
-  if (mode !== 'sliding-window' || !start || !end) {
+  if (
+    (mode !== 'sliding-window' && mode !== 'static-start') ||
+    !start ||
+    !end
+  ) {
     return timeFrame;
   }
   return {
@@ -256,6 +270,10 @@ export function calculateTimeRange(
     }
 
     return getLatestRange(offset);
+  }
+  if (mode === 'static-start') {
+    // The start stays pinned; the end always tracks the current month.
+    return getStaticStartRange(start);
   }
   if (mode === 'lastMonth') {
     const lastMonth = monthUtils.subMonths(monthUtils.currentMonth(), 1);

--- a/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
+++ b/packages/desktop-client/src/components/reports/reports/CustomReport.tsx
@@ -411,6 +411,7 @@ function CustomReportInner({
           latestTransactionDate,
           includeCurrentInterval,
           firstDayOfWeekIdx,
+          startDate,
         );
         setStartDate(dateStart);
         setEndDate(dateEnd);

--- a/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
+++ b/packages/desktop-client/src/components/reports/reports/GetCardData.tsx
@@ -96,6 +96,7 @@ export function GetCardData({
       latestTransaction,
       report.includeCurrentInterval,
       firstDayOfWeekIdx,
+      report.startDate,
     );
     startDate = dateStart || report.startDate;
     endDate = dateEnd || report.endDate;

--- a/packages/loot-core/src/types/models/dashboard.ts
+++ b/packages/loot-core/src/types/models/dashboard.ts
@@ -12,9 +12,10 @@ export type TimeFrame = {
   start: string;
   end: string;
   mode:
-    | 'sliding-window'
-    | 'static'
-    | 'full'
+    | 'sliding-window' // "Live": width preserved, end slides to now
+    | 'static' // fixed dates
+    | 'static-start' // fixed start date, end slides to the current month
+    | 'full' // all time
     | 'lastMonth'
     | 'lastYear'
     | 'yearToDate'

--- a/upcoming-release-notes/reports-fixed-start-time-filter.md
+++ b/upcoming-release-notes/reports-fixed-start-time-filter.md
@@ -1,0 +1,6 @@
+---
+category: Enhancements
+authors: [snqyz]
+---
+
+Reports and formula cards have a new "From start date" quick select in live mode: it pins the start date while the end keeps following the current month.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Adds a "fixed-start" live time filter so reports can show "from this date through now" with a rolling end.

- **Standard reports & dashboard cards** (Net Worth, Cash Flow, etc.): Live keeps its default width-preserving slide. A new quick-select "From start date" pins the start you pick and keeps the end tracking the current month.
- **Custom reports:** Live Range dropdown gains "From start date" with a `From:` picker when selected; dashboard custom-report cards roll forward the same way.
- **Formula cards:** ⋮ menu gains "From start date" — shows a read-only "From start date" summary, `From` stays editable (re-pins), `To` is disabled; picking `To` freezes to Static.

Implementation adds an internal mode `static-start` (no new top-level Live/Static button; UI stays Live/Static), range resolution in `reportRanges`/`getLiveRange`, and shared picker extensions (`selectStartOnly` / `commitOnSelect` / `isActive`).

For this PR I have used OpenCode and Ox Alpha.


<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

No known related issues

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

- `yarn typecheck`, `yarn lint` clean; `yarn test` passes across all 9 workspaces
- New unit tests for `reportRanges` (fixed-start) and `getLiveRange` (`fromStartDate`)
- New e2e in `reports.test.ts` — full "From start date" flow including Save + reload re-resolution
- Manual verification on :3001 for standard reports, custom reports, and formula cards


## Checklist

- [x] Release notes added (`upcoming-release-notes/reports-fixed-start-time-filter.md`)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+5.11 kB) | +0.04%
loot-core | 1 | 4.63 MB → 4.64 MB (+102 B) | +0.00%
api | 2 | 3.85 MB → 3.85 MB (+100 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+5.11 kB) | +0.04%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/reports/getLiveRange.ts` | 📈 +433 B (+19.75%) | 2.14 kB → 2.56 kB
`src/components/reports/Header.tsx` | 📈 +1.53 kB (+13.51%) | 11.3 kB → 12.83 kB
`home/runner/work/actual/actual/packages/component-library/src/DateRangePicker.tsx` | 📈 +556 B (+9.56%) | 5.68 kB → 6.22 kB
`src/components/reports/ReportSidebar.tsx` | 📈 +1.08 kB (+5.93%) | 18.25 kB → 19.33 kB
`src/components/reports/reportRanges.ts` | 📈 +330 B (+5.64%) | 5.72 kB → 6.04 kB
`src/components/formula/QueryManager.tsx` | 📈 +825 B (+3.13%) | 25.77 kB → 26.57 kB
`src/components/reports/disabledList.ts` | 📈 +103 B (+2.40%) | 4.18 kB → 4.29 kB
`src/components/reports/ReportOptions.ts` | 📈 +173 B (+2.22%) | 7.6 kB → 7.77 kB
`src/components/reports/reports/GetCardData.tsx` | 📈 +18 B (+0.22%) | 7.9 kB → 7.92 kB
`src/components/reports/reports/CustomReport.tsx` | 📈 +11 B (+0.04%) | 25.62 kB → 25.63 kB
`locale/en.json` | 📈 +65 B (+0.03%) | 245.85 kB → 245.91 kB
`locale/ru.json` | 📈 +46 B (+0.02%) | 209.56 kB → 209.6 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ReportRouter.js | 1.43 MB → 1.44 MB (+5 kB) | +0.34%
static/js/en.js | 245.85 kB → 245.91 kB (+65 B) | +0.03%
static/js/ru.js | 209.56 kB → 209.6 kB (+46 B) | +0.02%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.63 MB → 4.64 MB (+102 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +102 B (+0.63%) | 15.73 kB → 15.83 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.Cu0rfgW6.js | 4.63 MB → 0 B (-4.63 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+100 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📈 +100 B (+0.63%) | 15.4 kB → 15.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+100 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->