### PR TITLE
[AI] Fix linked transfer date sync for duplicated split transactions

### DIFF
--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -298,13 +298,16 @@ export function useTransactionBatchActions() {
         added: transactions.reduce(
           (newTransactions: TransactionEntity[], trans: TransactionEntity) => {
             return newTransactions.concat(
-              realizeTempTransactions(ungroupTransaction(trans)).map(t => ({
-                ...t,
-                cleared: false,
-                reconciled: false,
-                transfer_id: null,
-                schedule: null,
-              })),
+              realizeTempTransactions(ungroupTransaction(trans)).map(
+                t =>
+                  ({
+                    ...t,
+                    cleared: false,
+                    reconciled: false,
+                    transfer_id: null,
+                    schedule: null,
+                  }) as unknown as TransactionEntity,
+              ),
             );
           },
           [],

--- a/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
+++ b/packages/desktop-client/src/hooks/useTransactionBatchActions.ts
@@ -302,6 +302,8 @@ export function useTransactionBatchActions() {
                 ...t,
                 cleared: false,
                 reconciled: false,
+                transfer_id: null,
+                schedule: null,
               })),
             );
           },

--- a/packages/loot-core/src/server/__snapshots__/main.test.ts.snap
+++ b/packages/loot-core/src/server/__snapshots__/main.test.ts.snap
@@ -76,7 +76,7 @@ exports[`Accounts > Transfers are properly updated 2`] = `
       "id": "test-transfer",
       "imported_description": null,
       "isChild": 0,
-@@ -24,11 +24,11 @@
+@@ -24,15 +24,15 @@
       "tombstone": 0,
       "transferred_id": "id2",
       "type": null,
@@ -87,8 +87,13 @@ exports[`Accounts > Transfers are properly updated 2`] = `
       "amount": -5000,
       "category": null,
       "cleared": 0,
-      "date": 20170101,
-      "description": "transfer-one","
+-     "date": 20170101,
++     "date": 20170103,
+      "description": "transfer-one",
+      "error": null,
+      "financial_id": null,
+      "id": "id2",
+      "imported_description": null,"
 `;
 
 exports[`Accounts > Transfers are properly updated 3`] = `

--- a/packages/loot-core/src/server/transactions/__snapshots__/transfer.test.ts.snap
+++ b/packages/loot-core/src/server/transactions/__snapshots__/transfer.test.ts.snap
@@ -355,7 +355,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
 "- First value
 + Second value
 
-@@ -2,52 +2,52 @@
+@@ -2,73 +2,73 @@
     Object {
       "account": "one",
       "amount": 5000,
@@ -387,13 +387,48 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
 +     "transfer_id": "id8",
     },
     Object {
-      "account": "one",
-      "amount": 5000,
+-     "account": "one",
+-     "amount": 5000,
++     "account": "two",
++     "amount": -5000,
       "category": null,
-      "cleared": 1,
-      "date": 20170101,
+-     "cleared": 1,
+-     "date": 20170101,
++     "cleared": 0,
++     "date": 20170105,
       "error": null,
 -     "id": "id7",
++     "id": "id8",
+      "imported_id": null,
+      "imported_payee": null,
+      "is_child": 0,
+      "is_parent": 0,
+-     "notes": null,
++     "notes": "This is a note",
+      "parent_id": null,
+-     "payee": "id3",
++     "payee": "id2",
+      "payee_name": "",
+      "raw_synced_data": null,
+      "reconciled": 0,
+      "schedule": null,
+      "sort_order": 123456789,
+      "starting_balance_flag": 0,
+      "tombstone": 0,
+-     "transfer_id": "id8",
++     "transfer_id": "id7",
+    },
+    Object {
+-     "account": "two",
+-     "amount": -5000,
++     "account": "one",
++     "amount": 5000,
+      "category": null,
+-     "cleared": 0,
++     "cleared": 1,
+      "date": 20170101,
+      "error": null,
+-     "id": "id8",
 +     "id": "id6",
       "imported_id": null,
       "imported_payee": null,
@@ -401,7 +436,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
       "is_parent": 0,
       "notes": null,
       "parent_id": null,
--     "payee": "id3",
+-     "payee": "id2",
 -     "payee_name": "",
 +     "payee": "id5",
 +     "payee_name": "Non-transfer",
@@ -411,33 +446,17 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 3`] = `
       "sort_order": 123456789,
       "starting_balance_flag": 0,
       "tombstone": 0,
--     "transfer_id": "id8",
+-     "transfer_id": "id7",
 +     "transfer_id": null,
     },
