### PR TITLE
Cherry-pick nanoid update for release

### DIFF
--- a/upcoming-release-notes/bump-nanoid.md
+++ b/upcoming-release-notes/bump-nanoid.md
@@ -1,0 +1,6 @@
+---
+category: Maintenance
+authors: [tim-smart]
+---
+
+Update nanoid to address a security vulnerability.

--- a/yarn.lock
+++ b/yarn.lock
@@ -20231,11 +20231,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10/8004af92b5541af1dbd23b69845b5026f777d5b7ef07163cea1837aae86e052ced8b383cecbf8a4f1b5e77ae207df96dc45e16b9e0fa3c4b761d085f1e42851b
+  checksum: 10/1b3b4fdac831b92b56d1dbe8b1e63a372432faf86ea383134e3b53141ef8108a60b7f84343b5cefecac9550bb74edf8164da93ea07d1c4f757039bc75d8a5d9e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bump nanoid to 3.3.18 to address a security vulnerability.
