### PR TITLE
[AI] Fix schedule template underfunding for long day/week intervals

### DIFF
--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -4,7 +4,7 @@ import { getRuleForSchedule } from '#server/schedules/app';
 import type { Currency } from '#shared/currencies';
 import type { CategoryEntity } from '#types/models';
 
-import { isTrackingBudget } from './actions';
+import { getSheetValue, isTrackingBudget } from './actions';
 import { runSchedule } from './schedule-template';
 
 vi.mock('#server/db');
@@ -624,6 +624,45 @@ describe('runSchedule', () => {
       defaultCurrency,
     );
     expect(result.to_budget).toBe(3000);
+  });
+
+  it('keeps meeting the deadline for a schedule repeating every 360 days', async () => {
+    // Every 360 days is daily in shape but yearly in effect, so it sinks:
+    // $500 due 2026-05-15 spread over the five months from January is $100
+    // a month. Once January is funded, February used to drop to $41.67 --
+    // subDays(2026-05-15, 360) lands in May 2025, and that 12-month span
+    // became the divisor. The deadline and the $100 already saved were both
+    // ignored, so the category came up short in May.
+    const template_lines = [
+      {
+        type: 'schedule',
+        name: 'EveryThreeSixtyDays',
+        directive: 'template',
+        priority: 0,
+      } as const,
+    ];
+    mockSingleSchedule({
+      start: '2026-05-15',
+      amount: -50000,
+      frequency: 'daily',
+      interval: 360,
+    });
+    // January budgeted $100 and nothing was spent, so it carries forward and
+    // is also last month's goal.
+    vi.mocked(getSheetValue).mockResolvedValue(10000);
+
+    const result = await runSchedule(
+      template_lines,
+      '2026-02-01',
+      10000,
+      0,
+      10000,
+      0,
+      [],
+      defaultCategory,
+      defaultCurrency,
+    );
+    expect(result.to_budget).toBe(10000);
   });
 
   it('absorbs surplus when last-month balance exceeds a sinking schedule target', async () => {

--- a/packages/loot-core/src/server/budget/schedule-template.test.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.test.ts
@@ -3,6 +3,7 @@ import { Rule } from '#server/rules';
 import { getRuleForSchedule } from '#server/schedules/app';
 import type { Currency } from '#shared/currencies';
 import type { CategoryEntity } from '#types/models';
+import type { ScheduleTemplate } from '#types/models/templates';
 
 import { getSheetValue, isTrackingBudget } from './actions';
 import { runSchedule } from './schedule-template';
@@ -639,7 +640,7 @@ describe('runSchedule', () => {
         name: 'EveryThreeSixtyDays',
         directive: 'template',
         priority: 0,
-      } as const,
+      } satisfies ScheduleTemplate,
     ];
     mockSingleSchedule({
       start: '2026-05-15',

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -347,9 +347,13 @@ export async function runSchedule(
   // 360 days" schedule is daily in shape but yearly in effect: letting it
   // count here wrongly switches the category to the steady-accrual shortcut,
   // which ignores both the deadline and what has already been saved (#6644).
-  const isSubMonthly = c =>
-    (c.target_frequency === 'weekly' && c.target_interval <= 4) ||
-    (c.target_frequency === 'daily' && c.target_interval <= 31);
+  function isSubMonthly(schedule: ScheduleTemplateTarget) {
+    return (
+      (schedule.target_frequency === 'weekly' &&
+        schedule.target_interval <= 4) ||
+      (schedule.target_frequency === 'daily' && schedule.target_interval <= 31)
+    );
+  }
 
   const t_payMonthOf = t.t.filter(isPayMonthOf);
   const t_sinking = t.t

--- a/packages/loot-core/src/server/budget/schedule-template.ts
+++ b/packages/loot-core/src/server/budget/schedule-template.ts
@@ -342,8 +342,14 @@ export async function runSchedule(
     (c.target_frequency === 'daily' && c.target_interval <= 31) ||
     isTrackingBudget();
 
+  // A schedule only behaves "sub-monthly" when it recurs more often than
+  // monthly — the same weekly/daily caps `isPayMonthOf` uses. A "repeat every
+  // 360 days" schedule is daily in shape but yearly in effect: letting it
+  // count here wrongly switches the category to the steady-accrual shortcut,
+  // which ignores both the deadline and what has already been saved (#6644).
   const isSubMonthly = c =>
-    c.target_frequency === 'weekly' || c.target_frequency === 'daily';
+    (c.target_frequency === 'weekly' && c.target_interval <= 4) ||
+    (c.target_frequency === 'daily' && c.target_interval <= 31);
 
   const t_payMonthOf = t.t.filter(isPayMonthOf);
   const t_sinking = t.t

--- a/upcoming-release-notes/fix-schedule-template-long-day-interval.md
+++ b/upcoming-release-notes/fix-schedule-template-long-day-interval.md
@@ -1,0 +1,6 @@
+---
+category: Bugfix
+authors: [arbelonson-source]
+---
+
+Fix `#template schedule` underfunding a category when the schedule repeats every N days or weeks and N spans more than a month


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Make sure to follow the instructions to write release notes for your PR — it should only take a minute or two: https://actualbudget.org/docs/contributing/#writing-good-release-notes. Try running yarn generate:release-notes *before* pushing your PR for an interactive experience. -->

## Description

<!-- What does this PR do? Why is it needed? Please give context on the "why?": why do we need this change? What problem is it solving for you?-->

<!-- If AI tools wrote a significant part of this change, please disclose it here and name the tool you used. See https://actualbudget.org/docs/contributing/ai-usage-policy -->

## Related issue(s)

<!-- e.g. Fixes #123, Relates to #456 -->

## Testing

<!-- What did you test? How can we reproduce the issue you are fixing or how can we test the feature you built? -->

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.51 MB → 13.51 MB (+1.07 kB) | +0.01%
loot-core | 1 | 4.64 MB → 4.64 MB (+101 B) | +0.00%
api | 2 | 3.85 MB → 3.85 MB (+99 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.51 MB → 13.51 MB (+1.07 kB) | +0.01%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useRefEventListener.ts` | 📈 +124 B (+23.66%) | 524 B → 648 B
`locale/de.json` | 📈 +974 B (+0.51%) | 185 kB → 185.95 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/de.js | 185 kB → 185.95 kB (+974 B) | +0.51%
static/js/Value.js | 1.79 MB → 1.79 MB (+124 B) | +0.01%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/NotesTagFormatter.js | 25.94 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/TransactionList.js | 79.22 kB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.64 MB (+101 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +101 B (+1.15%) | 8.58 kB → 8.68 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.BR2Tawb5.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+99 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/budget/schedule-template.ts` | 📈 +99 B (+1.15%) | 8.41 kB → 8.51 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+99 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->