### PR TITLE
[WIP] Fix pluggy.ai linked-account balance display showing wrong amounts

### DIFF
--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.test.ts
@@ -1,7 +1,12 @@
 import { generateAccount } from '@actual-app/core/mocks';
 import { describe, expect, it } from 'vitest';
 
-import { getSyncSourceReadable, groupBankSyncAccounts } from './bankSyncUtils';
+import type { PluggyAiAccount } from './bankSyncUtils';
+import {
+  getSyncSourceReadable,
+  groupBankSyncAccounts,
+  mapPluggyAiExternalAccounts,
+} from './bankSyncUtils';
 
 describe('bankSyncUtils', () => {
   it('groups open accounts by provider and leaves unlinked last', () => {
@@ -49,5 +54,49 @@ describe('bankSyncUtils', () => {
     expect(readable.simpleFin).toBe('SimpleFIN');
     expect(readable.pluggyai).toBe('Pluggy.ai');
     expect(readable.unlinked).toBe('translated:Unlinked');
+  });
+
+  it('maps pluggy accounts to integer-cent balances', () => {
+    const bankAccount: PluggyAiAccount = {
+      id: 'bank-1',
+      name: 'Conta Corrente',
+      type: 'BANK',
+      taxNumber: '123.456.789-00',
+      owner: 'John Doe',
+      balance: 27903.6,
+      bankData: {
+        automaticallyInvestedBalance: 55807.2,
+        closingBalance: 27903.6,
+      },
+    };
+    const creditAccount: PluggyAiAccount = {
+      id: 'credit-1',
+      name: 'Cartão',
+      type: 'CREDIT',
+      taxNumber: '',
+      owner: 'John Doe',
+      balance: 27903.6,
+      bankData: {
+        automaticallyInvestedBalance: 0,
+        closingBalance: 0,
+      },
+    };
+
+    const [mappedBank, mappedCredit] = mapPluggyAiExternalAccounts([
+      bankAccount,
+      creditAccount,
+    ]);
+
+    expect(mappedBank.balance).toBe(8371080);
+    expect(Number.isInteger(mappedBank.balance)).toBe(true);
+    expect(mappedBank.name).toBe('Conta Corrente - 123.456.789-00');
+    expect(mappedBank.institution).toBe('Conta Corrente');
+    expect(mappedBank.orgDomain).toBeNull();
+    expect(mappedBank.orgId).toBe('bank-1');
+
+    expect(mappedCredit.balance).toBe(2790360);
+    expect(Number.isInteger(mappedCredit.balance)).toBe(true);
+    expect(mappedCredit.name).toBe('Cartão - John Doe');
+    expect(mappedCredit.account_id).toBe('credit-1');
   });
 });

--- a/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
+++ b/packages/desktop-client/src/components/banksync/bankSyncUtils.ts
@@ -1,3 +1,4 @@
+import { amountToInteger } from '@actual-app/core/shared/util';
 import type {
   AccountEntity,
   BankSyncProviders,
@@ -77,6 +78,49 @@ export function groupBankSyncAccounts(
   }
 
   return sortedAccounts;
+}
+
+export type PluggyAiAccount = {
+  id: string;
+  name: string;
+  type: 'BANK' | string;
+  taxNumber: string;
+  owner: string;
+  balance: number;
+  bankData: {
+    automaticallyInvestedBalance: number;
+    closingBalance: number;
+  };
+};
+
+export type PluggyAiExternalAccount = {
+  account_id: string;
+  name: string;
+  institution: string;
+  orgDomain: null;
+  orgId: string;
+  balance: number;
+};
+
+export function mapPluggyAiExternalAccounts(
+  accounts: PluggyAiAccount[],
+): PluggyAiExternalAccount[] {
+  return accounts.map(oldAccount => ({
+    account_id: oldAccount.id,
+    name: `${oldAccount.name.trim()} - ${
+      oldAccount.type === 'BANK' ? oldAccount.taxNumber : oldAccount.owner
+    }`,
+    institution: oldAccount.name,
+    orgDomain: null,
+    orgId: oldAccount.id,
+    balance:
+      oldAccount.type === 'BANK'
+        ? amountToInteger(
+            oldAccount.bankData.automaticallyInvestedBalance +
+              oldAccount.bankData.closingBalance,
+          )
+        : amountToInteger(oldAccount.balance),
+  }));
 }
 
 export function getGroupedBankSyncEntries(

--- a/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
+++ b/packages/desktop-client/src/components/banksync/useBuiltInBankSyncProviders.ts
@@ -23,7 +23,11 @@ import { pushModal } from '#modals/modalsSlice';
 import { addNotification } from '#notifications/notificationsSlice';
 import { useDispatch } from '#redux';
 
-import { BUILT_IN_BANK_SYNC_PROVIDERS } from './bankSyncUtils';
+import type { PluggyAiAccount } from './bankSyncUtils';
+import {
+  BUILT_IN_BANK_SYNC_PROVIDERS,
+  mapPluggyAiExternalAccounts,
+} from './bankSyncUtils';
 
 type ProviderAction = () => void | Promise<void>;
 
@@ -35,19 +39,6 @@ type SimpleFinAccount = {
     name: string;
     domain: string;
     id: string;
-  };
-};
-
-type PluggyAiAccount = {
-  id: string;
-  name: string;
-  type: 'BANK' | string;
-  taxNumber: string;
-  owner: string;
-  balance: number;
-  bankData: {
-    automaticallyInvestedBalance: number;
-    closingBalance: number;
   };
 };
 
@@ -503,24 +494,9 @@ export function useBuiltInBankSyncProviders({
       if ('error' in results) {
         throw new Error(results.error);
       }
-
-      const externalAccounts = (results.accounts as PluggyAiAccount[]).map(
-        oldAccount => ({
-          account_id: oldAccount.id,
-          name: `${oldAccount.name.trim()} - ${
-            oldAccount.type === 'BANK' ? oldAccount.taxNumber : oldAccount.owner
-          }`,
-          institution: oldAccount.name,
-          orgDomain: null,
-          orgId: oldAccount.id,
-          balance:
-            oldAccount.type === 'BANK'
-              ? oldAccount.bankData.automaticallyInvestedBalance +
-                oldAccount.bankData.closingBalance
-              : oldAccount.balance,
-        }),
+      const externalAccounts = mapPluggyAiExternalAccounts(
+        results.accounts as PluggyAiAccount[],
       );
-
       dispatch(
         pushModal({
           modal: {

--- a/upcoming-release-notes/fix-pluggyai-balance-display.md
+++ b/upcoming-release-notes/fix-pluggyai-balance-display.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [lorenzozanee]
+---
+
+Bank sync: fix linking pluggy.ai accounts failing or showing incorrect balances when the bank reports automatically invested balances


### PR DESCRIPTION
## Description

When linking a pluggy.ai account whose bank reports automatically invested balances, the account list computed the balance as a raw float sum of `automaticallyInvestedBalance + closingBalance`. With values like `55807.2 + 27903.6` this produces `83710.79999999999`, and rendering that balance in the link dialog goes through the number-formatting string path, which mangles the value into an integer that `safeNumber` rejects — so the balance shows wrong amounts and linking the account fails with an error.

This extracts the pluggy account mapping into `mapPluggyAiExternalAccounts` in `bankSyncUtils.ts` and computes balances in integer cents with `amountToInteger` — the same convention the sync server already uses for pluggy balances (`Math.round(balance * 100)`).

Note: the displayed balance for non-BANK pluggy accounts also becomes correct (previously single-decimal values displayed off by 10x). SimpleFin/Akahu still pass raw units through the same display path — left untouched here, could be a follow-up.

## Related issue(s)

Fixes #6345

## Testing

Added a regression test in `bankSyncUtils.test.ts` using a fixture payload with the values from the issue (`55807.2 + 27903.6`): the mapped balance must be `8371080` (integer cents). The test fails against the old float addition (produces `83710.79999999999`) and passes with the fix. All bank-sync-scoped desktop-client tests pass (8/8) and the strict typecheck passes.

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.6 MB → 13.6 MB (+94 B) | +0.00%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB | 0%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.6 MB → 13.6 MB (+94 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/components/banksync/bankSyncUtils.ts` | 📈 +493 B (+31.70%) | 1.52 kB → 2 kB
`src/components/banksync/useBuiltInBankSyncProviders.ts` | 📉 -399 B (-2.50%) | 15.61 kB → 15.22 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/ManageRules.js | 71.66 kB → 71.75 kB (+94 B) | +0.13%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 166.98 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.56 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 199.25 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB | 0%
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->