### PR TITLE
[AI] Rank exact payee matches above tied substring matches

### DIFF
--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.test.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.test.tsx
@@ -416,4 +416,26 @@ describe('PayeeAutocomplete.getPayeeSuggestions', () => {
         .flatMap(firstOrIncorrect),
     ).toStrictEqual(['Payees']);
   });
+
+  test('ranks an exact payee match above a longer tied substring match', async () => {
+    // 'Amazon Prime' is listed first, so a stable sort on a tied fzf score
+    // would otherwise leave it ahead of the exact 'Amazon' match.
+    const payees = [makePayee('Amazon Prime'), makePayee('Amazon')];
+    const autocomplete = renderPayeeAutocomplete({ payees });
+    await clickAutocomplete(autocomplete);
+
+    const input = autocomplete.querySelector('input')!;
+    await userEvent.type(input, 'Amazon');
+    await waitForAutocomplete();
+
+    expect(
+      [
+        ...screen
+          .getByTestId('autocomplete')
+          .querySelectorAll(ALL_PAYEE_ITEMS_SELECTOR),
+      ]
+        .map(e => e.getAttribute('data-testid'))
+        .flatMap(firstOrIncorrect),
+    ).toStrictEqual(['Amazon', 'Amazon Prime']);
+  });
 });

--- a/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
+++ b/packages/desktop-client/src/components/autocomplete/PayeeAutocomplete.tsx
@@ -30,7 +30,7 @@ import type {
   PayeeEntity,
 } from '@actual-app/core/types/models';
 import { css, cx } from '@emotion/css';
-import { Fzf } from 'fzf';
+import { byLengthAsc, byStartAsc, Fzf } from 'fzf';
 
 import { useAccounts } from '#hooks/useAccounts';
 import { useCommonPayees } from '#hooks/useCommonPayees';
@@ -461,6 +461,9 @@ export function PayeeAutocomplete({
       selector: item => item.name ?? '',
       limit: 100,
       casing: 'case-insensitive',
+      // Prefer exact/shorter matches over longer ones that merely contain
+      // the query as a substring when fzf scores them equally.
+      tiebreakers: [byLengthAsc, byStartAsc],
     })
       .find(rawPayee)
       .map(result => result.item);
@@ -515,6 +518,9 @@ export function PayeeAutocomplete({
         selector: item => item.name ?? '',
         limit: 100,
         casing: 'case-insensitive',
+        // Prefer exact/shorter matches over longer ones that merely contain
+        // the query as a substring when fzf scores them equally.
+        tiebreakers: [byLengthAsc, byStartAsc],
       })
         .find(value)
         .map(result => result.item);

--- a/upcoming-release-notes/fix-exact-match-payee-autocomplete-ranking.md
+++ b/upcoming-release-notes/fix-exact-match-payee-autocomplete-ranking.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [J-LCRX]
+---
+
+Rank exact payee matches above longer tied substring matches in autocomplete


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description
Actual's payee autocomplete field ranks suggestions using the fzf fuzzy-matching library. When two suggestions tied on fzf's match score e.g. typing "Amazon" against both a payee named "Amazon" (exact match) and one named "Amazon Prime", fzf broke the tie using the original array order rather than match quality. That meant the exact match a user typed could rank below a less-relevant match.

This was already solved elsewhere, useTags.ts filters tags with the same fzf library and fixes this exact scenario by passing tiebreakers: [byLengthAsc, byStartAsc] (prefer the shorter/exact match on a tie, then the match that starts earliest). That option had never been added to the payee code. This PR brings payee matching in line with that existing behaviour.

The code changes were generated by Claude Sonnet 5.

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing
- Unit tests added:
  - **PayeeAutocomplete.test.tsx**
    - new test ranks an exact payee match above a longer tied substring match. Same shape: payees ["Amazon Prime", "Amazon"], typed"Amazon" into the live autocomplete input, asserts rendered order is ["Amazon", "Amazon Prime"].

- Checks run:
  - yarn typecheck (10/10 packages clean)
  - yarn lint:fix (no changes needed)
  - full yarn test (9/9 workspaces passing, including the new/updated tests above).