-    Object {
-      "account": "two",
-      "amount": -5000,
-      "category": null,
-@@ -57,11 +57,11 @@
-      "id": "id8",
-      "imported_id": null,
-      "imported_payee": null,
-      "is_child": 0,
-      "is_parent": 0,
--     "notes": null,
-+     "notes": "This is a note",
-      "parent_id": null,
-      "payee": "id2",
-      "payee_name": "",
-      "raw_synced_data": null,
-      "reconciled": 0,"
+  ]"
 `;
 
 exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
 "- First value
 + Second value
 
-@@ -11,11 +11,11 @@
+@@ -11,22 +11,22 @@
       "imported_payee": null,
       "is_child": 0,
       "is_parent": 0,
@@ -450,10 +469,9 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
       "reconciled": 0,
       "schedule": null,
       "sort_order": 123456789,
-@@ -46,11 +46,11 @@
       "starting_balance_flag": 0,
       "tombstone": 0,
-      "transfer_id": null,
+      "transfer_id": "id8",
     },
     Object {
 -     "account": "two",
@@ -461,7 +479,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 4`] = `
       "amount": -5000,
       "category": null,
       "cleared": 0,
-      "date": 20170101,
+      "date": 20170105,
       "error": null,"
 `;
 
@@ -469,7 +487,7 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
 "- First value
 + Second value
 
-@@ -11,19 +11,19 @@
+@@ -11,43 +11,19 @@
       "imported_payee": null,
       "is_child": 0,
       "is_parent": 0,
@@ -486,25 +504,13 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
       "starting_balance_flag": 0,
       "tombstone": 0,
 -     "transfer_id": "id8",
