### PR TITLE
Envelope budgeting typo fix

### DIFF
--- a/packages/docs/docs/getting-started/envelope-budgeting.md
+++ b/packages/docs/docs/getting-started/envelope-budgeting.md
@@ -45,7 +45,7 @@ is working towards your financial goals.
 
 ## Zero-Sum Budgeting Strategies you can use
 
-Every one has a different situation so there isn't a once size fits all way to assign your available funds.
+Every one has a different situation so there isn't a one size fits all way to assign your available funds.
 Detailed below are a few strategies you can use.
 
 ### The Basics of Zero-Sum Budgeting

--- a/upcoming-release-notes/envelope-budgeting-typo-fix.md
+++ b/upcoming-release-notes/envelope-budgeting-typo-fix.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [chris-t-jansen]
+---
+
+Fixes a typo on the "Envelope Budgeting" page of the docs.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

Fixes a small typo on the "Envelope Budgeting" page of the docs which read "once size fits all" to now read "one size fits all".

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

No AI tools were used for this one-character change.

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

None that I found in searching the repo's issues; apologies if I missed any.

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

Ran `yarn start` to view the fixed line of documentation in a local development server to confirm the presence of the fix. I also ran `yarn typecheck` and `yarn lint:fix` per the contributing docs, though I hope those didn't matter much here!

## Checklist

- [X] Release notes added (see link above)
- [X] No obvious regressions in affected areas
- [X] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
