### PR TITLE
[AI] Fix global preferences persistence failing with EXDEV on Windows

### DIFF
--- a/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
+++ b/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts
@@ -99,10 +99,23 @@ async function writeStore(): Promise<void> {
 
   try {
     await fs.promises.writeFile(tmpPath, JSON.stringify(store), 'utf8');
-    await fs.promises.rename(tmpPath, storePath);
+    try {
+      await fs.promises.rename(tmpPath, storePath);
+    } catch (renameErr: unknown) {
+      const code = (renameErr as NodeJS.ErrnoException)?.code;
+      if (code === 'EXDEV') {
+        // Cross-device rename (e.g. Microsoft Store install on Windows where
+        // the temp and target are on different volumes). Fall back to
+        // copy+unlink which works across devices.
+        await fs.promises.copyFile(tmpPath, storePath);
+        await fs.promises.rm(tmpPath, { force: true });
+      } else {
+        throw renameErr;
+      }
+    }
   } catch (err) {
     // Best-effort cleanup of the temp file; ignore failures (it may never have
-    // been created).
+    // been created, or was already removed by the EXDEV fallback).
     try {
       await fs.promises.rm(tmpPath, { force: true });
     } catch {}

--- a/upcoming-release-notes/8823.md
+++ b/upcoming-release-notes/8823.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [lorenzozanee]
+---
+
+Fix perpetual "Loading global preferences" on Microsoft Store installs by handling EXDEV cross-device rename via copy fallback.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

Fixes the perpetual "Loading global preferences" hang after a fresh Microsoft Store install on Windows 11. The Electron `writeStore()` path writes to a temporary file next to `global-store.json` and then `rename()`s it into place. On the Microsoft Store distribution `rename` can fail with `EXDEV: cross-device link not permitted`, leaving the `setItem` promise rejected and never persisting the file. The fix catches `EXDEV` specifically and falls back to `copyFile` + `rm`, which works across devices, while still rethrowing any other error and cleaning up the temp file.

## Related issue(s)

Fixes #8660

## Testing

- Existing `loot-core` electron asyncStorage tests still pass (6/6).
- Added a local reproduction that mocks `fs.promises.rename` to throw `EXDEV`: on the base commit the write fails and `global-store.json` is not created; with the fix `copyFile` is called, the JSON is persisted correctly, and no `.tmp` leftover remains. A second test confirms non-EXDEV errors are still rethrown and do not create the store.
- `yarn typecheck` and `yarn lint` pass.

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.51 MB | 0%
loot-core | 1 | 4.64 MB | 0%
api | 2 | 3.85 MB → 3.85 MB (+206 B) | +0.01%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.51 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB | 0%
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+206 B) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/platform/server/asyncStorage/index.electron.ts` | 📈 +206 B (+8.77%) | 2.29 kB → 2.5 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+206 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->