-+     "transfer_id": null,
-    },
-    Object {
-      "account": "one",
-      "amount": 5000,
-      "category": null,
-@@ -44,31 +44,7 @@
-      "schedule": null,
-      "sort_order": 123456789,
-      "starting_balance_flag": 0,
-      "tombstone": 0,
-      "transfer_id": null,
 -   },
 -   Object {
 -     "account": "three",
 -     "amount": -5000,
 -     "category": null,
 -     "cleared": 0,
--     "date": 20170101,
+-     "date": 20170105,
 -     "error": null,
 -     "id": "id8",
 -     "imported_id": null,
@@ -522,8 +528,12 @@ exports[`Transfer > transfers are properly inserted/updated/deleted 5`] = `
 -     "starting_balance_flag": 0,
 -     "tombstone": 0,
 -     "transfer_id": "id7",
++     "transfer_id": null,
     },
-  ]"
+    Object {
+      "account": "one",
+      "amount": 5000,
+      "category": null,"
 `;
 
 exports[`Transfer > transfers are properly inserted/updated/deleted 6`] = `

--- a/packages/loot-core/src/server/transactions/duplicate-split-transfer-date.test.ts
+++ b/packages/loot-core/src/server/transactions/duplicate-split-transfer-date.test.ts
@@ -6,6 +6,7 @@ import {
   ungroupTransaction,
   updateTransaction,
 } from '#shared/transactions';
+import type { TransactionEntity } from '#types/models';
 
 beforeEach(global.emptyDatabase());
 
@@ -92,30 +93,35 @@ describe('Duplicate split with transfer date sync', () => {
     // For this regression test, we use the FIXED duplication (cleared) and expect date sync.
 
     const duplicated = realizeTempTransactions(
-      ungroupTransaction(grouped as any),
-    ).map(t => ({
-      ...t,
-      cleared: false,
-      reconciled: false,
-      transfer_id: null,
-      schedule: null,
-    }));
+      ungroupTransaction(grouped as unknown as TransactionEntity),
+    ).map(
+      t =>
+        ({
+          ...t,
+          cleared: false,
+          reconciled: false,
+          transfer_id: null,
+          schedule: null,
+        }) as unknown as TransactionEntity,
+    );
 
     // Verify duplicate children have no transfer_id before insert
     expect(duplicated.find(t => t.is_child)!.transfer_id).toBeNull();
 
     // Insert duplicated split via batchUpdateTransactions (which triggers transfer.onInsert)
-    await batchUpdateTransactions({ added: duplicated as any });
+    await batchUpdateTransactions({
+      added: duplicated as unknown as TransactionEntity[],
+    });
 
     // Find duplicated parent and its transfer child
-    const allTransactions = await db.all<any>(
+    const allTransactions = await db.all<db.DbViewTransaction>(
       `SELECT id, is_parent, is_child, parent_id, transfer_id, date, account FROM v_transactions WHERE tombstone = 0`,
     );
     const dupParentRow = allTransactions.find(
       r => r.is_parent === 1 && r.id !== parentId,
     );
     expect(dupParentRow).toBeDefined();
-    const dupParentId = dupParentRow.id;
+    const dupParentId = dupParentRow!.id;
 
     const dupChildren = allTransactions.filter(
       r => r.parent_id === dupParentId,
@@ -151,16 +157,21 @@ describe('Duplicate split with transfer date sync', () => {
       ...dupParent,
       subtransactions: [dupChild1, await db.getTransaction(dupChild2!.id)],
     };
-    const flat = ungroupTransaction(groupedDup as any);
+    const flat = ungroupTransaction(groupedDup as unknown as TransactionEntity);
     // Change parent date
     const newDate = '2025-02-15';
     const updatedParent = { ...dupParent, date: newDate };
     // Use shared logic to get diff (which updates children dates via makeChild)
-    const { diff } = updateTransaction(flat as any, updatedParent as any);
+    const { diff } = updateTransaction(
+      flat as unknown as TransactionEntity[],
+      updatedParent as unknown as TransactionEntity,
+    );
     // diff.updated should contain parent and children with new date
     expect(diff.updated.length).toBeGreaterThan(0);
     // Apply via batchUpdateTransactions
-    await batchUpdateTransactions({ updated: diff.updated as any });
+    await batchUpdateTransactions({
+      updated: diff.updated as unknown as TransactionEntity[],
+    });
 
     // After update, linked transfer date should equal new parent date
     const dupLinkedAfter = await db.getTransaction(dupLinkedTransferId!);
@@ -201,7 +212,7 @@ describe('Duplicate split with transfer date sync', () => {
       category: '1',
     });
     const parent = await db.getTransaction(parentId);
-    const all = await db.all<any>(
+    const all = await db.all<db.DbViewTransaction>(
       `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
       [parentId],
     );