- Manual verification: built and ran the app in a local Docker dev container. Confirmed in the payee autocomplete dropdown that typing a name matching an existing item exactly, now ranks that record above longer items that only contain the typed text as a substring.

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->



## Checklist

- [x] Release notes added (see link above)
- [x] No obvious regressions in affected areas
- [x] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.79 MB (+198.17 kB) | +1.42%
loot-core | 1 | 4.64 MB → 4.65 MB (+11.39 kB) | +0.24%
api | 2 | 3.85 MB → 3.86 MB (+10.44 kB) | +0.26%
cli | 1 | 8.02 MB → 8.02 MB (+953 B) | +0.01%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.79 MB (+198.17 kB) | +1.42%

<details>
<summary>Changeset (largest 100 files by percent change)</summary>

File | Δ | Size
---- | - | ----
`src/components/news/NewsEntryCard.tsx` | 🆕 +6.1 kB | 0 B → 6.1 kB
`src/components/autocomplete/AccountGroupAutocomplete.tsx` | 🆕 +5.32 kB | 0 B → 5.32 kB
`src/components/sidebar/redesign/SideGroup.tsx` | 🆕 +5.03 kB | 0 B → 5.03 kB
`src/components/reports/graphs/MonteCarloCashflowGraphTooltip.tsx` | 🆕 +4.9 kB | 0 B → 4.9 kB
`src/components/modals/AccountGroupsModal/AccountGroupRow.tsx` | 🆕 +4.54 kB | 0 B → 4.54 kB
`src/components/reports/graphs/MonteCarloCashflowGraph.tsx` | 🆕 +4.52 kB | 0 B → 4.52 kB
`src/components/sidebar/redesign/SidebarBudgetName.tsx` | 🆕 +4.39 kB | 0 B → 4.39 kB
`src/account-groups/mutations.ts` | 🆕 +4.22 kB | 0 B → 4.22 kB
`src/components/news/MarkdownBlockquote.tsx` | 🆕 +4.11 kB | 0 B → 4.11 kB
`src/components/sidebar/redesign/AccountsSection.tsx` | 🆕 +4.09 kB | 0 B → 4.09 kB
`src/components/autocomplete/NoteTagAutocomplete.tsx` | 🆕 +4.03 kB | 0 B → 4.03 kB
`src/components/sidebar/redesign/SyncStatusLine.tsx` | 🆕 +3.76 kB | 0 B → 3.76 kB
`src/components/sidebar/redesign/AccountRow.tsx` | 🆕 +3.66 kB | 0 B → 3.66 kB
`src/components/modals/AccountGroupsModal/AccountGroupsModal.tsx` | 🆕 +3.63 kB | 0 B → 3.63 kB
`src/components/sidebar/redesign/AccountsHeaderRow.tsx` | 🆕 +3.36 kB | 0 B → 3.36 kB
`src/components/news/NotificationsPage.tsx` | 🆕 +3.26 kB | 0 B → 3.26 kB
`src/components/reports/graphs/util/monteCarloCashflowChart.ts` | 🆕 +3.23 kB | 0 B → 3.23 kB
`src/components/reports/dateRangePresets.ts` | 🆕 +3.2 kB | 0 B → 3.2 kB
`src/components/sidebar/redesign/PrimaryNav.tsx` | 🆕 +2.96 kB | 0 B → 2.96 kB
`src/components/sidebar/redesign/AccountGroupHeader.tsx` | 🆕 +2.87 kB | 0 B → 2.87 kB
`src/components/sidebar/redesign/ClosedSection.tsx` | 🆕 +2.65 kB | 0 B → 2.65 kB
`src/components/news/NotificationsButton.tsx` | 🆕 +2.52 kB | 0 B → 2.52 kB
`src/components/sidebar/redesign/SidebarRedesign.tsx` | 🆕 +2.42 kB | 0 B → 2.42 kB
`src/components/sidebar/redesign/useSidebarCollapseState.ts` | 🆕 +2.29 kB | 0 B → 2.29 kB
`src/components/sidebar/redesign/SidebarAccountGroup.tsx` | 🆕 +2.28 kB | 0 B → 2.28 kB
`src/hooks/useNewsNotification.ts` | 🆕 +2.2 kB | 0 B → 2.2 kB
`src/components/sidebar/redesign/SyncDot.tsx` | 🆕 +2.12 kB | 0 B → 2.12 kB
`src/components/sidebar/redesign/SidebarIconButton.tsx` | 🆕 +2.04 kB | 0 B → 2.04 kB
`src/components/autocomplete/NoteInsertHashButton.tsx` | 🆕 +1.95 kB | 0 B → 1.95 kB
`src/components/sidebar/SidebarShell.tsx` | 🆕 +1.86 kB | 0 B → 1.86 kB
`src/hooks/useNewsFeed.ts` | 🆕 +1.78 kB | 0 B → 1.78 kB
`src/components/sidebar/redesign/NavRow.tsx` | 🆕 +1.76 kB | 0 B → 1.76 kB
`src/components/sidebar/redesign/SyncErrorRollup.tsx` | 🆕 +1.61 kB | 0 B → 1.61 kB
`src/components/reports/graphs/MonteCarloCashflowLegendGroup.tsx` | 🆕 +1.57 kB | 0 B → 1.57 kB
`src/components/sidebar/redesign/SidebarHeader.tsx` | 🆕 +1.46 kB | 0 B → 1.46 kB
`src/components/sidebar/redesign/useSidebarAccountTree.ts` | 🆕 +1.41 kB | 0 B → 1.41 kB
`src/news/fetchNewsFeed.ts` | 🆕 +1.24 kB | 0 B → 1.24 kB
`src/hooks/useSyncStatus.ts` | 🆕 +1.15 kB | 0 B → 1.15 kB
`src/components/common/DirectoryDisplay.tsx` | 🆕 +998 B | 0 B → 998 B
`src/news/fixtures.ts` | 🆕 +990 B | 0 B → 990 B
`src/news/admonitions.ts` | 🆕 +959 B | 0 B → 959 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/CheveronDownUp.tsx` | 🆕 +914 B | 0 B → 914 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/CheveronUpDown.tsx` | 🆕 +913 B | 0 B → 913 B
`src/components/sidebar/redesign/SidebarFooter.tsx` | 🆕 +769 B | 0 B → 769 B
`src/components/sidebar/redesign/SidebarBalance.tsx` | 🆕 +744 B | 0 B → 744 B
`src/components/common/Markdown.tsx` | 🆕 +716 B | 0 B → 716 B
`src/news/utils.ts` | 🆕 +704 B | 0 B → 704 B
`src/components/sidebar/redesign/CountPill.tsx` | 🆕 +667 B | 0 B → 667 B
`src/components/reports/graphs/util/useMonteCarloTickFormatter.ts` | 🆕 +607 B | 0 B → 607 B
`src/components/modals/AccountGroupsModal/SelectedIndicator.tsx` | 🆕 +476 B | 0 B → 476 B
`src/components/reports/monthRange.ts` | 🆕 +441 B | 0 B → 441 B
`src/account-groups/queries.ts` | 🆕 +339 B | 0 B → 339 B
`src/components/sidebar/redesign/CollapseChevron.tsx` | 🆕 +338 B | 0 B → 338 B
`src/components/reports/graphs/MonteCarloCashflowSwatch.tsx` | 🆕 +310 B | 0 B → 310 B
`src/hooks/useAccountGroups.ts` | 🆕 +286 B | 0 B → 286 B
`src/news/queries.ts` | 🆕 +277 B | 0 B → 277 B
`src/components/sidebar/redesign/styles.ts` | 🆕 +219 B | 0 B → 219 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/CloudWarning.tsx` | 🆕 +1.79 kB | 0 B → 1.79 kB
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/NotificationsOutline.tsx` | 🆕 +938 B | 0 B → 938 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/ArrowThinDown.tsx` | 🆕 +886 B | 0 B → 886 B
`home/runner/work/actual/actual/packages/component-library/src/icons/v1/ArrowThinUp.tsx` | 🆕 +879 B | 0 B → 879 B
`src/components/reports/ReportSummary.tsx` | 📈 +3.79 kB (+99.72%) | 3.8 kB → 7.58 kB
`src/components/FatalError.tsx` | 📈 +6.56 kB (+60.83%) | 10.79 kB → 17.36 kB
`src/components/reports/spreadsheets/net-worth-spreadsheet.ts` | 📈 +3.26 kB (+58.05%) | 5.62 kB → 8.88 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +293 B (+54.26%) | 540 B → 833 B
`src/components/reports/reports/monte-carlo/MonteCarloPotConfiguration.tsx` | 📈 +6.08 kB (+47.40%) | 12.83 kB → 18.91 kB
`home/runner/work/actual/actual/packages/component-library/src/tokens.ts` | 📈 +107 B (+43.67%) | 245 B → 352 B
`src/components/reports/reports/monte-carlo/MonteCarloRunDetailTable.tsx` | 📈 +8.54 kB (+32.28%) | 26.45 kB → 34.99 kB
`src/components/reports/reports/monte-carlo/monteCarloHistoricalReturns.ts` | 📈 +1.82 kB (+27.37%) | 6.64 kB → 8.45 kB
`src/hooks/useRefEventListener.ts` | 📈 +124 B (+23.66%) | 524 B → 648 B
`src/components/reports/reports/monte-carlo/monteCarloSimulation.ts` | 📈 +6.75 kB (+21.54%) | 31.33 kB → 38.07 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/light.css?inline` | 📈 +2.4 kB (+20.87%) | 11.49 kB → 13.89 kB
`src/components/reports/reports/monte-carlo/MonteCarloPotsTableHeader.tsx` | 📈 +1.2 kB (+20.79%) | 5.76 kB → 6.96 kB
`src/components/reports/reports/SankeyCard.tsx` | 📈 +808 B (+17.88%) | 4.41 kB → 5.2 kB
`src/hooks/useMetaThemeColor.ts` | 📈 +511 B (+17.81%) | 2.8 kB → 3.3 kB
`src/components/reports/reportRanges.ts` | 📈 +710 B (+12.12%) | 5.72 kB → 6.41 kB
`src/components/sidebar/index.tsx` | 📈 +212 B (+12.01%) | 1.72 kB → 1.93 kB
`src/sync-events.ts` | 📈 +949 B (+11.66%) | 7.95 kB → 8.88 kB
`src/components/reports/reports/monte-carlo/MonteCarlo.tsx` | 📈 +3.42 kB (+11.46%) | 29.86 kB → 33.28 kB
`src/components/settings/index.tsx` | 📈 +1.02 kB (+9.51%) | 10.76 kB → 11.79 kB
`home/runner/work/actual/actual/packages/component-library/src/styles.ts` | 📈 +277 B (+9.05%) | 2.99 kB → 3.26 kB
`src/spreadsheet/bindings.ts` | 📈 +343 B (+7.11%) | 4.71 kB → 5.05 kB
`src/components/modals/EditFieldModal.tsx` | 📈 +578 B (+6.81%) | 8.29 kB → 8.85 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/dark.css?inline` | 📈 +708 B (+6.03%) | 11.47 kB → 12.17 kB
`locale/uk.json` | 📈 +11.95 kB (+6.00%) | 199.25 kB → 211.2 kB
`home/runner/work/actual/actual/packages/component-library/src/themes/midnight.css?inline` | 📈 +710 B (+5.98%) | 11.6 kB → 12.29 kB
`src/components/reports/reports/monte-carlo/MonteCarloConfiguration.tsx` | 📈 +1.37 kB (+5.71%) | 24.02 kB → 25.39 kB
`locale/en.json` | 📈 +12.99 kB (+5.28%) | 245.91 kB → 258.91 kB
`package.json` | 📈 +509 B (+4.80%) | 10.37 kB → 10.86 kB
`home/runner/work/actual/actual/packages/component-library/src/theme.ts` | 📈 +588 B (+4.61%) | 12.46 kB → 13.03 kB
`src/hooks/useFeatureFlag.ts` | 📈 +22 B (+3.68%) | 598 B → 620 B
`src/components/App.tsx` | 📈 +287 B (+3.44%) | 8.14 kB → 8.42 kB
`src/components/reports/ReportOptions.ts` | 📈 +255 B (+3.28%) | 7.6 kB → 7.85 kB
`src/browser-preload.js` | 📈 +119 B (+2.71%) | 4.28 kB → 4.4 kB
`src/components/FinancesApp.tsx` | 📈 +595 B (+2.56%) | 22.73 kB → 23.31 kB
`src/components/settings/Experimental.tsx` | 📈 +198 B (+2.19%) | 8.82 kB → 9.01 kB
`src/components/reports/reports/NetWorthCard.tsx` | 📈 +79 B (+2.13%) | 3.62 kB → 3.7 kB
`src/components/formula/formulaCatalog.ts` | 📈 +761 B (+1.74%) | 42.76 kB → 43.5 kB
`src/components/reports/reports/GetCardData.tsx` | 📈 +114 B (+1.41%) | 7.9 kB → 8.01 kB
`locale/ru.json` | 📈 +2.88 kB (+1.38%) | 209.56 kB → 212.44 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB → 1.68 MB (+108.15 kB) | +6.70%
static/js/ReportRouter.js | 1.43 MB → 1.48 MB (+49.34 kB) | +3.37%
static/js/en.js | 245.91 kB → 258.91 kB (+12.99 kB) | +5.28%
static/js/uk.js | 199.25 kB → 211.2 kB (+11.95 kB) | +6.00%
static/js/DateSelect.js | 2.37 MB → 2.38 MB (+9.86 kB) | +0.41%
static/js/ru.js | 209.56 kB → 212.44 kB (+2.88 kB) | +1.38%
static/js/de.js | 185 kB → 186.5 kB (+1.5 kB) | +0.81%
static/js/FormulaEditor.js | 766.35 kB → 767.24 kB (+907 B) | +0.12%
static/js/theme.js | 31.1 kB → 31.68 kB (+588 B) | +1.85%
static/js/Value.js | 1.79 MB → 1.79 MB (+575 B) | +0.03%
static/js/pt-BR.js | 178.2 kB → 178.74 kB (+555 B) | +0.30%
static/js/wide.js | 274.04 kB → 274.53 kB (+498 B) | +0.18%
static/js/months.js | 574.72 kB → 575.1 kB (+384 B) | +0.07%
static/js/pl.js | 136.39 kB → 136.51 kB (+128 B) | +0.09%
static/js/it.js | 151.67 kB → 151.79 kB (+126 B) | +0.08%

**Smaller**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionEdit.js | 221.38 kB → 219.59 kB (-1.8 kB) | -0.81%
static/js/fr.js | 179.04 kB → 178.66 kB (-393 B) | -0.21%

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.65 MB (+11.39 kB) | +0.24%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.99 kB | 0 B → 2.99 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +973 B | 0 B → 973 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +406 B | 0 B → 406 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +167 B | 0 B → 167 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +497 B (+394.44%) | 126 B → 623 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.33 kB (+40.81%) | 3.27 kB → 4.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/errors.ts` | 📈 +552 B (+27.14%) | 1.99 kB → 2.53 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +700 B (+24.46%) | 2.79 kB → 3.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +464 B (+16.59%) | 2.73 kB → 3.18 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +212 B (+14.15%) | 1.46 kB → 1.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.26 kB (+8.89%) | 14.13 kB → 15.38 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +519 B (+8.11%) | 6.25 kB → 6.76 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +350 B (+7.65%) | 4.47 kB → 4.81 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/main.ts` | 📈 +373 B (+7.61%) | 4.79 kB → 5.15 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +375 B (+6.86%) | 5.33 kB → 5.7 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +145 B (+3.04%) | 4.66 kB → 4.8 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +98 B (+1.19%) | 8.06 kB → 8.16 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +238 B (+1.04%) | 22.36 kB → 22.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +97 B (+0.82%) | 11.51 kB → 11.6 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/merge.ts` | 📈 +38 B (+0.81%) | 4.56 kB → 4.59 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +173 B (+0.69%) | 24.6 kB → 24.77 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +130 B (+0.59%) | 21.37 kB → 21.5 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.6 kB → 5.62 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 614 B → 616 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +26 B (+0.08%) | 31.03 kB → 31.05 kB
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.41%) | 1.44 kB → 1.43 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -449 B (-2.77%) | 15.83 kB → 15.39 kB
`node_modules/date-fns/isFriday.js` | 🔥 -153 B (-100%) | 153 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CqHqoSL0.js | 0 B → 4.65 MB (+4.65 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.86 MB (+10.44 kB) | +0.26%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/replay.ts` | 🆕 +2.92 kB | 0 B → 2.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/serialization.ts` | 🆕 +944 B | 0 B → 944 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/messages-pending.ts` | 🆕 +405 B | 0 B → 405 B
`home/runner/work/actual/actual/packages/loot-core/migrations/1788468782000_add_messages_pending.js` | 🆕 +164 B | 0 B → 164 B
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/utils.ts` | 📈 +481 B (+391.06%) | 123 B → 604 B
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/connection/index.api.ts` | 📈 +400 B (+258.06%) | 155 B → 555 B
`home/runner/work/actual/actual/packages/loot-core/src/server/migrate/migrations.ts` | 📈 +1.31 kB (+41.05%) | 3.19 kB → 4.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/ofx2json.ts` | 📈 +689 B (+24.74%) | 2.72 kB → 3.39 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/xmlcamt2json.ts` | 📈 +456 B (+16.76%) | 2.66 kB → 3.1 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/reset.ts` | 📈 +210 B (+14.36%) | 1.43 kB → 1.63 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/sync/index.ts` | 📈 +1.24 kB (+9.05%) | 13.68 kB → 14.92 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/rule.ts` | 📈 +346 B (+8.04%) | 4.2 kB → 4.54 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/schedules.ts` | 📈 +507 B (+7.22%) | 6.86 kB → 7.35 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/preferences/app.ts` | 📈 +369 B (+6.90%) | 5.22 kB → 5.58 kB
`home/runner/work/actual/actual/packages/loot-core/src/shared/errors.ts` | 📈 +142 B (+3.02%) | 4.6 kB → 4.73 kB
`methods.ts` | 📈 +177 B (+2.37%) | 7.31 kB → 7.48 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/rules/action.ts` | 📈 +97 B (+1.25%) | 7.6 kB → 7.69 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transaction-rules.ts` | 📈 +226 B (+0.98%) | 22.45 kB → 22.67 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/merge.ts` | 📈 +40 B (+0.88%) | 4.43 kB → 4.47 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/budgetfiles/app.ts` | 📈 +92 B (+0.81%) | 11.14 kB → 11.23 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/api.ts` | 📈 +169 B (+0.69%) | 23.96 kB → 24.12 kB
`node_modules/csv-parse/lib/api/index.js` | 📈 +125 B (+0.59%) | 20.84 kB → 20.96 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/import/parse-file.ts` | 📈 +20 B (+0.35%) | 5.62 kB → 5.63 kB
`home/runner/work/actual/actual/packages/loot-core/migrations/1765518577215_multiple_dashboards.js` | 📈 +2 B (+0.33%) | 605 B → 607 B
`home/runner/work/actual/actual/packages/loot-core/src/server/accounts/app.ts` | 📈 +26 B (+0.08%) | 30.46 kB → 30.49 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/app.ts` | 📈 +2 B (+0.08%) | 2.56 kB → 2.56 kB
`node_modules/csv-parse/lib/utils/ResizeableBuffer.js` | 📉 -6 B (-0.43%) | 1.36 kB → 1.36 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/schedules/app.ts` | 📉 -439 B (-2.77%) | 15.5 kB → 15.07 kB
`node_modules/date-fns/isFriday.js` | 🔥 -550 B (-100%) | 550 B → 0 B
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.86 MB (+10.44 kB) | +0.26%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB → 8.02 MB (+953 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/config.ts` | 📈 +647 B (+17.73%) | 3.56 kB → 4.2 kB
`src/connection.ts` | 📈 +306 B (+9.01%) | 3.32 kB → 3.62 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB → 8.02 MB (+953 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->