@@ -210,23 +221,28 @@ describe('Duplicate split with transfer date sync', () => {
       subtransactions: await Promise.all(all.map(r => db.getTransaction(r.id))),
     };
     const duplicated = realizeTempTransactions(
-      ungroupTransaction(grouped as any),
-    ).map(t => ({
-      ...t,
-      cleared: false,
-      reconciled: false,
-      transfer_id: null,
-      schedule: null,
-    }));
-    await batchUpdateTransactions({ added: duplicated as any });
-    const allTransactions = await db.all<any>(
+      ungroupTransaction(grouped as unknown as TransactionEntity),
+    ).map(
+      t =>
+        ({
+          ...t,
+          cleared: false,
+          reconciled: false,
+          transfer_id: null,
+          schedule: null,
+        }) as unknown as TransactionEntity,
+    );
+    await batchUpdateTransactions({
+      added: duplicated as unknown as TransactionEntity[],
+    });
+    const allTransactions = await db.all<db.DbViewTransaction>(
       `SELECT * FROM v_transactions WHERE is_parent = 1 AND tombstone = 0`,
     );
     const dupParentRow = allTransactions.find(r => r.id !== parentId);
     expect(dupParentRow).toBeDefined();
-    const dupParentId = dupParentRow.id;
+    const dupParentId = dupParentRow!.id;
     const dupParent = await db.getTransaction(dupParentId);
-    const dupChildrenRows = await db.all<any>(
+    const dupChildrenRows = await db.all<db.DbViewTransaction>(
       `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
       [dupParentId],
     );
@@ -236,19 +252,21 @@ describe('Duplicate split with transfer date sync', () => {
         dupChildrenRows.map(r => db.getTransaction(r.id)),
       ),
     };
-    const flat = ungroupTransaction(groupedDup as any);
+    const flat = ungroupTransaction(groupedDup as unknown as TransactionEntity);
     const newDate = '2025-03-01';
     const { diff } = updateTransaction(
-      flat as any,
+      flat as unknown as TransactionEntity[],
       {
         ...dupParent,
         date: newDate,
-      } as any,
+      } as unknown as TransactionEntity,
     );
-    await batchUpdateTransactions({ updated: diff.updated as any });
+    await batchUpdateTransactions({
+      updated: diff.updated as unknown as TransactionEntity[],
+    });
     const updatedParent = await db.getTransaction(dupParentId);
     expect(updatedParent.date).toBe(newDate);
-    const updatedChildren = await db.all<any>(
+    const updatedChildren = await db.all<db.DbViewTransaction>(
       `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
       [dupParentId],
     );

--- a/packages/loot-core/src/server/transactions/duplicate-split-transfer-date.test.ts
+++ b/packages/loot-core/src/server/transactions/duplicate-split-transfer-date.test.ts
@@ -1,0 +1,260 @@
+import * as db from '#server/db';
+import { batchUpdateTransactions } from '#server/transactions';
+import * as transfer from '#server/transactions/transfer';
+import {
+  realizeTempTransactions,
+  ungroupTransaction,
+  updateTransaction,
+} from '#shared/transactions';
+
+beforeEach(global.emptyDatabase());
+
+async function prepareDatabase() {
+  await db.insertCategoryGroup({ id: 'group1', name: 'group1', is_income: 0 });
+  await db.insertCategory({
+    id: '1',
+    name: 'cat1',
+    cat_group: 'group1',
+    is_income: 0,
+  });
+  await db.insertAccount({ id: 'one', name: 'one' });
+  await db.insertAccount({ id: 'two', name: 'two' });
+  await db.insertPayee({ name: '', transfer_acct: 'one' });
+  await db.insertPayee({ name: '', transfer_acct: 'two' });
+}
+
+describe('Duplicate split with transfer date sync', () => {
+  test('duplicating split with transfer and changing parent date syncs linked transfer date', async () => {
+    await prepareDatabase();
+
+    const payeeTwo = await db.first<db.DbPayee>(
+      "SELECT * FROM payees WHERE transfer_acct = 'two'",
+    );
+    const normalPayee = await db.insertPayee({ name: 'Normal' });
+
+    // Create split parent
+    const parentId = await db.insertTransaction({
+      account: 'one',
+      amount: 5000,
+      date: '2025-01-01',
+      is_parent: true,
+      category: null,
+    });
+
+    // Child 1 is a transfer to account two
+    const child1Id = await db.insertTransaction({
+      account: 'one',
+      amount: 2000,
+      date: '2025-01-01',
+      payee: payeeTwo!.id,
+      is_child: true,
+      parent_id: parentId,
+      category: null,
+    });
+
+    const child2Id = await db.insertTransaction({
+      account: 'one',
+      amount: 3000,
+      date: '2025-01-01',
+      payee: normalPayee,
+      is_child: true,
+      parent_id: parentId,
+      category: '1',
+    });
+
+    // Create linked transfer for child1
+    const child1 = await db.getTransaction(child1Id);
+    await transfer.onInsert(child1);
+
+    // Re-fetch to get updated transfer_id
+    const freshChild1 = await db.getTransaction(child1Id);
+    expect(freshChild1.transfer_id).toBeDefined();
+    const originalTransferId = freshChild1.transfer_id;
+    const originalTransfer = await db.getTransaction(originalTransferId!);
+    expect(originalTransfer.date).toBe('2025-01-01');
+
+    // Simulate duplication as done in useTransactionBatchActions.onBatchDuplicate
+    // Fetch grouped transaction (parent with subtransactions)
+    const parent = await db.getTransaction(parentId);
+    const child1Fresh = await db.getTransaction(child1Id);
+    const child2Fresh = await db.getTransaction(child2Id);
+    // Grouped shape expected by realizeTempTransactions: need subtransactions field
+    const grouped = {
+      ...parent,
+      subtransactions: [child1Fresh, child2Fresh],
+    };
+
+    // This is the OLD buggy path: realizeTempTransactions retains transfer_id
+    // After fix, the hook should clear transfer_id and schedule.
+    // Here we simulate the FIXED hook behavior: clearing transfer_id/schedule
+    // The test should pass only when both layers are fixed: hook clears and updateTransfer syncs date.
+    // To reproduce the bug, we first test without clearing and without date sync.
+    // For this regression test, we use the FIXED duplication (cleared) and expect date sync.
+
+    const duplicated = realizeTempTransactions(
+      ungroupTransaction(grouped as any),
+    ).map(t => ({
+      ...t,
+      cleared: false,
+      reconciled: false,
+      transfer_id: null,
+      schedule: null,
+    }));
+
+    // Verify duplicate children have no transfer_id before insert
+    expect(duplicated.find(t => t.is_child)!.transfer_id).toBeNull();
+
+    // Insert duplicated split via batchUpdateTransactions (which triggers transfer.onInsert)
+    await batchUpdateTransactions({ added: duplicated as any });
+
+    // Find duplicated parent and its transfer child
+    const allTransactions = await db.all<any>(
+      `SELECT id, is_parent, is_child, parent_id, transfer_id, date, account FROM v_transactions WHERE tombstone = 0`,
+    );
+    const dupParentRow = allTransactions.find(
+      r => r.is_parent === 1 && r.id !== parentId,
+    );
+    expect(dupParentRow).toBeDefined();
+    const dupParentId = dupParentRow.id;
+
+    const dupChildren = allTransactions.filter(
+      r => r.parent_id === dupParentId,
+    );
+    expect(dupChildren.length).toBe(2);
+    // Alternative: find child whose transfer counterpart exists in account two
+    let dupTransferChildId: string | null = null;
+    let dupLinkedTransferId: string | null = null;
+    for (const c of dupChildren) {
+      if (c.transfer_id) {
+        const linked = await db.getTransaction(c.transfer_id);
+        if (linked) {
+          dupTransferChildId = c.id;
+          dupLinkedTransferId = linked.id;
+          break;
+        }
+      }
+    }
+    expect(dupTransferChildId).not.toBeNull();
+    expect(dupLinkedTransferId).not.toBeNull();
+    const dupLinkedBefore = await db.getTransaction(dupLinkedTransferId!);
+    expect(dupLinkedBefore.date).toBe('2025-01-01');
+
+    // Now change duplicated parent date via updateTransaction + batchUpdate (simulating UI edit)
+    // Need to use shared updateTransaction to propagate date to children
+    const dupParent = await db.getTransaction(dupParentId);
+    const dupChild1 = await db.getTransaction(dupTransferChildId!);
+    const dupChild2 = dupChildren.find(c => c.id !== dupTransferChildId);
+    // Build transactions array as expected by updateTransaction (flat list sorted)
+    // Simpler: use batchUpdate with updated parent date and rely on server transfer sync?
+    // But split date propagation is done client-side via updateTransaction diff.
+    const groupedDup = {
+      ...dupParent,
+      subtransactions: [dupChild1, await db.getTransaction(dupChild2!.id)],
+    };
+    const flat = ungroupTransaction(groupedDup as any);
+    // Change parent date
+    const newDate = '2025-02-15';
+    const updatedParent = { ...dupParent, date: newDate };
+    // Use shared logic to get diff (which updates children dates via makeChild)
+    const { diff } = updateTransaction(flat as any, updatedParent as any);
+    // diff.updated should contain parent and children with new date
+    expect(diff.updated.length).toBeGreaterThan(0);
+    // Apply via batchUpdateTransactions
+    await batchUpdateTransactions({ updated: diff.updated as any });
+
+    // After update, linked transfer date should equal new parent date
+    const dupLinkedAfter = await db.getTransaction(dupLinkedTransferId!);
+    expect(dupLinkedAfter.date).toBe(newDate);
+
+    // Also ensure non-transfer split case doesn't break: duplicate non-transfer split and change date
+    // Already covered by not throwing, but verify no linked transfer was incorrectly created
+    const nonTransferChildAfter = await db.getTransaction(dupChild2!.id);
+    expect(nonTransferChildAfter.transfer_id).toBeNull();
+  });
+
+  test('non-transfer split duplicate date change still works', async () => {
+    await prepareDatabase();
+    const normalPayee = await db.insertPayee({ name: 'Normal' });
+    const parentId = await db.insertTransaction({
+      account: 'one',
+      amount: 5000,
+      date: '2025-01-01',
+      is_parent: true,
+      category: null,
+    });
+    await db.insertTransaction({
+      account: 'one',
+      amount: 2000,
+      date: '2025-01-01',
+      payee: normalPayee,
+      is_child: true,
+      parent_id: parentId,
+      category: '1',
+    });
+    await db.insertTransaction({
+      account: 'one',
+      amount: 3000,
+      date: '2025-01-01',
+      payee: normalPayee,
+      is_child: true,
+      parent_id: parentId,
+      category: '1',
+    });
+    const parent = await db.getTransaction(parentId);
+    const all = await db.all<any>(
+      `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
+      [parentId],
+    );
+    const grouped = {
+      ...parent,
+      subtransactions: await Promise.all(all.map(r => db.getTransaction(r.id))),
+    };
+    const duplicated = realizeTempTransactions(
+      ungroupTransaction(grouped as any),
+    ).map(t => ({
+      ...t,
+      cleared: false,
+      reconciled: false,
+      transfer_id: null,
+      schedule: null,
+    }));
+    await batchUpdateTransactions({ added: duplicated as any });
+    const allTransactions = await db.all<any>(
+      `SELECT * FROM v_transactions WHERE is_parent = 1 AND tombstone = 0`,
+    );
+    const dupParentRow = allTransactions.find(r => r.id !== parentId);
+    expect(dupParentRow).toBeDefined();
+    const dupParentId = dupParentRow.id;
+    const dupParent = await db.getTransaction(dupParentId);
+    const dupChildrenRows = await db.all<any>(
+      `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
+      [dupParentId],
+    );
+    const groupedDup = {
+      ...dupParent,
+      subtransactions: await Promise.all(
+        dupChildrenRows.map(r => db.getTransaction(r.id)),
+      ),
+    };
+    const flat = ungroupTransaction(groupedDup as any);
+    const newDate = '2025-03-01';
+    const { diff } = updateTransaction(
+      flat as any,
+      {
+        ...dupParent,
+        date: newDate,
+      } as any,
+    );
+    await batchUpdateTransactions({ updated: diff.updated as any });
+    const updatedParent = await db.getTransaction(dupParentId);
+    expect(updatedParent.date).toBe(newDate);
+    const updatedChildren = await db.all<any>(
+      `SELECT * FROM v_transactions WHERE parent_id = ? AND tombstone = 0`,
+      [dupParentId],
+    );
+    for (const c of updatedChildren) {
+      const t = await db.getTransaction(c.id);
+      expect(t.date).toBe(newDate);
+    }
+  });
+});

--- a/packages/loot-core/src/server/transactions/index.ts
+++ b/packages/loot-core/src/server/transactions/index.ts
@@ -133,13 +133,16 @@ export async function batchUpdateTransactions({
   // Transfers update the transactions and we need to return updates
   // to the client so that can apply them. Note that added
   // transactions just return the full transaction.
-  const resultAdded = allAdded;
+  let resultAdded = allAdded;
   const resultUpdated = allUpdated;
   let transfersUpdated: Awaited<ReturnType<typeof transfer.onUpdate>>[];
 
   if (runTransfers) {
     await batchMessages(async () => {
       await Promise.all(allAdded.map(t => transfer.onInsert(t)));
+      if (addedIds.length > 0) {
+        resultAdded = await getTransactionsByIds(addedIds);
+      }
 
       // Return any updates from here
       transfersUpdated = (

--- a/packages/loot-core/src/server/transactions/transfer.ts
+++ b/packages/loot-core/src/server/transactions/transfer.ts
@@ -126,6 +126,7 @@ export async function updateTransfer(transaction, transferredAccount) {
     // Make sure to update the payee on the other side in case the
     // user moved this transaction into another account
     payee: payee.id,
+    date: transaction.date,
     notes: transaction.notes,
     amount: -transaction.amount,
     schedule: transaction.schedule,

--- a/upcoming-release-notes/fix-duplicate-split-transfer-date-sync.md
+++ b/upcoming-release-notes/fix-duplicate-split-transfer-date-sync.md
@@ -1,0 +1,6 @@
+---
+category: Bugfixes
+authors: [actualbudget]
+---
+
+Fix linked transfer date not updating when changing parent date on a duplicated split transaction

--- a/upcoming-release-notes/fix-duplicate-split-transfer-date-sync.md
+++ b/upcoming-release-notes/fix-duplicate-split-transfer-date-sync.md
@@ -1,6 +1,6 @@
 ---
-category: Bugfixes
-authors: [actualbudget]
+category: Bugfix
+authors: [lorenzozanee]
 ---
 
 Fix linked transfer date not updating when changing parent date on a duplicated split transaction


### PR DESCRIPTION
## Description

Duplicating a split transaction that contains a transfer linked the new child to the original transfer and left the counterpart date stale. Changing the duplicated parent's date updated the split children but not the paired transfer; now duplication creates a fresh link and transfer updates sync the date.

## Related issue(s)

Fixes #8822

## Testing

Reproduced the duplicated split transfer case where the linked date stayed on the original date; after the fix the counterpart follows the parent date. Verified non-transfer splits and existing transfer tests still pass.

## Checklist

- [ ] Release notes added (see link above)
- [ ] No obvious regressions in affected areas
- [ ] Self-review has been performed - I have read every line of this diff and can explain what each change does and why it is needed

<!--- actual-bot-sections --->
<hr />

<!--- bundlestats-action-comment key:combined start --->
### Bundle Stats

Bundle | Files count | Total bundle size | % Changed
------ | ----------- | ----------------- | ---------
desktop-client | 42 | 13.51 MB → 13.6 MB (+87.8 kB) | +0.63%
loot-core | 1 | 4.64 MB → 4.64 MB (+105 B) | +0.00%
api | 2 | 3.85 MB → 3.85 MB (+103 B) | +0.00%
cli | 1 | 8.02 MB | 0%
crdt | 1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle stats</summary>

#### desktop-client

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
42 | 13.51 MB → 13.6 MB (+87.8 kB) | +0.63%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`src/hooks/useTransactionBatchActions.ts` | 📈 +39 B (+0.38%) | 9.93 kB → 9.97 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/TransactionList.js | 79.22 kB → 166.98 kB (+87.76 kB) | +110.78%
static/js/NotesTagFormatter.js | 25.94 kB → 25.98 kB (+39 B) | +0.15%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
static/js/index.js | 1.58 MB | 0%
static/js/BackgroundImage.js | 121.09 kB | 0%
static/js/DateSelect.js | 2.37 MB | 0%
static/js/FormulaEditor.js | 766.35 kB | 0%
static/js/ManageRules.js | 71.66 kB | 0%
static/js/PayeeRuleCountLabel.js | 12.81 kB | 0%
static/js/ReportRouter.js | 1.43 MB | 0%
static/js/ScheduleEditForm.js | 75.41 kB | 0%
static/js/SchedulesTable.js | 171.25 kB | 0%
static/js/TourHost.js | 169.22 kB | 0%
static/js/TourProvider.js | 1.54 kB | 0%
static/js/TransactionEdit.js | 221.38 kB | 0%
static/js/Value.js | 1.79 MB | 0%
static/js/bootstrapHyperFormula.js | 302 B | 0%
static/js/ca.js | 170.64 kB | 0%
static/js/client.js | 452.05 kB | 0%
static/js/columns.js | 673.28 kB | 0%
static/js/de.js | 185 kB | 0%
static/js/en-GB.js | 11.1 kB | 0%
static/js/en.js | 245.91 kB | 0%
static/js/es.js | 164.81 kB | 0%
static/js/fr.js | 179.04 kB | 0%
static/js/indexeddb-main-thread-worker-e59fee74.js | 13.46 kB | 0%
static/js/it.js | 151.67 kB | 0%
static/js/months.js | 574.72 kB | 0%
static/js/narrow.js | 290.52 kB | 0%
static/js/nb-NO.js | 135.46 kB | 0%
static/js/nl.js | 151.78 kB | 0%
static/js/pl.js | 136.39 kB | 0%
static/js/pt-BR.js | 178.2 kB | 0%
static/js/ru.js | 209.6 kB | 0%
static/js/theme.js | 31.1 kB | 0%
static/js/uk.js | 201.42 kB | 0%
static/js/useFormatList.js | 10.22 kB | 0%
static/js/useLocalPref.js | 97.2 kB | 0%
static/js/useReducedMotion.js | 594 B | 0%
static/js/wide.js | 274.04 kB | 0%
static/js/workbox-window.prod.es5.js | 7.21 kB | 0%
static/js/zh-Hans.js | 106.8 kB | 0%
static/js/zh-Hant.js | 130.92 kB | 0%
</div>
</details>

---

#### loot-core

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 4.64 MB → 4.64 MB (+105 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/index.ts` | 📈 +78 B (+2.29%) | 3.32 kB → 3.4 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transfer.ts` | 📈 +27 B (+0.72%) | 3.68 kB → 3.71 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CzkRmmOa.js | 0 B → 4.64 MB (+4.64 MB) | -

**Removed**
Asset | File Size | % Changed
----- | --------- | ---------
kcab.worker.CokRHpI5.js | 4.64 MB → 0 B (-4.64 MB) | -100%

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
No assets were unchanged
</div>
</details>

---

#### api

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
2 | 3.85 MB → 3.85 MB (+103 B) | +0.00%

<details>
<summary>Changeset</summary>

File | Δ | Size
---- | - | ----
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/index.ts` | 📈 +77 B (+2.31%) | 3.25 kB → 3.33 kB
`home/runner/work/actual/actual/packages/loot-core/src/server/transactions/transfer.ts` | 📈 +26 B (+0.71%) | 3.58 kB → 3.61 kB
</details>

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 3.85 MB → 3.85 MB (+103 B) | +0.00%

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
models.js | 0 B | 0%
</div>
</details>

---

#### cli

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 8.02 MB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
cli.js | 8.02 MB | 0%
</div>
</details>

---

#### crdt

**Total**
Files count | Total bundle size | % Changed
----------- | ----------------- | ---------
1 | 11.16 kB | 0%

<details>
<summary>View detailed bundle breakdown</summary>
<div>

**Added**
No assets were added

**Removed**
No assets were removed

**Bigger**
No assets were bigger

**Smaller**
No assets were smaller

**Unchanged**
Asset | File Size | % Changed
----- | --------- | ---------
index.js | 11.16 kB | 0%
</div>
</details>
</details>

<!--- bundlestats-action-comment key:combined end --->